### PR TITLE
Fix silent recording on multi-channel audio interfaces

### DIFF
--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -139,6 +139,26 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         return Double(sampleBuffer.count) / Self.targetSampleRate
     }
 
+    /// Build a mono tap format from a (possibly multi-channel) input format.
+    ///
+    /// AVAudioConverter silently produces zero-filled output when asked to downmix
+    /// non-standard multi-channel layouts (e.g. 6-channel USB interfaces like
+    /// Focusrite Scarlett) to mono. By requesting a mono tap format, AVAudioEngine
+    /// performs the channel downmix internally — which handles arbitrary layouts
+    /// correctly — and the converter only needs to resample.
+    private static func monoTapFormat(for inputFormat: AVAudioFormat) -> AVAudioFormat {
+        if inputFormat.channelCount > 1,
+           let mono = AVAudioFormat(
+               commonFormat: .pcmFormatFloat32,
+               sampleRate: inputFormat.sampleRate,
+               channels: 1,
+               interleaved: false
+           ) {
+            return mono
+        }
+        return inputFormat
+    }
+
     func startRecording() throws {
         guard hasMicrophonePermission else {
             throw AudioRecordingError.microphonePermissionDenied
@@ -147,7 +167,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engine = AVAudioEngine()
 
         // Set the input device before reading the format
-        if let deviceID = selectedDeviceID,
+        if let deviceID = self.selectedDeviceID,
            let audioUnit = engine.inputNode.audioUnit {
             var id = deviceID
             AudioUnitSetProperty(
@@ -176,7 +196,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.engineStartFailed("Cannot create target audio format")
         }
 
-        let converter = AVAudioConverter(from: inputFormat, to: targetFormat)
+        let tapFormat = Self.monoTapFormat(for: inputFormat)
+
+        let converter = AVAudioConverter(from: tapFormat, to: targetFormat)
         guard let converter else {
             throw AudioRecordingError.engineStartFailed("Cannot create audio converter")
         }
@@ -186,7 +208,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         _peakRawAudioLevel = 0
         bufferLock.unlock()
 
-        inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: inputFormat) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
             self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
         }
 
@@ -282,12 +304,19 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             sampleRate: Self.targetSampleRate,
             channels: 1,
             interleaved: false
-        ), let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-            logger.error("Cannot restart engine: failed to create format/converter")
+        ) else {
+            logger.error("Cannot restart engine: failed to create target format")
             return
         }
 
-        inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: inputFormat) { [weak self] buffer, _ in
+        let tapFormat = Self.monoTapFormat(for: inputFormat)
+
+        guard let converter = AVAudioConverter(from: tapFormat, to: targetFormat) else {
+            logger.error("Cannot restart engine: failed to create audio converter")
+            return
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
             self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
         }
 


### PR DESCRIPTION
## Summary

- Dictation recording produces silence (peakLevel=0.0000) on multi-channel USB audio interfaces (e.g. Focusrite Scarlett 6-channel at 96 kHz)
- Root cause: `AVAudioConverter` silently produces **zero-filled output** when downmixing non-standard multi-channel layouts to mono — the tap receives real audio, the converter runs without error, but every output sample is zero
- Fix: request a **mono tap format** at the device's native sample rate so `AVAudioEngine` handles the channel downmix internally (which handles arbitrary layouts correctly), and the converter only resamples

## Details

The bug affects `startRecording()` and `handleConfigurationChange()` in `AudioRecordingService.swift`. Both paths passed the device's native multi-channel format directly to `AVAudioConverter(from: inputFormat, to: targetFormat)` where `inputFormat` could be e.g. `6 ch, 96000 Hz, Float32, deinterleaved` and `targetFormat` is `1 ch, 16000 Hz, Float32`.

The converter produced the expected number of frames but filled them with zeros, causing every recording to be discarded by the VAD as "no speech detected."

The fix extracts a helper `monoTapFormat(for:)` that returns a 1-channel Float32 format at the input's sample rate when `channelCount > 1`. The tap and converter both use this mono format, so:
- `AVAudioEngine` performs 6ch → 1ch downmix (works with any layout)
- `AVAudioConverter` performs 96kHz → 16kHz resample (mono → mono, trivial)

Single-channel devices (built-in mic) are unaffected — `monoTapFormat` returns the original format unchanged.

## Test plan

- [x] Tested with Focusrite Scarlett (96 kHz, 6 channels) on macOS 26.4 — recording works, transcription succeeds
- [ ] Verify built-in mic still works (should be no-op since channelCount == 1)
- [ ] Verify other multi-channel interfaces (e.g. PreSonus, MOTU, Universal Audio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)