### PR TITLE
Suppress indicator streaming text when plugin provides own display

### DIFF
--- a/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
+++ b/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
@@ -48,6 +48,8 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
         subscriptionId = host.eventBus.subscribe { [weak self] event in
             await self?.handleEvent(event)
         }
+
+        host.setStreamingDisplayActive(true)
     }
 
     func deactivate() {
@@ -55,6 +57,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
             host?.eventBus.unsubscribe(id: id)
             subscriptionId = nil
         }
+        host?.setStreamingDisplayActive(false)
         tearDownHotkeyMonitor()
         autoCloseTask?.cancel()
         Task { @MainActor [weak self] in

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -70,4 +70,12 @@ final class HostServicesImpl: HostServices, @unchecked Sendable {
             PluginManager.shared?.notifyPluginStateChanged()
         }
     }
+
+    // MARK: - Streaming Display
+
+    func setStreamingDisplayActive(_ active: Bool) {
+        DispatchQueue.main.async {
+            DictationViewModel._shared?.updateExternalStreamingDisplay(active: active)
+        }
+    }
 }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -34,6 +34,7 @@ final class DictationViewModel: ObservableObject {
     @Published var hotkeyMode: HotkeyService.HotkeyMode?
     @Published var partialText: String = ""
     @Published var isStreaming: Bool = false
+    @Published private(set) var externalStreamingDisplayCount: Int = 0
     @Published var audioDuckingEnabled: Bool {
         didSet { UserDefaults.standard.set(audioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled) }
     }
@@ -941,6 +942,10 @@ final class DictationViewModel: ObservableObject {
             guard !Task.isCancelled else { return }
             resetDictationState()
         }
+    }
+
+    func updateExternalStreamingDisplay(active: Bool) {
+        externalStreamingDisplayCount += active ? 1 : -1
     }
 
     private func showError(_ message: String, category: String = "general") {

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -19,6 +19,10 @@ struct NotchIndicatorView: View {
         geometry.hasNotch ? geometry.notchWidth + 2 * extensionWidth : 200
     }
 
+    private var suppressStreamingText: Bool {
+        viewModel.externalStreamingDisplayCount > 0
+    }
+
     private var hasActionFeedback: Bool {
         viewModel.state == .inserting && viewModel.actionFeedbackMessage != nil
     }
@@ -44,7 +48,7 @@ struct NotchIndicatorView: View {
                 .frame(width: currentWidth, height: geometry.notchHeight)
                 .frame(maxWidth: .infinity)
 
-            if viewModel.state == .recording {
+            if viewModel.state == .recording, !suppressStreamingText {
                 IndicatorExpandableText(
                     text: viewModel.partialText,
                     sizing: sizing,
@@ -96,6 +100,13 @@ struct NotchIndicatorView: View {
             } else {
                 dotPulse = false
                 textExpanded = false
+            }
+        }
+        .onChange(of: suppressStreamingText) {
+            if suppressStreamingText {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    textExpanded = false
+                }
             }
         }
         .animation(.easeInOut(duration: 1.0), value: dotPulse)

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -11,6 +11,10 @@ struct OverlayIndicatorView: View {
     private let sizing: IndicatorSizing = .overlay
     private var closedWidth: CGFloat { 280 }
 
+    private var suppressStreamingText: Bool {
+        viewModel.externalStreamingDisplayCount > 0
+    }
+
     private var hasActionFeedback: Bool {
         viewModel.state == .inserting && viewModel.actionFeedbackMessage != nil
     }
@@ -65,6 +69,13 @@ struct OverlayIndicatorView: View {
                 textExpanded = false
             }
         }
+        .onChange(of: suppressStreamingText) {
+            if suppressStreamingText {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    textExpanded = false
+                }
+            }
+        }
         .animation(.easeInOut(duration: 1.0), value: dotPulse)
     }
 
@@ -74,7 +85,7 @@ struct OverlayIndicatorView: View {
     private var expandableContent: some View {
         if isTop {
             // Top position: text expands downward, action feedback below text
-            if viewModel.state == .recording {
+            if viewModel.state == .recording, !suppressStreamingText {
                 IndicatorExpandableText(
                     text: viewModel.partialText,
                     sizing: sizing,
@@ -111,7 +122,7 @@ struct OverlayIndicatorView: View {
                 Divider().background(Color.white.opacity(0.1))
             }
 
-            if viewModel.state == .recording {
+            if viewModel.state == .recording, !suppressStreamingText {
                 IndicatorExpandableText(
                     text: viewModel.partialText,
                     sizing: sizing,

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -27,6 +27,10 @@ public protocol HostServices: Sendable {
 
     // Notify host that plugin capabilities changed (e.g. model loaded/unloaded)
     func notifyCapabilitiesChanged()
+
+    // Streaming display: call with true when the plugin provides its own streaming text UI,
+    // so the built-in indicator suppresses its streaming text display.
+    func setStreamingDisplayActive(_ active: Bool)
 }
 
 // MARK: - HTTP Client (Ephemeral Sessions)

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -57,6 +57,7 @@ private struct MockHostServices: HostServices {
     }
 
     func notifyCapabilitiesChanged() {}
+    func setStreamingDisplayActive(_ active: Bool) {}
 }
 
 @objc(MockTranscriptionPlugin)


### PR DESCRIPTION
## Summary

Adds a generic `setStreamingDisplayActive(_:)` method to the `HostServices` SDK protocol, allowing any plugin to signal that it provides its own streaming text UI. When active, the built-in notch and overlay indicators suppress their `IndicatorExpandableText` to avoid duplicate streaming text. LiveTranscriptPlugin uses this to claim display on activate and release on deactivate.

## Test Plan

- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features