### PR TITLE
Prepare v1.2.0-rc2 release notes and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ brew install --cask typewhisper/tap/typewhisper
 
 Download the latest DMG from [GitHub Releases](https://github.com/TypeWhisper/typewhisper-mac/releases/latest).
 
-Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.2.0-rc1` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
+Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.2.0-rc*` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
 Installed builds can switch channels in `Settings -> About` via the `Update Channel` picker.
 
 ## Quick Start

--- a/docs/1.1-readiness.md
+++ b/docs/1.1-readiness.md
@@ -1,6 +1,6 @@
 # TypeWhisper 1.x Release Readiness
 
-This document remains at `docs/1.1-readiness.md` for the current direct-download release line. It defines the release gates for the current `1.x` product path, including `1.2.0-rc1`.
+This document remains at `docs/1.1-readiness.md` for the current direct-download release line. It defines the release gates for the current `1.x` product path, including `1.2.0-rc2`.
 
 TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac App Store remains out of scope. For `1.2`, the focus is reliability, upgrade safety, and power-user polish across indicators, short clips, audio recovery, and plugin setup.
 
@@ -75,7 +75,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - There are no first-party build warnings.
 - Plugin manifests validate successfully.
 - README, security guidance, support matrix, and plugin documentation are up to date.
-- A `1.2.0-rc1` build ran on real machines for multiple days without P0/P1 blockers.
+- A `1.2.0-rc2` build ran on real machines for multiple days without P0/P1 blockers.
 - The default channel remains `stable`; `release-candidate` and `daily` exist as Sparkle channels for preview builds.
 - `1.2.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
 - The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,9 +8,9 @@
 - `bash scripts/check_first_party_warnings.sh build.log`
 - Review `README.md`, `SECURITY.md`, `docs/support-matrix.md`, `docs/1.1-readiness.md`, `Plugins/README.md`, and `TypeWhisperPluginSDK/README.md`
 - Confirm `MARKETING_VERSION = 1.2.0` across the app, CLI, and widgets
-- Prepare or refresh `docs/release-notes/1.2.0-rc1.md`
-- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.2.0-rc1` before pushing the tag
-- Otherwise the release workflow will publish `docs/release-notes/1.2.0-rc1.md` automatically when no release already exists
+- Prepare or refresh `docs/release-notes/1.2.0-rc2.md`
+- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.2.0-rc2` before pushing the tag
+- Otherwise the release workflow will publish `docs/release-notes/1.2.0-rc2.md` automatically when no release already exists
 
 ## RC Smoke Checks
 
@@ -52,7 +52,7 @@
 
 ## Before `1.2.0`
 
-- Observe `1.2.0-rc1` on real machines for multiple days
+- Observe `1.2.0-rc2` on real machines for multiple days
 - No open P0/P1 bugs in the core workflow
 - Finalize release notes
 - RC and daily tags must not update Homebrew or trigger stable website messaging

--- a/docs/release-notes/1.2.0-rc2.md
+++ b/docs/release-notes/1.2.0-rc2.md
@@ -1,0 +1,16 @@
+## Workflow & Automation
+
+- Added the supporter Discord claim flow for eligible supporters.
+- Fixed engine startup so TypeWhisper auto-selects the configured engine more reliably.
+- Added GPT-5 token parameter support to the OpenAI chat helper for SDK and plugin integrations.
+
+## Reliability & Input Handling
+
+- Fixed dictation start when no microphone is available, with a cleaner failure path.
+- Improved combo hotkey handling by ignoring Caps Lock as an origin key.
+- Switched plugin load error logging to structured OSLog interpolation for clearer diagnostics.
+
+## Plugins & Bundled Components
+
+- Hardened bundled plugin installation and update flows.
+- Prepared the bundled Parakeet plugin for the `1.2.3` release line.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,6 +1,6 @@
 # TypeWhisper Support Matrix
 
-This matrix describes the officially supported `1.x` direct-download path. For `1.2.0-rc1`, the public runtime support floor remains `macOS 14+`.
+This matrix describes the officially supported `1.x` direct-download path. For the current `1.2.0-rc*` preview line, the public runtime support floor remains `macOS 14+`.
 
 ## Platform
 


### PR DESCRIPTION
## Summary
- add curated release notes for `v1.2.0-rc2`
- update release docs and readiness references for the current RC
- keep RC distribution guidance generic for `1.2.0-rc*`

## Testing
- xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
- swift test --package-path TypeWhisperPluginSDK
- xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
- bash scripts/check_first_party_warnings.sh build.log