### PR TITLE
fix: harden audio engine startup for AirPods profile changes

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
+		3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
 		6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
 		6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */; };
 		BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */; };
@@ -81,6 +82,7 @@
 		AA00000000000000000095 /* WavEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000095 /* WavEncoder.swift */; };
 		AA00000000000000000096 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000096 /* KeychainService.swift */; };
 		AA00000000000000000102 /* AudioDeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000102 /* AudioDeviceService.swift */; };
+		AA00000000000000000320 /* AudioEngineRecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000320 /* AudioEngineRecoverySupport.swift */; };
 		AA00000000000000000103 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000103 /* main.swift */; };
 		AA00000000000000000104 /* CLIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000104 /* CLIClient.swift */; };
 		AA00000000000000000105 /* PortDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000105 /* PortDiscovery.swift */; };
@@ -348,6 +350,7 @@
 
 /* Begin PBXFileReference section */
 		05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDiffServiceTests.swift; sourceTree = "<group>"; };
+		3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
 		3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
 		7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoundServiceTests.swift; sourceTree = "<group>"; };
 		AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationShortSpeechTests.swift; sourceTree = "<group>"; };
@@ -413,6 +416,7 @@
 		BB00000000000000000095 /* WavEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WavEncoder.swift; sourceTree = "<group>"; };
 		BB00000000000000000096 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		BB00000000000000000102 /* AudioDeviceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceService.swift; sourceTree = "<group>"; };
+		BB00000000000000000320 /* AudioEngineRecoverySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupport.swift; sourceTree = "<group>"; };
 		BB00000000000000000103 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		BB00000000000000000104 /* CLIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIClient.swift; sourceTree = "<group>"; };
 		BB00000000000000000105 /* PortDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortDiscovery.swift; sourceTree = "<group>"; };
@@ -1037,6 +1041,7 @@
 				BB00000000000000000081 /* SnippetService.swift */,
 				BB00000000000000000086 /* SoundService.swift */,
 				BB00000000000000000102 /* AudioDeviceService.swift */,
+				BB00000000000000000320 /* AudioEngineRecoverySupport.swift */,
 				BB00000000000000000111 /* PromptActionService.swift */,
 				BB00000000000000000115 /* PromptProcessingService.swift */,
 				BB00000000000000000123 /* EventBus.swift */,
