### PR TITLE
Support GPT-5 token parameters in OpenAI chat helper

### DIFF
--- a/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -141,7 +141,8 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, LLMProviderPlugin
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            maxOutputTokenParameter: Self.outputTokenParameter(for: modelId)
         )
     }
 
@@ -231,6 +232,17 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, LLMProviderPlugin
         if excludeSuffixes.contains(where: { lowered.hasSuffix($0) }) { return false }
         if excludeContains.contains(where: { lowered.contains($0) }) { return false }
         return true
+    }
+
+    nonisolated static func outputTokenParameter(for modelID: String) -> String {
+        let lowered = modelID.lowercased()
+        if lowered.hasPrefix("gpt-5")
+            || lowered.hasPrefix("o1")
+            || lowered.hasPrefix("o3")
+            || lowered.hasPrefix("o4") {
+            return "max_completion_tokens"
+        }
+        return "max_tokens"
     }
 }
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
+		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
 		3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
 		6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
@@ -2689,6 +2690,7 @@
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
+				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -344,6 +344,24 @@ let result = try await helper.process(
 )
 ```
 
+You can override or omit the output-token parameter for providers that do not use the
+default `max_tokens` field:
+
+```swift
+let result = try await helper.process(
+    apiKey: apiKey,
+    model: "gpt-5.4",
+    systemPrompt: "Fix grammar",
+    userText: inputText,
+    maxOutputTokens: 4096,
+    maxOutputTokenParameter: "max_completion_tokens"
+)
+```
+
+This helper stays provider-agnostic. OpenAI-compatible servers may expect different
+token-limit parameter names, so plugin authors should set the appropriate field for
+their provider when needed.
+
 ### PluginWavEncoder
 
 Encode audio samples to WAV:

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -336,22 +336,22 @@ public struct PluginOpenAIChatHelper: Sendable {
         apiKey: String,
         model: String,
         systemPrompt: String,
-        userText: String
+        userText: String,
+        maxOutputTokens: Int? = 4096,
+        maxOutputTokenParameter: String = "max_tokens"
     ) async throws -> String {
         let endpoint = "\(baseURL)\(chatEndpoint)"
         guard let url = URL(string: endpoint) else {
             throw PluginChatError.apiError("Invalid URL: \(endpoint)")
         }
 
-        let requestBody: [String: Any] = [
-            "model": model,
-            "messages": [
-                ["role": "system", "content": systemPrompt],
-                ["role": "user", "content": userText]
-            ],
-            "temperature": 0.3,
-            "max_tokens": 4096
-        ]
+        let requestBody = requestBody(
+            model: model,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            maxOutputTokens: maxOutputTokens,
+            maxOutputTokenParameter: maxOutputTokenParameter
+        )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -392,6 +392,29 @@ public struct PluginOpenAIChatHelper: Sendable {
         }
 
         return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func requestBody(
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        maxOutputTokens: Int?,
+        maxOutputTokenParameter: String
+    ) -> [String: Any] {
+        var requestBody: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userText]
+            ],
+            "temperature": 0.3
+        ]
+
+        if let maxOutputTokens {
+            requestBody[maxOutputTokenParameter] = maxOutputTokens
+        }
+
+        return requestBody
     }
 }
 

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class OpenAIChatHelperTests: XCTestCase {
+    func testRequestBodyUsesMaxTokensByDefault() {
+        let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
+
+        let requestBody = helper.requestBody(
+            model: "gpt-4o",
+            systemPrompt: "Fix grammar",
+            userText: "hello world",
+            maxOutputTokens: 4096,
+            maxOutputTokenParameter: "max_tokens"
+        )
+
+        XCTAssertEqual(requestBody["model"] as? String, "gpt-4o")
+        XCTAssertEqual(requestBody["max_tokens"] as? Int, 4096)
+        XCTAssertNil(requestBody["max_completion_tokens"])
+    }
+
+    func testRequestBodySupportsMaxCompletionTokensOverride() {
+        let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
+
+        let requestBody = helper.requestBody(
+            model: "gpt-5.4",
+            systemPrompt: "Fix grammar",
+            userText: "hello world",
+            maxOutputTokens: 4096,
+            maxOutputTokenParameter: "max_completion_tokens"
+        )
+
+        XCTAssertEqual(requestBody["max_completion_tokens"] as? Int, 4096)
+        XCTAssertNil(requestBody["max_tokens"])
+    }
+
+    func testRequestBodyOmitsTokenLimitWhenRequested() {
+        let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
+
+        let requestBody = helper.requestBody(
+            model: "gpt-5.4",
+            systemPrompt: "Fix grammar",
+            userText: "hello world",
+            maxOutputTokens: nil,
+            maxOutputTokenParameter: "max_completion_tokens"
+        )
+
+        XCTAssertNil(requestBody["max_tokens"])
+        XCTAssertNil(requestBody["max_completion_tokens"])
+    }
+}

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -30,3 +30,17 @@ final class PluginManifestValidationTests: XCTestCase {
         }
     }
 }
+
+final class OpenAIPluginTokenParameterTests: XCTestCase {
+    func testLegacyOpenAIModelsKeepMaxTokens() {
+        XCTAssertEqual(OpenAIPlugin.outputTokenParameter(for: "gpt-4o"), "max_tokens")
+    }
+
+    func testGPT5ModelsUseMaxCompletionTokens() {
+        XCTAssertEqual(OpenAIPlugin.outputTokenParameter(for: "gpt-5.4"), "max_completion_tokens")
+    }
+
+    func testO4ModelsUseMaxCompletionTokens() {
+        XCTAssertEqual(OpenAIPlugin.outputTokenParameter(for: "o4-mini"), "max_completion_tokens")
+    }
+}


### PR DESCRIPTION
## Summary
- make `PluginOpenAIChatHelper` configurable for output token parameter names
- use `max_completion_tokens` for official OpenAI GPT-5 and reasoning model families
- add SDK and plugin tests covering request serialization and model heuristics

## Testing
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`