### PR TITLE
Fix hotkey dictation start delay

### DIFF
--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 import SwiftUI
 import FluidAudio
 import TypeWhisperPluginSDK
@@ -9,6 +10,9 @@ import TypeWhisperPluginSDK
 final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
+    private static let logger = Logger(subsystem: "com.typewhisper.plugin.parakeet", category: "Transcription")
+    private static let shortClipConfidenceThreshold: Float = 0.55
+    private static let shortClipConfidenceGateDuration: TimeInterval = 1.0
 
     fileprivate var host: HostServices?
     fileprivate var asrManager: AsrManager?
@@ -112,7 +116,31 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsA
             await configureBoostingIfNeeded(prompt: prompt)
         }
 
-        let result = try await asrManager.transcribe(audio.samples, source: .system)
+        let normalizedSamples = PluginAudioUtils.paddedSamples(
+            audio.samples,
+            minimumDuration: 1.0,
+            sampleRate: 16_000
+        )
+        let result = try await asrManager.transcribe(normalizedSamples, source: .system)
+        let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if audio.duration < Self.shortClipConfidenceGateDuration {
+            Self.logger.info(
+                "Short clip transcription: rawDuration=\(String(format: "%.3f", audio.duration), privacy: .public)s, confidence=\(String(format: "%.3f", result.confidence), privacy: .public), textLength=\(trimmedText.count, privacy: .public)"
+            )
+        }
+
+        guard PluginAudioUtils.shouldAcceptShortClipTranscription(
+            audioDuration: audio.duration,
+            confidence: result.confidence,
+            minimumDuration: Self.shortClipConfidenceGateDuration,
+            minimumConfidence: Self.shortClipConfidenceThreshold
+        ) else {
+            Self.logger.info(
+                "Discarding low-confidence short clip: rawDuration=\(String(format: "%.3f", audio.duration), privacy: .public)s, confidence=\(String(format: "%.3f", result.confidence), privacy: .public)"
+            )
+            return PluginTranscriptionResult(text: "", detectedLanguage: nil, segments: [])
+        }
 
         let segments: [PluginTranscriptionSegment]
         if let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty {
@@ -123,7 +151,6 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsA
 
         return PluginTranscriptionResult(text: result.text, detectedLanguage: nil, segments: segments)
     }