@@ -1579,6 +1584,7 @@
 			isa = PBXGroup;
 			children = (
 				E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */,
+				3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */,
 				CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */,
 				FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
@@ -2677,6 +2683,7 @@
 				24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */,
 				7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */,
+				3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,
 				BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,
 				B4CC04DF94001FF7220789BC /* DictionaryServiceTests.swift in Sources */,
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
@@ -2765,6 +2772,7 @@
 				AA00000000000000000095 /* WavEncoder.swift in Sources */,
 				AA00000000000000000096 /* KeychainService.swift in Sources */,
 				AA00000000000000000102 /* AudioDeviceService.swift in Sources */,
+				AA00000000000000000320 /* AudioEngineRecoverySupport.swift in Sources */,
 				AA00000000000000000110 /* PromptAction.swift in Sources */,
 				AA00000000000000000111 /* PromptActionService.swift in Sources */,
 				AA00000000000000000112 /* LLMProvider.swift in Sources */,

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -37,9 +37,14 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     private var listenerBlock: AudioObjectPropertyListenerBlock?
     private var previewEngine: AVAudioEngine?
+    private var previewConfigChangeObserver: NSObjectProtocol?
     private let deviceChangeSubject = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
     private var disconnectVerificationTask: Task<Void, Never>?
+    private let previewLock = NSLock()
+    private let previewRecoveryQueue = DispatchQueue(label: "com.typewhisper.preview-recovery", qos: .userInitiated)
+    private let previewRecoveryCoordinator = AudioEngineRecoveryCoordinator()
+    private var activePreviewDeviceID: AudioDeviceID?
 
     init() {
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -81,40 +86,43 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
 
         let engine = AVAudioEngine()
+        let preferredDeviceID = selectedDeviceID
 
-        if let deviceID = selectedDeviceID {
-            if !setInputDevice(deviceID, on: engine, label: "preview") {
-                logger.error("Failed to set preview input device (\(deviceID)), falling back to system default")
-            }
+        previewLock.withLock {
+            previewEngine = engine
+            activePreviewDeviceID = preferredDeviceID
         }
-
-        let inputNode = engine.inputNode
-        let format = inputNode.outputFormat(forBus: 0)
-        logger.info("Preview input format: sampleRate=\(format.sampleRate), channels=\(format.channelCount)")
-        guard format.sampleRate > 0, format.channelCount > 0 else {
-            logger.warning("No audio input available for preview")
-            return
-        }
-
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-            self?.processPreviewBuffer(buffer)
-        }
+        previewRecoveryCoordinator.beginStarting()
+        installPreviewConfigurationObserver(for: engine)
 
         do {
-            try engine.start()
-            previewEngine = engine
+            try startPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: "preview")
+
+            if previewRecoveryCoordinator.finishStartingSuccessfully() == .performImmediateRecovery {
+                logger.warning("Preview engine configuration changed while starting, restarting with fresh input format")
+                try restartPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: "preview-startup")
+                schedulePreviewRecoveryIfNeeded(previewRecoveryCoordinator.finishRecovery())
+            }
+
             isPreviewActive = true
         } catch {
             logger.error("Failed to start preview engine: \(error.localizedDescription)")
-            inputNode.removeTap(onBus: 0)
-            engine.stop()
+            cleanupAfterFailedPreviewStart(engine)
         }
     }
 
     func stopPreview() {
-        previewEngine?.inputNode.removeTap(onBus: 0)
-        previewEngine?.stop()
-        previewEngine = nil
+        previewRecoveryCoordinator.transitionToIdle()
+        removePreviewConfigurationObserver()
+        let engine: AVAudioEngine? = previewLock.withLock {
+            let engine = previewEngine
+            previewEngine = nil
+            activePreviewDeviceID = nil
+            return engine
+        }
+        if let engine {
+            teardownPreviewEngine(engine)
+        }
         isPreviewActive = false
         previewAudioLevel = 0
         previewRawLevel = 0
@@ -135,6 +143,142 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             self.previewAudioLevel = level
             self.previewRawLevel = rms
         }
