### PR TITLE
Add configurable sound feedback settings

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
 		6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
+		6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */; };
 		76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */; };
 		7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */; };
 		7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */; };
@@ -319,6 +320,7 @@
 /* Begin PBXFileReference section */
 		05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDiffServiceTests.swift; sourceTree = "<group>"; };
 		3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
+		7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoundServiceTests.swift; sourceTree = "<group>"; };
 		8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPRequestParserTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000001 /* TypeWhisperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeWhisperApp.swift; sourceTree = "<group>"; };
 		BB00000000000000000002 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
@@ -1441,6 +1443,7 @@
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				F41BD305007A3A158038C75C /* ProfileServiceTests.swift */,
+				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
 				05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */,
@@ -2431,6 +2434,7 @@
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
+				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,
 				A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */,
 				204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */,
 				76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */,

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -7,6 +7,9 @@ enum UserDefaultsKeys {
     static let audioDuckingEnabled = "audioDuckingEnabled"
     static let audioDuckingLevel = "audioDuckingLevel"
     static let soundFeedbackEnabled = "soundFeedbackEnabled"
+    static let soundRecordingStarted = "soundRecordingStarted"
+    static let soundTranscriptionSuccess = "soundTranscriptionSuccess"
+    static let soundError = "soundError"
     static let indicatorStyle = "indicatorStyle"
     static let preserveClipboard = "preserveClipboard"
 

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -5911,6 +5911,66 @@
           }
         }
       }
+    },
+    "Recording Start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmestart"
+          }
+        }
+      }
+    },
+    "Transcription Success": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription erfolgreich"
+          }
+        }
+      }
+    },
+    "Transcription success": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription erfolgreich"
+          }
+        }
+      }
+    },
+    "Preview sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sound abspielen"
+          }
+        }
+      }
+    },
+    "Add custom sound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigenen Sound hinzufuegen"
+          }
+        }
+      }
+    },
+    "Choose a sound file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sounddatei auswaehlen"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/TypeWhisper/Services/SoundService.swift
+++ b/TypeWhisper/Services/SoundService.swift
@@ -1,6 +1,82 @@
 import AppKit
+import UniformTypeIdentifiers
 
