### PR TITLE
Add toggle to disable history saving

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -51,6 +51,7 @@ enum UserDefaultsKeys {
     static let termPackRegistryLastUpdateCheck = "termPackRegistryLastUpdateCheck"
 
     // MARK: - History
+    static let historyEnabled = "historyEnabled"
     static let historyRetentionDays = "historyRetentionDays"
     static let saveAudioWithHistory = "saveAudioWithHistory"
 

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -4198,6 +4198,26 @@
         }
       }
     },
+    "Save history": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf speichern"
+          }
+        }
+      }
+    },
+    "Saves transcriptions to the history tab.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichert Transkriptionen im Verlauf-Tab."
+          }
+        }
+      }
+    },
     "Save audio with transcriptions": {
       "localizations": {
         "de": {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -690,19 +690,21 @@ final class DictationViewModel: ObservableObject {
                     cloudModelOverride: cloudModelOverride
                 )
 
-                historyService.addRecord(
-                    rawText: result.text,
-                    finalText: text,
-                    appName: activeApp.name,
-                    appBundleIdentifier: activeApp.bundleId,
-                    appURL: activeApp.url,
-                    durationSeconds: audioDuration,
-                    language: language,
-                    engineUsed: result.engineUsed,
-                    modelUsed: modelDisplayName,
-                    audioSamples: audioSamplesForHistory,
-                    pipelineSteps: ppResult.appliedSteps.isEmpty ? nil : ppResult.appliedSteps
-                )
+                if UserDefaults.standard.object(forKey: UserDefaultsKeys.historyEnabled) as? Bool ?? true {
+                    historyService.addRecord(
+                        rawText: result.text,
+                        finalText: text,
+                        appName: activeApp.name,
+                        appBundleIdentifier: activeApp.bundleId,
+                        appURL: activeApp.url,
+                        durationSeconds: audioDuration,
+                        language: language,
+                        engineUsed: result.engineUsed,
+                        modelUsed: modelDisplayName,
+                        audioSamples: audioSamplesForHistory,
+                        pipelineSteps: ppResult.appliedSteps.isEmpty ? nil : ppResult.appliedSteps
+                    )
+                }
 
                 EventBus.shared.emit(.transcriptionCompleted(TranscriptionCompletedPayload(
                     rawText: result.text,

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -11,6 +11,7 @@ struct AdvancedSettingsView: View {
     @State private var raycastInstalled = false
     @State private var showClearMemoryConfirmation = false
 
+    @AppStorage(UserDefaultsKeys.historyEnabled) private var historyEnabled: Bool = true
     @AppStorage(UserDefaultsKeys.historyRetentionDays) private var historyRetentionDays: Int = 0
     @AppStorage(UserDefaultsKeys.saveAudioWithHistory) private var saveAudioWithHistory: Bool = false
 
@@ -135,21 +136,28 @@ struct AdvancedSettingsView: View {
 
             // MARK: - History
             Section(String(localized: "History")) {
-                Toggle(String(localized: "Save audio with transcriptions"), isOn: $saveAudioWithHistory)
-                Text(String(localized: "Stores a WAV recording alongside each transcription. Uses approximately 1 MB per 30 seconds."))
+                Toggle(String(localized: "Save history"), isOn: $historyEnabled)
+                Text(String(localized: "Saves transcriptions to the history tab."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                Picker(String(localized: "Auto-delete after"), selection: $historyRetentionDays) {
-                    Text(String(localized: "Unlimited")).tag(0)
-                    Text(String(localized: "30 days")).tag(30)
-                    Text(String(localized: "60 days")).tag(60)
-                    Text(String(localized: "90 days")).tag(90)
-                    Text(String(localized: "180 days")).tag(180)
+                if historyEnabled {
+                    Toggle(String(localized: "Save audio with transcriptions"), isOn: $saveAudioWithHistory)
+                    Text(String(localized: "Stores a WAV recording alongside each transcription. Uses approximately 1 MB per 30 seconds."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Picker(String(localized: "Auto-delete after"), selection: $historyRetentionDays) {
+                        Text(String(localized: "Unlimited")).tag(0)
+                        Text(String(localized: "30 days")).tag(30)
+                        Text(String(localized: "60 days")).tag(60)
+                        Text(String(localized: "90 days")).tag(90)
+                        Text(String(localized: "180 days")).tag(180)
+                    }
+                    Text(String(localized: "Older entries are automatically removed at app launch."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-                Text(String(localized: "Older entries are automatically removed at app launch."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
 
             // MARK: - API Server


### PR DESCRIPTION
## Summary

Adds a "Save history" toggle in Settings > Advanced > History that lets users completely disable saving new transcription records. When disabled, the audio and retention sub-options are hidden. Existing history entries remain accessible. Default is enabled so nothing changes for existing users.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features