### PR TITLE
Add Prompts & AI wizard step and cross-tab navigation, fixes #135

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -2047,16 +2047,6 @@
         }
       }
     },
-    "Install an LLM provider plugin (e.g. Groq, OpenAI) from the Integrations tab to use prompts.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Installiere ein LLM-Anbieter-Plugin (z.B. Groq, OpenAI) im Reiter \"Integrationen\", um Prompts zu verwenden."
-          }
-        }
-      }
-    },
     "Install Command Line Tool": {
       "localizations": {
         "de": {
@@ -4127,7 +4117,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stellt die Zwischenablage nach dem Einf\u00FCgen wieder her. Ohne diese Option enth\u00E4lt die Zwischenablage nach dem Diktieren den transkribierten Text."
+            "value": "Stellt die Zwischenablage nach dem Einfügen wieder her. Ohne diese Option enthält die Zwischenablage nach dem Diktieren den transkribierten Text."
           }
         }
       }
@@ -6026,12 +6016,12 @@
     "Active profile": {},
     "Current shortcut: %@. Click to change.": {},
     "Uninstall %@": {},
-    "\u00A9 2024-2026 TypeWhisper Contributors": {
+    "© 2024-2026 TypeWhisper Contributors": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "\u00A9 2024-2026 TypeWhisper Contributors"
+            "value": "© 2024-2026 TypeWhisper Contributors"
           }
         }
       }
@@ -6092,6 +6082,186 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sounddatei auswaehlen"
+          }
+        }
+      }
+    },
+    "Prompts & AI": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompts & KI"
+          }
+        }
+      }
+    },
+    "Process your dictated text with AI - translate, reformat, summarize, and more.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verarbeite diktierten Text mit KI - übersetzen, formatieren, zusammenfassen und mehr."
+          }
+        }
+      }
+    },
+    "You have an LLM provider ready.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein LLM-Anbieter ist bereit."
+          }
+        }
+      }
+    },
+    "Already Installed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereits installiert"
+          }
+        }
+      }
+    },
+    "Free API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kostenloser API-Key"
+          }
+        }
+      }
+    },
+    "Groq is already installed and also works as an LLM provider.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Groq ist bereits installiert und funktioniert auch als LLM-Anbieter."
+          }
+        }
+      }
+    },
+    "Fast cloud AI. Also supports transcription. Requires a free API key.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnelle Cloud-KI. Unterstützt auch Transkription. Benötigt einen kostenlosen API-Key."
+          }
+        }
+      }
+    },
+    "Also Available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ebenfalls verfügbar"
+          }
+        }
+      }
+    },
+    "API key required": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Key erforderlich"
+          }
+        }
+      }
+    },
+    "Prompt Presets": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prompt-Vorlagen"
+          }
+        }
+      }
+    },
+    "Built-in prompts for common tasks like translation, email drafting, and formatting.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingebaute Prompts für häufige Aufgaben wie Übersetzung, E-Mail-Entwurf und Formatierung."
+          }
+        }
+      }
+    },
+    "All imported": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle importiert"
+          }
+        }
+      }
+    },
+    "Import Presets": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlagen importieren"
+          }
+        }
+      }
+    },
+    "You can manage prompts and install more providers in the Prompts and Integrations tabs after setup.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du kannst Prompts verwalten und weitere Anbieter im Prompts- und Integrations-Tab nach dem Setup installieren."
+          }
+        }
+      }
+    },
+    "On-device AI processing. No API key needed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-Verarbeitung auf dem Gerät. Kein API-Key nötig."
+          }
+        }
+      }
+    },
+    "Enable in System Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Systemeinstellungen aktivieren"
+          }
+        }
+      }
+    },
+    "Go to Integrations": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zu Integrationen"
+          }
+        }
+      }
+    },
+    "Install an LLM provider plugin (e.g. Groq, OpenAI) to use prompts.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installiere ein LLM-Provider-Plugin (z.B. Groq, OpenAI) um Prompts zu nutzen."
           }
         }
       }

