### PR TITLE
Prepare 1.2.0-rc1 release metadata and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,59 +403,73 @@ jobs:
               RANGE="$RANGE_END"
             fi
 
-            # Parse commits into categories
-            FEATURES=""
-            FIXES=""
-            OTHER=""
+            RELEASE_NOTES_FILE="docs/release-notes/${RAW_VERSION}.md"
 
-            while IFS= read -r line; do
-              # Skip empty lines
-              [ -z "$line" ] && continue
+            if [ -f "$RELEASE_NOTES_FILE" ]; then
+              echo "Using curated release notes from $RELEASE_NOTES_FILE"
+              CREATE_ARGS=(
+                "$TAG"
+                "$ASSET_DMG"
+                "$ASSET_ZIP"
+                --title "$TAG"
+                --notes-file "$RELEASE_NOTES_FILE"
+              )
+            else
 
-              # Extract message (remove short hash prefix)
-              MSG=$(echo "$line" | sed 's/^[a-f0-9]* //')
+              # Parse commits into categories
+              FEATURES=""
+              FIXES=""
+              OTHER=""
 
-              # Filter out noise
-              echo "$MSG" | grep -qiE '^(Merge |chore: bump|chore\(release\)|docs: update README)' && continue
+              while IFS= read -r line; do
+                # Skip empty lines
+                [ -z "$line" ] && continue
 
-              # Categorize by conventional commit prefix
-              if echo "$MSG" | grep -qE '^feat(\(.*\))?:'; then
-                ENTRY=$(echo "$MSG" | sed 's/^feat\(([^)]*)\)\{0,1\}: //')
-                FEATURES="${FEATURES}- ${ENTRY}\n"
-              elif echo "$MSG" | grep -qE '^fix(\(.*\))?:'; then
-                ENTRY=$(echo "$MSG" | sed 's/^fix\(([^)]*)\)\{0,1\}: //')
-                FIXES="${FIXES}- ${ENTRY}\n"
-              else
-                # Strip any other conventional prefix for cleaner display
-                ENTRY=$(echo "$MSG" | sed 's/^[a-z]*\(([^)]*)\)\{0,1\}: //')
-                OTHER="${OTHER}- ${ENTRY}\n"
+                # Extract message (remove short hash prefix)
+                MSG=$(echo "$line" | sed 's/^[a-f0-9]* //')
+
+                # Filter out noise
+                echo "$MSG" | grep -qiE '^(Merge |chore: bump|chore\(release\)|docs: update README)' && continue
+
+                # Categorize by conventional commit prefix
+                if echo "$MSG" | grep -qE '^feat(\(.*\))?:'; then
+                  ENTRY=$(echo "$MSG" | sed 's/^feat\(([^)]*)\)\{0,1\}: //')
+                  FEATURES="${FEATURES}- ${ENTRY}\n"
+                elif echo "$MSG" | grep -qE '^fix(\(.*\))?:'; then
+                  ENTRY=$(echo "$MSG" | sed 's/^fix\(([^)]*)\)\{0,1\}: //')
+                  FIXES="${FIXES}- ${ENTRY}\n"
+                else
+                  # Strip any other conventional prefix for cleaner display
+                  ENTRY=$(echo "$MSG" | sed 's/^[a-z]*\(([^)]*)\)\{0,1\}: //')
+                  OTHER="${OTHER}- ${ENTRY}\n"
+                fi
+              done <<< "$(git log --oneline --no-merges "$RANGE")"
+
+              # Build release notes
+              NOTES=""
+              if [ -n "$FEATURES" ]; then
+                NOTES="${NOTES}## New Features\n${FEATURES}\n"
               fi
-            done <<< "$(git log --oneline --no-merges "$RANGE")"
+              if [ -n "$FIXES" ]; then
+                NOTES="${NOTES}## Bug Fixes\n${FIXES}\n"
+              fi
+              if [ -n "$OTHER" ]; then
+                NOTES="${NOTES}## Other Changes\n${OTHER}\n"
+              fi
 
