### PR TITLE
Add Cohere cloud transcription plugin, fixes #177

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -55,6 +55,8 @@ jobs:
             claude) TARGET="ClaudePlugin" ;;
             cerebras) TARGET="CerebrasPlugin" ;;
             openrouter) TARGET="OpenRouterPlugin" ;;
+            soniox) TARGET="SonioxPlugin" ;;
+            cohere) TARGET="CoherePlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin

--- a/Plugins/CoherePlugin/CoherePlugin.swift
+++ b/Plugins/CoherePlugin/CoherePlugin.swift
@@ -1,0 +1,295 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+// MARK: - Supported Languages
+
+private let cohereSupportedLanguages = [
+    "ar", "bn", "de", "en", "es", "fr", "hi", "ja", "ko", "pt",
+    "ru", "sw", "tr", "zh",
+]
+
+// MARK: - Plugin Entry Point
+
+@objc(CoherePlugin)
+final class CoherePlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.cohere"
+    static let pluginName = "Cohere"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: "api-key")
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "cohere" }
+    var providerDisplayName: String { "Cohere" }
+
+    var isConfigured: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: "cohere-transcribe-03-2026", displayName: "Cohere Transcribe"),
+        ]
+    }
+
+    var selectedModelId: String? { transcriptionModels.first?.id }
+
+    func selectModel(_ modelId: String) {
+        // Single model, nothing to change
+    }
+
+    var supportsTranslation: Bool { false }
+    var supportsStreaming: Bool { false }
+
+    var supportedLanguages: [String] { cohereSupportedLanguages }
+
+    // MARK: - Transcription
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let model = "cohere-transcribe-03-2026"
+        let lang = language ?? "en"
+
+        guard let url = URL(string: "https://api.cohere.com/v2/audio/transcriptions") else {
+            throw PluginTranscriptionError.apiError("Invalid Cohere API URL")
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
+
+        // Build multipart form body
+        var body = Data()
+
+        // model field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(model)\r\n".data(using: .utf8)!)
+
+        // language field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"language\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(lang)\r\n".data(using: .utf8)!)
+
+        // file field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(audio.wavData)
+        body.append("\r\n".data(using: .utf8)!)
+
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (responseData, response) = try await PluginHTTPClient.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401:
+            throw PluginTranscriptionError.invalidApiKey
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        default:
+            let errorBody = String(data: responseData, encoding: .utf8) ?? "Unknown error"
+            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorBody)")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let text = json["text"] as? String else {
+            throw PluginTranscriptionError.apiError("Failed to parse Cohere response")
+        }
+
+        return PluginTranscriptionResult(text: text, detectedLanguage: lang)
+    }
+
+    // MARK: - API Key Validation
+
+    fileprivate func validateApiKey(_ key: String) async -> Bool {
+        guard let url = URL(string: "https://api.cohere.com/v2/models") else { return false }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return false }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(CohereSettingsView(plugin: self))
+    }
+
+    // MARK: - Internal Methods for Settings
+
+    fileprivate func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: key)
+            } catch {
+                print("[CoherePlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    fileprivate func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: "")
+            } catch {
+                print("[CoherePlugin] Failed to delete API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+}
+
+// MARK: - Settings View
+
+private struct CohereSettingsView: View {
+    let plugin: CoherePlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    private let bundle = Bundle(for: CoherePlugin.self)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // API Key Section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key", bundle: bundle)
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isConfigured {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            apiKeyInput = ""
+                            validationResult = nil
+                            plugin.removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = validationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result ? .green : .red)
+                        Text(result ? String(localized: "Valid API Key", bundle: bundle) : String(localized: "Invalid API Key", bundle: bundle))
+                            .font(.caption)
+                            .foregroundStyle(result ? .green : .red)
+                    }
+                }
+            }
+
+            if plugin.isConfigured {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Model", bundle: bundle)
+                        .font(.headline)
+                    Text("Cohere Transcribe (cohere-transcribe-03-2026)")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin._apiKey, !key.isEmpty {
+                apiKeyInput = key
+            }
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        plugin.setApiKey(trimmedKey)
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            await MainActor.run {
+                isValidating = false
+                validationResult = isValid
+            }
+        }
+    }
+}