+    }
+
+    private func handlePreviewConfigurationChangeNotification() {
+        schedulePreviewRecoveryIfNeeded(previewRecoveryCoordinator.noteConfigurationChange())
+    }
+
+    private func schedulePreviewRecoveryIfNeeded(_ action: AudioEngineRecoveryAction) {
+        guard case .schedule(let generation, let delay) = action else { return }
+
+        previewRecoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.performScheduledPreviewRecovery(generation: generation)
+        }
+    }
+
+    private func performScheduledPreviewRecovery(generation: UInt64) {
+        guard previewRecoveryCoordinator.beginScheduledRecovery(generation: generation) else { return }
+        defer {
+            schedulePreviewRecoveryIfNeeded(previewRecoveryCoordinator.finishRecovery())
+        }
+
+        let (engine, preferredDeviceID): (AVAudioEngine?, AudioDeviceID?) = previewLock.withLock {
+            (previewEngine, activePreviewDeviceID)
+        }
+        guard isPreviewActive, let engine else { return }
+
+        logger.warning("Preview audio engine configuration changed, restarting engine")
+
+        do {
+            try restartPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: "preview-config-change")
+        } catch {
+            logger.error("Failed to restart preview engine after configuration change: \(error.localizedDescription)")
+        }
+    }
+
+    private func installPreviewConfigurationObserver(for engine: AVAudioEngine) {
+        removePreviewConfigurationObserver()
+        previewConfigChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handlePreviewConfigurationChangeNotification()
+        }
+    }
+
+    private func removePreviewConfigurationObserver() {
+        if let observer = previewConfigChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            previewConfigChangeObserver = nil
+        }
+    }
+
+    private func startPreviewEngineWithRecovery(
+        _ engine: AVAudioEngine,
+        preferredDeviceID: AudioDeviceID?,
+        label: String
+    ) throws {
+        for (attempt, delay) in AudioEngineRecoveryPolicy.retryBackoff.enumerated() {
+            do {
+                try configureAndStartPreviewEngine(engine, preferredDeviceID: preferredDeviceID, label: label)
+                return
+            } catch {
+                guard AudioEngineRecoveryPolicy.isRetryable(error: error) else {
+                    throw error
+                }
+
+                logger.warning("\(label, privacy: .public) audio engine start failed with retryable error, retry \(attempt + 1) in \(delay, privacy: .public)s: \(error.localizedDescription, privacy: .public)")
+                Thread.sleep(forTimeInterval: delay)
+            }
+        }
+
+        try configureAndStartPreviewEngine(engine, preferredDeviceID: preferredDeviceID, label: label)
+    }
+
+    private func restartPreviewEngineWithRecovery(
+        _ engine: AVAudioEngine,
+        preferredDeviceID: AudioDeviceID?,
+        label: String
+    ) throws {
+        teardownPreviewEngine(engine)
+        try startPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: label)
+    }
+
+    private func configureAndStartPreviewEngine(
+        _ engine: AVAudioEngine,
+        preferredDeviceID: AudioDeviceID?,
+        label: String
+    ) throws {
+        if let preferredDeviceID {
+            if !setInputDevice(preferredDeviceID, on: engine, label: label) {
+                logger.error("Failed to set \(label, privacy: .public) input device (\(preferredDeviceID)), falling back to system default")
+            }
+        }
+
+        let inputNode = engine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        logger.info("\(label, privacy: .public) input format: sampleRate=\(format.sampleRate), channels=\(format.channelCount)")
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            throw NSError(
+                domain: "AudioDeviceService",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "No audio input available for preview"]
+            )
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.processPreviewBuffer(buffer)
+        }
+
+        do {
+            try engine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            engine.stop()
+            throw error
+        }
+    }
+
+    private func teardownPreviewEngine(_ engine: AVAudioEngine) {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+    }
+
+    private func cleanupAfterFailedPreviewStart(_ engine: AVAudioEngine) {
+        previewRecoveryCoordinator.transitionToIdle()
+        removePreviewConfigurationObserver()
+        previewLock.withLock {
+            if previewEngine === engine {
+                previewEngine = nil
+                activePreviewDeviceID = nil
+            }
+        }
+        teardownPreviewEngine(engine)
+        isPreviewActive = false
+        previewAudioLevel = 0
+        previewRawLevel = 0
     }
 
     // MARK: - CoreAudio Device Enumeration

