### PR TITLE
Fix recording started sound not playing, fixes #189

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -454,6 +454,9 @@ final class DictationViewModel: ObservableObject {
 
         do {
             if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
+            // Play start sound BEFORE engine setup - AVAudioEngine reconfigures
+            // audio hardware (aggregate device) which disrupts NSSound playback.
+            soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
             audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
             try audioRecordingService.startRecording()
             if audioDuckingEnabled {
@@ -464,7 +467,6 @@ final class DictationViewModel: ObservableObject {
             // not from key press. Slow device init (e.g. iPhone Continuity ~2-3s)
             // would otherwise make the hold appear as "long press" → PTT stop.
             hotkeyService.resetKeyDownTime()
-            soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
             accessibilityAnnouncementService.announceRecordingStarted()
             speechFeedbackService.announceEvent(.recordingStarted)
             partialText = ""


### PR DESCRIPTION
## Summary

Moves `soundService.play(.recordingStarted, ...)` to before `audioRecordingService.startRecording()` in `DictationViewModel.startRecording()`. AVAudioEngine startup reconfigures audio hardware (creates an aggregate device, stops the built-in speaker), which causes `NSSound.play()` called immediately after to fail silently. The success/error sounds were unaffected because they play after the engine has already stopped.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features