### PR TITLE
Show both STT and AI-processed text in history, fixes #176

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -2940,16 +2940,6 @@
         }
       }
     },
-    "Original": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Original"
-          }
-        }
-      }
-    },
     "Open an engine's settings to download a model.": {
       "comment": "A description below the list of transcription engines, explaining that users can open an engine's settings to download a model.",
       "extractionState": "stale",
@@ -6062,16 +6052,6 @@
         }
       }
     },
-    "Processed": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verarbeitet"
-          }
-        }
-      }
-    },
     "Error: %@": {},
     "Show terms for %@": {},
     "Pending": {
@@ -6382,6 +6362,76 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pausiert automatisch Musik und Videos während der Aufnahme und setzt die Wiedergabe fort, wenn fertig. Verwendet macOS-Systemsteuerung - funktioniert möglicherweise nicht mit allen Apps."
+          }
+        }
+      }
+    },
+    "Compare": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vergleich"
+          }
+        }
+      }
+    },
+    "Original Transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Originale Transkription"
+          }
+        }
+      }
+    },
+    "AI Processed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-verarbeitet"
+          }
+        }
+      }
+    },
+    "AI enhanced": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KI-verarbeitet"
+          }
+        }
+      }
+    },
+    "Copy original": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Original kopieren"
+          }
+        }
+      }
+    },
+    "Copy processed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verarbeitet kopieren"
+          }
+        }
+      }
+    },
+    "Diff": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diff"
           }
         }
       }

--- a/TypeWhisper/ViewModels/HistoryViewModel.swift
+++ b/TypeWhisper/ViewModels/HistoryViewModel.swift
@@ -57,7 +57,7 @@ struct AppEntry: Identifiable, Hashable {
 }
 
 enum HistoryDetailViewMode: Int {
-    case processed, diff, original
+    case compare, diff
 }
 
 // MARK: - ViewModel
