### PR TITLE
feat: add Fireworks AI plugin for transcription and LLM

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -49,6 +49,7 @@ jobs:
             cloudflare-asr) TARGET="CloudflareASRPlugin" ;;
             file-memory) TARGET="FileMemoryPlugin" ;;
             openai-vector-memory) TARGET="OpenAIVectorMemoryPlugin" ;;
+            fireworks) TARGET="FireworksPlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin

--- a/Plugins/FireworksPlugin/FireworksPlugin.swift
+++ b/Plugins/FireworksPlugin/FireworksPlugin.swift
@@ -1,0 +1,535 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+// MARK: - Plugin Entry Point
+
+@objc(FireworksPlugin)
+final class FireworksPlugin: NSObject, TranscriptionEnginePlugin, LLMProviderPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.fireworks"
+    static let pluginName = "Fireworks AI"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedModelId: String?
+    fileprivate var _selectedLLMModelId: String?
+    fileprivate var _fetchedLLMModels: [FireworksFetchedModel] = []
+
+    private let chatHelper = PluginOpenAIChatHelper(
+        baseURL: "https://api.fireworks.ai/inference"
+    )
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: "api-key")
+        if let data = host.userDefault(forKey: "fetchedLLMModels") as? Data,
+           let models = try? JSONDecoder().decode([FireworksFetchedModel].self, from: data) {
+            _fetchedLLMModels = models
+        }
+        _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
+            ?? transcriptionModels.first?.id
+        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+            ?? supportedModels.first?.id
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "fireworks" }
+    var providerDisplayName: String { "Fireworks AI" }
+
+    var isConfigured: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: "whisper-v3", displayName: "Whisper V3"),
+            PluginModelInfo(id: "whisper-v3-turbo", displayName: "Whisper V3 Turbo"),
+        ]
+    }
+
+    var selectedModelId: String? { _selectedModelId }
+
+    func selectModel(_ modelId: String) {
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedModel")
+    }
+
+    var supportsTranslation: Bool { true }
+    var supportsStreaming: Bool { true }
+
+    var supportedLanguages: [String] {
+        [
+            "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo",
+            "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es",
+            "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw",
+            "he", "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja",
+            "jw", "ka", "kk", "km", "kn", "ko", "la", "lb", "ln", "lo",
+            "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt",
+            "my", "ne", "nl", "nn", "no", "oc", "pa", "pl", "ps", "pt",
+            "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
+            "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl",
+            "tr", "tt", "uk", "ur", "uz", "vi", "vo", "yi", "yo", "yue",
+            "zh",
+        ]
+    }
+
+    // MARK: - Transcription (Non-Streaming)
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let baseURL = Self.transcriptionBaseURL(for: modelId)
+        let helper = PluginOpenAITranscriptionHelper(baseURL: baseURL, responseFormat: "json")
+
+        return try await helper.transcribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelId,
+            language: language,
+            translate: translate,
+            prompt: prompt
+        )
+    }
+
+    // MARK: - Transcription (Streaming Preview)
+
+    // Uses REST for intermediate polls (lower overhead than WebSocket per call,
+    // since StreamingHandler re-sends the full buffer each time anyway).
+    // WebSocket streaming would open a new connection every 1.5s just to re-send
+    // the same audio - REST is simpler and faster for this pattern.
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let baseURL = Self.transcriptionBaseURL(for: modelId)
+        let helper = PluginOpenAITranscriptionHelper(baseURL: baseURL, responseFormat: "json")
+        let result = try await helper.transcribe(
+            audio: audio, apiKey: apiKey, modelName: modelId,
+            language: language, translate: translate, prompt: prompt
+        )
+        _ = onProgress(result.text)
+        return result
+    }
+
+    // MARK: - Helpers
+
+    private static func transcriptionBaseURL(for modelId: String) -> String {
+        switch modelId {
+        case "whisper-v3-turbo": return "https://audio-turbo.api.fireworks.ai"
+        case "whisper-v3": return "https://audio-prod.api.fireworks.ai"
+        default: return "https://audio-prod.api.fireworks.ai"
+        }
+    }
+
+    // MARK: - LLMProviderPlugin
+
+    var providerName: String { "Fireworks AI" }
+
+    var isAvailable: Bool { isConfigured }
+
+    private static let fallbackLLMModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "accounts/fireworks/models/deepseek-v3p1", displayName: "DeepSeek V3p1"),
+        PluginModelInfo(id: "accounts/fireworks/models/llama-v3p3-70b-instruct", displayName: "Llama 3.3 70B"),
+        PluginModelInfo(id: "accounts/fireworks/models/llama-v3p1-8b-instruct", displayName: "Llama 3.1 8B"),
+        PluginModelInfo(id: "accounts/fireworks/models/qwen2p5-72b-instruct", displayName: "Qwen 2.5 72B"),
+        PluginModelInfo(id: "accounts/fireworks/models/gpt-oss-120b", displayName: "GPT-OSS 120B"),
+        PluginModelInfo(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
+    ]
+
+    var supportedModels: [PluginModelInfo] {
+        if !_fetchedLLMModels.isEmpty {
+            return _fetchedLLMModels.map {
+                PluginModelInfo(id: $0.id, displayName: $0.displayName ?? $0.id)
+            }
+        }
+        return Self.fallbackLLMModels
+    }
+
+    func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginChatError.notConfigured
+        }
+        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
+        return try await chatHelper.process(
+            apiKey: apiKey,
+            model: modelId,
+            systemPrompt: systemPrompt,
+            userText: userText
+        )
+    }
+
+    func selectLLMModel(_ modelId: String) {
+        _selectedLLMModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+    }
+
+    var selectedLLMModelId: String? { _selectedLLMModelId }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(FireworksSettingsView(plugin: self))
+    }
+
+    // Internal methods for settings
+    func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: key)
+            } catch {
+                print("[FireworksPlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: "")
+            } catch {
+                print("[FireworksPlugin] Failed to delete API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func validateApiKey(_ key: String) async -> Bool {
+        guard let url = URL(string: "https://api.fireworks.ai/inference/v1/models?page_size=1") else { return false }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return false }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    func addCustomModel(_ modelId: String) {
+        if !_fetchedLLMModels.contains(where: { $0.id == modelId }) {
+            _fetchedLLMModels.insert(FireworksFetchedModel(id: modelId, displayName: modelId), at: 0)
+            if let data = try? JSONEncoder().encode(_fetchedLLMModels) {
+                host?.setUserDefault(data, forKey: "fetchedLLMModels")
+            }
+        }
+        selectLLMModel(modelId)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func setFetchedLLMModels(_ models: [FireworksFetchedModel]) {
+        _fetchedLLMModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: "fetchedLLMModels")
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func fetchLLMModels() async -> [FireworksFetchedModel] {
+        guard let apiKey = _apiKey, !apiKey.isEmpty,
+              let url = URL(string: "https://api.fireworks.ai/inference/v1/models?page_size=200") else { return [] }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+
+            // Fireworks returns {"models": [{"name": "accounts/.../model-name", ...}]}
+            // not the OpenAI format {"data": [{"id": "..."}]}
+            struct FireworksModelsResponse: Decodable {
+                let models: [FireworksModelEntry]?
+                let data: [FireworksFetchedModel]? // OpenAI fallback
+            }
+            struct FireworksModelEntry: Decodable {
+                let name: String
+                let displayName: String?
+                let kind: String?
+            }
+
+            let decoded = try JSONDecoder().decode(FireworksModelsResponse.self, from: data)
+
+            // Prefer Fireworks-native format
+            if let models = decoded.models, !models.isEmpty {
+                return models
+                    .filter { Self.isLLMModel($0.name) }
+                    .map { FireworksFetchedModel(id: $0.name, displayName: $0.displayName) }
+                    .sorted { $0.id < $1.id }
+            }
+
+            // Fallback to OpenAI format
+            if let models = decoded.data {
+                return models
+                    .filter { Self.isLLMModel($0.id) }
+                    .sorted { $0.id < $1.id }
+            }
+
+            return []
+        } catch {
+            return []
+        }
+    }
+
+    nonisolated static func isLLMModel(_ id: String) -> Bool {
+        let lowered = id.lowercased()
+        let excluded = [
+            "whisper", "asr", "embedding", "audio", "tts",
+            "vision", "image", "stable-diffusion", "flux",
+        ]
+        return !excluded.contains(where: { lowered.contains($0) })
+    }
+}
+
+// MARK: - Fetched Model
+
+struct FireworksFetchedModel: Codable, Sendable {
+    let id: String
+    let displayName: String?
+
+    init(id: String, displayName: String? = nil) {
+        self.id = id
+        self.displayName = displayName
+    }
+}
+
+// MARK: - Settings View
+
+private struct FireworksSettingsView: View {
+    let plugin: FireworksPlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    @State private var selectedModel: String = ""
+    @State private var selectedLLMModel: String = ""
+    @State private var customModelId: String = ""
+    @State private var fetchedLLMModels: [FireworksFetchedModel] = []
+    private let bundle = Bundle(for: FireworksPlugin.self)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // API Key Section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key", bundle: bundle)
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isConfigured {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            apiKeyInput = ""
+                            validationResult = nil
+                            plugin.removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = validationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result ? .green : .red)
+                        Text(result ? String(localized: "Valid API Key", bundle: bundle) : String(localized: "Invalid API Key", bundle: bundle))
+                            .font(.caption)
+                            .foregroundStyle(result ? .green : .red)
+                    }
+                }
+            }
+
+            if plugin.isConfigured {
+                Divider()
+
+                // Transcription Model Selection
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Transcription Model", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Transcription Model", selection: $selectedModel) {
+                        ForEach(plugin.transcriptionModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedModel) {
+                        plugin.selectModel(selectedModel)
+                    }
+
+}
+
+                Divider()
+
+                // LLM Model Selection
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("LLM Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshLLMModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Picker("LLM Model", selection: $selectedLLMModel) {
+                        ForEach(plugin.supportedModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedLLMModel) {
+                        plugin.selectLLMModel(selectedLLMModel)
+                    }
+
+                    HStack(spacing: 8) {
+                        TextField("accounts/fireworks/models/...", text: $customModelId)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                        Button(String(localized: "Use", bundle: bundle)) {
+                            let trimmed = customModelId.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            plugin.addCustomModel(trimmed)
+                            selectedLLMModel = trimmed
+                            customModelId = ""
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(customModelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+
+                    Text("Enter any model ID from fireworks.ai/models", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin._apiKey, !key.isEmpty {
+                apiKeyInput = key
+            }
+            selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+            selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            fetchedLLMModels = plugin._fetchedLLMModels
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        plugin.setApiKey(trimmedKey)
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            if isValid {
+                let models = await plugin.fetchLLMModels()
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = true
+                    if !models.isEmpty {
+                        fetchedLLMModels = models
+                        plugin.setFetchedLLMModels(models)
+                    }
+                }
+            } else {
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = false
+                }
+            }
+        }
+    }
+
+    private func refreshLLMModels() {
+        Task {
+            let models = await plugin.fetchLLMModels()
+            await MainActor.run {
+                if !models.isEmpty {
+                    fetchedLLMModels = models
+                    plugin.setFetchedLLMModels(models)
+                    if !models.contains(where: { $0.id == selectedLLMModel }),
+                       let first = models.first {
+                        selectedLLMModel = first.id
+                        plugin.selectLLMModel(first.id)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Plugins/FireworksPlugin/Localizable.xcstrings
+++ b/Plugins/FireworksPlugin/Localizable.xcstrings
@@ -1,0 +1,136 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel werden sicher im Schlüsselbund gespeichert"
+          }
+        }
+      }
+    },
+    "Invalid API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger API-Schlüssel"
+          }
+        }
+      }
+    },
+    "LLM Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM-Modell"
+          }
+        }
+      }
+    },
+    "Refresh" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisieren"
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichern"
+          }
+        }
+      }
+    },
+    "Enter any model ID from fireworks.ai/models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beliebige Model-ID von fireworks.ai/models eingeben"
+          }
+        }
+      }
+    },
+    "Use" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwenden"
+          }
+        }
+      }
+    },
+    "Transcription Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transkriptionsmodell"
+          }
+        }
+      }
+    },
+    "Using default models. Press Refresh to fetch all available models." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standardmodelle werden verwendet. Aktualisieren drücken, um alle verfügbaren Modelle zu laden."
+          }
+        }
+      }
+    },
+    "Valid API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger API-Schlüssel"
+          }
+        }
+      }
+    },
+    "Validating..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird überprüft ..."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Plugins/FireworksPlugin/manifest.json
+++ b/Plugins/FireworksPlugin/manifest.json
@@ -1,0 +1,16 @@
+{
+    "id": "com.typewhisper.fireworks",
+    "name": "Fireworks AI",
+    "version": "1.0.0",
+    "minHostVersion": "0.9.0",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Cloud transcription and LLM via Fireworks AI. Streaming transcription, fast inference, requires API key.",
+    "descriptions": {
+        "de": "Cloud-Transkription und LLM ueber Fireworks AI. Streaming-Transkription, schnelle Inferenz, erfordert API-Key."
+    },
+    "category": "transcription",
+    "iconSystemName": "flame.fill",
+    "requiresAPIKey": true,
+    "principalClass": "FireworksPlugin"
+}

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -212,6 +212,10 @@
 		AA00000000000000000244 /* OpenAIVectorMemoryPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000232 /* OpenAIVectorMemoryPlugin.swift */; };
 		AA00000000000000000245 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000233 /* manifest.json */; };
 		AA00000000000000000246 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000033 /* TypeWhisperPluginSDK */; };
