### PR TITLE
Improve Hotkey Event Suppression and Sticky Keys

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -443,6 +443,7 @@ final class HotkeyService: ObservableObject {
         case down
         case up
         case repeatDown
+        case modifierRelease // Modifiers no longer match, but key is still physically down
     }
 
     /// Processes a key event against a hotkey, updating state booleans.
@@ -457,7 +458,7 @@ final class HotkeyService: ObservableObject {
 
         let value: Bool?
         switch result {
-        case .down, .repeatDown: value = true
+        case .down, .repeatDown, .modifierRelease: value = true
         case .up: value = false
         case .none: value = nil
         }
@@ -471,7 +472,7 @@ final class HotkeyService: ObservableObject {
         }
 
         let rawKeyDown = result == .down
-        let rawKeyUp = result == .up
+        let rawKeyUp = result == .up || result == .modifierRelease
         let isMatch = result != .none
 
         // For non-double-tap hotkeys, pass through directly
@@ -549,7 +550,12 @@ final class HotkeyService: ObservableObject {
             let current = event.modifierFlags.intersection(relevantMask)
             let allDown = current.contains(requiredFlags)
             if allDown, !modifierWasDown { return .down }
-            if !allDown, modifierWasDown { return .up }
+            if !allDown, modifierWasDown {
+                // If the sentinel keyCode (0xFFFF) is used, we have no physical key to track.
+                // Otherwise, we'd need to track which modifiers are still down.
+                // For now, modifier-only combos don't have a 'base key'.
+                return .up
+            }
             if allDown, modifierWasDown { return .repeatDown }
 
         case .keyWithModifiers:
@@ -560,11 +566,15 @@ final class HotkeyService: ObservableObject {
             if event.type == .keyDown, event.keyCode == hotkey.keyCode {
                 if currentRelevant == requiredFlags {
                     return keyWasDown ? .repeatDown : .down
+                } else if keyWasDown {
+                    return .repeatDown // Modifiers released but key held -> still ours
                 }
             } else if event.type == .keyUp, event.keyCode == hotkey.keyCode {
                 if keyWasDown { return .up }
-            } else if event.type == .flagsChanged, keyWasDown, !currentRelevant.contains(requiredFlags) {
-                return .up
+            } else if event.type == .flagsChanged, keyWasDown {
+                if !currentRelevant.contains(requiredFlags) {
+                    return .modifierRelease
+                }
             }
 
         case .bareKey:


### PR DESCRIPTION
This PR refactors the hotkey detection logic in `HotkeyService` to address two issues: macOS error sounds when holding hotkeys and character leaking when releasing modifiers before the base key.

## Summary of Changes

### 1. Suppression of Repeated Key Events
MacOS generates repeated `keyDown` events when a key is held. Previously, these were not suppressed by the `CGEventTap`, leading to "unhandled key" error sounds (beeps) and potential typing in other apps.
- Refactored `detectKeyEvent` to identify and return `.repeatDown` results.
- Updated `processKeyEvent` to ensure all matching events (initial down, repeats, and up) are marked for suppression.

### 2. Sticky Hotkey Suppression
If a user releases a modifier (e.g., CMD) while still holding the base key (e.g., §), the hotkey definition no longer matches, which previously caused the base key's subsequent repeats and final `keyUp` to leak into the focused app.
- Introduced `modifierRelease` to the `KeyEventResult` enum.
- The state machine now maintains `keyWasDown = true` when modifiers are neutralized but the physical key is still held.
- This ensures the base key remains suppressed until it is physically released.

## Verification
- [x] **No more beeps**: Holding the hotkey for Push-To-Talk no longer triggers macOS error sounds.
- [x] **No more character leaking**: Releasing modifiers before the base key no longer types the base character in other apps.
- [x] **Double-tap consistency**: Double-tap hotkeys maintain correct suppression across the full tap sequence.
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

Fixes an issue identified after PR #102.


