### PR TITLE
Add supporter Discord claim flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](doc
 - **MLX download controls** - Bundled Qwen3, Granite, and Voxtral plugins support an optional HuggingFace token for higher rate limits and clearer download errors
 - **HTTP API** - Local REST API for integration with external tools and scripts
 - **CLI tool** - Shell-friendly transcription via the command line
+- **Discord claim service** - Optional external service for Polar supporter and GitHub Sponsors Discord role claims
 
 ### General
 

--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -162,4 +162,35 @@ enum AppConstants {
         static let checkoutURLSupporterSilver = "https://buy.polar.sh/polar_cl_lXFAqnanhrrPd1RZ95SCb2L05L3lNrUQIkYVd0ZmK5b"
         static let checkoutURLSupporterGold = "https://buy.polar.sh/polar_cl_FpojMlLmyF73gOqpXLihSE0lNYnoQoaMxGp724IIor4"
     }
+
+    // MARK: - Discord Claim Service
+    enum DiscordClaim {
+        static let defaultBaseURLString = "http://127.0.0.1:8787"
+        static let callbackScheme = "typewhisper"
+        static let callbackHost = "community"
+        static let callbackPath = "/claim-result"
+
+        static var baseURL: URL {
+            let environment = ProcessInfo.processInfo.environment
+            let configured = environment["TYPEWHISPER_DISCORD_CLAIM_BASE_URL"]
+                ?? Bundle.main.object(forInfoDictionaryKey: "TypeWhisperDiscordClaimBaseURL") as? String
+                ?? defaultBaseURLString
+
+            return URL(string: configured) ?? URL(string: defaultBaseURLString)!
+        }
+
+        static var callbackURL: URL {
+            URL(string: "\(callbackScheme)://\(callbackHost)\(callbackPath)")!
+        }
+
+        static var githubSponsorsURL: URL {
+            baseURL.appendingPathComponent("claims").appendingPathComponent("github")
+        }
+
+        static func isCallbackURL(_ url: URL) -> Bool {
+            url.scheme == callbackScheme &&
+                url.host == callbackHost &&
+                url.path == callbackPath
+        }
+    }
 }

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -35,6 +35,7 @@ final class ServiceContainer: ObservableObject {
     let speechFeedbackService: SpeechFeedbackService
     let errorLogService: ErrorLogService
     let licenseService: LicenseService
+    let supporterDiscordService: SupporterDiscordService
 
     // HTTP API
     let httpServer: HTTPServer
@@ -93,6 +94,7 @@ final class ServiceContainer: ObservableObject {
         speechFeedbackService = SpeechFeedbackService()
         errorLogService = ErrorLogService()
         licenseService = LicenseService()
+        supporterDiscordService = SupporterDiscordService(licenseService: licenseService)
 
         // ViewModels (created before HTTP API so DictationViewModel is available)
         fileTranscriptionViewModel = FileTranscriptionViewModel(
@@ -166,6 +168,7 @@ final class ServiceContainer: ObservableObject {
 
         // License
         LicenseService.shared = licenseService
+        SupporterDiscordService.shared = supporterDiscordService
 
         // Plugin system
         EventBus.shared = EventBus()
@@ -212,6 +215,7 @@ final class ServiceContainer: ObservableObject {
         // Validate license if needed
         await licenseService.validateIfNeeded()
         await licenseService.validateSupporterIfNeeded()
+        await supporterDiscordService.refreshStatusIfNeeded()
 
         // Auto-start watch folder if configured
         if UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderAutoStart),

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -240,6 +240,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         return true
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            handleIncomingURL(url)
+        }
+    }
+
     private func openSettingsWindow() {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
@@ -260,6 +266,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         // Last resort: post notification for bridge view
         NotificationCenter.default.post(name: .openSettingsFromDock, object: nil)
+    }
+
+    private func handleIncomingURL(_ url: URL) {
+        guard SupporterDiscordService.canHandleCallbackURL(url) else { return }
+
+        openSettingsWindow()
+
+        Task { @MainActor in
+            await SupporterDiscordService.shared?.handleCallbackURL(url)
+        }
     }
 
     private func isManagedWindow(_ window: NSWindow) -> Bool {

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -114,4 +114,6 @@ enum UserDefaultsKeys {
     static let supporterTier = "supporterTier"
     static let supporterStatus = "supporterStatus"
     static let lastSupporterValidation = "lastSupporterValidation"
+    static let supporterDiscordClaimStatus = "supporterDiscordClaimStatus"
+    static let supporterDiscordSessionId = "supporterDiscordSessionId"
 }

--- a/TypeWhisper/Resources/Info.plist
+++ b/TypeWhisper/Resources/Info.plist
@@ -8,6 +8,19 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.typewhisper.mac.community</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>typewhisper</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleName</key>
 	<string>TypeWhisper</string>
 	<key>CFBundleShortVersionString</key>
@@ -40,6 +53,8 @@
 	<string>OdAMiN136Ckglxnq4FeLagPjcrZiASYGaeUWBkK6tuc=</string>
 	<key>TypeWhisperReleaseChannel</key>
 	<string>stable</string>
+	<key>TypeWhisperDiscordClaimBaseURL</key>
+	<string>https://community.typewhisper.com</string>
 	<key>AppGroupIdentifier</key>
 	<string>$(APP_GROUP_ID)</string>
 </dict>

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -93,6 +93,17 @@ final class LicenseService: ObservableObject {
     @Published var supporterDeactivationError: String?
 
     var isSupporter: Bool { supporterStatus == .active && supporterTier != nil }
+    var supporterClaimProof: SupporterClaimProof? {
+        guard supporterStatus == .active,
+              let supporterTier,
+              let stored = loadSupporterFromKeychain() else { return nil }
+
+        return SupporterClaimProof(
+            key: stored.key,
+            activationId: stored.activationId,
+            tier: supporterTier
+        )
+    }
 
     var needsWelcomeSheet: Bool {
         !UserDefaults.standard.bool(forKey: UserDefaultsKeys.welcomeSheetShown)
@@ -251,15 +262,8 @@ final class LicenseService: ObservableObject {
             UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
 
             // Detect tier from benefit description
-            if let validation = try? await polarValidate(key: key, activationId: response.id),
-               let description = validation.benefit?.description?.lowercased() {
-                if description.contains("gold") {
-                    supporterTier = .gold
-                } else if description.contains("silver") {
-                    supporterTier = .silver
-                } else {
-                    supporterTier = .bronze
-                }
+            if let validation = try? await polarValidate(key: key, activationId: response.id) {
+                supporterTier = supporterTier(from: validation.benefit?.description)
             } else {
                 supporterTier = .bronze
             }
@@ -279,6 +283,7 @@ final class LicenseService: ObservableObject {
                 supporterStatus = .unlicensed
                 supporterTier = nil
             }
+            SupporterDiscordService.shared?.handleSupporterEntitlementRemoved()
             return
         }
 
@@ -301,10 +306,13 @@ final class LicenseService: ObservableObject {
             let response = try await polarValidate(key: key, activationId: activationId)
             if response.status == "granted" {
                 supporterStatus = .active
+                supporterTier = supporterTier(from: response.benefit?.description)
                 UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
                 logger.info("Supporter validation successful")
             } else {
                 supporterStatus = .expired
+                supporterTier = nil
+                SupporterDiscordService.shared?.handleSupporterEntitlementRemoved()
                 logger.warning("Supporter revoked or disabled (status: \(response.status))")
             }
         } catch {
@@ -324,10 +332,18 @@ final class LicenseService: ObservableObject {
             supporterStatus = .unlicensed
             supporterTier = nil
             UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastSupporterValidation)
+            SupporterDiscordService.shared?.handleSupporterEntitlementRemoved()
         } catch {
             supporterDeactivationError = error.localizedDescription
             logger.error("Supporter deactivation failed: \(error)")
         }
+    }
+
+    private func supporterTier(from benefitDescription: String?) -> SupporterTier {
+        guard let description = benefitDescription?.lowercased() else { return .bronze }
+        if description.contains("gold") { return .gold }
+        if description.contains("silver") { return .silver }
+        return .bronze
     }
 
     // MARK: - Polar API
@@ -531,5 +547,425 @@ enum LicenseError: LocalizedError {
         case .deactivationFailed:
             return String(localized: "Deactivation failed. Please try again.")
         }
+    }
+}
+
+// MARK: - Discord Claim Models
+
+struct SupporterClaimProof: Equatable, Sendable {
+    let key: String
+    let activationId: String
+    let tier: SupporterTier
+}
+
+struct SupporterDiscordClaimStatus: Codable, Equatable, Sendable {
+    enum State: String, Codable, Sendable {
+        case unavailable
+        case unlinked
+        case pending
+        case linked
+        case failed
+    }
+
+    var state: State
+    var discordUsername: String?
+    var linkedRoles: [String]
+    var errorMessage: String?
+    var sessionId: String?
+    var updatedAt: Date
+
+    static let unavailable = SupporterDiscordClaimStatus(
+        state: .unavailable,
+        discordUsername: nil,
+        linkedRoles: [],
+        errorMessage: nil,
+        sessionId: nil,
+        updatedAt: Date()
+    )
+}
+
+private struct SupporterDiscordStartRequest: Encodable {
+    let key: String
+    let activationId: String
+    let tier: String
+    let appVersion: String
+}
+
+private struct SupporterDiscordStartResponse: Decodable {
+    let sessionId: String
+    let claimURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case claimURL = "claim_url"
+    }
+}
+
+private struct SupporterDiscordStatusResponse: Decodable {
+    let status: String
+    let discordUsername: String?
+    let linkedRoles: [String]
+    let errorMessage: String?
+    let sessionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case discordUsername = "discord_username"
+        case linkedRoles = "linked_roles"
+        case errorMessage = "error"
+        case sessionId = "session_id"
+    }
+}
+
+private struct SupporterDiscordServiceErrorResponse: Decodable {
+    let error: String
+}
+
+private struct SupporterDiscordCallbackPayload: Sendable {
+    let flow: String?
+    let status: String?
+    let sessionId: String?
+    let errorMessage: String?
+}
+
+enum SupporterDiscordServiceError: LocalizedError {
+    case notEligible
+    case invalidBaseURL
+    case invalidResponse
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notEligible:
+            return "An active supporter license is required before you can claim Discord status."
+        case .invalidBaseURL:
+            return "The Discord claim service URL is not configured correctly."
+        case .invalidResponse:
+            return "The Discord claim service returned an invalid response."
+        case .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+typealias SupporterDiscordTransport = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+@MainActor
+final class SupporterDiscordService: ObservableObject {
+    nonisolated(unsafe) static var shared: SupporterDiscordService?
+
+    @Published private(set) var claimStatus: SupporterDiscordClaimStatus
+    @Published private(set) var isWorking = false
+
+    private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "SupporterDiscordService")
+    private let defaults: UserDefaults
+    private let transport: SupporterDiscordTransport
+    private let claimProofProvider: @MainActor () -> SupporterClaimProof?
+    private let baseURLProvider: @MainActor () -> URL
+
+    init(
+        licenseService: LicenseService,
+        defaults: UserDefaults = .standard,
+        transport: @escaping SupporterDiscordTransport = { request in
+            try await URLSession.shared.data(for: request)
+        },
+        claimProofProvider: (@MainActor () -> SupporterClaimProof?)? = nil,
+        baseURLProvider: (@MainActor () -> URL)? = nil
+    ) {
+        self.defaults = defaults
+        self.transport = transport
+        self.claimProofProvider = claimProofProvider ?? { licenseService.supporterClaimProof }
+        self.baseURLProvider = baseURLProvider ?? { AppConstants.DiscordClaim.baseURL }
+        self.claimStatus = Self.loadPersistedStatus(defaults: defaults)
+    }
+
+    var githubSponsorsURL: URL {
+        AppConstants.DiscordClaim.githubSponsorsURL
+    }
+
+    static func canHandleCallbackURL(_ url: URL) -> Bool {
+        AppConstants.DiscordClaim.isCallbackURL(url)
+    }
+
+    @discardableResult
+    func createClaimSession() async -> URL? {
+        guard let proof = claimProofProvider() else {
+            handleSupporterEntitlementRemoved()
+            claimStatus = Self.status(
+                from: claimStatus,
+                state: .failed,
+                errorMessage: SupporterDiscordServiceError.notEligible.errorDescription
+            )
+            persist()
+            return nil
+        }
+
+        isWorking = true
+        defer { isWorking = false }
+
+        do {
+            let endpoint = try endpointURL(path: "/claims/polar/start")
+            var request = URLRequest(url: endpoint)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONEncoder().encode(
+                SupporterDiscordStartRequest(
+                    key: proof.key,
+                    activationId: proof.activationId,
+                    tier: proof.tier.rawValue,
+                    appVersion: AppConstants.appVersion
+                )
+            )
+
+            let response: SupporterDiscordStartResponse = try await send(request)
+            claimStatus = SupporterDiscordClaimStatus(
+                state: .pending,
+                discordUsername: nil,
+                linkedRoles: [],
+                errorMessage: nil,
+                sessionId: response.sessionId,
+                updatedAt: Date()
+            )
+            persist()
+            logger.info("Started Discord claim session \(response.sessionId, privacy: .public)")
+            return response.claimURL
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            claimStatus = Self.status(from: claimStatus, state: .failed, errorMessage: message)
+            persist()
+            logger.error("Failed to start Discord claim session: \(message, privacy: .public)")
+            return nil
+        }
+    }
+
+    @discardableResult
+    func reconnect() async -> URL? {
+        claimStatus = SupporterDiscordClaimStatus(
+            state: .unlinked,
+            discordUsername: nil,
+            linkedRoles: [],
+            errorMessage: nil,
+            sessionId: nil,
+            updatedAt: Date()
+        )
+        persist()
+        return await createClaimSession()
+    }
+
+    func refreshStatusIfNeeded() async {
+        guard claimProofProvider() != nil else {
+            handleSupporterEntitlementRemoved()
+            return
+        }
+
+        guard claimStatus.state == .pending || claimStatus.state == .linked || claimStatus.sessionId != nil else {
+            return
+        }
+
+        await refreshClaimStatus()
+    }
+
+    func refreshClaimStatus() async {
+        guard let proof = claimProofProvider() else {
+            handleSupporterEntitlementRemoved()
+            return
+        }
+
+        isWorking = true
+        defer { isWorking = false }
+
+        do {
+            let statusURL = try statusEndpointURL(
+                activationId: proof.activationId,
+                sessionId: claimStatus.sessionId
+            )
+            var request = URLRequest(url: statusURL)
+            request.httpMethod = "GET"
+
+            let response: SupporterDiscordStatusResponse = try await send(request)
+            claimStatus = Self.status(
+                from: claimStatus,
+                state: Self.mapState(response.status),
+                discordUsername: response.discordUsername,
+                linkedRoles: response.linkedRoles,
+                errorMessage: response.errorMessage,
+                sessionId: response.sessionId != nil ? .some(response.sessionId) : nil
+            )
+            persist()
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            logger.error("Failed to refresh Discord claim status: \(message, privacy: .public)")
+
+            if claimStatus.state == .linked {
+                claimStatus = Self.status(from: claimStatus, errorMessage: message)
+            } else {
+                claimStatus = Self.status(from: claimStatus, state: .failed, errorMessage: message)
+            }
+            persist()
+        }
+    }
+
+    @discardableResult
+    func handleCallbackURL(_ url: URL) async -> Bool {
+        guard let payload = Self.parseCallbackURL(url) else {
+            return false
+        }
+
+        guard payload.flow == nil || payload.flow == "polar" else {
+            return true
+        }
+
+        claimStatus = Self.status(
+            from: claimStatus,
+            state: Self.mapCallbackState(payload.status),
+            errorMessage: payload.errorMessage.map(Optional.some) ?? nil,
+            sessionId: payload.sessionId.map(Optional.some) ?? nil
+        )
+        persist()
+
+        await refreshClaimStatus()
+        return true
+    }
+
+    func handleSupporterEntitlementRemoved() {
+        claimStatus = SupporterDiscordClaimStatus(
+            state: .unavailable,
+            discordUsername: nil,
+            linkedRoles: [],
+            errorMessage: nil,
+            sessionId: nil,
+            updatedAt: Date()
+        )
+        defaults.removeObject(forKey: UserDefaultsKeys.supporterDiscordSessionId)
+        persist()
+    }
+
+    private func endpointURL(path: String) throws -> URL {
+        let baseURL = baseURLProvider()
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw SupporterDiscordServiceError.invalidBaseURL
+        }
+        components.path = path
+        guard let url = components.url else {
+            throw SupporterDiscordServiceError.invalidBaseURL
+        }
+        return url
+    }
+
+    private func statusEndpointURL(activationId: String, sessionId: String?) throws -> URL {
+        let url = try endpointURL(path: "/claims/polar/status")
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw SupporterDiscordServiceError.invalidBaseURL
+        }
+        var queryItems = [URLQueryItem(name: "activation_id", value: activationId)]
+        if let sessionId, !sessionId.isEmpty {
+            queryItems.append(URLQueryItem(name: "session_id", value: sessionId))
+        }
+        components.queryItems = queryItems
+        guard let composed = components.url else {
+            throw SupporterDiscordServiceError.invalidBaseURL
+        }
+        return composed
+    }
+
+    private func send<Response: Decodable>(_ request: URLRequest) async throws -> Response {
+        let (data, response) = try await transport(request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SupporterDiscordServiceError.invalidResponse
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            if let errorResponse = try? JSONDecoder().decode(SupporterDiscordServiceErrorResponse.self, from: data) {
+                throw SupporterDiscordServiceError.requestFailed(errorResponse.error)
+            }
+            throw SupporterDiscordServiceError.requestFailed("Discord claim service returned HTTP \(httpResponse.statusCode).")
+        }
+
+        do {
+            return try JSONDecoder().decode(Response.self, from: data)
+        } catch {
+            throw SupporterDiscordServiceError.invalidResponse
+        }
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(claimStatus) {
+            defaults.set(data, forKey: UserDefaultsKeys.supporterDiscordClaimStatus)
+        }
+        defaults.set(claimStatus.sessionId, forKey: UserDefaultsKeys.supporterDiscordSessionId)
+    }
+
+    private static func loadPersistedStatus(defaults: UserDefaults) -> SupporterDiscordClaimStatus {
+        if let data = defaults.data(forKey: UserDefaultsKeys.supporterDiscordClaimStatus),
+           let status = try? JSONDecoder().decode(SupporterDiscordClaimStatus.self, from: data) {
+            return status
+        }
+        return .unavailable
+    }
+
+    private static func mapState(_ rawValue: String) -> SupporterDiscordClaimStatus.State {
+        switch rawValue {
+        case "unlinked":
+            return .unlinked
+        case "pending":
+            return .pending
+        case "linked":
+            return .linked
+        case "failed":
+            return .failed
+        default:
+            return .failed
+        }
+    }
+
+    private static func mapCallbackState(_ rawValue: String?) -> SupporterDiscordClaimStatus.State? {
+        guard let rawValue else { return nil }
+        switch rawValue {
+        case "linked", "pending":
+            return .pending
+        case "unlinked":
+            return .unlinked
+        case "failed", "expired":
+            return .failed
+        default:
+            return nil
+        }
+    }
+
+    private static func parseCallbackURL(_ url: URL) -> SupporterDiscordCallbackPayload? {
+        guard canHandleCallbackURL(url),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let queryItems = components.queryItems ?? []
+        func value(_ name: String) -> String? {
+            queryItems.first(where: { $0.name == name })?.value
+        }
+
+        return SupporterDiscordCallbackPayload(
+            flow: value("flow"),
+            status: value("status"),
+            sessionId: value("session_id"),
+            errorMessage: value("error")
+        )
+    }
+
+    private static func status(
+        from current: SupporterDiscordClaimStatus,
+        state: SupporterDiscordClaimStatus.State? = nil,
+        discordUsername: String?? = nil,
+        linkedRoles: [String]? = nil,
+        errorMessage: String?? = nil,
+        sessionId: String?? = nil
+    ) -> SupporterDiscordClaimStatus {
+        SupporterDiscordClaimStatus(
+            state: state ?? current.state,
+            discordUsername: discordUsername ?? current.discordUsername,
+            linkedRoles: linkedRoles ?? current.linkedRoles,
+            errorMessage: errorMessage ?? current.errorMessage,
+            sessionId: sessionId ?? current.sessionId,
+            updatedAt: Date()
+        )
     }
 }

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct LicenseSettingsView: View {
     @ObservedObject private var license = LicenseService.shared
+    @ObservedObject private var supporterDiscord =
+        SupporterDiscordService.shared ?? SupporterDiscordService(licenseService: LicenseService.shared)
 
     @State private var licenseKeyInput = ""
     @State private var supporterKeyInput = ""
@@ -24,6 +26,13 @@ struct LicenseSettingsView: View {
         .formStyle(.grouped)
         .padding()
         .frame(minWidth: 500, minHeight: 300)
+        .task(id: "\(license.supporterStatus.rawValue)-\(license.supporterTier?.rawValue ?? "none")") {
+            if license.isSupporter {
+                await supporterDiscord.refreshStatusIfNeeded()
+            } else {
+                supporterDiscord.handleSupporterEntitlementRemoved()
+            }
+        }
     }
 
     // MARK: - User Type
@@ -162,9 +171,7 @@ struct LicenseSettingsView: View {
                     Spacer()
                 }
 
-                Text(String(localized: "Thank you for supporting TypeWhisper! Join our Discord to claim your supporter role."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                supporterDiscordSection(tier: tier)
 
                 Button {
                     if let url = URL(string: AppConstants.Polar.customerPortalURL) {
@@ -196,6 +203,12 @@ struct LicenseSettingsView: View {
                     supporterTierButton(tier: .gold, price: "50")
                 }
                 .padding(.vertical, 4)
+
+                Button {
+                    NSWorkspace.shared.open(supporterDiscord.githubSponsorsURL)
+                } label: {
+                    Label("Claim GitHub Sponsors status on the web", systemImage: "link")
+                }
 
                 keyActivationField(
                     input: $supporterKeyInput,
@@ -245,6 +258,108 @@ struct LicenseSettingsView: View {
     }
 
     // MARK: - Helpers
+
+    @ViewBuilder
+    private func supporterDiscordSection(tier: SupporterTier) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            switch supporterDiscord.claimStatus.state {
+            case .unavailable, .unlinked:
+                Label("Discord not connected", systemImage: "person.crop.circle.badge.xmark")
+                    .foregroundStyle(.secondary)
+
+                Text("Connect Discord to claim your \(supporterTierDisplayName(tier)) supporter status in the community server.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                actionButton(title: "Connect Discord", systemImage: "person.crop.circle.badge.plus") {
+                    await openClaimURL(await supporterDiscord.createClaimSession())
+                }
+            case .pending:
+                Label("Claim in progress", systemImage: "clock.badge")
+                    .foregroundStyle(.orange)
+
+                Text("Finish the Discord authorization flow in your browser, then refresh the status here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                actionButton(title: "Reconnect Discord", systemImage: "arrow.clockwise.circle") {
+                    await openClaimURL(await supporterDiscord.reconnect())
+                }
+
+                actionButton(title: "Refresh Discord Status", systemImage: "arrow.clockwise") {
+                    await supporterDiscord.refreshClaimStatus()
+                }
+            case .linked:
+                Label("Discord connected", systemImage: "checkmark.seal.fill")
+                    .foregroundStyle(.green)
+
+                if let username = supporterDiscord.claimStatus.discordUsername {
+                    Text("Linked account: \(username)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !supporterDiscord.claimStatus.linkedRoles.isEmpty {
+                    Text("Active roles: \(supporterDiscord.claimStatus.linkedRoles.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                actionButton(title: "Refresh Discord Status", systemImage: "arrow.clockwise") {
+                    await supporterDiscord.refreshClaimStatus()
+                }
+
+                actionButton(title: "Reconnect Discord", systemImage: "link.badge.plus") {
+                    await openClaimURL(await supporterDiscord.reconnect())
+                }
+            case .failed:
+                Label("Discord claim failed", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+
+                Text(supporterDiscord.claimStatus.errorMessage ?? "The Discord claim service returned an unknown error.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                actionButton(title: "Retry Discord Claim", systemImage: "arrow.clockwise.circle") {
+                    await openClaimURL(await supporterDiscord.reconnect())
+                }
+
+                actionButton(title: "Refresh Discord Status", systemImage: "arrow.clockwise") {
+                    await supporterDiscord.refreshClaimStatus()
+                }
+            }
+
+            if supporterDiscord.isWorking {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            if let message = supporterDiscord.claimStatus.errorMessage,
+               supporterDiscord.claimStatus.state == .linked {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func actionButton(
+        title: String,
+        systemImage: String,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task { await action() }
+        } label: {
+            Label(title, systemImage: systemImage)
+        }
+        .disabled(supporterDiscord.isWorking)
+    }
+
+    private func openClaimURL(_ url: URL?) async {
+        guard let url else { return }
+        NSWorkspace.shared.open(url)
+    }
 
     private func businessTierButton(tier: LicenseTier, price: String, suffix: String, url: String) -> some View {
         Button {

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+@testable import TypeWhisper
 
 final class CLISupportTests: XCTestCase {
     func testOutputFormatterRendersHumanReadableStatusAndModels() {
@@ -21,5 +22,140 @@ final class CLISupportTests: XCTestCase {
 
         XCTAssertEqual(PortDiscovery.discoverPort(dev: false, applicationSupportDirectory: applicationSupportRoot), 9911)
         XCTAssertEqual(PortDiscovery.discoverPort(dev: true, applicationSupportDirectory: applicationSupportRoot), PortDiscovery.defaultPort)
+    }
+
+    @MainActor
+    func testSupporterDiscordCreateClaimSessionPersistsPendingStatus() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = SupporterDiscordService(
+            licenseService: LicenseService(),
+            defaults: defaults,
+            transport: { request in
+                XCTAssertEqual(request.url?.path, "/claims/polar/start")
+                let body = """
+                {
+                  "session_id": "session-123",
+                  "claim_url": "https://claims.example.test/claims/polar/discord?session_id=session-123"
+                }
+                """
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            },
+            claimProofProvider: {
+                SupporterClaimProof(key: "supporter-key", activationId: "activation-123", tier: .gold)
+            },
+            baseURLProvider: {
+                URL(string: "https://claims.example.test")!
+            }
+        )
+
+        let claimURL = await service.createClaimSession()
+
+        XCTAssertEqual(claimURL?.absoluteString, "https://claims.example.test/claims/polar/discord?session_id=session-123")
+        XCTAssertEqual(service.claimStatus.state, .pending)
+        XCTAssertEqual(service.claimStatus.sessionId, "session-123")
+    }
+
+    @MainActor
+    func testSupporterDiscordRefreshMapsLinkedStatus() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("session-123", forKey: UserDefaultsKeys.supporterDiscordSessionId)
+
+        let persisted = SupporterDiscordClaimStatus(
+            state: .pending,
+            discordUsername: nil,
+            linkedRoles: [],
+            errorMessage: nil,
+            sessionId: "session-123",
+            updatedAt: Date()
+        )
+        defaults.set(try JSONEncoder().encode(persisted), forKey: UserDefaultsKeys.supporterDiscordClaimStatus)
+
+        let service = SupporterDiscordService(
+            licenseService: LicenseService(),
+            defaults: defaults,
+            transport: { request in
+                XCTAssertEqual(request.url?.path, "/claims/polar/status")
+                XCTAssertTrue(request.url?.query?.contains("activation_id=activation-123") == true)
+                let body = """
+                {
+                  "status": "linked",
+                  "discord_username": "marco#1234",
+                  "linked_roles": ["Supporter Gold"],
+                  "session_id": "session-123"
+                }
+                """
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            },
+            claimProofProvider: {
+                SupporterClaimProof(key: "supporter-key", activationId: "activation-123", tier: .gold)
+            },
+            baseURLProvider: {
+                URL(string: "https://claims.example.test")!
+            }
+        )
+
+        await service.refreshClaimStatus()
+
+        XCTAssertEqual(service.claimStatus.state, .linked)
+        XCTAssertEqual(service.claimStatus.discordUsername, "marco#1234")
+        XCTAssertEqual(service.claimStatus.linkedRoles, ["Supporter Gold"])
+        XCTAssertNil(service.claimStatus.errorMessage)
+    }
+
+    @MainActor
+    func testSupporterDiscordCallbackRefreshesPolarClaimState() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = SupporterDiscordService(
+            licenseService: LicenseService(),
+            defaults: defaults,
+            transport: { request in
+                XCTAssertEqual(request.url?.path, "/claims/polar/status")
+                XCTAssertTrue(request.url?.query?.contains("activation_id=activation-123") == true)
+                XCTAssertTrue(request.url?.query?.contains("session_id=session-999") == true)
+                let body = """
+                {
+                  "status": "linked",
+                  "discord_username": "marco#1234",
+                  "linked_roles": ["Supporter Gold"],
+                  "session_id": "session-999"
+                }
+                """
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            },
+            claimProofProvider: {
+                SupporterClaimProof(key: "supporter-key", activationId: "activation-123", tier: .gold)
+            },
+            baseURLProvider: {
+                URL(string: "https://claims.example.test")!
+            }
+        )
+
+        let handled = await service.handleCallbackURL(
+            URL(string: "typewhisper://community/claim-result?flow=polar&status=linked&session_id=session-999")!
+        )
+
+        XCTAssertEqual(handled, true)
+        XCTAssertEqual(service.claimStatus.state, .linked)
+        XCTAssertEqual(service.claimStatus.sessionId, "session-999")
+        XCTAssertEqual(service.claimStatus.discordUsername, "marco#1234")
+        XCTAssertEqual(service.claimStatus.linkedRoles, ["Supporter Gold"])
+    }
+
+    private func makeIsolatedDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "TypeWhisperTests.SupporterDiscord.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw XCTSkip("Failed to create isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+
+    private static func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
     }
 }


### PR DESCRIPTION
## Summary
- add a supporter Discord claim flow to the macOS app with persisted status, refresh, and reconnect handling
- register the `typewhisper://community/claim-result` callback and route incoming deep links back into the app
- configure the live community service base URL and cover the new claim flow in `CLISupportTests`

## Testing
- `xcodebuild test -project /Users/marco/.codex/worktrees/8da1/typewhisper-mac/TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/CLISupportTests`