+		AA00000000000000000263 /* FireworksPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000251 /* FireworksPlugin.swift */; };
+		AA00000000000000000264 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000252 /* manifest.json */; };
+		AA00000000000000000265 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000253 /* Localizable.xcstrings */; };
+		AA00000000000000000266 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000035 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000247 /* AppFormatterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000235 /* AppFormatterService.swift */; };
 		AA00000000000000000250 /* AudioRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000238 /* AudioRecorderService.swift */; };
 		AA00000000000000000251 /* AudioRecorderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000239 /* AudioRecorderViewModel.swift */; };
@@ -483,6 +487,10 @@
 		BB00000000000000000232 /* OpenAIVectorMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIVectorMemoryPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000233 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenAIVectorMemoryPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB00000000000000000251 /* FireworksPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireworksPlugin.swift; sourceTree = "<group>"; };
+		BB00000000000000000252 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		BB00000000000000000253 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		BB00000000000000000254 /* FireworksPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FireworksPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000235 /* AppFormatterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFormatterService.swift; sourceTree = "<group>"; };
 		BB00000000000000000238 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		BB00000000000000000239 /* AudioRecorderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderViewModel.swift; sourceTree = "<group>"; };
@@ -712,6 +720,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF00000000000000000124 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000266 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -766,6 +782,7 @@
 				CC00000000000000000034 /* CloudflareASRPlugin */,
 				CC00000000000000000035 /* FileMemoryPlugin */,
 				CC00000000000000000036 /* OpenAIVectorMemoryPlugin */,
