### PR TITLE
Add error checking and logging for audio device selection, fixes #181

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -82,20 +82,15 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         let engine = AVAudioEngine()
 
-        if let deviceID = selectedDeviceID,
-           let audioUnit = engine.inputNode.audioUnit {
-            var id = deviceID
-            AudioUnitSetProperty(
-                audioUnit,
-                kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global, 0,
-                &id,
-                UInt32(MemoryLayout<AudioDeviceID>.size)
-            )
+        if let deviceID = selectedDeviceID {
+            if !setInputDevice(deviceID, on: engine, label: "preview") {
+                logger.error("Failed to set preview input device (\(deviceID)), falling back to system default")
+            }
         }
 
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
+        logger.info("Preview input format: sampleRate=\(format.sampleRate), channels=\(format.channelCount)")
         guard format.sampleRate > 0, format.channelCount > 0 else {
             logger.warning("No audio input available for preview")
             return
@@ -345,4 +340,66 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             disconnectVerificationTask = nil
         }
     }
+}
+
+// MARK: - Audio Device Helper
+
+private let deviceHelperLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioDeviceHelper")
+
+/// Sets the CoreAudio input device on an AVAudioEngine's input node AUHAL.
+/// Checks the return status and verifies the device was actually set.
+/// Returns true if the device was set successfully.
+func setInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine, label: String) -> Bool {
+    guard let audioUnit = engine.inputNode.audioUnit else {
+        deviceHelperLogger.error("[\(label)] engine.inputNode.audioUnit is nil - cannot set device \(deviceID)")
+        return false
+    }
+
+    var id = deviceID
+    let setStatus = AudioUnitSetProperty(
+        audioUnit,
+        kAudioOutputUnitProperty_CurrentDevice,
+        kAudioUnitScope_Global, 0,
+        &id,
+        UInt32(MemoryLayout<AudioDeviceID>.size)
+    )
+
+    if setStatus != noErr {
+        deviceHelperLogger.error("[\(label)] AudioUnitSetProperty failed: status=\(setStatus) (\(audioStatusString(setStatus))), deviceID=\(deviceID)")
+        return false
+    }
+
+    // Verify by reading back the current device
+    var verifyID = AudioDeviceID(0)
+    var verifySize = UInt32(MemoryLayout<AudioDeviceID>.size)
+    let getStatus = AudioUnitGetProperty(
+        audioUnit,
+        kAudioOutputUnitProperty_CurrentDevice,
+        kAudioUnitScope_Global, 0,
+        &verifyID,
+        &verifySize
+    )
+
+    if getStatus != noErr {
+        deviceHelperLogger.warning("[\(label)] Could not verify device after set: status=\(getStatus)")
+    } else if verifyID != deviceID {
+        deviceHelperLogger.error("[\(label)] Device verification mismatch: requested=\(deviceID), actual=\(verifyID)")
+        return false
+    }
+
+    deviceHelperLogger.info("[\(label)] Input device set and verified: \(deviceID)")
+    return true
+}
+
+private func audioStatusString(_ status: OSStatus) -> String {
+    let bytes: [UInt8] = [
+        UInt8((status >> 24) & 0xFF),
+        UInt8((status >> 16) & 0xFF),
+        UInt8((status >> 8) & 0xFF),
+        UInt8(status & 0xFF),
+    ]
+    if bytes.allSatisfy({ $0 >= 0x20 && $0 < 0x7F }) {
+        return String(bytes.map { Character(UnicodeScalar($0)) })
+    }
+    return "\(status)"
 }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -147,20 +147,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engine = AVAudioEngine()
 
         // Set the input device before reading the format
-        if let deviceID = selectedDeviceID,
-           let audioUnit = engine.inputNode.audioUnit {
-            var id = deviceID
-            AudioUnitSetProperty(
-                audioUnit,
-                kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global, 0,
-                &id,
-                UInt32(MemoryLayout<AudioDeviceID>.size)
-            )
+        if let deviceID = selectedDeviceID {
+            if !setInputDevice(deviceID, on: engine, label: "recording") {
+                logger.error("Failed to set recording input device (\(deviceID)), falling back to system default")
+            }
         }
 
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
+        logger.info("Recording input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
 
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
             throw AudioRecordingError.engineStartFailed("No audio input available")
@@ -258,19 +253,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         engine.stop()
 
         let deviceID = selectedDeviceID
-        if let deviceID, let audioUnit = engine.inputNode.audioUnit {
-            var id = deviceID
-            AudioUnitSetProperty(
-                audioUnit,
-                kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global, 0,
-                &id,
-                UInt32(MemoryLayout<AudioDeviceID>.size)
-            )
+        if let deviceID {
+            if !setInputDevice(deviceID, on: engine, label: "config-change") {
+                logger.warning("Failed to re-set device after config change (\(deviceID)), using default")
+            }
         }
 
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
+        logger.info("Config-change input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
 
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
             logger.error("Cannot restart engine: no audio input available")


### PR DESCRIPTION
## Summary

When selecting a specific microphone (e.g. "MacBook Pro Microphone") instead of "System Default", `AudioUnitSetProperty` return status was silently ignored across all 3 call sites. If the call failed, the code continued with the system default device and the user saw no audio from their selected mic.

This PR centralizes device-setting logic into a shared `setInputDevice()` helper that checks the `OSStatus`, verifies the device was actually set via readback, and logs format info (sampleRate, channels) after the switch. On failure, it falls back gracefully to the system default with diagnostic logging (category `AudioDeviceHelper` in Console.app).

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features