### PR TITLE
Fix dictation start when no microphone is available

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -3612,6 +3612,16 @@
         }
       }
     },
+    "No mic detected." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Mikrofon erkannt."
+          }
+        }
+      }
+    },
     "No speech recognized" : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -283,7 +283,19 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     // MARK: - CoreAudio Device Enumeration
 
+    static func hasAvailableInputDevice() -> Bool {
+        !availableInputDevices().isEmpty
+    }
+
+    static func isInputDeviceAvailable(_ deviceID: AudioDeviceID) -> Bool {
+        inputChannelCount(for: deviceID) > 0 && !isAggregateDevice(deviceID)
+    }
+
     private func listInputDevices() -> [AudioInputDevice] {
+        Self.availableInputDevices()
+    }
+
+    private static func availableInputDevices() -> [AudioInputDevice] {
         var size: UInt32 = 0
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDevices,
@@ -307,8 +319,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         var devices: [AudioInputDevice] = []
         for id in deviceIDs {
-            guard inputChannelCount(for: id) > 0 else { continue }
-            guard !isAggregateDevice(id) else { continue }
+            guard isInputDeviceAvailable(id) else { continue }
             guard let name = deviceName(for: id),
                   let uid = deviceUID(for: id) else { continue }
             // Filter virtual/internal devices by known patterns
@@ -321,7 +332,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return devices
     }
 
-    private func deviceName(for deviceID: AudioDeviceID) -> String? {
+    private static func deviceName(for deviceID: AudioDeviceID) -> String? {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyDeviceNameCFString,
             mScope: kAudioObjectPropertyScopeGlobal,
@@ -330,7 +341,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return getCFStringProperty(deviceID: deviceID, address: &address)
     }
 
-    private func deviceUID(for deviceID: AudioDeviceID) -> String? {
+    private static func deviceUID(for deviceID: AudioDeviceID) -> String? {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyDeviceUID,
             mScope: kAudioObjectPropertyScopeGlobal,
@@ -339,7 +350,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return getCFStringProperty(deviceID: deviceID, address: &address)
     }
 
-    private func getCFStringProperty(deviceID: AudioDeviceID, address: inout AudioObjectPropertyAddress) -> String? {
+    private static func getCFStringProperty(deviceID: AudioDeviceID, address: inout AudioObjectPropertyAddress) -> String? {
         var value: Unmanaged<CFString>?
         var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
         let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value)
@@ -347,7 +358,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return cf.takeUnretainedValue() as String
     }
 
-    private func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
+    private static func inputChannelCount(for deviceID: AudioDeviceID) -> Int {
         var size: UInt32 = 0
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyStreamConfiguration,
@@ -375,7 +386,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return channels
     }
 
-    private func isAggregateDevice(_ deviceID: AudioDeviceID) -> Bool {
+    private static func isAggregateDevice(_ deviceID: AudioDeviceID) -> Bool {
         var transportType: UInt32 = 0
         var size = UInt32(MemoryLayout<UInt32>.size)
         var address = AudioObjectPropertyAddress(

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -66,6 +66,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     enum AudioRecordingError: LocalizedError {
         case microphonePermissionDenied
+        case noMicrophoneDetected
         case engineStartFailed(String)
         case noAudioData
 
@@ -73,6 +74,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             switch self {
             case .microphonePermissionDenied:
                 "Microphone permission denied. Please grant access in System Settings."
+            case .noMicrophoneDetected:
+                String(localized: "No mic detected.")
             case .engineStartFailed(let detail):
                 "Failed to start audio engine: \(detail)"
             case .noAudioData:
@@ -85,6 +88,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     @Published private(set) var audioLevel: Float = 0
     @Published private(set) var rawAudioLevel: Float = 0
     var hasMicrophonePermissionOverride: Bool?
+    var inputAvailabilityOverride: ((AudioDeviceID?) -> Bool)?
     var startRecordingOverride: (() throws -> Void)?
 
     /// CoreAudio device ID to use for recording. nil = system default input.
@@ -196,6 +200,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         guard hasMicrophonePermission else {
             throw AudioRecordingError.microphonePermissionDenied
         }
+
+        try validateRecordingInputAvailability()
 
         if let startRecordingOverride {
             bufferLock.lock()
@@ -367,7 +373,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         logger.info("\(label, privacy: .public) input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
 
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            throw AudioRecordingError.engineStartFailed("No audio input available")
+            throw AudioRecordingError.noMicrophoneDetected
         }
 
         guard let targetFormat = AVAudioFormat(
@@ -420,6 +426,26 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             self?.isRecording = false
             self?.audioLevel = 0
             self?.rawAudioLevel = 0
+        }
+    }
+
+    private func validateRecordingInputAvailability() throws {
+        if let inputAvailabilityOverride {
+            guard inputAvailabilityOverride(selectedDeviceID) else {
+                throw AudioRecordingError.noMicrophoneDetected
+            }
+            return
+        }
+
+        if let selectedDeviceID {
+            guard AudioDeviceService.isInputDeviceAvailable(selectedDeviceID) else {
+                throw AudioRecordingError.noMicrophoneDetected
+            }
+            return
+        }
+
+        guard AudioDeviceService.hasAvailableInputDevice() else {
+            throw AudioRecordingError.noMicrophoneDetected
         }
     }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -484,9 +484,16 @@ final class DictationViewModel: ObservableObject {
             urlResolutionTask = nil
             audioDuckingService.restoreAudio()
             mediaPlaybackService.resumeIfWePaused()
-            accessibilityAnnouncementService.announceError(error.localizedDescription)
-            speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
-            showError(error.localizedDescription, category: "recording")
+            let errorMessage: String
+            if let recordingError = error as? AudioRecordingService.AudioRecordingError,
+               case .noMicrophoneDetected = recordingError {
+                errorMessage = String(localized: "No mic detected.")
+            } else {
+                errorMessage = error.localizedDescription
+            }
+            accessibilityAnnouncementService.announceError(errorMessage)
+            speechFeedbackService.announceEvent(.error(reason: errorMessage))
+            showError(errorMessage, category: "recording")
             hotkeyService.cancelDictation()
         }
     }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreAudio
 import Foundation
 import XCTest
 import TypeWhisperPluginSDK
@@ -245,6 +246,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             return ("Notes", nil, nil)
         }
         context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
         context.audioRecordingService.startRecordingOverride = {
             events.append("start_audio")
         }
@@ -281,6 +283,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             ("Docs App", "com.typewhisper.tests", nil)
         }
         context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
         context.audioRecordingService.startRecordingOverride = {}
         context.textInsertionService.selectedTextOverride = { () -> String? in
             selectedTextCaptured.fulfill()
@@ -320,6 +323,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             return ("Music", "com.apple.Music", nil)
         }
         context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
         context.audioRecordingService.startRecordingOverride = {
             events.append("start_audio")
         }
@@ -398,6 +402,48 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(
             dictationViewModel.actionFeedbackMessage,
             TranscriptionEngineError.modelNotLoaded.localizedDescription
+        )
+    }
+
+    @MainActor
+    func testApiStartRecording_showsNoMicDetectedErrorWhenNoInputAvailable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in false }
+
+        context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, "No mic detected.")
+    }
+
+    @MainActor
+    func testApiStartRecording_preservesPermissionDeniedError() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.audioRecordingService.hasMicrophonePermissionOverride = false
+
+        context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            "Microphone permission required."
         )
     }
 