--- a/TypeWhisper/ViewModels/PromptActionsViewModel.swift
+++ b/TypeWhisper/ViewModels/PromptActionsViewModel.swift
@@ -13,6 +13,7 @@ class PromptActionsViewModel: ObservableObject {
 
     @Published var promptActions: [PromptAction] = []
     @Published var error: String?
+    @Published var navigateToIntegrations = false
 
     // Editor state
     @Published var isEditing = false

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -79,10 +79,15 @@ struct PromptActionsSettingsView: View {
                     Image(systemName: "puzzlepiece.extension")
                         .font(.system(size: 24))
                         .foregroundStyle(.secondary)
-                    Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) from the Integrations tab to use prompts."))
+                    Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) to use prompts."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
+                    Button(String(localized: "Go to Integrations")) {
+                        viewModel.navigateToIntegrations = true
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
@@ -102,16 +107,21 @@ struct PromptActionsSettingsView: View {
                     ProviderStatusView(
                         providerId: processingService.selectedProviderId,
                         processingService: processingService,
-                        cloudModel: $processingService.selectedCloudModel
+                        cloudModel: $processingService.selectedCloudModel,
+                        onNavigateToIntegrations: { viewModel.navigateToIntegrations = true }
                     )
 
                     if PluginManager.shared.llmProviders.isEmpty {
-                        Label(
-                            String(localized: "Install additional LLM providers from the Integrations tab."),
-                            systemImage: "info.circle"
-                        )
+                        Button {
+                            viewModel.navigateToIntegrations = true
+                        } label: {
+                            Label(
+                                String(localized: "Install additional LLM providers from the Integrations tab."),
+                                systemImage: "info.circle"
+                            )
+                        }
+                        .buttonStyle(.link)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -187,6 +197,7 @@ struct ProviderStatusView: View {
     let providerId: String
     let processingService: PromptProcessingService
     var cloudModel: Binding<String>?
+    var onNavigateToIntegrations: (() -> Void)? = nil
 
     var body: some View {
         if providerId == PromptProcessingService.appleIntelligenceId {
@@ -204,6 +215,15 @@ struct ProviderStatusView: View {
                 Label(String(localized: "API key configured"), systemImage: "checkmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(.green)
+            } else if let onNavigateToIntegrations {
+                Button {
+                    onNavigateToIntegrations()
+                } label: {
+                    Label(String(localized: "API key required - configure in Integrations tab"), systemImage: "exclamationmark.triangle.fill")
+                }
+                .buttonStyle(.link)
+                .font(.caption)
+                .foregroundStyle(.orange)
             } else {
                 Label(String(localized: "API key required - configure in Integrations tab"), systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
@@ -411,10 +431,15 @@ private struct PromptActionEditorSheet: View {
                                 Image(systemName: "puzzlepiece.extension")
                                     .font(.system(size: 20))
                                     .foregroundStyle(.secondary)
-                                Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) from the Integrations tab to use prompts."))
+                                Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) to use prompts."))
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                                     .multilineTextAlignment(.center)
+                                Button(String(localized: "Go to Integrations")) {
+                                    viewModel.navigateToIntegrations = true
+                                }
+                                .buttonStyle(.link)
+                                .font(.caption)
                             }
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 8)

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @ObservedObject private var fileTranscription = FileTranscriptionViewModel.shared
     @ObservedObject private var registryService = PluginRegistryService.shared
     @ObservedObject private var homeViewModel = HomeViewModel.shared
+    @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
     @AppStorage(UserDefaultsKeys.showRecorderTab) private var showRecorderTab = false
 
     var body: some View {
@@ -81,6 +82,12 @@ struct SettingsView: View {
             if navigate {
                 selectedTab = .history
                 homeViewModel.navigateToHistory = false
+            }
+        }
+        .onChange(of: promptActionsViewModel.navigateToIntegrations) { _, navigate in
+            if navigate {
+                selectedTab = .integrations
+                promptActionsViewModel.navigateToIntegrations = false
             }
         }
     }

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -7,6 +7,8 @@ struct SetupWizardView: View {
     @ObservedObject private var registryService = PluginRegistryService.shared
     @ObservedObject private var audioDevice = ServiceContainer.shared.audioDeviceService
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
+    @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
+    @ObservedObject private var promptProcessingService: PromptProcessingService
 
     @State private var currentStep: Int
     @State private var selectedProvider: String?
@@ -15,11 +17,12 @@ struct SetupWizardView: View {
     @State private var trialText = ""
     @FocusState private var isTrialFieldFocused: Bool
 
-    private let totalSteps = 5
+    private let totalSteps = 6
 
     init() {
         let saved = UserDefaults.standard.integer(forKey: UserDefaultsKeys.setupWizardCurrentStep)
-        _currentStep = State(initialValue: min(saved, 4))
+        _currentStep = State(initialValue: min(saved, 5))
+        _promptProcessingService = ObservedObject(wrappedValue: PromptActionsViewModel.shared.promptProcessingService)
 
         if UserDefaults.standard.data(forKey: UserDefaultsKeys.hybridHotkey) != nil {
             _selectedHotkeyMode = State(initialValue: .hybrid)
@@ -82,7 +85,8 @@ struct SetupWizardView: View {
         case 1: return String(localized: "Permissions")
         case 2: return String(localized: "Transcription Engine")
         case 3: return String(localized: "Hotkey")
-        case 4: return String(localized: "Try It Out")
+        case 4: return String(localized: "Prompts & AI")
+        case 5: return String(localized: "Try It Out")
         default: return String(localized: "Setup")
         }
     }
@@ -96,7 +100,8 @@ struct SetupWizardView: View {
             case 1: permissionsStep
             case 2: engineStep
             case 3: hotkeyStep
-            case 4: tryItOutStep
+            case 4: promptsAIStep
+            case 5: tryItOutStep
             default: EmptyView()
             }
         }
@@ -611,7 +616,265 @@ struct SetupWizardView: View {
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1))
     }
 
-    // MARK: - Step 4: Try It Out
+    // MARK: - Step 4: Prompts & AI
+
+    private var promptsAIStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(String(localized: "Process your dictated text with AI - translate, reformat, summarize, and more."))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            if hasAnyLLMProvider {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "You have an LLM provider ready."))
+                        .foregroundStyle(.secondary)
+                }
+                .font(.callout)
+            }
+
+            Text(String(localized: "Recommended"))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if #available(macOS 26, *) {
+                appleIntelligenceCard
+            }
+
+            llmProviderCard(
+                manifestId: "com.typewhisper.groq",
+                title: "Groq",
+                badge: groqAlreadyInstalled
+                    ? String(localized: "Already Installed")
+                    : String(localized: "Free API Key"),
+                description: groqAlreadyInstalled
+                    ? String(localized: "Groq is already installed and also works as an LLM provider.")
+                    : String(localized: "Fast cloud AI. Also supports transcription. Requires a free API key."),
+                systemImage: "bolt.fill"
+            )
+
+            let otherProviders = pluginManager.llmProviders
+                .filter { $0.providerName.caseInsensitiveCompare("Groq") != .orderedSame }
+            if !otherProviders.isEmpty {
+                Text(String(localized: "Also Available"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                ForEach(otherProviders, id: \.providerName) { provider in
+                    HStack {
+                        Text(provider.providerName)
+                            .font(.body.weight(.medium))
+                        Spacer()
+                        if provider.isAvailable {
+                            HStack(spacing: 4) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                Text(String(localized: "Ready"))
+                                    .font(.caption)
+                                    .foregroundStyle(.green)
+                            }
+                        } else {
+                            Text(String(localized: "API key required"))
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                    .padding(10)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
+                }
+            }
+
+            Divider()
+
+            Text(String(localized: "Prompt Presets"))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "Built-in prompts for common tasks like translation, email drafting, and formatting."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if promptActionsViewModel.availablePresets.isEmpty && !promptActionsViewModel.promptActions.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(String(localized: "All imported"))
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
+                } else {
+                    Button(String(localized: "Import Presets")) {
+                        promptActionsViewModel.loadPresets()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+            .padding(12)
+            .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
+
+            Text(String(localized: "You can manage prompts and install more providers in the Prompts and Integrations tabs after setup."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .task {
+            if registryService.fetchState == .idle {
+                await registryService.fetchRegistry()
+            }
+        }
+    }
+
+    private var hasAnyLLMProvider: Bool {
+        if #available(macOS 26, *) {
+            if promptProcessingService.isAppleIntelligenceAvailable { return true }
+        }
+        return !pluginManager.llmProviders.isEmpty
+    }
+
+    private var groqAlreadyInstalled: Bool {
+        pluginManager.loadedPlugins.contains { $0.manifest.id == "com.typewhisper.groq" }
+    }
+
+    @ViewBuilder
+    private func llmProviderCard(
+        manifestId: String,
+        title: String,
+        badge: String,
+        description: String,
+        systemImage: String
+    ) -> some View {
+        let loadedPlugin = pluginManager.loadedPlugins.first { $0.manifest.id == manifestId }
+        let isInstalled = loadedPlugin != nil
+        let llmProvider = loadedPlugin?.instance as? any LLMProviderPlugin
+        let isReady = llmProvider?.isAvailable ?? false
+        let registryPlugin = registryService.registry.first { $0.id == manifestId }
+        let installState = registryService.installStates[manifestId]
+
+        HStack(spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.title2)
+                .foregroundStyle(.blue)
+                .frame(width: 40, height: 40)
+                .background(Circle().fill(.blue.opacity(0.1)))
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.body.weight(.medium))
+
+                    Text(badge)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.blue.opacity(0.1))
+                        .foregroundStyle(.blue)
+                        .clipShape(Capsule())
+                }
+
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if isReady {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "Ready"))
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            } else if isInstalled {
+                RecommendationSettingsButton(manifestId: manifestId)
+            } else if let installState {
+                switch installState {
+                case .downloading(let progress):
+                    ProgressView(value: progress)
+                        .frame(width: 60)
+                case .extracting:
+                    ProgressView()
+                        .controlSize(.small)
+                case .error(let message):
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(1)
+                }
+            } else if let registryPlugin {
+                Button(String(localized: "Install")) {
+                    Task {
+                        await registryService.downloadAndInstall(registryPlugin)
+                        PluginManager.shared.setPluginEnabled(registryPlugin.id, enabled: true)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
+    }
+
+    @available(macOS 26, *)
+    private var appleIntelligenceCard: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "wand.and.stars")
+                .font(.title2)
+                .foregroundStyle(.blue)
+                .frame(width: 40, height: 40)
+                .background(Circle().fill(.blue.opacity(0.1)))
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text("Apple Intelligence")
+                        .font(.body.weight(.medium))
+
+                    Text(String(localized: "Built-in"))
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.blue.opacity(0.1))
+                        .foregroundStyle(.blue)
+                        .clipShape(Capsule())
+                }
+
+                Text(String(localized: "On-device AI processing. No API key needed."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if promptProcessingService.isAppleIntelligenceAvailable {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "Ready"))
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            } else {
+                Text(String(localized: "Enable in System Settings"))
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
+    }
+
+    // MARK: - Step 5: Try It Out
 
     private var tryItOutStep: some View {
         VStack(spacing: 20) {
@@ -718,10 +981,10 @@ struct SetupWizardView: View {
 
     private var navigation: some View {
         HStack {
-            if currentStep == 4 && trialSuccess {
+            if currentStep == 5 && trialSuccess {
                 Spacer()
             } else {
-                Button(currentStep == 4
+                Button(currentStep == 5
                     ? String(localized: "I'll try later")
                     : String(localized: "Skip Setup")
                 ) {
@@ -734,7 +997,7 @@ struct SetupWizardView: View {
                 Spacer()
             }
 
-            if currentStep == 4 {
+            if currentStep == 5 {
                 if trialSuccess {
                     Button(String(localized: "Try Again")) {
                         trialSuccess = false
@@ -781,6 +1044,7 @@ struct SetupWizardView: View {
         case 1: return !dictation.needsMicPermission
         case 2: return hasAnyEngineReady
         case 3: return true
+        case 4: return true
         default: return true
         }
     }

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -685,6 +685,20 @@ struct SetupWizardView: View {
                 }
             }
 
+            if case .error(let message) = registryService.fetchState {
+                HStack {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    Spacer()
+                    Button(String(localized: "Retry")) {
+                        Task { await registryService.fetchRegistry() }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+
             Divider()
 
             Text(String(localized: "Prompt Presets"))


### PR DESCRIPTION
## Summary

Improves discoverability of prompts and LLM providers by adding a new "Prompts & AI" step to the setup wizard (between Hotkey and Try It Out) and clickable navigation links from the Prompts settings tab to the Integrations tab.

The new wizard step shows LLM provider recommendations (Groq, Apple Intelligence on macOS 26+), lists other installed providers, and offers one-click preset import. All "install from Integrations tab" text references in the Prompts tab are now clickable buttons that navigate directly to the Integrations tab using the existing ViewModel publish pattern. Includes German translations for all 18 new strings.

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features