### PR TITLE
Add Auto Enter profile setting, fixes #167

### DIFF
--- a/TypeWhisper/Models/Profile.swift
+++ b/TypeWhisper/Models/Profile.swift
@@ -19,6 +19,7 @@ final class Profile {
     var outputFormat: String?
     var hotkeyData: Data?
     var inlineCommandsEnabled: Bool
+    var autoEnterEnabled: Bool = false
     var createdAt: Date
     var updatedAt: Date
 
@@ -49,6 +50,7 @@ final class Profile {
         outputFormat: String? = nil,
         hotkeyData: Data? = nil,
         inlineCommandsEnabled: Bool = false,
+        autoEnterEnabled: Bool = false,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -68,6 +70,7 @@ final class Profile {
         self.outputFormat = outputFormat
         self.hotkeyData = hotkeyData
         self.inlineCommandsEnabled = inlineCommandsEnabled
+        self.autoEnterEnabled = autoEnterEnabled
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -729,6 +729,16 @@
         }
       }
     },
+    "Auto Enter": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Enter"
+          }
+        }
+      }
+    },
     "Auto-unload model": {
       "localizations": {
         "de": {
@@ -745,6 +755,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Extrahiert automatisch Fakten, Präferenzen und Muster aus deinen Transkriptionen per LLM. Erinnerungen werden als Kontext in Prompts eingefügt."
+          }
+        }
+      }
+    },
+    "Automatically press Enter after inserting text. In chat apps this sends the message, in editors it adds a new line.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drückt nach dem Einfügen automatisch Enter. In Chat-Apps wird die Nachricht gesendet, in Editoren eine neue Zeile eingefügt."
           }
         }
       }

