### PR TITLE
Non-blocking model downloads

### DIFF
--- a/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/Plugins/GranitePlugin/GranitePlugin.swift
@@ -9,7 +9,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(GranitePlugin)
-final class GranitePlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+final class GranitePlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.granite"
     static let pluginName = "Granite Speech"
 
@@ -188,6 +188,17 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, @unchecked Senda
     }
 
     // MARK: - Settings View
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            return nil
+        case .loading:
+            return PluginSettingsActivity(message: "Preparing model")
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
 
     var settingsView: AnyView? {
         AnyView(GraniteSettingsView(plugin: self))

--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -6,7 +6,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(ParakeetPlugin)
-final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
 
@@ -343,6 +343,29 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Send
     }
 
     // MARK: - Settings View
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            break
+        case .downloading:
+            return PluginSettingsActivity(
+                message: "Downloading model",
+                progress: downloadProgress
+            )
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+
+        switch ctcModelState {
+        case .notDownloaded, .ready:
+            return nil
+        case .downloading:
+            return PluginSettingsActivity(message: "Downloading vocabulary model")
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
 
     var settingsView: AnyView? {
         AnyView(ParakeetSettingsView(plugin: self))

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 
@@ -187,6 +187,17 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendabl
     }
 
     // MARK: - Settings View
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            return nil
+        case .loading:
+            return PluginSettingsActivity(message: "Preparing model")
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
 
     var settingsView: AnyView? {
         AnyView(Qwen3SettingsView(plugin: self))

--- a/Plugins/ScriptPlugin/ScriptPlugin.swift
+++ b/Plugins/ScriptPlugin/ScriptPlugin.swift
@@ -307,6 +307,7 @@ enum ScriptError: LocalizedError {
 struct ScriptSettingsView: View {
     @ObservedObject var service: ScriptService
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.pluginSettingsClose) private var closeSettings
     @State private var editingScript: ScriptConfig?
 
     private let bundle = Bundle(for: ScriptService.self)
@@ -369,7 +370,11 @@ struct ScriptSettingsView: View {
             HStack {
                 Spacer()
                 Button(String(localized: "Done", bundle: bundle)) {
-                    dismiss()
+                    if let closeSettings {
+                        closeSettings()
+                    } else {
+                        dismiss()
+                    }
                 }
                 .keyboardShortcut(.cancelAction)
             }

--- a/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -9,7 +9,7 @@ import os
 
 @available(macOS 26, *)
 @objc(SpeechAnalyzerPlugin)
-final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.speechanalyzer"
     static let pluginName = "Apple Speech"
 
@@ -318,6 +318,20 @@ final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, @unchecke
     }
 
     // MARK: - Settings View
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            return nil
+        case .downloading:
+            return PluginSettingsActivity(
+                message: "Downloading language model",
+                progress: downloadProgress
+            )
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
 
     var settingsView: AnyView? {
         AnyView(SpeechAnalyzerSettingsView(plugin: self))

--- a/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -218,6 +218,7 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
 struct ExampleWebhookSettingsView: View {
     @ObservedObject var service: ExampleWebhookService
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.pluginSettingsClose) private var closeSettings
     @State private var editingWebhook: ExampleWebhookConfig?
 
     private let bundle = Bundle(for: ExampleWebhookService.self)
@@ -273,7 +274,11 @@ struct ExampleWebhookSettingsView: View {
             HStack {
                 Spacer()
                 Button(String(localized: "Done", bundle: bundle)) {
-                    dismiss()
+                    if let closeSettings {
+                        closeSettings()
+                    } else {
+                        dismiss()
+                    }
                 }
                 .keyboardShortcut(.cancelAction)
             }

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -6,7 +6,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(WhisperKitPlugin)
-final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.whisperkit"
     static let pluginName = "WhisperKit"
 
@@ -298,6 +298,31 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Se
     }
 
     // MARK: - Settings View
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            return nil
+        case .downloading:
+            return PluginSettingsActivity(
+                message: "Downloading model",
+                progress: downloadProgress
+            )
+        case .loading(let phase):
+            let message: String
+            switch phase {
+            case "prewarming":
+                message = "Optimizing model"
+            case "loading":
+                message = "Loading model"
+            default:
+                message = "Preparing model"
+            }
+            return PluginSettingsActivity(message: message)
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
 
     var settingsView: AnyView? {
         AnyView(WhisperKitSettingsView(plugin: self))

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1,5 +1,71 @@
+import AppKit
 import SwiftUI
 import TypeWhisperPluginSDK
+
+@MainActor
+final class PluginSettingsWindowManager {
+    static let shared = PluginSettingsWindowManager()
+
+    private var windows: [String: NSWindow] = [:]
+    private var delegates: [String: PluginSettingsWindowDelegate] = [:]
+
+    func present(_ plugin: LoadedPlugin) {
+        guard let settingsView = plugin.instance.settingsView else { return }
+
+        if let window = windows[plugin.id] {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hostingView = NSHostingView(
+            rootView: settingsView
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        )
+        hostingView.sizingOptions = []
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 440),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = plugin.manifest.name
+        window.contentMinSize = NSSize(width: 500, height: 400)
+        window.isReleasedWhenClosed = false
+        window.contentView = hostingView
+
+        let autosaveName = "plugin-settings.\(plugin.id)"
+        if !window.setFrameUsingName(autosaveName) {
+            window.center()
+        }
+        window.setFrameAutosaveName(autosaveName)
+
+        let delegate = PluginSettingsWindowDelegate(pluginId: plugin.id) { [weak self] pluginId in
+            self?.windows[pluginId] = nil
+            self?.delegates[pluginId] = nil
+        }
+        delegates[plugin.id] = delegate
+        windows[plugin.id] = window
+        window.delegate = delegate
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+private final class PluginSettingsWindowDelegate: NSObject, NSWindowDelegate {
+    private let pluginId: String
+    private let onClose: (String) -> Void
+
+    init(pluginId: String, onClose: @escaping (String) -> Void) {
+        self.pluginId = pluginId
+        self.onClose = onClose
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onClose(pluginId)
+    }
+}
 
 struct PluginSettingsView: View {
     @ObservedObject private var pluginManager = PluginManager.shared
@@ -359,7 +425,9 @@ private struct InstalledPluginRow: View {
     let registryPlugin: RegistryPlugin?
     let onUpdate: () -> Void
     let onUninstall: () -> Void
-    @State private var showSettings = false
+    @State private var pluginActivity: PluginSettingsActivity?
+
+    private let activityTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
     private var isCloud: Bool {
         registryPlugin?.requiresAPIKey == true || plugin.manifest.requiresAPIKey == true
@@ -449,6 +517,8 @@ private struct InstalledPluginRow: View {
                     onUpdate()
                 }
                 .controlSize(.small)
+            } else if let pluginActivity {
+                PluginSettingsActivityView(activity: pluginActivity)
             }
 
             if !plugin.isBundled {
@@ -465,7 +535,7 @@ private struct InstalledPluginRow: View {
 
             if plugin.instance.settingsView != nil {
                 Button {
-                    showSettings = true
+                    PluginSettingsWindowManager.shared.present(plugin)
                 } label: {
                     Image(systemName: "gear")
                 }
@@ -482,32 +552,16 @@ private struct InstalledPluginRow: View {
             .labelsHidden()
             .accessibilityLabel(String(localized: "Enable \(plugin.manifest.name)"))
         }
-        .sheet(isPresented: $showSettings) {
-            if let view = plugin.instance.settingsView {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Text(plugin.manifest.name)
-                            .font(.headline)
-                        Spacer()
-                        Button {
-                            showSettings = false
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
-                                .font(.title2)
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                    .padding()
-
-                    Divider()
-
-                    view
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                }
-                .frame(minWidth: 500, minHeight: 400)
-            }
+        .onAppear {
+            refreshPluginActivity()
         }
+        .onReceive(activityTimer) { _ in
+            refreshPluginActivity()
+        }
+    }
+
+    private func refreshPluginActivity() {
+        pluginActivity = (plugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
     }
 }
 
@@ -589,6 +643,42 @@ struct AvailablePluginRow: View {
                 }
                 .controlSize(.small)
                 .accessibilityLabel(String(localized: "Install \(plugin.name)"))
+            }
+        }
+    }
+}
+
+private struct PluginSettingsActivityView: View {
+    let activity: PluginSettingsActivity
+
+    var body: some View {
+        if let progress = activity.progress {
+            HStack(spacing: 6) {
+                ProgressView(value: progress)
+                    .frame(width: 80)
+                Text("\(Int(progress * 100))%")
+                    .font(.caption)
+                    .foregroundStyle(activity.isError ? .red : .secondary)
+                    .monospacedDigit()
+                    .frame(width: 32, alignment: .trailing)
+                Text(activity.message)
+                    .font(.caption)
+                    .foregroundStyle(activity.isError ? .red : .secondary)
+                    .lineLimit(1)
+            }
+        } else {
+            HStack(spacing: 6) {
+                if activity.isError {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                Text(activity.message)
+                    .font(.caption)
+                    .foregroundStyle(activity.isError ? .red : .secondary)
+                    .lineLimit(1)
             }
         }
     }

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -18,18 +18,20 @@ final class PluginSettingsWindowManager {
             return
         }
 
-        let hostingView = NSHostingView(
-            rootView: settingsView
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        )
-        hostingView.sizingOptions = []
-
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 560, height: 440),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
+        let hostingView = NSHostingView(
+            rootView: settingsView
+                .environment(\.pluginSettingsClose, { [weak window] in
+                    window?.close()
+                })
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        )
+        hostingView.sizingOptions = []
         window.title = plugin.manifest.name
         window.contentMinSize = NSSize(width: 500, height: 400)
         window.isReleasedWhenClosed = false

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -817,11 +817,12 @@ struct SetupWizardView: View {
 
 private struct RecommendationSettingsButton: View {
     let manifestId: String
-    @State private var showSettings = false
 
     var body: some View {
         Button {
-            showSettings = true
+            if let loaded = PluginManager.shared.loadedPlugins.first(where: { $0.manifest.id == manifestId }) {
+                PluginSettingsWindowManager.shared.present(loaded)
+            }
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: "gear")
@@ -831,33 +832,6 @@ private struct RecommendationSettingsButton: View {
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .sheet(isPresented: $showSettings) {
-            if let loaded = PluginManager.shared.loadedPlugins.first(where: { $0.manifest.id == manifestId }),
-               let view = loaded.instance.settingsView {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Text(loaded.manifest.name)
-                            .font(.headline)
-                        Spacer()
-                        Button {
-                            showSettings = false
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
-                                .font(.title2)
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                    .padding()
-
-                    Divider()
-
-                    view
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                }
-                .frame(minWidth: 500, minHeight: 400)
-            }
-        }
     }
 }
 
@@ -866,7 +840,6 @@ private struct RecommendationSettingsButton: View {
 private struct SetupEngineRow: View {
     let engine: any TranscriptionEnginePlugin
     @ObservedObject private var pluginManager = PluginManager.shared
-    @State private var showSettings = false
 
     var body: some View {
         HStack {
@@ -902,7 +875,7 @@ private struct SetupEngineRow: View {
                 ($0.instance as? any TranscriptionEnginePlugin)?.providerId == engine.providerId
             }), loaded.instance.settingsView != nil {
                 Button {
-                    showSettings = true
+                    PluginSettingsWindowManager.shared.present(loaded)
                 } label: {
                     Image(systemName: "gear")
                 }
@@ -911,33 +884,5 @@ private struct SetupEngineRow: View {
         }
         .padding(10)
         .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
-        .sheet(isPresented: $showSettings) {
-            if let loaded = PluginManager.shared.loadedPlugins.first(where: {
-                ($0.instance as? any TranscriptionEnginePlugin)?.providerId == engine.providerId
-            }), let view = loaded.instance.settingsView {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Text(loaded.manifest.name)
-                            .font(.headline)
-                        Spacer()
-                        Button {
-                            showSettings = false
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
-                                .font(.title2)
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                    .padding()
-
-                    Divider()
-
-                    view
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                }
-                .frame(minWidth: 500, minHeight: 400)
-            }
-        }
     }
 }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -39,6 +39,19 @@ public extension PluginSettingsActivityReporting {
     var currentSettingsActivity: PluginSettingsActivity? { nil }
 }
 
+// MARK: - Settings Window Environment
+
+private struct PluginSettingsCloseActionKey: EnvironmentKey {
+    static let defaultValue: (@MainActor @Sendable () -> Void)? = nil
+}
+
+public extension EnvironmentValues {
+    var pluginSettingsClose: (@MainActor @Sendable () -> Void)? {
+        get { self[PluginSettingsCloseActionKey.self] }
+        set { self[PluginSettingsCloseActionKey.self] = newValue }
+    }
+}
+
 // MARK: - LLM Provider Plugin
 
 public final class PluginModelInfo: @unchecked Sendable {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -17,6 +17,28 @@ public extension TypeWhisperPlugin {
     var settingsView: AnyView? { nil }
 }
 
+// MARK: - Shared Settings Activity
+
+public struct PluginSettingsActivity: Sendable, Equatable {
+    public let message: String
+    public let progress: Double?
+    public let isError: Bool
+
+    public init(message: String, progress: Double? = nil, isError: Bool = false) {
+        self.message = message
+        self.progress = progress
+        self.isError = isError
+    }
+}
+
+public protocol PluginSettingsActivityReporting: TypeWhisperPlugin {
+    var currentSettingsActivity: PluginSettingsActivity? { get }
+}
+
+public extension PluginSettingsActivityReporting {
+    var currentSettingsActivity: PluginSettingsActivity? { nil }
+}
+
 // MARK: - LLM Provider Plugin
 
 public final class PluginModelInfo: @unchecked Sendable {


### PR DESCRIPTION
## Summary

- Open plugin settings in non-modal windows so model downloads no longer block the rest of Settings.
- Add a shared plugin activity reporting API and surface download/loading/error state inline for WhisperKit, Parakeet, Qwen3, Granite, and Apple Speech.
- Reuse the same non-modal settings presentation in the setup wizard so engine setup stays navigable during long downloads.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features
- [x] Built with xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug build CODE_SIGNING_ALLOWED=NO
