### PR TITLE
feat: add minimal indicator style

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -173,11 +173,13 @@
 		AA00000000000000000202 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000020 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000203 /* MLXAudioSTT in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000021 /* MLXAudioSTT */; };
 		AA00000000000000000204 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000022 /* MLXAudioCore */; };
-		AA00000000000000000205 /* OverlayIndicatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000198 /* OverlayIndicatorPanel.swift */; };
-		AA00000000000000000206 /* OverlayIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000195 /* OverlayIndicatorView.swift */; };
-		AA00000000000000000207 /* IndicatorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000196 /* IndicatorCoordinator.swift */; };
-		AA00000000000000000208 /* SharedIndicatorComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000197 /* SharedIndicatorComponents.swift */; };
-		AA00000000000000000209 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
+			AA00000000000000000205 /* OverlayIndicatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000198 /* OverlayIndicatorPanel.swift */; };
+			AA00000000000000000206 /* OverlayIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000195 /* OverlayIndicatorView.swift */; };
+			AA00000000000000000207 /* IndicatorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000196 /* IndicatorCoordinator.swift */; };
+			AA00000000000000000208 /* SharedIndicatorComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000197 /* SharedIndicatorComponents.swift */; };
+			AA00000000000000000311 /* MinimalIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000309 /* MinimalIndicatorView.swift */; };
+			AA00000000000000000312 /* MinimalIndicatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000310 /* MinimalIndicatorPanel.swift */; };
+			AA00000000000000000209 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
 		AA00000000000000000210 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000201 /* manifest.json */; };
 		AA00000000000000000211 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000202 /* Localizable.xcstrings */; };
 		AA00000000000000000212 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000023 /* TypeWhisperPluginSDK */; };
