### PR TITLE
Avoid idle MediaRemote listener CPU usage

### DIFF
--- a/TypeWhisper/Services/MediaPlaybackService.swift
+++ b/TypeWhisper/Services/MediaPlaybackService.swift
@@ -6,57 +6,66 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "MediaPlaybackService")
 
+#if !APPSTORE
+protocol MediaPlaybackControlling: AnyObject {
+    func getPlaybackSnapshot(_ onReceive: @escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void)
+    func play()
+    func pause()
+}
+
+extension MediaController: MediaPlaybackControlling {
+    func getPlaybackSnapshot(_ onReceive: @escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void) {
+        getTrackInfo { trackInfo in
+            let playing = (trackInfo?.payload.isPlaying ?? false) || ((trackInfo?.payload.playbackRate ?? 0) > 0)
+            onReceive(playing, trackInfo?.payload.bundleIdentifier)
+        }
+    }
+}
+#endif
+
 @MainActor
 class MediaPlaybackService {
     private var didPause = false
 
     #if !APPSTORE
-    private var mediaController: MediaController?
-    private var isMediaPlaying = false
+    private let controllerFactory: () -> MediaPlaybackControlling
+    private lazy var mediaController: MediaPlaybackControlling = controllerFactory()
     private var nowPlayingBundleID: String?
+    private var trackInfoRequestGeneration = 0
 
-    init(startListening: Bool = true) {
-        guard startListening else { return }
-
-        let mediaController = MediaController()
-        mediaController.onTrackInfoReceived = { [weak self] trackInfo in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                if let info = trackInfo {
-                    let playing = info.payload.isPlaying ?? false
-                    let rate = info.payload.playbackRate ?? 0
-                    self.isMediaPlaying = playing || rate > 0
-                    self.nowPlayingBundleID = info.payload.bundleIdentifier
-                } else {
-                    self.isMediaPlaying = false
-                    self.nowPlayingBundleID = nil
-                }
-            }
-        }
-        mediaController.startListening()
-        self.mediaController = mediaController
-        logger.info("MediaRemoteAdapter listener started")
+    init(
+        startListening _: Bool = true,
+        controllerFactory: @escaping () -> MediaPlaybackControlling = { MediaController() }
+    ) {
+        self.controllerFactory = controllerFactory
     }
 
-    /// Pauses media playback only if something is actually playing.
+    /// Uses a one-shot status probe to avoid keeping MediaRemote listener processes
+    /// alive while TypeWhisper is idle in the menu bar.
     func pauseIfPlaying() {
         guard !didPause else { return }
-        guard let mediaController else { return }
+        trackInfoRequestGeneration += 1
+        let generation = trackInfoRequestGeneration
 
-        guard isMediaPlaying else {
-            logger.info("No media playing, skipping pause")
-            return
+        mediaController.getPlaybackSnapshot { [weak self] isPlaying, bundleIdentifier in
+            guard let self else { return }
+            guard generation == self.trackInfoRequestGeneration else { return }
+            guard isPlaying else {
+                logger.info("No media playing, skipping pause")
+                return
+            }
+
+            self.nowPlayingBundleID = bundleIdentifier
+            self.mediaController.pause()
+            self.didPause = true
+            logger.info("Media paused (nowPlaying: \(self.nowPlayingBundleID ?? "unknown"))")
         }
-
-        mediaController.pause()
-        didPause = true
-        logger.info("Media paused (nowPlaying: \(self.nowPlayingBundleID ?? "unknown"))")
     }
 
     /// Resumes playback only if we previously paused it.
     func resumeIfWePaused() {
+        trackInfoRequestGeneration += 1
         guard didPause else { return }
-        guard let mediaController else { return }
         mediaController.play()
         didPause = false
         logger.info("Media playback resumed")

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -78,13 +78,38 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         init(onPause: @escaping () -> Void) {
             self.onPause = onPause
-            super.init()
+            super.init(startListening: false)
         }
 
         override func pauseIfPlaying() {
             onPause()
         }
     }
+
+    #if !APPSTORE
+    private final class FakeMediaPlaybackController: MediaPlaybackControlling {
+        var returnedSnapshot: (isPlaying: Bool, bundleIdentifier: String?) = (false, nil)
+        var onGetPlaybackSnapshot: ((@escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void) -> Void)?
+        private(set) var pauseCalls = 0
+        private(set) var playCalls = 0
+
+        func getPlaybackSnapshot(_ onReceive: @escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void) {
+            if let onGetPlaybackSnapshot {
+                onGetPlaybackSnapshot(onReceive)
+                return
+            }
+            onReceive(returnedSnapshot.isPlaying, returnedSnapshot.bundleIdentifier)
+        }
+
+        func play() {
+            playCalls += 1
+        }
+
+        func pause() {
+            pauseCalls += 1
+        }
+    }
+    #endif
 
     func testRouterHandlesOptionsAndNotFound() async {
         let router = APIRouter()
@@ -332,6 +357,51 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(Array(events.prefix(3)), ["capture_app", "start_audio", "pause_media"])
     }
+
+    #if !APPSTORE
+    @MainActor
+    func testMediaPlaybackServicePausesAndResumesFromOneShotTrackInfo() {
+        let controller = FakeMediaPlaybackController()
+        controller.returnedSnapshot = (true, "com.apple.Music")
+        let service = MediaPlaybackService(startListening: false) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+        XCTAssertEqual(controller.playCalls, 1)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceSkipsPauseWhenPlaybackIsAlreadyStopped() {
+        let controller = FakeMediaPlaybackController()
+        controller.returnedSnapshot = (false, nil)
+        let service = MediaPlaybackService(startListening: false) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceIgnoresStalePauseProbeAfterResume() {
+        let controller = FakeMediaPlaybackController()
+        var deferredCallback: ((_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void)?
+        controller.onGetPlaybackSnapshot = { callback in
+            deferredCallback = callback
+        }
+        let service = MediaPlaybackService(startListening: false) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        deferredCallback?(true, "com.apple.Music")
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+    }
+    #endif
 
     @MainActor
     func testApiStartRecording_showsSelectModelErrorWhenNoProviderIsSelected() async throws {
@@ -657,7 +727,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let accessibilityAnnouncementService = AccessibilityAnnouncementService()
         let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
-        let mediaPlaybackService = mediaPlaybackService ?? MediaPlaybackService()
+        let mediaPlaybackService = mediaPlaybackService ?? MediaPlaybackService(startListening: false)
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,


### PR DESCRIPTION
## Summary
- replace the always-on `MediaRemoteAdapter` listener with an on-demand playback snapshot in `MediaPlaybackService`
- guard late async playback snapshots so `resumeIfWePaused()` cannot be undone by a stale callback
- add focused tests for pause/resume, skipped pause when nothing is playing, and the stale-callback race

## Root cause
`MediaPlaybackService` started `MediaController.startListening()` during app startup and kept the MediaRemote listener alive while TypeWhisper was idle in the menu bar. On affected systems that listener could keep a helper process active and burn CPU even when no recording was running.

## Impact
Idle CPU usage drops back to normal because TypeWhisper no longer keeps a persistent MediaRemote listener running in the background. Media pause/resume during recording still works, but playback state is now checked only when recording starts.

## Validation
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- local dev build run via `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run`
- local idle observation: TypeWhisper returned to near-0% CPU and no separate `MediaRemoteAdapter` helper remained alive while idle

Refs #231