### PR TITLE
Record mic and system audio on separate tracks

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -84,6 +84,7 @@ enum UserDefaultsKeys {
     static let recorderOutputFormat = "recorderOutputFormat"
     static let recorderTranscriptionEnabled = "recorderTranscriptionEnabled"
     static let recorderMicDuckingMode = "recorderMicDuckingMode"
+    static let recorderTrackMode = "recorderTrackMode"
     static let showRecorderTab = "showRecorderTab"
 
     // MARK: - Watch Folder

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -3524,6 +3524,22 @@
         }
       }
     },
+    "recorder.trackMode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spur-Modus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Track Mode"
+          }
+        }
+      }
+    },
     "recorder.mic": {
       "localizations": {
         "de": {
@@ -3664,6 +3680,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "System audio capture requires Screen Recording permission."
+          }
+        }
+      }
+    },
+    "trackMode.mixed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemischt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mixed"
+          }
+        }
+      }
+    },
+    "trackMode.separate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Getrennt (Mic L / System R)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separate (Mic L / System R)"
           }
         }
       }

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -112,6 +112,20 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         var fileExtension: String { rawValue }
     }
 
+    enum TrackMode: String, CaseIterable, Sendable {
+        case mixed
+        case separate
+
+        var displayName: String {
+            switch self {
+            case .mixed:
+                return String(localized: "trackMode.mixed")
+            case .separate:
+                return String(localized: "trackMode.separate")
+            }
+        }
+    }
+
     enum MicDuckingMode: String, CaseIterable, Sendable {
         case aggressive
         case medium
@@ -148,6 +162,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     private var outputFormat: OutputFormat = .wav
     private var micEnabled = false
     private var systemAudioEnabled = false
+    var trackMode: TrackMode = .mixed
     var micDuckingMode: MicDuckingMode = .aggressive
 
     // 16kHz mono buffer for streaming transcription
@@ -563,10 +578,10 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let micBuffer = try readAndConvert(file: micFile, to: mixFormat, totalFrames: totalFrames)
         let sysBuffer = try readAndConvert(file: sysFile, to: mixFormat, totalFrames: totalFrames)
 
-        let systemLeft = sysBuffer.floatChannelData?[0]
-        let systemRight = sysBuffer.format.channelCount > 1 ? sysBuffer.floatChannelData?[1] : nil
         let micDuckingProfile: MicDuckingProfile?
-        if let systemLeft {
+        if trackMode == .mixed,
+           let systemLeft = sysBuffer.floatChannelData?[0] {
+            let systemRight = sysBuffer.format.channelCount > 1 ? sysBuffer.floatChannelData?[1] : nil
             micDuckingProfile = Self.buildMicDuckingProfile(
                 frameCount: Int(totalFrames),
                 sampleRate: targetSampleRate,
@@ -586,16 +601,38 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         guard let mixedBuffer = AVAudioPCMBuffer(pcmFormat: mixFormat, frameCapacity: totalFrames) else { return }
         mixedBuffer.frameLength = totalFrames
 
-        for ch in 0..<Int(targetChannels) {
-            guard let mixedData = mixedBuffer.floatChannelData?[ch],
-                  let micData = micBuffer.floatChannelData?[ch],
-                  let sysData = sysBuffer.floatChannelData?[ch] else { continue }
+        if trackMode == .separate {
+            guard let leftData = mixedBuffer.floatChannelData?[0],
+                  let rightData = mixedBuffer.floatChannelData?[1],
+                  let micLeft = micBuffer.floatChannelData?[0],
+                  let systemLeft = sysBuffer.floatChannelData?[0] else { return }
+
+            let micRight = micBuffer.format.channelCount > 1 ? micBuffer.floatChannelData?[1] : nil
+            let systemRight = sysBuffer.format.channelCount > 1 ? sysBuffer.floatChannelData?[1] : nil
 
             for i in 0..<Int(totalFrames) {
-                let micSample = i < Int(micBuffer.frameLength) ? micData[i] : 0
-                let sysSample = i < Int(sysBuffer.frameLength) ? sysData[i] : 0
-                let micGain = micDuckingProfile?.gains[i] ?? 1
-                mixedData[i] = (micSample * micGain) + sysSample
+                leftData[i] = i < Int(micBuffer.frameLength)
+                    ? monoSample(left: micLeft, right: micRight, index: i)
+                    : 0
+            }
+
+            for i in 0..<Int(totalFrames) {
+                rightData[i] = i < Int(sysBuffer.frameLength)
+                    ? monoSample(left: systemLeft, right: systemRight, index: i)
+                    : 0
+            }
+        } else {
+            for ch in 0..<Int(targetChannels) {
+                guard let mixedData = mixedBuffer.floatChannelData?[ch],
+                      let micData = micBuffer.floatChannelData?[ch],
+                      let sysData = sysBuffer.floatChannelData?[ch] else { continue }
+
+                for i in 0..<Int(totalFrames) {
+                    let micSample = i < Int(micBuffer.frameLength) ? micData[i] : 0
+                    let sysSample = i < Int(sysBuffer.frameLength) ? sysData[i] : 0
+                    let micGain = micDuckingProfile?.gains[i] ?? 1
+                    mixedData[i] = (micSample * micGain) + sysSample
+                }
             }
         }
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -60,6 +60,12 @@ final class AudioRecorderViewModel: ObservableObject {
             recorderService.micDuckingMode = micDuckingMode
         }
     }
+    @Published var trackMode: AudioRecorderService.TrackMode {
+        didSet {
+            UserDefaults.standard.set(trackMode.rawValue, forKey: UserDefaultsKeys.recorderTrackMode)
+            recorderService.trackMode = trackMode
+        }
+    }
     @Published var transcriptionEnabled: Bool {
         didSet { UserDefaults.standard.set(transcriptionEnabled, forKey: UserDefaultsKeys.recorderTranscriptionEnabled) }
     }
@@ -111,6 +117,13 @@ final class AudioRecorderViewModel: ObservableObject {
             self.micDuckingMode = .aggressive
         }
 
+        if let modeString = defaults.string(forKey: UserDefaultsKeys.recorderTrackMode),
+           let mode = AudioRecorderService.TrackMode(rawValue: modeString) {
+            self.trackMode = mode
+        } else {
+            self.trackMode = .mixed
+        }
+
         if defaults.object(forKey: UserDefaultsKeys.recorderTranscriptionEnabled) == nil {
             self.transcriptionEnabled = true
         } else {
@@ -118,6 +131,7 @@ final class AudioRecorderViewModel: ObservableObject {
         }
 
         recorderService.micDuckingMode = micDuckingMode
+        recorderService.trackMode = trackMode
 
         setupBindings()
         loadRecordings()

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -108,12 +108,26 @@ struct AudioRecorderView: View {
                 }
                 .disabled(isEditingLocked)
 
+                if viewModel.micEnabled && viewModel.systemAudioEnabled {
+                    Picker(String(localized: "recorder.trackMode"), selection: $viewModel.trackMode) {
+                        ForEach(AudioRecorderService.TrackMode.allCases, id: \.self) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .disabled(isEditingLocked)
+                }
+
                 Picker(String(localized: "Echo Handling"), selection: $viewModel.micDuckingMode) {
                     ForEach(AudioRecorderService.MicDuckingMode.allCases, id: \.self) { mode in
                         Text(mode.displayName).tag(mode)
                     }
                 }
-                .disabled(isEditingLocked || !viewModel.micEnabled || !viewModel.systemAudioEnabled)
+                .disabled(
+                    isEditingLocked
+                    || !viewModel.micEnabled
+                    || !viewModel.systemAudioEnabled
+                    || viewModel.trackMode == .separate
+                )
 
                 Text(String(localized: "Affects only TypeWhisper recordings and transcriptions, not your live meeting microphone."))
                     .font(.caption)


### PR DESCRIPTION
## Summary

- Fixes #141
- add a recorder track mode to save microphone audio on the left channel and system audio on the right channel
- persist the selected mode, disable echo handling in separate mode, and localize the new recorder labels

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [ ] No regressions in existing features