@@ -496,11 +498,13 @@
 		BB00000000000000000192 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000193 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000194 /* CodeSigning.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CodeSigning.xcconfig; sourceTree = "<group>"; };
-		BB00000000000000000195 /* OverlayIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorView.swift; sourceTree = "<group>"; };
-		BB00000000000000000196 /* IndicatorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorCoordinator.swift; sourceTree = "<group>"; };
-		BB00000000000000000197 /* SharedIndicatorComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedIndicatorComponents.swift; sourceTree = "<group>"; };
-		BB00000000000000000198 /* OverlayIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorPanel.swift; sourceTree = "<group>"; };
-		BB00000000000000000199 /* DeepgramPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeepgramPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+			BB00000000000000000195 /* OverlayIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorView.swift; sourceTree = "<group>"; };
+			BB00000000000000000196 /* IndicatorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorCoordinator.swift; sourceTree = "<group>"; };
+			BB00000000000000000197 /* SharedIndicatorComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedIndicatorComponents.swift; sourceTree = "<group>"; };
+			BB00000000000000000198 /* OverlayIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorPanel.swift; sourceTree = "<group>"; };
+			BB00000000000000000309 /* MinimalIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalIndicatorView.swift; sourceTree = "<group>"; };
+			BB00000000000000000310 /* MinimalIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalIndicatorPanel.swift; sourceTree = "<group>"; };
+			BB00000000000000000199 /* DeepgramPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeepgramPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000200 /* DeepgramPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepgramPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000201 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000202 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -1077,14 +1081,16 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
-		CC00000000000000000008 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				BB00000000000000000198 /* OverlayIndicatorPanel.swift */,
-				BB00000000000000000195 /* OverlayIndicatorView.swift */,
-				BB00000000000000000197 /* SharedIndicatorComponents.swift */,
-				BB00000000000000000014 /* MenuBarView.swift */,
-				BB00000000000000000016 /* FileTranscriptionView.swift */,
+			CC00000000000000000008 /* Views */ = {
+				isa = PBXGroup;
+				children = (
+					BB00000000000000000198 /* OverlayIndicatorPanel.swift */,
+					BB00000000000000000195 /* OverlayIndicatorView.swift */,
+					BB00000000000000000310 /* MinimalIndicatorPanel.swift */,
+					BB00000000000000000309 /* MinimalIndicatorView.swift */,
+					BB00000000000000000197 /* SharedIndicatorComponents.swift */,
+					BB00000000000000000014 /* MenuBarView.swift */,
+					BB00000000000000000016 /* FileTranscriptionView.swift */,
 				BB00000000000000000017 /* SettingsView.swift */,
 				BB00000000000000000046 /* AdvancedSettingsView.swift */,
 				BB00000000000000000051 /* GeneralSettingsView.swift */,
@@ -2768,14 +2774,16 @@
 				AA00000000000000000117 /* PromptActionsSettingsView.swift in Sources */,
 				AA00000000000000000118 /* PromptPalettePanel.swift in Sources */,
 				AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */,
-				AA00000000000000000123 /* EventBus.swift in Sources */,
-				AA00000000000000000124 /* PluginManager.swift in Sources */,
-				AA00000000000000000160 /* PluginRegistryService.swift in Sources */,
-				AA00000000000000000125 /* HostServicesImpl.swift in Sources */,
-				AA00000000000000000205 /* OverlayIndicatorPanel.swift in Sources */,
-				AA00000000000000000206 /* OverlayIndicatorView.swift in Sources */,
-				AA00000000000000000208 /* SharedIndicatorComponents.swift in Sources */,
-				AA00000000000000000126 /* PostProcessingPipeline.swift in Sources */,
+					AA00000000000000000123 /* EventBus.swift in Sources */,
+					AA00000000000000000124 /* PluginManager.swift in Sources */,
+					AA00000000000000000160 /* PluginRegistryService.swift in Sources */,
+					AA00000000000000000125 /* HostServicesImpl.swift in Sources */,
+					AA00000000000000000205 /* OverlayIndicatorPanel.swift in Sources */,
+					AA00000000000000000206 /* OverlayIndicatorView.swift in Sources */,
+					AA00000000000000000312 /* MinimalIndicatorPanel.swift in Sources */,
+					AA00000000000000000311 /* MinimalIndicatorView.swift in Sources */,
+					AA00000000000000000208 /* SharedIndicatorComponents.swift in Sources */,
+					AA00000000000000000126 /* PostProcessingPipeline.swift in Sources */,
 				AA00000000000000000127 /* PluginSettingsView.swift in Sources */,
 				AA00000000000000000152 /* AppConstants.swift in Sources */,
 				AA00000000000000000189 /* WidgetData.swift in Sources */,

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -5936,6 +5936,16 @@
         }
       }
     },