--- a/Plugins/CoherePlugin/Localizable.xcstrings
+++ b/Plugins/CoherePlugin/Localizable.xcstrings
@@ -1,0 +1,86 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schl\u00FCssel"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schl\u00FCssel werden sicher im Schl\u00FCsselbund gespeichert"
+          }
+        }
+      }
+    },
+    "Invalid API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ung\u00FCltiger API-Schl\u00FCssel"
+          }
+        }
+      }
+    },
+    "Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell"
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern"
+          }
+        }
+      }
+    },
+    "Valid API Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "G\u00FCltiger API-Schl\u00FCssel"
+          }
+        }
+      }
+    },
+    "Validating..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird \u00FCberpr\u00FCft..."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Plugins/CoherePlugin/manifest.json
+++ b/Plugins/CoherePlugin/manifest.json
@@ -1,0 +1,16 @@
+{
+    "id": "com.typewhisper.cohere",
+    "name": "Cohere",
+    "version": "1.0.0",
+    "minHostVersion": "0.12.0",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Cloud transcription via Cohere Transcribe API. State-of-the-art accuracy across 14 languages. Requires API key.",
+    "descriptions": {
+        "de": "Cloud-Transkription ueber die Cohere Transcribe API. Beste Genauigkeit fuer 14 Sprachen. Erfordert API-Key."
+    },
+    "category": "transcription",
+    "iconSystemName": "waveform.badge.mic",
+    "requiresAPIKey": true,
+    "principalClass": "CoherePlugin"
+}

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -262,6 +262,10 @@
 		AA00000000000000000293 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000279 /* manifest.json */; };
 		AA00000000000000000294 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000280 /* Localizable.xcstrings */; };
 		AA00000000000000000295 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000042 /* TypeWhisperPluginSDK */; };
+		AA00000000000000000296 /* CoherePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000282 /* CoherePlugin.swift */; };
+		AA00000000000000000297 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000283 /* manifest.json */; };
+		AA00000000000000000298 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000284 /* Localizable.xcstrings */; };
+		AA00000000000000000299 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000043 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000275 /* ElevenLabsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000263 /* ElevenLabsPlugin.swift */; };
 		AA00000000000000000276 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000264 /* manifest.json */; };
 		AA00000000000000000277 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000265 /* Localizable.xcstrings */; };
@@ -577,6 +581,10 @@
 		BB00000000000000000279 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000280 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000281 /* SonioxPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SonioxPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB00000000000000000282 /* CoherePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoherePlugin.swift; sourceTree = "<group>"; };
+		BB00000000000000000283 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		BB00000000000000000284 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		BB00000000000000000285 /* CoherePlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoherePlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCloudSTTPlugin.swift; sourceTree = "<group>"; };
 		1D584661B6B55F6329CB5FC4 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		5CA4DB761B06383B5B8CF082 /* GoogleCloudSTTPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoogleCloudSTTPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -852,6 +860,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF00000000000000000152 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000299 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -913,6 +929,7 @@
 				CC00000000000000000040 /* ElevenLabsPlugin */,
 				CC00000000000000000091 /* OpenRouterPlugin */,
 				CC00000000000000000042 /* SonioxPlugin */,
+				CC00000000000000000043 /* CoherePlugin */,
 				CC00000000000000000025 /* TypeWhisperWidgetExtension */,
 				CC00000000000000000026 /* TypeWhisperWidgetShared */,
 				CC00000000000000000090 /* Products */,
@@ -1448,6 +1465,17 @@
 			path = Plugins/SonioxPlugin;
 			sourceTree = "<group>";
 		};
