### PR TITLE
Fix WhisperKit auto-detect transcribing Polish speech into English

### DIFF
--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -94,6 +94,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Se
             temperatureFallbackCount: 3,
             usePrefillPrompt: true,
             usePrefillCache: true,
+            detectLanguage: language == nil,
             skipSpecialTokens: true,
             withoutTimestamps: false,
             chunkingStrategy: .vad
@@ -132,6 +133,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Se
             temperatureFallbackCount: 3,
             usePrefillPrompt: true,
             usePrefillCache: true,
+            detectLanguage: language == nil,
             skipSpecialTokens: true,
             withoutTimestamps: false,
             chunkingStrategy: .vad


### PR DESCRIPTION
## Summary

This fixes a WhisperKit bug when `Spoken language` is set to `Auto-detect`.

I was able to reproduce this locally with WhisperKit + `large-v3`: speaking Polish with `Enable translation` turned off still produced English output. When I switched `Spoken language` to `Polish`, the same sentence was transcribed correctly in Polish.

The fix is to enable WhisperKit language detection when no language is explicitly selected by setting `detectLanguage` when `language == nil`.

## Test Plan

- reproduced locally with:
  - `Spoken language = Auto-detect`
  - `Enable translation = off`
  - `WhisperKit`
  - `large-v3`
  - spoken input in Polish
- confirmed the same setup produced English output before this change
- rebuilt the plugin locally and verified the same setup transcribes Polish correctly after this change
- confirmed manually setting `Spoken language = Polish` still works as before

Prepared with help from GPT-5.4 (High).