@@ -675,6 +721,30 @@ final class APIRouterAndHandlersTests: XCTestCase {
     private static func jsonObject(_ response: HTTPResponse) throws -> [String: Any] {
         let object = try JSONSerialization.jsonObject(with: response.body)
         return try XCTUnwrap(object as? [String: Any])
+    }
+}
+
+final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {
+    func testStartRecording_throwsNoMicrophoneDetectedBeforeStartingOverride() {
+        let service = AudioRecordingService()
+        var didReachStartOverride = false
+
+        service.hasMicrophonePermissionOverride = true
+        service.selectedDeviceID = AudioDeviceID(42)
+        service.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertEqual(selectedDeviceID, AudioDeviceID(42))
+            return false
+        }
+        service.startRecordingOverride = {
+            didReachStartOverride = true
+        }
+
+        XCTAssertThrowsError(try service.startRecording()) { error in
+            guard case AudioRecordingService.AudioRecordingError.noMicrophoneDetected = error else {
+                return XCTFail("Expected noMicrophoneDetected, got \(error)")
+            }
+        }
+        XCTAssertFalse(didReachStartOverride)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a microphone-availability preflight before starting dictation audio capture
- surface a dedicated `No mic detected.` indicator error instead of falling into an audio-engine crash path
- cover the no-mic path and related start-path regressions with tests

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/AudioRecordingServiceInputAvailabilityTests CODE_SIGNING_ALLOWED=NO`

Closes #237