### PR TITLE
Add lifetime licenses and private supporter tiers

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		AA00000000000000000300 /* LicenseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000286 /* LicenseService.swift */; };
 		AA00000000000000000301 /* LicenseSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000287 /* LicenseSettingsView.swift */; };
 		AA00000000000000000302 /* WelcomeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000288 /* WelcomeSheet.swift */; };
+		AA00000000000000000303 /* SupporterBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000289 /* SupporterBadgeView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -606,6 +607,7 @@
 		BB00000000000000000286 /* LicenseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseService.swift; sourceTree = "<group>"; };
 		BB00000000000000000287 /* LicenseSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseSettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000288 /* WelcomeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeSheet.swift; sourceTree = "<group>"; };
+		BB00000000000000000289 /* SupporterBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupporterBadgeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1106,6 +1108,7 @@
 				BB00000000000000000250 /* AboutSettingsView.swift */,
 				BB00000000000000000287 /* LicenseSettingsView.swift */,
 				BB00000000000000000288 /* WelcomeSheet.swift */,
+				BB00000000000000000289 /* SupporterBadgeView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2791,6 +2794,7 @@
 				AA00000000000000000300 /* LicenseService.swift in Sources */,
 				AA00000000000000000301 /* LicenseSettingsView.swift in Sources */,
 				AA00000000000000000302 /* WelcomeSheet.swift in Sources */,