+    "The indicator style is a compact power-user indicator that only shows status, errors, and action feedback." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Indikator-Stil ist ein kompakter Power-User-Indikator, der nur Status, Fehler und Aktions-Feedback zeigt."
+          }
+        }
+      }
+    },
     "When disabled, the indicator only shows recording status while transcription continues in the background." : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -7,6 +7,7 @@ import Combine
 final class IndicatorCoordinator {
     private let notchPanel = NotchIndicatorPanel()
     private let overlayPanel = OverlayIndicatorPanel()
+    private let minimalPanel = MinimalIndicatorPanel()
     private var cancellables = Set<AnyCancellable>()
 
     func startObserving() {
@@ -23,16 +24,23 @@ final class IndicatorCoordinator {
         // Both panels observe state; the coordinator and panels gate which one is active
         notchPanel.startObserving()
         overlayPanel.startObserving()
+        minimalPanel.startObserving()
     }
 
     private func switchStyle(_ style: IndicatorStyle, vm: DictationViewModel) {
         switch style {
         case .notch:
             overlayPanel.dismiss()
+            minimalPanel.dismiss()
             notchPanel.updateVisibility(state: vm.state, vm: vm)
         case .overlay:
             notchPanel.dismiss()
+            minimalPanel.dismiss()
             overlayPanel.updateVisibility(state: vm.state, vm: vm)
+        case .minimal:
+            notchPanel.dismiss()
+            overlayPanel.dismiss()
+            minimalPanel.updateVisibility(state: vm.state, vm: vm)
         }
     }
 }

--- a/TypeWhisper/ViewModels/DictationEnums.swift
+++ b/TypeWhisper/ViewModels/DictationEnums.swift
@@ -3,6 +3,7 @@ import Foundation
 enum IndicatorStyle: String, CaseIterable {
     case notch
     case overlay
+    case minimal
 }
 
 enum NotchIndicatorVisibility: String, CaseIterable {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -72,7 +72,7 @@ final class DictationViewModel: ObservableObject {
     private var actionDisplayDuration: TimeInterval = 3.5
 
     @Published var indicatorStyle: IndicatorStyle {
-        didSet { UserDefaults.standard.set(indicatorStyle.rawValue, forKey: UserDefaultsKeys.indicatorStyle) }
+        didSet { Self.persistIndicatorStyle(indicatorStyle) }
     }
 
     @Published var notchIndicatorVisibility: NotchIndicatorVisibility {
@@ -204,8 +204,7 @@ final class DictationViewModel: ObservableObject {
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
         self.spokenFeedbackEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
-        self.indicatorStyle = UserDefaults.standard.string(forKey: UserDefaultsKeys.indicatorStyle)
-            .flatMap { IndicatorStyle(rawValue: $0) } ?? .notch
+        self.indicatorStyle = Self.loadIndicatorStyle()
         self.notchIndicatorVisibility = UserDefaults.standard.string(forKey: UserDefaultsKeys.notchIndicatorVisibility)
             .flatMap { NotchIndicatorVisibility(rawValue: $0) } ?? .duringActivity
         self.notchIndicatorLeftContent = UserDefaults.standard.string(forKey: UserDefaultsKeys.notchIndicatorLeftContent)
@@ -268,6 +267,15 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistIndicatorTranscriptPreviewEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
         defaults.set(enabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+    }
+
+    nonisolated static func loadIndicatorStyle(defaults: UserDefaults = .standard) -> IndicatorStyle {
+        defaults.string(forKey: UserDefaultsKeys.indicatorStyle)
+            .flatMap { IndicatorStyle(rawValue: $0) } ?? .notch
+    }
+
+    nonisolated static func persistIndicatorStyle(_ style: IndicatorStyle, defaults: UserDefaults = .standard) {
+        defaults.set(style.rawValue, forKey: UserDefaultsKeys.indicatorStyle)
     }
 
     var needsMicPermission: Bool {

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -17,6 +17,14 @@ struct GeneralSettingsView: View {
     @ObservedObject private var settings = SettingsViewModel.shared
     @ObservedObject private var dictation = DictationViewModel.shared
 
+    private var supportsTranscriptPreview: Bool {
+        dictation.indicatorStyle != .minimal
+    }
+
+    private var supportsPositionSelection: Bool {
+        dictation.indicatorStyle == .overlay || dictation.indicatorStyle == .minimal
+    }
+
     var body: some View {
         Form {
             Section(String(localized: "Spoken Language")) {
@@ -108,12 +116,14 @@ struct GeneralSettingsView: View {
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Color.clear)
 
-                Toggle(String(localized: "Show live transcript preview"), isOn: $dictation.indicatorTranscriptPreviewEnabled)
+                if supportsTranscriptPreview {
+                    Toggle(String(localized: "Show live transcript preview"), isOn: $dictation.indicatorTranscriptPreviewEnabled)
 
-                if !dictation.indicatorTranscriptPreviewEnabled {
-                    Text(String(localized: "When disabled, the indicator only shows recording status while transcription continues in the background."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if !dictation.indicatorTranscriptPreviewEnabled {
+                        Text(String(localized: "When disabled, the indicator only shows recording status while transcription continues in the background."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Picker(String(localized: "Visibility"), selection: $dictation.notchIndicatorVisibility) {
@@ -128,15 +138,17 @@ struct GeneralSettingsView: View {
                     Text(String(localized: "Built-in Display")).tag(NotchIndicatorDisplay.builtInScreen)
                 }
 
-                if dictation.indicatorStyle == .overlay {
+                if supportsPositionSelection {
                     Picker(String(localized: "Position"), selection: $dictation.overlayPosition) {
                         Text(String(localized: "Top")).tag(OverlayPosition.top)
                         Text(String(localized: "Bottom")).tag(OverlayPosition.bottom)
                     }
                 }
 
-                Picker(String(localized: "Left Side"), selection: $dictation.notchIndicatorLeftContent) {
-                    notchContentPickerOptions
+                if dictation.indicatorStyle != .minimal {
+                    Picker(String(localized: "Left Side"), selection: $dictation.notchIndicatorLeftContent) {
+                        notchContentPickerOptions
+                    }
                 }
 
                 Picker(String(localized: "Right Side"), selection: $dictation.notchIndicatorRightContent) {
@@ -145,6 +157,10 @@ struct GeneralSettingsView: View {
 
                 if dictation.indicatorStyle == .notch {
                     Text(String(localized: "The notch indicator extends the MacBook notch area to show recording status."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if dictation.indicatorStyle == .minimal {
+                    Text(String(localized: "The indicator style is a compact power-user indicator that only shows status, errors, and action feedback."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {

--- a/TypeWhisper/Views/IndicatorPreviewView.swift
+++ b/TypeWhisper/Views/IndicatorPreviewView.swift
@@ -4,13 +4,17 @@ struct IndicatorPreviewView: View {
     @ObservedObject private var dictation = DictationViewModel.shared
 
     private let streamingText = String(localized: "Hello, this is a live preview of the streaming text...")
-    private var showTranscriptPreview: Bool { dictation.indicatorTranscriptPreviewEnabled }
+    private var showTranscriptPreview: Bool {
+        dictation.indicatorTranscriptPreviewEnabled && dictation.indicatorStyle != .minimal
+    }
     private var previewHeight: CGFloat {
         switch dictation.indicatorStyle {
         case .notch:
             return showTranscriptPreview ? 110 : 88
         case .overlay:
             return showTranscriptPreview ? 110 : 82
+        case .minimal:
+            return 72
         }
     }
 
@@ -22,8 +26,10 @@ struct IndicatorPreviewView: View {
             Group {
                 if dictation.indicatorStyle == .notch {
                     notchPreview
-                } else {
+                } else if dictation.indicatorStyle == .overlay {
                     overlayPreview
+                } else {
+                    minimalPreview
                 }
             }
             .environment(\.colorScheme, .dark)
@@ -116,6 +122,23 @@ struct IndicatorPreviewView: View {
         )
     }
 
+    @ViewBuilder
+    private var minimalPreview: some View {
+        HStack(spacing: 8) {
+            appIconPlaceholder(size: 14, cornerRadius: 3)
+            if dictation.notchIndicatorRightContent != .none {
+                contentLabel(dictation.notchIndicatorRightContent, size: 11)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(.black.opacity(0.85), in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.white.opacity(0.14), lineWidth: 1)
+        )
+    }
+
     // MARK: - App Icon Placeholder
 
     private func appIconPlaceholder(size: CGFloat, cornerRadius: CGFloat) -> some View {
@@ -170,45 +193,64 @@ struct IndicatorPreviewView: View {
 
 struct IndicatorStylePicker: View {
     @ObservedObject private var dictation = DictationViewModel.shared
+    private let notchTileWidth: CGFloat = 84
+    private let compactTileWidth: CGFloat = 70
 
     var body: some View {
         HStack(spacing: 8) {
             styleTile(.notch, label: String(localized: "Notch")) {
                 HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(.white.opacity(0.5))
-                        .frame(width: 16, height: 8)
-                    Color.clear.frame(width: 30)
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(.white.opacity(0.3))
-                        .frame(width: 8, height: 8)
+                    HStack(spacing: 3) {
+                        tileStatusIndicator(size: 7, cornerRadius: 2)
+                        tileContentLabel(dictation.notchIndicatorLeftContent, size: 7)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 6)
+
+                    Color.clear.frame(width: 24)
+
+                    tileContentLabel(dictation.notchIndicatorRightContent, size: 7)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .padding(.trailing, 6)
                 }
-                .padding(.leading, 6)
-                .frame(width: 70, height: 20)
+                .frame(width: notchTileWidth, height: 20)
                 .background(.black)
                 .clipShape(NotchShape(topCornerRadius: 3, bottomCornerRadius: 6))
             }
 
             styleTile(.overlay, label: String(localized: "Overlay")) {
-                HStack(spacing: 3) {
-                    Circle().fill(.white.opacity(0.5)).frame(width: 4, height: 4)
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(.white.opacity(0.3))
-                        .frame(width: 16, height: 4)
-                    Spacer()
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(.white.opacity(0.3))
-                        .frame(width: 8, height: 4)
+                HStack(spacing: 4) {
+                    tileStatusIndicator(size: 5, cornerRadius: 1.5)
+                    tileContentLabel(dictation.notchIndicatorLeftContent, size: 7)
+                    Spacer(minLength: 4)
+                    tileContentLabel(dictation.notchIndicatorRightContent, size: 7)
                 }
                 .padding(.horizontal, 6)
-                .frame(width: 70, height: 20)
+                .frame(width: compactTileWidth, height: 20)
                 .background(.black.opacity(0.85), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .stroke(Color.white.opacity(0.15), lineWidth: 0.5)
                 )
             }
+
+            styleTile(.minimal, label: String(localized: "Indicator")) {
+                HStack(spacing: 4) {
+                    tileStatusIndicator(size: 7, cornerRadius: 2)
+                    if dictation.notchIndicatorRightContent != .none {
+                        tileContentLabel(dictation.notchIndicatorRightContent, size: 7)
+                    }
+                }
+                .padding(.horizontal, 7)
+                .frame(width: 52, height: 20)
+                .background(.black.opacity(0.85), in: Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(Color.white.opacity(0.15), lineWidth: 0.5)
+                )
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
@@ -235,9 +277,50 @@ struct IndicatorStylePicker: View {
                     .stroke(isSelected ? Color.accentColor : Color.secondary.opacity(0.2), lineWidth: isSelected ? 2 : 1)
             )
         }
+        .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
         .accessibilityLabel(label)
         .accessibilityAddTraits(.isButton)
         .accessibilityValue(isSelected ? String(localized: "Selected") : "")
+    }
+
+    private func tileStatusIndicator(size: CGFloat, cornerRadius: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(.white.opacity(0.45))
+            .frame(width: size, height: size)
+    }
+
+    @ViewBuilder
+    private func tileContentLabel(_ content: NotchIndicatorContent, size: CGFloat) -> some View {
+        switch content {
+        case .indicator:
+            Circle()
+                .fill(Color.red)
+                .frame(width: size * 0.7, height: size * 0.7)
+        case .timer:
+            Text("1:23")
+                .font(.system(size: size, weight: .medium).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.65))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        case .waveform:
+            HStack(spacing: 1) {
+                ForEach(0..<5, id: \.self) { index in
+                    RoundedRectangle(cornerRadius: 0.7)
+                        .fill(.white.opacity(0.9))
+                        .frame(width: 1.8, height: [3, 6, 8, 5, 3][index])
+                }
+            }
+            .frame(height: 10)
+        case .profile:
+            Text("P")
+                .font(.system(size: size * 0.9, weight: .medium))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 3)
+                .padding(.vertical, 1)
+                .background(.white.opacity(0.2), in: Capsule())
+        case .none:
+            Color.clear.frame(width: 0, height: 0)
+        }
     }
 }

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -1,0 +1,136 @@
+import AppKit
+import SwiftUI
+import Combine
+
+/// Floating panel for the compact minimal indicator mode.
+class MinimalIndicatorPanel: NSPanel {
+    private static let panelWidth: CGFloat = 420
+    private static let panelHeight: CGFloat = 160
+
+    private var cancellables = Set<AnyCancellable>()
+    private var cachedScreen: NSScreen?
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
+            styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        isMovable = false
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        appearance = NSAppearance(named: .darkAqua)
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        hidesOnDeactivate = false
+        ignoresMouseEvents = true
+
+        let hostingView = NSHostingView(rootView: MinimalIndicatorView())
+        hostingView.sizingOptions = []
+        contentView = hostingView
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    func startObserving() {
+        let vm = DictationViewModel.shared
+
+        vm.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.updateVisibility(state: state, vm: vm)
+            }
+            .store(in: &cancellables)
+
+        vm.$notchIndicatorVisibility
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateVisibility(state: vm.state, vm: vm)
+            }
+            .store(in: &cancellables)
+
+        vm.$notchIndicatorDisplay
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.cachedScreen = nil
+                self?.updateVisibility(state: vm.state, vm: vm)
+            }
+            .store(in: &cancellables)
+
+        vm.$overlayPosition
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self, self.isVisible else { return }
+                self.show()
+            }
+            .store(in: &cancellables)
+    }
+
+    func updateVisibility(state: DictationViewModel.State, vm: DictationViewModel) {
+        guard vm.indicatorStyle == .minimal else {
+            dismiss()
+            return
+        }
+
+        switch vm.notchIndicatorVisibility {
+        case .always:
+            show()
+        case .duringActivity:
+            switch state {
+            case .recording, .processing, .inserting, .error:
+                show()
+            case .idle, .promptSelection, .promptProcessing:
+                dismiss()
+            }
+        case .never:
+            dismiss()
+        }
+    }
+
+    func show() {
+        let screen: NSScreen
+        if let cached = cachedScreen, isVisible {
+            screen = cached
+        } else {
+            screen = resolveScreen()
+            cachedScreen = screen
+        }
+
+        let screenFrame = screen.visibleFrame
+        let x = screenFrame.midX - Self.panelWidth / 2
+
+        let y: CGFloat
+        switch DictationViewModel.shared.overlayPosition {
+        case .bottom:
+            y = screenFrame.origin.y + 20
+        case .top:
+            y = screenFrame.origin.y + screenFrame.height - Self.panelHeight - 20
+        }
+
+        setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
+        orderFrontRegardless()
+    }
+
+    private func resolveScreen() -> NSScreen {
+        let display = DictationViewModel.shared.notchIndicatorDisplay
+        switch display {
+        case .activeScreen:
+            let mouseLocation = NSEvent.mouseLocation
+            return NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main ?? NSScreen.screens[0]
+        case .primaryScreen:
+            return NSScreen.main ?? NSScreen.screens[0]
+        case .builtInScreen:
+            return NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main ?? NSScreen.screens[0]
+        }
+    }
+
+    func dismiss() {
+        cachedScreen = nil
+        orderOut(nil)
+    }
+}

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+/// Compact floating indicator for power users who only want essential status.
+struct MinimalIndicatorView: View {
+    @ObservedObject private var viewModel = DictationViewModel.shared
+    @State private var dotPulse = false
+
+    private let sizing: IndicatorSizing = .minimal
+    private let idleWidth: CGFloat = 42
+    private let processingWidth: CGFloat = 76
+    private let insertingWidth: CGFloat = 44
+    private let messageWidth: CGFloat = 320
+
+    private var recordingWidth: CGFloat {
+        switch viewModel.notchIndicatorRightContent {
+        case .none:
+            return idleWidth
+        case .indicator:
+            return 58
+        case .waveform:
+            return 90
+        case .timer:
+            return 118
+        case .profile:
+            guard let name = viewModel.activeProfileName, !name.isEmpty else {
+                return idleWidth
+            }
+            let estimatedTextWidth = CGFloat(min(name.count, 18)) * 7
+            return min(max(96, estimatedTextWidth + 44), 190)
+        }
+    }
+
+    private var isTop: Bool {
+        viewModel.overlayPosition == .top
+    }
+
+    private var actionFeedbackMessage: String? {
+        guard viewModel.state == .inserting else { return nil }
+        return viewModel.actionFeedbackMessage
+    }
+
+    private var errorMessage: String? {
+        guard case let .error(message) = viewModel.state else { return nil }
+        return message
+    }
+
+    private var showsExpandedMessage: Bool {
+        actionFeedbackMessage != nil || errorMessage != nil
+    }
+
+    private var currentWidth: CGFloat {
+        if showsExpandedMessage {
+            return messageWidth
+        }
+
+        switch viewModel.state {
+        case .recording:
+            return recordingWidth
+        case .processing:
+            return processingWidth
+        case .inserting:
+            return insertingWidth
+        case .idle, .promptSelection, .promptProcessing:
+            return idleWidth
+        case .error:
+            return messageWidth
+        }
+    }
+
+    private var strokeColor: Color {
+        errorMessage == nil ? .white.opacity(0.14) : .red.opacity(0.55)
+    }
+
+    private var shadowColor: Color {
+        errorMessage == nil ? .black.opacity(0.22) : .red.opacity(0.18)
+    }
+
+    var body: some View {
+        content
+            .frame(width: currentWidth)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isTop ? .top : .bottom)
+            .preferredColorScheme(.dark)
+            .animation(.easeInOut(duration: 0.2), value: currentWidth)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.state)
+            .animation(.easeInOut(duration: 1.0), value: dotPulse)
+            .onChange(of: viewModel.state) {
+                if viewModel.state == .recording {
+                    withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                        dotPulse = true
+                    }
+                } else {
+                    dotPulse = false
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+        }
+
+    private var accessibilityLabel: String {
+        if let message = actionFeedbackMessage {
+            return message
+        }
+
+        switch viewModel.state {
+        case .idle, .promptSelection, .promptProcessing:
+            return String(localized: "Idle")
+        case .recording:
+            return String(localized: "Recording")
+        case .processing:
+            return String(localized: "Processing transcription")
+        case .inserting:
+            return String(localized: "Inserting text")
+        case .error(let message):
+            return String(localized: "Error - \(message)")
+        }
+    }
+
+    private var content: some View {
+        HStack(spacing: 8) {
+            if let message = errorMessage {
+                compactMessage(
+                    text: message,
+                    icon: "xmark.circle.fill",
+                    iconColor: .red
+                )
+            } else if let message = actionFeedbackMessage {
+                compactMessage(
+                    text: message,
+                    icon: viewModel.actionFeedbackIcon ?? (viewModel.actionFeedbackIsError ? "xmark.circle.fill" : "checkmark.circle.fill"),
+                    iconColor: viewModel.actionFeedbackIsError ? .red : .green
+                )
+            } else {
+                compactStatus
+            }
+        }
+        .padding(.horizontal, showsExpandedMessage ? 14 : 12)
+        .padding(.vertical, showsExpandedMessage ? 9 : 10)
+        .background(.black.opacity(0.84), in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(strokeColor, lineWidth: 1)
+        )
+        .shadow(color: shadowColor, radius: 10, y: 4)
+    }
+
+    @ViewBuilder
+    private var compactStatus: some View {
+        switch viewModel.state {
+        case .recording:
+            HStack(spacing: viewModel.notchIndicatorRightContent == .none ? 0 : 8) {
+                IndicatorLeftStatus(
+                    viewModel: viewModel,
+                    sizing: sizing,
+                    dotPulse: dotPulse,
+                    hasActionFeedback: false
+                )
+
+                if viewModel.notchIndicatorRightContent != .none {
+                    IndicatorRecordingContent(
+                        viewModel: viewModel,
+                        content: viewModel.notchIndicatorRightContent,
+                        sizing: sizing,
+                        dotPulse: dotPulse
+                    )
+                }
+            }
+        case .processing:
+            HStack(spacing: 8) {
+                if let icon = viewModel.activeAppIcon {
+                    IndicatorAppIconView(icon: icon, sizing: sizing)
+                }
+                ProgressView()
+                    .controlSize(.mini)
+                    .tint(.white)
+            }
+        case .inserting:
+            IndicatorLeftStatus(
+                viewModel: viewModel,
+                sizing: sizing,
+                dotPulse: false,
+                hasActionFeedback: false
+            )
+        case .idle, .promptSelection, .promptProcessing:
+            Color.clear
+                .frame(width: 1, height: 1)
+        case .error:
+            EmptyView()
+        }
+    }
+
+    private func compactMessage(text: String, icon: String, iconColor: Color) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 14))
+                .foregroundStyle(iconColor)
+                .accessibilityHidden(true)
+
+            Text(text)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white.opacity(0.92))
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -42,6 +42,20 @@ struct IndicatorSizing {
         textFontSize: 13,
         textExpandedHeight: 100
     )
+
+    static let minimal = IndicatorSizing(
+        iconSize: 14,
+        iconCornerRadius: 3,
+        dotSize: 6,
+        symbolSize: 12,
+        timerFontSize: 11,
+        timerOpacity: 0.75,
+        profileFontSize: 10,
+        profilePaddingH: 5,
+        profilePaddingV: 2,
+        textFontSize: 12,
+        textExpandedHeight: 0
+    )
 }
 
 // MARK: - App Icon
@@ -172,10 +186,10 @@ struct IndicatorRecordingContent: View {
                     .accessibilityLabel(String(localized: "Active profile"))
                     .accessibilityValue(name)
             } else {
-                Color.clear
+                Color.clear.frame(width: 0, height: 0)
             }
         case .none:
-            Color.clear
+            Color.clear.frame(width: 0, height: 0)
         }
     }
 }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -38,4 +38,23 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
 
         XCTAssertTrue(DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults))
     }
+
+    func testIndicatorStyleDefaultsToNotch() {
+        defaults.removeObject(forKey: UserDefaultsKeys.indicatorStyle)
+
+        XCTAssertEqual(DictationViewModel.loadIndicatorStyle(defaults: defaults), .notch)
+    }
+
+    func testIndicatorStylePersistsMinimal() {
+        DictationViewModel.persistIndicatorStyle(.minimal, defaults: defaults)
+
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.indicatorStyle), IndicatorStyle.minimal.rawValue)
+        XCTAssertEqual(DictationViewModel.loadIndicatorStyle(defaults: defaults), .minimal)
+    }
+
+    func testUnknownIndicatorStyleFallsBackToNotch() {
+        defaults.set("mystery", forKey: UserDefaultsKeys.indicatorStyle)
+
+        XCTAssertEqual(DictationViewModel.loadIndicatorStyle(defaults: defaults), .notch)
+    }
 }


### PR DESCRIPTION
## Summary
- add a third `Indicator` style as a compact power-user alternative while keeping `Notch` as the default
- add the new minimal indicator panel/view plus style-aware settings and previews
- share the right-side content selection across `Notch`, `Overlay`, and `Indicator`, while keeping the minimal style's left side fixed

## Testing
- xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests

## Notes
- manual in-app QA was not run in this pass