### PR TITLE
Fix clipboard preservation toggle not working, fixes #198

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -347,7 +347,6 @@ enum InsertionResult {
         let hadFocusedTextField = autoEnter && hasFocusedTextField()
         let pasteboard = pasteboardProvider()
         let savedItems = preserveClipboard ? saveClipboard(from: pasteboard) : []
-        let pasteVerificationState = preserveClipboard ? capturePasteVerificationState() : nil
 
         // Set transcribed text on clipboard and simulate Cmd+V.
         // Text stays on clipboard as fallback if no text field is focused.
@@ -357,9 +356,7 @@ enum InsertionResult {
 
         if preserveClipboard {
             try? await Task.sleep(for: .milliseconds(200))
-            if let pasteVerificationState, canRestoreClipboard(afterPasteUsing: pasteVerificationState) {
-                restoreClipboard(savedItems, to: pasteboard)
-            }
+            restoreClipboard(savedItems, to: pasteboard)
         }
 
         if hadFocusedTextField {

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -199,7 +199,6 @@ final class PromptPaletteHandler {
                 // Save clipboard if preservation is enabled
                 let preserveClipboard = getPreserveClipboard?() ?? false
                 let savedClipboard = preserveClipboard ? textInsertionService.saveClipboard() : []
-                let pasteVerificationState = preserveClipboard ? textInsertionService.capturePasteVerificationState() : nil
 
                 // Always put result on clipboard so the user can paste it
                 let pasteboard = NSPasteboard.general
@@ -224,32 +223,30 @@ final class PromptPaletteHandler {
                     insertionOutcome = .failed
                 }
 
-                // Restore clipboard if insertion succeeded; keep result on clipboard as fallback otherwise
+                // Restore clipboard unconditionally when preservation is enabled
                 if preserveClipboard {
-                    switch insertionOutcome {
-                    case .insertedViaAccessibility:
-                        textInsertionService.restoreClipboard(savedClipboard)
-                    case .insertedViaPaste:
+                    if insertionOutcome == .insertedViaPaste {
                         try? await Task.sleep(for: .milliseconds(200))
-                        if let pasteVerificationState,
-                           textInsertionService.canRestoreClipboard(afterPasteUsing: pasteVerificationState) {
-                            textInsertionService.restoreClipboard(savedClipboard)
-                        }
-                    case .failed:
-                        break
                     }
+                    textInsertionService.restoreClipboard(savedClipboard)
                 }
 
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                 self.accessibilityAnnouncementService.announcePromptComplete()
                 self.speechFeedbackService.announceEvent(.promptComplete)
-                onShowNotchFeedback?(
-                    insertionOutcome == .failed ? String(localized: "Copied to clipboard") : String(localized: "Text replaced"),
-                    insertionOutcome == .failed ? "doc.on.clipboard.fill" : "checkmark.circle.fill",
-                    2.5,
-                    false,
-                    nil
-                )
+                let feedbackMessage: String
+                let feedbackIcon: String
+                if insertionOutcome == .failed && preserveClipboard {
+                    feedbackMessage = String(localized: "Insertion failed")
+                    feedbackIcon = "xmark.circle"
+                } else if insertionOutcome == .failed {
+                    feedbackMessage = String(localized: "Copied to clipboard")
+                    feedbackIcon = "doc.on.clipboard.fill"
+                } else {
+                    feedbackMessage = String(localized: "Text replaced")
+                    feedbackIcon = "checkmark.circle.fill"
+                }
+                onShowNotchFeedback?(feedbackMessage, feedbackIcon, 2.5, false, nil)
             } catch {
                 guard !Task.isCancelled else { return }
                 soundService.play(.error, enabled: soundFeedbackEnabled)


### PR DESCRIPTION
## Summary

The "Preserve clipboard content" toggle had no effect because clipboard restoration was gated behind an Accessibility API verification check (`canRestoreClipboard()`) that fails in many apps (Electron, browsers, apps without proper AX support). When verification failed, the clipboard stayed overwritten despite the user's preference.

Now unconditionally restores the clipboard when the setting is enabled, in both the dictation flow (`TextInsertionService`) and the prompt palette flow (`PromptPaletteHandler`). Also fixes a misleading "Copied to clipboard" feedback message when insertion fails with preservation enabled.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features