--- a/TypeWhisper/Services/AudioEngineRecoverySupport.swift
+++ b/TypeWhisper/Services/AudioEngineRecoverySupport.swift
@@ -1,0 +1,144 @@
+import Foundation
+import AudioToolbox
+import os
+
+enum AudioEngineRecoveryAction: Equatable {
+    case none
+    case performImmediateRecovery
+    case schedule(generation: UInt64, delay: TimeInterval)
+}
+
+enum AudioEngineRecoveryPolicy {
+    static let configurationDebounce: TimeInterval = 0.15
+    static let retryBackoff: [TimeInterval] = [0.15, 0.30, 0.50]
+
+    private static let retryableOSStatusCodes: Set<OSStatus> = [
+        kAudioUnitErr_FormatNotSupported,
+        kAudioUnitErr_InvalidElement,
+    ]
+
+    static func isRetryable(error: Error) -> Bool {
+        let nsError = error as NSError
+        let detail = nsError.localizedDescription
+        return isRetryable(detail: detail, osStatus: extractOSStatus(from: error))
+    }
+
+    static func isRetryable(detail: String, osStatus: OSStatus?) -> Bool {
+        if let osStatus, retryableOSStatusCodes.contains(osStatus) {
+            return true
+        }
+
+        let lowercasedDetail = detail.lowercased()
+        return lowercasedDetail.contains("config change pending")
+            || lowercasedDetail.contains("format mismatch")
+            || lowercasedDetail.contains("error -10868")
+            || lowercasedDetail.contains("error -10877")
+    }
+
+    static func extractOSStatus(from error: Error) -> OSStatus? {
+        let nsError = error as NSError
+        if nsError.domain == NSOSStatusErrorDomain {
+            return OSStatus(nsError.code)
+        }
+
+        let detail = nsError.localizedDescription
+        if detail.contains("-10868") { return kAudioUnitErr_FormatNotSupported }
+        if detail.contains("-10877") { return kAudioUnitErr_InvalidElement }
+        return nil
+    }
+}
+
+final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
+    private enum LifecycleState {
+        case idle
+        case starting
+        case running
+    }
+
+    private struct State {
+        var lifecycle: LifecycleState = .idle
+        var pendingConfigurationChange = false
+        var recoveryInFlight = false
+        var generation: UInt64 = 0
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func beginStarting() {
+        state.withLock { state in
+            state.lifecycle = .starting
+            state.pendingConfigurationChange = false
+            state.recoveryInFlight = false
+            state.generation &+= 1
+        }
+    }
+
+    func finishStartingSuccessfully() -> AudioEngineRecoveryAction {
+        state.withLock { state in
+            state.lifecycle = .running
+            guard state.pendingConfigurationChange else {
+                return .none
+            }
+
+            state.pendingConfigurationChange = false
+            state.recoveryInFlight = true
+            return .performImmediateRecovery
+        }
+    }
+
+    func noteConfigurationChange() -> AudioEngineRecoveryAction {
+        state.withLock { state in
+            switch state.lifecycle {
+            case .idle:
+                return .none
+            case .starting:
+                state.pendingConfigurationChange = true
+                return .none
+            case .running:
+                state.pendingConfigurationChange = true
+                guard !state.recoveryInFlight else {
+                    return .none
+                }
+
+                state.generation &+= 1
+                return .schedule(generation: state.generation, delay: AudioEngineRecoveryPolicy.configurationDebounce)
+            }
+        }
+    }
+
+    func beginScheduledRecovery(generation: UInt64) -> Bool {
+        state.withLock { state in
+            guard state.lifecycle == .running,
+                  !state.recoveryInFlight,
+                  state.generation == generation,
+                  state.pendingConfigurationChange else {
+                return false
+            }
+
+            state.pendingConfigurationChange = false
+            state.recoveryInFlight = true
+            return true
+        }
+    }
+
+    func finishRecovery() -> AudioEngineRecoveryAction {
+        state.withLock { state in
+            state.recoveryInFlight = false
+            guard state.lifecycle == .running, state.pendingConfigurationChange else {
+                return .none
+            }
+
+            state.generation &+= 1
+            return .schedule(generation: state.generation, delay: AudioEngineRecoveryPolicy.configurationDebounce)
+        }
+    }
+
+    func transitionToIdle() {
+        state.withLock { state in
+            state.lifecycle = .idle
+            state.pendingConfigurationChange = false
+            state.recoveryInFlight = false
+            state.generation &+= 1
+        }
+    }
+}

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -104,7 +104,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let stopStateLock = NSLock()
     private let engineLock = NSLock()
     private let processingQueue = DispatchQueue(label: "com.typewhisper.audio-processing", qos: .userInteractive)
+    private let recoveryQueue = DispatchQueue(label: "com.typewhisper.audio-recovery", qos: .userInitiated)
     private let engineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.audio-engine-teardown")
+    private let recoveryCoordinator = AudioEngineRecoveryCoordinator()
     private var _lastStopGraceCaptureApplied = false
 
     static let targetSampleRate: Double = 16000
@@ -205,69 +207,25 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             return
         }
 
