### PR TITLE
feat: add double-tap hotkey support

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -3184,6 +3184,16 @@
         }
       }
     },
+    "tap again for double-tap…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "erneut drücken für Doppel-Tap…"
+          }
+        }
+      }
+    },
     "Press to start, press again to stop." : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -8,6 +8,7 @@ struct UnifiedHotkey: Equatable, Sendable, Codable {
     let keyCode: UInt16
     let modifierFlags: UInt
     let isFn: Bool
+    let isDoubleTap: Bool
 
     /// Sentinel keyCode for modifier-only combos (e.g. CMD+OPT).
     /// 0x00 is the "A" key, so we use 0xFFFF which is not a real keyCode.
@@ -27,6 +28,22 @@ struct UnifiedHotkey: Equatable, Sendable, Codable {
         if keyCode == Self.modifierComboKeyCode && modifierFlags != 0 { return .modifierCombo }
         if modifierFlags != 0 { return .keyWithModifiers }
         return .bareKey
+    }
+
+    init(keyCode: UInt16, modifierFlags: UInt, isFn: Bool, isDoubleTap: Bool = false) {
+        self.keyCode = keyCode
+        self.modifierFlags = modifierFlags
+        self.isFn = isFn
+        self.isDoubleTap = isDoubleTap
+    }
+
+    // Backward-compatible decoding: old hotkeys without isDoubleTap decode as single-tap
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        keyCode = try container.decode(UInt16.self, forKey: .keyCode)
+        modifierFlags = try container.decode(UInt.self, forKey: .modifierFlags)
+        isFn = try container.decode(Bool.self, forKey: .isFn)
+        isDoubleTap = try container.decodeIfPresent(Bool.self, forKey: .isDoubleTap) ?? false
     }
 }
 
