### PR TITLE
fix: honor streaming preview in no-speech guard

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -555,6 +555,8 @@ final class DictationViewModel: ObservableObject {
         mediaPlaybackService.resumeIfWePaused()
         streamingHandler.stop()
         stopRecordingTimer()
+        let previewText = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasPreviewText = !previewText.isEmpty
 
         if !partialText.isEmpty {
             let elapsed = recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
@@ -569,11 +571,15 @@ final class DictationViewModel: ObservableObject {
         var samples = await audioRecordingService.stopRecording(policy: stopPolicy)
         let peakLevel = audioRecordingService.peakRawAudioLevel
         let rawDuration = Double(samples.count) / AudioRecordingService.targetSampleRate
-        let decision = classifyShortSpeech(rawDuration: rawDuration, peakLevel: peakLevel)
+        let decision = classifyShortSpeech(
+            rawDuration: rawDuration,
+            peakLevel: peakLevel,
+            hasPreviewText: hasPreviewText
+        )
         let graceApplied = audioRecordingService.lastStopGraceCaptureApplied
 
         logger.info(
-            "Stop finalized: rawDuration=\(String(format: "%.3f", rawDuration), privacy: .public)s, bufferedSamples=\(samples.count), peakLevel=\(String(format: "%.4f", peakLevel), privacy: .public), stopPolicy=\(stopPolicy.logDescription, privacy: .public), graceApplied=\(graceApplied, privacy: .public), decision=\(decision.logDescription, privacy: .public)"
+            "Stop finalized: rawDuration=\(String(format: "%.3f", rawDuration), privacy: .public)s, bufferedSamples=\(samples.count), peakLevel=\(String(format: "%.4f", peakLevel), privacy: .public), hasPreviewText=\(hasPreviewText, privacy: .public), previewTextLength=\(previewText.count, privacy: .public), stopPolicy=\(stopPolicy.logDescription, privacy: .public), graceApplied=\(graceApplied, privacy: .public), decision=\(decision.logDescription, privacy: .public)"
         )
 
         switch decision {
@@ -987,8 +993,9 @@ enum ShortSpeechDecision: Equatable {
     }
 }
 
-func classifyShortSpeech(rawDuration: TimeInterval, peakLevel: Float) -> ShortSpeechDecision {
+func classifyShortSpeech(rawDuration: TimeInterval, peakLevel: Float, hasPreviewText: Bool) -> ShortSpeechDecision {
     guard rawDuration >= 0.04 else { return .discardTooShort }
+    if hasPreviewText { return .transcribe }
 
     if rawDuration < 0.25 {
         return peakLevel < 0.006 ? .discardNoSpeech : .transcribe

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -16,17 +16,21 @@ final class DictationShortSpeechTests: XCTestCase {
     }
 
     func testEmptyBuffer_isDiscardedAsTooShort() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0, peakLevel: 0), .discardTooShort)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0, peakLevel: 0, hasPreviewText: false), .discardTooShort)
     }
 
     func testThirtyMsHighPeak_isStillTooShort() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2), .discardTooShort)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2, hasPreviewText: false), .discardTooShort)
+    }
+
+    func testThirtyMsPreviewText_isStillTooShort() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2, hasPreviewText: true), .discardTooShort)
     }
 
     func testEightyMsSpeechAtPointZeroZeroEight_transcribesAndPadsToZeroPointSevenFive() {
         let samples = makeSamples(duration: 0.08)
 
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.08, peakLevel: 0.008), .transcribe)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.08, peakLevel: 0.008, hasPreviewText: false), .transcribe)
 
         let paddedSamples = paddedSamplesForFinalTranscription(samples, rawDuration: 0.08)
         XCTAssertEqual(paddedSamples.count, 12_000)
@@ -34,16 +38,24 @@ final class DictationShortSpeechTests: XCTestCase {
     }
 
     func testOneHundredTwentyMsQuietClip_isNoSpeech() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.005), .discardNoSpeech)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.005, hasPreviewText: false), .discardNoSpeech)
+    }
+
+    func testOneHundredTwentyMsQuietClip_withPreviewText_transcribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.005, hasPreviewText: true), .transcribe)
     }
 
     func testFourHundredMsSpeech_usesStandardNoSpeechThresholdAndNoMinimumPad() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009), .discardNoSpeech)
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.011), .transcribe)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009, hasPreviewText: false), .discardNoSpeech)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.011, hasPreviewText: false), .transcribe)
 
         let paddedSamples = paddedSamplesForFinalTranscription(makeSamples(duration: 0.4), rawDuration: 0.4)
         XCTAssertEqual(paddedSamples.count, 12_000)
         XCTAssertEqual(Double(paddedSamples.count) / AudioRecordingService.targetSampleRate, 0.75, accuracy: 0.0001)
+    }
+
+    func testFourHundredMsQuietClip_withPreviewText_transcribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009, hasPreviewText: true), .transcribe)
     }
 
     func testFinalizeShortSpeechPolicy_waitsOnlyWhenBufferedDurationIsBelowFiveHundredths() {


### PR DESCRIPTION
## Summary
- use non-empty streaming preview text as an explicit signal in the dictation stop path
- keep the `too short` guard intact, but prevent low-peak sessions with visible preview text from being discarded as `No speech detected`
- extend short-speech tests to cover preview-text bypass cases without introducing preview-text insertion fallback

Closes #213.

## Test Coverage
- Added unit coverage for low-peak clips with and without preview text in `TypeWhisperTests/DictationShortSpeechTests.swift`

## Verification Results
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`

## Test Plan
1. Use a streaming-capable dictation engine.
2. Dictate quietly into a text field until preview text is visible.
3. Release the hotkey.
4. Verify the session no longer ends with `No speech detected`; it should proceed to final transcription and either insert text or show `No speech recognized` if the final result is empty.
5. Confirm that a very short accidental tap still shows `Too short, hold the hotkey a bit longer` and that true silence without preview text still shows `No speech detected`.