### PR TITLE
feat: add error display UI with notch banner fix and error log

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -207,6 +207,9 @@
 		AA00000000000000000252 /* AudioRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000240 /* AudioRecorderView.swift */; };
 		AA00000000000000000253 /* WatchFolderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000241 /* WatchFolderService.swift */; };
 		AA00000000000000000254 /* WatchFolderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000242 /* WatchFolderViewModel.swift */; };
+		AA00000000000000000255 /* ErrorLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000243 /* ErrorLogEntry.swift */; };
+		AA00000000000000000256 /* ErrorLogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000244 /* ErrorLogService.swift */; };
+		AA00000000000000000257 /* ErrorLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000245 /* ErrorLogView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -407,6 +410,9 @@
 		BB00000000000000000240 /* AudioRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderView.swift; sourceTree = "<group>"; };
 		BB00000000000000000241 /* WatchFolderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchFolderService.swift; sourceTree = "<group>"; };
 		BB00000000000000000242 /* WatchFolderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchFolderViewModel.swift; sourceTree = "<group>"; };
+		BB00000000000000000243 /* ErrorLogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogEntry.swift; sourceTree = "<group>"; };
+		BB00000000000000000244 /* ErrorLogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogService.swift; sourceTree = "<group>"; };
+		BB00000000000000000245 /* ErrorLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -809,6 +815,7 @@
 				BB00000000000000000078 /* TermPack.swift */,
 				BB00000000000000000080 /* Snippet.swift */,
 				BB00000000000000000110 /* PromptAction.swift */,
+				BB00000000000000000243 /* ErrorLogEntry.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -848,6 +855,7 @@
 				BB00000000000000000228 /* MemoryService.swift */,
 				BB00000000000000000238 /* AudioRecorderService.swift */,
 				BB00000000000000000241 /* WatchFolderService.swift */,
+				BB00000000000000000244 /* ErrorLogService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -912,6 +920,7 @@
 				BB00000000000000000127 /* PluginSettingsView.swift */,
 				BB00000000000000000207 /* IndicatorPreviewView.swift */,
 				BB00000000000000000240 /* AudioRecorderView.swift */,
+				BB00000000000000000245 /* ErrorLogView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2100,6 +2109,9 @@
 				AA00000000000000000252 /* AudioRecorderView.swift in Sources */,
 				AA00000000000000000253 /* WatchFolderService.swift in Sources */,
 				AA00000000000000000254 /* WatchFolderViewModel.swift in Sources */,
