### PR TITLE
Add media pause during recording, fixes #159

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		AA00000000000000000282 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000039 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000283 /* DictionaryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000271 /* DictionaryExporter.swift */; };
 		AA00000000000000000284 /* TermPackRegistryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000272 /* TermPackRegistryService.swift */; };
+		AA00000000000000000285 /* MediaPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000273 /* MediaPlaybackService.swift */; };
 		C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */; };
 		AA00000000000000000275 /* ElevenLabsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000263 /* ElevenLabsPlugin.swift */; };
 		AA00000000000000000276 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000264 /* manifest.json */; };
@@ -561,6 +562,7 @@
 		BB00000000000000000266 /* ElevenLabsPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ElevenLabsPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000271 /* DictionaryExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExporter.swift; sourceTree = "<group>"; };
 		BB00000000000000000272 /* TermPackRegistryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermPackRegistryService.swift; sourceTree = "<group>"; };
+		BB00000000000000000273 /* MediaPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackService.swift; sourceTree = "<group>"; };
 		A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryExporterTests.swift; sourceTree = "<group>"; };
 		01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCloudSTTPlugin.swift; sourceTree = "<group>"; };
 		1D584661B6B55F6329CB5FC4 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -945,6 +947,7 @@
 				BB00000000000000000066 /* ProfileService.swift */,
 				BB00000000000000000073 /* TranslationService.swift */,
 				BB00000000000000000074 /* AudioDuckingService.swift */,
+				BB00000000000000000273 /* MediaPlaybackService.swift */,
 				BB00000000000000000079 /* DictionaryService.swift */,
 				BB00000000000000000271 /* DictionaryExporter.swift */,
 				BB00000000000000000081 /* SnippetService.swift */,
@@ -2498,6 +2501,7 @@
 				AA00000000000000000070 /* UpdateChecker.swift in Sources */,
 				AA00000000000000000073 /* TranslationService.swift in Sources */,
 				AA00000000000000000074 /* AudioDuckingService.swift in Sources */,