+        clearRecordingBuffer()
         let engine = AVAudioEngine()
-
-        // Set the input device before reading the format
-        if let deviceID = selectedDeviceID {
-            if !setInputDevice(deviceID, on: engine, label: "recording") {
-                logger.error("Failed to set recording input device (\(deviceID)), falling back to system default")
-            }
-        }
-
-        let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-        logger.info("Recording input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
-
-        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            throw AudioRecordingError.engineStartFailed("No audio input available")
-        }
-
-        // Target format: 16kHz mono Float32
-        guard let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Self.targetSampleRate,
-            channels: 1,
-            interleaved: false
-        ) else {
-            throw AudioRecordingError.engineStartFailed("Cannot create target audio format")
-        }
-
-        let tapFormat = Self.monoTapFormat(for: inputFormat)
-
-        let converter = AVAudioConverter(from: tapFormat, to: targetFormat)
-        guard let converter else {
-            throw AudioRecordingError.engineStartFailed("Cannot create audio converter")
-        }
-
-        bufferLock.lock()
-        sampleBuffer.removeAll()
-        _peakRawAudioLevel = 0
-        bufferLock.unlock()
-
-        inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
-            self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
-        }
-
-        let engineStartTime = CFAbsoluteTimeGetCurrent()
-        do {
-            try engine.start()
-            let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
-            logger.info("Audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
-        } catch {
-            inputNode.removeTap(onBus: 0)
-            throw AudioRecordingError.engineStartFailed(error.localizedDescription)
-        }
-
         engineLock.withLock { audioEngine = engine }
-        isRecording = true
+        recoveryCoordinator.beginStarting()
+        installConfigurationObserver(for: engine)
 
-        // Restart engine when macOS changes audio config (e.g. notification sounds)
-        configChangeObserver = NotificationCenter.default.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: engine,
-            queue: .main
-        ) { [weak self] _ in
-            self?.handleConfigurationChange()
+        do {
+            try startEngineWithRecovery(engine, label: "recording")
+
+            if recoveryCoordinator.finishStartingSuccessfully() == .performImmediateRecovery {
+                logger.warning("Audio engine configuration changed while recording was starting, restarting with fresh input format")
+                try restartEngineWithRecovery(engine, label: "recording-startup")
+                scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
+            }
+
+            isRecording = true
+        } catch {
+            cleanupAfterFailedStart(engine)
+            throw error
         }
     }
 
@@ -294,13 +252,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         setLastStopGraceCaptureApplied(graceApplied)
+        recoveryCoordinator.transitionToIdle()
 
-        if let observer = configChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            configChangeObserver = nil
-        }
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
+        removeConfigurationObserver()
+        teardownEngine(engine)
         // Keep the engine alive briefly so CoreAudio's internal teardown callbacks
         // cannot outlive the AVAudioEngine objects they still reference.
         engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
@@ -320,28 +275,99 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     /// Re-setup the audio engine after a system configuration change (e.g. notification sound).
     /// Preserves already-buffered samples so no audio is lost.
-    private func handleConfigurationChange() {
+    private func handleConfigurationChangeNotification() {
+        scheduleRecoveryIfNeeded(recoveryCoordinator.noteConfigurationChange())
+    }
+
+    private func scheduleRecoveryIfNeeded(_ action: AudioEngineRecoveryAction) {
+        guard case .schedule(let generation, let delay) = action else { return }
+
+        recoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.performScheduledRecovery(generation: generation)
+        }
+    }
+
+    private func performScheduledRecovery(generation: UInt64) {
+        guard recoveryCoordinator.beginScheduledRecovery(generation: generation) else { return }
+        defer {
+            scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
+        }
+
         let engine: AVAudioEngine? = engineLock.withLock { audioEngine }
         guard isRecording, let engine else { return }
+
         logger.warning("Audio engine configuration changed during recording, restarting engine")
 
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
+        do {
+            try restartEngineWithRecovery(engine, label: "config-change")
+        } catch {
+            logger.error("Failed to restart audio engine after configuration change: \(error.localizedDescription)")
+        }
+    }
 
