### PR TITLE
Fix iPhone Continuity mic causing recording to immediately stop

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -39,6 +39,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private var previewEngine: AVAudioEngine?
     private let deviceChangeSubject = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
+    private var disconnectVerificationTask: Task<Void, Never>?
 
     init() {
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -65,6 +66,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     }
 
     deinit {
+        disconnectVerificationTask?.cancel()
         removeDeviceListener()
         stopPreview()
     }
@@ -306,18 +308,37 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         let newDevices = listInputDevices()
         inputDevices = newDevices
 
-        // Check if selected device was disconnected
         if let uid = selectedDeviceUID,
            !newDevices.contains(where: { $0.uid == uid }) {
-            let disconnectedName = oldDevices.first(where: { $0.uid == uid })?.name
-            logger.info("Selected device disconnected: \(disconnectedName ?? uid)")
+            // Device UID not in current list - could be transient (Continuity/Bluetooth
+            // reconfiguration) or genuine disconnect. Schedule a delayed re-check.
+            let deviceName = oldDevices.first(where: { $0.uid == uid })?.name
+            logger.info("Selected device missing from list, scheduling re-verification: \(deviceName ?? uid)")
 
-            if isPreviewActive {
-                stopPreview()
+            disconnectVerificationTask?.cancel()
+            disconnectVerificationTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(1.5))
+                guard !Task.isCancelled else { return }
+                guard let self else { return }
+
+                guard let currentUID = self.selectedDeviceUID, currentUID == uid else { return }
+
+                let refreshedDevices = self.listInputDevices()
+                if refreshedDevices.contains(where: { $0.uid == uid }) {
+                    logger.info("Device reappeared after reconfiguration: \(deviceName ?? uid)")
+                    self.inputDevices = refreshedDevices
+                } else {
+                    logger.info("Selected device confirmed disconnected: \(deviceName ?? uid)")
+                    self.inputDevices = refreshedDevices
+                    if self.isPreviewActive { self.stopPreview() }
+                    self.selectedDeviceUID = nil
+                    self.disconnectedDeviceName = deviceName
+                }
             }
-
-            selectedDeviceUID = nil
-            disconnectedDeviceName = disconnectedName
+        } else {
+            // Selected device still present - cancel any pending disconnect verification
+            disconnectVerificationTask?.cancel()
+            disconnectVerificationTask = nil
         }
     }
 }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -127,6 +127,12 @@ final class HotkeyService: ObservableObject {
         return nil
     }
 
+    /// Resets keyDownTime to now, so hybrid toggle/PTT threshold counts from
+    /// when recording actually started (not from key press). Call after slow device init.
+    func resetKeyDownTime() {
+        keyDownTime = Date()
+    }
+
     func cancelDictation() {
         isActive = false
         activeSlotType = nil

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -290,9 +290,17 @@ final class DictationViewModel: ObservableObject {
             .compactMap { $0 }
             .sink { [weak self] _ in
                 guard let self, self.state == .recording else { return }
-                self.stopDictation()
+                self.audioDuckingService.restoreAudio()
+                self.streamingHandler.stop()
+                self.stopRecordingTimer()
+                _ = self.audioRecordingService.stopRecording()
                 self.hotkeyService.cancelDictation()
-                self.showError(String(localized: "Microphone disconnected. Falling back to system default."))
+                self.showNotchFeedback(
+                    message: String(localized: "Microphone disconnected"),
+                    icon: "mic.slash",
+                    duration: 3.0,
+                    isError: true
+                )
             }
             .store(in: &cancellables)
     }
@@ -401,6 +409,10 @@ final class DictationViewModel: ObservableObject {
                 audioDuckingService.duckAudio(to: Float(audioDuckingLevel))
             }
             state = .recording
+            // Reset hotkey timer so hybrid threshold counts from recording start,
+            // not from key press. Slow device init (e.g. iPhone Continuity ~2-3s)
+            // would otherwise make the hold appear as "long press" → PTT stop.
+            hotkeyService.resetKeyDownTime()
             soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
             partialText = ""
             recordingStartTime = Date()


### PR DESCRIPTION
## Summary

- iPhone Continuity and Bluetooth mics temporarily disappear from CoreAudio's device list during reconfiguration, causing TypeWhisper to immediately treat them as disconnected. This adds a 1.5s delayed re-verification before confirming a disconnect, allowing transient reconfiguration to complete without interrupting recording.
- Slow device init (~2-3s for Continuity mics) made the hybrid hotkey misinterpret the hold duration as a "long press" (PTT stop). `resetKeyDownTime()` resets the timer when recording actually starts.
- The mic-disconnect handler now does manual teardown instead of calling `stopDictation()`, avoiding unnecessary transcription of partial audio from a vanished device.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features