+				CC00000000000000000037 /* FireworksPlugin */,
 				CC00000000000000000025 /* TypeWhisperWidgetExtension */,
 				CC00000000000000000026 /* TypeWhisperWidgetShared */,
 				CC00000000000000000090 /* Products */,
@@ -1222,6 +1239,17 @@
 			path = Plugins/OpenAIVectorMemoryPlugin;
 			sourceTree = "<group>";
 		};
+		CC00000000000000000037 /* FireworksPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				BB00000000000000000251 /* FireworksPlugin.swift */,
+				BB00000000000000000252 /* manifest.json */,
+				BB00000000000000000253 /* Localizable.xcstrings */,
+			);
+			name = FireworksPlugin;
+			path = Plugins/FireworksPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000090 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1247,6 +1275,7 @@
 				BB00000000000000000227 /* CloudflareASRPlugin.bundle */,
 				BB00000000000000000231 /* FileMemoryPlugin.bundle */,
 				BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */,
+				BB00000000000000000254 /* FireworksPlugin.bundle */,
 				BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */,
 				E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */,
 			);
@@ -1764,6 +1793,26 @@
 			productReference = BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		DD00000000000000000025 /* FireworksPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF00000000000000000126 /* Build configuration list for PBXNativeTarget "FireworksPlugin" */;