-            # Build release notes
-            NOTES=""
-            if [ -n "$FEATURES" ]; then
-              NOTES="${NOTES}## New Features\n${FEATURES}\n"
-            fi
-            if [ -n "$FIXES" ]; then
-              NOTES="${NOTES}## Bug Fixes\n${FIXES}\n"
-            fi
-            if [ -n "$OTHER" ]; then
-              NOTES="${NOTES}## Other Changes\n${OTHER}\n"
-            fi
+              # Fallback if no categorized commits
+              if [ -z "$NOTES" ]; then
+                NOTES="Maintenance release ${TAG}"
+              fi
 
-            # Fallback if no categorized commits
-            if [ -z "$NOTES" ]; then
-              NOTES="Maintenance release ${TAG}"
+              CREATE_ARGS=(
+                "$TAG"
+                "$ASSET_DMG"
+                "$ASSET_ZIP"
+                --title "$TAG"
+                --notes "$(printf '%b' "$NOTES")"
+              )
             fi
-
-            CREATE_ARGS=(
-              "$TAG"
-              "$ASSET_DMG"
-              "$ASSET_ZIP"
-              --title "$TAG"
-              --notes "$(printf '%b' "$NOTES")"
-            )
 
             if [ "$IS_PRERELEASE" = "true" ]; then
               CREATE_ARGS+=(--prerelease)
@@ -511,7 +525,7 @@ jobs:
             --url "$DOWNLOAD_URL" \
             --signature "$ED_SIGNATURE" \
             --length "$ED_LENGTH" \
-            --minimum-system-version "15.0"
+            --minimum-system-version "14.0"
 
           cd /tmp/gh-pages
           git add appcast.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ echo 'DEVELOPMENT_TEAM = YOUR_TEAM_ID' > CodeSigning.local.xcconfig
 
 ## Development Setup
 
-- **macOS 15.0+** required
+- **Product runtime support:** macOS 14.0+
+- **Contributor machine:** macOS 15.0+ recommended for the current Xcode toolchain
 - **Swift 6** with strict concurrency
 - Debug builds use a separate data directory (`TypeWhisper-Dev`) and keychain prefix, so they don't interfere with release builds
 

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -42,8 +42,8 @@ Plugins can subscribe to events without modifying the transcription pipeline:
     "id": "com.yourname.plugin-id",
     "name": "My Plugin",
     "version": "1.0.0",
-    "minHostVersion": "0.9.0",
-    "minOSVersion": "15.0",
+    "minHostVersion": "1.0.0",
+    "minOSVersion": "14.0",
     "author": "Your Name",
     "principalClass": "MyPluginClassName"
 }
@@ -60,6 +60,9 @@ Each plugin receives a `HostServices` object providing:
 - **Profiles**: `availableProfileNames` - list of user-defined profile names
 - **Event Bus**: `eventBus` for subscribing to events
 - **Capabilities**: `notifyCapabilitiesChanged()` - notify the host when plugin state changes (e.g. model loaded/unloaded)
+- **Streaming display hint**: `setStreamingDisplayActive(_:)` - tell TypeWhisper that your plugin renders its own streaming UI
+
+Bundled MLX plugins such as Qwen3, Granite, and Voxtral store their optional HuggingFace token via the same plugin-scoped keychain helpers.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Speech-to-text and AI text processing for macOS. Transcribe audio using on-device AI models or cloud APIs (Groq, OpenAI), then process the result with custom LLM prompts. Your voice data stays on your Mac with local models - or use cloud APIs for faster processing.
 
-TypeWhisper `1.1` is scoped as a reliable direct-download release. The supported core remains system-wide dictation, file transcription, prompt processing, profiles, history, dictionary, snippets, and bundled integrations. HTTP API, CLI, widgets, Watch Folder, and the plugin SDK remain available as advanced surfaces.
+TypeWhisper `1.x` is the direct-download macOS release line. The supported core remains system-wide dictation, file transcription, prompt processing, profiles, history, dictionary, snippets, and bundled integrations. HTTP API, CLI, widgets, watch folders, and the plugin SDK remain supported advanced surfaces.
 
 See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](docs/support-matrix.md), and [docs/release-checklist.md](docs/release-checklist.md) for the current release definition and ship gates.
 
