### PR TITLE
Fix plugin install robustness and Parakeet compatibility handling

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - 'plugin-*-v*'
+  workflow_dispatch:
+    inputs:
+      plugin_name:
+        description: Plugin slug, for example `parakeet`
+        required: true
+        type: string
+      plugin_version:
+        description: Plugin version, for example `1.2.1`
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -17,13 +27,20 @@ jobs:
     steps:
       - name: Parse tag
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          # Extract plugin name and version from tag: plugin-qwen3-v1.0.0
-          PLUGIN_NAME=$(echo "$TAG" | sed 's/^plugin-//' | sed 's/-v[0-9].*//')
-          PLUGIN_VERSION=$(echo "$TAG" | sed 's/.*-v//')
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PLUGIN_NAME="${{ inputs.plugin_name }}"
+            PLUGIN_VERSION="${{ inputs.plugin_version }}"
+            TAG="plugin-${PLUGIN_NAME}-v${PLUGIN_VERSION}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            # Extract plugin name and version from tag: plugin-qwen3-v1.0.0
+            PLUGIN_NAME=$(echo "$TAG" | sed 's/^plugin-//' | sed 's/-v[0-9].*//')
+            PLUGIN_VERSION=$(echo "$TAG" | sed 's/.*-v//')
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
           echo "PLUGIN_NAME=$PLUGIN_NAME" >> $GITHUB_ENV
           echo "PLUGIN_VERSION=$PLUGIN_VERSION" >> $GITHUB_ENV
-          echo "Plugin: $PLUGIN_NAME, Version: $PLUGIN_VERSION"
+          echo "Plugin: $PLUGIN_NAME, Version: $PLUGIN_VERSION, Tag: $TAG"
 
       - name: Resolve target name
         run: |
@@ -193,10 +210,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
           ASSET="build/Release/${TARGET}.zip"
 
           gh release create "$TAG" "$ASSET" \
+            --target "$GITHUB_SHA" \
             --title "${TARGET} v${PLUGIN_VERSION}" \
             --notes ""
 
@@ -204,7 +221,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
           DOWNLOAD_URL="https://github.com/TypeWhisper/typewhisper-mac/releases/download/${TAG}/${TARGET}.zip"
           MANIFEST_PATH=$(find Plugins -name manifest.json -path "*${TARGET}*" 2>/dev/null | head -1)
 

--- a/Plugins/ParakeetPlugin/manifest.json
+++ b/Plugins/ParakeetPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
-    "version": "1.2.0",
+    "version": "1.2.3",
     "minHostVersion": "0.12.0",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -5,6 +5,23 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "PluginManager")
 