@@ -79,7 +79,7 @@ final class HistoryViewModel: ObservableObject {
     @Published var editedText: String = ""
     @Published var correctionSuggestions: [CorrectionSuggestion] = []
     @Published var showCorrectionBanner: Bool = false
-    @Published var detailViewMode: HistoryDetailViewMode = .processed
+    @Published var detailViewMode: HistoryDetailViewMode = .compare
 
     let audioPlaybackService = AudioPlaybackService()
 
@@ -160,7 +160,7 @@ final class HistoryViewModel: ObservableObject {
 
     func selectRecord(_ record: TranscriptionRecord?) {
         cancelEditing()
-        detailViewMode = .processed
+        detailViewMode = .compare
         audioPlaybackService.stop()
         if let record {
             selectedRecordIDs = [record.id]
@@ -171,7 +171,7 @@ final class HistoryViewModel: ObservableObject {
 
     func startEditing() {
         guard let record = selectedRecord else { return }
-        detailViewMode = .processed
+        detailViewMode = .compare
         editedText = record.finalText
         isEditing = true
         showCorrectionBanner = false
@@ -189,7 +189,7 @@ final class HistoryViewModel: ObservableObject {
         }
 
         historyService.updateRecord(record, finalText: newText)
-        detailViewMode = .processed
+        detailViewMode = .compare
         isEditing = false
 
         let suggestions = textDiffService.extractCorrections(original: originalText, edited: newText)

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -304,6 +304,13 @@ private struct RecordRow: View {
                         .foregroundStyle(.tertiary)
                 }
 
+                if record.wasPostProcessed {
+                    Image(systemName: "sparkles")
+                        .font(.caption2)
+                        .foregroundStyle(.purple.opacity(0.7))
+                        .help(String(localized: "AI enhanced"))
+                }
+
                 Spacer()
 
                 Text(formatDuration(record.durationSeconds))
@@ -434,12 +441,11 @@ private struct RecordDetailView: View {
                 .padding(.top, 8)
             }
 
-            // Raw/Processed/Diff toggle
+            // Compare/Diff toggle
             if record.wasPostProcessed && !viewModel.isEditing {
                 Picker("", selection: $viewModel.detailViewMode) {
-                    Text(String(localized: "Processed")).tag(HistoryDetailViewMode.processed)
+                    Text(String(localized: "Compare")).tag(HistoryDetailViewMode.compare)
                     Text(String(localized: "Diff")).tag(HistoryDetailViewMode.diff)
-                    Text(String(localized: "Original")).tag(HistoryDetailViewMode.original)
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal, 10)
@@ -454,20 +460,70 @@ private struct RecordDetailView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ScrollView {
-                    Group {
-                        switch viewModel.detailViewMode {
-                        case .diff where record.wasPostProcessed:
-                            Text(diffAttributedString(segments: viewModel.diffSegments(for: record)))
-                        case .original where record.wasPostProcessed:
-                            Text(record.rawText)
-                        default:
-                            Text(record.finalText)
+                    if viewModel.detailViewMode == .compare && record.wasPostProcessed {
+                        VStack(alignment: .leading, spacing: 0) {
+                            // Original STT section
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Label(String(localized: "Original Transcription"), systemImage: "waveform")
+                                        .font(.caption.bold())
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Button {
+                                        viewModel.copyToClipboard(record.rawText)
+                                    } label: {
+                                        Image(systemName: "doc.on.doc")
+                                            .font(.caption2)
+                                    }
+                                    .buttonStyle(.borderless)
+                                    .help(String(localized: "Copy original"))
+                                }
+                                Text(record.rawText)
+                                    .textSelection(.enabled)
+                                    .font(.body)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .padding(10)
+
+                            Divider()
+                                .padding(.horizontal, 10)
+
+                            // AI Processed section
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Label(String(localized: "AI Processed"), systemImage: "sparkles")
+                                        .font(.caption.bold())
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Button {
+                                        viewModel.copyToClipboard(record.finalText)
+                                    } label: {
+                                        Image(systemName: "doc.on.doc")
+                                            .font(.caption2)
+                                    }
+                                    .buttonStyle(.borderless)
+                                    .help(String(localized: "Copy processed"))
+                                }
+                                Text(record.finalText)
+                                    .textSelection(.enabled)
+                                    .font(.body)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .padding(10)
                         }
+                    } else if viewModel.detailViewMode == .diff && record.wasPostProcessed {
+                        Text(diffAttributedString(segments: viewModel.diffSegments(for: record)))
+                            .textSelection(.enabled)
+                            .font(.body)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                    } else {
+                        Text(record.finalText)
+                            .textSelection(.enabled)
+                            .font(.body)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
                     }
-                    .textSelection(.enabled)
-                    .font(.body)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(10)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
@@ -475,7 +531,7 @@ private struct RecordDetailView: View {
         .onChange(of: record.id) {
             viewModel.cancelEditing()
             viewModel.audioPlaybackService.stop()
-            viewModel.detailViewMode = .processed
+            viewModel.detailViewMode = .compare
         }
     }
 
@@ -494,9 +550,7 @@ private struct RecordDetailView: View {
                 .controlSize(.small)
             } else {
                 Button {
-                    let text = viewModel.detailViewMode == .original && record.wasPostProcessed
-                        ? record.rawText : record.finalText
-                    viewModel.copyToClipboard(text)
+                    viewModel.copyToClipboard(record.finalText)
                 } label: {
                     Image(systemName: "doc.on.doc")
                 }


### PR DESCRIPTION
## Summary

Replaces the 3-mode segmented picker (Processed/Diff/Original) with a 2-mode Compare/Diff picker in the history detail view. Compare mode shows both the original STT transcription and the AI-processed text stacked vertically with clear labels and per-section copy buttons, so users can see both versions simultaneously. Also adds a sparkles indicator on list rows for post-processed records.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features