--- a/TypeWhisper/Services/ProfileService.swift
+++ b/TypeWhisper/Services/ProfileService.swift
@@ -54,6 +54,7 @@ final class ProfileService: ObservableObject {
         outputFormat: String? = nil,
         hotkeyData: Data? = nil,
         inlineCommandsEnabled: Bool = false,
+        autoEnterEnabled: Bool = false,
         priority: Int = 0
     ) {
         let profile = Profile(
@@ -70,7 +71,8 @@ final class ProfileService: ObservableObject {
             memoryEnabled: memoryEnabled,
             outputFormat: outputFormat,
             hotkeyData: hotkeyData,
-            inlineCommandsEnabled: inlineCommandsEnabled
+            inlineCommandsEnabled: inlineCommandsEnabled,
+            autoEnterEnabled: autoEnterEnabled
         )
         modelContext.insert(profile)
         save()

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -10,6 +10,11 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhis
 /// Inserts transcribed text into the active application via clipboard + simulated Cmd+V.
 @MainActor
 final class TextInsertionService {
+    var accessibilityGrantedOverride: Bool?
+    var pasteboardProvider: () -> NSPasteboard = { .general }
+    var focusedTextFieldOverride: (() -> Bool)?
+    var pasteSimulatorOverride: (() -> Void)?
+    var returnSimulatorOverride: (() -> Void)?
 
 enum InsertionResult {
         case pasted
@@ -30,7 +35,7 @@ enum InsertionResult {
     }
 
     var isAccessibilityGranted: Bool {
-        AXIsProcessTrusted()
+        accessibilityGrantedOverride ?? AXIsProcessTrusted()
     }
 
     func requestAccessibilityPermission() {
@@ -330,13 +335,18 @@ enum InsertionResult {
         )
     }
 
-    func insertText(_ text: String, preserveClipboard: Bool = false) async throws -> InsertionResult {
+    func insertText(
+        _ text: String,
+        preserveClipboard: Bool = false,
+        autoEnter: Bool = false
+    ) async throws -> InsertionResult {
         guard isAccessibilityGranted else {
             throw TextInsertionError.accessibilityNotGranted
         }
 
-        let pasteboard = NSPasteboard.general
-        let savedItems = preserveClipboard ? saveClipboard() : []
+        let hadFocusedTextField = autoEnter && hasFocusedTextField()
+        let pasteboard = pasteboardProvider()
+        let savedItems = preserveClipboard ? saveClipboard(from: pasteboard) : []
         let pasteVerificationState = preserveClipboard ? capturePasteVerificationState() : nil
 
         // Set transcribed text on clipboard and simulate Cmd+V.
@@ -348,8 +358,13 @@ enum InsertionResult {
         if preserveClipboard {
             try? await Task.sleep(for: .milliseconds(200))
             if let pasteVerificationState, canRestoreClipboard(afterPasteUsing: pasteVerificationState) {
-                restoreClipboard(savedItems)
+                restoreClipboard(savedItems, to: pasteboard)
             }
+        }
+
+        if hadFocusedTextField {
+            try? await Task.sleep(for: .milliseconds(50))
+            simulateReturn()
         }
 
         return .pasted
@@ -377,6 +392,9 @@ enum InsertionResult {
 
     /// Checks if the currently focused UI element is a text input field.
     func hasFocusedTextField() -> Bool {
+        if let focusedTextFieldOverride {
+            return focusedTextFieldOverride()
+        }
         guard isAccessibilityGranted else { return false }
 
         let systemWide = AXUIElementCreateSystemWide()
@@ -423,7 +441,26 @@ enum InsertionResult {
         return point
     }
 
+    func simulateReturn() {
+        if let returnSimulatorOverride {
+            returnSimulatorOverride()
+            return
+        }
+        let returnKeyCode: CGKeyCode = 0x24
+        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true)
+        keyDown?.flags = []
+        keyDown?.post(tap: .cgSessionEventTap)
+
+        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
+        keyUp?.flags = []
+        keyUp?.post(tap: .cgSessionEventTap)
+    }
+
     private func simulatePaste() {
+        if let pasteSimulatorOverride {
+            pasteSimulatorOverride()
+            return
+        }
         let vKeyCode = virtualKeyCode(for: "v") ?? 0x09 // Fallback to QWERTY
         // Use nil source + .cgSessionEventTap for App Sandbox compatibility
         let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: vKeyCode, keyDown: true)

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -677,7 +677,11 @@ final class DictationViewModel: ObservableObject {
                         activeApp: activeApp, language: language, originalText: result.text
                     )
                 } else {
-                    _ = try await textInsertionService.insertText(text, preserveClipboard: preserveClipboard)
+                    _ = try await textInsertionService.insertText(
+                        text,
+                        preserveClipboard: preserveClipboard,
+                        autoEnter: self.matchedProfile?.autoEnterEnabled == true
+                    )
                     EventBus.shared.emit(.textInserted(TextInsertedPayload(
                         text: text,
                         appName: activeApp.name,

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -43,6 +43,7 @@ final class ProfilesViewModel: ObservableObject {
     @Published var editorMemoryEnabled: Bool = false
     @Published var editorOutputFormat: String?
     @Published var editorInlineCommandsEnabled = false
+    @Published var editorAutoEnterEnabled = false
     @Published var editorHotkey: UnifiedHotkey?
     @Published var editorHotkeyLabel: String = ""
     @Published var editorPriority: Int = 0
@@ -96,6 +97,7 @@ final class ProfilesViewModel: ObservableObject {
             outputFormat: editorOutputFormat,
             hotkeyData: editorHotkey.flatMap { try? JSONEncoder().encode($0) },
             inlineCommandsEnabled: editorInlineCommandsEnabled,
+            autoEnterEnabled: editorAutoEnterEnabled,
             priority: editorPriority
         )
     }
@@ -114,6 +116,7 @@ final class ProfilesViewModel: ObservableObject {
             profile.memoryEnabled = editorMemoryEnabled
             profile.outputFormat = editorOutputFormat
             profile.inlineCommandsEnabled = editorInlineCommandsEnabled
+            profile.autoEnterEnabled = editorAutoEnterEnabled
             profile.hotkey = editorHotkey
             profile.priority = editorPriority
             profileService.updateProfile(profile)
@@ -147,6 +150,7 @@ final class ProfilesViewModel: ObservableObject {
         editorMemoryEnabled = false
         editorOutputFormat = nil
         editorInlineCommandsEnabled = false
+        editorAutoEnterEnabled = false
         editorHotkey = nil
         editorHotkeyLabel = ""
         editorPriority = 0
@@ -178,6 +182,7 @@ final class ProfilesViewModel: ObservableObject {
         editorMemoryEnabled = profile.memoryEnabled
         editorOutputFormat = profile.outputFormat
         editorInlineCommandsEnabled = profile.inlineCommandsEnabled
+        editorAutoEnterEnabled = profile.autoEnterEnabled
         editorHotkey = profile.hotkey
         editorHotkeyLabel = profile.hotkey.map { HotkeyService.displayName(for: $0) } ?? ""
         editorPriority = profile.priority

--- a/TypeWhisper/Views/ProfilesSettingsView.swift
+++ b/TypeWhisper/Views/ProfilesSettingsView.swift
@@ -372,6 +372,11 @@ private struct ProfileEditorSheet: View {
                     Text(String(localized: "Format transcribed text for the target app. Auto-detect chooses the format based on the app's bundle ID. Requires app-aware formatting to be enabled in Recording settings."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    Toggle(String(localized: "Auto Enter"), isOn: $viewModel.editorAutoEnterEnabled)
+                    Text(String(localized: "Automatically press Enter after inserting text. In chat apps this sends the message, in editors it adds a new line."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section(String(localized: "Priority")) {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -114,6 +114,51 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testAutoEnterSkipsReturnWithoutFocusedTextField() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextFieldOverride = { false }
+
+        var didSimulatePaste = false
+        service.pasteSimulatorOverride = {
+            didSimulatePaste = true
+        }
+
+        var didSimulateReturn = false
+        service.returnSimulatorOverride = {
+            didSimulateReturn = true
+        }
+
+        _ = try await service.insertText("Hello", autoEnter: true)
+
+        XCTAssertTrue(didSimulatePaste)
+        XCTAssertFalse(didSimulateReturn)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+    }
+
+    @MainActor
+    func testAutoEnterTriggersReturnWithFocusedTextField() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextFieldOverride = { true }
+        service.pasteSimulatorOverride = {}
+
+        var didSimulateReturn = false
+        service.returnSimulatorOverride = {
+            didSimulateReturn = true
+        }
+
+        _ = try await service.insertText("Hello", autoEnter: true)
+
+        XCTAssertTrue(didSimulateReturn)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+    }
+
+    @MainActor
     private static func makeAPIContext(appSupportDirectory: URL) -> APIContext {
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
 


### PR DESCRIPTION
## Summary

Adds an "Auto Enter" toggle to profile settings that automatically presses Enter after inserting transcribed text. This is useful for chat apps (Slack, Messages) where Enter sends the message. The setting is per-profile, so users can enable it only for apps where it makes sense.

Key changes:
- New `autoEnterEnabled` field on Profile model
- `simulateReturn()` in TextInsertionService with explicit empty flags to prevent Command modifier leaking from the preceding Cmd+V paste
- `hasFocusedTextField()` guard to only send Return when a text field is focused
- Toggle with description in profile editor UI
- EN + DE localization

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features