### PR TITLE
Fix AVAudioEngine teardown race in stopRecording (#209)

### DIFF
--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -7,6 +7,21 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioRecordingService")
 
+final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
+    private let queue: DispatchQueue
+
+    init(label: String, qos: DispatchQoS = .utility) {
+        queue = DispatchQueue(label: label, qos: qos)
+    }
+
+    func retain(_ object: Object, for duration: TimeInterval) {
+        let retainedObject = object
+        queue.asyncAfter(deadline: .now() + duration) {
+            withExtendedLifetime(retainedObject) {}
+        }
+    }
+}
+
 /// Captures microphone audio via AVAudioEngine and converts to 16kHz mono Float32 samples.
 final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     enum StopPolicy {
@@ -79,10 +94,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let stopStateLock = NSLock()
     private let engineLock = NSLock()
     private let processingQueue = DispatchQueue(label: "com.typewhisper.audio-processing", qos: .userInteractive)
+    private let engineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.audio-engine-teardown")
     private var _lastStopGraceCaptureApplied = false
 
     static let targetSampleRate: Double = 16000
     private static let captureTapFrames: AVAudioFrameCount = 1024
+    private static let engineTeardownRetentionInterval: TimeInterval = 0.3
 
     var peakRawAudioLevel: Float {
         bufferLock.lock()
@@ -222,7 +239,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         configChangeObserver = NotificationCenter.default.addObserver(
             forName: .AVAudioEngineConfigurationChange,
             object: engine,
-            queue: nil
+            queue: .main
         ) { [weak self] _ in
             self?.handleConfigurationChange()
         }
@@ -258,6 +275,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+        // Keep the engine alive briefly so CoreAudio's internal teardown callbacks
+        // cannot outlive the AVAudioEngine objects they still reference.
+        engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
 
         // Flush pending audio processing before grabbing the buffer
         processingQueue.sync { }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -8,6 +8,14 @@ import os
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioRecordingService")
 
 final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
+    private final class RetainedObjectBox: @unchecked Sendable {
+        let object: Object
+
+        init(_ object: Object) {
+            self.object = object
+        }
+    }
+
     private let queue: DispatchQueue
 
     init(label: String, qos: DispatchQoS = .utility) {
@@ -15,7 +23,7 @@ final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
     }
 
     func retain(_ object: Object, for duration: TimeInterval) {
-        let retainedObject = object
+        let retainedObject = RetainedObjectBox(object)
         queue.asyncAfter(deadline: .now() + duration) {
             withExtendedLifetime(retainedObject) {}
         }

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -3,7 +3,17 @@ import XCTest
 @testable import TypeWhisper
 
 final class DictationShortSpeechTests: XCTestCase {
-    private final class ReleaseProbe {}
+    private final class ReleaseProbe {
+        private let onDeinit: () -> Void
+
+        init(onDeinit: @escaping () -> Void = {}) {
+            self.onDeinit = onDeinit
+        }
+
+        deinit {
+            onDeinit()
+        }
+    }
 
     func testEmptyBuffer_isDiscardedAsTooShort() {
         XCTAssertEqual(classifyShortSpeech(rawDuration: 0, peakLevel: 0), .discardTooShort)
@@ -46,19 +56,24 @@ final class DictationShortSpeechTests: XCTestCase {
         XCTAssertFalse(AudioRecordingService.StopPolicy.immediate.shouldApplyGracePeriod(bufferedDuration: 0.01))
     }
 
-    func testDelayedReleaseRetainer_keepsObjectAliveUntilDelayExpires() async throws {
+    func testDelayedReleaseRetainer_keepsObjectAliveUntilDelayExpires() throws {
         let retainer = DelayedReleaseRetainer<ReleaseProbe>(label: "com.typewhisper.tests.delayed-release")
-        var probe: ReleaseProbe? = ReleaseProbe()
-        weak var weakProbe = probe
+        let released = expectation(description: "release after delay")
+        let releaseLock = NSLock()
+        var didRelease = false
+        var probe: ReleaseProbe? = ReleaseProbe {
+            releaseLock.withLock {
+                didRelease = true
+            }
+            released.fulfill()
+        }
 
         retainer.retain(try XCTUnwrap(probe), for: 0.1)
         probe = nil
 
-        try await Task.sleep(for: .milliseconds(30))
-        XCTAssertNotNil(weakProbe)
-
-        try await Task.sleep(for: .milliseconds(180))
-        XCTAssertNil(weakProbe)
+        Thread.sleep(forTimeInterval: 0.03)
+        XCTAssertFalse(releaseLock.withLock { didRelease })
+        wait(for: [released], timeout: 0.5)
     }
 
     private func makeSamples(duration: TimeInterval) -> [Float] {

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import TypeWhisper
 
 final class DictationShortSpeechTests: XCTestCase {
+    private final class ReleaseProbe {}
+
     func testEmptyBuffer_isDiscardedAsTooShort() {
         XCTAssertEqual(classifyShortSpeech(rawDuration: 0, peakLevel: 0), .discardTooShort)
     }
@@ -42,6 +44,21 @@ final class DictationShortSpeechTests: XCTestCase {
         XCTAssertFalse(policy.shouldApplyGracePeriod(bufferedDuration: 0.05))
         XCTAssertFalse(policy.shouldApplyGracePeriod(bufferedDuration: 0.08))
         XCTAssertFalse(AudioRecordingService.StopPolicy.immediate.shouldApplyGracePeriod(bufferedDuration: 0.01))
+    }
+
+    func testDelayedReleaseRetainer_keepsObjectAliveUntilDelayExpires() async throws {
+        let retainer = DelayedReleaseRetainer<ReleaseProbe>(label: "com.typewhisper.tests.delayed-release")
+        var probe: ReleaseProbe? = ReleaseProbe()
+        weak var weakProbe = probe
+
+        retainer.retain(try XCTUnwrap(probe), for: 0.1)
+        probe = nil
+
+        try await Task.sleep(for: .milliseconds(30))
+        XCTAssertNotNil(weakProbe)
+
+        try await Task.sleep(for: .milliseconds(180))
+        XCTAssertNil(weakProbe)
     }
 
     private func makeSamples(duration: TimeInterval) -> [Float] {


### PR DESCRIPTION
## Summary
- keep `AVAudioEngine` alive briefly after `stopRecording()` teardown so CoreAudio internal callbacks cannot outlive the engine
- move `AVAudioEngineConfigurationChange` handling onto the main queue instead of the posting thread
- add a unit test for the delayed-release helper used by the teardown path

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationShortSpeechTests`

Fixes #209