@@ -39,13 +39,24 @@ See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](doc
   <a href=".github/screenshots/advanced.png"><img src=".github/screenshots/advanced.png" width="270" alt="Advanced Settings"></a>
 </p>
 
+## What's New in 1.2
+
+- **Minimal indicator** - A compact power-user status view alongside the existing Notch and Overlay styles
+- **Transcript preview toggle** - Live preview can now be disabled for Notch and Overlay indicators
+- **Faster dictation start** - Metadata capture and URL resolution move off the critical start path
+- **Short-clip improvements** - Better handling for brief utterances, especially with streaming preview and Parakeet
+- **Audio recovery fixes** - More resilient recording and preview after device switches, AirPods profile changes, and `AVAudioEngine` reconfiguration
+- **MLX plugin setup** - Qwen3, Granite, and Voxtral now support an optional HuggingFace token in settings for higher download limits
+- **Localized term packs** - Built-in term pack metadata now renders in English and German
+
 ## Features
 
 ### Transcription
 
-- **Eight engines** - WhisperKit (99+ languages, streaming, translation), Parakeet TDT v3 (25 European languages, extremely fast), Apple SpeechAnalyzer (macOS 26+, no model download needed), Qwen3 ASR (MLX-based), Voxtral (local Voxtral Mini 4B, MLX-based), Groq Whisper, OpenAI Whisper, and OpenAI Compatible (any OpenAI-compatible API)
+- **Nine engines** - WhisperKit (99+ languages, streaming, translation), Parakeet TDT v3 (25 European languages, extremely fast), Apple SpeechAnalyzer (macOS 26+, no model download needed), Granite Speech (MLX-based), Qwen3 ASR (MLX-based), Voxtral (local Voxtral Mini 4B, MLX-based), Groq Whisper, OpenAI Whisper, and OpenAI Compatible (any OpenAI-compatible API)
 - **On-device or cloud** - All processing happens locally on your Mac, or use Groq/OpenAI Whisper APIs for faster processing
 - **Streaming preview** - See partial transcription in real-time while speaking (WhisperKit)
+- **Short-clip handling** - Better retention of brief utterances and fewer false no-speech discards
 - **File transcription** - Batch-process multiple audio/video files with drag & drop
 - **Subtitle export** - Export transcriptions as SRT or WebVTT with timestamps
 
@@ -53,8 +64,9 @@ See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](doc
 
 - **System-wide** - Push-to-talk, toggle, or hybrid mode via global hotkey, auto-pastes into any app
 - **Modifier-key hotkeys** - Use a single modifier key (Command, Shift, Option, Control) as your hotkey
+- **Indicator styles** - Choose Notch, Overlay, or Minimal, with optional live transcript preview where supported
 - **Sound feedback** - Audio cues for recording start, transcription success, and errors
-- **Microphone selection** - Choose a specific input device with live preview
+- **Microphone selection** - Choose a specific input device with live preview and improved recovery after route changes
 
 ### AI Processing
 
@@ -66,12 +78,14 @@ See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](doc
 
 - **Profiles** - Per-app and per-website overrides for language, task, engine, prompt, hotkey, and auto-submit. Match by app (bundle ID) and/or domain with subdomain support
 - **Dictionary** - Terms improve cloud recognition accuracy. Corrections fix common transcription mistakes automatically. Auto-learns from manual corrections. Includes importable term packs
+- **Localized term packs** - Built-in term pack names and descriptions are localized in English and German
 - **Snippets** - Text shortcuts with trigger/replacement. Supports placeholders like `{{DATE}}`, `{{TIME}}`, and `{{CLIPBOARD}}`
 - **History** - Searchable transcription history with inline editing, correction detection, app context tracking, timeline grouping, filters, bulk delete, multi-select export, auto-retention, and a standalone window accessible from the tray menu
 
 ### Integration & Extensibility
 
-- **Plugin system** - Extend TypeWhisper with custom LLM providers, transcription engines, post-processors, and action plugins. Groq, OpenAI, OpenAI Compatible, Gemini, Linear, Voxtral, and Webhook ship as bundled plugins. Linear plugin enables voice-to-issue creation. See [Plugins/README.md](Plugins/README.md)
+- **Plugin system** - Extend TypeWhisper with custom LLM providers, transcription engines, post-processors, and action plugins. Granite, Groq, OpenAI, OpenAI Compatible, Gemini, Linear, Qwen3, Voxtral, and Webhook ship as bundled plugins, alongside the local engine plugins. Linear plugin enables voice-to-issue creation. See [Plugins/README.md](Plugins/README.md)
+- **MLX download controls** - Bundled Qwen3, Granite, and Voxtral plugins support an optional HuggingFace token for higher rate limits and clearer download errors
 - **HTTP API** - Local REST API for integration with external tools and scripts
 - **CLI tool** - Shell-friendly transcription via the command line
 
@@ -96,7 +110,7 @@ brew install --cask typewhisper/tap/typewhisper
 
 Download the latest DMG from [GitHub Releases](https://github.com/TypeWhisper/typewhisper-mac/releases/latest).
 
-Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.1.0-rc1` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
+Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.2.0-rc1` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
 Installed builds can switch channels in `Settings -> About` via the `Update Channel` picker.
 
 ## Quick Start
@@ -280,7 +294,7 @@ cat audio.wav | typewhisper transcribe -
 typewhisper transcribe meeting.m4a --json | jq -r '.text'
 ```
 
-The CLI requires the API server to be running (Settings > Advanced) and follows the documented `1.1.x` command and flag surface.
+The CLI requires the API server to be running (Settings > Advanced) and follows the documented `1.x` command and flag surface.
 
 ## Profiles
 
@@ -307,7 +321,7 @@ Multiple engines can be loaded simultaneously for instant switching between prof
 
 TypeWhisper supports plugins for adding custom LLM providers, transcription engines, post-processors, and action plugins. Plugins are macOS `.bundle` files placed in `~/Library/Application Support/TypeWhisper/Plugins/`.
 
-All 11 engines and integrations (WhisperKit, Parakeet, SpeechAnalyzer, Qwen3, Voxtral, Groq, OpenAI, OpenAI Compatible, Gemini, Linear, Webhook) are implemented as bundled plugins and serve as reference implementations.
+All 12 engines and integrations (WhisperKit, Parakeet, SpeechAnalyzer, Granite, Qwen3, Voxtral, Groq, OpenAI, OpenAI Compatible, Gemini, Linear, Webhook) are implemented as bundled plugins and serve as reference implementations.
 
 See [Plugins/README.md](Plugins/README.md) for the full plugin development guide, including the event bus, host services API, and manifest format.
 
@@ -316,8 +330,8 @@ See [Plugins/README.md](Plugins/README.md) for the full plugin development guide
 ```
 TypeWhisper/
 ├── typewhisper-cli/           # Command-line tool (status, models, transcribe)
-├── Plugins/                # Bundled plugins (WhisperKit, Parakeet, SpeechAnalyzer, Qwen3,
-│                           #   Voxtral, Groq, OpenAI, OpenAI Compatible, Gemini, Linear, Webhook)
+├── Plugins/                # Bundled plugins (WhisperKit, Parakeet, SpeechAnalyzer, Granite,
+│                           #   Qwen3, Voxtral, Groq, OpenAI, OpenAI Compatible, Gemini, Linear, Webhook)
 ├── TypeWhisperPluginSDK/   # Plugin SDK (Swift package)
 ├── TypeWhisperWidgetExtension/ # WidgetKit widgets (stats, activity, history)
 ├── TypeWhisperWidgetShared/    # Shared widget data models

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -3296,7 +3296,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -3324,7 +3324,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -3339,7 +3339,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_NAME = "typewhisper-cli";
 				SWIFT_VERSION = 6.0;
 			};
@@ -3351,7 +3351,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_NAME = "typewhisper-cli";
 				SWIFT_VERSION = 6.0;
 			};
