### PR TITLE
feat: reorganize Settings tabs for cleaner UX

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -213,6 +213,9 @@
 		AA00000000000000000257 /* ErrorLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000245 /* ErrorLogView.swift */; };
 		AA00000000000000000258 /* AccessibilityAnnouncementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000246 /* AccessibilityAnnouncementService.swift */; };
 		AA00000000000000000259 /* SpeechFeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000247 /* SpeechFeedbackService.swift */; };
+		AA00000000000000000260 /* HotkeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000248 /* HotkeyRecorderView.swift */; };
+		AA00000000000000000261 /* HotkeySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000249 /* HotkeySettingsView.swift */; };
+		AA00000000000000000262 /* AboutSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000250 /* AboutSettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -419,6 +422,9 @@
 		BB00000000000000000245 /* ErrorLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogView.swift; sourceTree = "<group>"; };
 		BB00000000000000000246 /* AccessibilityAnnouncementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAnnouncementService.swift; sourceTree = "<group>"; };
 		BB00000000000000000247 /* SpeechFeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackService.swift; sourceTree = "<group>"; };
+		BB00000000000000000248 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
+		BB00000000000000000249 /* HotkeySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeySettingsView.swift; sourceTree = "<group>"; };
+		BB00000000000000000250 /* AboutSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -930,6 +936,9 @@
 				BB00000000000000000207 /* IndicatorPreviewView.swift */,
 				BB00000000000000000240 /* AudioRecorderView.swift */,
 				BB00000000000000000245 /* ErrorLogView.swift */,
+				BB00000000000000000248 /* HotkeyRecorderView.swift */,
+				BB00000000000000000249 /* HotkeySettingsView.swift */,
+				BB00000000000000000250 /* AboutSettingsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2124,6 +2133,9 @@
 				AA00000000000000000257 /* ErrorLogView.swift in Sources */,
 				AA00000000000000000258 /* AccessibilityAnnouncementService.swift in Sources */,
 				AA00000000000000000259 /* SpeechFeedbackService.swift in Sources */,