-
     // MARK: - Token-to-Segment Grouping
 
     private static func groupTokensIntoSegments(_ tokenTimings: [TokenTiming]) -> [PluginTranscriptionSegment] {

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -84,6 +84,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     @Published private(set) var isRecording = false
     @Published private(set) var audioLevel: Float = 0
     @Published private(set) var rawAudioLevel: Float = 0
+    var hasMicrophonePermissionOverride: Bool?
+    var startRecordingOverride: (() throws -> Void)?
 
     /// CoreAudio device ID to use for recording. nil = system default input.
     var selectedDeviceID: AudioDeviceID? {
@@ -120,7 +122,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     var hasMicrophonePermission: Bool {
-        AVAudioApplication.shared.recordPermission == .granted
+        if let hasMicrophonePermissionOverride {
+            return hasMicrophonePermissionOverride
+        }
+        return AVAudioApplication.shared.recordPermission == .granted
     }
 
     func requestMicrophonePermission() async -> Bool {
@@ -190,6 +195,16 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.microphonePermissionDenied
         }
 
+        if let startRecordingOverride {
+            bufferLock.lock()
+            sampleBuffer.removeAll()
+            _peakRawAudioLevel = 0
+            bufferLock.unlock()
+            try startRecordingOverride()
+            isRecording = true
+            return
+        }
+
         let engine = AVAudioEngine()
 
         // Set the input device before reading the format
@@ -233,8 +248,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
         }
 
+        let engineStartTime = CFAbsoluteTimeGetCurrent()
         do {
             try engine.start()
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
+            logger.info("Audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
         } catch {
             inputNode.removeTap(onBus: 0)
             throw AudioRecordingError.engineStartFailed(error.localizedDescription)

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -15,6 +15,8 @@ final class TextInsertionService {
     var focusedTextFieldOverride: (() -> Bool)?
     var pasteSimulatorOverride: (() -> Void)?
     var returnSimulatorOverride: (() -> Void)?
+    var captureActiveAppOverride: (() -> (name: String?, bundleId: String?, url: String?))?
+    var selectedTextOverride: (() -> String?)?
 
 enum InsertionResult {
         case pasted
@@ -50,6 +52,9 @@ enum InsertionResult {
     }
 
     func captureActiveApp() -> (name: String?, bundleId: String?, url: String?) {
+        if let captureActiveAppOverride {
+            return captureActiveAppOverride()
+        }
         let app = NSWorkspace.shared.frontmostApplication
         let bundleId = app?.bundleIdentifier
         return (app?.localizedName, bundleId, nil)
@@ -241,7 +246,10 @@ enum InsertionResult {
     }
 
     func getSelectedText() -> String? {
-        getTextSelection()?.text
+        if let selectedTextOverride {
+            return selectedTextOverride()
+        }
+        return getTextSelection()?.text
     }
 
     /// Returns the selected text and the AXUIElement, so the selection can be replaced later.

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -130,6 +130,7 @@ final class DictationViewModel: ObservableObject {
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
     private var urlResolutionTask: Task<Void, Never>?
+    private var metadataCaptureTask: Task<Void, Never>?
     private var isStopInFlight = false
 
     init(
@@ -391,6 +392,8 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func startRecording(forcedProfileId: UUID? = nil) {
+        let startTimestamp = CFAbsoluteTimeGetCurrent()
+
         // Dismiss prompt palette if active
         promptPaletteHandler.hide()
 
@@ -412,22 +415,18 @@ final class DictationViewModel: ObservableObject {
         transcriptionTask = nil
         insertingResetTask?.cancel()
         insertingResetTask = nil
+        metadataCaptureTask?.cancel()
+        metadataCaptureTask = nil
+        urlResolutionTask?.cancel()
+        urlResolutionTask = nil
 
         self.forcedProfileId = forcedProfileId
 
         // Match profile: forced profile or app-based matching
         let activeApp = textInsertionService.captureActiveApp()
         capturedActiveApp = activeApp
-        capturedSelectedText = textInsertionService.getSelectedText()
-        if let sel = capturedSelectedText {
-            logger.info("Captured selected text (\(sel.count) chars)")
-        }
-        if let bundleId = activeApp.bundleId,
-           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
-            activeAppIcon = NSWorkspace.shared.icon(forFile: appURL.path)
-        } else {
-            activeAppIcon = nil
-        }
+        capturedSelectedText = nil
+        activeAppIcon = nil
 
         if let forcedProfileId,
            let forcedProfile = profileService.profiles.first(where: { $0.id == forcedProfileId && $0.isEnabled }) {
@@ -437,49 +436,15 @@ final class DictationViewModel: ObservableObject {
             matchedProfile = profileService.matchProfile(bundleIdentifier: activeApp.bundleId, url: nil)
             activeProfileName = matchedProfile?.name
         }
-
-        // Resolve browser URL asynchronously to avoid blocking the main thread.
-        // If a more specific URL profile matches, update the active profile on the fly.
-        // Skip URL resolution when a forced profile is set (profile hotkey overrides app matching).
-        if forcedProfileId == nil, let bundleId = activeApp.bundleId {
-            urlResolutionTask = Task { [weak self] in
-                guard let self else { return }
-                logger.info("URL resolution: starting for bundleId=\(bundleId)")
-                let resolvedURL = await textInsertionService.resolveBrowserURL(bundleId: bundleId)
-                logger.info("URL resolution: resolvedURL=\(resolvedURL ?? "nil"), state=\(String(describing: self.state))")
-                guard state == .recording || state == .processing else {
-                    logger.info("URL resolution: skipped - state is \(String(describing: self.state))")
-                    return
-                }
-                guard let currentApp = capturedActiveApp, currentApp.bundleId == bundleId else {
-                    logger.info("URL resolution: skipped - bundleId mismatch")
-                    return
-                }
-
-                capturedActiveApp = (name: currentApp.name, bundleId: currentApp.bundleId, url: resolvedURL)
-
-                guard let resolvedURL else {
-                    logger.info("URL resolution: no URL resolved")
-                    return
-                }
-                guard let refinedProfile = profileService.matchProfile(bundleIdentifier: bundleId, url: resolvedURL) else {
-                    logger.info("URL resolution: no profile matched for URL \(resolvedURL)")
-                    return
-                }
-
-                logger.info("URL resolution: matched profile '\(refinedProfile.name)'")
-                matchedProfile = refinedProfile
-                activeProfileName = refinedProfile.name
-            }
-        }
+        let immediateContextMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
 
         do {
-            if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
             // Play start sound BEFORE engine setup - AVAudioEngine reconfigures
             // audio hardware (aggregate device) which disrupts NSSound playback.
             soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
             audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
             try audioRecordingService.startRecording()
+            if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
             if audioDuckingEnabled {
                 audioDuckingService.duckAudio(to: Float(audioDuckingLevel))
             }
@@ -506,13 +471,85 @@ final class DictationViewModel: ObservableObject {
                 appName: capturedActiveApp?.name,
                 bundleIdentifier: capturedActiveApp?.bundleId
             )))
+            scheduleDeferredRecordingMetadataCapture(activeApp: activeApp, forcedProfileId: forcedProfileId)
+
+            let totalStartMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
+            logger.info(
+                "Recording started: immediateContextMs=\(String(format: "%.1f", immediateContextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
+            )
         } catch {
+            metadataCaptureTask?.cancel()
+            metadataCaptureTask = nil
+            urlResolutionTask?.cancel()
+            urlResolutionTask = nil
             audioDuckingService.restoreAudio()
             mediaPlaybackService.resumeIfWePaused()
             accessibilityAnnouncementService.announceError(error.localizedDescription)
             speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
             showError(error.localizedDescription, category: "recording")
             hotkeyService.cancelDictation()
+        }
+    }
+
+    private func scheduleDeferredRecordingMetadataCapture(
+        activeApp: (name: String?, bundleId: String?, url: String?),
+        forcedProfileId: UUID?
+    ) {
+        let metadataStartTimestamp = CFAbsoluteTimeGetCurrent()
+
+        metadataCaptureTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            let selectedText = textInsertionService.getSelectedText()
+            guard !Task.isCancelled else { return }
+            capturedSelectedText = selectedText
+            if let selectedText {
+                logger.info("Captured selected text (\(selectedText.count) chars)")
+            }
+
+            if let bundleId = activeApp.bundleId,
+               let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+                activeAppIcon = NSWorkspace.shared.icon(forFile: appURL.path)
+            } else {
+                activeAppIcon = nil
+            }
+
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - metadataStartTimestamp) * 1000
+            logger.info("Deferred recording metadata captured in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
+        }
+
+        // Resolve browser URL asynchronously after recording has already started.
+        // If a more specific URL profile matches, update the active profile on the fly.
+        // Skip URL resolution when a forced profile is set (profile hotkey overrides app matching).
+        guard forcedProfileId == nil, let bundleId = activeApp.bundleId else { return }
+        urlResolutionTask = Task { [weak self] in
+            guard let self else { return }
+            logger.info("URL resolution: starting for bundleId=\(bundleId)")
+            let resolvedURL = await textInsertionService.resolveBrowserURL(bundleId: bundleId)
+            logger.info("URL resolution: resolvedURL=\(resolvedURL ?? "nil"), state=\(String(describing: self.state))")
+            guard state == .recording || state == .processing else {
+                logger.info("URL resolution: skipped - state is \(String(describing: self.state))")
+                return
+            }
+            guard let currentApp = capturedActiveApp, currentApp.bundleId == bundleId else {
+                logger.info("URL resolution: skipped - bundleId mismatch")
+                return
+            }
+
+            capturedActiveApp = (name: currentApp.name, bundleId: currentApp.bundleId, url: resolvedURL)
+
+            guard let resolvedURL else {
+                logger.info("URL resolution: no URL resolved")
+                return
+            }
+            guard let refinedProfile = profileService.matchProfile(bundleIdentifier: bundleId, url: resolvedURL) else {
+                logger.info("URL resolution: no profile matched for URL \(resolvedURL)")
+                return
+            }
+
+            logger.info("URL resolution: matched profile '\(refinedProfile.name)'")
+            matchedProfile = refinedProfile
+            activeProfileName = refinedProfile.name
         }
     }
 
@@ -687,6 +724,7 @@ final class DictationViewModel: ObservableObject {
                     nil
                 }
                 self.processingPhase = String(localized: "Processing...")
+                await metadataCaptureTask?.value
                 let ppContext = PostProcessingContext(
                     appName: activeApp.name,
                     bundleIdentifier: activeApp.bundleId,
@@ -813,6 +851,8 @@ final class DictationViewModel: ObservableObject {
         insertingResetTask = nil
         urlResolutionTask?.cancel()
         urlResolutionTask = nil
+        metadataCaptureTask?.cancel()
+        metadataCaptureTask = nil
         isStopInFlight = false
         state = .idle
         partialText = ""
@@ -1017,8 +1057,10 @@ func classifyShortSpeech(rawDuration: TimeInterval, peakLevel: Float, hasPreview
     guard rawDuration >= 0.04 else { return .discardTooShort }
     if hasPreviewText { return .transcribe }
 
-    if rawDuration < 0.25 {
-        return peakLevel < 0.006 ? .discardNoSpeech : .transcribe
+    if rawDuration < 1.0 {
+        // Bias toward transcribing short clips. False negatives here are worse than
+        // letting the recognizer return empty text for actual silence.
+        return peakLevel < 0.005 ? .discardNoSpeech : .transcribe
     }
 
     return peakLevel < 0.01 ? .discardNoSpeech : .transcribe

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -144,10 +144,29 @@ public enum PluginTranscriptionError: LocalizedError, Sendable {
 public struct PluginOpenAITranscriptionHelper: Sendable {
     public let baseURL: String
     public let responseFormat: String
+    static let minimumUploadDuration: TimeInterval = 1.0
+    static let uploadSampleRate = 16000
 
     public init(baseURL: String, responseFormat: String = "verbose_json") {
         self.baseURL = baseURL
         self.responseFormat = responseFormat
+    }
+
+    func normalizedAudioForUpload(_ audio: AudioData) -> AudioData {
+        guard audio.duration < Self.minimumUploadDuration else { return audio }
+
+        let paddedSamples = PluginAudioUtils.paddedSamples(
+            audio.samples,
+            minimumDuration: Self.minimumUploadDuration,
+            sampleRate: Self.uploadSampleRate
+        )
+        guard paddedSamples.count != audio.samples.count else { return audio }
+
+        return AudioData(
+            samples: paddedSamples,
+            wavData: PluginWavEncoder.encode(paddedSamples, sampleRate: Self.uploadSampleRate),
+            duration: Double(paddedSamples.count) / Double(Self.uploadSampleRate)
+        )
     }
 
     public func transcribe(
@@ -177,13 +196,14 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 30
 
+        let uploadAudio = normalizedAudioForUpload(audio)
         var body = Data()
 
         // file field
         body.append("--\(boundary)\r\n".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
         body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
-        body.append(audio.wavData)
+        body.append(uploadAudio.wavData)
         body.append("\r\n".data(using: .utf8)!)
 
         // model field

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -121,6 +121,31 @@ public struct AudioData: Sendable {
     }
 }
 
+public enum PluginAudioUtils {
+    public static func paddedSamples(
+        _ samples: [Float],
+        minimumDuration: TimeInterval,
+        sampleRate: Int = 16_000
+    ) -> [Float] {
+        let minimumSampleCount = Int(minimumDuration * Double(sampleRate))
+        guard samples.count < minimumSampleCount else { return samples }
+
+        var paddedSamples = samples
+        paddedSamples.append(contentsOf: repeatElement(Float.zero, count: minimumSampleCount - samples.count))
+        return paddedSamples
+    }
+
+    public static func shouldAcceptShortClipTranscription(
+        audioDuration: TimeInterval,
+        confidence: Float,
+        minimumDuration: TimeInterval = 1.0,
+        minimumConfidence: Float = 0.55
+    ) -> Bool {
+        guard audioDuration < minimumDuration else { return true }
+        return confidence >= minimumConfidence
+    }
+}
+
 public struct PluginTranscriptionSegment: Sendable {
     public let text: String
     public let start: Double

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class OpenAITranscriptionHelperTests: XCTestCase {
+    func testPluginAudioUtilsPadsShortSamplesToMinimumDuration() {
+        let samples = [Float](repeating: 0.1, count: 6_400)
+
+        let paddedSamples = PluginAudioUtils.paddedSamples(samples, minimumDuration: 1.0)
+
+        XCTAssertEqual(paddedSamples.count, 16_000)
+    }
+
+    func testPluginAudioUtilsLeavesLongEnoughSamplesUnchanged() {
+        let samples = [Float](repeating: 0.1, count: 16_000)
+
+        let paddedSamples = PluginAudioUtils.paddedSamples(samples, minimumDuration: 1.0)
+
+        XCTAssertEqual(paddedSamples, samples)
+    }
+
+    func testPluginAudioUtilsRejectsLowConfidenceShortClipTranscription() {
+        XCTAssertFalse(
+            PluginAudioUtils.shouldAcceptShortClipTranscription(
+                audioDuration: 0.6,
+                confidence: 0.42
+            )
+        )
+    }
+
+    func testPluginAudioUtilsAcceptsHighConfidenceShortClipTranscription() {
+        XCTAssertTrue(
+            PluginAudioUtils.shouldAcceptShortClipTranscription(
+                audioDuration: 0.6,
+                confidence: 0.72
+            )
+        )
+    }
+
+    func testPluginAudioUtilsAcceptsLongClipRegardlessOfConfidence() {
+        XCTAssertTrue(
+            PluginAudioUtils.shouldAcceptShortClipTranscription(
+                audioDuration: 1.4,
+                confidence: 0.2
+            )
+        )
+    }
+
+    func testNormalizedAudioForUploadPadsShortAudioToOneSecond() {
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.com")
+        let samples = [Float](repeating: 0.1, count: 8_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 0.5
+        )
+
+        let normalized = helper.normalizedAudioForUpload(audio)
+
+        XCTAssertEqual(normalized.samples.count, 16_000)
+        XCTAssertEqual(normalized.duration, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(String(data: normalized.wavData.prefix(4), encoding: .utf8), "RIFF")
+    }
+
+    func testNormalizedAudioForUploadLeavesOneSecondAudioUnchanged() {
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.com")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let wavData = PluginWavEncoder.encode(samples)
+        let audio = AudioData(
+            samples: samples,
+            wavData: wavData,
+            duration: 1.0
+        )
+
+        let normalized = helper.normalizedAudioForUpload(audio)
+
+        XCTAssertEqual(normalized.samples.count, samples.count)
+        XCTAssertEqual(normalized.duration, audio.duration, accuracy: 0.0001)
+        XCTAssertEqual(normalized.wavData, wavData)
+    }
+}

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1,9 +1,33 @@
 import AppKit
 import Foundation
 import XCTest
+import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class APIRouterAndHandlersTests: XCTestCase {
+    @objc(APIRouterMockTranscriptionPlugin)
+    private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.transcription" }
+        static var pluginName: String { "Mock Transcription" }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "mock" }
+        var providerDisplayName: String { "Mock" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [PluginModelInfo(id: "tiny", displayName: "Tiny")] }
+        var selectedModelId: String? { "tiny" }
+        func selectModel(_ modelId: String) {}
+        var supportsTranslation: Bool { false }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
     private final class APIContext: @unchecked Sendable {
         let router: APIRouter
         let historyService: HistoryService
@@ -15,6 +39,20 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.historyService = historyService
             self.profileService = profileService
             self.retainedObjects = retainedObjects
+        }
+    }
+
+    @MainActor
+    private final class MockMediaPlaybackService: MediaPlaybackService {
+        let onPause: () -> Void
+
+        init(onPause: @escaping () -> Void) {
+            self.onPause = onPause
+            super.init()
+        }
+
+        override func pauseIfPlaying() {
+            onPause()
         }
     }
 
@@ -159,6 +197,110 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testApiStartRecording_startsAudioBeforeDeferredSelectedTextCapture() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+
+        var events: [String] = []
+        let selectedTextCaptured = expectation(description: "selected text captured")
+
+        context.textInsertionService.captureActiveAppOverride = { () -> (name: String?, bundleId: String?, url: String?) in
+            events.append("capture_app")
+            return ("Notes", nil, nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.startRecordingOverride = {
+            events.append("start_audio")
+        }
+        context.textInsertionService.selectedTextOverride = { () -> String? in
+            events.append("selected_text")
+            selectedTextCaptured.fulfill()
+            return "Already selected"
+        }
+
+        context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
+        XCTAssertEqual(events, ["capture_app", "start_audio"])
+
+        await fulfillment(of: [selectedTextCaptured], timeout: 1.0)
+        XCTAssertEqual(Array(events.prefix(3)), ["capture_app", "start_audio", "selected_text"])
+    }
+
+    @MainActor
+    func testApiStartRecording_appliesBundleProfileBeforeDeferredMetadataCapture() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.profileService.addProfile(name: "Docs", bundleIdentifiers: ["com.typewhisper.tests"])
+
+        let selectedTextCaptured = expectation(description: "selected text captured")
+        context.textInsertionService.captureActiveAppOverride = { () -> (name: String?, bundleId: String?, url: String?) in
+            ("Docs App", "com.typewhisper.tests", nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.startRecordingOverride = {}
+        context.textInsertionService.selectedTextOverride = { () -> String? in
+            selectedTextCaptured.fulfill()
+            return nil
+        }
+
+        context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
+        XCTAssertEqual(context.dictationViewModel.activeProfileName, "Docs")
+
+        await fulfillment(of: [selectedTextCaptured], timeout: 1.0)
+    }
+
+    @MainActor
+    func testApiStartRecording_pausesMediaAfterAudioStart() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var events: [String] = []
+        let mediaPlaybackService = MockMediaPlaybackService {
+            events.append("pause_media")
+        }
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            mediaPlaybackService: mediaPlaybackService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.mediaPauseEnabled = true
+
+        context.textInsertionService.captureActiveAppOverride = { () -> (name: String?, bundleId: String?, url: String?) in
+            events.append("capture_app")
+            return ("Music", "com.apple.Music", nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.startRecordingOverride = {
+            events.append("start_audio")
+        }
+
+        context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(Array(events.prefix(3)), ["capture_app", "start_audio", "pause_media"])
+    }
+
+    @MainActor
     private static func makeAPIContext(appSupportDirectory: URL) -> APIContext {
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
 
@@ -244,6 +386,134 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 dictationViewModel,
                 router,
                 handlers
+            ]
+        )
+    }
+
+    private final class DictationContext: @unchecked Sendable {
+        let dictationViewModel: DictationViewModel
+        let audioRecordingService: AudioRecordingService
+        let textInsertionService: TextInsertionService
+        let profileService: ProfileService
+        private let retainedObjects: [AnyObject]
+
+        init(
+            dictationViewModel: DictationViewModel,
+            audioRecordingService: AudioRecordingService,
+            textInsertionService: TextInsertionService,
+            profileService: ProfileService,
+            retainedObjects: [AnyObject]
+        ) {
+            self.dictationViewModel = dictationViewModel
+            self.audioRecordingService = audioRecordingService
+            self.textInsertionService = textInsertionService
+            self.profileService = profileService
+            self.retainedObjects = retainedObjects
+        }
+    }
+
+    @MainActor
+    private static func makeDictationContext(
+        appSupportDirectory: URL,
+        mediaPlaybackService: MediaPlaybackService? = nil
+    ) -> DictationContext {
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let mockPlugin = MockTranscriptionPlugin()
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.transcription",
+            name: "Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterMockTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: mockPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(mockPlugin.providerId)
+
+        let audioRecordingService = AudioRecordingService()
+        let hotkeyService = HotkeyService()
+        let textInsertionService = TextInsertionService()
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let audioDuckingService = AudioDuckingService()
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        let soundService = SoundService()
+        let audioDeviceService = AudioDeviceService()
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let promptProcessingService = PromptProcessingService()
+        let appFormatterService = AppFormatterService()
+        let speechFeedbackService = SpeechFeedbackService()
+        let accessibilityAnnouncementService = AccessibilityAnnouncementService()
+        let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
+        let settingsViewModel = SettingsViewModel(modelManager: modelManager)
+        let mediaPlaybackService = mediaPlaybackService ?? MediaPlaybackService()
+
+        let dictationViewModel = DictationViewModel(
+            audioRecordingService: audioRecordingService,
+            textInsertionService: textInsertionService,
+            hotkeyService: hotkeyService,
+            modelManager: modelManager,
+            settingsViewModel: settingsViewModel,
+            historyService: historyService,
+            profileService: profileService,
+            translationService: nil,
+            audioDuckingService: audioDuckingService,
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            soundService: soundService,
+            audioDeviceService: audioDeviceService,
+            promptActionService: promptActionService,
+            promptProcessingService: promptProcessingService,
+            appFormatterService: appFormatterService,
+            speechFeedbackService: speechFeedbackService,
+            accessibilityAnnouncementService: accessibilityAnnouncementService,
+            errorLogService: errorLogService,
+            mediaPlaybackService: mediaPlaybackService
+        )
+        dictationViewModel.soundFeedbackEnabled = false
+        dictationViewModel.spokenFeedbackEnabled = false
+        dictationViewModel.audioDuckingEnabled = false
+        dictationViewModel.mediaPauseEnabled = false
+
+        return DictationContext(
+            dictationViewModel: dictationViewModel,
+            audioRecordingService: audioRecordingService,
+            textInsertionService: textInsertionService,
+            profileService: profileService,
+            retainedObjects: [
+                EventBus.shared,
+                PluginManager.shared,
+                modelManager,
+                audioRecordingService,
+                hotkeyService,
+                textInsertionService,
+                historyService,
+                profileService,
+                audioDuckingService,
+                dictionaryService,
+                snippetService,
+                soundService,
+                audioDeviceService,
+                promptActionService,
+                promptProcessingService,
+                appFormatterService,
+                speechFeedbackService,
+                accessibilityAnnouncementService,
+                errorLogService,
+                settingsViewModel,
+                mediaPlaybackService,
+                dictationViewModel
             ]
         )
     }

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -38,16 +38,16 @@ final class DictationShortSpeechTests: XCTestCase {
     }
 
     func testOneHundredTwentyMsQuietClip_isNoSpeech() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.005, hasPreviewText: false), .discardNoSpeech)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0049, hasPreviewText: false), .discardNoSpeech)
     }
 
     func testOneHundredTwentyMsQuietClip_withPreviewText_transcribes() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.005, hasPreviewText: true), .transcribe)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0049, hasPreviewText: true), .transcribe)
     }
 
-    func testFourHundredMsSpeech_usesStandardNoSpeechThresholdAndNoMinimumPad() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009, hasPreviewText: false), .discardNoSpeech)
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.011, hasPreviewText: false), .transcribe)
+    func testFourHundredMsSpeech_usesRelaxedShortClipThresholdAndNoMinimumPad() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0049, hasPreviewText: false), .discardNoSpeech)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009, hasPreviewText: false), .transcribe)
 
         let paddedSamples = paddedSamplesForFinalTranscription(makeSamples(duration: 0.4), rawDuration: 0.4)
         XCTAssertEqual(paddedSamples.count, 12_000)
