### PR TITLE
fix: crash on macOS 26 when starting recording (EXC_BAD_ACCESS in StreamingHandler)

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -406,7 +406,7 @@ final class DictationViewModel: ObservableObject {
                 language: effectiveLanguage,
                 task: effectiveTask,
                 cloudModelOverride: effectiveCloudModelOverride,
-                stateCheck: { [weak self] in self?.state ?? .idle }
+                stateCheck: { @MainActor [weak self] in self?.state ?? .idle }
             )
             EventBus.shared.emit(.recordingStarted(RecordingStartedPayload(
                 appName: capturedActiveApp?.name,

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -32,7 +32,7 @@ final class StreamingHandler {
         language: String?,
         task: TranscriptionTask,
         cloudModelOverride: String?,
-        stateCheck: @escaping () -> DictationViewModel.State
+        stateCheck: @MainActor @escaping () -> DictationViewModel.State
     ) {
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
@@ -64,8 +64,8 @@ final class StreamingHandler {
                             onProgress: { [weak self] text in
                                 guard let self, !Task.isCancelled else { return false }
                                 let stable = Self.stabilizeText(confirmed: confirmed, new: text)
-                                DispatchQueue.main.async {
-                                    self.onPartialTextUpdate?(stable)
+                                Task { @MainActor [weak self] in
+                                    self?.onPartialTextUpdate?(stable)
                                 }
                                 return true
                             }


### PR DESCRIPTION
## Summary

- On macOS 26, the app crashes immediately when you start speaking with `EXC_BAD_ACCESS` / `SIGBUS` (Bus error: 10)
- Root cause: `DispatchQueue.main.async` inside `StreamingHandler.start()` mixes GCD with Swift Concurrency's `@MainActor` — on macOS 26, Apple tightened memory protection on dyld's `__DATA_DIRTY` region (now non-executable), which corrupts the `onProgress` closure's function pointer to point into that region
- The CPU then tries to execute from `_main_thread + 224` (a data address) and crashes with an instruction abort / permission fault

## Changes

`StreamingHandler.swift` — replace `DispatchQueue.main.async` with a `@MainActor` Task, and mark `stateCheck` as `@MainActor`:

Before:
```swift
DispatchQueue.main.async {
    self.onPartialTextUpdate?(stable)
}
```
After:
```swift
Task { @MainActor [weak self] in
    self?.onPartialTextUpdate?(stable)
}
```

`DictationViewModel.swift` — add `@MainActor` annotation to the `stateCheck` closure to match the updated parameter signature.

## Crash details

- macOS 26.3.1 (25D2128), TypeWhisper 0.12.7
- Exception: `EXC_BAD_ACCESS (SIGBUS)` — `KERN_PROTECTION_FAILURE`
- ESR: `(Instruction Abort) Permission fault`
- Faulting symbol: `partial apply for closure #1 in closure #1 in StreamingHandler.start(engineOverrideId:selectedProviderId:language:task:cloudModelOverride:stateCheck:)`
- Fault address `0x1FA23B1E0` = `_main_thread + 224` in `__DATA_DIRTY` of `/usr/lib/dyld`

## Test plan

- [ ] Build and run on macOS 26.x — recording should start without crashing
- [ ] Verify streaming partial text previews still appear during recording
- [ ] Verify no regression on macOS 14/15 — recording and streaming work normally

Generated with [Claude Code](https://claude.com/claude-code)
