### PR TITLE
Add business licensing with Polar.sh integration

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -273,6 +273,9 @@
 		BF1DFDDFBF91D87134DA57E7 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1D584661B6B55F6329CB5FC4 /* manifest.json */; };
 		F1177F582D186041B081F9C5 /* GoogleCloudSTTPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */; };
 		F774802B61AFC0DCA9E8E668 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 67BE633BCFA1507F72199015 /* TypeWhisperPluginSDK */; };
+		AA00000000000000000300 /* LicenseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000286 /* LicenseService.swift */; };
+		AA00000000000000000301 /* LicenseSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000287 /* LicenseSettingsView.swift */; };
+		AA00000000000000000302 /* WelcomeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000288 /* WelcomeSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -592,6 +595,9 @@
 		BB00000000000000000275 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000276 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000277 /* OpenRouterPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenRouterPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB00000000000000000286 /* LicenseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseService.swift; sourceTree = "<group>"; };
+		BB00000000000000000287 /* LicenseSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseSettingsView.swift; sourceTree = "<group>"; };
+		BB00000000000000000288 /* WelcomeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1022,6 +1028,7 @@
 				BB00000000000000000246 /* AccessibilityAnnouncementService.swift */,
 				BB00000000000000000247 /* SpeechFeedbackService.swift */,
 				BB00000000000000000272 /* TermPackRegistryService.swift */,
+				BB00000000000000000286 /* LicenseService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1080,6 +1087,8 @@
 				BB00000000000000000248 /* HotkeyRecorderView.swift */,
 				BB00000000000000000249 /* HotkeySettingsView.swift */,
 				BB00000000000000000250 /* AboutSettingsView.swift */,
+				BB00000000000000000287 /* LicenseSettingsView.swift */,
+				BB00000000000000000288 /* WelcomeSheet.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2720,6 +2729,9 @@
 				AA00000000000000000260 /* HotkeyRecorderView.swift in Sources */,
 				AA00000000000000000261 /* HotkeySettingsView.swift in Sources */,
 				AA00000000000000000262 /* AboutSettingsView.swift in Sources */,
