### PR TITLE
Dashboard Redesign: Bento Grid Layout & Issue #78 Fixes

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -2375,6 +2375,16 @@
         }
       }
     },
+    "No transcriptions yet." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Transkriptionen."
+          }
+        }
+      }
+    },
     "No speech detected" : {
       "localizations" : {
         "de" : {
@@ -3083,6 +3093,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erfordert einen laufenden API-Server. Das CLI-Tool verbindet sich mit TypeWhispers API fuer schnelle Transkription ohne Modell-Kaltstart."
+          }
+        }
+      }
+    },
+    "Recent Transcriptions" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte Transkriptionen"
           }
         }
       }

--- a/TypeWhisper/ViewModels/HomeViewModel.swift
+++ b/TypeWhisper/ViewModels/HomeViewModel.swift
@@ -4,18 +4,21 @@ import Combine
 enum TimePeriod: String, CaseIterable {
     case week
     case month
+    case allTime
 
     var displayName: String {
         switch self {
         case .week: return String(localized: "Week")
         case .month: return String(localized: "Month")
+        case .allTime: return String(localized: "All Time")
         }
     }
 
-    var days: Int {
+    var days: Int? {
         switch self {
         case .week: return 7
         case .month: return 30
+        case .allTime: return nil
         }
     }
 }
@@ -42,6 +45,12 @@ final class HomeViewModel: ObservableObject {
     @Published var appsUsed: Int = 0
     @Published var timeSaved: String = "—"
     @Published var chartData: [ActivityDataPoint] = []
+    @Published var wordsTrend: Double? = nil
+    @Published var wpmTrend: Double? = nil
+    @Published var appsTrend: Double? = nil
+    @Published var timeSavedTrend: Double? = nil
+    @Published var recentTranscriptions: [TranscriptionRecord] = []
+    @Published var navigateToHistory = false
     @Published var showSetupWizard: Bool {
         didSet { UserDefaults.standard.set(!showSetupWizard, forKey: UserDefaultsKeys.setupWizardCompleted) }
     }
@@ -66,6 +75,7 @@ final class HomeViewModel: ObservableObject {
 
         $selectedTimePeriod
             .dropFirst()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.refresh() }
             .store(in: &cancellables)
     }
@@ -80,35 +90,82 @@ final class HomeViewModel: ObservableObject {
     }
 
     func refresh() {
-        let cutoff = Calendar.current.date(byAdding: .day, value: -selectedTimePeriod.days, to: Date()) ?? Date()
-        let filtered = historyService.records.filter { $0.timestamp >= cutoff }
+        let now = Date()
+        let allRecords = historyService.records
 
-        // Words count
-        wordsCount = filtered.reduce(0) { $0 + $1.wordsCount }
-
-        // Average WPM
-        let totalMinutes = filtered.reduce(0.0) { $0 + $1.durationSeconds } / 60.0
-        if totalMinutes > 0 && wordsCount > 0 {
-            let wpm = Int(Double(wordsCount) / totalMinutes)
-            averageWPM = "\(wpm)"
+        // Filter records for current period
+        let filtered: [TranscriptionRecord]
+        if let days = selectedTimePeriod.days {
+            let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
+            filtered = allRecords.filter { $0.timestamp >= cutoff }
         } else {
-            averageWPM = "—"
+            filtered = allRecords
         }
 
-        // Apps used
-        let uniqueApps = Set(filtered.compactMap { $0.appBundleIdentifier })
-        appsUsed = uniqueApps.count
+        // Stats for current period
+        let stats = computeStats(for: filtered)
+        wordsCount = stats.words
+        averageWPM = stats.wpm
+        appsUsed = stats.apps
+        timeSaved = stats.timeSaved
 
-        // Time saved (typing at 45 WPM baseline vs dictation duration)
-        let typingMinutes = Double(wordsCount) / 45.0
-        let dictationMinutes = totalMinutes
-        let savedMinutes = typingMinutes - dictationMinutes
-        if savedMinutes > 0 {
-            let mins = Int(savedMinutes)
+        // Trends (compare with previous period of same length)
+        if let days = selectedTimePeriod.days {
+            let currentCutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
+            let prevCutoff = Calendar.current.date(byAdding: .day, value: -days, to: currentCutoff) ?? currentCutoff
+            let prevFiltered = allRecords.filter { $0.timestamp >= prevCutoff && $0.timestamp < currentCutoff }
+            let prevStats = computeStats(for: prevFiltered)
+
+            wordsTrend = Self.trendPercent(current: Double(stats.words), previous: Double(prevStats.words))
+            appsTrend = Self.trendPercent(current: Double(stats.apps), previous: Double(prevStats.apps))
+            wpmTrend = Self.trendPercent(current: stats.rawWPM, previous: prevStats.rawWPM)
+            timeSavedTrend = Self.trendPercent(current: stats.rawSavedMinutes, previous: prevStats.rawSavedMinutes)
+        } else {
+            wordsTrend = nil
+            wpmTrend = nil
+            appsTrend = nil
+            timeSavedTrend = nil
+        }
+
+        // Chart data
+        chartData = buildChartData(records: filtered)
+
+        // Recent transcriptions
+        recentTranscriptions = Array(allRecords.prefix(3))
+    }
+
+    private struct PeriodStats {
+        let words: Int
+        let wpm: String
+        let rawWPM: Double
+        let apps: Int
+        let timeSaved: String
+        let rawSavedMinutes: Double
+    }
+
+    private func computeStats(for records: [TranscriptionRecord]) -> PeriodStats {
+        let words = records.reduce(0) { $0 + $1.wordsCount }
+        let totalMinutes = records.reduce(0.0) { $0 + $1.durationSeconds } / 60.0
+
+        let rawWPM: Double
+        let wpm: String
+        if totalMinutes > 0 && words > 0 {
+            rawWPM = Double(words) / totalMinutes
+            wpm = "\(Int(rawWPM))"
+        } else {
+            rawWPM = 0
+            wpm = "—"
+        }
+
+        let apps = Set(records.compactMap { $0.appBundleIdentifier }).count
+
+        let typingMinutes = Double(words) / 45.0
+        let rawSavedMinutes = typingMinutes - totalMinutes
+        let timeSaved: String
+        if rawSavedMinutes > 0 {
+            let mins = Int(rawSavedMinutes)
             if mins >= 60 {
-                let hours = mins / 60
-                let remainder = mins % 60
-                timeSaved = String(localized: "\(hours)h \(remainder)m")
+                timeSaved = String(localized: "\(mins / 60)h \(mins % 60)m")
             } else {
                 timeSaved = String(localized: "\(mins)m")
             }
@@ -116,15 +173,21 @@ final class HomeViewModel: ObservableObject {
             timeSaved = "—"
         }
 
-        // Chart data
-        chartData = buildChartData(records: filtered)
+        return PeriodStats(words: words, wpm: wpm, rawWPM: rawWPM, apps: apps, timeSaved: timeSaved, rawSavedMinutes: rawSavedMinutes)
+    }
 
+    nonisolated static func trendPercent(current: Double, previous: Double) -> Double? {
+        guard previous > 0 else { return nil }
+        return ((current - previous) / previous) * 100
     }
 
     private func buildChartData(records: [TranscriptionRecord]) -> [ActivityDataPoint] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-        let days = selectedTimePeriod.days
+        let days = selectedTimePeriod.days ?? max(1, {
+            guard let oldest = records.last?.timestamp else { return 30 }
+            return calendar.dateComponents([.day], from: oldest, to: today).day.map { $0 + 1 } ?? 30
+        }())
 
         var dataByDay: [Date: Int] = [:]
         for i in 0..<days {

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -147,8 +147,8 @@ struct HistoryView: View {
             }
             .font(.caption)
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
             .background(.bar)
             .confirmationDialog(
                 String(localized: "Delete Entries"),

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -15,98 +15,141 @@ struct HomeSettingsView: View {
     }
 
     private var dashboardView: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                // Time period picker
-                HStack {
-                    Text(String(localized: "Dashboard"))
-                        .font(.title2)
-                        .fontWeight(.semibold)
-                    Spacer()
-                    Picker("", selection: $viewModel.selectedTimePeriod) {
-                        ForEach(TimePeriod.allCases, id: \.self) { period in
-                            Text(period.displayName).tag(period)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 160)
-                }
-
-                // Permissions warning
-                if dictation.needsMicPermission || dictation.needsAccessibilityPermission {
-                    permissionsBanner
-                }
-
-                // Stats grid
-                statsGrid
-
-                // Activity chart
-                chartSection
-
-                // Run setup again
-                HStack {
-                    Spacer()
-                    Button {
-                        viewModel.resetSetupWizard()
-                    } label: {
-                        Label(String(localized: "Run setup again"), systemImage: "arrow.counterclockwise")
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-                }
-
-                #if DEBUG
-                HStack(spacing: 8) {
-                    Spacer()
-                    Button("Seed Demo Data") {
-                        let historyService = ServiceContainer.shared.historyService
-                        historyService.seedDemoData()
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.orange)
-                    .font(.caption)
-                    Button("Clear All Data") {
-                        let historyService = ServiceContainer.shared.historyService
-                        historyService.clearAll()
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.red)
-                    .font(.caption)
-                }
-                #endif
+        VStack(alignment: .leading, spacing: 0) {
+            // Row 0: Permissions banner (outside scroll)
+            if dictation.needsMicPermission || dictation.needsAccessibilityPermission {
+                permissionsBanner
+                    .padding(.horizontal)
+                    .padding(.top)
             }
-            .padding()
+
+            // Header: Title + picker (outside scroll, always clickable)
+            HStack {
+                Text(String(localized: "Dashboard"))
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+                timePeriodPicker
+            }
+            .padding(.horizontal)
+            .padding(.top)
+            .padding(.bottom, 8)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    // Row 1: Stats grid
+                    statsGrid
+
+                    // Row 2: Activity chart
+                    chartSection
+
+                    // Row 3: Recent transcriptions
+                    recentTranscriptionsSection
+
+                    // Footer
+                    HStack {
+                        Spacer()
+                        Button {
+                            viewModel.resetSetupWizard()
+                        } label: {
+                            Label(String(localized: "Run setup again"), systemImage: "arrow.counterclockwise")
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    }
+
+                    #if DEBUG
+                    HStack(spacing: 8) {
+                        Spacer()
+                        Button("Seed Demo Data") {
+                            let historyService = ServiceContainer.shared.historyService
+                            historyService.seedDemoData()
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                        Button("Clear All Data") {
+                            let historyService = ServiceContainer.shared.historyService
+                            historyService.clearAll()
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                    }
+                    #endif
+                }
+                .padding(.horizontal)
+                .padding(.bottom)
+            }
         }
         .frame(minWidth: 500, minHeight: 400)
     }
 
-    private var statsGrid: some View {
-        Grid(horizontalSpacing: 12, verticalSpacing: 12) {
-            GridRow {
-                StatCard(
-                    title: String(localized: "Words"),
-                    value: "\(viewModel.wordsCount)",
-                    systemImage: "text.word.spacing"
-                )
-                StatCard(
-                    title: String(localized: "Avg. WPM"),
-                    value: viewModel.averageWPM,
-                    systemImage: "speedometer"
-                )
-                StatCard(
-                    title: String(localized: "Apps Used"),
-                    value: "\(viewModel.appsUsed)",
-                    systemImage: "app.badge"
-                )
-                StatCard(
-                    title: String(localized: "Time Saved"),
-                    value: viewModel.timeSaved,
-                    systemImage: "clock.badge.checkmark"
-                )
+    // MARK: - Time Period Picker
+
+    private var timePeriodPicker: some View {
+        HStack(spacing: 2) {
+            periodButton(.week)
+            periodButton(.month)
+            periodButton(.allTime)
+        }
+        .padding(2)
+        .background(.quaternary.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func periodButton(_ period: TimePeriod) -> some View {
+        let isSelected = viewModel.selectedTimePeriod == period
+        return Text(period.displayName)
+            .font(.caption)
+            .fontWeight(isSelected ? .semibold : .regular)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(isSelected ? Color.accentColor : Color.clear)
+            .foregroundStyle(isSelected ? .white : .secondary)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .contentShape(Rectangle())
+            .onTapGesture {
+                viewModel.selectedTimePeriod = period
             }
+    }
+
+    // MARK: - Stats Grid
+
+    private var statsGrid: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 4), spacing: 12) {
+            StatCard(
+                title: String(localized: "Words"),
+                value: "\(viewModel.wordsCount)",
+                systemImage: "text.word.spacing",
+                trend: viewModel.wordsTrend
+            )
+            StatCard(
+                title: String(localized: "Avg. WPM"),
+                value: viewModel.averageWPM,
+                systemImage: "speedometer",
+                trend: viewModel.wpmTrend
+            )
+            StatCard(
+                title: String(localized: "Apps Used"),
+                value: "\(viewModel.appsUsed)",
+                systemImage: "app.badge",
+                trend: viewModel.appsTrend
+            )
+            StatCard(
+                title: String(localized: "Time Saved"),
+                value: viewModel.timeSaved,
+                systemImage: "clock.badge.checkmark",
+                trend: viewModel.timeSavedTrend
+            )
         }
     }
+
+    // MARK: - Chart
+
+    @State private var hoveredDate: Date?
+    @State private var hoverLocation: CGPoint = .zero
 
     private var chartSection: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -118,18 +161,60 @@ struct HomeSettingsView: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 200)
             } else {
-                Chart(viewModel.chartData) { point in
-                    BarMark(
-                        x: .value(String(localized: "Date"), point.date, unit: .day),
-                        y: .value(String(localized: "Words"), point.wordCount)
-                    )
-                    .foregroundStyle(.blue.gradient)
-                    .cornerRadius(4)
-                }
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .day, count: viewModel.selectedTimePeriod == .week ? 1 : 5)) { value in
-                        AxisGridLine()
-                        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                ZStack(alignment: .top) {
+                    Chart(viewModel.chartData) { point in
+                        BarMark(
+                            x: .value(String(localized: "Date"), point.date, unit: .day),
+                            y: .value(String(localized: "Words"), point.wordCount)
+                        )
+                        .foregroundStyle(
+                            hoveredDate != nil && Calendar.current.isDate(point.date, inSameDayAs: hoveredDate!)
+                                ? Color.blue
+                                : Color.blue.opacity(0.7)
+                        )
+                        .cornerRadius(4)
+                    }
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .day, count: chartAxisStride)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartOverlay { proxy in
+                        GeometryReader { _ in
+                            Rectangle()
+                                .fill(.clear)
+                                .contentShape(Rectangle())
+                                .onContinuousHover { phase in
+                                    switch phase {
+                                    case .active(let location):
+                                        hoverLocation = location
+                                        if let date: Date = proxy.value(atX: location.x) {
+                                            hoveredDate = Calendar.current.startOfDay(for: date)
+                                        }
+                                    case .ended:
+                                        hoveredDate = nil
+                                    }
+                                }
+                        }
+                    }
+                    .id(viewModel.selectedTimePeriod)
+                    .overlay(alignment: .topLeading) {
+                        if let hoveredDate, let point = viewModel.chartData.first(where: { Calendar.current.isDate($0.date, inSameDayAs: hoveredDate) }), point.wordCount > 0 {
+                            VStack(spacing: 2) {
+                                Text("\(point.wordCount)")
+                                    .font(.caption.bold())
+                                    .monospacedDigit()
+                                Text(point.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+                            .offset(x: max(0, hoverLocation.x - 30), y: max(0, hoverLocation.y - 50))
+                            .allowsHitTesting(false)
+                        }
                     }
                 }
                 .frame(height: 200)
@@ -139,6 +224,73 @@ struct HomeSettingsView: View {
         .background(.quaternary.opacity(0.3))
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
+
+    private var chartAxisStride: Int {
+        switch viewModel.selectedTimePeriod {
+        case .week: return 1
+        case .month: return 5
+        case .allTime: return 7
+        }
+    }
+
+    // MARK: - Recent Transcriptions
+
+    private var recentTranscriptionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "Recent Transcriptions"))
+                .font(.headline)
+
+            if viewModel.recentTranscriptions.isEmpty {
+                Text(String(localized: "No transcriptions yet."))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 60)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(viewModel.recentTranscriptions, id: \.id) { record in
+                        Button {
+                            viewModel.navigateToHistory = true
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(record.preview)
+                                        .lineLimit(1)
+                                        .font(.body)
+                                        .foregroundStyle(.primary)
+                                    HStack(spacing: 4) {
+                                        Text(record.timestamp, format: .relative(presentation: .named))
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        if let appName = record.appName {
+                                            Text("- \(appName)")
+                                                .font(.caption)
+                                                .foregroundStyle(.tertiary)
+                                        }
+                                    }
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 4)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        if record.id != viewModel.recentTranscriptions.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(.quaternary.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Permissions Banner
 
     private var permissionsBanner: some View {
         VStack(spacing: 8) {
@@ -178,10 +330,13 @@ struct HomeSettingsView: View {
     }
 }
 
+// MARK: - Stat Card
+
 private struct StatCard: View {
     let title: String
     let value: String
     let systemImage: String
+    var trend: Double? = nil
 
     var body: some View {
         VStack(spacing: 6) {
@@ -192,6 +347,9 @@ private struct StatCard: View {
                 .font(.title)
                 .fontWeight(.bold)
                 .monospacedDigit()
+            if let trend {
+                trendLabel(trend)
+            }
             Text(title)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -200,5 +358,19 @@ private struct StatCard: View {
         .padding(.vertical, 12)
         .background(.quaternary.opacity(0.3))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private func trendLabel(_ percent: Double) -> some View {
+        let isPositive = percent >= 0
+        let displayPercent = Int(abs(percent))
+        HStack(spacing: 2) {
+            Image(systemName: isPositive ? "arrow.up.right" : "arrow.down.right")
+                .font(.caption2)
+            Text("\(displayPercent)%")
+                .font(.caption2)
+                .monospacedDigit()
+        }
+        .foregroundStyle(isPositive ? .green : .red)
     }
 }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @State private var selectedTab: SettingsTab = .home
     @ObservedObject private var fileTranscription = FileTranscriptionViewModel.shared
     @ObservedObject private var registryService = PluginRegistryService.shared
+    @ObservedObject private var homeViewModel = HomeViewModel.shared
 
     var body: some View {
         Group {
@@ -59,6 +60,12 @@ struct SettingsView: View {
         .onAppear { navigateToFileTranscriptionIfNeeded() }
         .onChange(of: fileTranscription.showFilePickerFromMenu) { _, _ in
             navigateToFileTranscriptionIfNeeded()
+        }
+        .onChange(of: homeViewModel.navigateToHistory) { _, navigate in
+            if navigate {
+                selectedTab = .history
+                homeViewModel.navigateToHistory = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Completely redesigned Home Dashboard as a Bento Grid layout. Moved picker outside ScrollView to fix macOS 26 Picker caching bug that caused data to load one click late. Added trend indicators on stats cards, hover tooltip on activity chart that follows mouse, and recent transcriptions section with History tab navigation. Also fixed History footer padding (8→12px horizontal) so "Delete All Visible" button has proper breathing room from window edge.

## Test Plan

- [x] Built and ran locally
- [x] Tested Week/Month/All Time picker - data updates immediately on first click
- [x] Tested chart hover - tooltip appears and follows cursor
- [x] Tested Recent Transcriptions - clicking navigates to History tab
- [x] Tested History footer - "Delete All Visible" has adequate spacing
- [x] No regressions in existing features