+				AA00000000000000000285 /* MediaPlaybackService.swift in Sources */,
 				AA00000000000000000075 /* TranslationHostWindow.swift in Sources */,
 				AA00000000000000000077 /* DictionaryEntry.swift in Sources */,
 				AA00000000000000000078 /* TermPack.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -16,6 +16,7 @@ final class ServiceContainer: ObservableObject {
     let profileService: ProfileService
     let translationService: AnyObject? // TranslationService (macOS 15+)
     let audioDuckingService: AudioDuckingService
+    let mediaPlaybackService: MediaPlaybackService
     let dictionaryService: DictionaryService
     let snippetService: SnippetService
     let soundService: SoundService
@@ -71,6 +72,7 @@ final class ServiceContainer: ObservableObject {
         translationService = nil
         #endif
         audioDuckingService = AudioDuckingService()
+        mediaPlaybackService = MediaPlaybackService()
         dictionaryService = DictionaryService()
         snippetService = SnippetService()
         soundService = SoundService()
@@ -115,7 +117,8 @@ final class ServiceContainer: ObservableObject {
             appFormatterService: appFormatterService,
             speechFeedbackService: speechFeedbackService,
             accessibilityAnnouncementService: accessibilityAnnouncementService,
-            errorLogService: errorLogService
+            errorLogService: errorLogService,
+            mediaPlaybackService: mediaPlaybackService
         )
 
 

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -12,6 +12,7 @@ enum UserDefaultsKeys {
     static let soundError = "soundError"
     static let indicatorStyle = "indicatorStyle"
     static let preserveClipboard = "preserveClipboard"
+    static let mediaPauseEnabled = "mediaPauseEnabled"
 
     // MARK: - Hotkey (JSON-encoded UnifiedHotkey per slot)
     static let hybridHotkey = "hybridHotkey"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -6275,6 +6275,36 @@
           }
         }
       }
+    },
+    "Media Pause": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medienwiedergabe"
+          }
+        }
+      }
+    },
+    "Pause media playback during recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medienwiedergabe während der Aufnahme pausieren"
+          }
+        }
+      }
+    },
+    "Automatically pauses music and videos while recording and resumes when done. Uses macOS system media controls - may not work with all apps.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pausiert automatisch Musik und Videos während der Aufnahme und setzt die Wiedergabe fort, wenn fertig. Verwendet macOS-Systemsteuerung - funktioniert möglicherweise nicht mit allen Apps."
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/TypeWhisper/Services/MediaPlaybackService.swift
+++ b/TypeWhisper/Services/MediaPlaybackService.swift
@@ -21,8 +21,10 @@ class MediaPlaybackService {
     }
 
     /// Pauses media playback. kMRPause (1) is an explicit pause - safe to send even if nothing plays.
-    /// Note: MRMediaRemoteGetNowPlayingApplicationIsPlaying returns false inside signed apps,
-    /// so we skip the isPlaying check and send pause unconditionally.
+    /// Note: All MediaRemote query APIs (isPlaying, NowPlayingInfo) return empty/false inside signed
+    /// apps, so we send pause unconditionally and always resume. This means manually-paused media
+    /// will be resumed after recording - an acceptable trade-off since the command APIs are the only
+    /// ones that work.
     func pauseIfPlaying() {
         guard !didPause, let sendCommand else { return }
         let result = sendCommand(1, nil)

--- a/TypeWhisper/Services/MediaPlaybackService.swift
+++ b/TypeWhisper/Services/MediaPlaybackService.swift
@@ -1,0 +1,45 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "MediaPlaybackService")
+
+@MainActor
+class MediaPlaybackService {
+    private var didPause = false
+
+    #if !APPSTORE
+    private let sendCommand: (@convention(c) (Int, CFDictionary?) -> Bool)?
+
+    init() {
+        let handle = dlopen("/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote", RTLD_NOW)
+        if let handle, let sym = dlsym(handle, "MRMediaRemoteSendCommand") {
+            sendCommand = unsafeBitCast(sym, to: (@convention(c) (Int, CFDictionary?) -> Bool).self)
+        } else {
+            sendCommand = nil
+            logger.info("MediaRemote framework not available - media pause disabled")
+        }
+    }
+
+    /// Pauses media playback. kMRPause (1) is an explicit pause - safe to send even if nothing plays.
+    /// Note: MRMediaRemoteGetNowPlayingApplicationIsPlaying returns false inside signed apps,
+    /// so we skip the isPlaying check and send pause unconditionally.
+    func pauseIfPlaying() {
+        guard !didPause, let sendCommand else { return }
+        let result = sendCommand(1, nil)
+        didPause = result
+        logger.info("Media pause sent, result=\(result)")
+    }
+
+    /// Resumes playback only if we previously paused it.
+    func resumeIfWePaused() {
+        guard didPause, let sendCommand else { return }
+        _ = sendCommand(0, nil)
+        didPause = false
+        logger.info("Media playback resumed")
+    }
+    #else
+    init() {}
+    func pauseIfPlaying() {}
+    func resumeIfWePaused() {}
+    #endif
+}

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -46,6 +46,9 @@ final class DictationViewModel: ObservableObject {
     @Published var preserveClipboard: Bool {
         didSet { UserDefaults.standard.set(preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard) }
     }
+    @Published var mediaPauseEnabled: Bool {
+        didSet { UserDefaults.standard.set(mediaPauseEnabled, forKey: UserDefaultsKeys.mediaPauseEnabled) }
+    }
     @Published var spokenFeedbackEnabled: Bool {
         didSet { speechFeedbackService.spokenFeedbackEnabled = spokenFeedbackEnabled }
     }
@@ -106,6 +109,7 @@ final class DictationViewModel: ObservableObject {
     private let speechFeedbackService: SpeechFeedbackService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
     private let errorLogService: ErrorLogService
+    private let mediaPlaybackService: MediaPlaybackService
     private let postProcessingPipeline: PostProcessingPipeline
     private var matchedProfile: Profile?
     private var forcedProfileId: UUID?
@@ -143,7 +147,8 @@ final class DictationViewModel: ObservableObject {
         appFormatterService: AppFormatterService,
         speechFeedbackService: SpeechFeedbackService,
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
-        errorLogService: ErrorLogService
+        errorLogService: ErrorLogService,
+        mediaPlaybackService: MediaPlaybackService
     ) {
         self.audioRecordingService = audioRecordingService
         self.textInsertionService = textInsertionService
@@ -163,6 +168,7 @@ final class DictationViewModel: ObservableObject {
         self.speechFeedbackService = speechFeedbackService
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
         self.errorLogService = errorLogService
+        self.mediaPlaybackService = mediaPlaybackService
         self.postProcessingPipeline = PostProcessingPipeline(
             snippetService: snippetService,
             dictionaryService: dictionaryService,
@@ -191,6 +197,7 @@ final class DictationViewModel: ObservableObject {
         self.audioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2
         self.soundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
+        self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
         self.spokenFeedbackEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
         self.indicatorStyle = UserDefaults.standard.string(forKey: UserDefaultsKeys.indicatorStyle)
             .flatMap { IndicatorStyle(rawValue: $0) } ?? .notch
@@ -446,6 +453,7 @@ final class DictationViewModel: ObservableObject {
         }
 
         do {
+            if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
             audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
             try audioRecordingService.startRecording()
             if audioDuckingEnabled {
@@ -477,6 +485,7 @@ final class DictationViewModel: ObservableObject {
             )))
         } catch {
             audioDuckingService.restoreAudio()
+            mediaPlaybackService.resumeIfWePaused()
             accessibilityAnnouncementService.announceError(error.localizedDescription)
             speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
             showError(error.localizedDescription, category: "recording")
@@ -534,6 +543,7 @@ final class DictationViewModel: ObservableObject {
 
     private func finalizeStopDictation() async {
         audioDuckingService.restoreAudio()
+        mediaPlaybackService.resumeIfWePaused()
         streamingHandler.stop()
         stopRecordingTimer()
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -337,6 +337,14 @@ struct RecordingSettingsView: View {
                 }
             }
 
+            Section(String(localized: "Media Pause")) {
+                Toggle(String(localized: "Pause media playback during recording"), isOn: $dictation.mediaPauseEnabled)
+
+                Text(String(localized: "Automatically pauses music and videos while recording and resumes when done. Uses macOS system media controls - may not work with all apps."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             if needsPermissions {
                 Section(String(localized: "Permissions")) {
                     if dictation.needsMicPermission {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -156,7 +156,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             appFormatterService: appFormatterService,
             speechFeedbackService: speechFeedbackService,
             accessibilityAnnouncementService: accessibilityAnnouncementService,
-            errorLogService: errorLogService
+            errorLogService: errorLogService,
+            mediaPlaybackService: MediaPlaybackService()
         )
 
         let router = APIRouter()


### PR DESCRIPTION
## Summary

Adds optional media pause/resume during dictation recording via MediaRemote.framework private API (`MRMediaRemoteSendCommand`). When enabled, media playback (Apple Music, browser videos) is paused at recording start and resumed when recording stops. Toggle in Settings > Recording > Media Pause. Disabled in App Store builds (`#if !APPSTORE`).

Known limitation: `MRMediaRemoteGetNowPlayingApplicationIsPlaying` returns false inside signed apps, so pause is sent unconditionally (safe - `kMRPause` is idempotent). Only targets the active Now Playing session, so multiple simultaneous players are not fully supported.

## Test Plan

- [x] Built and ran locally
- [x] Tested with Apple Music - pauses and resumes correctly
- [x] Tested with YouTube in Brave browser - pauses and resumes correctly
- [x] No regressions in existing features