+				AA00000000000000000255 /* ErrorLogEntry.swift in Sources */,
+				AA00000000000000000256 /* ErrorLogService.swift in Sources */,
+				AA00000000000000000257 /* ErrorLogView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -28,6 +28,7 @@ final class ServiceContainer: ObservableObject {
     let memoryService: MemoryService
     let audioRecorderService: AudioRecorderService
     let watchFolderService: WatchFolderService
+    let errorLogService: ErrorLogService
 
     // HTTP API
     let httpServer: HTTPServer
@@ -79,6 +80,7 @@ final class ServiceContainer: ObservableObject {
         audioRecorderService = AudioRecorderService()
         promptProcessingService.memoryService = memoryService
         watchFolderService = WatchFolderService(audioFileService: audioFileService, modelManagerService: modelManagerService)
+        errorLogService = ErrorLogService()
 
         // ViewModels (created before HTTP API so DictationViewModel is available)
         fileTranscriptionViewModel = FileTranscriptionViewModel(
@@ -101,7 +103,8 @@ final class ServiceContainer: ObservableObject {
             soundService: soundService,
             audioDeviceService: audioDeviceService,
             promptActionService: promptActionService,
-            promptProcessingService: promptProcessingService
+            promptProcessingService: promptProcessingService,
+            errorLogService: errorLogService
         )
 
 

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -33,6 +33,12 @@ struct TypeWhisperApp: App {
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 900, height: 500)
+
+        Window(String(localized: "Error Log"), id: "errors") {
+            ErrorLogView()
+        }
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 500, height: 400)
     }
 
     private var settingsScene: some Scene {
@@ -213,6 +219,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let id = window.identifier?.rawValue else { return false }
         return id.localizedCaseInsensitiveContains("settings")
             || id.localizedCaseInsensitiveContains("history")
+            || id.localizedCaseInsensitiveContains("errors")
     }
 
     @MainActor private var hasVisibleManagedWindow: Bool {

--- a/TypeWhisper/Models/ErrorLogEntry.swift
+++ b/TypeWhisper/Models/ErrorLogEntry.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct ErrorLogEntry: Codable, Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let message: String
+    let category: String
+
+    init(message: String, category: String = "general") {
+        self.id = UUID()
+        self.timestamp = Date()
+        self.message = message
+        self.category = category
+    }
+
+    var categoryIcon: String {
+        switch category {
+        case "transcription": return "waveform"
+        case "recording": return "mic"
+        case "prompt": return "text.bubble"
+        case "plugin": return "puzzlepiece"
+        default: return "exclamationmark.triangle"
+        }
+    }
+
+    var categoryDisplayName: String {
+        switch category {
+        case "transcription": return String(localized: "Transcription")
+        case "recording": return String(localized: "Recording")
+        case "prompt": return String(localized: "Prompt")
+        case "plugin": return String(localized: "Plugin")
+        default: return String(localized: "General")
+        }
+    }
+}

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -1,0 +1,47 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "ErrorLogService")
+
+@MainActor
+final class ErrorLogService: ObservableObject {
+    @Published private(set) var entries: [ErrorLogEntry] = []
+
+    private static let maxEntries = 200
+    private let fileURL: URL
+
+    init() {
+        let dir = AppConstants.appSupportDirectory
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        fileURL = dir.appendingPathComponent("error-log.json")
+        loadEntries()
+    }
+
+    func addEntry(message: String, category: String = "general") {
+        let entry = ErrorLogEntry(message: message, category: category)
+        entries.insert(entry, at: 0)
+
+        if entries.count > Self.maxEntries {
+            entries = Array(entries.prefix(Self.maxEntries))
+        }
+
+        saveEntries()
+        logger.info("Error logged: [\(category)] \(message)")
+    }
+
+    func clearAll() {
+        entries.removeAll()
+        saveEntries()
+    }
+
+    private func loadEntries() {
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([ErrorLogEntry].self, from: data) else { return }
+        entries = decoded
+    }
+
+    private func saveEntries() {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -51,6 +51,7 @@ final class DictationViewModel: ObservableObject {
     @Published var activeProfileName: String?
     @Published var actionFeedbackMessage: String?
     @Published var actionFeedbackIcon: String?
+    @Published var actionFeedbackIsError: Bool = false
     @Published var activeAppIcon: NSImage?
     private var actionDisplayDuration: TimeInterval = 3.5
 
@@ -93,6 +94,7 @@ final class DictationViewModel: ObservableObject {
     private let audioDeviceService: AudioDeviceService
     private let promptActionService: PromptActionService
     private let promptProcessingService: PromptProcessingService
+    private let errorLogService: ErrorLogService
     private let postProcessingPipeline: PostProcessingPipeline
     private var matchedProfile: Profile?
     private var forcedProfileId: UUID?
@@ -125,7 +127,8 @@ final class DictationViewModel: ObservableObject {
         soundService: SoundService,
         audioDeviceService: AudioDeviceService,
         promptActionService: PromptActionService,
-        promptProcessingService: PromptProcessingService
+        promptProcessingService: PromptProcessingService,
+        errorLogService: ErrorLogService
     ) {
         self.audioRecordingService = audioRecordingService
         self.textInsertionService = textInsertionService
@@ -142,6 +145,7 @@ final class DictationViewModel: ObservableObject {
         self.audioDeviceService = audioDeviceService
         self.promptActionService = promptActionService
         self.promptProcessingService = promptProcessingService
+        self.errorLogService = errorLogService
         self.postProcessingPipeline = PostProcessingPipeline(
             snippetService: snippetService,
             dictionaryService: dictionaryService
@@ -196,11 +200,11 @@ final class DictationViewModel: ObservableObject {
             self?.isStreaming = streaming
         }
 
-        promptPaletteHandler.onShowNotchFeedback = { [weak self] message, icon, duration, isError in
-            self?.showNotchFeedback(message: message, icon: icon, duration: duration, isError: isError)
+        promptPaletteHandler.onShowNotchFeedback = { [weak self] message, icon, duration, isError, category in
+            self?.showNotchFeedback(message: message, icon: icon, duration: duration, isError: isError, errorCategory: category ?? "general")
         }
         promptPaletteHandler.onShowError = { [weak self] message in
-            self?.showError(message)
+            self?.showError(message, category: "prompt")
         }
         promptPaletteHandler.executeActionPlugin = { [weak self] plugin, pluginId, text, activeApp, originalText, language in
             try await self?.executeActionPlugin(plugin, pluginId: pluginId, text: text, activeApp: activeApp, language: language, originalText: originalText)
@@ -305,7 +309,8 @@ final class DictationViewModel: ObservableObject {
                     message: String(localized: "Microphone disconnected"),
                     icon: "mic.slash",
                     duration: 3.0,
-                    isError: true
+                    isError: true,
+                    errorCategory: "recording"
                 )
             }
             .store(in: &cancellables)
@@ -337,12 +342,12 @@ final class DictationViewModel: ObservableObject {
         modelManager.cancelAutoUnloadTimer()
 
         guard canDictate else {
-            showError("No model loaded. Please download a model first.")
+            showError("No model loaded. Please download a model first.", category: "recording")
             return
         }
 
         guard audioRecordingService.hasMicrophonePermission else {
-            showError("Microphone permission required.")
+            showError("Microphone permission required.", category: "recording")
             return
         }
 
@@ -441,8 +446,7 @@ final class DictationViewModel: ObservableObject {
             )))
         } catch {
             audioDuckingService.restoreAudio()
-            soundService.play(.error, enabled: soundFeedbackEnabled)
-            showError(error.localizedDescription)
+            showError(error.localizedDescription, category: "recording")
             hotkeyService.cancelDictation()
         }
     }
@@ -659,8 +663,7 @@ final class DictationViewModel: ObservableObject {
                     appName: capturedActiveApp?.name,
                     bundleIdentifier: capturedActiveApp?.bundleId
                 )))
-                soundService.play(.error, enabled: soundFeedbackEnabled)
-                showError(error.localizedDescription)
+                showError(error.localizedDescription, category: "transcription")
                 matchedProfile = nil
                 forcedProfileId = nil
                 capturedActiveApp = nil
@@ -700,6 +703,7 @@ final class DictationViewModel: ObservableObject {
         activeProfileName = nil
         actionFeedbackMessage = nil
         actionFeedbackIcon = nil
+        actionFeedbackIsError = false
         actionDisplayDuration = 3.5
     }
 
@@ -801,11 +805,17 @@ final class DictationViewModel: ObservableObject {
         promptPaletteHandler.triggerSelection(currentState: state, soundFeedbackEnabled: soundFeedbackEnabled)
     }
 
-    private func showNotchFeedback(message: String, icon: String, duration: TimeInterval = 2.5, isError: Bool = false) {
+    private func showNotchFeedback(message: String, icon: String, duration: TimeInterval = 2.5, isError: Bool = false, errorCategory: String = "general") {
         actionFeedbackMessage = message
         actionFeedbackIcon = icon
+        actionFeedbackIsError = isError
         actionDisplayDuration = duration
-        state = isError ? .error(message) : .inserting
+        state = .inserting
+
+        if isError {
+            errorLogService.addEntry(message: message, category: errorCategory)
+        }
+
         insertingResetTask?.cancel()
         insertingResetTask = Task {
             try? await Task.sleep(for: .seconds(duration))
@@ -814,15 +824,9 @@ final class DictationViewModel: ObservableObject {
         }
     }
 
-    private func showError(_ message: String) {
-        state = .error(message)
-        errorResetTask?.cancel()
-        errorResetTask = Task {
-            try? await Task.sleep(for: .seconds(3))
-            if case .error = state {
-                state = .idle
-            }
-        }
+    private func showError(_ message: String, category: String = "general") {
+        soundService.play(.error, enabled: soundFeedbackEnabled)
+        showNotchFeedback(message: message, icon: "xmark.circle.fill", duration: 3.0, isError: true, errorCategory: category)
     }
 
     private func startRecordingTimer() {

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -25,7 +25,7 @@ final class PromptPaletteHandler {
     private let promptProcessingService: PromptProcessingService
     private let soundService: SoundService
 
-    var onShowNotchFeedback: ((String, String, TimeInterval, Bool) -> Void)?
+    var onShowNotchFeedback: ((String, String, TimeInterval, Bool, String?) -> Void)?
     var onShowError: ((String) -> Void)?
     var executeActionPlugin: ((any ActionPlugin, String, String,
         (name: String?, bundleId: String?, url: String?), String?, String?) async throws -> Void)?
@@ -143,7 +143,7 @@ final class PromptPaletteHandler {
         guard let ctx = paletteContext else { return }
         paletteContext = nil
 
-        onShowNotchFeedback?(action.name + "...", "ellipsis.circle", 30, false)
+        onShowNotchFeedback?(action.name + "...", "ellipsis.circle", 30, false, nil)
 
         Task { [weak self] in
             guard let self else { return }
@@ -173,7 +173,8 @@ final class PromptPaletteHandler {
                         feedback.0 ?? "Done",
                         feedback.1 ?? "checkmark.circle.fill",
                         feedback.2,
-                        false
+                        false,
+                        nil
                     )
                     return
                 }
@@ -199,12 +200,13 @@ final class PromptPaletteHandler {
                     inserted ? String(localized: "Text replaced") : String(localized: "Copied to clipboard"),
                     inserted ? "checkmark.circle.fill" : "doc.on.clipboard.fill",
                     2.5,
-                    false
+                    false,
+                    nil
                 )
             } catch {
                 guard !Task.isCancelled else { return }
                 soundService.play(.error, enabled: soundFeedbackEnabled)
-                onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true)
+                onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "prompt")
             }
         }
     }

--- a/TypeWhisper/Views/ErrorLogView.swift
+++ b/TypeWhisper/Views/ErrorLogView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct ErrorLogView: View {
+    @ObservedObject private var errorLogService = ServiceContainer.shared.errorLogService
+
+    @State private var showClearConfirmation = false
+
+    var body: some View {
+        Group {
+            if errorLogService.entries.isEmpty {
+                emptyState
+            } else {
+                errorList
+            }
+        }
+        .frame(minWidth: 400, minHeight: 300)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(role: .destructive) {
+                    showClearConfirmation = true
+                } label: {
+                    Label(String(localized: "Clear All"), systemImage: "trash")
+                }
+                .disabled(errorLogService.entries.isEmpty)
+                .confirmationDialog(
+                    String(localized: "Clear Error Log?"),
+                    isPresented: $showClearConfirmation
+                ) {
+                    Button(String(localized: "Clear All"), role: .destructive) {
+                        errorLogService.clearAll()
+                    }
+                } message: {
+                    Text(String(localized: "This will permanently delete all recorded errors."))
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(String(localized: "No errors recorded."))
+                .font(.title3)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var errorList: some View {
+        List(errorLogService.entries) { entry in
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: entry.categoryIcon)
+                    .foregroundStyle(.red)
+                    .font(.system(size: 14))
+                    .frame(width: 20, alignment: .center)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(entry.message)
+                        .font(.callout)
+                        .lineLimit(3)
+                    HStack(spacing: 6) {
+                        Text(entry.categoryDisplayName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("-")
+                            .font(.caption)
+                            .foregroundStyle(.quaternary)
+                        Text(entry.timestamp, style: .relative)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -98,6 +98,13 @@ struct MenuBarView: View {
         }
 
         Button {
+            openWindow(id: "errors")
+            activateAppWindow("errors")
+        } label: {
+            Label(String(localized: "Error Log"), systemImage: "exclamationmark.triangle")
+        }
+
+        Button {
             openWindow(id: "settings")
             activateAppWindow("settings")
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -59,6 +59,7 @@ struct NotchIndicatorView: View {
                 IndicatorActionFeedback(
                     message: viewModel.actionFeedbackMessage ?? "",
                     icon: viewModel.actionFeedbackIcon,
+                    isError: viewModel.actionFeedbackIsError,
                     contentPadding: contentPadding
                 )
             }

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -95,6 +95,7 @@ struct OverlayIndicatorView: View {
                 IndicatorActionFeedback(
                     message: viewModel.actionFeedbackMessage ?? "",
                     icon: viewModel.actionFeedbackIcon,
+                    isError: viewModel.actionFeedbackIsError,
                     contentPadding: contentPadding
                 )
             }
@@ -104,6 +105,7 @@ struct OverlayIndicatorView: View {
                 IndicatorActionFeedback(
                     message: viewModel.actionFeedbackMessage ?? "",
                     icon: viewModel.actionFeedbackIcon,
+                    isError: viewModel.actionFeedbackIsError,
                     contentPadding: contentPadding
                 )
                 Divider().background(Color.white.opacity(0.1))

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -202,17 +202,18 @@ struct IndicatorExpandableText: View {
 struct IndicatorActionFeedback: View {
     let message: String
     let icon: String?
+    let isError: Bool
     let contentPadding: CGFloat
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: icon ?? "checkmark.circle.fill")
-                .foregroundStyle(.green)
+            Image(systemName: icon ?? (isError ? "xmark.circle.fill" : "checkmark.circle.fill"))
+                .foregroundStyle(isError ? .red : .green)
                 .font(.system(size: 16))
             Text(message)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.white.opacity(0.9))
-                .lineLimit(1)
+                .lineLimit(2)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 10)


### PR DESCRIPTION
## Summary

Errors were previously only visible in the macOS console. This PR fixes two bugs in the notch banner (icon was always green even for errors, and error banners were never shown due to a state mismatch) and adds a persistent Error Log window accessible from the tray menu.

- Fix `IndicatorActionFeedback` to show red icon/color for errors instead of always green
- Fix `showNotchFeedback` state bug: error banners were never displayed because `hasActionFeedback` checked for `.inserting` state but errors set `.error` state
- Add `ErrorLogService` with JSON-based persistence (max 200 entries, categorized as recording/transcription/prompt/plugin/general)
- Add `ErrorLogView` as a standalone window (like History) with category icons, timestamps, and a clear button
- Add "Error Log" menu item in the tray menu

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features