-        let deviceID = selectedDeviceID
-        if let deviceID {
-            if !setInputDevice(deviceID, on: engine, label: "config-change") {
-                logger.warning("Failed to re-set device after config change (\(deviceID)), using default")
+    private func installConfigurationObserver(for engine: AVAudioEngine) {
+        removeConfigurationObserver()
+        configChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleConfigurationChangeNotification()
+        }
+    }
+
+    private func removeConfigurationObserver() {
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
+    }
+
+    private func startEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+        for (attempt, delay) in AudioEngineRecoveryPolicy.retryBackoff.enumerated() {
+            do {
+                try configureAndStartEngine(engine, label: label)
+                return
+            } catch let error as AudioRecordingError {
+                throw error
+            } catch {
+                guard AudioEngineRecoveryPolicy.isRetryable(error: error) else {
+                    throw AudioRecordingError.engineStartFailed(error.localizedDescription)
+                }
+
+                logger.warning("\(label, privacy: .public) audio engine start failed with retryable error, retry \(attempt + 1) in \(delay, privacy: .public)s: \(error.localizedDescription, privacy: .public)")
+                Thread.sleep(forTimeInterval: delay)
+            }
+        }
+
+        do {
+            try configureAndStartEngine(engine, label: label)
+        } catch let error as AudioRecordingError {
+            throw error
+        } catch {
+            throw AudioRecordingError.engineStartFailed(error.localizedDescription)
+        }
+    }
+
+    private func restartEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+        teardownEngine(engine)
+        try startEngineWithRecovery(engine, label: label)
+    }
+
+    private func configureAndStartEngine(_ engine: AVAudioEngine, label: String) throws {
+        // Set the input device before reading the format so each retry sees fresh hardware state.
+        if let deviceID = selectedDeviceID {
+            if !setInputDevice(deviceID, on: engine, label: label) {
+                logger.error("Failed to set \(label, privacy: .public) input device (\(deviceID)), falling back to system default")
             }
         }
 
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
-        logger.info("Config-change input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
+        logger.info("\(label, privacy: .public) input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
 
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            logger.error("Cannot restart engine: no audio input available")
-            return
+            throw AudioRecordingError.engineStartFailed("No audio input available")
         }
 
         guard let targetFormat = AVAudioFormat(
@@ -350,28 +376,58 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             channels: 1,
             interleaved: false
         ) else {
-            logger.error("Cannot restart engine: failed to create target format")
-            return
+            throw AudioRecordingError.engineStartFailed("Cannot create target audio format")
         }
 
         let tapFormat = Self.monoTapFormat(for: inputFormat)
 
         guard let converter = AVAudioConverter(from: tapFormat, to: targetFormat) else {
-            logger.error("Cannot restart engine: failed to create audio converter")
-            return
+            throw AudioRecordingError.engineStartFailed("Cannot create audio converter")
         }
 
         inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
             self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
         }
 
+        let engineStartTime = CFAbsoluteTimeGetCurrent()
         do {
             try engine.start()
-            logger.info("Audio engine restarted successfully")
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
+            logger.info("\(label, privacy: .public) audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
         } catch {
             inputNode.removeTap(onBus: 0)
-            logger.error("Failed to restart audio engine: \(error.localizedDescription)")
+            engine.stop()
+            throw error
         }
+    }
+
+    private func teardownEngine(_ engine: AVAudioEngine) {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+    }
+
+    private func cleanupAfterFailedStart(_ engine: AVAudioEngine) {
+        recoveryCoordinator.transitionToIdle()
+        removeConfigurationObserver()
+        engineLock.withLock {
+            if audioEngine === engine {
+                audioEngine = nil
+            }
+        }
+        teardownEngine(engine)
+        engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        DispatchQueue.main.async { [weak self] in
+            self?.isRecording = false
+            self?.audioLevel = 0
+            self?.rawAudioLevel = 0
+        }
+    }
+
+    private func clearRecordingBuffer() {
+        bufferLock.lock()
+        sampleBuffer.removeAll()
+        _peakRawAudioLevel = 0
+        bufferLock.unlock()
     }
 
     private func processAudioBuffer(

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1,0 +1,71 @@
+import AudioToolbox
+import XCTest
+@testable import TypeWhisper
+
+final class AudioEngineRecoverySupportTests: XCTestCase {
+    func testRetryableErrorClassification_matchesKnownAudioUnitCodes() {
+        let formatError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_FormatNotSupported))
+        let invalidElementError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_InvalidElement))
+        let permissionError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_Unauthorized))
+
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: formatError))
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: invalidElementError))
+        XCTAssertFalse(AudioEngineRecoveryPolicy.isRetryable(error: permissionError))
+    }
+
+    func testRetryableErrorClassification_matchesKnownLogMessages() {
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "Failed to create tap, config change pending!", osStatus: nil))
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "Format mismatch: input hw 24000 Hz, client format 48000 Hz", osStatus: nil))
+        XCTAssertFalse(AudioEngineRecoveryPolicy.isRetryable(detail: "Microphone permission denied", osStatus: nil))
+    }
+
+    func testConfigurationChangeDuringStart_triggersImmediateRecoveryOnceStartSucceeds() {
+        let coordinator = AudioEngineRecoveryCoordinator()
+
+        coordinator.beginStarting()
+        XCTAssertEqual(coordinator.noteConfigurationChange(), .none)
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .performImmediateRecovery)
+        XCTAssertEqual(coordinator.finishRecovery(), .none)
+    }
+
+    func testMultipleConfigurationChanges_coalesceToLatestScheduledGeneration() {
+        let coordinator = AudioEngineRecoveryCoordinator()
+
+        coordinator.beginStarting()
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .none)
+
+        guard case .schedule(let firstGeneration, let firstDelay) = coordinator.noteConfigurationChange() else {
+            return XCTFail("Expected first configuration change to schedule recovery")
+        }
+        guard case .schedule(let secondGeneration, let secondDelay) = coordinator.noteConfigurationChange() else {
+            return XCTFail("Expected second configuration change to reschedule recovery")
+        }
+
+        XCTAssertEqual(firstDelay, AudioEngineRecoveryPolicy.configurationDebounce)
+        XCTAssertEqual(secondDelay, AudioEngineRecoveryPolicy.configurationDebounce)
+        XCTAssertNotEqual(firstGeneration, secondGeneration)
+        XCTAssertFalse(coordinator.beginScheduledRecovery(generation: firstGeneration))
+        XCTAssertTrue(coordinator.beginScheduledRecovery(generation: secondGeneration))
+        XCTAssertEqual(coordinator.finishRecovery(), .none)
+    }
+
+    func testConfigurationChangeDuringRecovery_schedulesOneFollowUpPass() {
+        let coordinator = AudioEngineRecoveryCoordinator()
+
+        coordinator.beginStarting()
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .none)
+
+        guard case .schedule(let generation, _) = coordinator.noteConfigurationChange() else {
+            return XCTFail("Expected scheduled recovery")
+        }
+        XCTAssertTrue(coordinator.beginScheduledRecovery(generation: generation))
+        XCTAssertEqual(coordinator.noteConfigurationChange(), .none)
+
+        guard case .schedule(let followUpGeneration, let delay) = coordinator.finishRecovery() else {
+            return XCTFail("Expected follow-up recovery after a new pending change")
+        }
+
+        XCTAssertNotEqual(generation, followUpGeneration)
+        XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationDebounce)
+    }
+}


### PR DESCRIPTION
Fixes #218

## Summary
- harden `AVAudioEngine` startup against transient AirPods profile switches and stale input formats
- apply the same recovery and configuration-change handling to microphone preview
- add unit tests for retryable audio errors and restart coalescing

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests -only-testing:TypeWhisperTests/DictationShortSpeechTests`