+		CC00000000000000000043 /* CoherePlugin */ = {
+			isa = PBXGroup;
+			children = (
+				BB00000000000000000282 /* CoherePlugin.swift */,
+				BB00000000000000000283 /* manifest.json */,
+				BB00000000000000000284 /* Localizable.xcstrings */,
+			);
+			name = CoherePlugin;
+			path = Plugins/CoherePlugin;
+			sourceTree = "<group>";
+		};
 		0C3F892FBBE11FA7B5924B24 /* GoogleCloudSTTPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -1490,6 +1518,7 @@
 				BB00000000000000000266 /* ElevenLabsPlugin.bundle */,
 				BB00000000000000000277 /* OpenRouterPlugin.bundle */,
 				BB00000000000000000281 /* SonioxPlugin.bundle */,
+				BB00000000000000000285 /* CoherePlugin.bundle */,
 				BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */,
 				5CA4DB761B06383B5B8CF082 /* GoogleCloudSTTPlugin.bundle */,
 				E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */,
@@ -2151,6 +2180,26 @@
 			productReference = BB00000000000000000281 /* SonioxPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		DD00000000000000000032 /* CoherePlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FF00000000000000000154 /* Build configuration list for PBXNativeTarget "CoherePlugin" */;
+			buildPhases = (
+				FF00000000000000000151 /* Sources */,
+				FF00000000000000000152 /* Frameworks */,
+				FF00000000000000000153 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoherePlugin;
+			packageProductDependencies = (
+				PP00000000000000000043 /* TypeWhisperPluginSDK */,
+			);
+			productName = CoherePlugin;
+			productReference = BB00000000000000000285 /* CoherePlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		F3E17BDD5CED7E75F4153E95 /* GoogleCloudSTTPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7C80F8B2CDA6AFA512E7E2E3 /* Build configuration list for PBXNativeTarget "GoogleCloudSTTPlugin" */;
@@ -2240,6 +2289,7 @@
 				DD00000000000000000028 /* ElevenLabsPlugin */,
 				DD00000000000000000030 /* OpenRouterPlugin */,
 				DD00000000000000000031 /* SonioxPlugin */,
+				DD00000000000000000032 /* CoherePlugin */,
 				DD00000000000000000014 /* TypeWhisperWidgetExtension */,
 				40F22D3F350BA09ADEFBD2CB /* TypeWhisperTests */,
 				F3E17BDD5CED7E75F4153E95 /* GoogleCloudSTTPlugin */,
@@ -2521,6 +2571,15 @@
 			files = (
 				AA00000000000000000293 /* manifest.json in Resources */,
 				AA00000000000000000294 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000153 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000297 /* manifest.json in Resources */,
+				AA00000000000000000298 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2909,6 +2968,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000288 /* OpenRouterPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FF00000000000000000151 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA00000000000000000296 /* CoherePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4457,6 +4524,54 @@
 			};
 			name = Release;
 		};
+		XX00000000000000000123 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Cohere;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = CoherePlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.cohere;
+				PRODUCT_NAME = CoherePlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		XX00000000000000000124 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Cohere;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = CoherePlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.cohere;
+				PRODUCT_NAME = CoherePlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		31C90797268650EB47DEEB4B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4835,6 +4950,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FF00000000000000000154 /* Build configuration list for PBXNativeTarget "CoherePlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XX00000000000000000123 /* Debug */,
+				XX00000000000000000124 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7C80F8B2CDA6AFA512E7E2E3 /* Build configuration list for PBXNativeTarget "GoogleCloudSTTPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -5070,6 +5194,10 @@
 			productName = MediaRemoteAdapter;
 		};
 		PP00000000000000000042 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		PP00000000000000000043 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};


### PR DESCRIPTION
## Summary

Adds CoherePlugin for cloud transcription via the Cohere Transcribe API (`cohere-transcribe-03-2026`). Simple REST-only plugin supporting 14 languages with state-of-the-art accuracy. No streaming or translation support. Also adds the missing `soniox` CI mapping in plugin-release.yml from #174.

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features