### PR TITLE
Sort marketplace plugins by download count

### DIFF
--- a/.github/workflows/update-plugin-downloads.yml
+++ b/.github/workflows/update-plugin-downloads.yml
@@ -1,0 +1,91 @@
+name: Update Plugin Download Counts
+
+on:
+  schedule:
+    - cron: '30 5 * * *' # Daily at 05:30 UTC
+  workflow_dispatch:
+
+jobs:
+  update-counts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch download counts from GitHub Releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/TypeWhisper/typewhisper-mac/releases --paginate > /tmp/releases.json
+
+      - name: Update plugins.json on gh-pages
+        run: |
+          git fetch origin gh-pages
+          git worktree add -B gh-pages /tmp/gh-pages origin/gh-pages
+
+          update_registry() {
+            cd /tmp/gh-pages
+            git fetch origin gh-pages
+            git reset --hard origin/gh-pages
+
+            python3 << 'PYEOF'
+          import json, re
+
+          with open("/tmp/releases.json") as f:
+              releases = json.load(f)
+
+          # Sum download counts per plugin across all versions
+          counts = {}
+          for release in releases:
+              tag = release.get("tag_name", "")
+              m = re.match(r"^plugin-(.+)-v\d", tag)
+              if not m:
+                  continue
+              plugin_name = m.group(1)
+              for asset in release.get("assets", []):
+                  counts[plugin_name] = counts.get(plugin_name, 0) + asset.get("download_count", 0)
+
+          with open("/tmp/gh-pages/plugins.json") as f:
+              registry = json.load(f)
+
+          changed = False
+          for plugin in registry["plugins"]:
+              pid = plugin["id"]  # e.g. "com.typewhisper.qwen3"
+              for name, count in counts.items():
+                  if name in pid:
+                      old = plugin.get("downloadCount", 0)
+                      if old != count:
+                          plugin["downloadCount"] = count
+                          changed = True
+                          print(f"{pid}: {old} -> {count}")
+                      break
+
+          if changed:
+              with open("/tmp/gh-pages/plugins.json", "w") as f:
+                  json.dump(registry, f, indent=2)
+                  f.write("\n")
+              print("plugins.json updated")
+          else:
+              print("No changes needed")
+          PYEOF
+
+            git add plugins.json
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git diff --cached --quiet || git commit -m "Update plugin download counts"
+            git push origin gh-pages
+          }
+
+          for i in 1 2 3 4 5; do
+            if update_registry; then
+              echo "Successfully updated plugins.json (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 5 ]; then
+              echo "Failed to update plugins.json after 5 attempts"
+              exit 1
+            fi
+            echo "Attempt $i failed, retrying..."
+            sleep 2
+          done

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -6435,6 +6435,16 @@
           }
         }
       }
+    },
+    "%@ downloads": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Downloads"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -63,6 +63,7 @@ struct RegistryPlugin: Codable, Identifiable {
     let iconSystemName: String?
     let requiresAPIKey: Bool?
     let descriptions: [String: String]?
+    let downloadCount: Int?
 
     var localizedDescription: String {
         if let descriptions,
@@ -369,6 +370,17 @@ final class PluginRegistryService: ObservableObject {
         formatter.allowedUnits = [.useMB, .useGB]
         formatter.countStyle = .file
         return formatter.string(fromByteCount: bytes)
+    }
+
+    static func formattedDownloadCount(_ count: Int) -> String {
+        if count >= 1000 {
+            let k = Double(count) / 1000.0
+            if k.truncatingRemainder(dividingBy: 1) == 0 {
+                return "\(Int(k))K"
+            }
+            return String(format: "%.1fK", k)
+        }
+        return "\(count)"
     }
 }
 

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -235,7 +235,12 @@ struct PluginSettingsView: View {
         }
         return grouped
             .sorted { $0.key.sortOrder < $1.key.sortOrder }
-            .map { (category: $0.key, plugins: $0.value.sorted { $0.name.localizedCompare($1.name) == .orderedAscending }) }
+            .map { (category: $0.key, plugins: $0.value.sorted {
+                let d0 = $0.downloadCount ?? 0
+                let d1 = $1.downloadCount ?? 0
+                if d0 != d1 { return d0 > d1 }
+                return $0.name.localizedCompare($1.name) == .orderedAscending
+            }) }
     }
 
     private var availableTab: some View {
@@ -595,6 +600,12 @@ struct AvailablePluginRow: View {
                     Text("v\(plugin.version)")
                     Text(plugin.author)
                     Text(PluginRegistryService.formattedSize(plugin.size))
+                    if let count = plugin.downloadCount, count > 0 {
+                        Label(
+                            String(localized: "\(PluginRegistryService.formattedDownloadCount(count)) downloads"),
+                            systemImage: "arrow.down.circle"
+                        )
+                    }
                 }
                 .font(.caption2)
                 .foregroundStyle(.tertiary)


### PR DESCRIPTION
## Summary

Adds download count sorting to the plugin marketplace. A new daily CI workflow fetches download counts from the GitHub Releases API, sums them across all versions per plugin, and writes `downloadCount` into `plugins.json` on gh-pages. The Available tab now sorts plugins by downloads (descending) within each category, with alphabetical name as tiebreaker. Each plugin row shows its download count when > 0.

## Test Plan

- [x] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features