+				AA00000000000000000260 /* HotkeyRecorderView.swift in Sources */,
+				AA00000000000000000261 /* HotkeySettingsView.swift in Sources */,
+				AA00000000000000000262 /* AboutSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct AboutSettingsView: View {
+    var body: some View {
+        Form {
+            Section {
+                VStack(spacing: 12) {
+                    Image(nsImage: NSApp.applicationIconImage)
+                        .resizable()
+                        .frame(width: 96, height: 96)
+
+                    Text("TypeWhisper")
+                        .font(.title)
+                        .fontWeight(.semibold)
+
+                    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+                    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+                    Text("Version \(version) (\(build))")
+                        .foregroundStyle(.secondary)
+
+                    Text(String(localized: "Fast, private speech-to-text for your Mac. Transcribe with local or cloud engines, process text with AI prompts, and insert directly into any app."))
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: 400)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+            }
+
+            #if !APPSTORE
+            Section {
+                HStack {
+                    Spacer()
+                    Button(String(localized: "Check for Updates...")) {
+                        UpdateChecker.shared?.checkForUpdates()
+                    }
+                    .disabled(UpdateChecker.shared?.canCheckForUpdates() != true)
+                    Spacer()
+                }
+            }
+            #endif
+
+            Section {
+                VStack(spacing: 4) {
+                    Text(String(localized: "\u{00A9} 2024-2026 TypeWhisper Contributors"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Text(String(localized: "Licensed under the GNU General Public License v3.0"))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .frame(minWidth: 500, minHeight: 300)
+    }
+}

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -4,6 +4,8 @@ struct AdvancedSettingsView: View {
     @ObservedObject private var viewModel = APIServerViewModel.shared
     @ObservedObject private var memoryService = ServiceContainer.shared.memoryService
     @ObservedObject private var promptProcessingService = ServiceContainer.shared.promptProcessingService
+    @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
+    @ObservedObject private var dictation = DictationViewModel.shared
     #if !APPSTORE
     @State private var cliInstalled = false
     @State private var cliSymlinkTarget = ""
@@ -104,6 +106,33 @@ struct AdvancedSettingsView: View {
                         Text(String(localized: "This will permanently delete all stored memories from all plugins. This cannot be undone."))
                     }
                 }
+            }
+
+            // MARK: - Recording
+            Section(String(localized: "Recording")) {
+                Picker(String(localized: "Auto-unload model"), selection: Binding(
+                    get: { modelManager.autoUnloadSeconds },
+                    set: { modelManager.autoUnloadSeconds = $0 }
+                )) {
+                    Text(String(localized: "Never")).tag(0)
+                    Divider()
+                    Text(String(localized: "Immediate")).tag(-1)
+                    Text(String(localized: "After 2 minutes")).tag(120)
+                    Text(String(localized: "After 5 minutes")).tag(300)
+                    Text(String(localized: "After 10 minutes")).tag(600)
+                    Text(String(localized: "After 30 minutes")).tag(1800)
+                    Text(String(localized: "After 1 hour")).tag(3600)
+                }
+
+                Text(String(localized: "Automatically unloads local models from memory after inactivity. It reloads when needed. Does not affect cloud engines."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle(String(localized: "Spoken feedback"), isOn: $dictation.spokenFeedbackEnabled)
+
+                Text(String(localized: "Reads back the transcribed text via speech synthesis after each dictation."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             // MARK: - History

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -146,23 +146,6 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            #if !APPSTORE
-            Section(String(localized: "Updates")) {
-                HStack {
-                    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-                    let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
-                    Text("Version \(version) (\(build))")
-                        .foregroundStyle(.secondary)
-
-                    Spacer()
-
-                    Button(String(localized: "Check for Updates...")) {
-                        UpdateChecker.shared?.checkForUpdates()
-                    }
-                    .disabled(UpdateChecker.shared?.canCheckForUpdates() != true)
-                }
-            }
-            #endif
         }
         .formStyle(.grouped)
         .padding()

--- a/TypeWhisper/Views/HotkeyRecorderView.swift
+++ b/TypeWhisper/Views/HotkeyRecorderView.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+
+struct HotkeyRecorderView: View {
+    let label: String
+    var title: String = String(localized: "Dictation shortcut")
+    var subtitle: String? = nil
+    let onRecord: (UnifiedHotkey) -> Void
+    let onClear: () -> Void
+
+    @State private var isRecording = false
+    @State private var pendingModifiers: NSEvent.ModifierFlags = []
+    @State private var peakModifiers: NSEvent.ModifierFlags = []
+    @State private var localMonitor: Any?
+    @State private var globalMonitor: Any?
+    @State private var modifierReleaseTimer: DispatchWorkItem?
+    private static var activeRecorder: UUID?
+    @State private var id = UUID()
+    // Double-tap recording state
+    @State private var firstTapHotkey: UnifiedHotkey?
+    @State private var firstTapDisplayName: String?
+    @State private var doubleTapTimer: DispatchWorkItem?
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if isRecording {
+                Button {
+                    cancelRecording()
+                } label: {
+                    if let displayName = firstTapDisplayName {
+                        Text("\(displayName) - \(String(localized: "tap again for double-tap…"))")
+                            .foregroundStyle(.orange)
+                    } else {
+                        Text(pendingModifierString.isEmpty
+                            ? String(localized: "Press a key…")
+                            : pendingModifierString)
+                            .foregroundStyle(.orange)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel(String(localized: "Recording shortcut - press a key or Escape to cancel"))
+            } else if label.isEmpty {
+                Button {
+                    startRecording()
+                } label: {
+                    Text(String(localized: "Record Shortcut"))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel(String(localized: "Record shortcut for \(title)"))
+            } else {
+                HStack(spacing: 4) {
+                    Button {
+                        startRecording()
+                    } label: {
+                        Text(label)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(localized: "Current shortcut: \(label). Click to change."))
+                    Button {
+                        onClear()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(localized: "Clear shortcut"))
+                }
+            }
+        }
+    }
+
+    private var pendingModifierString: String {
+        var parts: [String] = []
+        if pendingModifiers.contains(.function) { parts.append("Fn") }
+        if pendingModifiers.contains(.control) { parts.append("⌃") }
+        if pendingModifiers.contains(.option) { parts.append("⌥") }
+        if pendingModifiers.contains(.shift) { parts.append("⇧") }
+        if pendingModifiers.contains(.command) { parts.append("⌘") }
+        return parts.joined()
+    }
+
+    private func startRecording() {
+        if let activeId = Self.activeRecorder, activeId != id {
+            return
+        }
+        Self.activeRecorder = id
+        isRecording = true
+        pendingModifiers = []
+        peakModifiers = []
+        ServiceContainer.shared.hotkeyService.suspendMonitoring()
+
+        // Local monitor - can swallow events (return nil)
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
+            let handled = handleRecorderEvent(event)
+            return handled ? nil : event
+        }
+
+        // Global monitor - captures events intercepted by macOS (e.g. Ctrl+Space for input switching)
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
+            handleRecorderEvent(event)
+        }
+    }
+
+    /// Shared event processing for both local and global monitors.
+    /// Returns true if the event was handled (consumed).
+    @discardableResult
+    private func handleRecorderEvent(_ event: NSEvent) -> Bool {
+        guard isRecording else { return false }
+
+        if event.type == .flagsChanged {
+            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
+            let current = event.modifierFlags.intersection(relevantMask)
+
+            // Track peak modifier set (most modifiers held simultaneously)
+            if current.isSuperset(of: peakModifiers) {
+                peakModifiers = current
+            }
+
+            if current.isEmpty, !pendingModifiers.isEmpty {
+                let modifierList: [NSEvent.ModifierFlags] = [.command, .option, .control, .shift, .function]
+                let peakCount = modifierList.filter { peakModifiers.contains($0) }.count
+
+                // Build the candidate single-tap hotkey for this release
+                let candidateHotkey: UnifiedHotkey?
+                if peakCount > 1 {
+                    candidateHotkey = UnifiedHotkey(keyCode: UnifiedHotkey.modifierComboKeyCode, modifierFlags: peakModifiers.rawValue, isFn: false)
+                } else if peakModifiers.contains(.function) {
+                    candidateHotkey = UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
+                } else if HotkeyService.modifierKeyCodes.contains(event.keyCode) {
+                    candidateHotkey = UnifiedHotkey(keyCode: event.keyCode, modifierFlags: 0, isFn: false)
+                } else {
+                    candidateHotkey = nil
+                }
+
+                if let candidate = candidateHotkey {
+                    // Check if this is a second tap of the same key (double-tap detection)
+                    if let firstTap = firstTapHotkey, firstTap == candidate {
+                        // Second tap - finish as double-tap
+                        doubleTapTimer?.cancel()
+                        doubleTapTimer = nil
+                        let doubleTapHotkey = UnifiedHotkey(keyCode: candidate.keyCode, modifierFlags: candidate.modifierFlags, isFn: candidate.isFn, isDoubleTap: true)
+                        let work = DispatchWorkItem { [self] in
+                            finishRecording(doubleTapHotkey)
+                        }
+                        modifierReleaseTimer = work
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
+                    } else {
+                        // First tap - wait for possible second tap
+                        doubleTapTimer?.cancel()
+                        firstTapHotkey = candidate
+                        firstTapDisplayName = HotkeyService.displayName(for: candidate)
+                        let singleTapHotkey = candidate
+                        let work = DispatchWorkItem { [self] in
+                            // Timer expired - finish as single-tap
+                            firstTapHotkey = nil
+                            firstTapDisplayName = nil
+                            finishRecording(singleTapHotkey)
+                        }
+                        doubleTapTimer = work
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
+                    }
+                    pendingModifiers = []
+                    peakModifiers = []
+                    return true
+                }
+            }
+
+            pendingModifiers = current
+            return true
+        }
+
+        if event.type == .keyDown {
+            modifierReleaseTimer?.cancel()
+            modifierReleaseTimer = nil
+
+            if event.keyCode == 0x35, pendingModifiers.isEmpty {
+                cancelRecording()
+                return true
+            }
+
+            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
+            let modifiers = event.modifierFlags.intersection(relevantMask).rawValue
+
+            finishRecording(UnifiedHotkey(keyCode: event.keyCode, modifierFlags: modifiers, isFn: false))
+            return true
+        }
+
+        return false
+    }
+
+    private func finishRecording(_ hotkey: UnifiedHotkey) {
+        modifierReleaseTimer?.cancel()
+        modifierReleaseTimer = nil
+        doubleTapTimer?.cancel()
+        doubleTapTimer = nil
+        firstTapHotkey = nil
+        firstTapDisplayName = nil
+        if Self.activeRecorder == id {
+            Self.activeRecorder = nil
+        }
+        isRecording = false
+        pendingModifiers = []
+        peakModifiers = []
+        removeMonitors()
+        ServiceContainer.shared.hotkeyService.resumeMonitoring()
+        onRecord(hotkey)
+    }
+
+    private func cancelRecording() {
+        modifierReleaseTimer?.cancel()
+        modifierReleaseTimer = nil
+        doubleTapTimer?.cancel()
+        doubleTapTimer = nil
+        firstTapHotkey = nil
+        firstTapDisplayName = nil
+        if Self.activeRecorder == id {
+            Self.activeRecorder = nil
+        }
+        isRecording = false
+        pendingModifiers = []
+        peakModifiers = []
+        removeMonitors()
+        ServiceContainer.shared.hotkeyService.resumeMonitoring()
+    }
+
+    private func removeMonitors() {
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+    }
+}

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct HotkeySettingsView: View {
+    @ObservedObject private var dictation = DictationViewModel.shared
+
+    var body: some View {
+        Form {
+            Section(String(localized: "Hotkeys")) {
+                HotkeyRecorderView(
+                    label: dictation.hybridHotkeyLabel,
+                    title: String(localized: "Hybrid"),
+                    subtitle: String(localized: "Short press to toggle, hold to push-to-talk."),
+                    onRecord: { hotkey in
+                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .hybrid) {
+                            dictation.clearHotkey(for: conflict)
+                        }
+                        dictation.setHotkey(hotkey, for: .hybrid)
+                    },
+                    onClear: { dictation.clearHotkey(for: .hybrid) }
+                )
+
+                HotkeyRecorderView(
+                    label: dictation.pttHotkeyLabel,
+                    title: String(localized: "Push-to-Talk"),
+                    subtitle: String(localized: "Hold to record, release to stop."),
+                    onRecord: { hotkey in
+                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .pushToTalk) {
+                            dictation.clearHotkey(for: conflict)
+                        }
+                        dictation.setHotkey(hotkey, for: .pushToTalk)
+                    },
+                    onClear: { dictation.clearHotkey(for: .pushToTalk) }
+                )
+
+                HotkeyRecorderView(
+                    label: dictation.toggleHotkeyLabel,
+                    title: String(localized: "Toggle"),
+                    subtitle: String(localized: "Press to start, press again to stop."),
+                    onRecord: { hotkey in
+                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .toggle) {
+                            dictation.clearHotkey(for: conflict)
+                        }
+                        dictation.setHotkey(hotkey, for: .toggle)
+                    },
+                    onClear: { dictation.clearHotkey(for: .toggle) }
+                )
+            }
+
+            Section(String(localized: "Prompt Palette")) {
+                HotkeyRecorderView(
+                    label: dictation.promptPaletteHotkeyLabel,
+                    title: String(localized: "Palette shortcut"),
+                    onRecord: { hotkey in
+                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .promptPalette) {
+                            dictation.clearHotkey(for: conflict)
+                        }
+                        dictation.setHotkey(hotkey, for: .promptPalette)
+                    },
+                    onClear: { dictation.clearHotkey(for: .promptPalette) }
+                )
+
+                Text(String(localized: "Select text in any app, press the shortcut, and choose a prompt to process the text."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .frame(minWidth: 500, minHeight: 300)
+    }
+}

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 enum SettingsTab: Hashable {
-    case home, general, recording, recorder
-    case fileTranscription, history, dictionary, snippets, profiles, prompts, integrations, advanced
+    case home, general, recording, hotkeys, recorder
+    case fileTranscription, history, dictionary, snippets, profiles, prompts, integrations, advanced, about
 }
 
 struct SettingsView: View {
@@ -31,6 +31,9 @@ struct SettingsView: View {
                         RecordingSettingsView()
                             .tabItem { Label(String(localized: "Recording"), systemImage: "mic.fill") }
                             .tag(SettingsTab.recording)
+                        HotkeySettingsView()
+                            .tabItem { Label(String(localized: "Hotkeys"), systemImage: "keyboard") }
+                            .tag(SettingsTab.hotkeys)
                         FileTranscriptionView()
                             .tabItem { Label(String(localized: "File Transcription"), systemImage: "doc.text") }
                             .tag(SettingsTab.fileTranscription)
@@ -62,6 +65,9 @@ struct SettingsView: View {
                         AdvancedSettingsView()
                             .tabItem { Label(String(localized: "Advanced"), systemImage: "gearshape.2") }
                             .tag(SettingsTab.advanced)
+                        AboutSettingsView()
+                            .tabItem { Label(String(localized: "About"), systemImage: "info.circle") }
+                            .tag(SettingsTab.about)
                     }
                 }
             }
@@ -100,6 +106,9 @@ private struct SettingsMainTabs: TabContent {
         Tab(String(localized: "Recording"), systemImage: "mic.fill", value: SettingsTab.recording) {
             RecordingSettingsView()
         }
+        Tab(String(localized: "Hotkeys"), systemImage: "keyboard", value: SettingsTab.hotkeys) {
+            HotkeySettingsView()
+        }
         Tab(String(localized: "File Transcription"), systemImage: "doc.text", value: SettingsTab.fileTranscription) {
             FileTranscriptionView()
         }
@@ -137,6 +146,9 @@ private struct SettingsExtraTabs: TabContent {
         .badge(self.pluginUpdatesBadge)
         Tab(String(localized: "Advanced"), systemImage: "gearshape.2", value: SettingsTab.advanced) {
             AdvancedSettingsView()
+        }
+        Tab(String(localized: "About"), systemImage: "info.circle", value: SettingsTab.about) {
+            AboutSettingsView()
         }
     }
 }
@@ -198,83 +210,7 @@ struct RecordingSettingsView: View {
                         }
                     }
 
-                    Picker(String(localized: "Auto-unload model"), selection: Binding(
-                        get: { modelManager.autoUnloadSeconds },
-                        set: { modelManager.autoUnloadSeconds = $0 }
-                    )) {
-                        Text(String(localized: "Never")).tag(0)
-                        Divider()
-                        Text(String(localized: "Immediate")).tag(-1)
-                        Text(String(localized: "After 2 minutes")).tag(120)
-                        Text(String(localized: "After 5 minutes")).tag(300)
-                        Text(String(localized: "After 10 minutes")).tag(600)
-                        Text(String(localized: "After 30 minutes")).tag(1800)
-                        Text(String(localized: "After 1 hour")).tag(3600)
-                    }
-
-                    Text(String(localized: "Automatically unloads local models from memory after inactivity. It reloads when needed. Does not affect cloud engines."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
-            }
-
-            Section(String(localized: "Hotkeys")) {
-                HotkeyRecorderView(
-                    label: dictation.hybridHotkeyLabel,
-                    title: String(localized: "Hybrid"),
-                    subtitle: String(localized: "Short press to toggle, hold to push-to-talk."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .hybrid) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .hybrid)
-                    },
-                    onClear: { dictation.clearHotkey(for: .hybrid) }
-                )
-
-                HotkeyRecorderView(
-                    label: dictation.pttHotkeyLabel,
-                    title: String(localized: "Push-to-Talk"),
-                    subtitle: String(localized: "Hold to record, release to stop."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .pushToTalk) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .pushToTalk)
-                    },
-                    onClear: { dictation.clearHotkey(for: .pushToTalk) }
-                )
-
-                HotkeyRecorderView(
-                    label: dictation.toggleHotkeyLabel,
-                    title: String(localized: "Toggle"),
-                    subtitle: String(localized: "Press to start, press again to stop."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .toggle) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .toggle)
-                    },
-                    onClear: { dictation.clearHotkey(for: .toggle) }
-                )
-            }
-
-            Section(String(localized: "Prompt Palette")) {
-                HotkeyRecorderView(
-                    label: dictation.promptPaletteHotkeyLabel,
-                    title: String(localized: "Palette shortcut"),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .promptPalette) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .promptPalette)
-                    },
-                    onClear: { dictation.clearHotkey(for: .promptPalette) }
-                )
-
-                Text(String(localized: "Select text in any app, press the shortcut, and choose a prompt to process the text."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
 
             Section(String(localized: "Microphone")) {
@@ -347,11 +283,6 @@ struct RecordingSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                Toggle(String(localized: "Spoken feedback"), isOn: $dictation.spokenFeedbackEnabled)
-
-                Text(String(localized: "Reads back the transcribed text via speech synthesis after each dictation."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
 
             Section(String(localized: "Output Formatting")) {
@@ -383,48 +314,42 @@ struct RecordingSettingsView: View {
                 }
             }
 
-            Section(String(localized: "Permissions")) {
-                HStack {
-                    Label(
-                        String(localized: "Microphone"),
-                        systemImage: dictation.needsMicPermission ? "mic.slash" : "mic.fill"
-                    )
-                    .foregroundStyle(dictation.needsMicPermission ? .orange : .green)
-
-                    Spacer()
-
+            if needsPermissions {
+                Section(String(localized: "Permissions")) {
                     if dictation.needsMicPermission {
-                        Button(String(localized: "Grant Access")) {
-                            dictation.requestMicPermission()
+                        HStack {
+                            Label(
+                                String(localized: "Microphone"),
+                                systemImage: "mic.slash"
+                            )
+                            .foregroundStyle(.orange)
+
+                            Spacer()
+
+                            Button(String(localized: "Grant Access")) {
+                                dictation.requestMicPermission()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
                         }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    } else {
-                        Text(String(localized: "Granted"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
                     }
-                }
-
-                HStack {
-                    Label(
-                        String(localized: "Accessibility"),
-                        systemImage: dictation.needsAccessibilityPermission ? "lock.shield" : "lock.shield.fill"
-                    )
-                    .foregroundStyle(dictation.needsAccessibilityPermission ? .orange : .green)
-
-                    Spacer()
 
                     if dictation.needsAccessibilityPermission {
-                        Button(String(localized: "Grant Access")) {
-                            dictation.requestAccessibilityPermission()
+                        HStack {
+                            Label(
+                                String(localized: "Accessibility"),
+                                systemImage: "lock.shield"
+                            )
+                            .foregroundStyle(.orange)
+
+                            Spacer()
+
+                            Button(String(localized: "Grant Access")) {
+                                dictation.requestAccessibilityPermission()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
                         }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    } else {
-                        Text(String(localized: "Granted"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -485,252 +410,3 @@ struct PermissionsBanner: View {
     }
 }
 
-// MARK: - Hotkey Recorder
-
-struct HotkeyRecorderView: View {
-    let label: String
-    var title: String = String(localized: "Dictation shortcut")
-    var subtitle: String? = nil
-    let onRecord: (UnifiedHotkey) -> Void
-    let onClear: () -> Void
-
-    @State private var isRecording = false
-    @State private var pendingModifiers: NSEvent.ModifierFlags = []
-    @State private var peakModifiers: NSEvent.ModifierFlags = []
-    @State private var localMonitor: Any?
-    @State private var globalMonitor: Any?
-    @State private var modifierReleaseTimer: DispatchWorkItem?
-    private static var activeRecorder: UUID?
-    @State private var id = UUID()
-    // Double-tap recording state
-    @State private var firstTapHotkey: UnifiedHotkey?
-    @State private var firstTapDisplayName: String?
-    @State private var doubleTapTimer: DispatchWorkItem?
-
-    var body: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                if let subtitle {
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
-            if isRecording {
-                Button {
-                    cancelRecording()
-                } label: {
-                    if let displayName = firstTapDisplayName {
-                        Text("\(displayName) - \(String(localized: "tap again for double-tap…"))")
-                            .foregroundStyle(.orange)
-                    } else {
-                        Text(pendingModifierString.isEmpty
-                            ? String(localized: "Press a key…")
-                            : pendingModifierString)
-                            .foregroundStyle(.orange)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .accessibilityLabel(String(localized: "Recording shortcut - press a key or Escape to cancel"))
-            } else if label.isEmpty {
-                Button {
-                    startRecording()
-                } label: {
-                    Text(String(localized: "Record Shortcut"))
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .accessibilityLabel(String(localized: "Record shortcut for \(title)"))
-            } else {
-                HStack(spacing: 4) {
-                    Button {
-                        startRecording()
-                    } label: {
-                        Text(label)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(localized: "Current shortcut: \(label). Click to change."))
-                    Button {
-                        onClear()
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(localized: "Clear shortcut"))
-                }
-            }
-        }
-    }
-
-    private var pendingModifierString: String {
-        var parts: [String] = []
-        if pendingModifiers.contains(.function) { parts.append("Fn") }
-        if pendingModifiers.contains(.control) { parts.append("⌃") }
-        if pendingModifiers.contains(.option) { parts.append("⌥") }
-        if pendingModifiers.contains(.shift) { parts.append("⇧") }
-        if pendingModifiers.contains(.command) { parts.append("⌘") }
-        return parts.joined()
-    }
-
-    private func startRecording() {
-        if let activeId = Self.activeRecorder, activeId != id {
-            return
-        }
-        Self.activeRecorder = id
-        isRecording = true
-        pendingModifiers = []
-        peakModifiers = []
-        ServiceContainer.shared.hotkeyService.suspendMonitoring()
-
-        // Local monitor - can swallow events (return nil)
-        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
-            let handled = handleRecorderEvent(event)
-            return handled ? nil : event
-        }
-
-        // Global monitor - captures events intercepted by macOS (e.g. Ctrl+Space for input switching)
-        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
-            handleRecorderEvent(event)
-        }
-    }
-
-    /// Shared event processing for both local and global monitors.
-    /// Returns true if the event was handled (consumed).
-    @discardableResult
-    private func handleRecorderEvent(_ event: NSEvent) -> Bool {
-        guard isRecording else { return false }
-
-        if event.type == .flagsChanged {
-            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
-            let current = event.modifierFlags.intersection(relevantMask)
-
-            // Track peak modifier set (most modifiers held simultaneously)
-            if current.isSuperset(of: peakModifiers) {
-                peakModifiers = current
-            }
-
-            if current.isEmpty, !pendingModifiers.isEmpty {
-                let modifierList: [NSEvent.ModifierFlags] = [.command, .option, .control, .shift, .function]
-                let peakCount = modifierList.filter { peakModifiers.contains($0) }.count
-
-                // Build the candidate single-tap hotkey for this release
-                let candidateHotkey: UnifiedHotkey?
-                if peakCount > 1 {
-                    candidateHotkey = UnifiedHotkey(keyCode: UnifiedHotkey.modifierComboKeyCode, modifierFlags: peakModifiers.rawValue, isFn: false)
-                } else if peakModifiers.contains(.function) {
-                    candidateHotkey = UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
-                } else if HotkeyService.modifierKeyCodes.contains(event.keyCode) {
-                    candidateHotkey = UnifiedHotkey(keyCode: event.keyCode, modifierFlags: 0, isFn: false)
-                } else {
-                    candidateHotkey = nil
-                }
-
-                if let candidate = candidateHotkey {
-                    // Check if this is a second tap of the same key (double-tap detection)
-                    if let firstTap = firstTapHotkey, firstTap == candidate {
-                        // Second tap - finish as double-tap
-                        doubleTapTimer?.cancel()
-                        doubleTapTimer = nil
-                        let doubleTapHotkey = UnifiedHotkey(keyCode: candidate.keyCode, modifierFlags: candidate.modifierFlags, isFn: candidate.isFn, isDoubleTap: true)
-                        let work = DispatchWorkItem { [self] in
-                            finishRecording(doubleTapHotkey)
-                        }
-                        modifierReleaseTimer = work
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
-                    } else {
-                        // First tap - wait for possible second tap
-                        doubleTapTimer?.cancel()
-                        firstTapHotkey = candidate
-                        firstTapDisplayName = HotkeyService.displayName(for: candidate)
-                        let singleTapHotkey = candidate
-                        let work = DispatchWorkItem { [self] in
-                            // Timer expired - finish as single-tap
-                            firstTapHotkey = nil
-                            firstTapDisplayName = nil
-                            finishRecording(singleTapHotkey)
-                        }
-                        doubleTapTimer = work
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
-                    }
-                    pendingModifiers = []
-                    peakModifiers = []
-                    return true
-                }
-            }
-
-            pendingModifiers = current
-            return true
-        }
-
-        if event.type == .keyDown {
-            modifierReleaseTimer?.cancel()
-            modifierReleaseTimer = nil
-
-            if event.keyCode == 0x35, pendingModifiers.isEmpty {
-                cancelRecording()
-                return true
-            }
-
-            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
-            let modifiers = event.modifierFlags.intersection(relevantMask).rawValue
-
-            finishRecording(UnifiedHotkey(keyCode: event.keyCode, modifierFlags: modifiers, isFn: false))
-            return true
-        }
-
-        return false
-    }
-
-    private func finishRecording(_ hotkey: UnifiedHotkey) {
-        modifierReleaseTimer?.cancel()
-        modifierReleaseTimer = nil
-        doubleTapTimer?.cancel()
-        doubleTapTimer = nil
-        firstTapHotkey = nil
-        firstTapDisplayName = nil
-        if Self.activeRecorder == id {
-            Self.activeRecorder = nil
-        }
-        isRecording = false
-        pendingModifiers = []
-        peakModifiers = []
-        removeMonitors()
-        ServiceContainer.shared.hotkeyService.resumeMonitoring()
-        onRecord(hotkey)
-    }
-
-    private func cancelRecording() {
-        modifierReleaseTimer?.cancel()
-        modifierReleaseTimer = nil
-        doubleTapTimer?.cancel()
-        doubleTapTimer = nil
-        firstTapHotkey = nil
-        firstTapDisplayName = nil
-        if Self.activeRecorder == id {
-            Self.activeRecorder = nil
-        }
-        isRecording = false
-        pendingModifiers = []
-        peakModifiers = []
-        removeMonitors()
-        ServiceContainer.shared.hotkeyService.resumeMonitoring()
-    }
-
-    private func removeMonitors() {
-        if let monitor = localMonitor {
-            NSEvent.removeMonitor(monitor)
-            localMonitor = nil
-        }
-        if let monitor = globalMonitor {
-            NSEvent.removeMonitor(monitor)
-            globalMonitor = nil
-        }
-    }
-}


### PR DESCRIPTION
## Summary

- Split the overloaded Recording tab: hotkey configuration moved to a new **Hotkeys** tab, power-user options (auto-unload model, spoken feedback) moved to **Advanced**
- New **About** tab at the bottom with app icon, version info, Check for Updates button, and copyright/license notice (moved from General)
- Permissions section in Recording now only appears when access is actually missing
- Extracted `HotkeyRecorderView` (246 lines) from `SettingsView.swift` into its own file

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features