### PR TITLE
fix: prevent caps lock from triggering combo hotkeys

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -123,6 +123,8 @@ final class HotkeyService: ObservableObject {
     private static let toggleThreshold: TimeInterval = 1.0
     private static let doubleTapThreshold: TimeInterval = 0.4
     private static let monitorDedupWindow: TimeInterval = 0.12
+    private static let capsLockKeyCode: UInt16 = 0x39
+    private static let capsLockSuppressionWindow: TimeInterval = 0.25
 
     // MARK: - Per-Slot State
 
@@ -136,6 +138,16 @@ final class HotkeyService: ObservableObject {
         // Double-tap tracking
         var lastTapUpTime: Date?
         var tapCount: Int = 0 // 0=idle, 1=first tap released, 2=second tap active
+
+        mutating func resetTransientState() {
+            fnWasDown = false
+            fnComboKeyPressed = false
+            modifierWasDown = false
+            keyWasDown = false
+            mouseButtonWasDown = false
+            lastTapUpTime = nil
+            tapCount = 0
+        }
     }
 
     private var slots: [HotkeySlotType: SlotState] = [
@@ -158,6 +170,16 @@ final class HotkeyService: ObservableObject {
         // Double-tap tracking
         var lastTapUpTime: Date?
         var tapCount: Int = 0
+
+        mutating func resetTransientState() {
+            fnWasDown = false
+            fnComboKeyPressed = false
+            modifierWasDown = false
+            keyWasDown = false
+            mouseButtonWasDown = false
+            lastTapUpTime = nil
+            tapCount = 0
+        }
     }
 
     private var profileSlots: [UUID: ProfileHotkeyState] = [:]
@@ -167,6 +189,7 @@ final class HotkeyService: ObservableObject {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var recentEventTapDispatches: [HotkeyDispatchKey: Date] = [:]
+    private var capsLockOriginSuppressionUntil: Date?
 
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "HotkeyService")
 
@@ -338,6 +361,7 @@ final class HotkeyService: ObservableObject {
             runLoopSource = nil
         }
         recentEventTapDispatches.removeAll()
+        capsLockOriginSuppressionUntil = nil
     }
 
     func suspendMonitoring() {
@@ -431,11 +455,17 @@ final class HotkeyService: ObservableObject {
             return false
         }
 
+        updateCapsLockOriginTracker(for: event)
         var shouldSuppress = false
 
         // Global slots
         for slotType in HotkeySlotType.allCases {
             guard var state = slots[slotType], let hotkey = state.hotkey else { continue }
+            if shouldSuppressForCapsLockOrigin(event, hotkey: hotkey, keyWasDown: state.keyWasDown) {
+                state.resetTransientState()
+                slots[slotType] = state
+                continue
+            }
             let (keyDown, keyUp, isMatch) = processKeyEvent(event, hotkey: hotkey, state: &state)
             slots[slotType] = state
             if isMatch { shouldSuppress = true }
@@ -451,6 +481,11 @@ final class HotkeyService: ObservableObject {
         // Profile slots
         for profileId in Array(profileSlots.keys) {
             guard var pState = profileSlots[profileId] else { continue }
+            if shouldSuppressForCapsLockOrigin(event, hotkey: pState.hotkey, keyWasDown: pState.keyWasDown) {
+                pState.resetTransientState()
+                profileSlots[profileId] = pState
+                continue
+            }
             var state = SlotState(hotkey: pState.hotkey, fnWasDown: pState.fnWasDown,
                                   fnComboKeyPressed: pState.fnComboKeyPressed,
                                   modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown,
@@ -476,6 +511,42 @@ final class HotkeyService: ObservableObject {
         }
 
         return shouldSuppress
+    }
+
+    private func updateCapsLockOriginTracker(for event: NSEvent) {
+        let now = Date()
+        if let until = capsLockOriginSuppressionUntil, now >= until {
+            capsLockOriginSuppressionUntil = nil
+        }
+
+        guard event.type == .flagsChanged, event.keyCode == Self.capsLockKeyCode else { return }
+        capsLockOriginSuppressionUntil = now.addingTimeInterval(Self.capsLockSuppressionWindow)
+    }
+
+    private func shouldSuppressForCapsLockOrigin(
+        _ event: NSEvent,
+        hotkey: UnifiedHotkey,
+        keyWasDown: Bool
+    ) -> Bool {
+        guard let until = capsLockOriginSuppressionUntil, Date() < until else {
+            capsLockOriginSuppressionUntil = nil
+            return false
+        }
+
+        switch hotkey.kind {
+        case .modifierCombo:
+            return event.type == .flagsChanged
+        case .keyWithModifiers:
+            if event.type == .keyDown || event.type == .keyUp {
+                return event.keyCode == hotkey.keyCode
+            }
+            if event.type == .flagsChanged {
+                return keyWasDown || event.keyCode == Self.capsLockKeyCode
+            }
+            return false
+        case .fn, .modifierOnly, .bareKey, .mouseButton:
+            return false
+        }
     }
 
     private func dispatchGlobalMatch(

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -743,6 +743,104 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testCapsLockOriginSuppressesModifierComboHotkey() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let capsLockEvent = try makeFlagsChangedEvent(keyCode: 0x39, modifierFlags: [.capsLock])
+        let comboEvent = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+
+        XCTAssertFalse(service.processEventForTesting(capsLockEvent, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(comboEvent, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testCapsLockOriginSuppressesKeyWithModifiersHotkey() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionAHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let capsLockEvent = try makeFlagsChangedEvent(keyCode: 0x39, modifierFlags: [.capsLock])
+        let keyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+        let keyUp = try makeKeyboardEvent(keyCode: 0x00, keyDown: false, flags: [.maskCommand, .maskAlternate])
+
+        XCTAssertFalse(service.processEventForTesting(capsLockEvent, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testModifierComboStillWorksWithoutCapsLockOrigin() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let comboEvent = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+
+        XCTAssertTrue(service.processEventForTesting(comboEvent, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testKeyWithModifiersStillWorksWithoutCapsLockOrigin() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionAHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testBareKeyHotkeyRemainsAllowedAfterCapsLockOrigin() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(bareSpaceHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let capsLockEvent = try makeFlagsChangedEvent(keyCode: 0x39, modifierFlags: [.capsLock])
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true, flags: [])
+
+        XCTAssertFalse(service.processEventForTesting(capsLockEvent, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
     private func spaceHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
             keyCode: 0x31,
@@ -751,12 +849,62 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
     }
 
-    private func makeKeyboardEvent(keyCode: UInt16, keyDown: Bool) throws -> NSEvent {
-        let flags: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
+    @MainActor
+    private func commandOptionComboHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: UnifiedHotkey.modifierComboKeyCode,
+            modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func commandOptionAHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x00,
+            modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func bareSpaceHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x31,
+            modifierFlags: 0,
+            isFn: false
+        )
+    }
+
+    private func makeKeyboardEvent(
+        keyCode: UInt16,
+        keyDown: Bool,
+        flags: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
+    ) throws -> NSEvent {
         let event = try XCTUnwrap(
             CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(keyCode), keyDown: keyDown)
         )
         event.flags = flags
         return try XCTUnwrap(NSEvent(cgEvent: event))
+    }
+
+    private func makeFlagsChangedEvent(
+        keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags
+    ) throws -> NSEvent {
+        try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .flagsChanged,
+                location: .zero,
+                modifierFlags: modifierFlags,
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: 0,
+                context: nil,
+                characters: "",
+                charactersIgnoringModifiers: "",
+                isARepeat: false,
+                keyCode: keyCode
+            )
+        )
     }
 }


### PR DESCRIPTION
Closes #219

## Summary
- suppress `modifierCombo` and `keyWithModifiers` hotkeys when the event sequence originates from physical Caps Lock
- reset transient hotkey state for suppressed events so stale key down state cannot leak into later handling
- add regression coverage for Caps Lock-originated sequences and verify bare-key hotkeys still work

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`