+				AA00000000000000000300 /* LicenseService.swift in Sources */,
+				AA00000000000000000301 /* LicenseSettingsView.swift in Sources */,
+				AA00000000000000000302 /* WelcomeSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -140,4 +140,13 @@ enum AppConstants {
         return false
         #endif
     }()
+
+    // MARK: - Polar.sh Licensing
+    enum Polar {
+        static let organizationId = "96de503c-3c8b-4d08-9ded-c7f6e20fdde4"
+        static let checkoutURL = "https://polar.sh/typewhisper"
+        static let checkoutURLIndividual = "https://buy.polar.sh/polar_cl_Yfw7BSIXSNFESlrNPL0fNG8GHPqX9qhmxGce32wZfYJ"
+        static let checkoutURLTeam = "https://buy.polar.sh/polar_cl_kSqGfvss0Ces3W7R4xw7hr5NdgvEbPbhhUGRH4ad3Hj"
+        static let checkoutURLEnterprise = "https://buy.polar.sh/polar_cl_uzCNIsF0vY9gx2peWljyJU7JQoEzxHUueCPTA0MoOQe"
+    }
 }

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -34,6 +34,7 @@ final class ServiceContainer: ObservableObject {
     let accessibilityAnnouncementService: AccessibilityAnnouncementService
     let speechFeedbackService: SpeechFeedbackService
     let errorLogService: ErrorLogService
+    let licenseService: LicenseService
 
     // HTTP API
     let httpServer: HTTPServer
@@ -91,6 +92,7 @@ final class ServiceContainer: ObservableObject {
         accessibilityAnnouncementService = AccessibilityAnnouncementService()
         speechFeedbackService = SpeechFeedbackService()
         errorLogService = ErrorLogService()
+        licenseService = LicenseService()
 
         // ViewModels (created before HTTP API so DictationViewModel is available)
         fileTranscriptionViewModel = FileTranscriptionViewModel(
@@ -162,6 +164,9 @@ final class ServiceContainer: ObservableObject {
         AudioRecorderViewModel._shared = audioRecorderViewModel
         WatchFolderViewModel._shared = watchFolderViewModel
 
+        // License
+        LicenseService.shared = licenseService
+
         // Plugin system
         EventBus.shared = EventBus()
         PluginManager.shared = pluginManager
@@ -202,6 +207,9 @@ final class ServiceContainer: ObservableObject {
 
         // Start memory service
         memoryService.startListening()
+
+        // Validate license if needed
+        await licenseService.validateIfNeeded()
 
         // Auto-start watch folder if configured
         if UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderAutoStart),

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
 struct TypeWhisperApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @AppStorage(UserDefaultsKeys.showMenuBarIcon) private var showMenuBarIcon = true
+    @State private var showWelcomeSheet = false
 
     var body: some Scene {
         MenuBarExtra(AppConstants.isDevelopment ? "TypeWhisper Dev" : "TypeWhisper", systemImage: "waveform", isInserted: $showMenuBarIcon) {
@@ -62,6 +63,14 @@ struct TypeWhisperApp: App {
         } else {
             SettingsView()
                 .background(SettingsWindowBridge())
+                .sheet(isPresented: $showWelcomeSheet) {
+                    WelcomeSheet()
+                }
+                .task {
+                    if LicenseService.shared.needsWelcomeSheet {
+                        showWelcomeSheet = true
+                    }
+                }
         }
     }
 

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -100,4 +100,11 @@ enum UserDefaultsKeys {
     static let watchFolderLanguage = "watchFolderLanguage"
     static let watchFolderEngine = "watchFolderEngine"
     static let watchFolderModel = "watchFolderModel"
+
+    // MARK: - Licensing
+    static let userType = "userType"
+    static let licenseStatus = "licenseStatus"
+    static let licenseTier = "licenseTier"
+    static let lastLicenseValidation = "lastLicenseValidation"
+    static let welcomeSheetShown = "welcomeSheetShown"
 }

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -1,0 +1,339 @@
+import Combine
+import Foundation
+import Security
+import os
+
+enum LicenseUserType: String {
+    case privateUser = "private"
+    case business = "business"
+}
+
+enum LicenseStatus: String {
+    case unlicensed
+    case active = "polar_active"
+    case expired = "polar_expired"
+}
+
+enum LicenseTier: String {
+    case individual
+    case team
+    case enterprise
+}
+
+struct PolarActivationResponse: Codable {
+    let id: String
+}
+
+struct PolarValidationResponse: Codable {
+    let id: String
+    let status: String
+    let expiresAt: String?
+    let benefit: PolarBenefit?
+
+    enum CodingKeys: String, CodingKey {
+        case id, status
+        case expiresAt = "expires_at"
+        case benefit
+    }
+
+    struct PolarBenefit: Codable {
+        let id: String
+        let description: String?
+    }
+}
+
+struct PolarErrorResponse: Codable {
+    let detail: String?
+    let type: String?
+}
+
+@MainActor
+final class LicenseService: ObservableObject {
+    nonisolated(unsafe) static var shared: LicenseService!
+
+    private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "LicenseService")
+    private let keychainKeyPrefix = AppConstants.keychainServicePrefix
+    private let validationInterval: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+
+    // MARK: - Published state
+
+    @Published var userType: LicenseUserType? {
+        didSet { UserDefaults.standard.set(userType?.rawValue, forKey: UserDefaultsKeys.userType) }
+    }
+    @Published var licenseStatus: LicenseStatus {
+        didSet { UserDefaults.standard.set(licenseStatus.rawValue, forKey: UserDefaultsKeys.licenseStatus) }
+    }
+    @Published var licenseTier: LicenseTier? {
+        didSet { UserDefaults.standard.set(licenseTier?.rawValue, forKey: UserDefaultsKeys.licenseTier) }
+    }
+    @Published var isActivating = false
+    @Published var activationError: String?
+    @Published var deactivationError: String?
+
+    var needsWelcomeSheet: Bool {
+        !UserDefaults.standard.bool(forKey: UserDefaultsKeys.welcomeSheetShown)
+    }
+
+    var shouldShowReminder: Bool {
+        userType == .business && licenseStatus != .active
+    }
+
+    // MARK: - Init
+
+    init() {
+        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.userType) {
+            self.userType = LicenseUserType(rawValue: raw)
+        } else {
+            self.userType = nil
+        }
+        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.licenseStatus),
+           let status = LicenseStatus(rawValue: raw) {
+            self.licenseStatus = status
+        } else {
+            self.licenseStatus = .unlicensed
+        }
+        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.licenseTier) {
+            self.licenseTier = LicenseTier(rawValue: raw)
+        } else {
+            self.licenseTier = nil
+        }
+    }
+
+    // MARK: - Welcome Sheet
+
+    func markWelcomeSheetShown() {
+        UserDefaults.standard.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+    }
+
+    func setUserType(_ type: LicenseUserType) {
+        userType = type
+        markWelcomeSheetShown()
+    }
+
+    // MARK: - Polar License Key
+
+    func activateLicenseKey(_ key: String) async {
+        isActivating = true
+        activationError = nil
+        deactivationError = nil
+
+        do {
+            let response = try await polarActivate(key: key)
+            saveLicenseToKeychain(key: key, activationId: response.id)
+            licenseStatus = .active
+            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
+            logger.info("License activated via Polar (activation: \(response.id))")
+        } catch {
+            activationError = error.localizedDescription
+            logger.error("License activation failed: \(error)")
+        }
+
+        isActivating = false
+    }
+
+    func validateLicense() async {
+        guard let (key, activationId) = loadLicenseFromKeychain() else { return }
+
+        do {
+            let response = try await polarValidate(key: key, activationId: activationId)
+            if response.status == "granted" {
+                licenseStatus = .active
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
+                logger.info("License validation successful")
+            } else {
+                licenseStatus = .expired
+                logger.warning("License revoked or disabled (status: \(response.status))")
+            }
+        } catch {
+            logger.error("License validation failed: \(error)")
+            // Keep current status on network errors - don't downgrade offline users
+        }
+    }
+
+    func validateIfNeeded() async {
+        guard hasStoredLicense else {
+            if licenseStatus != .unlicensed || licenseTier != nil {
+                licenseStatus = .unlicensed
+                licenseTier = nil
+            }
+            return
+        }
+
+        if licenseStatus != .active {
+            await validateLicense()
+            return
+        }
+
+        guard let lastValidation = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastLicenseValidation) as? Date else {
+            await validateLicense()
+            return
+        }
+        if Date().timeIntervalSince(lastValidation) > validationInterval {
+            await validateLicense()
+        }
+    }
+
+    func deactivateLicense() async {
+        guard let (key, activationId) = loadLicenseFromKeychain() else { return }
+        deactivationError = nil
+
+        do {
+            try await polarDeactivate(key: key, activationId: activationId)
+            logger.info("License deactivated on Polar")
+
+            removeLicenseFromKeychain()
+            licenseStatus = .unlicensed
+            licenseTier = nil
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastLicenseValidation)
+        } catch {
+            deactivationError = error.localizedDescription
+            logger.error("Polar deactivation failed: \(error)")
+        }
+    }
+
+    // MARK: - Polar API
+
+    private func polarActivate(key: String) async throws -> PolarActivationResponse {
+        let url = URL(string: "https://api.polar.sh/v1/customer-portal/license-keys/activate")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let deviceLabel = Host.current().localizedName ?? "Mac"
+        let body: [String: Any] = [
+            "key": key,
+            "organization_id": AppConstants.Polar.organizationId,
+            "label": deviceLabel,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LicenseError.networkError
+        }
+
+        if httpResponse.statusCode == 200 {
+            return try JSONDecoder().decode(PolarActivationResponse.self, from: data)
+        } else {
+            let errorResponse = try? JSONDecoder().decode(PolarErrorResponse.self, from: data)
+            throw LicenseError.activationFailed(errorResponse?.detail ?? "HTTP \(httpResponse.statusCode)")
+        }
+    }
+
+    private func polarValidate(key: String, activationId: String) async throws -> PolarValidationResponse {
+        let url = URL(string: "https://api.polar.sh/v1/customer-portal/license-keys/validate")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "key": key,
+            "organization_id": AppConstants.Polar.organizationId,
+            "activation_id": activationId,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LicenseError.networkError
+        }
+
+        if httpResponse.statusCode == 200 {
+            return try JSONDecoder().decode(PolarValidationResponse.self, from: data)
+        } else {
+            throw LicenseError.validationFailed("HTTP \(httpResponse.statusCode)")
+        }
+    }
+
+    private func polarDeactivate(key: String, activationId: String) async throws {
+        let url = URL(string: "https://api.polar.sh/v1/customer-portal/license-keys/deactivate")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "key": key,
+            "organization_id": AppConstants.Polar.organizationId,
+            "activation_id": activationId,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200 ... 299).contains(httpResponse.statusCode) else {
+            throw LicenseError.deactivationFailed
+        }
+    }
+
+    // MARK: - Keychain
+
+    private var keychainService: String { keychainKeyPrefix + "license" }
+    private var hasStoredLicense: Bool { loadLicenseFromKeychain() != nil }
+
+    private func saveLicenseToKeychain(key: String, activationId: String) {
+        let data = "\(key)|\(activationId)".data(using: .utf8)!
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "polar-license",
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    private func loadLicenseFromKeychain() -> (key: String, activationId: String)? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "polar-license",
+            kSecReturnData as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        let parts = string.split(separator: "|", maxSplits: 1)
+        guard parts.count == 2 else { return nil }
+        return (key: String(parts[0]), activationId: String(parts[1]))
+    }
+
+    private func removeLicenseFromKeychain() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "polar-license",
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+// MARK: - Errors
+
+enum LicenseError: LocalizedError {
+    case networkError
+    case activationFailed(String)
+    case validationFailed(String)
+    case deactivationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .networkError:
+            return String(localized: "Network error. Please check your internet connection.")
+        case .activationFailed(let detail):
+            return String(localized: "Activation failed: \(detail)")
+        case .validationFailed(let detail):
+            return String(localized: "Validation failed: \(detail)")
+        case .deactivationFailed:
+            return String(localized: "Deactivation failed. Please try again.")
+        }
+    }
+}

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+struct LicenseSettingsView: View {
+    @ObservedObject private var license = LicenseService.shared
+
+    @State private var licenseKeyInput = ""
+
+    var body: some View {
+        Form {
+            Section(String(localized: "License Status")) {
+                statusView
+            }
+
+            if license.licenseStatus != .active {
+                Section(String(localized: "Activate with License Key")) {
+                    Text(String(localized: "If you need a commercial license for proprietary or otherwise non-GPL-compliant use, purchase it on Polar.sh and enter the key below."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        TextField(String(localized: "TYPEWHISPER-xxxx-xxxx"), text: $licenseKeyInput)
+                            .textFieldStyle(.roundedBorder)
+
+                        Button(String(localized: "Activate")) {
+                            Task {
+                                await license.activateLicenseKey(licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines))
+                            }
+                        }
+                        .disabled(licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || license.isActivating)
+                    }
+
+                    if license.isActivating {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+
+                    if let error = license.activationError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                    }
+                }
+
+                Section(String(localized: "Purchase")) {
+                    HStack(spacing: 16) {
+                        tierButton(tier: .individual, price: "5", url: AppConstants.Polar.checkoutURLIndividual)
+                        tierButton(tier: .team, price: "19", url: AppConstants.Polar.checkoutURLTeam)
+                        tierButton(tier: .enterprise, price: "99", url: AppConstants.Polar.checkoutURLEnterprise)
+                    }
+                    .padding(.vertical, 4)
+
+                    Text(String(localized: "Pay-what-you-want starting at the listed price. Click a tier to open the checkout page."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+            }
+
+            if license.licenseStatus == .active {
+                Section(String(localized: "Manage")) {
+                    Button(String(localized: "Deactivate License on This Mac"), role: .destructive) {
+                        Task { await license.deactivateLicense() }
+                    }
+
+                    Text(String(localized: "Removes the license from this device. You can reactivate it on another Mac."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let error = license.deactivationError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                    }
+                }
+            }
+
+            Section(String(localized: "User Type")) {
+                Picker(String(localized: "I use TypeWhisper"), selection: Binding(
+                    get: { license.userType ?? .privateUser },
+                    set: { license.setUserType($0) }
+                )) {
+                    Text(String(localized: "Personal / OSS")).tag(LicenseUserType.privateUser)
+                    Text(String(localized: "Proprietary")).tag(LicenseUserType.business)
+                }
+                .pickerStyle(.segmented)
+
+                Text(String(localized: "Personal use and GPL-compliant open-source use are free. Proprietary or otherwise non-GPL-compliant use requires a commercial license."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .frame(minWidth: 500, minHeight: 300)
+    }
+
+    @ViewBuilder
+    private var statusView: some View {
+        switch license.licenseStatus {
+        case .active:
+            HStack {
+                Label(String(localized: "Licensed"), systemImage: "checkmark.seal.fill")
+                    .foregroundStyle(.green)
+                if let tier = license.licenseTier {
+                    Text("(\(tierDisplayName(tier)))")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        case .expired:
+            Label(String(localized: "License expired or revoked"), systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+        case .unlicensed:
+            if license.userType == .business {
+                Label(String(localized: "No active commercial license"), systemImage: "key")
+                    .foregroundStyle(.secondary)
+            } else {
+                Label(String(localized: "Free for personal and GPL-compliant open-source use"), systemImage: "checkmark.circle")
+                    .foregroundStyle(.green)
+            }
+        }
+    }
+
+    private func tierButton(tier: LicenseTier, price: String, url: String) -> some View {
+        Button {
+            if let checkoutURL = URL(string: url) {
+                NSWorkspace.shared.open(checkoutURL)
+            }
+        } label: {
+            VStack(spacing: 4) {
+                Text(tierDisplayName(tier))
+                    .font(.caption.bold())
+                Text(String(localized: "from \(price) EUR/mo"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private func tierDisplayName(_ tier: LicenseTier) -> String {
+        switch tier {
+        case .individual: return "Individual Business"
+        case .team: return "Team"
+        case .enterprise: return "Enterprise"
+        }
+    }
+}

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -154,6 +154,13 @@ private struct SettingsExtraTabs: TabContent {
             PluginSettingsView()
         }
         .badge(self.pluginUpdatesBadge)
+        SettingsBottomTabs()
+    }
+}
+
+@available(macOS 15, *)
+private struct SettingsBottomTabs: TabContent {
+    var body: some TabContent<SettingsTab> {
         Tab(String(localized: "Advanced"), systemImage: "gearshape.2", value: SettingsTab.advanced) {
             AdvancedSettingsView()
         }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 enum SettingsTab: Hashable {
     case home, general, recording, hotkeys, recorder
-    case fileTranscription, history, dictionary, snippets, profiles, prompts, integrations, advanced, about
+    case fileTranscription, history, dictionary, snippets, profiles, prompts, integrations, advanced, license, about
 }
 
 struct SettingsView: View {
@@ -66,6 +66,9 @@ struct SettingsView: View {
                         AdvancedSettingsView()
                             .tabItem { Label(String(localized: "Advanced"), systemImage: "gearshape.2") }
                             .tag(SettingsTab.advanced)
+                        LicenseSettingsView()
+                            .tabItem { Label(String(localized: "License"), systemImage: "key") }
+                            .tag(SettingsTab.license)
                         AboutSettingsView()
                             .tabItem { Label(String(localized: "About"), systemImage: "info.circle") }
                             .tag(SettingsTab.about)
@@ -153,6 +156,9 @@ private struct SettingsExtraTabs: TabContent {
         .badge(self.pluginUpdatesBadge)
         Tab(String(localized: "Advanced"), systemImage: "gearshape.2", value: SettingsTab.advanced) {
             AdvancedSettingsView()
+        }
+        Tab(String(localized: "License"), systemImage: "key", value: SettingsTab.license) {
+            LicenseSettingsView()
         }
         Tab(String(localized: "About"), systemImage: "info.circle", value: SettingsTab.about) {
             AboutSettingsView()

--- a/TypeWhisper/Views/WelcomeSheet.swift
+++ b/TypeWhisper/Views/WelcomeSheet.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct WelcomeSheet: View {
+    @ObservedObject private var license = LicenseService.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 80, height: 80)
+
+            Text(String(localized: "Welcome to TypeWhisper!"))
+                .font(.title2.bold())
+
+            Text(String(localized: "TypeWhisper is open source.\nPersonal use and GPL-compliant open-source use are free.\nProprietary or otherwise non-GPL-compliant use requires a commercial license."))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 16) {
+                Button {
+                    license.setUserType(.privateUser)
+                    dismiss()
+                } label: {
+                    Label(String(localized: "Personal or open source"), systemImage: "person")
+                        .frame(maxWidth: .infinity)
+                }
+                .controlSize(.large)
+
+                Button {
+                    license.setUserType(.business)
+                    dismiss()
+                } label: {
+                    Label(String(localized: "Proprietary use"), systemImage: "building.2")
+                        .frame(maxWidth: .infinity)
+                }
+                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(32)
+        .frame(width: 440)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a commercial licensing system using Polar.sh for proprietary/non-GPL use of TypeWhisper. Three pay-what-you-want tiers (Individual 5 EUR, Team 19 EUR, Enterprise 99 EUR) with license key activation via Polar's unauthenticated API. Includes a first-start WelcomeSheet for user type selection (personal/OSS vs proprietary), a License settings tab with key entry and tier checkout buttons, and periodic re-validation every 7 days. No feature-gating - all features remain available to all users; only soft reminders for unlicensed proprietary use. Also splits `SettingsExtraTabs` into smaller structs to fix a Swift type-checker memory explosion.

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features