### PR TITLE
Add Gemini as LLM provider for custom prompts

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -465,6 +465,16 @@
         }
       }
     },
+    "API Key Saved" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schluessel gespeichert"
+          }
+        }
+      }
+    },
     "API key configured" : {
       "localizations" : {
         "de" : {
@@ -940,7 +950,18 @@
         }
       }
     },
+    "Configure cloud providers for transcription and AI prompts. An API key is required for each provider." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud-Anbieter fuer Transkription und KI-Prompts konfigurieren. Fuer jeden Anbieter wird ein API-Schluessel benoetigt."
+          }
+        }
+      }
+    },
     "Configure cloud transcription providers. An API key is required for each provider." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2737,6 +2758,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prompts"
+          }
+        }
+      }
+    },
+    "Prompts Only" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur Prompts"
           }
         }
       }

--- a/TypeWhisper/Services/LLM/CloudLLMProvider.swift
+++ b/TypeWhisper/Services/LLM/CloudLLMProvider.swift
@@ -7,6 +7,7 @@ final class CloudLLMProvider: LLMProvider, @unchecked Sendable {
     let baseURL: String
     let model: String
     private let keychainId: String
+    private let chatEndpoint: String
 
     var isAvailable: Bool {
         let apiKey = KeychainService.load(service: keychainId)
@@ -15,6 +16,7 @@ final class CloudLLMProvider: LLMProvider, @unchecked Sendable {
 
     init(config: CloudProviderConfig, model: String? = nil) {
         self.baseURL = config.baseURL
+        self.chatEndpoint = config.chatEndpoint
         self.model = model ?? config.defaultModel
         self.keychainId = config.keychainId
     }
@@ -24,7 +26,7 @@ final class CloudLLMProvider: LLMProvider, @unchecked Sendable {
             throw LLMError.noApiKey
         }
 
-        let endpoint = "\(baseURL)/v1/chat/completions"
+        let endpoint = "\(baseURL)\(chatEndpoint)"
         guard let url = URL(string: endpoint) else {
             throw LLMError.providerError("Invalid URL: \(endpoint)")
         }

--- a/TypeWhisper/Services/LLM/LLMProvider.swift
+++ b/TypeWhisper/Services/LLM/LLMProvider.swift
@@ -6,6 +6,7 @@ import Foundation
 /// To add a new provider: add a case to LLMProviderType, add its cloudConfig entry, done.
 struct CloudProviderConfig: Sendable {
     let baseURL: String
+    let chatEndpoint: String
     let defaultModel: String
     let keychainId: String
     let knownModels: [String]
@@ -17,6 +18,7 @@ enum LLMProviderType: String, CaseIterable, Identifiable {
     case appleIntelligence
     case groq
     case openai
+    case gemini
 
     var id: String { rawValue }
 
@@ -25,10 +27,16 @@ enum LLMProviderType: String, CaseIterable, Identifiable {
         case .appleIntelligence: "Apple Intelligence"
         case .groq: "Groq"
         case .openai: "OpenAI"
+        case .gemini: "Gemini"
         }
     }
 
     var isCloudProvider: Bool { cloudConfig != nil }
+
+    /// LLM-only providers that have no corresponding EngineType (not used for transcription).
+    static var llmOnlyCases: [LLMProviderType] {
+        allCases.filter { $0.isCloudProvider && EngineType(rawValue: $0.rawValue) == nil }
+    }
 
     /// Cloud provider configuration. Returns nil for non-cloud providers (Apple Intelligence).
     var cloudConfig: CloudProviderConfig? {
@@ -38,6 +46,7 @@ enum LLMProviderType: String, CaseIterable, Identifiable {
         case .groq:
             CloudProviderConfig(
                 baseURL: "https://api.groq.com/openai",
+                chatEndpoint: "/v1/chat/completions",
                 defaultModel: "llama-3.3-70b-versatile",
                 keychainId: "groq",
                 knownModels: [
@@ -50,6 +59,7 @@ enum LLMProviderType: String, CaseIterable, Identifiable {
         case .openai:
             CloudProviderConfig(
                 baseURL: "https://api.openai.com",
+                chatEndpoint: "/v1/chat/completions",
                 defaultModel: "gpt-4.1-nano",
                 keychainId: "openai",
                 knownModels: [
@@ -60,6 +70,20 @@ enum LLMProviderType: String, CaseIterable, Identifiable {
                     "gpt-4.1-mini",
                     "gpt-4.1-nano",
                     "o4-mini",
+                ]
+            )
+        case .gemini:
+            CloudProviderConfig(
+                baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+                chatEndpoint: "/chat/completions",
+                defaultModel: "gemini-2.5-flash",
+                keychainId: "gemini",
+                knownModels: [
+                    "gemini-3.1-pro-preview",
+                    "gemini-3-flash-preview",
+                    "gemini-2.5-pro",
+                    "gemini-2.5-flash",
+                    "gemini-2.5-flash-lite",
                 ]
             )
         }

--- a/TypeWhisper/Views/ModelManagerView.swift
+++ b/TypeWhisper/Views/ModelManagerView.swift
@@ -61,12 +61,16 @@ struct ModelManagerView: View {
                         }
 
                     case .cloudProvider:
-                        Text(String(localized: "Configure cloud transcription providers. An API key is required for each provider."))
+                        Text(String(localized: "Configure cloud providers for transcription and AI prompts. An API key is required for each provider."))
                             .font(.callout)
                             .foregroundStyle(.secondary)
 
                         ForEach(EngineType.cloudCases) { provider in
                             CloudProviderSection(provider: provider, viewModel: viewModel)
+                        }
+
+                        ForEach(LLMProviderType.llmOnlyCases) { provider in
+                            LLMProviderSection(providerType: provider)
                         }
 
                         Text(String(localized: "API keys are stored securely in the Keychain"))
@@ -224,6 +228,94 @@ struct ModelRow: View {
             return String(format: "%.1f MB/s", mbps)
         } else {
             return String(format: "%.0f KB/s", bytesPerSecond / 1024)
+        }
+    }
+}
+
+struct LLMProviderSection: View {
+    let providerType: LLMProviderType
+
+    @State private var apiKeyInput = ""
+    @State private var showApiKey = false
+    @State private var isConfigured = false
+
+    private var keychainId: String? { providerType.cloudConfig?.keychainId }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(providerType.displayName)
+                    .font(.body.weight(.medium))
+
+                Text(String(localized: "Prompts Only"))
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.purple.opacity(0.15), in: Capsule())
+                    .foregroundStyle(.purple)
+
+                Spacer()
+
+                if isConfigured {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(String(localized: "API Key Saved"))
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
+                }
+            }
+
+            HStack(spacing: 8) {
+                if showApiKey {
+                    TextField("API Key", text: $apiKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                } else {
+                    SecureField("API Key", text: $apiKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Button {
+                    showApiKey.toggle()
+                } label: {
+                    Image(systemName: showApiKey ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.borderless)
+
+                if isConfigured {
+                    Button(String(localized: "Remove")) {
+                        apiKeyInput = ""
+                        if let id = keychainId {
+                            try? KeychainService.delete(service: id)
+                        }
+                        isConfigured = false
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .foregroundStyle(.red)
+                } else {
+                    Button(String(localized: "Save")) {
+                        guard let id = keychainId else { return }
+                        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        try? KeychainService.save(key: trimmed, service: id)
+                        isConfigured = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
+        .onAppear {
+            if let id = keychainId, let existingKey = KeychainService.load(service: id) {
+                apiKeyInput = existingKey
+                isConfigured = !existingKey.isEmpty
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds Gemini as a new LLM provider for custom prompts (not for transcription)
- Gemini uses Google's OpenAI-compatible chat endpoint with a slightly different path (`/chat/completions` instead of `/v1/chat/completions`), handled via a new configurable `chatEndpoint` property on `CloudProviderConfig`
- New `LLMProviderSection` UI in the Cloud Provider tab with API key field and "Prompts Only" badge

## Test plan
- [ ] Build succeeds without compiler errors
- [ ] Settings > Models > Cloud Provider: Gemini section visible with API key field (no model list)
- [ ] Save/remove Gemini API key works via KeychainService
- [ ] Settings > Prompts > Provider: Gemini appears as option
- [ ] Model picker shows Gemini models when Gemini is selected
- [ ] Execute a custom prompt with Gemini provider
- [ ] Groq/OpenAI behave unchanged

Closes #16