+private enum PluginLoadError: LocalizedError {
+    case incompatibleHostVersion(pluginName: String, required: String, current: String)
+    case failedToCreateBundle(bundleName: String)
+    case missingPrincipalClass(className: String, bundleName: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .incompatibleHostVersion(let pluginName, let required, let current):
+            return "\(pluginName) requires TypeWhisper \(required) or newer (current: \(current))"
+        case .failedToCreateBundle(let bundleName):
+            return "Failed to create bundle for \(bundleName)"
+        case .missingPrincipalClass(let className, let bundleName):
+            return "Failed to find class \(className) in \(bundleName)"
+        }
+    }
+}
+
 // MARK: - Loaded Plugin
 
 struct LoadedPlugin: Identifiable {
@@ -98,7 +115,11 @@ final class PluginManager: ObservableObject {
         logger.info("Found \(bundles.count) plugin bundle(s)")
 
         for bundleURL in bundles {
-            loadPlugin(at: bundleURL)
+            do {
+                try loadPlugin(at: bundleURL)
+            } catch {
+                logger.error("Failed to load plugin at \(bundleURL.lastPathComponent): \(error.localizedDescription)")
+            }
         }
 
         // Built-in plugins from app bundle
@@ -107,17 +128,31 @@ final class PluginManager: ObservableObject {
             let builtInBundles = builtIn.filter { $0.pathExtension == "bundle" }
             logger.info("Found \(builtInBundles.count) built-in plugin bundle(s)")
             for bundleURL in builtInBundles {
-                loadPlugin(at: bundleURL)
+                do {
+                    try loadPlugin(at: bundleURL)
+                } catch {
+                    logger.error("Failed to load built-in plugin \(bundleURL.lastPathComponent): \(error.localizedDescription)")
+                }
             }
         }
     }
 
-    func loadPlugin(at url: URL) {
+    func loadPlugin(at url: URL) throws {
         let manifestURL = url.appendingPathComponent("Contents/Resources/manifest.json")
-        guard let data = try? Data(contentsOf: manifestURL),
-              let manifest = try? JSONDecoder().decode(PluginManifest.self, from: data) else {
-            logger.error("Failed to read manifest from \(url.lastPathComponent)")
-            return
+        let data: Data
+        do {
+            data = try Data(contentsOf: manifestURL)
+        } catch {
+            logger.error("Failed to read manifest from \(url.lastPathComponent): \(error.localizedDescription)")
+            throw error
+        }
+
+        let manifest: PluginManifest
+        do {
+            manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+        } catch {
+            logger.error("Invalid manifest in \(url.lastPathComponent): \(error.localizedDescription)")
+            throw error
         }
 
         if let minOS = manifest.minOSVersion {
@@ -133,26 +168,51 @@ final class PluginManager: ObservableObject {
             }
         }
 
-        guard !loadedPlugins.contains(where: { $0.manifest.id == manifest.id }) else {
-            logger.warning("Plugin \(manifest.id) already loaded, skipping")
-            return
+        if let minHostVersion = manifest.minHostVersion {
+            let currentAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
+            if PluginRegistryService.compareVersions(minHostVersion, currentAppVersion) == .orderedDescending {
+                throw PluginLoadError.incompatibleHostVersion(
+                    pluginName: manifest.name,
+                    required: minHostVersion,
+                    current: currentAppVersion
+                )
+            }
+        }
+
+        if let existingIndex = loadedPlugins.firstIndex(where: { $0.manifest.id == manifest.id }) {
+            let existing = loadedPlugins[existingIndex]
+            guard shouldReplace(existing: existing, with: manifest, from: url) else {
+                logger.warning("Plugin \(manifest.id) already loaded from preferred source, skipping \(url.lastPathComponent)")
+                return
+            }
+
+            if existing.isEnabled {
+                existing.instance.deactivate()
+            }
+            existing.bundle.unload()
+            loadedPlugins.remove(at: existingIndex)
+            logger.info("Replacing plugin \(manifest.id) from \(existing.sourceURL.lastPathComponent) with \(url.lastPathComponent)")
         }
 
         guard let bundle = Bundle(url: url) else {
             logger.error("Failed to create Bundle for \(url.lastPathComponent)")
-            return
+            throw PluginLoadError.failedToCreateBundle(bundleName: url.lastPathComponent)
         }
 
         do {
             try bundle.loadAndReturnError()
         } catch {
             logger.error("Failed to load bundle \(url.lastPathComponent): \(error.localizedDescription)")
-            return
+            throw error
         }
 
         guard let pluginClass = NSClassFromString(manifest.principalClass) as? TypeWhisperPlugin.Type else {
-            logger.error("Failed to find class \(manifest.principalClass) in \(url.lastPathComponent)")
-            return
+            let error = PluginLoadError.missingPrincipalClass(
+                className: manifest.principalClass,
+                bundleName: url.lastPathComponent
+            )
+            logger.error(error.localizedDescription)
+            throw error
         }
 
         let instance = pluginClass.init()
@@ -240,5 +300,19 @@ final class PluginManager: ObservableObject {
 
     func bundleURL(for pluginId: String) -> URL? {
         loadedPlugins.first { $0.manifest.id == pluginId }?.sourceURL
+    }
+
+    private func shouldReplace(existing: LoadedPlugin, with incomingManifest: PluginManifest, from incomingURL: URL) -> Bool {
+        let incomingIsBundled = Bundle.main.builtInPlugInsURL.map { incomingURL.path.hasPrefix($0.path) } ?? false
+        let versionComparison = PluginRegistryService.compareVersions(incomingManifest.version, existing.manifest.version)
+
+        if incomingIsBundled != existing.isBundled {
+            if incomingIsBundled {
+                return versionComparison != .orderedAscending
+            }
+            return versionComparison == .orderedDescending
+        }
+
+        return versionComparison == .orderedDescending
     }
 }

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -211,7 +211,7 @@ final class PluginManager: ObservableObject {
                 className: manifest.principalClass,
                 bundleName: url.lastPathComponent
             )
-            logger.error(error.localizedDescription)
+            logger.error("\(error.localizedDescription, privacy: .public)")
             throw error
         }
 

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TypeWhisperPluginSDK
 import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "PluginRegistry")
@@ -267,26 +268,11 @@ final class PluginRegistryService: ObservableObject {
                 return
             }
 
-            // Unload existing version if present
-            PluginManager.shared.unloadPlugin(plugin.id)
-
-            let destURL = PluginManager.shared.pluginsDirectory
-                .appendingPathComponent(bundleURL.lastPathComponent)
-
-            // Remove existing bundle if present
-            if FileManager.default.fileExists(atPath: destURL.path) {
-                try FileManager.default.removeItem(at: destURL)
-            }
-
-            try FileManager.default.moveItem(at: bundleURL, to: destURL)
-            PluginManager.shared.loadPlugin(at: destURL)
-
-            // Verify plugin actually loaded (e.g. incompatible macOS version fails silently)
-            if !PluginManager.shared.loadedPlugins.contains(where: { $0.manifest.id == plugin.id }) {
-                installStates[plugin.id] = .error(String(localized: "Plugin incompatible with this macOS version"))
-                logger.error("Plugin \(plugin.id) downloaded but failed to load")
-                return
-            }
+            try installBundle(
+                at: bundleURL,
+                expectedPluginId: plugin.id,
+                copyBundle: false
+            )
 
             installStates.removeValue(forKey: plugin.id)
             lastFetchDate = nil // invalidate cache so installInfo refreshes
@@ -322,15 +308,9 @@ final class PluginRegistryService: ObservableObject {
 
     func installFromFile(_ url: URL) async throws {
         let fm = FileManager.default
-        let pluginsDir = PluginManager.shared.pluginsDirectory
 
         if url.pathExtension == "bundle" {
-            let destURL = pluginsDir.appendingPathComponent(url.lastPathComponent)
-            if fm.fileExists(atPath: destURL.path) {
-                try fm.removeItem(at: destURL)
-            }
-            try fm.copyItem(at: url, to: destURL)
-            PluginManager.shared.loadPlugin(at: destURL)
+            try installBundle(at: url, expectedPluginId: nil, copyBundle: true)
         } else if url.pathExtension == "zip" {
             let tempDir = fm.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -354,12 +334,85 @@ final class PluginRegistryService: ObservableObject {
                               userInfo: [NSLocalizedDescriptionKey: "No .bundle found in ZIP"])
             }
 
-            let destURL = pluginsDir.appendingPathComponent(bundleURL.lastPathComponent)
-            if fm.fileExists(atPath: destURL.path) {
-                try fm.removeItem(at: destURL)
+            try installBundle(at: bundleURL, expectedPluginId: nil, copyBundle: false)
+        }
+    }
+
+    private func installBundle(at bundleURL: URL, expectedPluginId: String?, copyBundle: Bool) throws {
+        let fm = FileManager.default
+        let manifest = try readManifest(at: bundleURL)
+        let existingLoadedBundleURL = PluginManager.shared.bundleURL(for: manifest.id)
+
+        if let expectedPluginId, manifest.id != expectedPluginId {
+            throw NSError(
+                domain: "PluginRegistry",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Downloaded bundle ID \(manifest.id) does not match expected plugin \(expectedPluginId)"]
+            )
+        }
+
+        let destinationURL: URL
+        if let currentURL = PluginManager.shared.bundleURL(for: manifest.id),
+           !currentURL.path.hasPrefix(Bundle.main.builtInPlugInsURL?.path ?? "/__no_builtin_plugins__") {
+            destinationURL = currentURL
+        } else {
+            destinationURL = PluginManager.shared.pluginsDirectory.appendingPathComponent(bundleURL.lastPathComponent)
+        }
+
+        let backupURL = destinationURL.deletingLastPathComponent()
+            .appendingPathComponent("\(destinationURL.lastPathComponent).backup-\(UUID().uuidString)")
+        let hadExistingBundle = fm.fileExists(atPath: destinationURL.path)
+
+        do {
+            PluginManager.shared.unloadPlugin(manifest.id)
+
+            if hadExistingBundle {
+                try fm.moveItem(at: destinationURL, to: backupURL)
             }
-            try fm.moveItem(at: bundleURL, to: destURL)
-            PluginManager.shared.loadPlugin(at: destURL)
+
+            if copyBundle {
+                try fm.copyItem(at: bundleURL, to: destinationURL)
+            } else {
+                try fm.moveItem(at: bundleURL, to: destinationURL)
+            }
+
+            try PluginManager.shared.loadPlugin(at: destinationURL)
+            try removeDuplicateBundles(for: manifest.id, keeping: destinationURL)
+
+            if hadExistingBundle, fm.fileExists(atPath: backupURL.path) {
+                try fm.removeItem(at: backupURL)
+            }
+        } catch {
+            if fm.fileExists(atPath: destinationURL.path) {
+                try? fm.removeItem(at: destinationURL)
+            }
+            if hadExistingBundle, fm.fileExists(atPath: backupURL.path) {
+                try? fm.moveItem(at: backupURL, to: destinationURL)
+                try? PluginManager.shared.loadPlugin(at: destinationURL)
+            } else if let existingLoadedBundleURL {
+                try? PluginManager.shared.loadPlugin(at: existingLoadedBundleURL)
+            }
+            throw error
+        }
+    }
+
+    private func readManifest(at bundleURL: URL) throws -> PluginManifest {
+        let manifestURL = bundleURL.appendingPathComponent("Contents/Resources/manifest.json")
+        let data = try Data(contentsOf: manifestURL)
+        return try JSONDecoder().decode(PluginManifest.self, from: data)
+    }
+
+    private func removeDuplicateBundles(for pluginId: String, keeping keptURL: URL) throws {
+        let fm = FileManager.default
+        let bundleURLs = try fm.contentsOfDirectory(
+            at: PluginManager.shared.pluginsDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "bundle" && $0.standardizedFileURL != keptURL.standardizedFileURL }
+
+        for url in bundleURLs {
+            guard let manifest = try? readManifest(at: url), manifest.id == pluginId else { continue }
+            try fm.removeItem(at: url)
         }
     }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -146,6 +146,36 @@ public enum PluginAudioUtils {
     }
 }
 
+// Backward-compatibility shim for older plugins that referenced `AudioUtils`.
+@available(*, deprecated, message: "Use PluginAudioUtils instead")
+public enum AudioUtils {
+    public static func paddedSamples(
+        _ samples: [Float],
+        minimumDuration: TimeInterval,
+        sampleRate: Int = 16_000
+    ) -> [Float] {
+        PluginAudioUtils.paddedSamples(
+            samples,
+            minimumDuration: minimumDuration,
+            sampleRate: sampleRate
+        )
+    }
+
+    public static func shouldAcceptShortClipTranscription(
+        audioDuration: TimeInterval,
+        confidence: Float,
+        minimumDuration: TimeInterval = 1.0,
+        minimumConfidence: Float = 0.55
+    ) -> Bool {
+        PluginAudioUtils.shouldAcceptShortClipTranscription(
+            audioDuration: audioDuration,
+            confidence: confidence,
+            minimumDuration: minimumDuration,
+            minimumConfidence: minimumConfidence
+        )
+    }
+}
+
 public struct PluginTranscriptionSegment: Sendable {
     public let text: String
     public let start: Double

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -27,6 +27,14 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         )
     }
 
+    func testAudioUtilsPadsShortSamplesToMinimumDuration() {
+        let samples = [Float](repeating: 0.1, count: 6_400)
+
+        let paddedSamples = AudioUtils.paddedSamples(samples, minimumDuration: 1.0)
+
+        XCTAssertEqual(paddedSamples.count, 16_000)
+    }
+
     func testPluginAudioUtilsAcceptsHighConfidenceShortClipTranscription() {
         XCTAssertTrue(
             PluginAudioUtils.shouldAcceptShortClipTranscription(


### PR DESCRIPTION
## Summary
- harden plugin loading and replacement logic for duplicate or stale bundles
- make plugin installs atomic with manifest validation and rollback on failure
- add Parakeet 1.2.3 release prep and workflow dispatch support for plugin releases

## Notes
- Parakeet plugin release `plugin-parakeet-v1.2.3` has already been published successfully
- this also improves app-side reporting for plugin compatibility/load failures
