### PR TITLE
Fix prompt toggle not responding to clicks, fixes #186

### DIFF
--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -603,6 +603,10 @@ private struct OpenHandCursorView: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {}
 
     class CursorView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            return nil
+        }
+
         override func resetCursorRects() {
             addCursorRect(bounds, cursor: .openHand)
         }


### PR DESCRIPTION
## Summary

The prompt enable/disable toggle in Settings > Prompts was unresponsive. The `OpenHandCursorView` (NSViewRepresentable for the drag-reorder cursor) was overlaid on the entire prompt card, intercepting click events before they reached the Toggle control (NSSwitch). Fixed by overriding `hitTest` to return `nil`, making the cursor view transparent to events while keeping the open-hand cursor functional.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features