### PR TITLE
fix: update FluidAudio for Swift 6 actor safety

### DIFF
--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -35,7 +35,9 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Send
     }
 
     func deactivate() {
-        asrManager?.disableVocabularyBoosting()
+        if let manager = asrManager {
+            Task { await manager.disableVocabularyBoosting() }
+        }
         ctcModels = nil
         ctcTokenizer = nil
         ctcModelState = .notDownloaded
@@ -207,7 +209,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Send
         lastConfiguredPrompt = prompt
 
         guard let prompt, !prompt.isEmpty else {
-            asrManager.disableVocabularyBoosting()
+            await asrManager.disableVocabularyBoosting()
             lastBoostingTermCount = 0
             return
         }
@@ -231,7 +233,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Send
         }
 
         guard !terms.isEmpty else {
-            asrManager.disableVocabularyBoosting()
+            await asrManager.disableVocabularyBoosting()
             lastBoostingTermCount = 0
             return
         }
@@ -251,7 +253,9 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Send
         vocabularyBoostingEnabled = enabled
         host?.setUserDefault(enabled, forKey: "vocabularyBoostingEnabled")
         if !enabled {
-            asrManager?.disableVocabularyBoosting()
+            if let manager = asrManager {
+                Task { await manager.disableVocabularyBoosting() }
+            }
             lastConfiguredPrompt = nil
             lastBoostingTermCount = 0
         }
@@ -294,7 +298,9 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Send
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel() } }
 
     func unloadModel(clearPersistence: Bool = true) {
-        asrManager?.disableVocabularyBoosting()
+        if let manager = asrManager {
+            Task { await manager.disableVocabularyBoosting() }
+        }
         ctcModels = nil
         ctcTokenizer = nil
         ctcModelState = .notDownloaded

--- a/Plugins/ParakeetPlugin/manifest.json
+++ b/Plugins/ParakeetPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "minHostVersion": "0.12.0",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8341b7626a7ee02b4d34779982afd1c8f269f19e"
+        "revision" : "12ad53803592aa39bbcbdf655774cfe0ce361386"
       }
     },
     {


### PR DESCRIPTION
## Summary

Updates FluidAudio dependency to latest `main` (`12ad538`) where `AsrManager` was refactored from `class` to `actor`, fixing strict concurrency errors when building with Xcode 26.4. The latest FluidAudio also removed its `swift-transformers` dependency entirely (replaced with built-in BPE tokenizer), which eliminates the version conflict that existed between FluidAudio (>= 1.2.0), WhisperKit (< 1.2.0), and mlx-swift-lm.

ParakeetPlugin is the only plugin using FluidAudio. Added `await` to `disableVocabularyBoosting()` calls that are now actor-isolated. No other code changes needed.

Fixes #129

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features