@@ -55,7 +55,11 @@ final class DictationShortSpeechTests: XCTestCase {
     }
 
     func testFourHundredMsQuietClip_withPreviewText_transcribes() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009, hasPreviewText: true), .transcribe)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0049, hasPreviewText: true), .transcribe)
+    }
+
+    func testEightHundredEightyFiveMsClip_withLowSpeechPeakStillTranscribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.885, peakLevel: 0.0069, hasPreviewText: false), .transcribe)
     }
 
     func testFinalizeShortSpeechPolicy_waitsOnlyWhenBufferedDurationIsBelowFiveHundredths() {


### PR DESCRIPTION
Closes #212

## Summary
- start recording before expensive metadata capture in `DictationViewModel`, so hotkey dictation begins immediately instead of waiting on selection and app metadata
- keep profile matching intact while deferring selected-text, icon, and URL enrichment until after recording has started
- harden short-clip handling by padding sub-1s uploads for OpenAI-compatible paths, padding Parakeet input to 1s, and discarding low-confidence short Parakeet transcripts that were hallucinating on weak audio
- cover the reordered start path and short-clip regressions with focused app and SDK tests

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests`
- `swift test` in `TypeWhisperPluginSDK`
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme ParakeetPlugin -configuration Debug -destination 'platform=macOS,arch=arm64'`
