### PR TITLE
Add OpenRouter LLM plugin with model search and pricing

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -54,6 +54,7 @@ jobs:
             elevenlabs) TARGET="ElevenLabsPlugin" ;;
             claude) TARGET="ClaudePlugin" ;;
             cerebras) TARGET="CerebrasPlugin" ;;
+            openrouter) TARGET="OpenRouterPlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin

--- a/Plugins/OpenRouterPlugin/Localizable.xcstrings
+++ b/Plugins/OpenRouterPlugin/Localizable.xcstrings
@@ -1,0 +1,146 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel werden sicher im Schlüsselbund gespeichert"
+          }
+        }
+      }
+    },
+    "Free" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kostenlos"
+          }
+        }
+      }
+    },
+    "Get API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel erstellen"
+          }
+        }
+      }
+    },
+    "Invalid API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger API-Schlüssel"
+          }
+        }
+      }
+    },
+    "LLM Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM-Modell"
+          }
+        }
+      }
+    },
+    "Refresh" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisieren"
+          }
+        }
+      }
+    },
+    "Remaining: $%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbleibend: %@ $"
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichern"
+          }
+        }
+      }
+    },
+    "Search models..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelle suchen ..."
+          }
+        }
+      }
+    },
+    "Using default models. Press Refresh to fetch all available models." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standardmodelle werden verwendet. Aktualisieren drücken, um alle verfügbaren Modelle abzurufen."
+          }
+        }
+      }
+    },
+    "Valid API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger API-Schlüssel"
+          }
+        }
+      }
+    },
+    "Validating..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird überprüft ..."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -1,0 +1,471 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+// MARK: - Plugin Entry Point
+
+@objc(OpenRouterPlugin)
+final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.openrouter"
+    static let pluginName = "OpenRouter"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedLLMModelId: String?
+    fileprivate var _fetchedModels: [OpenRouterFetchedModel] = []
+
+    private let chatHelper = PluginOpenAIChatHelper(
+        baseURL: "https://openrouter.ai/api"
+    )
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: "api-key")
+        if let data = host.userDefault(forKey: "fetchedModels") as? Data,
+           let models = try? JSONDecoder().decode([OpenRouterFetchedModel].self, from: data) {
+            _fetchedModels = models
+        }
+        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+            ?? supportedModels.first?.id
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - LLMProviderPlugin
+
+    var providerName: String { "OpenRouter" }
+
+    var isAvailable: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    private static let fallbackModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "openai/gpt-4o", displayName: "OpenAI: GPT-4o"),
+        PluginModelInfo(id: "anthropic/claude-sonnet-4", displayName: "Anthropic: Claude Sonnet 4"),
+        PluginModelInfo(id: "google/gemini-2.5-flash-preview", displayName: "Google: Gemini 2.5 Flash"),
+        PluginModelInfo(id: "meta-llama/llama-3.3-70b-instruct", displayName: "Meta: Llama 3.3 70B"),
+    ]
+
+    var supportedModels: [PluginModelInfo] {
+        if _fetchedModels.isEmpty {
+            return Self.fallbackModels
+        }
+        return _fetchedModels.map {
+            PluginModelInfo(id: $0.id, displayName: $0.name)
+        }
+    }
+
+    func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginChatError.notConfigured
+        }
+        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
+        return try await chatHelper.process(
+            apiKey: apiKey,
+            model: modelId,
+            systemPrompt: systemPrompt,
+            userText: userText
+        )
+    }
+
+    func selectLLMModel(_ modelId: String) {
+        _selectedLLMModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+    }
+
+    var selectedLLMModelId: String? { _selectedLLMModelId }
+    @objc var preferredModelId: String? { _selectedLLMModelId }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(OpenRouterSettingsView(plugin: self))
+    }
+
+    // MARK: - API Key Management
+
+    func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: key)
+            } catch {
+                print("[OpenRouterPlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: "")
+            } catch {
+                print("[OpenRouterPlugin] Failed to delete API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func validateApiKey(_ key: String) async -> Bool {
+        guard !key.isEmpty,
+              let url = URL(string: "https://openrouter.ai/api/v1/auth/key") else { return false }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return false }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Model Fetching
+
+    fileprivate func setFetchedModels(_ models: [OpenRouterFetchedModel]) {
+        _fetchedModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: "fetchedModels")
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func fetchModels() async -> [OpenRouterFetchedModel] {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/models") else { return [] }
+
+        var request = URLRequest(url: url)
+        if let apiKey = _apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+
+            let decoded = try JSONDecoder().decode(OpenRouterModelsResponse.self, from: data)
+            return decoded.data
+                .filter { Self.isTextLLM($0) }
+                .map { model in
+                    OpenRouterFetchedModel(
+                        id: model.id,
+                        name: model.name,
+                        promptPrice: model.pricing?.prompt ?? "0",
+                        completionPrice: model.pricing?.completion ?? "0"
+                    )
+                }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            return []
+        }
+    }
+
+    private static func isTextLLM(_ model: OpenRouterAPIModel) -> Bool {
+        let modality = model.architecture?.modality ?? ""
+        if !modality.isEmpty {
+            return modality.hasSuffix("->text")
+        }
+        let lowered = model.id.lowercased()
+        let excluded = ["embed", "tts", "audio", "image-gen", "dall-e", "stable-diffusion",
+                        "midjourney", "whisper", "moderation"]
+        return !excluded.contains(where: { lowered.contains($0) })
+    }
+
+    // MARK: - Credits
+
+    fileprivate func fetchCredits() async -> Double? {
+        guard let apiKey = _apiKey, !apiKey.isEmpty,
+              let url = URL(string: "https://openrouter.ai/api/v1/auth/key") else { return nil }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return nil }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataObj = json["data"] as? [String: Any] else { return nil }
+
+            if let limit = dataObj["limit"] as? Double,
+               let usage = dataObj["usage"] as? Double {
+                return limit - usage
+            }
+            if let limitCredits = dataObj["limit_remaining"] as? Double {
+                return limitCredits
+            }
+            return nil
+        } catch {
+            return nil
+        }
+    }
+}
+
+// MARK: - API Response Models
+
+private struct OpenRouterModelsResponse: Decodable {
+    let data: [OpenRouterAPIModel]
+}
+
+private struct OpenRouterAPIModel: Decodable {
+    let id: String
+    let name: String
+    let pricing: OpenRouterPricing?
+    let architecture: OpenRouterArchitecture?
+}
+
+private struct OpenRouterPricing: Decodable {
+    let prompt: String?
+    let completion: String?
+}
+
+private struct OpenRouterArchitecture: Decodable {
+    let modality: String?
+}
+
+// MARK: - Fetched Model (persisted)
+
+struct OpenRouterFetchedModel: Codable, Sendable {
+    let id: String
+    let name: String
+    let promptPrice: String
+    let completionPrice: String
+
+    var formattedPricing: String {
+        let promptPer1M = (Double(promptPrice) ?? 0) * 1_000_000
+        let completionPer1M = (Double(completionPrice) ?? 0) * 1_000_000
+        if promptPer1M == 0 && completionPer1M == 0 {
+            return String(localized: "Free", bundle: Bundle(for: OpenRouterPlugin.self))
+        }
+        return String(format: "$%.2f/$%.2f per 1M", promptPer1M, completionPer1M)
+    }
+}
+
+// MARK: - Settings View
+
+private struct OpenRouterSettingsView: View {
+    let plugin: OpenRouterPlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    @State private var selectedModel: String = ""
+    @State private var fetchedModels: [OpenRouterFetchedModel] = []
+    @State private var searchText = ""
+    @State private var remainingCredits: Double?
+    private let bundle = Bundle(for: OpenRouterPlugin.self)
+
+    private var filteredModels: [OpenRouterFetchedModel] {
+        if searchText.isEmpty { return fetchedModels }
+        let query = searchText.lowercased()
+        return fetchedModels.filter {
+            $0.name.lowercased().contains(query) || $0.id.lowercased().contains(query)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // API Key Section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key", bundle: bundle)
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isAvailable {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            apiKeyInput = ""
+                            validationResult = nil
+                            remainingCredits = nil
+                            plugin.removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = validationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result ? .green : .red)
+                        Text(result ? String(localized: "Valid API Key", bundle: bundle) : String(localized: "Invalid API Key", bundle: bundle))
+                            .font(.caption)
+                            .foregroundStyle(result ? .green : .red)
+                    }
+                }
+
+                if let credits = remainingCredits {
+                    HStack(spacing: 4) {
+                        Image(systemName: "creditcard")
+                            .foregroundStyle(.secondary)
+                        Text("Remaining: $\(String(format: "%.2f", credits))", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Link(String(localized: "Get API Key", bundle: bundle),
+                     destination: URL(string: "https://openrouter.ai/keys")!)
+                    .font(.caption)
+            }
+
+            if plugin.isAvailable {
+                Divider()
+
+                // LLM Model Selection
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("LLM Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    TextField(String(localized: "Search models...", bundle: bundle), text: $searchText)
+                        .textFieldStyle(.roundedBorder)
+
+                    let models = filteredModels
+                    Picker("LLM Model", selection: $selectedModel) {
+                        ForEach(models, id: \.id) { model in
+                            Text("\(model.name) - \(model.formattedPricing)").tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedModel) {
+                        plugin.selectLLMModel(selectedModel)
+                    }
+
+                    if fetchedModels.isEmpty {
+                        Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin._apiKey, !key.isEmpty {
+                apiKeyInput = key
+            }
+            fetchedModels = plugin._fetchedModels
+            selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+
+            if plugin.isAvailable {
+                Task {
+                    if let credits = await plugin.fetchCredits() {
+                        await MainActor.run {
+                            remainingCredits = credits
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        plugin.setApiKey(trimmedKey)
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            if isValid {
+                async let modelsTask = plugin.fetchModels()
+                async let creditsTask = plugin.fetchCredits()
+                let (models, credits) = await (modelsTask, creditsTask)
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = true
+                    remainingCredits = credits
+                    if !models.isEmpty {
+                        fetchedModels = models
+                        plugin.setFetchedModels(models)
+                    }
+                }
+            } else {
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = false
+                }
+            }
+        }
+    }
+
+    private func refreshModels() {
+        Task {
+            let models = await plugin.fetchModels()
+            await MainActor.run {
+                if !models.isEmpty {
+                    fetchedModels = models
+                    plugin.setFetchedModels(models)
+                    if !models.contains(where: { $0.id == selectedModel }),
+                       let first = models.first {
+                        selectedModel = first.id
+                        plugin.selectLLMModel(first.id)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Plugins/OpenRouterPlugin/manifest.json
+++ b/Plugins/OpenRouterPlugin/manifest.json
@@ -1,0 +1,16 @@
+{
+    "id": "com.typewhisper.openrouter",
+    "name": "OpenRouter",
+    "version": "1.0.0",
+    "minHostVersion": "0.9.0",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Access 300+ LLMs from OpenAI, Anthropic, Meta, Google and more via OpenRouter. Shows model pricing and account balance. Requires API key.",
+    "descriptions": {
+        "de": "Zugriff auf ueber 300 LLMs von OpenAI, Anthropic, Meta, Google und mehr ueber OpenRouter. Zeigt Modellpreise und Kontoguthaben. Erfordert API-Key."
+    },
+    "category": "llm",
+    "iconSystemName": "globe",
+    "requiresAPIKey": true,
+    "principalClass": "OpenRouterPlugin"
+}

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -254,6 +254,10 @@
 		AA00000000000000000286 /* MediaRemoteAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000040 /* MediaRemoteAdapter */; };
 		AA00000000000000000287 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000040 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */; };
+		AA00000000000000000288 /* OpenRouterPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000274 /* OpenRouterPlugin.swift */; };
+		AA00000000000000000289 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000275 /* manifest.json */; };
+		AA00000000000000000290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000276 /* Localizable.xcstrings */; };
+		AA00000000000000000291 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000041 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000275 /* ElevenLabsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000263 /* ElevenLabsPlugin.swift */; };
 		AA00000000000000000276 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000264 /* manifest.json */; };
 		AA00000000000000000277 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000265 /* Localizable.xcstrings */; };
@@ -568,6 +572,10 @@
 		01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCloudSTTPlugin.swift; sourceTree = "<group>"; };
 		1D584661B6B55F6329CB5FC4 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		5CA4DB761B06383B5B8CF082 /* GoogleCloudSTTPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoogleCloudSTTPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB00000000000000000274 /* OpenRouterPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRouterPlugin.swift; sourceTree = "<group>"; };
+		BB00000000000000000275 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		BB00000000000000000276 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		BB00000000000000000277 /* OpenRouterPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenRouterPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -820,6 +828,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF00000000000000000144 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000291 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -879,6 +895,7 @@
 				CC00000000000000000039 /* ClaudePlugin */,
 				CC00000000000000000041 /* GladiaPlugin */,
 				CC00000000000000000040 /* ElevenLabsPlugin */,
+				CC00000000000000000091 /* OpenRouterPlugin */,
 				CC00000000000000000025 /* TypeWhisperWidgetExtension */,
 				CC00000000000000000026 /* TypeWhisperWidgetShared */,
 				CC00000000000000000090 /* Products */,
@@ -1381,6 +1398,17 @@
 			path = Plugins/GladiaPlugin;
 			sourceTree = "<group>";
 		};
+		CC00000000000000000091 /* OpenRouterPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				BB00000000000000000274 /* OpenRouterPlugin.swift */,
+				BB00000000000000000275 /* manifest.json */,
+				BB00000000000000000276 /* Localizable.xcstrings */,
+			);
+			name = OpenRouterPlugin;
+			path = Plugins/OpenRouterPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000040 /* ElevenLabsPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -1432,6 +1460,7 @@
 				BB00000000000000000262 /* ClaudePlugin.bundle */,
 				BB00000000000000000270 /* GladiaPlugin.bundle */,
 				BB00000000000000000266 /* ElevenLabsPlugin.bundle */,
+				BB00000000000000000277 /* OpenRouterPlugin.bundle */,
 				BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */,
 				5CA4DB761B06383B5B8CF082 /* GoogleCloudSTTPlugin.bundle */,
 				E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */,
@@ -2033,6 +2062,26 @@
 			productReference = BB00000000000000000270 /* GladiaPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		DD00000000000000000030 /* OpenRouterPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF00000000000000000146 /* Build configuration list for PBXNativeTarget "OpenRouterPlugin" */;
+			buildPhases = (
+				FF00000000000000000143 /* Sources */,
+				FF00000000000000000144 /* Frameworks */,
+				FF00000000000000000145 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenRouterPlugin;
+			packageProductDependencies = (
+				PP00000000000000000041 /* TypeWhisperPluginSDK */,
+			);
+			productName = OpenRouterPlugin;
+			productReference = BB00000000000000000277 /* OpenRouterPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000028 /* ElevenLabsPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000138 /* Build configuration list for PBXNativeTarget "ElevenLabsPlugin" */;
@@ -2140,6 +2189,7 @@
 				DD00000000000000000027 /* ClaudePlugin */,
 				DD00000000000000000029 /* GladiaPlugin */,
 				DD00000000000000000028 /* ElevenLabsPlugin */,
+				DD00000000000000000030 /* OpenRouterPlugin */,
 				DD00000000000000000014 /* TypeWhisperWidgetExtension */,
 				40F22D3F350BA09ADEFBD2CB /* TypeWhisperTests */,
 				F3E17BDD5CED7E75F4153E95 /* GoogleCloudSTTPlugin */,
@@ -2403,6 +2453,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF1DFDDFBF91D87134DA57E7 /* manifest.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000145 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000289 /* manifest.json in Resources */,
+				AA00000000000000000290 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2775,6 +2834,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				F1177F582D186041B081F9C5 /* GoogleCloudSTTPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000143 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000288 /* OpenRouterPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4323,6 +4390,54 @@
 			};
 			name = Release;
 		};
+		XX00000000000000000119 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = OpenRouter;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = OpenRouterPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.openrouter;
+				PRODUCT_NAME = OpenRouterPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		XX00000000000000000120 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = OpenRouter;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = OpenRouterPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.openrouter;
+				PRODUCT_NAME = OpenRouterPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4605,6 +4720,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FF00000000000000000146 /* Build configuration list for PBXNativeTarget "OpenRouterPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XX00000000000000000119 /* Debug */,
+				XX00000000000000000120 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -4816,6 +4940,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = RR00000000000000000007 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
 			productName = MediaRemoteAdapter;
+		};
+		PP00000000000000000041 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -101,7 +101,8 @@ class PromptProcessingService: ObservableObject {
         // Validate cloud model against available models for the selected provider
         let models = modelsForProvider(selectedProviderId)
         if !models.isEmpty && !models.contains(where: { $0.id == selectedCloudModel }) {
-            selectedCloudModel = models.first?.id ?? ""
+            let pluginPreferred = (PluginManager.shared.llmProvider(for: selectedProviderId) as? LLMModelSelectable)?.preferredModelId as? String
+            selectedCloudModel = pluginPreferred ?? models.first?.id ?? ""
         }
     }
 
@@ -135,12 +136,13 @@ class PromptProcessingService: ObservableObject {
             throw LLMError.noApiKey
         }
 
-        let model = cloudModelOverride ?? selectedCloudModel
+        let preferred = (plugin as? LLMModelSelectable)?.preferredModelId as? String
+        let model = cloudModelOverride ?? preferred ?? (selectedCloudModel.isEmpty ? nil : selectedCloudModel)
         logger.info("Processing prompt with plugin \(effectiveId)")
         let result = try await plugin.process(
             systemPrompt: effectivePrompt,
             userText: text,
-            model: model.isEmpty ? nil : model
+            model: model
         )
         logger.info("Prompt processing complete, result length: \(result.count)")
         return result

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -98,11 +98,6 @@ struct PromptActionsSettingsView: View {
                             Text(provider.displayName).tag(provider.id)
                         }
                     }
