### PR TITLE
feat: support modifier keys (Command, Shift, Option, Control) as single-key hotkeys

### DIFF
--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -259,9 +259,17 @@ struct SingleKeyRecorderView: View {
     private func startRecording() {
         isRecording = true
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
-            if event.type == .flagsChanged, event.modifierFlags.contains(.function) {
-                finishRecording(code: 0, isFn: true)
-                return nil
+            if event.type == .flagsChanged {
+                if event.modifierFlags.contains(.function) {
+                    finishRecording(code: 0, isFn: true)
+                    return nil
+                }
+                // Capture modifier-only keys (Command, Shift, Option, Control)
+                let modifierKeyCodes: Set<UInt16> = [0x37, 0x36, 0x38, 0x3C, 0x3A, 0x3D, 0x3B, 0x3E]
+                if modifierKeyCodes.contains(event.keyCode) {
+                    finishRecording(code: event.keyCode, isFn: false)
+                    return nil
+                }
             }
             if event.type == .keyDown {
                 finishRecording(code: event.keyCode, isFn: false)


### PR DESCRIPTION
## Problem

The single-key hotkey recorder and handler only recognized the **Fn** key via `flagsChanged` events. Modifier keys like **Right Command**, **Right Option**, etc. also generate `flagsChanged` events but were silently ignored — making it impossible to assign them as dictation hotkeys.

## Changes

### `HotkeyService.swift`
- Added a `modifierKeyCodes` set covering all 8 modifier key variants (Left/Right × Command/Shift/Option/Control)
- New `singleKeyIsModifier` flag that's persisted to UserDefaults alongside existing single-key settings
- Extended `handleSingleKeyEvent` with a dedicated branch for modifier keys that tracks press/release via `flagsChanged` and the appropriate `NSEvent.ModifierFlags`
- Added display names for all modifier keys in `keyName(for:isFn:)`

### `SettingsView.swift` (`SingleKeyRecorderView`)
- Updated the event monitor in `startRecording()` to detect modifier key codes from `flagsChanged` events (previously only Fn was captured)

## Testing

Verified on macOS with Right Command — the recorder correctly captures the key, displays "⌘ Right Command", and the hotkey triggers dictation on press/release as expected. All existing hotkey modes (Fn, regular keys, KeyboardShortcuts combo) continue to work unchanged.