### PR TITLE
Fix notch indicator not displaying on other virtual desktops, fixes #165

### DIFF
--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -58,6 +58,7 @@ class NotchIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
 
         let hostingView = FirstMouseHostingView(rootView: NotchIndicatorView(geometry: notchGeometry))
+        hostingView.sizingOptions = []
         contentView = hostingView
     }
 
@@ -86,6 +87,15 @@ class NotchIndicatorPanel: NSPanel {
             .sink { [weak self] _ in
                 self?.cachedScreen = nil
                 self?.updateVisibility(state: vm.state, vm: vm)
+            }
+            .store(in: &cancellables)
+
+        NSWorkspace.shared.notificationCenter
+            .publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self, self.isVisible else { return }
+                self.orderFrontRegardless()
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## Summary

Fixes the notch indicator not appearing on virtual desktops other than Space 1. Adds `sizingOptions = []` to the hosting view (matching the OverlayIndicatorPanel pattern) and observes `activeSpaceDidChangeNotification` to re-assert window ordering after space transitions. Could not reproduce locally but the fix is defensive and safe.

## Test Plan

- [x] Built and ran locally
- [ ] Tested the changed functionality manually
- [x] No regressions in existing features