### PR TITLE
Add missing plugin release mappings, fixes #175

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -55,6 +55,7 @@ jobs:
             claude) TARGET="ClaudePlugin" ;;
             cerebras) TARGET="CerebrasPlugin" ;;
             openrouter) TARGET="OpenRouterPlugin" ;;
+            soniox) TARGET="SonioxPlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin


### PR DESCRIPTION
## Summary
- Add `soniox` case to plugin-release.yml workflow mapping
- ClaudePlugin mapping already exists but was never tagged for release
- SonioxPlugin was missing from both the mapping and releases

## After merge
Push release tags:
- `plugin-claude-v1.0.0`
- `plugin-soniox-v1.0.0`