### PR TITLE
[codex] Update README video attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ TypeWhisper `1.0` is scoped as a reliable direct-download release. The supported
 See [docs/1.0-readiness.md](docs/1.0-readiness.md), [docs/support-matrix.md](docs/support-matrix.md), and [docs/release-checklist.md](docs/release-checklist.md) for the current release definition and ship gates.
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/98e1aef9-de31-434b-aa13-cfd36c0f3155" autoplay loop muted playsinline width="270"></video>
+  <video src="https://github.com/user-attachments/assets/22fe922d-4a4c-47d1-805e-684a148ebd03" autoplay loop muted playsinline width="270"></video>
 </p>
 
 ## Screenshots


### PR DESCRIPTION
## Summary

This PR updates the README demo embed to the newly uploaded GitHub attachment URL from issue #120. The previous `user-attachments` asset referenced an outdated product video, so the repository landing page continued to show stale UI even after the published demo asset was regenerated. Closes #120.

## Test Plan

- [ ] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features
- [x] Verified the README `<video>` tag now points at the new attachment URL
