### PR TITLE
feat: Qwen3 ASR plugin (local MLX speech-to-text)

### DIFF
--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -1,0 +1,463 @@
+import Foundation
+import SwiftUI
+import HuggingFace
+import MLX
+import MLXAudioSTT
+import TypeWhisperPluginSDK
+
+// MARK: - Plugin Entry Point
+
+@objc(Qwen3Plugin)
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.qwen3"
+    static let pluginName = "Qwen3 ASR"
+
+    fileprivate var host: HostServices?
+    fileprivate var _selectedModelId: String?
+    fileprivate var model: Qwen3ASRModel?
+    fileprivate var loadedModelId: String?
+
+    // Observable state for settings UI
+    fileprivate var modelState: Qwen3ModelState = .notLoaded
+
+    private static let primaryParams = STTGenerateParameters(
+        maxTokens: 2048,
+        temperature: 0.0,
+        language: "English",
+        chunkDuration: 30.0,
+        minChunkDuration: 1.0
+    )
+
+    private static let fallbackParams = STTGenerateParameters(
+        maxTokens: 1536,
+        temperature: 0.0,
+        language: "English",
+        chunkDuration: 15.0,
+        minChunkDuration: 1.0
+    )
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
+            ?? Self.availableModels.first?.id
+    }
+
+    func deactivate() {
+        model = nil
+        loadedModelId = nil
+        modelState = .notLoaded
+        host = nil
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "qwen3" }
+    var providerDisplayName: String { "Qwen3 ASR (MLX)" }
+
+    var isConfigured: Bool {
+        model != nil && loadedModelId != nil
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        Self.availableModels.map {
+            PluginModelInfo(id: $0.id, displayName: $0.displayName)
+        }
+    }
+
+    var selectedModelId: String? { _selectedModelId }
+
+    func selectModel(_ modelId: String) {
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedModel")
+    }
+
+    var supportsTranslation: Bool { false }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard let model else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let audioArray = MLXArray(audio.samples)
+        let languageName = Self.resolveLanguageName(language)
+        let primaryParams = Self.makeParams(Self.primaryParams, language: languageName)
+
+        let primaryOutput = model.generate(audio: audioArray, generationParameters: primaryParams)
+        let primaryText = Self.normalizeTranscript(primaryOutput.text)
+        let text: String
+
+        if QwenTranscriptGuard.isLikelyLooped(primaryText) {
+            let fallbackParams = Self.makeParams(Self.fallbackParams, language: languageName)
+            let fallbackOutput = model.generate(audio: audioArray, generationParameters: fallbackParams)
+            let fallbackText = Self.normalizeTranscript(fallbackOutput.text)
+
+            if fallbackText.isEmpty {
+                text = primaryText
+            } else if QwenTranscriptGuard.isLikelyLooped(fallbackText) {
+                text = QwenTranscriptGuard.preferredTranscript(primary: primaryText, fallback: fallbackText)
+            } else {
+                text = fallbackText
+            }
+        } else {
+            text = primaryText
+        }
+
+        return PluginTranscriptionResult(text: text, detectedLanguage: language)
+    }
+
+    // MARK: - Model Management
+
+    fileprivate func loadModel(_ modelDef: Qwen3ModelDef) async throws {
+        modelState = .loading
+        do {
+            let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models")
+                ?? FileManager.default.temporaryDirectory
+            try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
+
+            let cache = HubCache(cacheDirectory: modelsDir)
+            let loaded = try await Qwen3ASRModel.fromPretrained(modelDef.repoId, cache: cache)
+
+            model = loaded
+            loadedModelId = modelDef.id
+            _selectedModelId = modelDef.id
+            host?.setUserDefault(modelDef.id, forKey: "selectedModel")
+            host?.setUserDefault(modelDef.id, forKey: "loadedModel")
+            modelState = .ready(modelDef.id)
+        } catch {
+            modelState = .error(error.localizedDescription)
+            throw error
+        }
+    }
+
+    fileprivate func unloadModel() {
+        model = nil
+        loadedModelId = nil
+        modelState = .notLoaded
+        host?.setUserDefault(nil, forKey: "loadedModel")
+    }
+
+    fileprivate func deleteModelFiles(_ modelDef: Qwen3ModelDef) {
+        guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
+        let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
+        let modelDir = modelsDir
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(subdirectory)
+        try? FileManager.default.removeItem(at: modelDir)
+    }
+
+    fileprivate func restoreLoadedModel() async {
+        guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
+              let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
+            return
+        }
+        try? await loadModel(modelDef)
+    }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(Qwen3SettingsView(plugin: self))
+    }
+
+    // MARK: - Model Definitions
+
+    static let availableModels: [Qwen3ModelDef] = [
+        Qwen3ModelDef(
+            id: "qwen3-asr-0.6b-4bit",
+            displayName: "Qwen3 0.6B (4-bit)",
+            repoId: "mlx-community/Qwen3-ASR-0.6B-4bit",
+            sizeDescription: "~400 MB",
+            ramRequirement: "8 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-0.6b-8bit",
+            displayName: "Qwen3 0.6B (8-bit)",
+            repoId: "mlx-community/Qwen3-ASR-0.6B-8bit",
+            sizeDescription: "~800 MB",
+            ramRequirement: "16 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-1.7b-4bit",
+            displayName: "Qwen3 1.7B (4-bit)",
+            repoId: "mlx-community/Qwen3-ASR-1.7B-4bit",
+            sizeDescription: "~1 GB",
+            ramRequirement: "16 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-1.7b-8bit",
+            displayName: "Qwen3 1.7B (8-bit)",
+            repoId: "mlx-community/Qwen3-ASR-1.7B-8bit",
+            sizeDescription: "~2 GB",
+            ramRequirement: "32 GB+"
+        ),
+    ]
+
+    // MARK: - Helpers
+
+    // ISO 639-1 code to English language name (used by Qwen3 ASR API)
+    private static let languageNames: [String: String] = [
+        "zh": "Chinese", "en": "English", "yue": "Cantonese",
+        "ar": "Arabic", "de": "German", "fr": "French",
+        "es": "Spanish", "pt": "Portuguese", "id": "Indonesian",
+        "it": "Italian", "ko": "Korean", "ru": "Russian",
+        "th": "Thai", "vi": "Vietnamese", "ja": "Japanese",
+        "tr": "Turkish", "hi": "Hindi", "ms": "Malay",
+        "nl": "Dutch", "sv": "Swedish", "da": "Danish",
+        "fi": "Finnish", "pl": "Polish", "cs": "Czech",
+        "fil": "Filipino", "fa": "Persian", "el": "Greek",
+        "hu": "Hungarian", "mk": "Macedonian", "ro": "Romanian",
+    ]
+
+    fileprivate static func resolveLanguageName(_ isoCode: String?) -> String {
+        guard let code = isoCode else { return "English" }
+        return languageNames[code] ?? "English"
+    }
+
+    private static func makeParams(_ base: STTGenerateParameters, language: String) -> STTGenerateParameters {
+        STTGenerateParameters(
+            maxTokens: base.maxTokens,
+            temperature: base.temperature,
+            language: language,
+            chunkDuration: base.chunkDuration,
+            minChunkDuration: base.minChunkDuration
+        )
+    }
+
+    fileprivate static func normalizeTranscript(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Model Types
+
+struct Qwen3ModelDef: Identifiable {
+    let id: String
+    let displayName: String
+    let repoId: String
+    let sizeDescription: String
+    let ramRequirement: String
+}
+
+enum Qwen3ModelState: Equatable {
+    case notLoaded
+    case loading
+    case ready(String) // loaded model ID
+    case error(String)
+
+    static func == (lhs: Qwen3ModelState, rhs: Qwen3ModelState) -> Bool {
+        switch (lhs, rhs) {
+        case (.notLoaded, .notLoaded): true
+        case (.loading, .loading): true
+        case let (.ready(a), .ready(b)): a == b
+        case let (.error(a), .error(b)): a == b
+        default: false
+        }
+    }
+}
+
+// MARK: - QwenTranscriptGuard (Loop Detection)
+
+enum QwenTranscriptGuard {
+    static func isLikelyLooped(_ text: String) -> Bool {
+        let words = words(in: text)
+        guard words.count >= 16 else { return false }
+
+        let metrics = LoopMetrics(words: words)
+        let dominantShare = Double(metrics.maxFrequency) / Double(words.count)
+
+        if metrics.longestRun >= 7 { return true }
+        if dominantShare >= 0.5, metrics.uniqueRatio <= 0.3 { return true }
+        if metrics.hasRepeatedNGram(n: 3, minRepeats: 5), metrics.uniqueRatio <= 0.45 { return true }
+        return false
+    }
+
+    static func preferredTranscript(primary: String, fallback: String) -> String {
+        let primaryMetrics = LoopMetrics(words: words(in: primary))
+        let fallbackMetrics = LoopMetrics(words: words(in: fallback))
+        let primaryScore = primaryMetrics.qualityScore
+        let fallbackScore = fallbackMetrics.qualityScore
+
+        if primaryScore == fallbackScore {
+            return primary.count <= fallback.count ? primary : fallback
+        }
+        return primaryScore >= fallbackScore ? primary : fallback
+    }
+
+    private static func words(in text: String) -> [String] {
+        text
+            .lowercased()
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != "'" })
+            .map(String.init)
+    }
+
+    private struct LoopMetrics {
+        let words: [String]
+        let uniqueRatio: Double
+        let maxFrequency: Int
+        let longestRun: Int
+
+        init(words: [String]) {
+            self.words = words
+            if words.isEmpty {
+                uniqueRatio = 0
+                maxFrequency = 0
+                longestRun = 0
+                return
+            }
+
+            var counts: [String: Int] = [:]
+            counts.reserveCapacity(words.count)
+            var currentRun = 0
+            var lastWord: String?
+            var bestRun = 0
+
+            for word in words {
+                counts[word, default: 0] += 1
+                if word == lastWord {
+                    currentRun += 1
+                } else {
+                    currentRun = 1
+                    lastWord = word
+                }
+                if currentRun > bestRun {
+                    bestRun = currentRun
+                }
+            }
+
+            uniqueRatio = Double(counts.count) / Double(words.count)
+            maxFrequency = counts.values.max() ?? 0
+            longestRun = bestRun
+        }
+
+        var qualityScore: Double {
+            guard !words.isEmpty else { return -Double.greatestFiniteMagnitude }
+            let runPenalty = Double(longestRun) / Double(words.count)
+            let dominancePenalty = Double(maxFrequency) / Double(words.count)
+            return uniqueRatio - runPenalty - dominancePenalty
+        }
+
+        func hasRepeatedNGram(n: Int, minRepeats: Int) -> Bool {
+            guard n > 0, words.count >= n * minRepeats else { return false }
+            var counts: [String: Int] = [:]
+            counts.reserveCapacity(words.count / n)
+            let limit = words.count - n
+            for index in 0...limit {
+                let key = words[index..<(index + n)].joined(separator: " ")
+                counts[key, default: 0] += 1
+                if counts[key, default: 0] >= minRepeats {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+}
+
+// MARK: - Settings View
+
+private struct Qwen3SettingsView: View {
+    let plugin: Qwen3Plugin
+    @State private var modelState: Qwen3ModelState = .notLoaded
+    @State private var selectedModelId: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Qwen3 ASR (MLX)")
+                .font(.headline)
+
+            Text("Local speech-to-text powered by MLX on Apple Silicon. 30 languages, no API key required.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            // Model Selection
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Model")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                ForEach(Qwen3Plugin.availableModels) { modelDef in
+                    modelRow(modelDef)
+                }
+            }
+
+            if case .error(let message) = modelState {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding()
+        .onAppear {
+            modelState = plugin.modelState
+            selectedModelId = plugin.selectedModelId ?? Qwen3Plugin.availableModels.first?.id ?? ""
+        }
+        .task {
+            // Auto-restore previously loaded model
+            if case .notLoaded = plugin.modelState {
+                await plugin.restoreLoadedModel()
+                modelState = plugin.modelState
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func modelRow(_ modelDef: Qwen3ModelDef) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(modelDef.displayName)
+                    .font(.body)
+                Text("\(modelDef.sizeDescription) - RAM: \(modelDef.ramRequirement)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if case .loading = modelState, selectedModelId == modelDef.id {
+                ProgressView()
+                    .controlSize(.small)
+            } else if case .ready(let loadedId) = modelState, loadedId == modelDef.id {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Button("Unload") {
+                        plugin.unloadModel()
+                        plugin.deleteModelFiles(modelDef)
+                        modelState = plugin.modelState
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            } else {
+                Button("Download & Load") {
+                    selectedModelId = modelDef.id
+                    Task {
+                        try? await plugin.loadModel(modelDef)
+                        modelState = plugin.modelState
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(modelState == .loading)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Plugins/Qwen3Plugin/manifest.json
+++ b/Plugins/Qwen3Plugin/manifest.json
@@ -1,0 +1,8 @@
+{
+    "id": "com.typewhisper.qwen3",
+    "name": "Qwen3 ASR",
+    "version": "1.0.0",
+    "minHostVersion": "0.11.0",
+    "author": "TypeWhisper",
+    "principalClass": "Qwen3Plugin"
+}

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -125,6 +125,12 @@
 		AA00000000000000000150 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000010 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000151 /* LinearPlugin.bundle in Embed Plugins */ = {isa = PBXBuildFile; fileRef = BB00000000000000000146 /* LinearPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AA00000000000000000152 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000147 /* AppConstants.swift */; };
+		AA00000000000000000154 /* Qwen3Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000150 /* Qwen3Plugin.swift */; };
+		AA00000000000000000155 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000151 /* manifest.json */; };
+		AA00000000000000000156 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000011 /* TypeWhisperPluginSDK */; };
+		AA00000000000000000157 /* MLXAudioSTT in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000012 /* MLXAudioSTT */; };
+		AA00000000000000000158 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000013 /* MLXAudioCore */; };
+		AA00000000000000000159 /* Qwen3Plugin.bundle in Embed Plugins */ = {isa = PBXBuildFile; fileRef = BB00000000000000000149 /* Qwen3Plugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -242,6 +248,9 @@
 		BB00000000000000000145 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000146 /* LinearPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinearPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000147 /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
+		BB00000000000000000149 /* Qwen3Plugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Qwen3Plugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB00000000000000000150 /* Qwen3Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Qwen3Plugin.swift; sourceTree = "<group>"; };
+		BB00000000000000000151 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -300,6 +309,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000150 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000059 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000156 /* TypeWhisperPluginSDK in Frameworks */,
+				AA00000000000000000157 /* MLXAudioSTT in Frameworks */,
+				AA00000000000000000158 /* MLXAudioCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -387,6 +406,13 @@
 			remoteGlobalIDString = DD00000000000000000007;
 			remoteInfo = LinearPlugin;
 		};
+		HH00000000000000000008 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE00000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD00000000000000000009;
+			remoteInfo = Qwen3Plugin;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXTargetDependency section */
@@ -420,6 +446,11 @@
 			target = DD00000000000000000007 /* LinearPlugin */;
 			targetProxy = HH00000000000000000006 /* PBXContainerItemProxy */;
 		};
+		GG00000000000000000008 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD00000000000000000009 /* Qwen3Plugin */;
+			targetProxy = HH00000000000000000008 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXGroup section */
@@ -433,6 +464,7 @@
 				CC00000000000000000017 /* OpenAIPlugin */,
 				CC00000000000000000018 /* GeminiPlugin */,
 				CC00000000000000000019 /* LinearPlugin */,
+				CC00000000000000000020 /* Qwen3Plugin */,
 				CC00000000000000000090 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -645,6 +677,7 @@
 				BB00000000000000000135 /* OpenAIPlugin.bundle */,
 				BB00000000000000000143 /* GeminiPlugin.bundle */,
 				BB00000000000000000146 /* LinearPlugin.bundle */,
+				BB00000000000000000149 /* Qwen3Plugin.bundle */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -697,6 +730,16 @@
 			);
 			name = LinearPlugin;
 			path = Plugins/LinearPlugin;
+			sourceTree = "<group>";
+		};
+		CC00000000000000000020 /* Qwen3Plugin */ = {
+			isa = PBXGroup;
+			children = (
+				BB00000000000000000150 /* Qwen3Plugin.swift */,
+				BB00000000000000000151 /* manifest.json */,
+			);
+			name = Qwen3Plugin;
+			path = Plugins/Qwen3Plugin;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -872,6 +915,28 @@
 			productReference = BB00000000000000000146 /* LinearPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		DD00000000000000000009 /* Qwen3Plugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF00000000000000000061 /* Build configuration list for PBXNativeTarget "Qwen3Plugin" */;
+			buildPhases = (
+				FF00000000000000000058 /* Sources */,
+				FF00000000000000000059 /* Frameworks */,
+				FF00000000000000000060 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Qwen3Plugin;
+			packageProductDependencies = (
+				PP00000000000000000011 /* TypeWhisperPluginSDK */,
+				PP00000000000000000012 /* MLXAudioSTT */,
+				PP00000000000000000013 /* MLXAudioCore */,
+			);
+			productName = Qwen3Plugin;
+			productReference = BB00000000000000000149 /* Qwen3Plugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -905,6 +970,7 @@
 				RR00000000000000000002 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				RR00000000000000000004 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				RR00000000000000000005 /* XCLocalSwiftPackageReference "TypeWhisperPluginSDK" */,
+				RR00000000000000000006 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */,
 			);
 			productRefGroup = CC00000000000000000090 /* Products */;
 			projectDirPath = "";
@@ -917,6 +983,7 @@
 				DD00000000000000000005 /* OpenAIPlugin */,
 				DD00000000000000000006 /* GeminiPlugin */,
 				DD00000000000000000007 /* LinearPlugin */,
+				DD00000000000000000009 /* Qwen3Plugin */,
 			);
 		};
 /* End PBXProject section */
@@ -972,6 +1039,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000149 /* manifest.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000060 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000155 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1115,6 +1190,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000148 /* LinearPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000058 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000154 /* Qwen3Plugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2009,6 +2092,98 @@
 			};
 			name = AppStoreRelease;
 		};
+		XX00000000000000000037 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 2D8ALY3LCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Qwen3 ASR (MLX)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = Qwen3Plugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.qwen3;
+				PRODUCT_NAME = Qwen3Plugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		XX00000000000000000038 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 2D8ALY3LCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Qwen3 ASR (MLX)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = Qwen3Plugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.qwen3;
+				PRODUCT_NAME = Qwen3Plugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		XX00000000000000000039 /* AppStoreDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 2D8ALY3LCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Qwen3 ASR (MLX)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = Qwen3Plugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.qwen3;
+				PRODUCT_NAME = Qwen3Plugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = AppStoreDebug;
+		};
+		XX00000000000000000040 /* AppStoreRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 2D8ALY3LCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Qwen3 ASR (MLX)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = Qwen3Plugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.qwen3;
+				PRODUCT_NAME = Qwen3Plugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = AppStoreRelease;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2100,6 +2275,17 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FF00000000000000000061 /* Build configuration list for PBXNativeTarget "Qwen3Plugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XX00000000000000000037 /* Debug */,
+				XX00000000000000000038 /* Release */,
+				XX00000000000000000039 /* AppStoreDebug */,
+				XX00000000000000000040 /* AppStoreRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -2125,6 +2311,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.0;
+			};
+		};
+		RR00000000000000000006 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Blaizzy/mlx-audio-swift.git";
+			requirement = {
+				branch = main;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -2175,6 +2369,20 @@
 		PP00000000000000000010 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
+		};
+		PP00000000000000000011 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		PP00000000000000000012 /* MLXAudioSTT */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = RR00000000000000000006 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
+			productName = MLXAudioSTT;
+		};
+		PP00000000000000000013 /* MLXAudioCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = RR00000000000000000006 /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
+			productName = MLXAudioCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "5d9e17740fad055010e7f35026b3410f08bb378cb47f471c2cccc28e5c915a94",
+  "originHash" : "b37808a3a2bc34b0aa9cfad3b2d1060962db10d16227f269b02af3a95b7db217",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client",
+      "state" : {
+        "revision" : "2fc4652fb4689eb24af10e55cabaa61d8ba774fd",
+        "version" : "1.32.0"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "bd64824505da71a1a403adb221f6e25413c0bc7f",
+        "version" : "1.4.0"
+      }
+    },
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
@@ -8,6 +26,33 @@
       "state" : {
         "branch" : "main",
         "revision" : "8341b7626a7ee02b4d34779982afd1c8f269f19e"
+      }
+    },
+    {
+      "identity" : "mlx-audio-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "b76c81fa3d15600e68323b94d740bb346f3455ef"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
+        "version" : "0.30.6"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "7e19e09027923d89ac47dd087d9627f610e5a91a",
+        "version" : "2.30.6"
       }
     },
     {
@@ -20,12 +65,57 @@
       }
     },
     {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "2971dd5d9f6e0515664b01044826bcea16e59fac",
+        "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
       }
     },
     {
@@ -38,6 +128,60 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "1bb939fe7bbb00b8f8bab664cc90020c035c08d9",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "e109d8b5308d0e05201d9a1dd1c475446a946a11",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "7198b0633394b688859917249f1295542683790d",
+        "version" : "0.8.0"
+      }
+    },
+    {
       "identity" : "swift-jinja",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
@@ -47,12 +191,111 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
+        "version" : "2.95.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
+        "version" : "1.32.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
+        "version" : "1.40.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
+        "version" : "2.36.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
         "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
         "version" : "1.1.6"
+      }
+    },
+    {
+      "identity" : "swift-xet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/swift-xet.git",
+      "state" : {
+        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
+        "version" : "0.2.3"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Adds **Qwen3 ASR** as a TranscriptionEnginePlugin using MLX on Apple Silicon
- 4 model variants: 0.6B/1.7B with 4-bit/8-bit quantization, downloaded from HuggingFace Hub
- Loop detection (QwenTranscriptGuard) with automatic fallback to shorter chunk duration
- Settings UI for model download, load/unload, and deletion
- Auto-restores previously loaded model on plugin activation
- 30 language support, no API key required

## Test plan
- [ ] Build succeeds with new Qwen3Plugin target and mlx-audio-swift SPM dependency
- [ ] Enable plugin in Integrations tab, open settings
- [ ] Download a model (e.g. 0.6B 4-bit), verify progress and completion
- [ ] Record audio and transcribe using Qwen3 engine
- [ ] Unload model, verify it can be re-loaded (auto-restore on next activation)
- [ ] Test with different languages (e.g. German, Chinese)