+			buildPhases = (
+				FF00000000000000000123 /* Sources */,
+				FF00000000000000000124 /* Frameworks */,
+				FF00000000000000000125 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FireworksPlugin;
+			packageProductDependencies = (
+				PP00000000000000000035 /* TypeWhisperPluginSDK */,
+			);
+			productName = FireworksPlugin;
+			productReference = BB00000000000000000254 /* FireworksPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1825,6 +1874,7 @@
 				DD00000000000000000022 /* CloudflareASRPlugin */,
 				DD00000000000000000023 /* FileMemoryPlugin */,
 				DD00000000000000000024 /* OpenAIVectorMemoryPlugin */,
+				DD00000000000000000025 /* FireworksPlugin */,
 				DD00000000000000000014 /* TypeWhisperWidgetExtension */,
 				40F22D3F350BA09ADEFBD2CB /* TypeWhisperTests */,
 			);
@@ -2034,6 +2084,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000245 /* manifest.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000125 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000264 /* manifest.json in Resources */,
+				AA00000000000000000265 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2371,6 +2430,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000244 /* OpenAIVectorMemoryPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000123 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000263 /* FireworksPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4870,6 +4937,102 @@
 			};
 			name = AppStoreRelease;
 		};
+		XX00000000000000000101 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Fireworks AI";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FireworksPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.fireworks;
+				PRODUCT_NAME = FireworksPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		XX00000000000000000102 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Fireworks AI";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FireworksPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.fireworks;
+				PRODUCT_NAME = FireworksPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		XX00000000000000000103 /* AppStoreDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Fireworks AI";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FireworksPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.fireworks;
+				PRODUCT_NAME = FireworksPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = AppStoreDebug;
+		};
+		XX00000000000000000104 /* AppStoreRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Fireworks AI";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FireworksPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.fireworks;
+				PRODUCT_NAME = FireworksPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = AppStoreRelease;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -5148,6 +5311,17 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FF00000000000000000126 /* Build configuration list for PBXNativeTarget "FireworksPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XX00000000000000000101 /* Debug */,
+				XX00000000000000000102 /* Release */,
+				XX00000000000000000103 /* AppStoreDebug */,
+				XX00000000000000000104 /* AppStoreRelease */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -5319,6 +5493,10 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000034 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		PP00000000000000000035 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -362,12 +362,12 @@ private struct InstalledPluginRow: View {
     @State private var showSettings = false
 
     private var isCloud: Bool {
-        registryPlugin?.requiresAPIKey == true
+        registryPlugin?.requiresAPIKey == true || plugin.manifest.requiresAPIKey == true
     }
 
     var body: some View {
         HStack {
-            Image(systemName: registryPlugin?.iconSystemName ?? "puzzlepiece.extension")
+            Image(systemName: registryPlugin?.iconSystemName ?? plugin.manifest.iconSystemName ?? "puzzlepiece.extension")
                 .font(.title2)
                 .foregroundStyle(.blue)
                 .frame(width: 32)

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
@@ -8,6 +8,9 @@ public struct PluginManifest: Codable, Equatable, Sendable {
     public let minOSVersion: String?
     public let author: String?
     public let principalClass: String
+    public let requiresAPIKey: Bool?
+    public let iconSystemName: String?
+    public let category: String?
 
     public init(
         id: String,
@@ -16,7 +19,10 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         minHostVersion: String? = nil,
         minOSVersion: String? = nil,
         author: String? = nil,
-        principalClass: String
+        principalClass: String,
+        requiresAPIKey: Bool? = nil,
+        iconSystemName: String? = nil,
+        category: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -25,5 +31,8 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         self.minOSVersion = minOSVersion
         self.author = author
         self.principalClass = principalClass
+        self.requiresAPIKey = requiresAPIKey
+        self.iconSystemName = iconSystemName
+        self.category = category
     }
 }


### PR DESCRIPTION
## Summary

Adds a new FireworksPlugin with cloud transcription (Whisper v3/v3-turbo with per-model base URLs), LLM chat completions (OpenAI-compatible), and a custom model ID text field since Fireworks has no API to list all serverless models. Also extends `PluginManifest` in the SDK with `requiresAPIKey`, `iconSystemName`, and `category` fields so the Cloud badge and icon display correctly for plugins not yet in the gh-pages registry. Includes CI workflow mapping, pbxproj target, and EN/DE localization.

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features