### PR TITLE
Fix EXC_BAD_ACCESS crash in AppDelegate.windowDidBecomeKey

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -277,21 +277,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         !isMenuBarIconHidden && !hasVisibleManagedWindow
     }
 
-    @objc private func windowDidBecomeKey(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow,
-              isManagedWindow(window),
-              window.isVisible
-        else { return }
-        NSApp.setActivationPolicy(.regular)
-        NSApp.activate()
+    @objc nonisolated private func windowDidBecomeKey(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        DispatchQueue.main.async { [self] in
+            guard isManagedWindow(window), window.isVisible else { return }
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate()
+        }
     }
 
-    @objc private func windowWillClose(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow,
-              isManagedWindow(window)
-        else { return }
+    @objc nonisolated private func windowWillClose(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
         // Only go back to accessory if menu bar icon is visible and no other managed window is open
         DispatchQueue.main.async { [weak self] in
+            guard self?.isManagedWindow(window) == true else { return }
             if self?.shouldRevertToAccessory == true {
                 NSApp.setActivationPolicy(.accessory)
             }


### PR DESCRIPTION
## Summary

- Fix `EXC_BAD_ACCESS (SIGSEGV)` crash in `@objc AppDelegate.windowDidBecomeKey(_:)` after extended runtime (~26h)
- Root cause: Swift 6 compiler generates an executor isolation check thunk for `@objc` methods on `@MainActor` classes. After long uptime, `swift_task_isMainExecutorImpl` accesses a corrupted executor reference, crashing in `objc_msgSend`
- Fix: Mark `windowDidBecomeKey` and `windowWillClose` as `nonisolated` to remove the thunk, move AppKit calls into `DispatchQueue.main.async`

## Crash stack
```
0  objc_msgSend + 56
1  swift_getObjectType + 204
2  swift_task_isMainExecutorImpl + 36
3  swift::SerialExecutorRef::isMainExecutor() const + 24
4  swift_task_isCurrentExecutorWithFlagsImpl + 72
5  @objc AppDelegate.windowDidBecomeKey(_:) + 164
```

## Test plan
- [x] Build succeeds with no warnings (Swift 6 strict concurrency)
- [ ] Launch app, open/close Settings - activation policy toggles correctly
- [ ] Hide menu bar icon - Dock icon appears, Settings opens on Dock click