### PR TITLE
docs: update 1.1 release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 Speech-to-text and AI text processing for macOS. Transcribe audio using on-device AI models or cloud APIs (Groq, OpenAI), then process the result with custom LLM prompts. Your voice data stays on your Mac with local models - or use cloud APIs for faster processing.
 
-TypeWhisper `1.0` is scoped as a reliable direct-download release. The supported core is system-wide dictation, file transcription, prompt processing, profiles, history, dictionary, snippets, and bundled integrations. HTTP API, CLI, widgets, and the plugin SDK remain available as advanced surfaces.
+TypeWhisper `1.1` is scoped as a reliable direct-download release. The supported core remains system-wide dictation, file transcription, prompt processing, profiles, history, dictionary, snippets, and bundled integrations. HTTP API, CLI, widgets, Watch Folder, and the plugin SDK remain available as advanced surfaces.
 
-See [docs/1.0-readiness.md](docs/1.0-readiness.md), [docs/support-matrix.md](docs/support-matrix.md), and [docs/release-checklist.md](docs/release-checklist.md) for the current release definition and ship gates.
+See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](docs/support-matrix.md), and [docs/release-checklist.md](docs/release-checklist.md) for the current release definition and ship gates.
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/22fe922d-4a4c-47d1-805e-684a148ebd03" autoplay loop muted playsinline width="270"></video>
@@ -96,7 +96,7 @@ brew install --cask typewhisper/tap/typewhisper
 
 Download the latest DMG from [GitHub Releases](https://github.com/TypeWhisper/typewhisper-mac/releases/latest).
 
-Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.0.0-rc1` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
+Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.1.0-rc1` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
 Installed builds can switch channels in `Settings -> About` via the `Update Channel` picker.
 
 ## Quick Start
@@ -280,7 +280,7 @@ cat audio.wav | typewhisper transcribe -
 typewhisper transcribe meeting.m4a --json | jq -r '.text'
 ```
 
-The CLI requires the API server to be running (Settings > Advanced) and follows the documented `1.0.x` command and flag surface.
+The CLI requires the API server to be running (Settings > Advanced) and follows the documented `1.1.x` command and flag surface.
 
 ## Profiles
 

--- a/docs/1.1-readiness.md
+++ b/docs/1.1-readiness.md
@@ -1,6 +1,6 @@
-# TypeWhisper 1.0 Readiness
+# TypeWhisper 1.1 Readiness
 
-TypeWhisper `1.0` is a stable direct-download release for macOS. The Mac App Store is completely out of scope for this release definition. Before `1.0`, no major new product surfaces will be added; the focus is reliability, clear product boundaries, upgrade safety, and fast support diagnostics.
+TypeWhisper `1.1` is a stable direct-download release for macOS. The Mac App Store remains out of scope for this release definition. Before `1.1`, the focus is reliability, clear product boundaries, upgrade safety, and fast support diagnostics across the features already shipping in the `1.1` line.
 
 ## Audience
 
@@ -17,9 +17,9 @@ TypeWhisper `1.0` is a stable direct-download release for macOS. The Mac App Sto
 - History, Dictionary, and Snippets
 - Bundled default integrations and default plugins
 
-## Advanced Surfaces in 1.0
+## Advanced Surfaces in 1.1
 
-These surfaces remain part of `1.0`, but they are positioned as advanced or automation surfaces:
+These surfaces remain part of `1.1`, but they are positioned as advanced or automation surfaces:
 
 - Local HTTP API under `/v1/*`
 - `typewhisper` CLI
@@ -27,12 +27,12 @@ These surfaces remain part of `1.0`, but they are positioned as advanced or auto
 - Widgets
 - Watch Folder
 
-## Non-Goals Before 1.0
+## Non-Goals Before 1.1
 
 - No Mac App Store launch and no App Store-specific gates
 - No new major engines, plugin classes, or public API families
 - No breaking changes to the documented HTTP API, CLI, or Plugin SDK
-- No broad UI automation requirement for `1.0`
+- No broad UI automation requirement for `1.1`
 
 ## Stability Contracts for 1.x
 
@@ -61,7 +61,7 @@ These surfaces remain part of `1.0`, but they are positioned as advanced or auto
 
 ## Release Gates
 
-`1.0.0` is only tagged once all of the following conditions are met:
+`1.1.0` is only tagged once all of the following conditions are met:
 
 - `xcodebuild test` for the app scheme passes.
 - `swift test --package-path TypeWhisperPluginSDK` passes.
@@ -69,9 +69,9 @@ These surfaces remain part of `1.0`, but they are positioned as advanced or auto
 - There are no first-party build warnings.
 - Plugin manifests validate successfully.
 - README, security guidance, and the support matrix are up to date.
-- A `1.0.0-rc1` build ran on real machines for multiple days without P0/P1 blockers.
+- A `1.1.0-rc1` build ran on real machines for multiple days without P0/P1 blockers.
 - The default channel remains `stable`; `release-candidate` and `daily` exist as Sparkle channels for preview builds.
-- `1.0.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
+- `1.1.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
 
 ## Manual Smoke Checks Before Tagging
 
@@ -80,12 +80,17 @@ These surfaces remain part of `1.0`, but they are positioned as advanced or auto
 - First successful dictation
 - File transcription
 - Prompt action from the app
+- Prompt wizard flow across tabs
 - History edit/export
+- History entry shows both STT and AI-processed text where applicable
 - Profile matching for app and URL
+- Auto Enter profile behavior
 - Plugin enable/disable
+- Community term pack download and apply
+- Sound feedback settings and sound switching
 - CLI against a running local server
 - HTTP API `status`, `models`, `transcribe`
-- Upgrade from `0.14.x` with History, Profiles, Dictionary, Snippets, hotkeys, and plugin state preserved
+- Upgrade from `1.0.0` with History, Profiles, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
 
 ## Support and Diagnostics
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,6 +1,6 @@
 # TypeWhisper Support Matrix
 
-This matrix describes the officially supported `1.0` path for direct-download releases.
+This matrix describes the officially supported `1.1` path for direct-download releases.
 
 ## Platform
 
@@ -14,10 +14,10 @@ This matrix describes the officially supported `1.0` path for direct-download re
 
 | Feature | macOS 14 | macOS 15 | macOS 26+ | Notes |
 | --- | --- | --- | --- | --- |
-| System-wide dictation | Yes | Yes | Yes | Core workflow for `1.0` |
-| File transcription | Yes | Yes | Yes | Core workflow for `1.0` |
-| Prompt processing | Yes | Yes | Yes | Core workflow for `1.0` |
-| Profiles, History, Dictionary, Snippets | Yes | Yes | Yes | Core workflow for `1.0` |
+| System-wide dictation | Yes | Yes | Yes | Core workflow for `1.1` |
+| File transcription | Yes | Yes | Yes | Core workflow for `1.1` |
+| Prompt processing | Yes | Yes | Yes | Core workflow for `1.1` |
+| Profiles, History, Dictionary, Snippets | Yes | Yes | Yes | Core workflow for `1.1` |
 | Widgets | Yes | Yes | Yes | Not part of the core path |
 | HTTP API | Yes | Yes | Yes | Loopback-only, disabled by default |
 | CLI | Yes | Yes | Yes | Requires the local API server to be running |
@@ -28,17 +28,17 @@ This matrix describes the officially supported `1.0` path for direct-download re
 
 ## Engine Notes
 
-| Engine Type | Support in 1.0 | Notes |
+| Engine Type | Support in 1.1 | Notes |
 | --- | --- | --- |
 | Local engines | Yes | Recommended default path |
 | Cloud engines | Yes | Require valid API keys |
 | Bundled plugins | Yes | Part of the tested product path |
-| External third-party plugins | Best effort | Not a launch blocker for `1.0` |
+| External third-party plugins | Best effort | Not a launch blocker for `1.1` |
 
 ## Automation Notes
 
-| Surface | Status in 1.0 |
+| Surface | Status in 1.1 |
 | --- | --- |
 | HTTP API `/v1/*` | Stable for `1.x` |
-| `typewhisper` CLI | Stable for `1.0.x` |
+| `typewhisper` CLI | Stable for `1.1.x` |
 | Plugin SDK | Stable for `1.x` |


### PR DESCRIPTION
## Summary
- update the README release framing and links from 1.0 to 1.1/1.1.0
- rename the readiness guide to `docs/1.1-readiness.md` and refresh it for the current 1.1 release line
- align the support matrix language with the 1.1 release definition while keeping the intentional `1.0.0 -> 1.1.0` upgrade checks

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`

## Review
- Pre-Landing Review: No issues found.
- Test Coverage Audit: skipped, doc-only diff with no application code paths changed.
- Eval Suites: skipped, no prompt-related files changed.