@@ -3837,7 +3837,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3864,7 +3864,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -21,8 +21,8 @@ Create `Contents/Resources/manifest.json` in your bundle:
   "id": "com.yourname.myplugin",
   "name": "My Plugin",
   "version": "1.0.0",
-  "minHostVersion": "0.11",
-  "minOSVersion": "15.0",
+  "minHostVersion": "1.0.0",
+  "minOSVersion": "14.0",
   "author": "Your Name",
   "principalClass": "MyPlugin"
 }
@@ -254,6 +254,10 @@ func activate(host: HostServices) {
 
     // Profile names
     let profiles = host.availableProfileNames
+
+    // Host UI coordination
+    host.notifyCapabilitiesChanged()
+    host.setStreamingDisplayActive(true)
 }
 ```
 
@@ -306,13 +310,25 @@ The view appears as a sheet when the user clicks the gear icon in Settings > Int
 
 ### PluginOpenAITranscriptionHelper
 
-For OpenAI-compatible Whisper APIs:
+For OpenAI-compatible Whisper APIs. Clips shorter than one second are padded automatically before upload so providers do not reject them as too short:
 
 ```swift
 let helper = PluginOpenAITranscriptionHelper(baseURL: "https://api.groq.com/openai")
 let result = try await helper.transcribe(
     audio: audio, apiKey: apiKey, modelName: "whisper-large-v3",
     language: "en", translate: false, prompt: nil
+)
+```
+
+### PluginAudioUtils
+
+Helpers for short-clip handling:
+
+```swift
+let padded = PluginAudioUtils.paddedSamples(samples, minimumDuration: 1.0)
+let shouldKeep = PluginAudioUtils.shouldAcceptShortClipTranscription(
+    audioDuration: audio.duration,
+    confidence: confidence
 )
 ```
 
@@ -345,8 +361,8 @@ let wavData = PluginWavEncoder.encode(samples, sampleRate: 16000)
 | `id` | Yes | Unique reverse-domain ID (e.g. `com.yourname.myplugin`) |
 | `name` | Yes | Display name |
 | `version` | Yes | Semver string (e.g. `1.0.0`) |
-| `minHostVersion` | No | Minimum TypeWhisper version |
-| `minOSVersion` | No | Minimum macOS version (e.g. `15.0`, `26.0`). Plugin is skipped on older systems. |
+| `minHostVersion` | No | Minimum TypeWhisper version (e.g. `1.0.0`) |
+| `minOSVersion` | No | Minimum macOS version (e.g. `14.0`, `26.0`). Plugin is skipped on older systems. |
 | `author` | No | Author name |
 | `principalClass` | Yes | Objective-C class name, must match `@objc(Name)` |
 
@@ -368,8 +384,8 @@ Registry entry format:
   "id": "com.yourname.myplugin",
   "name": "My Plugin",
   "version": "1.0.0",
-  "minHostVersion": "0.11",
-  "minOSVersion": "15.0",
+  "minHostVersion": "1.0.0",
+  "minOSVersion": "14.0",
   "author": "Your Name",
   "description": "What your plugin does.",
   "category": "transcription|llm|postprocessor|action",
@@ -383,6 +399,6 @@ Registry entry format:
 
 ## Requirements
 
-- macOS 15.0+
+- macOS 14.0+
 - Swift 6.0
-- TypeWhisper 0.11+
+- TypeWhisper 1.0+

--- a/docs/1.1-readiness.md
+++ b/docs/1.1-readiness.md
@@ -1,12 +1,14 @@
-# TypeWhisper 1.1 Readiness
+# TypeWhisper 1.x Release Readiness
 
-TypeWhisper `1.1` is a stable direct-download release for macOS. The Mac App Store remains out of scope for this release definition. Before `1.1`, the focus is reliability, clear product boundaries, upgrade safety, and fast support diagnostics across the features already shipping in the `1.1` line.
+This document remains at `docs/1.1-readiness.md` for the current direct-download release line. It defines the release gates for the current `1.x` product path, including `1.2.0-rc1`.
+
+TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac App Store remains out of scope. For `1.2`, the focus is reliability, upgrade safety, and power-user polish across indicators, short clips, audio recovery, and plugin setup.
 
 ## Audience
 
 - macOS users who want system-wide dictation with their own engine choice
 - Users who want to transcribe audio or video files locally or through the API
-- Power users who need prompt processing, profiles, and local automation
+- Power users who need prompt processing, profiles, plugins, and local automation
 
 ## Officially Supported Core
 
@@ -15,11 +17,11 @@ TypeWhisper `1.1` is a stable direct-download release for macOS. The Mac App Sto
 - Prompt processing with bundled presets and custom actions
 - Profiles for app- and URL-based control
 - History, Dictionary, and Snippets
-- Bundled default integrations and default plugins
+- Bundled default integrations and bundled plugins
 
-## Advanced Surfaces in 1.1
+## Supported Advanced Surfaces
 
-These surfaces remain part of `1.1`, but they are positioned as advanced or automation surfaces:
+These surfaces remain part of `1.x`, but they are positioned as advanced or automation surfaces:
 
 - Local HTTP API under `/v1/*`
 - `typewhisper` CLI
@@ -27,14 +29,18 @@ These surfaces remain part of `1.1`, but they are positioned as advanced or auto
 - Widgets
 - Watch Folder
 
-## Non-Goals Before 1.1
+## `1.2` Focus Areas
 
-- No Mac App Store launch and no App Store-specific gates
-- No new major engines, plugin classes, or public API families
-- No breaking changes to the documented HTTP API, CLI, or Plugin SDK
-- No broad UI automation requirement for `1.1`
+- Minimal indicator style for compact status display
+- Live transcript preview toggle for Notch and Overlay indicators
+- Lower dictation start latency via deferred metadata capture
+- Better handling of short clips and streaming preview
+- Audio engine recovery during device, route, and configuration changes
+- Better compatibility with remapped Hyperkeys and AirPods/Bluetooth profile switches
+- Optional HuggingFace token support for bundled MLX plugins
+- Localized built-in term pack metadata
 
-## Stability Contracts for 1.x
+## Stability Contracts for `1.x`
 
 ### HTTP API
 
@@ -61,17 +67,18 @@ These surfaces remain part of `1.1`, but they are positioned as advanced or auto
 
 ## Release Gates
 
-`1.1.0` is only tagged once all of the following conditions are met:
+`1.2.0` is only tagged once all of the following conditions are met:
 
 - `xcodebuild test` for the app scheme passes.
 - `swift test --package-path TypeWhisperPluginSDK` passes.
 - The app release build passes.
 - There are no first-party build warnings.
 - Plugin manifests validate successfully.
-- README, security guidance, and the support matrix are up to date.
-- A `1.1.0-rc1` build ran on real machines for multiple days without P0/P1 blockers.
+- README, security guidance, support matrix, and plugin documentation are up to date.
+- A `1.2.0-rc1` build ran on real machines for multiple days without P0/P1 blockers.
 - The default channel remains `stable`; `release-candidate` and `daily` exist as Sparkle channels for preview builds.
-- `1.1.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
+- `1.2.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
+- The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.
 
 ## Manual Smoke Checks Before Tagging
 
@@ -90,7 +97,19 @@ These surfaces remain part of `1.1`, but they are positioned as advanced or auto
 - Sound feedback settings and sound switching
 - CLI against a running local server
 - HTTP API `status`, `models`, `transcribe`
-- Upgrade from `1.0.0` with History, Profiles, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
+- Notch, Overlay, and Minimal indicator styles
+- Transcript preview toggle
+- MLX plugin settings for HuggingFace token storage and removal
+- Very short speech clips and streaming-preview/no-speech guard behavior
+- Audio preview and recording after device changes, especially AirPods/Bluetooth profile switches
+- Upgrade from `1.1.0` with History, Profiles, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
+
+## Release Outputs
+
+- Stable releases publish DMG and ZIP assets
+- RC and daily releases publish GitHub prereleases only
+- Stable releases update Homebrew and the stable appcast entry
+- RC and daily releases update only their own Sparkle channels
 
 ## Support and Diagnostics
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,16 +1,20 @@
 # Release Checklist
 
-## Before the RC
+## Before the RC Tag
 
 - `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
 - `swift test --package-path TypeWhisperPluginSDK`
 - `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
 - `bash scripts/check_first_party_warnings.sh build.log`
-- Review README, Security Policy, and Support Matrix
+- Review `README.md`, `SECURITY.md`, `docs/support-matrix.md`, `docs/1.1-readiness.md`, `Plugins/README.md`, and `TypeWhisperPluginSDK/README.md`
+- Confirm `MARKETING_VERSION = 1.2.0` across the app, CLI, and widgets
+- Prepare or refresh `docs/release-notes/1.2.0-rc1.md`
+- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.2.0-rc1` before pushing the tag
+- Otherwise the release workflow will publish `docs/release-notes/1.2.0-rc1.md` automatically when no release already exists
 
-## RC Smoke-Checks
+## RC Smoke Checks
 
-- Publish `1.1.0-rc*` on the `release-candidate` channel and daily builds on the `daily` channel
+- Publish `1.2.0-rc*` on the `release-candidate` channel and daily builds on the `daily` channel
 - Stable builds must use only the default channel
 - Fresh install
 - Permission recovery
@@ -21,27 +25,36 @@
 - Prompt drag-and-drop reordering
 - History edit/export
 - Post-processing transparency in history and indicators
-- Profile matching
+- Profile matching for app and URL
+- Notch, Overlay, and Minimal indicator styles
+- Transcript preview toggle for Notch and Overlay
 - Plugin enable/disable
+- MLX plugin settings: save and remove HuggingFace token, then verify download error copy for Qwen3, Granite, and Voxtral
 - Community term pack download and apply
+- Built-in term packs render localized metadata in English and German
 - App audio recording with separate tracks
 - Google Cloud Speech-to-Text plugin
-- Sound feedback settings (enable/disable/change sounds)
+- Sound feedback settings (enable, disable, and custom sounds)
 - Non-blocking model download
 - Dictionary JSON export and import
 - Parakeet V2/V3 model version selection
+- Very short speech clips with and without actual speech
+- Streaming preview versus the no-speech guard
 - Media pause during recording (play music, start recording, verify pause, stop recording, verify resume)
 - Mouse button shortcut (configure and trigger dictation)
+- Remapped Hyperkey shortcut (record, stop, and prompt palette paths)
+- Audio preview and recording after input-device changes, especially AirPods and Bluetooth profile switches
 - Auto Enter profile setting (enable in profile, verify Enter is sent after dictation)
 - Disable history saving (toggle off, dictate, verify no entry created)
-- STT and AI-processed text both shown in history entry
+- STT and AI-processed text both shown in the history entry
 - Verify CLI and HTTP API locally
-- Upgrade from `1.0.0`
+- Upgrade from `1.1.0`
 
-## Before `1.1.0`
+## Before `1.2.0`
 
-- Observe `1.1.0-rc1` on real machines for multiple days
+- Observe `1.2.0-rc1` on real machines for multiple days
 - No open P0/P1 bugs in the core workflow
-- Update release notes
-- RC and daily tags must not update Homebrew
-- Verify DMG, appcast, and Homebrew update only at the final `1.1.0`
+- Finalize release notes
+- RC and daily tags must not update Homebrew or trigger stable website messaging
+- Verify DMG, ZIP, and the `release-candidate` appcast entry with `minimumSystemVersion` set to `14.0`
+- Verify Homebrew and the stable appcast update only at the final `1.2.0`

--- a/docs/release-notes/1.2.0-rc1.md
+++ b/docs/release-notes/1.2.0-rc1.md
@@ -1,0 +1,21 @@
+## New UI & Workflow
+
+- Added a new Minimal indicator style for users who want a compact floating status view.
+- Added a transcript preview toggle for the Notch and Overlay indicators.
+- Reduced dictation start latency by moving metadata capture and browser URL resolution off the critical startup path.
+- Improved handling for very short clips, especially when streaming preview is active or Parakeet is selected.
+
+## Reliability & Compatibility
+
+- Hardened recording and preview startup after `AVAudioEngine` configuration changes.
+- Improved recovery after AirPods and Bluetooth profile switches.
+- Fixed `stopRecording` and audio-engine teardown race conditions.
+- Restored reliable behavior for remapped Hyperkey hotkeys.
+- Fixed a crash around `windowDidBecomeKey`.
+
+## Models & Plugins
+
+- Added optional HuggingFace token support to the bundled Qwen3, Granite, and Voxtral plugins.
+- Improved error messages for MLX and HuggingFace download failures.
+- Localized built-in term pack metadata in English and German.
+- Updated bundled plugin versions where required for the current `1.2` release candidate line.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,44 +1,46 @@
 # TypeWhisper Support Matrix
 
-This matrix describes the officially supported `1.1` path for direct-download releases.
+This matrix describes the officially supported `1.x` direct-download path. For `1.2.0-rc1`, the public runtime support floor remains `macOS 14+`.
 
 ## Platform
 
 | Area | Support |
 | --- | --- |
-| Base support | macOS 14+ |
+| Runtime floor | macOS 14+ |
 | Recommended hardware | Apple Silicon |
-| Intel | Smoke-test before releases as long as Universal Binary support is advertised |
+| Intel | Smoke-test before every final release as long as Universal Binary support is advertised |
+| Distribution | Stable via direct download and Homebrew, preview builds via direct download only |
 
 ## Feature Matrix by macOS Version
 
 | Feature | macOS 14 | macOS 15 | macOS 26+ | Notes |
 | --- | --- | --- | --- | --- |
-| System-wide dictation | Yes | Yes | Yes | Core workflow for `1.1` |
-| File transcription | Yes | Yes | Yes | Core workflow for `1.1` |
-| Prompt processing | Yes | Yes | Yes | Core workflow for `1.1` |
-| Profiles, History, Dictionary, Snippets | Yes | Yes | Yes | Core workflow for `1.1` |
-| Widgets | Yes | Yes | Yes | Not part of the core path |
+| System-wide dictation | Yes | Yes | Yes | Core workflow for `1.x` |
+| File transcription | Yes | Yes | Yes | Core workflow for `1.x` |
+| Prompt processing | Yes | Yes | Yes | Core workflow for `1.x` |
+| Profiles, History, Dictionary, Snippets | Yes | Yes | Yes | Core workflow for `1.x` |
+| Notch, Overlay, and Minimal indicators | Yes | Yes | Yes | User-facing status surfaces in `1.2` |
+| Widgets | Yes | Yes | Yes | Supported advanced surface |
 | HTTP API | Yes | Yes | Yes | Loopback-only, disabled by default |
 | CLI | Yes | Yes | Yes | Requires the local API server to be running |
 | Apple Translate integration | No | Yes | Yes | Advanced surface |
-| Improved settings UI | No | Yes | Yes | Optional usability improvement |
-| Apple Intelligence provider | No | No | Yes | Optional, not part of the core path |
-| SpeechAnalyzer engine | No | No | Yes | Optional, not part of the core path |
+| Apple Intelligence provider | No | No | Yes | Optional provider surface |
+| SpeechAnalyzer engine | No | No | Yes | Optional engine surface |
 
 ## Engine Notes
 
-| Engine Type | Support in 1.1 | Notes |
+| Surface | Support in `1.x` | Notes |
 | --- | --- | --- |
 | Local engines | Yes | Recommended default path |
 | Cloud engines | Yes | Require valid API keys |
+| Bundled MLX engines | Yes | Qwen3, Granite, and Voxtral support an optional HuggingFace token for higher download rate limits |
 | Bundled plugins | Yes | Part of the tested product path |
-| External third-party plugins | Best effort | Not a launch blocker for `1.1` |
+| External third-party plugins | Best effort | Not a stable-release blocker for `1.x` |
 
 ## Automation Notes
 
-| Surface | Status in 1.1 |
+| Surface | Status in `1.x` |
 | --- | --- |
 | HTTP API `/v1/*` | Stable for `1.x` |
-| `typewhisper` CLI | Stable for `1.1.x` |
+| `typewhisper` CLI | Stable for `1.x` |
 | Plugin SDK | Stable for `1.x` |

--- a/scripts/update_appcast.py
+++ b/scripts/update_appcast.py
@@ -96,7 +96,7 @@ def main() -> None:
     parser.add_argument("--url", required=True)
     parser.add_argument("--signature", required=True)
     parser.add_argument("--length", required=True)
-    parser.add_argument("--minimum-system-version", default="15.0")
+    parser.add_argument("--minimum-system-version", default="14.0")
     args = parser.parse_args()
 
     appcast_path = Path(args.appcast)


### PR DESCRIPTION
## Summary
- bump `MARKETING_VERSION` to `1.2.0` for the app, CLI, and widgets and align preview appcast minimum system version to `14.0`
- let the release workflow publish curated notes from `docs/release-notes/1.2.0-rc1.md`
- refresh README, release docs, and plugin/SDK docs for the current `1.2.0-rc1` release candidate scope

## Validation
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build-ship -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `bash scripts/check_first_party_warnings.sh /tmp/ship_sdk_test.log`
- `bash scripts/check_first_party_warnings.sh /tmp/ship_xcode_test.log`
- `bash scripts/check_first_party_warnings.sh /tmp/ship_xcode_release.log`
- `python3 -m py_compile scripts/update_appcast.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`

## Notes
- Pre-landing review auto-fixed one release-checklist note so it matches the new workflow behavior.
- No plan file was detected, so the plan completion audit was skipped.
- No app code paths changed on this branch, so the coverage audit was skipped.