-                    .onChange(of: processingService.selectedProviderId) { _, newId in
-                        // Reset cloud model when switching providers
-                        let models = processingService.modelsForProvider(newId)
-                        processingService.selectedCloudModel = models.first?.id ?? ""
-                    }
 
                     ProviderStatusView(
                         providerId: processingService.selectedProviderId,
@@ -230,17 +225,60 @@ struct ProviderStatusView: View {
                     .foregroundStyle(.orange)
             }
 
-            let models = processingService.modelsForProvider(providerId)
-            if let cloudModel, !models.isEmpty {
-                Picker(String(localized: "Model"), selection: cloudModel) {
-                    ForEach(models, id: \.id) { model in
-                        Text(model.displayName).tag(model.id)
+            if let plugin = PluginManager.shared.llmProvider(for: providerId) {
+                if let modelId = (plugin as? LLMModelSelectable)?.preferredModelId as? String {
+                    // Plugin manages its own model selection - just show info
+                    let displayName = plugin.supportedModels.first(where: { $0.id == modelId })?.displayName ?? modelId
+                    HStack(spacing: 4) {
+                        Text(String(localized: "Model:"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(displayName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let cloudModel {
+                    // Plugin without LLMModelSelectable - show picker as before
+                    let models = plugin.supportedModels
+                    if !models.isEmpty {
+                        ModelPickerView(models: models, selection: cloudModel)
                     }
                 }
-                .onAppear {
-                    if cloudModel.wrappedValue.isEmpty || !models.contains(where: { $0.id == cloudModel.wrappedValue }) {
-                        cloudModel.wrappedValue = models.first?.id ?? ""
-                    }
+            }
+        }
+    }
+}
+
+// MARK: - Model Picker with Search
+
+struct ModelPickerView: View {
+    let models: [PluginModelInfo]
+    @Binding var selection: String
+    @State private var searchText = ""
+
+    private var filteredModels: [PluginModelInfo] {
+        if searchText.isEmpty { return models }
+        let query = searchText.lowercased()
+        return models.filter {
+            $0.displayName.lowercased().contains(query) || $0.id.lowercased().contains(query)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if models.count > 20 {
+                TextField(String(localized: "Search models..."), text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .controlSize(.small)
+            }
+            Picker(String(localized: "Model"), selection: $selection) {
+                ForEach(filteredModels, id: \.id) { model in
+                    Text(model.displayName).tag(model.id)
+                }
+            }
+            .onAppear {
+                if selection.isEmpty || !models.contains(where: { $0.id == selection }) {
+                    selection = models.first?.id ?? ""
                 }
             }
         }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -75,6 +75,12 @@ public protocol LLMProviderPlugin: TypeWhisperPlugin {
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String
 }
 
+/// Optional protocol for LLM plugins that expose their selected model.
+/// Kept separate from LLMProviderPlugin to preserve binary compatibility with existing plugins.
+@objc public protocol LLMModelSelectable {
+    @objc optional var preferredModelId: String? { get }
+}
+
 // MARK: - Post-Processor Plugin
 
 public struct PostProcessingContext: Sendable {


### PR DESCRIPTION
## Summary

Adds a dedicated OpenRouterPlugin providing access to 300+ LLMs via the OpenRouter API. The plugin includes a searchable model picker with per-model pricing display and account credits/balance in settings. Also introduces `LLMModelSelectable`, a binary-compatible `@objc` protocol that lets plugins expose their preferred model - the Prompts tab uses it when available and falls back to the existing global model picker for older plugins. A `ModelPickerView` with search field is added for providers with large model lists (20+).

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features