### PR TITLE
Fix infinite "Loading model..." spinner in WhisperKit and Parakeet settings

### DIFF
--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -257,6 +257,8 @@ private struct ParakeetSettingsView: View {
         .onAppear {
             modelState = plugin.modelState
             downloadProgress = plugin.downloadProgress
+            // If the plugin is mid-load (e.g., restoring on app launch), start polling
+            if case .downloading = plugin.modelState { isPolling = true }
         }
         .onReceive(pollTimer) { _ in
             guard isPolling else { return }

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -431,6 +431,9 @@ private struct WhisperKitSettingsView: View {
             modelState = plugin.modelState
             downloadProgress = plugin.downloadProgress
             activeModelId = plugin._selectedModelId
+            // If the plugin is mid-load (e.g., restoring on app launch), start polling
+            if case .downloading = plugin.modelState { isPolling = true }
+            else if case .loading = plugin.modelState { isPolling = true }
         }
         .onReceive(pollTimer) { _ in
             guard isPolling else { return }


### PR DESCRIPTION
## Problem

When the app launches, `WhisperKitPlugin.activate()` fires a background `Task { await restoreLoadedModel() }` to reload the previously-used model. If the user opens **Settings > Integrations > WhisperKit** while this background restore is still in progress, the settings view captures the intermediate `.loading(phase: "loading")` state in `onAppear` but **never starts polling for updates**.

Since `isPolling` remains `false`, the timer-based polling — which is the only mechanism to sync the view's `@State` with the plugin's non-observable `fileprivate var modelState` — never runs. The background restore eventually completes, but the view is stuck showing "Loading model..." forever.

The same bug exists in `ParakeetPlugin`.

<img width="1038" height="602" alt="Screenshot 2026-03-01 at 20 05 07" src="https://github.com/user-attachments/assets/973642ea-79c0-4e85-95b2-ffdc5c4c6acb" />

## Root Cause

In `WhisperKitPlugin.swift` (line ~430), the `onAppear` block reads the plugin state but does **not** activate polling when the plugin is already mid-load:

```swift
.onAppear {
    modelState = plugin.modelState          // captures .loading(phase: "loading")
    downloadProgress = plugin.downloadProgress
    activeModelId = plugin._selectedModelId
    // isPolling stays false — timer never updates the view
}
```

The `Qwen3Plugin` already handles this correctly — it restores within a `.task {}` modifier and sets `isPolling = true` during restore. WhisperKit and Parakeet were missing this.

## Fix

Start polling in `onAppear` when the plugin is already in a transient state (`.downloading` or `.loading`), so the timer picks up the eventual state transition:

**WhisperKitPlugin** — check both `.downloading` and `.loading`:
```swift
.onAppear {
    modelState = plugin.modelState
    downloadProgress = plugin.downloadProgress
    activeModelId = plugin._selectedModelId
    // If the plugin is mid-load (e.g., restoring on app launch), start polling
    if case .downloading = plugin.modelState { isPolling = true }
    else if case .loading = plugin.modelState { isPolling = true }
}
```

**ParakeetPlugin** — only `.downloading` (Parakeet's enum doesn't have a `.loading` case):
```swift
.onAppear {
    modelState = plugin.modelState
    downloadProgress = plugin.downloadProgress
    // If the plugin is mid-load (e.g., restoring on app launch), start polling
    if case .downloading = plugin.modelState { isPolling = true }
}
```

## Test Plan

- [ ] Launch the app with a previously-loaded WhisperKit model, open Settings > Integrations > WhisperKit while the model is restoring — spinner should resolve to a green checkmark once loading finishes
- [ ] Click "Download & Load" for a new model — existing download/load flow still works (spinner → progress → checkmark)
- [ ] Repeat for Parakeet plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)