+				AA00000000000000000303 /* SupporterBadgeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -145,8 +145,21 @@ enum AppConstants {
     enum Polar {
         static let organizationId = "96de503c-3c8b-4d08-9ded-c7f6e20fdde4"
         static let checkoutURL = "https://polar.sh/typewhisper"
+        static let customerPortalURL = "https://polar.sh/typewhisper/portal"
+
+        // Business Monthly
         static let checkoutURLIndividual = "https://buy.polar.sh/polar_cl_Yfw7BSIXSNFESlrNPL0fNG8GHPqX9qhmxGce32wZfYJ"
         static let checkoutURLTeam = "https://buy.polar.sh/polar_cl_kSqGfvss0Ces3W7R4xw7hr5NdgvEbPbhhUGRH4ad3Hj"
         static let checkoutURLEnterprise = "https://buy.polar.sh/polar_cl_uzCNIsF0vY9gx2peWljyJU7JQoEzxHUueCPTA0MoOQe"
+
+        // Business Lifetime
+        static let checkoutURLIndividualLifetime = "https://buy.polar.sh/polar_cl_Uiv5AnvLoQjx4JowO3gGciT7MLOovY4oY4ESz3PIxgI"
+        static let checkoutURLTeamLifetime = "https://buy.polar.sh/polar_cl_GjG4jf1fT9HGQn051cgN6xsWH9Xm6Z7oe0Ke71xq6Po"
+        static let checkoutURLEnterpriseLifetime = "https://buy.polar.sh/polar_cl_ngagiyJjXtxDBqv19EooEGJOLRcgzBWKBFYrZ2V2Xm7"
+
+        // Private Supporter
+        static let checkoutURLSupporterBronze = "https://buy.polar.sh/polar_cl_yilyo1V90RnuUX59V2PyLUIg45FpzYI8aMhG824wYn8"
+        static let checkoutURLSupporterSilver = "https://buy.polar.sh/polar_cl_lXFAqnanhrrPd1RZ95SCb2L05L3lNrUQIkYVd0ZmK5b"
+        static let checkoutURLSupporterGold = "https://buy.polar.sh/polar_cl_FpojMlLmyF73gOqpXLihSE0lNYnoQoaMxGp724IIor4"
     }
 }

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -210,6 +210,7 @@ final class ServiceContainer: ObservableObject {
 
         // Validate license if needed
         await licenseService.validateIfNeeded()
+        await licenseService.validateSupporterIfNeeded()
 
         // Auto-start watch folder if configured
         if UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderAutoStart),

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -106,5 +106,11 @@ enum UserDefaultsKeys {
     static let licenseStatus = "licenseStatus"
     static let licenseTier = "licenseTier"
     static let lastLicenseValidation = "lastLicenseValidation"
+    static let licenseIsLifetime = "licenseIsLifetime"
     static let welcomeSheetShown = "welcomeSheetShown"
+
+    // MARK: - Supporter
+    static let supporterTier = "supporterTier"
+    static let supporterStatus = "supporterStatus"
+    static let lastSupporterValidation = "lastSupporterValidation"
 }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -452,7 +452,14 @@
       }
     },
     "Activate" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren"
+          }
+        }
+      }
     },
     "Activate with License Key" : {
 
@@ -1572,7 +1579,14 @@
       }
     },
     "Deactivate License on This Mac" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenz auf diesem Mac deaktivieren"
+          }
+        }
+      }
     },
     "Deactivation failed. Please try again." : {
 
@@ -2229,10 +2243,34 @@
       }
     },
     "Free for personal and GPL-compliant open-source use" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kostenlos für privaten und GPL-konformen Open-Source-Gebrauch"
+          }
+        }
+      }
+    },
+    "from %@ %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ab %@ %@"
+          }
+        }
+      }
     },
     "from %@ EUR/mo" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ab %@ EUR/Monat"
+          }
+        }
+      }
     },
     "General" : {
       "localizations" : {
@@ -2397,7 +2435,14 @@
       }
     },
     "I use TypeWhisper" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ich nutze TypeWhisper"
+          }
+        }
+      }
     },
     "I'll try later" : {
       "comment" : "A button label that says the user can skip the setup process later.",
@@ -2417,7 +2462,14 @@
 
     },
     "If you need a commercial license for proprietary or otherwise non-GPL-compliant use, purchase it on Polar.sh and enter the key below." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn du eine kommerzielle Lizenz für proprietären oder nicht GPL-konformen Gebrauch brauchst, kaufe sie auf Polar.sh und gib den Key unten ein."
+          }
+        }
+      }
     },
     "Immediate" : {
       "localizations" : {
@@ -2805,13 +2857,34 @@
 
     },
     "License expired or revoked" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenz abgelaufen oder widerrufen"
+          }
+        }
+      }
     },
     "License Status" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenzstatus"
+          }
+        }
+      }
     },
     "Licensed" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenziert"
+          }
+        }
+      }
     },
     "Licensed under the GNU General Public License v3.0" : {
       "localizations" : {
@@ -3179,7 +3252,14 @@
       }
     },
     "No active commercial license" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine aktive kommerzielle Lizenz"
+          }
+        }
+      }
     },
     "No activity in this period." : {
       "localizations" : {
@@ -3701,7 +3781,14 @@
       }
     },
     "Pay-what-you-want starting at the listed price. Click a tier to open the checkout page." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zahle, was du möchtest, ab dem angegebenen Preis. Klicke auf eine Stufe, um die Checkout-Seite zu öffnen."
+          }
+        }
+      }
     },
     "Pending" : {
       "comment" : "A label indicating that a file is currently being processed.",
@@ -3728,13 +3815,27 @@
       }
     },
     "Personal / OSS" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privat / OSS"
+          }
+        }
+      }
     },
     "Personal or open source" : {
 
     },
     "Personal use and GPL-compliant open-source use are free. Proprietary or otherwise non-GPL-compliant use requires a commercial license." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privater und GPL-konformer Open-Source-Gebrauch sind kostenlos. Proprietärer oder nicht GPL-konformer Gebrauch erfordert eine kommerzielle Lizenz."
+          }
+        }
+      }
     },
     "Pipe to clipboard:" : {
       "localizations" : {
@@ -4191,7 +4292,14 @@
       }
     },
     "Proprietary" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proprietär"
+          }
+        }
+      }
     },
     "Proprietary use" : {
 
@@ -4780,7 +4888,14 @@
 
     },
     "Removes the license from this device. You can reactivate it on another Mac." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernt die Lizenz von diesem Gerät. Du kannst sie auf einem anderen Mac wieder aktivieren."
+          }
+        }
+      }
     },
     "Replacement" : {
       "localizations" : {
@@ -6097,7 +6212,14 @@
       }
     },
     "User Type" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutzertyp"
+          }
+        }
+      }
     },
     "Uses Apple Translate (on-device)" : {
       "localizations" : {
@@ -6750,6 +6872,196 @@
     },
     "Your words appear as text instantly." : {
 
+    },
+    "Already have a key?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bereits einen Key?"
+          }
+        }
+      }
+    },
+    "Bronze Supporter" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bronze-Unterstützer"
+          }
+        }
+      }
+    },
+    "Silver Supporter" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silber-Unterstützer"
+          }
+        }
+      }
+    },
+    "Gold Supporter" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gold-Unterstützer"
+          }
+        }
+      }
+    },
+    "Supporter Status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unterstützer-Status"
+          }
+        }
+      }
+    },
+    "Support TypeWhisper" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper unterstützen"
+          }
+        }
+      }
+    },
+    "Deactivate Supporter License" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supporter-Lizenz deaktivieren"
+          }
+        }
+      }
+    },
+    "Thank you for supporting TypeWhisper! Join our Discord to claim your supporter role." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danke für deine Unterstützung! Tritt unserem Discord bei, um deine Supporter-Rolle zu erhalten."
+          }
+        }
+      }
+    },
+    "TypeWhisper is free for personal use. If you'd like to support development, grab a supporter license for a Discord role and an in-app badge." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper ist für den privaten Gebrauch kostenlos. Wenn du die Entwicklung unterstützen möchtest, hol dir eine Supporter-Lizenz für eine Discord-Rolle und ein In-App-Badge."
+          }
+        }
+      }
+    },
+    "Manage Purchase" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kauf verwalten"
+          }
+        }
+      }
+    },
+    "Manage Subscription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abo verwalten"
+          }
+        }
+      }
+    },
+    "Opens the Polar.sh customer portal where you can manage your subscription, update payment methods, or cancel." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffnet das Polar.sh-Kundenportal, wo du dein Abo verwalten, Zahlungsmethoden ändern oder kündigen kannst."
+          }
+        }
+      }
+    },
+    "Monthly Subscription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monatsabo"
+          }
+        }
+      }
+    },
+    "Lifetime (one-time)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lifetime (einmalig)"
+          }
+        }
+      }
+    },
+    "One-time payment. Use TypeWhisper commercially forever with no recurring fees." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einmalzahlung. Nutze TypeWhisper kommerziell für immer ohne laufende Kosten."
+          }
+        }
+      }
+    },
+    "Purchase a License" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenz kaufen"
+          }
+        }
+      }
+    },
+    "2 devices" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 Geräte"
+          }
+        }
+      }
+    },
+    "10 devices" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 Geräte"
+          }
+        }
+      }
+    },
+    "Unlimited devices" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unbegrenzt Geräte"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -20,6 +20,12 @@ enum LicenseTier: String {
     case enterprise
 }
 
+enum SupporterTier: String, CaseIterable {
+    case bronze
+    case silver
+    case gold
+}
+
 struct PolarActivationResponse: Codable {
     let id: String
 }
@@ -54,8 +60,9 @@ final class LicenseService: ObservableObject {
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "LicenseService")
     private let keychainKeyPrefix = AppConstants.keychainServicePrefix
     private let validationInterval: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    private let supporterValidationInterval: TimeInterval = 30 * 24 * 60 * 60 // 30 days
 
-    // MARK: - Published state
+    // MARK: - Published state (Business)
 
     @Published var userType: LicenseUserType? {
         didSet { UserDefaults.standard.set(userType?.rawValue, forKey: UserDefaultsKeys.userType) }
@@ -66,9 +73,26 @@ final class LicenseService: ObservableObject {
     @Published var licenseTier: LicenseTier? {
         didSet { UserDefaults.standard.set(licenseTier?.rawValue, forKey: UserDefaultsKeys.licenseTier) }
     }
+    @Published var licenseIsLifetime: Bool {
+        didSet { UserDefaults.standard.set(licenseIsLifetime, forKey: UserDefaultsKeys.licenseIsLifetime) }
+    }
     @Published var isActivating = false
     @Published var activationError: String?
     @Published var deactivationError: String?
+
+    // MARK: - Published state (Supporter)
+
+    @Published var supporterTier: SupporterTier? {
+        didSet { UserDefaults.standard.set(supporterTier?.rawValue, forKey: UserDefaultsKeys.supporterTier) }
+    }
+    @Published var supporterStatus: LicenseStatus {
+        didSet { UserDefaults.standard.set(supporterStatus.rawValue, forKey: UserDefaultsKeys.supporterStatus) }
+    }
+    @Published var isSupporterActivating = false
+    @Published var supporterActivationError: String?
+    @Published var supporterDeactivationError: String?
+
+    var isSupporter: Bool { supporterStatus == .active && supporterTier != nil }
 
     var needsWelcomeSheet: Bool {
         !UserDefaults.standard.bool(forKey: UserDefaultsKeys.welcomeSheetShown)
@@ -81,6 +105,7 @@ final class LicenseService: ObservableObject {
     // MARK: - Init
 
     init() {
+        // Business license state
         if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.userType) {
             self.userType = LicenseUserType(rawValue: raw)
         } else {
@@ -96,6 +121,20 @@ final class LicenseService: ObservableObject {
             self.licenseTier = LicenseTier(rawValue: raw)
         } else {
             self.licenseTier = nil
+        }
+        self.licenseIsLifetime = UserDefaults.standard.bool(forKey: UserDefaultsKeys.licenseIsLifetime)
+
+        // Supporter state
+        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.supporterStatus),
+           let status = LicenseStatus(rawValue: raw) {
+            self.supporterStatus = status
+        } else {
+            self.supporterStatus = .unlicensed
+        }
+        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.supporterTier) {
+            self.supporterTier = SupporterTier(rawValue: raw)
+        } else {
+            self.supporterTier = nil
         }
     }
 
@@ -122,7 +161,12 @@ final class LicenseService: ObservableObject {
             saveLicenseToKeychain(key: key, activationId: response.id)
             licenseStatus = .active
             UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
-            logger.info("License activated via Polar (activation: \(response.id))")
+
+            // Detect lifetime vs subscription
+            let validation = try? await polarValidate(key: key, activationId: response.id)
+            licenseIsLifetime = validation?.expiresAt == nil
+
+            logger.info("License activated via Polar (activation: \(response.id), lifetime: \(self.licenseIsLifetime))")
         } catch {
             activationError = error.localizedDescription
             logger.error("License activation failed: \(error)")
@@ -138,8 +182,9 @@ final class LicenseService: ObservableObject {
             let response = try await polarValidate(key: key, activationId: activationId)
             if response.status == "granted" {
                 licenseStatus = .active
+                licenseIsLifetime = response.expiresAt == nil
                 UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
-                logger.info("License validation successful")
+                logger.info("License validation successful (lifetime: \(self.licenseIsLifetime))")
             } else {
                 licenseStatus = .expired
                 logger.warning("License revoked or disabled (status: \(response.status))")
@@ -184,6 +229,7 @@ final class LicenseService: ObservableObject {
             removeLicenseFromKeychain()
             licenseStatus = .unlicensed
             licenseTier = nil
+            licenseIsLifetime = false
             UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastLicenseValidation)
         } catch {
             deactivationError = error.localizedDescription
@@ -191,7 +237,110 @@ final class LicenseService: ObservableObject {
         }
     }
 
+    // MARK: - Supporter License
+
+    func activateSupporterKey(_ key: String) async {
+        isSupporterActivating = true
+        supporterActivationError = nil
+        supporterDeactivationError = nil
+
+        do {
+            let response = try await polarActivate(key: key)
+            saveSupporterToKeychain(key: key, activationId: response.id)
+            supporterStatus = .active
+            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
+
+            // Detect tier from benefit description
+            if let validation = try? await polarValidate(key: key, activationId: response.id),
+               let description = validation.benefit?.description?.lowercased() {
+                if description.contains("gold") {
+                    supporterTier = .gold
+                } else if description.contains("silver") {
+                    supporterTier = .silver
+                } else {
+                    supporterTier = .bronze
+                }
+            } else {
+                supporterTier = .bronze
+            }
+
+            logger.info("Supporter activated via Polar (activation: \(response.id), tier: \(self.supporterTier?.rawValue ?? "unknown"))")
+        } catch {
+            supporterActivationError = error.localizedDescription
+            logger.error("Supporter activation failed: \(error)")
+        }
+
+        isSupporterActivating = false
+    }
+
+    func validateSupporterIfNeeded() async {
+        guard let (key, activationId) = loadSupporterFromKeychain() else {
+            if supporterStatus != .unlicensed || supporterTier != nil {
+                supporterStatus = .unlicensed
+                supporterTier = nil
+            }
+            return
+        }
+
+        if supporterStatus != .active {
+            await validateSupporter(key: key, activationId: activationId)
+            return
+        }
+
+        guard let lastValidation = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastSupporterValidation) as? Date else {
+            await validateSupporter(key: key, activationId: activationId)
+            return
+        }
+        if Date().timeIntervalSince(lastValidation) > supporterValidationInterval {
+            await validateSupporter(key: key, activationId: activationId)
+        }
+    }
+
+    private func validateSupporter(key: String, activationId: String) async {
+        do {
+            let response = try await polarValidate(key: key, activationId: activationId)
+            if response.status == "granted" {
+                supporterStatus = .active
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
+                logger.info("Supporter validation successful")
+            } else {
+                supporterStatus = .expired
+                logger.warning("Supporter revoked or disabled (status: \(response.status))")
+            }
+        } catch {
+            logger.error("Supporter validation failed: \(error)")
+        }
+    }
+
+    func deactivateSupporterLicense() async {
+        guard let (key, activationId) = loadSupporterFromKeychain() else { return }
+        supporterDeactivationError = nil
+
+        do {
+            try await polarDeactivate(key: key, activationId: activationId)
+            logger.info("Supporter deactivated on Polar")
+
+            removeSupporterFromKeychain()
+            supporterStatus = .unlicensed
+            supporterTier = nil
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastSupporterValidation)
+        } catch {
+            supporterDeactivationError = error.localizedDescription
+            logger.error("Supporter deactivation failed: \(error)")
+        }
+    }
+
     // MARK: - Polar API
+
+    private func withRetry<T>(_ operation: () async throws -> T) async throws -> T {
+        do {
+            return try await operation()
+        } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorNetworkConnectionLost {
+            logger.info("Network connection lost, retrying once...")
+            try await Task.sleep(for: .milliseconds(500))
+            return try await operation()
+        }
+    }
 
     private func polarActivate(key: String) async throws -> PolarActivationResponse {
         let url = URL(string: "https://api.polar.sh/v1/customer-portal/license-keys/activate")!
@@ -207,7 +356,7 @@ final class LicenseService: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await withRetry { try await URLSession.shared.data(for: request) }
         guard let httpResponse = response as? HTTPURLResponse else {
             throw LicenseError.networkError
         }
@@ -233,7 +382,7 @@ final class LicenseService: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await withRetry { try await URLSession.shared.data(for: request) }
         guard let httpResponse = response as? HTTPURLResponse else {
             throw LicenseError.networkError
         }
@@ -258,7 +407,7 @@ final class LicenseService: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await withRetry { try await URLSession.shared.data(for: request) }
         guard let httpResponse = response as? HTTPURLResponse,
               (200 ... 299).contains(httpResponse.statusCode) else {
             throw LicenseError.deactivationFailed
@@ -311,6 +460,53 @@ final class LicenseService: ObservableObject {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
             kSecAttrAccount as String: "polar-license",
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: - Supporter Keychain
+
+    private func saveSupporterToKeychain(key: String, activationId: String) {
+        let data = "\(key)|\(activationId)".data(using: .utf8)!
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "polar-supporter",
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    private func loadSupporterFromKeychain() -> (key: String, activationId: String)? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "polar-supporter",
+            kSecReturnData as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        let parts = string.split(separator: "|", maxSplits: 1)
+        guard parts.count == 2 else { return nil }
+        return (key: String(parts[0]), activationId: String(parts[1]))
+    }
+
+    private func removeSupporterFromKeychain() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: "polar-supporter",
         ]
         SecItemDelete(query as CFDictionary)
     }

--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct AboutSettingsView: View {
+    @ObservedObject private var license = LicenseService.shared
     @AppStorage(UserDefaultsKeys.updateChannel) private var selectedUpdateChannelRawValue = AppConstants.defaultReleaseChannel.rawValue
 
     private var selectedUpdateChannel: AppConstants.ReleaseChannel {
@@ -29,6 +30,10 @@ struct AboutSettingsView: View {
                     Text("TypeWhisper")
                         .font(.title)
                         .fontWeight(.semibold)
+
+                    if license.isSupporter, let tier = license.supporterTier {
+                        SupporterBadgeView(tier: tier)
+                    }
 
                     let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
                     let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -4,89 +4,21 @@ struct LicenseSettingsView: View {
     @ObservedObject private var license = LicenseService.shared
 
     @State private var licenseKeyInput = ""
+    @State private var supporterKeyInput = ""
+
+    private var isPrivateUser: Bool {
+        license.userType == .privateUser
+    }
 
     var body: some View {
         Form {
-            Section(String(localized: "License Status")) {
-                statusView
-            }
+            userTypeSection
 
-            if license.licenseStatus != .active {
-                Section(String(localized: "Activate with License Key")) {
-                    Text(String(localized: "If you need a commercial license for proprietary or otherwise non-GPL-compliant use, purchase it on Polar.sh and enter the key below."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    HStack {
-                        TextField(String(localized: "TYPEWHISPER-xxxx-xxxx"), text: $licenseKeyInput)
-                            .textFieldStyle(.roundedBorder)
-
-                        Button(String(localized: "Activate")) {
-                            Task {
-                                await license.activateLicenseKey(licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines))
-                            }
-                        }
-                        .disabled(licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || license.isActivating)
-                    }
-
-                    if license.isActivating {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-
-                    if let error = license.activationError {
-                        Label(error, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .font(.caption)
-                    }
-                }
-
-                Section(String(localized: "Purchase")) {
-                    HStack(spacing: 16) {
-                        tierButton(tier: .individual, price: "5", url: AppConstants.Polar.checkoutURLIndividual)
-                        tierButton(tier: .team, price: "19", url: AppConstants.Polar.checkoutURLTeam)
-                        tierButton(tier: .enterprise, price: "99", url: AppConstants.Polar.checkoutURLEnterprise)
-                    }
-                    .padding(.vertical, 4)
-
-                    Text(String(localized: "Pay-what-you-want starting at the listed price. Click a tier to open the checkout page."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-            }
-
-            if license.licenseStatus == .active {
-                Section(String(localized: "Manage")) {
-                    Button(String(localized: "Deactivate License on This Mac"), role: .destructive) {
-                        Task { await license.deactivateLicense() }
-                    }
-
-                    Text(String(localized: "Removes the license from this device. You can reactivate it on another Mac."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    if let error = license.deactivationError {
-                        Label(error, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .font(.caption)
-                    }
-                }
-            }
-
-            Section(String(localized: "User Type")) {
-                Picker(String(localized: "I use TypeWhisper"), selection: Binding(
-                    get: { license.userType ?? .privateUser },
-                    set: { license.setUserType($0) }
-                )) {
-                    Text(String(localized: "Personal / OSS")).tag(LicenseUserType.privateUser)
-                    Text(String(localized: "Proprietary")).tag(LicenseUserType.business)
-                }
-                .pickerStyle(.segmented)
-
-                Text(String(localized: "Personal use and GPL-compliant open-source use are free. Proprietary or otherwise non-GPL-compliant use requires a commercial license."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            if isPrivateUser {
+                privateStatusSection
+                supporterSection
+            } else {
+                businessSection
             }
         }
         .formStyle(.grouped)
@@ -94,15 +26,119 @@ struct LicenseSettingsView: View {
         .frame(minWidth: 500, minHeight: 300)
     }
 
+    // MARK: - User Type
+
+    private var userTypeSection: some View {
+        Section(String(localized: "User Type")) {
+            Picker(String(localized: "I use TypeWhisper"), selection: Binding(
+                get: { license.userType ?? .privateUser },
+                set: { license.setUserType($0) }
+            )) {
+                Text(String(localized: "Personal / OSS")).tag(LicenseUserType.privateUser)
+                Text(String(localized: "Proprietary")).tag(LicenseUserType.business)
+            }
+            .pickerStyle(.segmented)
+
+            Text(String(localized: "Personal use and GPL-compliant open-source use are free. Proprietary or otherwise non-GPL-compliant use requires a commercial license."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Private
+
+    private var privateStatusSection: some View {
+        Section(String(localized: "License Status")) {
+            Label(String(localized: "Free for personal and GPL-compliant open-source use"), systemImage: "checkmark.circle")
+                .foregroundStyle(.green)
+        }
+    }
+
+    // MARK: - Business
+
     @ViewBuilder
-    private var statusView: some View {
+    private var businessSection: some View {
+        Section(String(localized: "License Status")) {
+            businessStatusView
+        }
+
+        if license.licenseStatus == .active {
+            Section(String(localized: "Manage")) {
+                Button {
+                    if let url = URL(string: AppConstants.Polar.customerPortalURL) {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Label(String(localized: "Manage Subscription"), systemImage: "arrow.up.right.square")
+                }
+
+                Text(String(localized: "Opens the Polar.sh customer portal where you can manage your subscription, update payment methods, or cancel."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Button(String(localized: "Deactivate License on This Mac"), role: .destructive) {
+                    Task { await license.deactivateLicense() }
+                }
+
+                Text(String(localized: "Removes the license from this device. You can reactivate it on another Mac."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let error = license.deactivationError {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+        } else {
+            Section(String(localized: "Purchase a License")) {
+                Text(String(localized: "Monthly Subscription"))
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+
+                HStack(spacing: 16) {
+                    businessTierButton(tier: .individual, price: "5", suffix: String(localized: "EUR/mo"), url: AppConstants.Polar.checkoutURLIndividual)
+                    businessTierButton(tier: .team, price: "19", suffix: String(localized: "EUR/mo"), url: AppConstants.Polar.checkoutURLTeam)
+                    businessTierButton(tier: .enterprise, price: "99", suffix: String(localized: "EUR/mo"), url: AppConstants.Polar.checkoutURLEnterprise)
+                }
+
+                Text(String(localized: "Lifetime (one-time)"))
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+
+                HStack(spacing: 16) {
+                    businessTierButton(tier: .individual, price: "99", suffix: String(localized: "EUR"), url: AppConstants.Polar.checkoutURLIndividualLifetime)
+                    businessTierButton(tier: .team, price: "299", suffix: String(localized: "EUR"), url: AppConstants.Polar.checkoutURLTeamLifetime)
+                    businessTierButton(tier: .enterprise, price: "999", suffix: String(localized: "EUR"), url: AppConstants.Polar.checkoutURLEnterpriseLifetime)
+                }
+
+                Text(String(localized: "Pay-what-you-want starting at the listed price. Click a tier to open the checkout page."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                keyActivationField(
+                    input: $licenseKeyInput,
+                    isActivating: license.isActivating,
+                    error: license.activationError
+                ) {
+                    await license.activateLicenseKey(licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var businessStatusView: some View {
         switch license.licenseStatus {
         case .active:
             HStack {
                 Label(String(localized: "Licensed"), systemImage: "checkmark.seal.fill")
                     .foregroundStyle(.green)
                 if let tier = license.licenseTier {
-                    Text("(\(tierDisplayName(tier)))")
+                    let lifetimeLabel = license.licenseIsLifetime ? String(localized: ", Lifetime") : ""
+                    Text("(\(businessTierDisplayName(tier))\(lifetimeLabel))")
                         .foregroundStyle(.secondary)
                 }
             }
@@ -110,26 +146,119 @@ struct LicenseSettingsView: View {
             Label(String(localized: "License expired or revoked"), systemImage: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
         case .unlicensed:
-            if license.userType == .business {
-                Label(String(localized: "No active commercial license"), systemImage: "key")
+            Label(String(localized: "No active commercial license"), systemImage: "key")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Supporter
+
+    @ViewBuilder
+    private var supporterSection: some View {
+        if license.isSupporter, let tier = license.supporterTier {
+            Section(String(localized: "Supporter Status")) {
+                HStack {
+                    SupporterBadgeView(tier: tier)
+                    Spacer()
+                }
+
+                Text(String(localized: "Thank you for supporting TypeWhisper! Join our Discord to claim your supporter role."))
+                    .font(.caption)
                     .foregroundStyle(.secondary)
-            } else {
-                Label(String(localized: "Free for personal and GPL-compliant open-source use"), systemImage: "checkmark.circle")
-                    .foregroundStyle(.green)
+
+                Button {
+                    if let url = URL(string: AppConstants.Polar.customerPortalURL) {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Label(String(localized: "Manage Purchase"), systemImage: "arrow.up.right.square")
+                }
+
+                Button(String(localized: "Deactivate Supporter License"), role: .destructive) {
+                    Task { await license.deactivateSupporterLicense() }
+                }
+
+                if let error = license.supporterDeactivationError {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+        } else {
+            Section(String(localized: "Support TypeWhisper")) {
+                Text(String(localized: "TypeWhisper is free for personal use. If you'd like to support development, grab a supporter license for a Discord role and an in-app badge."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 16) {
+                    supporterTierButton(tier: .bronze, price: "10")
+                    supporterTierButton(tier: .silver, price: "25")
+                    supporterTierButton(tier: .gold, price: "50")
+                }
+                .padding(.vertical, 4)
+
+                keyActivationField(
+                    input: $supporterKeyInput,
+                    isActivating: license.isSupporterActivating,
+                    error: license.supporterActivationError
+                ) {
+                    await license.activateSupporterKey(supporterKeyInput.trimmingCharacters(in: .whitespacesAndNewlines))
+                }
             }
         }
     }
 
-    private func tierButton(tier: LicenseTier, price: String, url: String) -> some View {
+    // MARK: - Shared Key Activation
+
+    @ViewBuilder
+    private func keyActivationField(
+        input: Binding<String>,
+        isActivating: Bool,
+        error: String?,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Text(String(localized: "Already have a key?"))
+            .font(.caption.bold())
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+
+        HStack {
+            TextField(String(localized: "TYPEWHISPER-xxxx-xxxx"), text: input)
+                .textFieldStyle(.roundedBorder)
+
+            Button(String(localized: "Activate")) {
+                Task { await action() }
+            }
+            .disabled(input.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isActivating)
+        }
+
+        if isActivating {
+            ProgressView()
+                .controlSize(.small)
+        }
+
+        if let error {
+            Label(error, systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
+                .font(.caption)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func businessTierButton(tier: LicenseTier, price: String, suffix: String, url: String) -> some View {
         Button {
             if let checkoutURL = URL(string: url) {
                 NSWorkspace.shared.open(checkoutURL)
             }
         } label: {
             VStack(spacing: 4) {
-                Text(tierDisplayName(tier))
+                Text(businessTierDisplayName(tier))
                     .font(.caption.bold())
-                Text(String(localized: "from \(price) EUR/mo"))
+                Text(businessTierFeature(tier))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Text(String(localized: "from \(price) \(suffix)"))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -139,11 +268,69 @@ struct LicenseSettingsView: View {
         .buttonStyle(.bordered)
     }
 
-    private func tierDisplayName(_ tier: LicenseTier) -> String {
+    private func businessTierDisplayName(_ tier: LicenseTier) -> String {
         switch tier {
-        case .individual: return "Individual Business"
+        case .individual: return "Individual"
         case .team: return "Team"
         case .enterprise: return "Enterprise"
+        }
+    }
+
+    private func businessTierFeature(_ tier: LicenseTier) -> String {
+        switch tier {
+        case .individual: return String(localized: "2 devices")
+        case .team: return String(localized: "10 devices")
+        case .enterprise: return String(localized: "Unlimited devices")
+        }
+    }
+
+    private func supporterTierButton(tier: SupporterTier, price: String) -> some View {
+        Button {
+            let url: String = switch tier {
+            case .bronze: AppConstants.Polar.checkoutURLSupporterBronze
+            case .silver: AppConstants.Polar.checkoutURLSupporterSilver
+            case .gold: AppConstants.Polar.checkoutURLSupporterGold
+            }
+            if let checkoutURL = URL(string: url) {
+                NSWorkspace.shared.open(checkoutURL)
+            }
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: supporterTierIcon(tier))
+                    .foregroundStyle(supporterTierColor(tier))
+                Text(supporterTierDisplayName(tier))
+                    .font(.caption.bold())
+                Text(String(localized: "\(price) EUR"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private func supporterTierDisplayName(_ tier: SupporterTier) -> String {
+        switch tier {
+        case .bronze: return "Bronze"
+        case .silver: return "Silver"
+        case .gold: return "Gold"
+        }
+    }
+
+    private func supporterTierIcon(_ tier: SupporterTier) -> String {
+        switch tier {
+        case .bronze: return "heart.fill"
+        case .silver: return "star.fill"
+        case .gold: return "crown.fill"
+        }
+    }
+
+    private func supporterTierColor(_ tier: SupporterTier) -> Color {
+        switch tier {
+        case .bronze: return Color(red: 0.804, green: 0.498, blue: 0.196)
+        case .silver: return Color(red: 0.753, green: 0.753, blue: 0.753)
+        case .gold: return Color(red: 1.0, green: 0.843, blue: 0.0)
         }
     }
 }

--- a/TypeWhisper/Views/SupporterBadgeView.swift
+++ b/TypeWhisper/Views/SupporterBadgeView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct SupporterBadgeView: View {
+    let tier: SupporterTier
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: tierIcon)
+                .foregroundStyle(tierColor)
+            Text(tierName)
+                .font(.caption.bold())
+                .foregroundStyle(tierColor)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(tierColor.opacity(0.12), in: Capsule())
+    }
+
+    private var tierIcon: String {
+        switch tier {
+        case .bronze: return "heart.fill"
+        case .silver: return "star.fill"
+        case .gold: return "crown.fill"
+        }
+    }
+
+    private var tierName: String {
+        switch tier {
+        case .bronze: return String(localized: "Bronze Supporter")
+        case .silver: return String(localized: "Silver Supporter")
+        case .gold: return String(localized: "Gold Supporter")
+        }
+    }
+
+    private var tierColor: Color {
+        switch tier {
+        case .bronze: return Color(red: 0.804, green: 0.498, blue: 0.196) // #CD7F32
+        case .silver: return Color(red: 0.753, green: 0.753, blue: 0.753) // #C0C0C0
+        case .gold: return Color(red: 1.0, green: 0.843, blue: 0.0) // #FFD700
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new licensing options to TypeWhisper:

- **Private Supporter Tiers** (Bronze 10 EUR / Silver 25 EUR / Gold 50 EUR one-time): Cosmetic-only donation option for personal users with in-app badge (SupporterBadgeView in About + License tabs) and Discord role. Fully separate from business licensing with own Keychain entry and 30-day validation.
- **Business Lifetime Licenses** (Individual 99 EUR / Team 299 EUR / Enterprise 999 EUR one-time): Alternative to existing monthly subscriptions, detected via `expiresAt == nil` from Polar API.

Also redesigns the License Settings tab with context-dependent UI (private vs business), consolidated purchase sections with device counts per tier, Polar customer portal link for subscription management, and automatic retry on QUIC/HTTP3 network errors. All new and existing license strings are translated to German.

Polar.sh products and checkout links have been created for all 6 new tiers.

## Test Plan

- [x] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features