@@ -70,6 +87,7 @@ final class HotkeyService: ObservableObject {
     private(set) var activeProfileId: UUID?
 
     private static let toggleThreshold: TimeInterval = 1.0
+    private static let doubleTapThreshold: TimeInterval = 0.4
 
     // MARK: - Per-Slot State
 
@@ -78,6 +96,9 @@ final class HotkeyService: ObservableObject {
         var fnWasDown = false
         var modifierWasDown = false
         var keyWasDown = false
+        // Double-tap tracking
+        var lastTapUpTime: Date?
+        var tapCount: Int = 0 // 0=idle, 1=first tap released, 2=second tap active
     }
 
     private var slots: [HotkeySlotType: SlotState] = [
@@ -95,6 +116,9 @@ final class HotkeyService: ObservableObject {
         var fnWasDown = false
         var modifierWasDown = false
         var keyWasDown = false
+        // Double-tap tracking
+        var lastTapUpTime: Date?
+        var tapCount: Int = 0
     }
 
     private var profileSlots: [UUID: ProfileHotkeyState] = [:]
@@ -138,9 +162,15 @@ final class HotkeyService: ObservableObject {
     }
 
     /// Returns which slot already has this hotkey assigned, excluding a given slot.
+    /// Also detects conflicts between single-tap and double-tap variants of the same key.
     func isHotkeyAssigned(_ hotkey: UnifiedHotkey, excluding: HotkeySlotType) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases where slotType != excluding {
-            if slots[slotType]?.hotkey == hotkey {
+            guard let existing = slots[slotType]?.hotkey else { continue }
+            if existing == hotkey { return slotType }
+            if existing.keyCode == hotkey.keyCode
+                && existing.modifierFlags == hotkey.modifierFlags
+                && existing.isFn == hotkey.isFn
+                && existing.isDoubleTap != hotkey.isDoubleTap {
                 return slotType
             }
         }
@@ -175,13 +205,26 @@ final class HotkeyService: ObservableObject {
     func isHotkeyAssignedToProfile(_ hotkey: UnifiedHotkey, excludingProfileId: UUID?) -> UUID? {
         for (id, state) in profileSlots where id != excludingProfileId {
             if state.hotkey == hotkey { return id }
+            if state.hotkey.keyCode == hotkey.keyCode
+                && state.hotkey.modifierFlags == hotkey.modifierFlags
+                && state.hotkey.isFn == hotkey.isFn
+                && state.hotkey.isDoubleTap != hotkey.isDoubleTap {
+                return id
+            }
         }
         return nil
     }
 
     func isHotkeyAssignedToGlobalSlot(_ hotkey: UnifiedHotkey) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases {
-            if slots[slotType]?.hotkey == hotkey { return slotType }
+            guard let existing = slots[slotType]?.hotkey else { continue }
+            if existing == hotkey { return slotType }
+            if existing.keyCode == hotkey.keyCode
+                && existing.modifierFlags == hotkey.modifierFlags
+                && existing.isFn == hotkey.isFn
+                && existing.isDoubleTap != hotkey.isDoubleTap {
+                return slotType
+            }
         }
         return nil
     }
@@ -340,11 +383,14 @@ final class HotkeyService: ObservableObject {
         for profileId in Array(profileSlots.keys) {
             guard var pState = profileSlots[profileId] else { continue }
             var state = SlotState(hotkey: pState.hotkey, fnWasDown: pState.fnWasDown,
-                                  modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown)
+                                  modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown,
+                                  lastTapUpTime: pState.lastTapUpTime, tapCount: pState.tapCount)
             let (keyDown, keyUp) = processKeyEvent(event, hotkey: pState.hotkey, state: &state)
             pState.fnWasDown = state.fnWasDown
             pState.modifierWasDown = state.modifierWasDown
             pState.keyWasDown = state.keyWasDown
+            pState.lastTapUpTime = state.lastTapUpTime
+            pState.tapCount = state.tapCount
             profileSlots[profileId] = pState
             if keyDown {
                 shouldSuppress = true
@@ -380,11 +426,14 @@ final class HotkeyService: ObservableObject {
         for profileId in Array(profileSlots.keys) {
             guard var pState = profileSlots[profileId] else { continue }
             var state = SlotState(hotkey: pState.hotkey, fnWasDown: pState.fnWasDown,
-                                  modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown)
+                                  modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown,
+                                  lastTapUpTime: pState.lastTapUpTime, tapCount: pState.tapCount)
             let (keyDown, keyUp) = processKeyEvent(event, hotkey: pState.hotkey, state: &state)
             pState.fnWasDown = state.fnWasDown
             pState.modifierWasDown = state.modifierWasDown
             pState.keyWasDown = state.keyWasDown
+            pState.lastTapUpTime = state.lastTapUpTime
+            pState.tapCount = state.tapCount
             profileSlots[profileId] = pState
             if keyDown { handleProfileKeyDown(profileId: profileId) }
             else if keyUp { handleProfileKeyUp(profileId: profileId) }
@@ -394,13 +443,13 @@ final class HotkeyService: ObservableObject {
     /// Processes a key event against a hotkey, updating state booleans.
     /// Returns (keyDown, keyUp) flags.
     private func processKeyEvent(_ event: NSEvent, hotkey: UnifiedHotkey, state: inout SlotState) -> (keyDown: Bool, keyUp: Bool) {
-        let (keyDown, keyUp) = detectKeyEvent(
+        let (rawKeyDown, rawKeyUp) = detectKeyEvent(
             event, hotkey: hotkey,
             fnWasDown: state.fnWasDown,
             modifierWasDown: state.modifierWasDown,
             keyWasDown: state.keyWasDown
         )
-        let value = keyDown ? true : keyUp ? false : nil
+        let value = rawKeyDown ? true : rawKeyUp ? false : nil
         if let value {
             switch hotkey.kind {
             case .fn: state.fnWasDown = value
@@ -408,7 +457,43 @@ final class HotkeyService: ObservableObject {
             case .keyWithModifiers, .bareKey: state.keyWasDown = value
             }
         }
-        return (keyDown, keyUp)
+
+        // For non-double-tap hotkeys, pass through directly
+        guard hotkey.isDoubleTap else {
+            return (rawKeyDown, rawKeyUp)
+        }
+
+        // Double-tap state machine: layer on top of single-tap detection
+        if rawKeyDown {
+            if state.tapCount == 1,
+               let lastUp = state.lastTapUpTime,
+               Date().timeIntervalSince(lastUp) < Self.doubleTapThreshold {
+                // Second tap within threshold - fire
+                state.tapCount = 2
+                state.lastTapUpTime = nil
+                return (true, false)
+            } else {
+                // First tap (or threshold expired) - don't fire yet
+                state.tapCount = 0
+                state.lastTapUpTime = nil
+                return (false, false)
+            }
+        }
+
+        if rawKeyUp {
+            if state.tapCount == 2 {
+                // Release after second tap - real keyUp
+                state.tapCount = 0
+                return (false, true)
+            } else {
+                // Release after first tap - start waiting for second
+                state.tapCount = 1
+                state.lastTapUpTime = Date()
+                return (false, false)
+            }
+        }
+
+        return (false, false)
     }
 
     /// Generic key event detection: returns (isKeyDown, isKeyUp) for a given hotkey configuration.
@@ -562,7 +647,7 @@ final class HotkeyService: ObservableObject {
     // MARK: - Display Name
 
     nonisolated static func displayName(for hotkey: UnifiedHotkey) -> String {
-        if hotkey.isFn { return "Fn" }
+        if hotkey.isFn { return hotkey.isDoubleTap ? "Fn x2" : "Fn" }
 
         var parts: [String] = []
 
@@ -577,7 +662,8 @@ final class HotkeyService: ObservableObject {
             parts.append(keyName(for: hotkey.keyCode))
         }
 
-        return parts.joined()
+        let baseName = parts.joined()
+        return hotkey.isDoubleTap ? "\(baseName) x2" : baseName
     }
 
     nonisolated static func keyName(for keyCode: UInt16) -> String {

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -473,6 +473,10 @@ struct HotkeyRecorderView: View {
     @State private var modifierReleaseTimer: DispatchWorkItem?
     private static var activeRecorder: UUID?
     @State private var id = UUID()
+    // Double-tap recording state
+    @State private var firstTapHotkey: UnifiedHotkey?
+    @State private var firstTapDisplayName: String?
+    @State private var doubleTapTimer: DispatchWorkItem?
 
     var body: some View {
         HStack {
@@ -489,10 +493,15 @@ struct HotkeyRecorderView: View {
                 Button {
                     cancelRecording()
                 } label: {
-                    Text(pendingModifierString.isEmpty
-                        ? String(localized: "Press a key…")
-                        : pendingModifierString)
-                        .foregroundStyle(.orange)
+                    if let displayName = firstTapDisplayName {
+                        Text("\(displayName) - \(String(localized: "tap again for double-tap…"))")
+                            .foregroundStyle(.orange)
+                    } else {
+                        Text(pendingModifierString.isEmpty
+                            ? String(localized: "Press a key…")
+                            : pendingModifierString)
+                            .foregroundStyle(.orange)
+                    }
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
@@ -578,35 +587,45 @@ struct HotkeyRecorderView: View {
                 let modifierList: [NSEvent.ModifierFlags] = [.command, .option, .control, .shift, .function]
                 let peakCount = modifierList.filter { peakModifiers.contains($0) }.count
 
+                // Build the candidate single-tap hotkey for this release
+                let candidateHotkey: UnifiedHotkey?
                 if peakCount > 1 {
-                    // Multi-modifier combo (e.g. CMD+OPT, Fn+CMD)
-                    let comboFlags = peakModifiers
-                    let work = DispatchWorkItem { [self] in
-                        finishRecording(UnifiedHotkey(keyCode: UnifiedHotkey.modifierComboKeyCode, modifierFlags: comboFlags.rawValue, isFn: false))
-                    }
-                    modifierReleaseTimer = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
-                    pendingModifiers = []
-                    peakModifiers = []
-                    return true
+                    candidateHotkey = UnifiedHotkey(keyCode: UnifiedHotkey.modifierComboKeyCode, modifierFlags: peakModifiers.rawValue, isFn: false)
                 } else if peakModifiers.contains(.function) {
-                    // Fn alone
-                    let work = DispatchWorkItem { [self] in
-                        finishRecording(UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true))
-                    }
-                    modifierReleaseTimer = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
-                    pendingModifiers = []
-                    peakModifiers = []
-                    return true
+                    candidateHotkey = UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
                 } else if HotkeyService.modifierKeyCodes.contains(event.keyCode) {
-                    // Single modifier key (CMD, OPT, etc.)
-                    let keyCode = event.keyCode
-                    let work = DispatchWorkItem { [self] in
-                        finishRecording(UnifiedHotkey(keyCode: keyCode, modifierFlags: 0, isFn: false))
+                    candidateHotkey = UnifiedHotkey(keyCode: event.keyCode, modifierFlags: 0, isFn: false)
+                } else {
+                    candidateHotkey = nil
+                }
+
+                if let candidate = candidateHotkey {
+                    // Check if this is a second tap of the same key (double-tap detection)
+                    if let firstTap = firstTapHotkey, firstTap == candidate {
+                        // Second tap - finish as double-tap
+                        doubleTapTimer?.cancel()
+                        doubleTapTimer = nil
+                        let doubleTapHotkey = UnifiedHotkey(keyCode: candidate.keyCode, modifierFlags: candidate.modifierFlags, isFn: candidate.isFn, isDoubleTap: true)
+                        let work = DispatchWorkItem { [self] in
+                            finishRecording(doubleTapHotkey)
+                        }
+                        modifierReleaseTimer = work
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
+                    } else {
+                        // First tap - wait for possible second tap
+                        doubleTapTimer?.cancel()
+                        firstTapHotkey = candidate
+                        firstTapDisplayName = HotkeyService.displayName(for: candidate)
+                        let singleTapHotkey = candidate
+                        let work = DispatchWorkItem { [self] in
+                            // Timer expired - finish as single-tap
+                            firstTapHotkey = nil
+                            firstTapDisplayName = nil
+                            finishRecording(singleTapHotkey)
+                        }
+                        doubleTapTimer = work
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
                     }
-                    modifierReleaseTimer = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
                     pendingModifiers = []
                     peakModifiers = []
                     return true
@@ -639,6 +658,10 @@ struct HotkeyRecorderView: View {
     private func finishRecording(_ hotkey: UnifiedHotkey) {
         modifierReleaseTimer?.cancel()
         modifierReleaseTimer = nil
+        doubleTapTimer?.cancel()
+        doubleTapTimer = nil
+        firstTapHotkey = nil
+        firstTapDisplayName = nil
         if Self.activeRecorder == id {
             Self.activeRecorder = nil
         }
@@ -653,6 +676,10 @@ struct HotkeyRecorderView: View {
     private func cancelRecording() {
         modifierReleaseTimer?.cancel()
         modifierReleaseTimer = nil
+        doubleTapTimer?.cancel()
+        doubleTapTimer = nil
+        firstTapHotkey = nil
+        firstTapDisplayName = nil
         if Self.activeRecorder == id {
             Self.activeRecorder = nil
         }


### PR DESCRIPTION
## Summary

Adds double-tap modifier key support as hotkey triggers (e.g., double-tap Option to start recording). Fixes #106.

- Adds `isDoubleTap` property to `UnifiedHotkey` with backward-compatible Codable decoding
- Event-driven state machine in `processKeyEvent()` detects double-tap within 400ms threshold
- HotkeyRecorderView detects double-tap during recording with "tap again for double-tap" visual feedback
- First tap passes through to other apps (not suppressed), second tap is suppressed by CGEventTap
- Conflict detection prevents single-tap and double-tap of the same key on different slots

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features