-enum SoundEvent {
+enum SoundChoice: Hashable, Sendable {
+    case bundled(String)
+    case system(String)
+    case custom(String)
+    case none
+
+    var storageKey: String {
+        switch self {
+        case .bundled(let name): return "bundled:\(name)"
+        case .system(let name): return "system:\(name)"
+        case .custom(let name): return "custom:\(name)"
+        case .none: return "none"
+        }
+    }
+
+    init(storageKey: String) {
+        if storageKey == "none" {
+            self = .none
+        } else if storageKey.hasPrefix("bundled:") {
+            self = .bundled(String(storageKey.dropFirst(8)))
+        } else if storageKey.hasPrefix("system:") {
+            self = .system(String(storageKey.dropFirst(7)))
+        } else if storageKey.hasPrefix("custom:") {
+            self = .custom(String(storageKey.dropFirst(7)))
+        } else {
+            self = .none
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .bundled(let name):
+            return Self.bundledSounds.first(where: { $0.name == name })?.displayName ?? name
+        case .system(let name):
+            return name
+        case .custom(let name):
+            return name
+        case .none:
+            return String(localized: "None")
+        }
+    }
+
+    static let systemSounds: [String] = [
+        "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass",
+        "Hero", "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink"
+    ]
+
+    static let bundledSounds: [(name: String, displayName: String)] = [
+        ("recording_start", String(localized: "Recording Start")),
+        ("transcription_success", String(localized: "Transcription Success")),
+        ("error", String(localized: "Error"))
+    ]
+
+    static var customSoundsDirectory: URL {
+        AppConstants.appSupportDirectory.appendingPathComponent("Sounds", isDirectory: true)
+    }
+
+    static func installedCustomSounds() -> [String] {
+        let dir = customSoundsDirectory
+        guard let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        let audioExtensions: Set<String> = ["wav", "aiff", "aif", "mp3", "m4a", "caf"]
+        return contents
+            .filter { audioExtensions.contains($0.pathExtension.lowercased()) }
+            .map { $0.lastPathComponent }
+            .sorted()
+    }
+
+    static let allowedContentTypes: [UTType] = [
+        .wav, .aiff, .mp3, .mpeg4Audio,
+        UTType(filenameExtension: "caf") ?? .audio
+    ]
+}
+
+enum SoundEvent: CaseIterable {
     case recordingStarted
     case transcriptionSuccess
     case error
@@ -12,28 +88,129 @@ enum SoundEvent {
         case .error: return "error"
         }
     }
+
+    var defaultChoice: SoundChoice {
+        .bundled(fileName)
+    }
+
+    var userDefaultsKey: String {
+        switch self {
+        case .recordingStarted: return UserDefaultsKeys.soundRecordingStarted
+        case .transcriptionSuccess: return UserDefaultsKeys.soundTranscriptionSuccess
+        case .error: return UserDefaultsKeys.soundError
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .recordingStarted: return String(localized: "Recording started")
+        case .transcriptionSuccess: return String(localized: "Transcription success")
+        case .error: return String(localized: "Error")
+        }
+    }
 }
 
 @MainActor
 class SoundService {
     private var sounds: [SoundEvent: NSSound] = [:]
+    private var choices: [SoundEvent: SoundChoice] = [:]
+    private var resolvedSounds: [SoundChoice: NSSound] = [:]
+    private var previewSound: NSSound?
 
     init() {
         preloadSounds()
+        loadChoices()
     }
 
     func play(_ event: SoundEvent, enabled: Bool) {
         guard enabled else { return }
-        if let sound = sounds[event] {
-            sound.stop()
-            sound.play()
+        let choice = choices[event] ?? event.defaultChoice
+        guard let sound = sound(for: choice) else { return }
+        sound.stop()
+        sound.play()
+    }
+
+    func choice(for event: SoundEvent) -> SoundChoice {
+        choices[event] ?? event.defaultChoice
+    }
+
+    func updateChoice(for event: SoundEvent, choice: SoundChoice) {
+        choices[event] = choice
+        UserDefaults.standard.set(choice.storageKey, forKey: event.userDefaultsKey)
+    }
+
+    func preview(_ choice: SoundChoice) {
+        previewSound?.stop()
+        guard let sound = sound(for: choice) else { return }
+        previewSound = sound
+        sound.play()
+    }
+
+    func importCustomSound(from sourceURL: URL) throws -> String {
+        let dir = SoundChoice.customSoundsDirectory
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let filename = sourceURL.lastPathComponent
+        let destination = dir.appendingPathComponent(filename)
+        resolvedSounds[.custom(filename)] = nil
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.copyItem(at: sourceURL, to: destination)
+        return filename
+    }
+
+    func deleteCustomSound(_ filename: String) {
+        let path = SoundChoice.customSoundsDirectory.appendingPathComponent(filename)
+        try? FileManager.default.removeItem(at: path)
+        resolvedSounds[.custom(filename)] = nil
+        for event in SoundEvent.allCases {
+            if choices[event] == .custom(filename) {
+                updateChoice(for: event, choice: event.defaultChoice)
+            }
         }
     }
 
+    func sound(for choice: SoundChoice) -> NSSound? {
+        if let sound = resolvedSounds[choice] {
+            return sound
+        }
+
+        let sound: NSSound?
+        switch choice {
+        case .bundled(let name):
+            if let event = SoundEvent.allCases.first(where: { $0.fileName == name }) {
+                sound = sounds[event]
+            } else {
+                guard let url = Bundle.main.url(forResource: name, withExtension: "wav") else { return nil }
+                sound = NSSound(contentsOf: url, byReference: true)
+            }
+        case .system(let name):
+            sound = NSSound(named: NSSound.Name(name))
+        case .custom(let filename):
+            let url = SoundChoice.customSoundsDirectory.appendingPathComponent(filename)
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            sound = NSSound(contentsOf: url, byReference: true)
+        case .none:
+            return nil
+        }
+
+        guard let sound else { return nil }
+        resolvedSounds[choice] = sound
+        return sound
+    }
+
     private func preloadSounds() {
-        for event in [SoundEvent.recordingStarted, .transcriptionSuccess, .error] {
+        for event in SoundEvent.allCases {
             if let url = Bundle.main.url(forResource: event.fileName, withExtension: "wav") {
                 sounds[event] = NSSound(contentsOf: url, byReference: true)
+            }
+        }
+    }
+
+    private func loadChoices() {
+        for event in SoundEvent.allCases {
+            if let key = UserDefaults.standard.string(forKey: event.userDefaultsKey) {
+                choices[event] = SoundChoice(storageKey: key)
             }
         }
     }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -159,6 +159,8 @@ struct RecordingSettingsView: View {
     @ObservedObject private var pluginManager = PluginManager.shared
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
     @State private var selectedProvider: String?
+    @State private var customSounds: [String] = SoundChoice.installedCustomSounds()
+    private let soundService = ServiceContainer.shared.soundService
 
     private var needsPermissions: Bool {
         dictation.needsMicPermission || dictation.needsAccessibilityPermission
@@ -279,6 +281,12 @@ struct RecordingSettingsView: View {
             Section(String(localized: "Sound")) {
                 Toggle(String(localized: "Play sound feedback"), isOn: $dictation.soundFeedbackEnabled)
 
+                if dictation.soundFeedbackEnabled {
+                    SoundEventPicker(event: .recordingStarted, soundService: soundService, customSounds: $customSounds)
+                    SoundEventPicker(event: .transcriptionSuccess, soundService: soundService, customSounds: $customSounds)
+                    SoundEventPicker(event: .error, soundService: soundService, customSounds: $customSounds)
+                }
+
                 Text(String(localized: "Plays a sound when recording starts and when transcription completes."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -367,9 +375,93 @@ struct RecordingSettingsView: View {
         .frame(minWidth: 500, minHeight: 300)
         .onAppear {
             selectedProvider = modelManager.selectedProviderId
+            customSounds = SoundChoice.installedCustomSounds()
         }
     }
 
+}
+
+// MARK: - Sound Event Picker
+
+private struct SoundEventPicker: View {
+    let event: SoundEvent
+    let soundService: SoundService
+    @Binding var customSounds: [String]
+    @State private var selection: String
+
+    init(event: SoundEvent, soundService: SoundService, customSounds: Binding<[String]>) {
+        self.event = event
+        self.soundService = soundService
+        self._customSounds = customSounds
+        self._selection = State(initialValue: soundService.choice(for: event).storageKey)
+    }
+
+    var body: some View {
+        HStack {
+            Picker(event.displayName, selection: $selection) {
+                Text(String(localized: "Default")).tag(event.defaultChoice.storageKey)
+
+                Divider()
+
+                ForEach(SoundChoice.bundledSounds, id: \.name) { sound in
+                    Text(sound.displayName).tag(SoundChoice.bundled(sound.name).storageKey)
+                }
+
+                if !customSounds.isEmpty {
+                    Divider()
+                    ForEach(customSounds, id: \.self) { name in
+                        Text(name).tag(SoundChoice.custom(name).storageKey)
+                    }
+                }
+
+                Divider()
+
+                ForEach(SoundChoice.systemSounds, id: \.self) { name in
+                    Text(name).tag(SoundChoice.system(name).storageKey)
+                }
+
+                Divider()
+
+                Text(String(localized: "None")).tag(SoundChoice.none.storageKey)
+            }
+            .onChange(of: selection) { _, newValue in
+                let choice = SoundChoice(storageKey: newValue)
+                soundService.updateChoice(for: event, choice: choice)
+                soundService.preview(choice)
+            }
+
+            Button {
+                soundService.preview(SoundChoice(storageKey: selection))
+            } label: {
+                Image(systemName: "speaker.wave.2")
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Preview sound"))
+
+            Button {
+                importCustomSound()
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "Add custom sound"))
+        }
+    }
+
+    private func importCustomSound() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = SoundChoice.allowedContentTypes
+        panel.allowsMultipleSelection = false
+        panel.message = String(localized: "Choose a sound file")
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let filename = try soundService.importCustomSound(from: url)
+            customSounds = SoundChoice.installedCustomSounds()
+            selection = SoundChoice.custom(filename).storageKey
+        } catch {
+            // File copy failed - silently ignore
+        }
+    }
 }
 
 // MARK: - Permissions Banner
@@ -417,4 +509,3 @@ struct PermissionsBanner: View {
         }
     }
 }
-

--- a/TypeWhisperTests/SoundServiceTests.swift
+++ b/TypeWhisperTests/SoundServiceTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import TypeWhisper
+
+final class SoundServiceTests: XCTestCase {
+    @MainActor
+    func testSoundResolutionCachesImportedCustomSounds() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let storedDefaults = captureSoundDefaults()
+        defer {
+            restoreSoundDefaults(storedDefaults)
+            AppConstants.testAppSupportDirectoryOverride = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        AppConstants.testAppSupportDirectoryOverride = appSupportDirectory
+
+        let service = SoundService()
+        let filename = try service.importCustomSound(from: testSoundURL)
+
+        let firstSound = try XCTUnwrap(service.sound(for: .custom(filename)))
+        let secondSound = try XCTUnwrap(service.sound(for: .custom(filename)))
+
+        XCTAssertTrue(firstSound === secondSound)
+        XCTAssertEqual(SoundChoice.installedCustomSounds(), [filename])
+    }
+
+    @MainActor
+    func testDeletingCustomSoundResetsAffectedEventChoices() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let storedDefaults = captureSoundDefaults()
+        defer {
+            restoreSoundDefaults(storedDefaults)
+            AppConstants.testAppSupportDirectoryOverride = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        AppConstants.testAppSupportDirectoryOverride = appSupportDirectory
+
+        let service = SoundService()
+        let filename = try service.importCustomSound(from: testSoundURL)
+
+        service.updateChoice(for: .recordingStarted, choice: .custom(filename))
+        service.updateChoice(for: .error, choice: .custom(filename))
+        service.updateChoice(for: .transcriptionSuccess, choice: .system("Ping"))
+
+        service.deleteCustomSound(filename)
+
+        XCTAssertEqual(service.choice(for: .recordingStarted), .bundled("recording_start"))
+        XCTAssertEqual(service.choice(for: .error), .bundled("error"))
+        XCTAssertEqual(service.choice(for: .transcriptionSuccess), .system("Ping"))
+        XCTAssertEqual(SoundChoice.installedCustomSounds(), [])
+    }
+
+    private var testSoundURL: URL {
+        TestSupport.repoRoot.appendingPathComponent("TypeWhisper/Resources/Sounds/error.wav", isDirectory: false)
+    }
+
+    private func captureSoundDefaults() -> [String: String?] {
+        [
+            UserDefaultsKeys.soundRecordingStarted: UserDefaults.standard.string(forKey: UserDefaultsKeys.soundRecordingStarted),
+            UserDefaultsKeys.soundTranscriptionSuccess: UserDefaults.standard.string(forKey: UserDefaultsKeys.soundTranscriptionSuccess),
+            UserDefaultsKeys.soundError: UserDefaults.standard.string(forKey: UserDefaultsKeys.soundError)
+        ]
+    }
+
+    private func restoreSoundDefaults(_ values: [String: String?]) {
+        for (key, value) in values {
+            if let value {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add per-event sound feedback pickers for recording start, transcription success, and errors
- support bundled, system, custom imported, and no-sound choices with persisted user defaults
- fix custom sound playback retention and keep imported custom sounds in sync across all pickers
- add localized strings and unit tests for custom sound caching and deletion behavior

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -sdk macosx build`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' test -only-testing:TypeWhisperTests/SoundServiceTests`