### PR TITLE
Reframe profiles as rules with a guided editor

### DIFF
--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -57,7 +57,7 @@ Each plugin receives a `HostServices` object providing:
 - **UserDefaults** (plugin-scoped): `userDefault(forKey:)`, `setUserDefault(_:forKey:)`
 - **Data directory**: `pluginDataDirectory` - persistent storage at `~/Library/Application Support/TypeWhisper/PluginData/<pluginId>/`
 - **App context**: `activeAppBundleId`, `activeAppName`
-- **Profiles**: `availableProfileNames` - list of user-defined profile names
+- **Rules**: `availableRuleNames` - list of user-defined rule names
 - **Event Bus**: `eventBus` for subscribing to events
 - **Capabilities**: `notifyCapabilitiesChanged()` - notify the host when plugin state changes (e.g. model loaded/unloaded)
 - **Streaming display hint**: `setStreamingDisplayActive(_:)` - tell TypeWhisper that your plugin renders its own streaming UI

--- a/Plugins/ScriptPlugin/ScriptPlugin.swift
+++ b/Plugins/ScriptPlugin/ScriptPlugin.swift
@@ -43,10 +43,10 @@ final class ScriptPlugin: NSObject, PostProcessorPlugin, @unchecked Sendable {
 
         var result = text
         for script in scripts {
-            // Profile filter: empty = all, otherwise match by name
+            // Rule filter: empty = all, otherwise match by name
             if !script.profileFilter.isEmpty {
-                guard let profileName = context.profileName,
-                      script.profileFilter.contains(profileName) else {
+                guard let ruleName = context.ruleName,
+                      script.profileFilter.contains(ruleName) else {
                     continue
                 }
             }
@@ -172,7 +172,10 @@ final class ScriptService: ObservableObject, @unchecked Sendable {
                 if let bundleId = context.bundleIdentifier { env["TYPEWHISPER_BUNDLE_ID"] = bundleId }
                 if let url = context.url { env["TYPEWHISPER_URL"] = url }
                 if let language = context.language { env["TYPEWHISPER_LANGUAGE"] = language }
-                if let profileName = context.profileName { env["TYPEWHISPER_PROFILE"] = profileName }
+                if let ruleName = context.ruleName {
+                    env["TYPEWHISPER_RULE"] = ruleName
+                    env["TYPEWHISPER_PROFILE"] = ruleName
+                }
                 if let selectedText = context.selectedText { env["TYPEWHISPER_SELECTED_TEXT"] = selectedText }
                 process.environment = env
 
@@ -383,7 +386,7 @@ struct ScriptSettingsView: View {
         .sheet(item: $editingScript) { script in
             ScriptEditView(
                 script: script,
-                availableProfiles: service.host.availableProfileNames,
+                availableProfiles: service.host.availableRuleNames,
                 onSave: { updated in
                     service.updateScript(updated)
                     editingScript = nil
@@ -416,7 +419,7 @@ private struct ScriptRow: View {
                         .lineLimit(1)
                 }
                 if !script.profileFilter.isEmpty {
-                    Text("Profiles: \(script.profileFilter.joined(separator: ", "))")
+                    Text("Rules: \(script.profileFilter.joined(separator: ", "))")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
@@ -526,9 +529,9 @@ private struct ScriptEditView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Section(String(localized: "Profiles", bundle: bundle)) {
+                Section("Rules") {
                     if availableProfiles.isEmpty {
-                        Text("No profiles configured.", bundle: bundle)
+                        Text("No rules configured.")
                             .foregroundStyle(.secondary)
                             .font(.caption)
                     } else {
@@ -548,7 +551,7 @@ private struct ScriptEditView: View {
 
                     Text(script.profileFilter.isEmpty
                          ? String(localized: "Active for all transcriptions.", bundle: bundle)
-                         : String(localized: "Only active for selected profiles.", bundle: bundle))
+                         : "Only active for selected rules.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -74,7 +74,7 @@ struct ExampleWebhookConfig: Codable, Identifiable {
     var httpMethod: String
     var headers: [String: String]
     var isEnabled: Bool
-    var profileFilter: [String]  // Empty = all profiles
+    var profileFilter: [String]  // Empty = all rules
 
     init(name: String = "", url: String = "", httpMethod: String = "POST",
          headers: [String: String] = ["Content-Type": "application/json"],
@@ -152,10 +152,10 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
 
     func sendWebhooks(for payload: TranscriptionCompletedPayload) async {
         for webhook in webhooks where webhook.isEnabled {
-            // Profile filter: empty = all, otherwise match by name
+            // Rule filter: empty = all, otherwise match by name
             if !webhook.profileFilter.isEmpty {
-                guard let profileName = payload.profileName,
-                      webhook.profileFilter.contains(profileName) else {
+                guard let ruleName = payload.ruleName,
+                      webhook.profileFilter.contains(ruleName) else {
                     continue
                 }
             }
@@ -287,7 +287,7 @@ struct ExampleWebhookSettingsView: View {
         .sheet(item: $editingWebhook) { webhook in
             ExampleWebhookEditView(
                 webhook: webhook,
-                availableProfiles: service.host.availableProfileNames,
+                availableProfiles: service.host.availableRuleNames,
                 onSave: { updated in
                     service.updateWebhook(updated)
                     editingWebhook = nil
@@ -320,7 +320,7 @@ private struct WebhookRow: View {
                         .lineLimit(1)
                 }
                 if !webhook.profileFilter.isEmpty {
-                    Text("Profiles: \(webhook.profileFilter.joined(separator: ", "))")
+                    Text("Rules: \(webhook.profileFilter.joined(separator: ", "))")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
@@ -425,9 +425,9 @@ private struct ExampleWebhookEditView: View {
                     }
                 }
 
-                Section(String(localized: "Profiles", bundle: bundle)) {
+                Section("Rules") {
                     if availableProfiles.isEmpty {
-                        Text("No profiles configured.", bundle: bundle)
+                        Text("No rules configured.")
                             .foregroundStyle(.secondary)
                             .font(.caption)
                     } else {
@@ -447,7 +447,7 @@ private struct ExampleWebhookEditView: View {
 
                     Text(webhook.profileFilter.isEmpty
                          ? String(localized: "Active for all transcriptions.", bundle: bundle)
-                         : String(localized: "Only active for selected profiles.", bundle: bundle))
+                         : "Only active for selected rules.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Speech-to-text and AI text processing for macOS. Transcribe audio using on-device AI models or cloud APIs (Groq, OpenAI), then process the result with custom LLM prompts. Your voice data stays on your Mac with local models - or use cloud APIs for faster processing.
 
-TypeWhisper `1.x` is the direct-download macOS release line. The supported core remains system-wide dictation, file transcription, prompt processing, profiles, history, dictionary, snippets, and bundled integrations. HTTP API, CLI, widgets, watch folders, and the plugin SDK remain supported advanced surfaces.
+TypeWhisper `1.x` is the direct-download macOS release line. The supported core remains system-wide dictation, file transcription, prompt processing, rules, history, dictionary, snippets, and bundled integrations. HTTP API, CLI, widgets, watch folders, and the plugin SDK remain supported advanced surfaces.
 
 See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](docs/support-matrix.md), and [docs/release-checklist.md](docs/release-checklist.md) for the current release definition and ship gates.
 
@@ -25,7 +25,7 @@ See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](doc
 <p align="center">
   <a href=".github/screenshots/history.png"><img src=".github/screenshots/history.png" width="270" alt="Transcription History"></a>
   <a href=".github/screenshots/dictionary.png"><img src=".github/screenshots/dictionary.png" width="270" alt="Dictionary"></a>
-  <a href=".github/screenshots/profiles.png"><img src=".github/screenshots/profiles.png" width="270" alt="Profiles"></a>
+  <a href=".github/screenshots/profiles.png"><img src=".github/screenshots/profiles.png" width="270" alt="Rules"></a>
 </p>
 
 <p align="center">
@@ -76,7 +76,7 @@ See [docs/1.1-readiness.md](docs/1.1-readiness.md), [docs/support-matrix.md](doc
 
 ### Personalization
 
-- **Profiles** - Per-app and per-website overrides for language, task, engine, prompt, hotkey, and auto-submit. Match by app (bundle ID) and/or domain with subdomain support
+- **Rules** - Per-app and per-website overrides for language, task, engine, prompt, hotkey, and auto-submit. Match by app (bundle ID) and/or domain with subdomain support
 - **Dictionary** - Terms improve cloud recognition accuracy. Corrections fix common transcription mistakes automatically. Auto-learns from manual corrections. Includes importable term packs
 - **Localized term packs** - Built-in term pack names and descriptions are localized in English and German
 - **Snippets** - Text shortcuts with trigger/replacement. Supports placeholders like `{{DATE}}`, `{{TIME}}`, and `{{CLIPBOARD}}`
@@ -233,14 +233,14 @@ curl "http://localhost:8978/v1/history?q=meeting&limit=10&offset=0"
 curl -X DELETE "http://localhost:8978/v1/history?id=<uuid>"
 ```
 
-### Profiles
+### Rules
 
 ```bash
-# List all profiles
-curl http://localhost:8978/v1/profiles
+# List all rules
+curl http://localhost:8978/v1/rules
 
-# Toggle a profile on/off
-curl -X PUT "http://localhost:8978/v1/profiles/toggle?id=<uuid>"
+# Toggle a rule on/off
+curl -X PUT "http://localhost:8978/v1/rules/toggle?id=<uuid>"
 ```
 
 ### Dictation Control
@@ -297,9 +297,9 @@ typewhisper transcribe meeting.m4a --json | jq -r '.text'
 
 The CLI requires the API server to be running (Settings > Advanced) and follows the documented `1.x` command and flag surface.
 
-## Profiles
+## Rules
 
-Profiles let you configure transcription settings per application or website. For example:
+Rules let you configure transcription settings per application or website. For example:
 
 - **Mail** - German language, Whisper Large v3
 - **Slack** - English language, Parakeet TDT v3
@@ -307,14 +307,14 @@ Profiles let you configure transcription settings per application or website. Fo
 - **github.com** - English language (matches in any browser)
 - **docs.google.com** - German language, translate to English
 
-Create profiles in Settings > Profiles. Assign apps and/or URL patterns, set language/task/engine overrides, assign a custom prompt for automatic post-processing, configure a per-profile hotkey, enable auto-submit (automatically sends text in chat apps), and adjust priority. URL patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`. The domain autocomplete suggests domains from your transcription history.
+Create rules in Settings > Regeln. Assign apps and/or URL patterns, set language/task/engine overrides, assign a custom prompt for automatic post-processing, optionally configure a manual rule shortcut, enable auto-submit (automatically sends text in chat apps), and adjust priority. URL patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`. The domain autocomplete suggests domains from your transcription history.
 
-When you start dictating, TypeWhisper matches the active app and browser URL against your profiles with the following priority:
+When you start dictating, TypeWhisper matches the active app and browser URL against your rules with the following priority:
 1. **App + URL match** - highest specificity (e.g. Chrome + github.com)
-2. **URL-only match** - cross-browser profiles (e.g. github.com in any browser)
-3. **App-only match** - generic app profiles (e.g. all of Chrome)
+2. **URL-only match** - cross-browser rules (e.g. github.com in any browser)
+3. **App-only match** - generic app rules (e.g. all of Chrome)
 
-The active profile name is shown as a badge in the notch indicator.
+The active rule name is shown as a badge in the notch indicator, together with a short explanation of why it matched.
 
 Multiple engines can be loaded simultaneously for instant switching between profiles. Note that loading multiple local models increases memory usage. Cloud engines (Groq, OpenAI) have negligible memory overhead.
 

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -192,7 +192,7 @@ final class ServiceContainer: ObservableObject {
             apiServerViewModel.startServer()
         }
 
-        pluginManager.setProfileNamesProvider { [weak self] in
+        pluginManager.setRuleNamesProvider { [weak self] in
             self?.profileService.profiles.map(\.name) ?? []
         }
         pluginManager.scanAndLoadPlugins()

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -26,8 +26,10 @@ final class APIHandlers: @unchecked Sendable {
         router.register("GET", "/v1/models", handler: handleModels)
         router.register("GET", "/v1/history", handler: handleGetHistory)
         router.register("DELETE", "/v1/history", handler: handleDeleteHistory)
-        router.register("GET", "/v1/profiles", handler: handleGetProfiles)
-        router.register("PUT", "/v1/profiles/toggle", handler: handleToggleProfile)
+        router.register("GET", "/v1/rules", handler: handleGetRules)
+        router.register("PUT", "/v1/rules/toggle", handler: handleToggleRule)
+        router.register("GET", "/v1/profiles", handler: handleGetRules)
+        router.register("PUT", "/v1/profiles/toggle", handler: handleToggleRule)
         router.register("POST", "/v1/dictation/start", handler: handleStartDictation)
         router.register("POST", "/v1/dictation/stop", handler: handleStopDictation)
         router.register("GET", "/v1/dictation/status", handler: handleDictationStatus)
@@ -355,12 +357,12 @@ final class APIHandlers: @unchecked Sendable {
         }
     }
 
-    // MARK: - GET /v1/profiles
+    // MARK: - GET /v1/rules
 
-    private func handleGetProfiles(_ request: HTTPRequest) async -> HTTPResponse {
+    private func handleGetRules(_ request: HTTPRequest) async -> HTTPResponse {
         let profileService = self.profileService
         return await MainActor.run {
-            struct ProfileEntry: Encodable {
+            struct RuleEntry: Encodable {
                 let id: String
                 let name: String
                 let is_enabled: Bool
@@ -371,12 +373,13 @@ final class APIHandlers: @unchecked Sendable {
                 let translation_target_language: String?
             }
 
-            struct ProfilesResponse: Encodable {
-                let profiles: [ProfileEntry]
+            struct RulesResponse: Encodable {
+                let rules: [RuleEntry]
+                let profiles: [RuleEntry]
             }
 
             let entries = profileService.profiles.map { profile in
-                ProfileEntry(
+                RuleEntry(
                     id: profile.id.uuidString,
                     name: profile.name,
                     is_enabled: profile.isEnabled,
@@ -388,13 +391,13 @@ final class APIHandlers: @unchecked Sendable {
                 )
             }
 
-            return .json(ProfilesResponse(profiles: entries))
+            return .json(RulesResponse(rules: entries, profiles: entries))
         }
     }
 
-    // MARK: - PUT /v1/profiles/toggle
+    // MARK: - PUT /v1/rules/toggle
 
-    private func handleToggleProfile(_ request: HTTPRequest) async -> HTTPResponse {
+    private func handleToggleRule(_ request: HTTPRequest) async -> HTTPResponse {
         guard let idString = request.queryParams["id"],
               let uuid = UUID(uuidString: idString) else {
             return .error(status: 400, message: "Missing or invalid 'id' query parameter")
@@ -403,7 +406,7 @@ final class APIHandlers: @unchecked Sendable {
         let profileService = self.profileService
         return await MainActor.run {
             guard let profile = profileService.profiles.first(where: { $0.id == uuid }) else {
-                return .error(status: 404, message: "Profile not found")
+                return .error(status: 404, message: "Rule not found")
             }
 
             profileService.toggleProfile(profile)
@@ -411,12 +414,16 @@ final class APIHandlers: @unchecked Sendable {
             struct ToggleResponse: Encodable {
                 let id: String
                 let name: String
+                let rule_name: String
+                let profile_name: String
                 let is_enabled: Bool
             }
 
             return .json(ToggleResponse(
                 id: profile.id.uuidString,
                 name: profile.name,
+                rule_name: profile.name,
+                profile_name: profile.name,
                 is_enabled: profile.isEnabled
             ))
         }

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -6,12 +6,12 @@ final class HostServicesImpl: HostServices, @unchecked Sendable {
     let pluginId: String
     let pluginDataDirectory: URL
     let eventBus: EventBusProtocol
-    private let profileNamesProvider: () -> [String]
+    private let ruleNamesProvider: () -> [String]
 
-    init(pluginId: String, eventBus: EventBusProtocol, profileNamesProvider: @escaping () -> [String]) {
+    init(pluginId: String, eventBus: EventBusProtocol, ruleNamesProvider: @escaping () -> [String]) {
         self.pluginId = pluginId
         self.eventBus = eventBus
-        self.profileNamesProvider = profileNamesProvider
+        self.ruleNamesProvider = ruleNamesProvider
 
         self.pluginDataDirectory = AppConstants.appSupportDirectory
             .appendingPathComponent("PluginData", isDirectory: true)
@@ -57,10 +57,10 @@ final class HostServicesImpl: HostServices, @unchecked Sendable {
         NSWorkspace.shared.frontmostApplication?.localizedName
     }
 
-    // MARK: - Profiles
+    // MARK: - Rules
 
-    var availableProfileNames: [String] {
-        profileNamesProvider()
+    var availableRuleNames: [String] {
+        ruleNamesProvider()
     }
 
     // MARK: - Capabilities

--- a/TypeWhisper/Services/MemoryService.swift
+++ b/TypeWhisper/Services/MemoryService.swift
@@ -83,9 +83,9 @@ Return ONLY the JSON array, nothing else.
     private func handleTranscription(_ payload: TranscriptionCompletedPayload) {
         guard isEnabled, payload.finalText.count >= minimumTextLength else { return }
 
-        // Per-profile gate
-        if let profileName = payload.profileName,
-           let profile = ServiceContainer.shared.profileService.profiles.first(where: { $0.name == profileName }) {
+        // Per-rule gate
+        if let ruleName = payload.ruleName,
+           let profile = ServiceContainer.shared.profileService.profiles.first(where: { $0.name == ruleName }) {
             guard profile.memoryEnabled else { return }
         } else {
             return
@@ -125,7 +125,7 @@ Return ONLY the JSON array, nothing else.
         let entries = parseExtractedMemories(result, source: MemorySource(
             appName: payload.appName,
             bundleIdentifier: payload.bundleIdentifier,
-            profileName: payload.profileName,
+            ruleName: payload.ruleName,
             timestamp: payload.timestamp
         ))
         guard !entries.isEmpty else { return }

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -48,7 +48,7 @@ final class PluginManager: ObservableObject {
     @Published var loadedPlugins: [LoadedPlugin] = []
 
     let pluginsDirectory: URL
-    private var profileNamesProvider: () -> [String] = { [] }
+    private var ruleNamesProvider: () -> [String] = { [] }
 
     var postProcessors: [PostProcessorPlugin] {
         loadedPlugins
@@ -242,14 +242,19 @@ final class PluginManager: ObservableObject {
         logger.info("Loaded plugin: \(manifest.name) v\(manifest.version)")
     }
 
-    func setProfileNamesProvider(_ provider: @escaping () -> [String]) {
-        self.profileNamesProvider = provider
+    func setRuleNamesProvider(_ provider: @escaping () -> [String]) {
+        self.ruleNamesProvider = provider
     }
 
     private func activatePlugin(_ plugin: LoadedPlugin) {
-        let host = HostServicesImpl(pluginId: plugin.manifest.id, eventBus: EventBus.shared, profileNamesProvider: profileNamesProvider)
+        let host = HostServicesImpl(pluginId: plugin.manifest.id, eventBus: EventBus.shared, ruleNamesProvider: ruleNamesProvider)
         plugin.instance.activate(host: host)
         logger.info("Activated plugin: \(plugin.manifest.id)")
+    }
+
+    @available(*, deprecated, renamed: "setRuleNamesProvider")
+    func setProfileNamesProvider(_ provider: @escaping () -> [String]) {
+        setRuleNamesProvider(provider)
     }
 
     func setPluginEnabled(_ pluginId: String, enabled: Bool) {

--- a/TypeWhisper/Services/ProfileService.swift
+++ b/TypeWhisper/Services/ProfileService.swift
@@ -5,6 +5,34 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "ProfileService")
 
+enum RuleMatchKind: String, Sendable {
+    case appAndWebsite
+    case websiteOnly
+    case appOnly
+    case manualOverride
+
+    var label: String {
+        switch self {
+        case .appAndWebsite:
+            "App + Website"
+        case .websiteOnly:
+            "Nur Website"
+        case .appOnly:
+            "Nur App"
+        case .manualOverride:
+            "Manuell erzwungen"
+        }
+    }
+}
+
+struct RuleMatchResult {
+    let profile: Profile
+    let kind: RuleMatchKind
+    let matchedDomain: String?
+    let competingProfileCount: Int
+    let wonByPriority: Bool
+}
+
 @MainActor
 final class ProfileService: ObservableObject {
     @Published var profiles: [Profile] = []
@@ -42,6 +70,7 @@ final class ProfileService: ObservableObject {
 
     func addProfile(
         name: String,
+        isEnabled: Bool = true,
         bundleIdentifiers: [String] = [],
         urlPatterns: [String] = [],
         inputLanguage: String? = nil,
@@ -60,6 +89,7 @@ final class ProfileService: ObservableObject {
     ) {
         let profile = Profile(
             name: name,
+            isEnabled: isEnabled,
             priority: priority,
             bundleIdentifiers: bundleIdentifiers,
             urlPatterns: urlPatterns,
@@ -81,6 +111,10 @@ final class ProfileService: ObservableObject {
         fetchProfiles()
     }
 
+    func nextPriority() -> Int {
+        (profiles.map(\.priority).max() ?? -1) + 1
+    }
+
     func updateProfile(_ profile: Profile) {
         profile.updatedAt = Date()
         save()
@@ -100,42 +134,65 @@ final class ProfileService: ObservableObject {
         fetchProfiles()
     }
 
-    func matchProfile(bundleIdentifier: String?, url: String? = nil) -> Profile? {
+    func reorderProfiles(_ orderedProfiles: [Profile]) {
+        let highestPriority = max(orderedProfiles.count - 1, 0)
+
+        for (index, profile) in orderedProfiles.enumerated() {
+            profile.priority = highestPriority - index
+            profile.updatedAt = Date()
+        }
+
+        save()
+        fetchProfiles()
+    }
+
+    func forcedRuleMatch(for profile: Profile) -> RuleMatchResult {
+        RuleMatchResult(
+            profile: profile,
+            kind: .manualOverride,
+            matchedDomain: nil,
+            competingProfileCount: 0,
+            wonByPriority: false
+        )
+    }
+
+    func matchRule(bundleIdentifier: String?, url: String? = nil) -> RuleMatchResult? {
         let bundleId = bundleIdentifier ?? ""
         let domain = extractDomain(from: url)
         let enabled = profiles.filter { $0.isEnabled }
 
-        // Tier 1: bundleId + URL match (highest specificity)
         if !bundleId.isEmpty, let domain {
             let matches = enabled.filter { profile in
                 profile.bundleIdentifiers.contains(bundleId) &&
                 profile.urlPatterns.contains { domainMatches(domain, pattern: $0) }
             }
-            if let best = matches.sorted(by: { $0.priority > $1.priority }).first {
-                return best
+            if let result = bestMatch(from: matches, kind: .appAndWebsite, matchedDomain: domain) {
+                return result
             }
         }
 
-        // Tier 2: URL-only match (cross-browser)
         if let domain {
             let matches = enabled.filter { profile in
                 !profile.urlPatterns.isEmpty &&
                 profile.urlPatterns.contains { domainMatches(domain, pattern: $0) }
             }
-            if let best = matches.sorted(by: { $0.priority > $1.priority }).first {
-                return best
+            if let result = bestMatch(from: matches, kind: .websiteOnly, matchedDomain: domain) {
+                return result
             }
         }
 
-        // Tier 3: bundleId-only match
         if !bundleId.isEmpty {
             let matches = enabled.filter { $0.bundleIdentifiers.contains(bundleId) }
-            if let best = matches.sorted(by: { $0.priority > $1.priority }).first {
-                return best
+            if let result = bestMatch(from: matches, kind: .appOnly, matchedDomain: nil) {
+                return result
             }
         }
 
         return nil
+    }
+
+    func matchProfile(bundleIdentifier: String?, url: String? = nil) -> Profile? {
+        matchRule(bundleIdentifier: bundleIdentifier, url: url)?.profile
     }
 
     /// Extracts a clean domain from a URL string, stripping "www." prefix.
@@ -152,6 +209,26 @@ final class ProfileService: ObservableObject {
         let d = domain.lowercased()
         let p = pattern.lowercased()
         return d == p || d.hasSuffix("." + p)
+    }
+
+    private func bestMatch(from matches: [Profile], kind: RuleMatchKind, matchedDomain: String?) -> RuleMatchResult? {
+        let sorted = matches.sorted {
+            if $0.priority != $1.priority {
+                return $0.priority > $1.priority
+            }
+            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+
+        guard let best = sorted.first else { return nil }
+        let secondPriority = sorted.dropFirst().first?.priority
+
+        return RuleMatchResult(
+            profile: best,
+            kind: kind,
+            matchedDomain: matchedDomain,
+            competingProfileCount: max(sorted.count - 1, 0),
+            wonByPriority: secondPriority.map { best.priority > $0 } ?? false
+        )
     }
 
     private func fetchProfiles() {

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -79,6 +79,11 @@ enum InsertionResult {
     }
 
     nonisolated private static func identifyBrowser(_ bundleId: String) -> BrowserType {
+        let normalized = bundleId.lowercased()
+        if normalized.contains("wavebox") {
+            return .chromiumBased
+        }
+
         switch bundleId {
         case "com.apple.Safari":
             return .safari

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -63,7 +63,9 @@ final class DictationViewModel: ObservableObject {
     var pttHotkeyLabel: String { Self.loadHotkeyLabel(for: .pushToTalk) }
     var toggleHotkeyLabel: String { Self.loadHotkeyLabel(for: .toggle) }
     var promptPaletteHotkeyLabel: String { Self.loadHotkeyLabel(for: .promptPalette) }
-    @Published var activeProfileName: String?
+    @Published var activeRuleName: String?
+    @Published var activeRuleReasonLabel: String?
+    @Published var activeRuleExplanation: String?
     @Published var processingPhase: String?
     @Published var actionFeedbackMessage: String?
     @Published var actionFeedbackIcon: String?
@@ -116,6 +118,7 @@ final class DictationViewModel: ObservableObject {
     private let mediaPlaybackService: MediaPlaybackService
     private let postProcessingPipeline: PostProcessingPipeline
     private var matchedProfile: Profile?
+    private var activeRuleMatch: RuleMatchResult?
     private var forcedProfileId: UUID?
     private var capturedActiveApp: (name: String?, bundleId: String?, url: String?)?
     private var capturedSelectedText: String?
@@ -261,6 +264,9 @@ final class DictationViewModel: ObservableObject {
     var canDictate: Bool {
         modelManager.canTranscribe
     }
+
+    @available(*, deprecated, renamed: "activeRuleName")
+    var activeProfileName: String? { activeRuleName }
 
     nonisolated static func loadIndicatorTranscriptPreviewEnabled(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled) as? Bool ?? true
@@ -422,7 +428,7 @@ final class DictationViewModel: ObservableObject {
 
         self.forcedProfileId = forcedProfileId
 
-        // Match profile: forced profile or app-based matching
+        // Match rule: forced manual override or app-based matching
         let activeApp = textInsertionService.captureActiveApp()
         capturedActiveApp = activeApp
         capturedSelectedText = nil
@@ -430,11 +436,9 @@ final class DictationViewModel: ObservableObject {
 
         if let forcedProfileId,
            let forcedProfile = profileService.profiles.first(where: { $0.id == forcedProfileId && $0.isEnabled }) {
-            matchedProfile = forcedProfile
-            activeProfileName = forcedProfile.name
+            applyRuleMatch(profileService.forcedRuleMatch(for: forcedProfile), activeApp: activeApp)
         } else {
-            matchedProfile = profileService.matchProfile(bundleIdentifier: activeApp.bundleId, url: nil)
-            activeProfileName = matchedProfile?.name
+            applyRuleMatch(profileService.matchRule(bundleIdentifier: activeApp.bundleId, url: nil), activeApp: activeApp)
         }
         let immediateContextMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
 
@@ -526,8 +530,8 @@ final class DictationViewModel: ObservableObject {
         }
 
         // Resolve browser URL asynchronously after recording has already started.
-        // If a more specific URL profile matches, update the active profile on the fly.
-        // Skip URL resolution when a forced profile is set (profile hotkey overrides app matching).
+        // If a more specific URL rule matches, update the active rule on the fly.
+        // Skip URL resolution when a forced rule is set (manual rule shortcut overrides app matching).
         guard forcedProfileId == nil, let bundleId = activeApp.bundleId else { return }
         urlResolutionTask = Task { [weak self] in
             guard let self else { return }
@@ -549,14 +553,13 @@ final class DictationViewModel: ObservableObject {
                 logger.info("URL resolution: no URL resolved")
                 return
             }
-            guard let refinedProfile = profileService.matchProfile(bundleIdentifier: bundleId, url: resolvedURL) else {
-                logger.info("URL resolution: no profile matched for URL \(resolvedURL)")
+            guard let refinedRule = profileService.matchRule(bundleIdentifier: bundleId, url: resolvedURL) else {
+                logger.info("URL resolution: no rule matched for URL \(resolvedURL)")
                 return
             }
 
-            logger.info("URL resolution: matched profile '\(refinedProfile.name)'")
-            matchedProfile = refinedProfile
-            activeProfileName = refinedProfile.name
+            logger.info("URL resolution: matched rule '\(refinedRule.profile.name)'")
+            applyRuleMatch(refinedRule, activeApp: capturedActiveApp)
         }
     }
 
@@ -737,7 +740,7 @@ final class DictationViewModel: ObservableObject {
                     bundleIdentifier: activeApp.bundleId,
                     url: activeApp.url,
                     language: language,
-                    profileName: self.matchedProfile?.name,
+                    ruleName: self.matchedProfile?.name,
                     selectedText: self.capturedSelectedText
                 )
                 let ppResult = try await postProcessingPipeline.process(
@@ -800,7 +803,7 @@ final class DictationViewModel: ObservableObject {
                     appName: activeApp.name,
                     bundleIdentifier: activeApp.bundleId,
                     url: activeApp.url,
-                    profileName: self.matchedProfile?.name
+                    ruleName: self.matchedProfile?.name
                 )))
 
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
@@ -829,11 +832,9 @@ final class DictationViewModel: ObservableObject {
                 accessibilityAnnouncementService.announceError(error.localizedDescription)
                 speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
                 showError(error.localizedDescription, category: "transcription")
-                matchedProfile = nil
-                forcedProfileId = nil
+                clearActiveRuleState()
                 capturedActiveApp = nil
                 activeAppIcon = nil
-                activeProfileName = nil
             }
         }
     }
@@ -864,17 +865,65 @@ final class DictationViewModel: ObservableObject {
         state = .idle
         partialText = ""
         recordingStartTime = nil
-        matchedProfile = nil
-        forcedProfileId = nil
+        clearActiveRuleState()
         capturedActiveApp = nil
         capturedSelectedText = nil
         activeAppIcon = nil
-        activeProfileName = nil
         processingPhase = nil
         actionFeedbackMessage = nil
         actionFeedbackIcon = nil
         actionFeedbackIsError = false
         actionDisplayDuration = 3.5
+    }
+
+    private func applyRuleMatch(
+        _ match: RuleMatchResult?,
+        activeApp: (name: String?, bundleId: String?, url: String?)?
+    ) {
+        activeRuleMatch = match
+        matchedProfile = match?.profile
+        activeRuleName = match?.profile.name
+        activeRuleReasonLabel = match?.kind.label
+        activeRuleExplanation = match.map { ruleExplanation(for: $0, activeApp: activeApp) }
+    }
+
+    private func clearActiveRuleState() {
+        matchedProfile = nil
+        activeRuleMatch = nil
+        forcedProfileId = nil
+        activeRuleName = nil
+        activeRuleReasonLabel = nil
+        activeRuleExplanation = nil
+    }
+
+    private func ruleExplanation(
+        for match: RuleMatchResult,
+        activeApp: (name: String?, bundleId: String?, url: String?)?
+    ) -> String {
+        let appDescriptor = activeApp?.name ?? activeApp?.bundleId ?? "the active app"
+
+        let base: String
+        switch match.kind {
+        case .appAndWebsite:
+            if let domain = match.matchedDomain {
+                base = "Diese Regel greift, weil \(appDescriptor) zusammen mit \(domain) erkannt wurde."
+            } else {
+                base = "Diese Regel greift, weil App und Website zusammen erkannt wurden."
+            }
+        case .websiteOnly:
+            if let domain = match.matchedDomain {
+                base = "Diese Regel greift, weil \(domain) erkannt wurde."
+            } else {
+                base = "Diese Regel greift, weil die aktuelle Website erkannt wurde."
+            }
+        case .appOnly:
+            base = "Diese Regel greift, weil \(appDescriptor) erkannt wurde."
+        case .manualOverride:
+            base = "Diese Regel wurde manuell über ihre Tastenkombination erzwungen."
+        }
+
+        guard match.wonByPriority else { return base }
+        return base + " Unter gleich spezifischen Regeln gewinnt hier die höhere Priorität."
     }
 
     // MARK: - Shared Helpers

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -16,6 +16,23 @@ struct InstalledApp: Identifiable, Hashable {
     }
 }
 
+enum RuleEditorStep: Int, CaseIterable {
+    case scope
+    case behavior
+    case review
+
+    var title: String {
+        switch self {
+        case .scope:
+            "Wo gilt diese Regel?"
+        case .behavior:
+            "Wie soll TypeWhisper reagieren?"
+        case .review:
+            "Review & Erweitert"
+        }
+    }
+}
+
 @MainActor
 final class ProfilesViewModel: ObservableObject {
     nonisolated(unsafe) static var _shared: ProfilesViewModel?
@@ -30,6 +47,9 @@ final class ProfilesViewModel: ObservableObject {
 
     // Editor state
     @Published var showingEditor = false
+    @Published var editorStep: RuleEditorStep = .scope
+    @Published var editorIsEnabled = true
+    @Published var showingAdvancedSettings = false
     @Published var editingProfile: Profile?
     @Published var editorName = ""
     @Published var editorBundleIdentifiers: [String] = []
@@ -57,12 +77,19 @@ final class ProfilesViewModel: ObservableObject {
     // Domain autocomplete
     @Published var urlPatternInput = ""
     @Published var domainSuggestions: [String] = []
+    @Published var editorDetectedAppName: String?
+    @Published var editorDetectedBundleIdentifier: String?
+    @Published var editorDetectedURL: String?
+    @Published var editorDetectedDomain: String?
+    @Published var editorDetectedIsSupportedBrowser = false
+    @Published var showingWebsiteScope = false
     var availableDomains: [String] = []
 
     private let profileService: ProfileService
     private let historyService: HistoryService
     let settingsViewModel: SettingsViewModel
     private var cancellables = Set<AnyCancellable>()
+    private var editorNameManuallyEdited = false
 
     init(profileService: ProfileService, historyService: HistoryService, settingsViewModel: SettingsViewModel) {
         self.profileService = profileService
@@ -81,11 +108,45 @@ final class ProfilesViewModel: ObservableObject {
         }
     }
 
+    var suggestedRuleName: String {
+        let appNames = editorBundleIdentifiers.prefix(2).map(appName(for:))
+        let domains = editorUrlPatterns.prefix(2)
+
+        switch (!appNames.isEmpty, !domains.isEmpty) {
+        case (true, true):
+            return "\(appNames.joined(separator: " + ")) @ \(domains.joined(separator: " + "))"
+        case (true, false):
+            return appNames.joined(separator: " + ")
+        case (false, true):
+            return domains.joined(separator: " + ")
+        case (false, false):
+            return "New Rule"
+        }
+    }
+
+    var currentRuleName: String {
+        let trimmed = editorName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if editorNameManuallyEdited, !trimmed.isEmpty {
+            return trimmed
+        }
+        return suggestedRuleName
+    }
+
+    var canAdvanceFromCurrentStep: Bool {
+        switch editorStep {
+        case .scope:
+            return !editorBundleIdentifiers.isEmpty || !editorUrlPatterns.isEmpty
+        case .behavior, .review:
+            return true
+        }
+    }
+
     // MARK: - CRUD
 
     func addProfile() {
         profileService.addProfile(
-            name: editorName,
+            name: currentRuleName,
+            isEnabled: editorIsEnabled,
             bundleIdentifiers: editorBundleIdentifiers,
             urlPatterns: editorUrlPatterns,
             inputLanguage: editorInputLanguage,
@@ -100,13 +161,14 @@ final class ProfilesViewModel: ObservableObject {
             hotkeyData: editorHotkey.flatMap { try? JSONEncoder().encode($0) },
             inlineCommandsEnabled: editorInlineCommandsEnabled,
             autoEnterEnabled: editorAutoEnterEnabled,
-            priority: editorPriority
+            priority: profileService.nextPriority()
         )
     }
 
     func saveProfile() {
         if let profile = editingProfile {
-            profile.name = editorName
+            profile.name = currentRuleName
+            profile.isEnabled = editorIsEnabled
             profile.bundleIdentifiers = editorBundleIdentifiers
             profile.urlPatterns = editorUrlPatterns
             profile.inputLanguage = editorInputLanguage
@@ -133,15 +195,49 @@ final class ProfilesViewModel: ObservableObject {
         profileService.deleteProfile(profile)
     }
 
+    func moveProfile(fromIndex: Int, toIndex: Int) {
+        guard fromIndex != toIndex,
+              profiles.indices.contains(fromIndex),
+              profiles.indices.contains(toIndex) else { return }
+
+        var reorderedProfiles = profiles
+        let movedProfile = reorderedProfiles.remove(at: fromIndex)
+        let insertionIndex = fromIndex < toIndex ? max(toIndex - 1, 0) : toIndex
+        reorderedProfiles.insert(movedProfile, at: insertionIndex)
+        profileService.reorderProfiles(reorderedProfiles)
+    }
+
     func toggleProfile(_ profile: Profile) {
         profileService.toggleProfile(profile)
+    }
+
+    func goToNextStep() {
+        guard canAdvanceFromCurrentStep else { return }
+        if let next = RuleEditorStep(rawValue: editorStep.rawValue + 1) {
+            editorStep = next
+        }
+    }
+
+    func goToPreviousStep() {
+        if let previous = RuleEditorStep(rawValue: editorStep.rawValue - 1) {
+            editorStep = previous
+        }
+    }
+
+    func updateRuleName(_ name: String) {
+        editorName = name
+        editorNameManuallyEdited = true
     }
 
     // MARK: - Editor
 
     func prepareNewProfile() {
         editingProfile = nil
+        editorStep = .scope
+        editorIsEnabled = true
+        showingAdvancedSettings = false
         editorName = ""
+        editorNameManuallyEdited = false
         editorBundleIdentifiers = []
         editorUrlPatterns = []
         editorInputLanguage = nil
@@ -160,13 +256,24 @@ final class ProfilesViewModel: ObservableObject {
         editorPriority = 0
         urlPatternInput = ""
         domainSuggestions = []
+        editorDetectedAppName = nil
+        editorDetectedBundleIdentifier = nil
+        editorDetectedURL = nil
+        editorDetectedDomain = nil
+        editorDetectedIsSupportedBrowser = false
+        showingWebsiteScope = false
         loadAvailableDomains()
+        refreshEditorContext()
         showingEditor = true
     }
 
     func prepareEditProfile(_ profile: Profile) {
         editingProfile = profile
+        editorStep = .scope
+        editorIsEnabled = profile.isEnabled
+        showingAdvancedSettings = false
         editorName = profile.name
+        editorNameManuallyEdited = true
         editorBundleIdentifiers = profile.bundleIdentifiers
         editorUrlPatterns = profile.urlPatterns
         editorInputLanguage = profile.inputLanguage
@@ -193,7 +300,14 @@ final class ProfilesViewModel: ObservableObject {
         editorPriority = profile.priority
         urlPatternInput = ""
         domainSuggestions = []
+        editorDetectedAppName = nil
+        editorDetectedBundleIdentifier = nil
+        editorDetectedURL = nil
+        editorDetectedDomain = nil
+        editorDetectedIsSupportedBrowser = false
+        showingWebsiteScope = !profile.urlPatterns.isEmpty
         loadAvailableDomains()
+        refreshEditorContext()
         showingEditor = true
     }
 
@@ -277,6 +391,7 @@ final class ProfilesViewModel: ObservableObject {
         }
 
         editorUrlPatterns.append(input)
+        showingWebsiteScope = true
         urlPatternInput = ""
         domainSuggestions = []
     }
@@ -286,6 +401,13 @@ final class ProfilesViewModel: ObservableObject {
         editorUrlPatterns.append(domain)
         urlPatternInput = ""
         domainSuggestions = []
+        showingWebsiteScope = true
+    }
+
+    func addDetectedDomainToEditor() {
+        guard let domain = editorDetectedDomain, !editorUrlPatterns.contains(domain) else { return }
+        editorUrlPatterns.append(domain)
+        showingWebsiteScope = true
     }
 
     // MARK: - Helpers
@@ -294,43 +416,244 @@ final class ProfilesViewModel: ObservableObject {
         installedApps.first { $0.id == bundleId }?.name ?? bundleId
     }
 
-    func profileSubtitle(_ profile: Profile) -> String {
-        var parts: [String] = []
-        if let hotkey = profile.hotkey {
-            parts.append("⌨ " + HotkeyService.displayName(for: hotkey))
+    func ruleContextSummary(bundleIdentifiers: [String], urlPatterns: [String]) -> String {
+        let appNames = bundleIdentifiers.prefix(2).map(appName(for:))
+        let domains = urlPatterns.prefix(2)
+
+        switch (!appNames.isEmpty, !domains.isEmpty) {
+        case (true, true):
+            return "\(appNames.joined(separator: " oder ")) aktiv ist und \(domains.joined(separator: " oder ")) erkannt wird"
+        case (true, false):
+            return "\(appNames.joined(separator: " oder ")) aktiv ist"
+        case (false, true):
+            return "\(domains.joined(separator: " oder ")) erkannt wird"
+        case (false, false):
+            return "sie manuell ausgelöst wird"
         }
-        let appNames = profile.bundleIdentifiers.prefix(3).map { appName(for: $0) }
-        if !appNames.isEmpty {
-            parts.append(appNames.joined(separator: ", "))
-            if profile.bundleIdentifiers.count > 3 {
-                parts[parts.count - 1] += " +\(profile.bundleIdentifiers.count - 3)"
+    }
+
+    func ruleBehaviorSummary(
+        inputLanguage: String?,
+        translationEnabled: Bool?,
+        translationTargetLanguage: String?,
+        promptActionId: String?,
+        engineOverride: String?,
+        outputFormat: String?,
+        inlineCommandsEnabled: Bool,
+        autoEnterEnabled: Bool
+    ) -> String {
+        var parts: [String] = []
+
+        if let promptActionId,
+           let action = PromptActionsViewModel.shared.promptActions.first(where: { $0.id.uuidString == promptActionId }) {
+            parts.append("den Prompt „\(action.name)“")
+        }
+
+        if let lang = inputLanguage {
+            let languageName = lang == "auto"
+                ? "auto-detect"
+                : (Locale.current.localizedString(forLanguageCode: lang) ?? lang)
+            parts.append("mit \(languageName)")
+        }
+
+        if translationEnabled == false {
+            parts.append("ohne Übersetzung")
+        } else if let lang = translationTargetLanguage {
+            let languageName = Locale.current.localizedString(forLanguageCode: lang) ?? lang
+            parts.append("mit Übersetzung nach \(languageName)")
+        } else if translationEnabled == true {
+            parts.append("mit Übersetzung")
+        }
+
+        if let engine = engineOverride {
+            let displayName = PluginManager.shared.transcriptionEngine(for: engine)?.providerDisplayName ?? engine
+            parts.append("über \(displayName)")
+        }
+
+        if let outputFormat {
+            switch outputFormat {
+            case "auto":
+                parts.append("mit automatischem Format")
+            case "markdown":
+                parts.append("als Markdown")
+            case "html":
+                parts.append("als HTML")
+            case "plaintext":
+                parts.append("als Plain Text")
+            case "code":
+                parts.append("als Code")
+            default:
+                parts.append("mit \(outputFormat)")
             }
         }
-        if !profile.urlPatterns.isEmpty {
-            let domains = profile.urlPatterns.prefix(2).joined(separator: ", ")
-            let suffix = profile.urlPatterns.count > 2 ? " +\(profile.urlPatterns.count - 2)" : ""
-            parts.append(domains + suffix)
+
+        if inlineCommandsEnabled {
+            parts.append("mit Inline Commands")
         }
-        if let lang = profile.inputLanguage {
-            let name = Locale.current.localizedString(forLanguageCode: lang) ?? lang
-            parts.append(name)
+
+        if autoEnterEnabled {
+            parts.append("mit Auto Enter")
         }
-        if profile.translationEnabled == false {
-            parts.append(String(localized: "Translation Off"))
-        } else if let lang = profile.translationTargetLanguage {
-            let name = Locale.current.localizedString(forLanguageCode: lang) ?? lang
-            parts.append("→ " + name)
-        } else if profile.translationEnabled == true {
-            parts.append(String(localized: "Translation On"))
+
+        return parts.isEmpty ? "die globalen Einstellungen" : parts.prefix(3).joined(separator: ", ")
+    }
+
+    func ruleNarrative(for profile: Profile) -> String {
+        "Wenn \(ruleContextSummary(bundleIdentifiers: profile.bundleIdentifiers, urlPatterns: profile.urlPatterns)), nutzt TypeWhisper \(ruleBehaviorSummary(inputLanguage: profile.inputLanguage, translationEnabled: profile.translationEnabled, translationTargetLanguage: profile.translationTargetLanguage, promptActionId: profile.promptActionId, engineOverride: profile.engineOverride, outputFormat: profile.outputFormat, inlineCommandsEnabled: profile.inlineCommandsEnabled, autoEnterEnabled: profile.autoEnterEnabled))."
+    }
+
+    var editorRuleNarrative: String {
+        "Wenn \(ruleContextSummary(bundleIdentifiers: editorBundleIdentifiers, urlPatterns: editorUrlPatterns)), nutzt TypeWhisper \(ruleBehaviorSummary(inputLanguage: editorInputLanguage, translationEnabled: editorTranslationEnabled, translationTargetLanguage: editorTranslationTargetLanguage, promptActionId: editorPromptActionId, engineOverride: editorEngineOverride, outputFormat: editorOutputFormat, inlineCommandsEnabled: editorInlineCommandsEnabled, autoEnterEnabled: editorAutoEnterEnabled))."
+    }
+
+    func matchingExplanation(bundleIdentifiers: [String], urlPatterns: [String], hasManualOverride: Bool) -> String {
+        let hasApps = !bundleIdentifiers.isEmpty
+        let hasDomains = !urlPatterns.isEmpty
+
+        switch (hasApps, hasDomains) {
+        case (true, true):
+            var text = "Diese Regel ist am stärksten, wenn App und Website gleichzeitig passen. Wenn mehrere gleich spezifische Regeln passen, gewinnt die höhere Priorität."
+            if hasManualOverride {
+                text += " Mit manueller Übersteuerung kann sie jederzeit direkt erzwungen werden."
+            }
+            return text
+        case (false, true):
+            var text = "Diese Regel greift browserübergreifend über die Website. App + Website ist noch spezifischer; gegen andere Website-Regeln entscheidet die Priorität."
+            if hasManualOverride {
+                text += " Mit manueller Übersteuerung kannst du sie trotzdem jederzeit direkt erzwingen."
+            }
+            return text
+        case (true, false):
+            var text = "Diese Regel greift, sobald eine der ausgewählten Apps aktiv ist. Website-Regeln sind spezifischer; gegen andere App-Regeln entscheidet die Priorität."
+            if hasManualOverride {
+                text += " Mit manueller Übersteuerung kannst du sie trotzdem jederzeit direkt erzwingen."
+            }
+            return text
+        case (false, false):
+            return "Ohne App oder Website greift diese Regel nicht automatisch. Nutze dafür eine manuelle Übersteuerung."
         }
-        if let engine = profile.engineOverride {
-            let displayName = PluginManager.shared.transcriptionEngine(for: engine)?.providerDisplayName ?? engine
-            parts.append(displayName)
+    }
+
+    func matchingExplanation(for profile: Profile) -> String {
+        matchingExplanation(
+            bundleIdentifiers: profile.bundleIdentifiers,
+            urlPatterns: profile.urlPatterns,
+            hasManualOverride: profile.hotkey != nil
+        )
+    }
+
+    var editorMatchingExplanation: String {
+        matchingExplanation(
+            bundleIdentifiers: editorBundleIdentifiers,
+            urlPatterns: editorUrlPatterns,
+            hasManualOverride: editorHotkey != nil
+        )
+    }
+
+    func manualOverrideSummary(for profile: Profile) -> String {
+        guard let hotkey = profile.hotkey else { return "Keine manuelle Übersteuerung" }
+        return "Manuelle Übersteuerung: \(HotkeyService.displayName(for: hotkey))"
+    }
+
+    var editorManualOverrideSummary: String {
+        guard let editorHotkey else { return "Keine manuelle Übersteuerung" }
+        return "Manuelle Übersteuerung: \(HotkeyService.displayName(for: editorHotkey))"
+    }
+
+    var editorRelevantBrowserName: String? {
+        if editorDetectedIsSupportedBrowser, let appName = editorDetectedAppName {
+            return appName
         }
-        if profile.inlineCommandsEnabled {
-            parts.append(String(localized: "Inline Commands"))
+
+        guard let bundleId = firstSelectedBrowserBundleIdentifier else { return nil }
+        return appName(for: bundleId)
+    }
+
+    var editorHasSelectedBrowser: Bool {
+        firstSelectedBrowserBundleIdentifier != nil
+    }
+
+    private var firstSelectedBrowserBundleIdentifier: String? {
+        editorBundleIdentifiers.first { bundleId in
+            isSupportedBrowser(bundleIdentifier: bundleId, appName: appName(for: bundleId))
         }
-        return parts.joined(separator: " · ")
+    }
+
+    private func refreshEditorContext() {
+        let activeApp = ServiceContainer.shared.textInsertionService.captureActiveApp()
+        editorDetectedAppName = activeApp.name
+        editorDetectedBundleIdentifier = activeApp.bundleId
+        editorDetectedURL = nil
+        editorDetectedDomain = nil
+        editorDetectedIsSupportedBrowser = isSupportedBrowser(bundleIdentifier: activeApp.bundleId, appName: activeApp.name)
+        showingWebsiteScope = !editorUrlPatterns.isEmpty || editorDetectedIsSupportedBrowser || editorHasSelectedBrowser
+
+        let bundleIdSnapshot = activeApp.bundleId
+
+        guard let bundleId = bundleIdSnapshot else { return }
+
+        Task { [weak self] in
+            let resolvedURL = await ServiceContainer.shared.textInsertionService.resolveBrowserURL(bundleId: bundleId)
+
+            await MainActor.run {
+                guard let self else { return }
+                guard self.editorDetectedBundleIdentifier == bundleIdSnapshot else { return }
+                self.editorDetectedURL = resolvedURL
+                self.editorDetectedDomain = self.normalizedDomain(from: resolvedURL)
+            }
+        }
+    }
+
+    private func normalizedDomain(from urlString: String?) -> String? {
+        guard
+            let urlString,
+            let url = URL(string: urlString),
+            let host = url.host?.lowercased()
+        else {
+            return nil
+        }
+
+        if host.hasPrefix("www.") {
+            return String(host.dropFirst(4))
+        }
+
+        return host
+    }
+
+    private func isSupportedBrowser(bundleIdentifier: String?, appName: String?) -> Bool {
+        let normalizedBundle = bundleIdentifier?.lowercased() ?? ""
+        let normalizedName = appName?.lowercased() ?? ""
+
+        let knownBundleFragments = [
+            "com.apple.safari",
+            "company.thebrowser.browser",
+            "com.google.chrome",
+            "com.brave.browser",
+            "com.microsoft.edgemac",
+            "com.operasoftware.opera",
+            "com.vivaldi.vivaldi",
+            "org.chromium.chromium",
+            "wavebox"
+        ]
+
+        if knownBundleFragments.contains(where: normalizedBundle.contains) {
+            return true
+        }
+
+        let knownNames = [
+            "safari",
+            "arc",
+            "chrome",
+            "brave",
+            "edge",
+            "opera",
+            "vivaldi",
+            "chromium",
+            "wave",
+            "wavebox"
+        ]
+
+        return knownNames.contains(where: normalizedName.contains)
     }
 
     private func setupBindings() {
@@ -348,6 +671,19 @@ final class ProfilesViewModel: ObservableObject {
             .dropFirst()
             .sink { [weak self] _ in
                 self?.editorCloudModelOverride = nil
+            }
+            .store(in: &cancellables)
+
+        $editorBundleIdentifiers
+            .dropFirst()
+            .sink { [weak self] bundleIdentifiers in
+                guard let self else { return }
+                let hasBrowserSelection = bundleIdentifiers.contains { bundleId in
+                    self.isSupportedBrowser(bundleIdentifier: bundleId, appName: self.appName(for: bundleId))
+                }
+                if hasBrowserSelection {
+                    self.showingWebsiteScope = true
+                }
             }
             .store(in: &cancellables)
     }

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -205,7 +205,7 @@ struct GeneralSettingsView: View {
         Text(String(localized: "Recording Indicator")).tag(NotchIndicatorContent.indicator)
         Text(String(localized: "Timer")).tag(NotchIndicatorContent.timer)
         Text(String(localized: "Waveform")).tag(NotchIndicatorContent.waveform)
-        Text(String(localized: "Profile")).tag(NotchIndicatorContent.profile)
+        Text("Rule").tag(NotchIndicatorContent.profile)
         Text(String(localized: "None")).tag(NotchIndicatorContent.none)
     }
 

--- a/TypeWhisper/Views/IndicatorPreviewView.swift
+++ b/TypeWhisper/Views/IndicatorPreviewView.swift
@@ -175,7 +175,7 @@ struct IndicatorPreviewView: View {
             }
             .frame(height: 14)
         case .profile:
-            Text("Profile")
+            Text("Rule")
                 .font(.system(size: size * 0.85, weight: .medium))
                 .foregroundStyle(.white)
                 .lineLimit(1)

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -22,7 +22,7 @@ struct MinimalIndicatorView: View {
         case .timer:
             return 118
         case .profile:
-            guard let name = viewModel.activeProfileName, !name.isEmpty else {
+            guard let name = viewModel.activeRuleName, !name.isEmpty else {
                 return idleWidth
             }
             let estimatedTextWidth = CGFloat(min(name.count, 18)) * 7

--- a/TypeWhisper/Views/ProfilesSettingsView.swift
+++ b/TypeWhisper/Views/ProfilesSettingsView.swift
@@ -2,175 +2,518 @@ import SwiftUI
 
 struct ProfilesSettingsView: View {
     @ObservedObject private var viewModel = ProfilesViewModel.shared
+    @ObservedObject private var dictationViewModel = DictationViewModel.shared
 
     var body: some View {
         VStack(spacing: 0) {
-            // Toolbar
-            HStack {
-                Text(String(localized: "Profiles"))
-                    .font(.headline)
-                Spacer()
-                Button {
-                    viewModel.prepareNewProfile()
-                } label: {
-                    Label(String(localized: "Add Profile"), systemImage: "plus")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-            .padding(12)
-            .background(.bar)
+            header
 
             Divider()
 
-            if viewModel.profiles.isEmpty {
-                ContentUnavailableView {
-                    Label(String(localized: "No Profiles"), systemImage: "person.crop.rectangle.stack")
-                } description: {
-                    Text(String(localized: "Create profiles to use app-specific transcription settings."))
-                }
-                .frame(maxHeight: .infinity)
-            } else {
-                List {
-                    ForEach(viewModel.profiles, id: \.id) { profile in
-                        ProfileRow(profile: profile, viewModel: viewModel)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    if let activeRuleName = dictationViewModel.activeRuleName {
+                        ActiveRuleBanner(
+                            ruleName: activeRuleName,
+                            reasonLabel: dictationViewModel.activeRuleReasonLabel,
+                            explanation: dictationViewModel.activeRuleExplanation
+                        )
+                    }
+
+                    if viewModel.profiles.isEmpty {
+                        emptyState
+                    } else {
+                        rulesList
                     }
                 }
-                .listStyle(.inset)
+                .padding(16)
             }
         }
-        .frame(minWidth: 500, minHeight: 300)
+        .frame(minWidth: 620, minHeight: 420)
         .sheet(isPresented: $viewModel.showingEditor) {
-            ProfileEditorSheet(viewModel: viewModel)
+            RuleEditorSheet(viewModel: viewModel)
         }
     }
-}
 
-// MARK: - Profile Row
-
-private struct ProfileRow: View {
-    let profile: Profile
-    @ObservedObject var viewModel: ProfilesViewModel
-
-    var body: some View {
+    private var header: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(profile.name)
-                    .font(.body.weight(.medium))
-
-                let subtitle = viewModel.profileSubtitle(profile)
-                if !subtitle.isEmpty {
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Regeln")
+                    .font(.headline)
+                Text("Wenn Kontext X erkannt wird, nutzt TypeWhisper Verhalten Y.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             }
 
             Spacer()
 
-            Toggle("", isOn: Binding(
-                get: { profile.isEnabled },
-                set: { _ in viewModel.toggleProfile(profile) }
-            ))
-            .toggleStyle(.switch)
-            .controlSize(.small)
-            .labelsHidden()
-            .accessibilityLabel(String(localized: "Enable \(profile.name)"))
-
             Button {
-                viewModel.prepareEditProfile(profile)
+                viewModel.prepareNewProfile()
             } label: {
-                Image(systemName: "pencil")
+                Label("Neue Regel", systemImage: "plus")
             }
-            .buttonStyle(.borderless)
-            .accessibilityLabel(String(localized: "Edit \(profile.name)"))
-
-            Button(role: .destructive) {
-                viewModel.deleteProfile(profile)
-            } label: {
-                Image(systemName: "trash")
-            }
-            .buttonStyle(.borderless)
-            .accessibilityLabel(String(localized: "Delete \(profile.name)"))
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
         }
-        .padding(.vertical, 4)
-        .contentShape(Rectangle())
-        .onTapGesture(count: 2) {
-            viewModel.prepareEditProfile(profile)
+        .padding(16)
+        .background(.bar)
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("Noch keine Regeln", systemImage: "point.3.connected.trianglepath.dotted")
+        } description: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Regeln erklären TypeWhisper, wann welche Sprache, Engine oder Ausgabeform gelten soll.")
+                Text("Beispiele: Slack -> Englisch mit Auto Enter, github.com -> Code-Prompt, Mail -> Deutsch mit Übersetzung.")
+            }
+            .frame(maxWidth: 420, alignment: .leading)
+        } actions: {
+            Button("Erste Regel erstellen") {
+                viewModel.prepareNewProfile()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 280)
+        .background {
+            groupedListSurface(cornerRadius: 16)
+        }
+    }
+
+    private var rulesList: some View {
+        let indexedProfiles = Array(viewModel.profiles.enumerated())
+
+        return LazyVStack(spacing: 0) {
+            ForEach(indexedProfiles, id: \.element.id) { index, profile in
+                RuleRow(profile: profile, viewModel: viewModel)
+
+                if index < indexedProfiles.count - 1 {
+                    Divider()
+                        .padding(.leading, 62)
+                }
+            }
+        }
+        .background {
+            groupedListSurface(cornerRadius: 14)
         }
     }
 }
 
-// MARK: - Editor Sheet
+private struct ActiveRuleBanner: View {
+    let ruleName: String
+    let reasonLabel: String?
+    let explanation: String?
 
-private struct ProfileEditorSheet: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Aktive Regel")
+                .font(.headline)
+
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(ruleName)
+                        .font(.title3.weight(.semibold))
+
+                    if let explanation, !explanation.isEmpty {
+                        Text(explanation)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                if let reasonLabel {
+                    Text(reasonLabel)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(.blue.opacity(0.14), in: Capsule())
+                }
+            }
+        }
+        .padding(16)
+        .background {
+            groupedListSurface(cornerRadius: 16)
+        }
+    }
+}
+
+private struct RuleRow: View {
+    let profile: Profile
+    @ObservedObject var viewModel: ProfilesViewModel
+    @State private var isDropTargeted = false
+    @State private var isHovered = false
+    @State private var isPressingReorderHandle = false
+    @State private var showingDeleteConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                reorderPill
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Text(profile.name)
+                            .font(.headline)
+
+                        if let hotkey = profile.hotkey {
+                            Text("Manuell: \(HotkeyService.displayName(for: hotkey))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Text(viewModel.ruleNarrative(for: profile))
+                        .font(.subheadline)
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: 8) {
+                        Text(viewModel.manualOverrideSummary(for: profile))
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 8) {
+                    Toggle("", isOn: Binding(
+                        get: { profile.isEnabled },
+                        set: { _ in viewModel.toggleProfile(profile) }
+                    ))
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+
+                    HStack(spacing: 6) {
+                        Button {
+                            viewModel.prepareEditProfile(profile)
+                        } label: {
+                            Image(systemName: "pencil")
+                        }
+                        .buttonStyle(.borderless)
+
+                        Button(role: .destructive) {
+                            showingDeleteConfirmation = true
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(rowHighlightColor)
+        }
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .onTapGesture(count: 2) {
+            viewModel.prepareEditProfile(profile)
+        }
+        .draggable(profile.id.uuidString)
+        .dropDestination(for: String.self) { droppedItems, _ in
+            guard let droppedId = droppedItems.first,
+                  let fromIndex = viewModel.profiles.firstIndex(where: { $0.id.uuidString == droppedId }),
+                  let toIndex = viewModel.profiles.firstIndex(where: { $0.id == profile.id }) else {
+                return false
+            }
+
+            viewModel.moveProfile(fromIndex: fromIndex, toIndex: toIndex)
+            return true
+        } isTargeted: { targeted in
+            isDropTargeted = targeted
+        }
+        .alert("Regel löschen?", isPresented: $showingDeleteConfirmation) {
+            Button("Löschen", role: .destructive) {
+                viewModel.deleteProfile(profile)
+            }
+            Button("Abbrechen", role: .cancel) {}
+        } message: {
+            Text("Möchtest du „\(profile.name)“ wirklich löschen?")
+        }
+    }
+
+    private var rowHighlightColor: Color {
+        if isDropTargeted {
+            return Color.accentColor.opacity(0.08)
+        }
+
+        if isHovered {
+            return Color.white.opacity(0.025)
+        }
+
+        return Color.clear
+    }
+
+    private var reorderPill: some View {
+        Image(systemName: "line.3.horizontal")
+            .font(.body.weight(.semibold))
+            .foregroundStyle(isDropTargeted ? Color.accentColor : Color.secondary.opacity(0.75))
+            .frame(width: 18, height: 28)
+            .padding(6)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isPressingReorderHandle ? Color.primary.opacity(0.08) : Color.clear)
+            }
+            .animation(.easeInOut(duration: 0.12), value: isPressingReorderHandle)
+            .onLongPressGesture(minimumDuration: 0, maximumDistance: .infinity) {} onPressingChanged: { isPressing in
+                isPressingReorderHandle = isPressing
+            }
+            .help("Reihenfolge per Drag & Drop ändern")
+    }
+}
+
+private struct RuleEditorSheet: View {
     @ObservedObject var viewModel: ProfilesViewModel
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text(viewModel.editingProfile == nil
-                     ? String(localized: "New Profile")
-                     : String(localized: "Edit Profile"))
-                    .font(.headline)
-                Spacer()
-            }
-            .padding()
+            header
 
             Divider()
 
-            Form {
-                Section(String(localized: "Name")) {
-                    TextField(String(localized: "Profile name"), text: $viewModel.editorName)
-                }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    RuleStepHeader(currentStep: viewModel.editorStep)
 
-                Section(String(localized: "Hotkey")) {
-                    HotkeyRecorderView(
-                        label: viewModel.editorHotkeyLabel,
-                        title: String(localized: "Profile shortcut"),
-                        onRecord: { hotkey in
-                            // Check profile-vs-profile conflict
-                            if let conflictId = ServiceContainer.shared.hotkeyService.isHotkeyAssignedToProfile(
-                                hotkey, excludingProfileId: viewModel.editingProfile?.id
-                            ) {
-                                // Auto-clear the other profile's hotkey
-                                if let conflictProfile = viewModel.profiles.first(where: { $0.id == conflictId }) {
-                                    conflictProfile.hotkey = nil
-                                }
-                            }
-                            viewModel.editorHotkey = hotkey
-                            viewModel.editorHotkeyLabel = HotkeyService.displayName(for: hotkey)
-                        },
-                        onClear: {
-                            viewModel.editorHotkey = nil
-                            viewModel.editorHotkeyLabel = ""
-                        }
-                    )
-
-                    // Warn if conflicts with global slot
-                    if let hotkey = viewModel.editorHotkey,
-                       let globalSlot = ServiceContainer.shared.hotkeyService.isHotkeyAssignedToGlobalSlot(hotkey) {
-                        Label(
-                            String(localized: "This hotkey is also assigned to the \(globalSlot.rawValue) slot."),
-                            systemImage: "exclamationmark.triangle"
-                        )
-                        .foregroundStyle(.orange)
-                        .font(.caption)
+                    switch viewModel.editorStep {
+                    case .scope:
+                        RuleScopeStep(viewModel: viewModel)
+                    case .behavior:
+                        RuleBehaviorStep(viewModel: viewModel)
+                    case .review:
+                        RuleReviewStep(viewModel: viewModel)
                     }
-
-                    Text(String(localized: "Assign a hotkey to always use this profile, regardless of the active app."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
+                .padding(24)
+            }
 
-                Section(String(localized: "Apps")) {
+            Divider()
+
+            footer
+        }
+        .frame(width: 700, height: 790)
+        .background(sheetBackground)
+        .sheet(isPresented: $viewModel.showingAppPicker) {
+            AppPickerSheet(viewModel: viewModel)
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 10) {
+                infoChip(viewModel.editingProfile == nil ? "Regel-Wizard" : "Regel anpassen", tint: .accentColor)
+
+                Text(viewModel.editingProfile == nil ? "Neue Regel" : "Regel bearbeiten")
+                    .font(.title2.weight(.semibold))
+
+                Text("Von Kontext zu Verhalten in drei klaren Schritten.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 10) {
+                infoChip("Schritt \(currentStepNumber) von \(totalSteps)", tint: .orange)
+
+                if viewModel.editorStep == .review {
+                    Toggle("Aktiv", isOn: $viewModel.editorIsEnabled)
+                        .toggleStyle(.switch)
+                }
+            }
+        }
+        .padding(24)
+    }
+
+    private var footer: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Schritt \(currentStepNumber) von \(totalSteps)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(stepGuidance)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+            }
+
+            Spacer()
+
+            Button("Abbrechen") {
+                dismiss()
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+
+            if viewModel.editorStep != .scope {
+                Button("Zurück") {
+                    viewModel.goToPreviousStep()
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if viewModel.editorStep == .review {
+                Button("Regel speichern") {
+                    viewModel.saveProfile()
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            } else {
+                Button("Weiter") {
+                    viewModel.goToNextStep()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!viewModel.canAdvanceFromCurrentStep)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+        .background(.bar)
+    }
+
+    private var currentStepNumber: Int { viewModel.editorStep.rawValue + 1 }
+
+    private var totalSteps: Int { RuleEditorStep.allCases.count }
+
+    private var stepGuidance: String {
+        switch viewModel.editorStep {
+        case .scope:
+            return viewModel.canAdvanceFromCurrentStep
+                ? "Kontext steht. Du kannst jetzt das Verhalten festlegen."
+                : "Wähle mindestens eine App oder Website, damit die Regel automatisch greifen kann."
+        case .behavior:
+            return "Lege fest, wie TypeWhisper in diesem Kontext reagieren soll."
+        case .review:
+            return "Prüfe Name, Matching und fortgeschrittene Optionen vor dem Speichern."
+        }
+    }
+
+    private var sheetBackground: some View {
+        ZStack(alignment: .top) {
+            Color(nsColor: .windowBackgroundColor)
+
+            Rectangle()
+                .fill(Color.accentColor.opacity(0.028))
+                .frame(height: 150)
+                .blur(radius: 30)
+                .offset(y: -18)
+        }
+    }
+}
+
+private struct RuleStepHeader: View {
+    let currentStep: RuleEditorStep
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ForEach(Array(RuleEditorStep.allCases.enumerated()), id: \.element.rawValue) { index, step in
+                stepItem(for: step)
+
+                if index < RuleEditorStep.allCases.count - 1 {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func stepItem(for step: RuleEditorStep) -> some View {
+        let isCurrent = step == currentStep
+        let isCompleted = step.rawValue < currentStep.rawValue
+        let isReachable = step.rawValue <= currentStep.rawValue
+
+        return HStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(stepCircleFill(isCurrent: isCurrent, isCompleted: isCompleted))
+                    .frame(width: 30, height: 30)
+
+                if isCompleted {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white)
+                } else {
+                    Text("\(step.rawValue + 1)")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(isCurrent ? .white : .primary)
+                }
+            }
+
+            Text(step.title)
+                .font(.subheadline.weight(isCurrent ? .semibold : .regular))
+                .foregroundStyle(isReachable ? .primary : .secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(isCurrent ? Color.accentColor.opacity(0.12) : Color.clear, in: Capsule())
+    }
+
+    private func stepCircleFill(isCurrent: Bool, isCompleted: Bool) -> some ShapeStyle {
+        if isCurrent {
+            return AnyShapeStyle(
+                LinearGradient(
+                    colors: [Color.accentColor, Color.accentColor.opacity(0.72)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+        }
+
+        if isCompleted {
+            return AnyShapeStyle(Color.accentColor.opacity(0.72))
+        }
+
+        return AnyShapeStyle(Color.primary.opacity(0.10))
+    }
+
+    private func stepBackground(isCurrent: Bool, isCompleted: Bool) -> some ShapeStyle {
+        if isCurrent {
+            return AnyShapeStyle(Color.accentColor.opacity(0.12))
+        }
+
+        if isCompleted {
+            return AnyShapeStyle(Color.accentColor.opacity(0.10))
+        }
+
+        return AnyShapeStyle(Color(nsColor: .controlBackgroundColor))
+    }
+}
+
+private struct RuleScopeStep: View {
+    @ObservedObject var viewModel: ProfilesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Wo gilt diese Regel?")
+                    .font(.title3.weight(.semibold))
+                Text("Wähle mindestens eine App oder Website. Beides zusammen ergibt die spezifischste Regel.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            card(
+                title: "Apps",
+                description: "Wähle die Apps, in denen diese Regel automatisch greifen darf.",
+                icon: "square.stack.3d.up.fill",
+                tint: .blue
+            ) {
+                VStack(alignment: .leading, spacing: 14) {
                     if viewModel.editorBundleIdentifiers.isEmpty {
-                        Text(String(localized: "No apps assigned"))
+                        Text("Keine Apps ausgewählt.")
                             .foregroundStyle(.secondary)
-                            .font(.caption)
                     } else {
                         ForEach(viewModel.editorBundleIdentifiers, id: \.self) { bundleId in
                             HStack {
@@ -182,6 +525,8 @@ private struct ProfileEditorSheet: View {
                                 } else {
                                     Text(bundleId)
                                         .font(.caption.monospaced())
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
                                 }
                                 Spacer()
                                 Button {
@@ -192,247 +537,707 @@ private struct ProfileEditorSheet: View {
                                 }
                                 .buttonStyle(.borderless)
                             }
+                            .padding(10)
+                            .background(Color.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
                     }
 
-                    Button(String(localized: "Choose Apps...")) {
+                    Button("Apps auswählen…") {
                         viewModel.appSearchQuery = ""
                         viewModel.showingAppPicker = true
                     }
                 }
+            }
 
-                Section(String(localized: "URL Patterns")) {
-                    if viewModel.editorUrlPatterns.isEmpty {
-                        Text(String(localized: "No URL patterns"))
+            websiteScopeSection
+        }
+    }
+
+    private var websiteToggleTitle: String {
+        if let appName = viewModel.editorRelevantBrowserName {
+            return "Website in \(appName) eingrenzen"
+        }
+
+        return "Optional: auf eine Website eingrenzen"
+    }
+
+    private var websiteToggleDescription: String {
+        if let detectedDomain = viewModel.editorDetectedDomain, viewModel.editorDetectedIsSupportedBrowser {
+            return "Aktuell erkannt: \(detectedDomain). Die Regel kann damit auf eine konkrete Seite oder Domain begrenzt werden."
+        }
+
+        if let appName = viewModel.editorRelevantBrowserName {
+            return "\(appName) ist als Browser gewählt. Ergänze hier optional eine Domain, wenn die Regel nicht für alle Seiten gelten soll."
+        }
+
+        return "Domains sind nur nötig, wenn die Regel nicht für die ganze App, sondern nur für bestimmte Seiten gelten soll."
+    }
+
+    private var websiteScopeSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    viewModel.showingWebsiteScope.toggle()
+                }
+            } label: {
+                HStack(spacing: 12) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.orange.opacity(0.14))
+                            .frame(width: 36, height: 36)
+
+                        Image(systemName: "globe")
+                            .foregroundStyle(.orange)
+                    }
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 8) {
+                            Text(websiteToggleTitle)
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+
+                            if !viewModel.editorUrlPatterns.isEmpty {
+                                infoChip("\(viewModel.editorUrlPatterns.count)", tint: .orange)
+                            }
+                        }
+
+                        Text(websiteToggleDescription)
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
-                            .font(.caption)
-                    } else {
-                        ForEach(viewModel.editorUrlPatterns, id: \.self) { pattern in
-                            HStack {
-                                Image(systemName: "globe")
-                                    .foregroundStyle(.secondary)
-                                Text(pattern)
-                                Spacer()
-                                Button {
-                                    viewModel.editorUrlPatterns.removeAll { $0 == pattern }
-                                } label: {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .foregroundStyle(.secondary)
-                                }
-                                .buttonStyle(.borderless)
-                            }
-                        }
+                            .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    HStack {
-                        TextField(String(localized: "e.g. github.com"), text: $viewModel.urlPatternInput)
-                            .textFieldStyle(.roundedBorder)
-                            .onSubmit {
-                                viewModel.addUrlPattern()
-                            }
-                            .onChange(of: viewModel.urlPatternInput) {
-                                viewModel.filterDomainSuggestions()
-                            }
+                    Spacer()
 
-                        Button(String(localized: "Add")) {
-                            viewModel.addUrlPattern()
-                        }
-                        .disabled(viewModel.urlPatternInput.trimmingCharacters(in: .whitespaces).isEmpty)
-                    }
-
-                    if !viewModel.domainSuggestions.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
-                            ForEach(viewModel.domainSuggestions, id: \.self) { domain in
-                                Button {
-                                    viewModel.selectDomainSuggestion(domain)
-                                } label: {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "globe")
-                                            .font(.caption)
-                                        Text(domain)
-                                            .font(.caption)
-                                    }
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.plain)
-                                .padding(.vertical, 2)
-                                .padding(.horizontal, 4)
-                            }
-                        }
-                        .padding(4)
-                        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
-                    }
-
-                    Text(String(localized: "Subdomains are included automatically. E.g. \"google.com\" also matches \"docs.google.com\"."))
-                        .font(.caption)
+                    Image(systemName: viewModel.showingWebsiteScope ? "chevron.up" : "chevron.down")
+                        .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.secondary)
                 }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
 
-                Section(String(localized: "Overrides")) {
-                    // Input language override
-                    Picker(String(localized: "Spoken language"), selection: $viewModel.editorInputLanguage) {
-                        Text(String(localized: "Global Setting")).tag(nil as String?)
-                        Divider()
-                        Text(String(localized: "Auto-detect")).tag("auto" as String?)
-                        Divider()
-                        ForEach(viewModel.settingsViewModel.availableLanguages, id: \.code) { lang in
-                            Text(lang.name).tag(lang.code as String?)
+            if viewModel.showingWebsiteScope {
+                websiteScopeContent
+            }
+        }
+        .padding(18)
+        .background {
+            elevatedPanel(cornerRadius: 20)
+        }
+    }
+
+    private var websiteScopeContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let detectedDomain = viewModel.editorDetectedDomain, viewModel.editorDetectedIsSupportedBrowser {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Aktuelle Website")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        Text(detectedDomain)
+                            .font(.headline)
+
+                        if let detectedURL = viewModel.editorDetectedURL {
+                            Text(detectedURL)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                                .lineLimit(2)
+                                .truncationMode(.middle)
                         }
                     }
 
-                    // Translation override
-                    #if canImport(Translation)
-                    if #available(macOS 15, *) {
-                        Picker(String(localized: "Translation"), selection: $viewModel.editorTranslationEnabled) {
-                            Text(String(localized: "Global Setting")).tag(nil as Bool?)
-                            Divider()
-                            Text(String(localized: "On")).tag(true as Bool?)
-                            Text(String(localized: "Off")).tag(false as Bool?)
+                    Spacer()
+
+                    if !viewModel.editorUrlPatterns.contains(detectedDomain) {
+                        Button("Domain übernehmen") {
+                            viewModel.addDetectedDomainToEditor()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                }
+                .padding(12)
+                .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                if viewModel.editorUrlPatterns.isEmpty {
+                    Text("Keine Websites ausgewählt.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.editorUrlPatterns, id: \.self) { pattern in
+                        HStack {
+                            Image(systemName: "globe")
+                                .foregroundStyle(.orange)
+                            Text(pattern)
+                            Spacer()
+                            Button {
+                                viewModel.editorUrlPatterns.removeAll { $0 == pattern }
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                        .padding(10)
+                        .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+                }
+
+                HStack {
+                    TextField("z. B. github.com", text: $viewModel.urlPatternInput)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit {
+                            viewModel.addUrlPattern()
+                        }
+                        .onChange(of: viewModel.urlPatternInput) {
+                            viewModel.filterDomainSuggestions()
                         }
 
-                        if viewModel.editorTranslationEnabled != false {
-                            Picker(String(localized: "Target language"), selection: $viewModel.editorTranslationTargetLanguage) {
-                                Text(String(localized: "Global Setting")).tag(nil as String?)
+                    Button("Hinzufügen") {
+                        viewModel.addUrlPattern()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.urlPatternInput.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+
+                if !viewModel.domainSuggestions.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(viewModel.domainSuggestions, id: \.self) { domain in
+                            Button {
+                                viewModel.selectDomainSuggestion(domain)
+                            } label: {
+                                HStack(spacing: 6) {
+                                    Image(systemName: "globe")
+                                        .font(.caption)
+                                    Text(domain)
+                                        .font(.caption)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .padding(10)
+                    .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+
+                Text("Subdomains werden automatisch mit eingeschlossen. `google.com` matcht also auch `docs.google.com`.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct RuleBehaviorStep: View {
+    @ObservedObject var viewModel: ProfilesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Wie soll TypeWhisper reagieren?")
+                    .font(.title3.weight(.semibold))
+                Text("Hier legst du Sprache, Prompt, Engine und Ausgabe für diesen Kontext fest. Priorität und manuelle Übersteuerung folgen erst im nächsten Schritt.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            card(
+                title: "Sprache & Umwandlung",
+                description: "Wie gesprochener Text verstanden und optional weiterverarbeitet wird.",
+                icon: "waveform.badge.mic",
+                tint: .accentColor
+            ) {
+                VStack(spacing: 0) {
+                    settingRow(
+                        title: "Gesprochene Sprache",
+                        description: "Welche Sprache TypeWhisper in diesem Kontext erwarten soll."
+                    ) {
+                        Picker("Gesprochene Sprache", selection: $viewModel.editorInputLanguage) {
+                            Text("Globale Einstellung").tag(nil as String?)
+                            Divider()
+                            Text("Automatisch erkennen").tag("auto" as String?)
+                            Divider()
+                            ForEach(viewModel.settingsViewModel.availableLanguages, id: \.code) { lang in
+                                Text(lang.name).tag(lang.code as String?)
+                            }
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+
+                    #if canImport(Translation)
+                    if #available(macOS 15, *) {
+                        Divider()
+
+                        settingRow(
+                            title: "Übersetzung",
+                            description: "Ob TypeWhisper den Text vor dem Einfügen automatisch übersetzen soll."
+                        ) {
+                            Picker("Übersetzung", selection: $viewModel.editorTranslationEnabled) {
+                                Text("Globale Einstellung").tag(nil as Bool?)
                                 Divider()
-                                ForEach(TranslationService.availableTargetLanguages, id: \.code) { lang in
-                                    Text(lang.name).tag(lang.code as String?)
+                                Text("Ein").tag(true as Bool?)
+                                Text("Aus").tag(false as Bool?)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+
+                        if viewModel.editorTranslationEnabled != false {
+                            Divider()
+
+                            settingRow(
+                                title: "Zielsprache",
+                                description: "Welche Sprache nach der Übersetzung ausgegeben werden soll."
+                            ) {
+                                Picker("Zielsprache", selection: $viewModel.editorTranslationTargetLanguage) {
+                                    Text("Globale Einstellung").tag(nil as String?)
+                                    Divider()
+                                    ForEach(TranslationService.availableTargetLanguages, id: \.code) { lang in
+                                        Text(lang.name).tag(lang.code as String?)
+                                    }
                                 }
                             }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
                         }
                     }
                     #endif
 
-                    // Engine override
-                    Picker(String(localized: "Transcription Engine"), selection: $viewModel.editorEngineOverride) {
-                        Text(String(localized: "Global Setting")).tag(nil as String?)
-                        Divider()
-                        ForEach(PluginManager.shared.transcriptionEngines, id: \.providerId) { engine in
-                            Text(engine.providerDisplayName).tag(engine.providerId as String?)
+                    Divider()
+
+                    settingRow(
+                        title: "Prompt",
+                        description: "Optionaler Nachbearbeitungsschritt für diese Regel."
+                    ) {
+                        Picker("Prompt", selection: $viewModel.editorPromptActionId) {
+                            Text("Keiner").tag(nil as String?)
+                            Divider()
+                            ForEach(PromptActionsViewModel.shared.promptActions.filter(\.isEnabled)) { action in
+                                Label(action.name, systemImage: action.icon).tag(action.id.uuidString as String?)
+                            }
                         }
                     }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                }
+            }
+
+            card(
+                title: "Engine & Modell",
+                description: "Welche Engine diesen Kontext bevorzugt behandeln soll.",
+                icon: "cpu",
+                tint: .accentColor
+            ) {
+                VStack(spacing: 0) {
+                    settingRow(
+                        title: "Transkriptions-Engine",
+                        description: "Welche Engine TypeWhisper hier bevorzugt verwenden soll."
+                    ) {
+                        Picker("Transkriptions-Engine", selection: $viewModel.editorEngineOverride) {
+                            Text("Globale Einstellung").tag(nil as String?)
+                            Divider()
+                            ForEach(PluginManager.shared.transcriptionEngines, id: \.providerId) { engine in
+                                Text(engine.providerDisplayName).tag(engine.providerId as String?)
+                            }
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
 
                     if let override = viewModel.editorEngineOverride,
                        let plugin = PluginManager.shared.transcriptionEngine(for: override) {
                         let models = plugin.transcriptionModels
                         if models.count > 1 {
-                            Picker(String(localized: "Model"), selection: $viewModel.editorCloudModelOverride) {
-                                Text(String(localized: "Default")).tag(nil as String?)
-                                Divider()
-                                ForEach(models, id: \.id) { model in
-                                    Text(model.displayName).tag(model.id as String?)
+                            Divider()
+
+                            settingRow(
+                                title: "Modell",
+                                description: "Optionales Modell innerhalb der gewählten Engine."
+                            ) {
+                                Picker("Modell", selection: $viewModel.editorCloudModelOverride) {
+                                    Text("Standard").tag(nil as String?)
+                                    Divider()
+                                    ForEach(models, id: \.id) { model in
+                                        Text(model.displayName).tag(model.id as String?)
+                                    }
                                 }
                             }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
                         }
                     }
-
-                    // Prompt action override
-                    Picker(String(localized: "Prompt"), selection: $viewModel.editorPromptActionId) {
-                        Text(String(localized: "None")).tag(nil as String?)
-                        Divider()
-                        ForEach(PromptActionsViewModel.shared.promptActions.filter(\.isEnabled)) { action in
-                            Label(action.name, systemImage: action.icon).tag(action.id.uuidString as String?)
-                        }
-                    }
-
-                    if let promptId = viewModel.editorPromptActionId,
-                       let action = PromptActionsViewModel.shared.promptActions.first(where: { $0.id.uuidString == promptId }),
-                       let providerType = action.providerType, !providerType.isEmpty {
-                        let providerName = PluginManager.shared.llmProvider(for: providerType)?.providerName ?? providerType
-                        let modelName = action.cloudModel ?? ""
-                        HStack(spacing: 4) {
-                            Text("LLM:")
-                                .foregroundStyle(.secondary)
-                            Text(providerName)
-                            if !modelName.isEmpty {
-                                Text("(\(modelName))")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .font(.caption)
-                    }
-
-                    Text(String(localized: "When a prompt is assigned, dictated text will be processed by the LLM before insertion. This replaces translation."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    Toggle(String(localized: "Inline Commands"), isOn: $viewModel.editorInlineCommandsEnabled)
-
-                    Text(String(localized: "Detect spoken instructions in your dictation (e.g., 'write this as an email') and apply them automatically via LLM."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    // Memory toggle
-                    Toggle(String(localized: "Memory"), isOn: $viewModel.editorMemoryEnabled)
-                    Text(String(localized: "When enabled, transcriptions from this profile are stored as memories and used as context for prompts."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    // Output format
-                    Picker(String(localized: "Output Format"), selection: $viewModel.editorOutputFormat) {
-                        Text(String(localized: "None")).tag(nil as String?)
-                        Divider()
-                        Text(String(localized: "Auto-detect")).tag("auto" as String?)
-                        Text(String(localized: "Markdown")).tag("markdown" as String?)
-                        Text(String(localized: "HTML")).tag("html" as String?)
-                        Text(String(localized: "Plain Text")).tag("plaintext" as String?)
-                        Text(String(localized: "Code")).tag("code" as String?)
-                    }
-                    Text(String(localized: "Format transcribed text for the target app. Auto-detect chooses the format based on the app's bundle ID. Requires app-aware formatting to be enabled in Recording settings."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    Toggle(String(localized: "Auto Enter"), isOn: $viewModel.editorAutoEnterEnabled)
-                    Text(String(localized: "Automatically press Enter after inserting text. In chat apps this sends the message, in editors it adds a new line."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Section(String(localized: "Priority")) {
-                    Stepper(value: $viewModel.editorPriority, in: 0...100) {
-                        HStack {
-                            Text(String(localized: "Priority"))
-                            Spacer()
-                            Text("\(viewModel.editorPriority)")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    Text(String(localized: "Higher priority profiles take precedence when multiple profiles match."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
             }
-            .formStyle(.grouped)
 
-            Divider()
+            card(
+                title: "Ausgabe",
+                description: "Wie das Ergebnis im Zielkontext eingefügt werden soll.",
+                icon: "text.badge.checkmark",
+                tint: .accentColor
+            ) {
+                VStack(spacing: 0) {
+                    settingRow(
+                        title: "Ausgabeformat",
+                        description: "In welchem Format das Ergebnis eingefügt werden soll."
+                    ) {
+                        Picker("Ausgabeformat", selection: $viewModel.editorOutputFormat) {
+                            Text("Keins").tag(nil as String?)
+                            Divider()
+                            Text("Automatisch erkennen").tag("auto" as String?)
+                            Text("Markdown").tag("markdown" as String?)
+                            Text("HTML").tag("html" as String?)
+                            Text("Plain Text").tag("plaintext" as String?)
+                            Text("Code").tag("code" as String?)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
 
-            // Footer buttons
-            HStack {
-                Button(String(localized: "Cancel")) {
-                    dismiss()
+                    Divider()
+
+                    settingRow(
+                        title: "Senden nach dem Einfügen",
+                        description: "Drückt nach dem Einfügen automatisch Enter, wenn der Zielkontext das erwartet."
+                    ) {
+                        Toggle("Enter automatisch drücken", isOn: $viewModel.editorAutoEnterEnabled)
+                    }
                 }
-                .keyboardShortcut(.cancelAction)
-
-                Spacer()
-
-                Button(String(localized: "Save")) {
-                    viewModel.saveProfile()
-                    dismiss()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(viewModel.editorName.trimmingCharacters(in: .whitespaces).isEmpty)
             }
-            .padding()
-        }
-        .frame(width: 480, height: 720)
-        .sheet(isPresented: $viewModel.showingAppPicker) {
-            AppPickerSheet(viewModel: viewModel)
         }
     }
 }
 
-// MARK: - App Picker Sheet
+private struct RuleReviewStep: View {
+    @ObservedObject var viewModel: ProfilesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Review & Erweitert")
+                    .font(.title3.weight(.semibold))
+                Text("Vergib zuerst einen Namen für die Regel. Danach siehst du die Vorschau, und alles Weitere ist optional.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            card(
+                title: "Name",
+                description: "Pflichtfeld für diese Regel.",
+                icon: "text.cursor",
+                tint: .accentColor
+            ) {
+                VStack(alignment: .leading, spacing: 14) {
+                    TextField(
+                        "Regelname",
+                        text: Binding(
+                            get: { viewModel.currentRuleName },
+                            set: { viewModel.updateRuleName($0) }
+                        )
+                    )
+                    .textFieldStyle(.roundedBorder)
+
+                    Toggle("Regel aktivieren", isOn: $viewModel.editorIsEnabled)
+                }
+            }
+
+            card(
+                title: "Vorschau",
+                description: "So liest sich die Regel vor dem Speichern.",
+                icon: "sparkles",
+                tint: .accentColor
+            ) {
+                RulePreviewCard(
+                    title: "Diese Regel macht Folgendes",
+                    name: viewModel.currentRuleName,
+                    narrative: viewModel.editorRuleNarrative
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        viewModel.showingAdvancedSettings.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Erweiterte Optionen")
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+
+                            Text("Manuelle Übersteuerung, Priorität, Memory und weitere Details.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer()
+
+                        Image(systemName: viewModel.showingAdvancedSettings ? "chevron.up" : "chevron.down")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                if viewModel.showingAdvancedSettings {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Divider()
+                            .padding(.top, 12)
+
+                        card(
+                            title: "Manuelle Übersteuerung",
+                            description: "Optional: erzwingt diese Regel unabhängig vom aktuellen Kontext.",
+                            icon: "command",
+                            tint: .accentColor
+                        ) {
+                            VStack(alignment: .leading, spacing: 12) {
+                                HotkeyRecorderView(
+                                    label: viewModel.editorHotkeyLabel,
+                                    title: "Manuelle Übersteuerung",
+                                    onRecord: { hotkey in
+                                        if let conflictId = ServiceContainer.shared.hotkeyService.isHotkeyAssignedToProfile(
+                                            hotkey,
+                                            excludingProfileId: viewModel.editingProfile?.id
+                                        ) {
+                                            if let conflictProfile = viewModel.profiles.first(where: { $0.id == conflictId }) {
+                                                conflictProfile.hotkey = nil
+                                            }
+                                        }
+                                        viewModel.editorHotkey = hotkey
+                                        viewModel.editorHotkeyLabel = HotkeyService.displayName(for: hotkey)
+                                    },
+                                    onClear: {
+                                        viewModel.editorHotkey = nil
+                                        viewModel.editorHotkeyLabel = ""
+                                    }
+                                )
+
+                                if let hotkey = viewModel.editorHotkey,
+                                   let globalSlot = ServiceContainer.shared.hotkeyService.isHotkeyAssignedToGlobalSlot(hotkey) {
+                                    Label(
+                                        "Dieser Hotkey ist auch dem Slot \(globalSlot.rawValue) zugewiesen.",
+                                        systemImage: "exclamationmark.triangle"
+                                    )
+                                    .foregroundStyle(.orange)
+                                    .font(.caption)
+                                }
+
+                                Text(viewModel.editorManualOverrideSummary)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        card(
+                            title: "Erweitertes Verhalten",
+                            description: "Nur für Power User. Diese Optionen ändern nicht das Matching, sondern das Verhalten nach dem Match.",
+                            icon: "gearshape.2.fill",
+                            tint: .teal
+                        ) {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Toggle("Inline Commands", isOn: $viewModel.editorInlineCommandsEnabled)
+                                Toggle("Memory", isOn: $viewModel.editorMemoryEnabled)
+
+                                HStack(spacing: 12) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Reihenfolge")
+                                        Text("Zwischen gleich spezifischen Regeln gewinnt die höher einsortierte Regel.")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+
+                                    Spacer()
+
+                                    Text("Per Drag & Drop")
+                                        .font(.caption.weight(.semibold))
+                                        .padding(.horizontal, 10)
+                                        .padding(.vertical, 6)
+                                        .background(Color.accentColor.opacity(0.14), in: Capsule())
+                                }
+
+                                Text("Die Reihenfolge änderst du in der Regeln-Liste über die Ziehen-Pille.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(18)
+            .background {
+                elevatedPanel(cornerRadius: 20)
+            }
+        }
+    }
+}
+
+private struct RulePreviewCard: View {
+    let title: String
+    let name: String
+    let narrative: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.14))
+                        .frame(width: 42, height: 42)
+
+                    Image(systemName: "sparkles")
+                        .foregroundStyle(Color.accentColor)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    Text(name)
+                        .font(.title3.weight(.semibold))
+                }
+
+                Spacer()
+            }
+
+            Text(narrative)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(18)
+        .background {
+            elevatedPanel(cornerRadius: 22)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(0.12), lineWidth: 1)
+        }
+    }
+}
+
+private func card<Content: View>(
+    title: String,
+    description: String,
+    icon: String = "square.stack.3d.up",
+    tint: Color = .accentColor,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(tint.opacity(0.14))
+                    .frame(width: 42, height: 42)
+
+                Image(systemName: icon)
+                    .foregroundStyle(tint)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        content()
+    }
+    .padding(18)
+    .background {
+        elevatedPanel(cornerRadius: 20)
+    }
+}
+
+private func infoChip(_ text: String, tint: Color) -> some View {
+    Text(text)
+        .font(.caption.weight(.semibold))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(tint.opacity(0.14), in: Capsule())
+}
+
+private func elevatedPanel(cornerRadius: CGFloat) -> some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color(nsColor: .controlBackgroundColor).opacity(0.98))
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.18), radius: 16, x: 0, y: 10)
+        .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
+}
+
+private func groupedListSurface(cornerRadius: CGFloat) -> some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color.white.opacity(0.022))
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.038), lineWidth: 1)
+        }
+}
+
+private func settingTile<Content: View>(
+    title: String,
+    icon: String,
+    tint: Color,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tint)
+
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+
+        content()
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(12)
+    .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    .overlay {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .strokeBorder(tint.opacity(0.12), lineWidth: 1)
+    }
+}
+
+private func settingRow<Content: View>(
+    title: String,
+    description: String,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    HStack(alignment: .top, spacing: 18) {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+
+            Text(description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        Spacer(minLength: 16)
+
+        content()
+            .frame(minWidth: 220, idealWidth: 240, maxWidth: 260, alignment: .leading)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.vertical, 12)
+}
 
 private struct AppPickerSheet: View {
     @ObservedObject var viewModel: ProfilesViewModel
@@ -441,7 +1246,7 @@ private struct AppPickerSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text(String(localized: "Choose Apps"))
+                Text("Apps auswählen")
                     .font(.headline)
                 Spacer()
             }
@@ -449,11 +1254,10 @@ private struct AppPickerSheet: View {
 
             Divider()
 
-            // Search
             HStack {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
-                TextField(String(localized: "Search apps..."), text: $viewModel.appSearchQuery)
+                TextField("Apps durchsuchen…", text: $viewModel.appSearchQuery)
                     .textFieldStyle(.plain)
                 if !viewModel.appSearchQuery.isEmpty {
                     Button {
@@ -494,7 +1298,7 @@ private struct AppPickerSheet: View {
 
             HStack {
                 Spacer()
-                Button(String(localized: "Done")) {
+                Button("Fertig") {
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingsView: View {
                             .tabItem { Label(String(localized: "Snippets"), systemImage: "text.badge.plus") }
                             .tag(SettingsTab.snippets)
                         ProfilesSettingsView()
-                            .tabItem { Label(String(localized: "Profiles"), systemImage: "person.crop.rectangle.stack") }
+                            .tabItem { Label("Regeln", systemImage: "point.3.connected.trianglepath.dotted") }
                             .tag(SettingsTab.profiles)
                         PromptActionsSettingsView()
                             .tabItem { Label(String(localized: "Prompts"), systemImage: "sparkles") }
@@ -144,7 +144,7 @@ private struct SettingsExtraTabs: TabContent {
         Tab(String(localized: "Snippets"), systemImage: "text.badge.plus", value: SettingsTab.snippets) {
             SnippetsSettingsView()
         }
-        Tab(String(localized: "Profiles"), systemImage: "person.crop.rectangle.stack", value: SettingsTab.profiles) {
+        Tab("Regeln", systemImage: "point.3.connected.trianglepath.dotted", value: SettingsTab.profiles) {
             ProfilesSettingsView()
         }
         Tab(String(localized: "Prompts"), systemImage: "sparkles", value: SettingsTab.prompts) {

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -174,7 +174,7 @@ struct IndicatorRecordingContent: View {
                 compact: true
             )
         case .profile:
-            if let name = viewModel.activeProfileName {
+            if let name = viewModel.activeRuleName {
                 Text(name)
                     .font(.system(size: sizing.profileFontSize, weight: .medium))
                     .foregroundStyle(.white)
@@ -183,7 +183,7 @@ struct IndicatorRecordingContent: View {
                     .padding(.horizontal, sizing.profilePaddingH)
                     .padding(.vertical, sizing.profilePaddingV)
                     .background(.white.opacity(0.2), in: Capsule())
-                    .accessibilityLabel(String(localized: "Active profile"))
+                    .accessibilityLabel("Active rule")
                     .accessibilityValue(name)
             } else {
                 Color.clear.frame(width: 0, height: 0)

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -252,8 +252,8 @@ func activate(host: HostServices) {
     let appName = host.activeAppName
     let bundleId = host.activeAppBundleId
 
-    // Profile names
-    let profiles = host.availableProfileNames
+    // Rule names
+    let rules = host.availableRuleNames
 
     // Host UI coordination
     host.notifyCapabilitiesChanged()

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -22,8 +22,8 @@ public protocol HostServices: Sendable {
     // Event bus
     var eventBus: EventBusProtocol { get }
 
-    // Available profile names
-    var availableProfileNames: [String] { get }
+    // Available rule names
+    var availableRuleNames: [String] { get }
 
     // Notify host that plugin capabilities changed (e.g. model loaded/unloaded)
     func notifyCapabilitiesChanged()
@@ -31,6 +31,11 @@ public protocol HostServices: Sendable {
     // Streaming display: call with true when the plugin provides its own streaming text UI,
     // so the built-in indicator suppresses its streaming text display.
     func setStreamingDisplayActive(_ active: Bool)
+}
+
+public extension HostServices {
+    @available(*, deprecated, renamed: "availableRuleNames")
+    var availableProfileNames: [String] { availableRuleNames }
 }
 
 // MARK: - HTTP Client (Ephemeral Sessions)

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperEvent.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperEvent.swift
@@ -55,8 +55,50 @@ public struct TranscriptionCompletedPayload: Sendable, Codable {
     public let appName: String?
     public let bundleIdentifier: String?
     public let url: String?
-    public let profileName: String?
+    public let ruleName: String?
 
+    enum CodingKeys: String, CodingKey {
+        case timestamp
+        case rawText
+        case finalText
+        case language
+        case engineUsed
+        case modelUsed
+        case durationSeconds
+        case appName
+        case bundleIdentifier
+        case url
+        case ruleName
+        case profileName
+    }
+
+    public init(
+        timestamp: Date = Date(),
+        rawText: String,
+        finalText: String,
+        language: String? = nil,
+        engineUsed: String,
+        modelUsed: String? = nil,
+        durationSeconds: Double,
+        appName: String? = nil,
+        bundleIdentifier: String? = nil,
+        url: String? = nil,
+        ruleName: String? = nil
+    ) {
+        self.timestamp = timestamp
+        self.rawText = rawText
+        self.finalText = finalText
+        self.language = language
+        self.engineUsed = engineUsed
+        self.modelUsed = modelUsed
+        self.durationSeconds = durationSeconds
+        self.appName = appName
+        self.bundleIdentifier = bundleIdentifier
+        self.url = url
+        self.ruleName = ruleName
+    }
+
+    @available(*, deprecated, renamed: "init(timestamp:rawText:finalText:language:engineUsed:modelUsed:durationSeconds:appName:bundleIdentifier:url:ruleName:)")
     public init(
         timestamp: Date = Date(),
         rawText: String,
@@ -70,17 +112,54 @@ public struct TranscriptionCompletedPayload: Sendable, Codable {
         url: String? = nil,
         profileName: String? = nil
     ) {
-        self.timestamp = timestamp
-        self.rawText = rawText
-        self.finalText = finalText
-        self.language = language
-        self.engineUsed = engineUsed
-        self.modelUsed = modelUsed
-        self.durationSeconds = durationSeconds
-        self.appName = appName
-        self.bundleIdentifier = bundleIdentifier
-        self.url = url
-        self.profileName = profileName
+        self.init(
+            timestamp: timestamp,
+            rawText: rawText,
+            finalText: finalText,
+            language: language,
+            engineUsed: engineUsed,
+            modelUsed: modelUsed,
+            durationSeconds: durationSeconds,
+            appName: appName,
+            bundleIdentifier: bundleIdentifier,
+            url: url,
+            ruleName: profileName
+        )
+    }
+
+    @available(*, deprecated, renamed: "ruleName")
+    public var profileName: String? { ruleName }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        rawText = try container.decode(String.self, forKey: .rawText)
+        finalText = try container.decode(String.self, forKey: .finalText)
+        language = try container.decodeIfPresent(String.self, forKey: .language)
+        engineUsed = try container.decode(String.self, forKey: .engineUsed)
+        modelUsed = try container.decodeIfPresent(String.self, forKey: .modelUsed)
+        durationSeconds = try container.decode(Double.self, forKey: .durationSeconds)
+        appName = try container.decodeIfPresent(String.self, forKey: .appName)
+        bundleIdentifier = try container.decodeIfPresent(String.self, forKey: .bundleIdentifier)
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+        ruleName = try container.decodeIfPresent(String.self, forKey: .ruleName)
+            ?? container.decodeIfPresent(String.self, forKey: .profileName)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(rawText, forKey: .rawText)
+        try container.encode(finalText, forKey: .finalText)
+        try container.encodeIfPresent(language, forKey: .language)
+        try container.encode(engineUsed, forKey: .engineUsed)
+        try container.encodeIfPresent(modelUsed, forKey: .modelUsed)
+        try container.encode(durationSeconds, forKey: .durationSeconds)
+        try container.encodeIfPresent(appName, forKey: .appName)
+        try container.encodeIfPresent(bundleIdentifier, forKey: .bundleIdentifier)
+        try container.encodeIfPresent(url, forKey: .url)
+        try container.encodeIfPresent(ruleName, forKey: .ruleName)
+        try container.encodeIfPresent(ruleName, forKey: .profileName)
     }
 }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -88,17 +88,25 @@ public struct PostProcessingContext: Sendable {
     public let bundleIdentifier: String?
     public let url: String?
     public let language: String?
-    public let profileName: String?
+    public let ruleName: String?
     public let selectedText: String?
 
-    public init(appName: String? = nil, bundleIdentifier: String? = nil, url: String? = nil, language: String? = nil, profileName: String? = nil, selectedText: String? = nil) {
+    public init(appName: String? = nil, bundleIdentifier: String? = nil, url: String? = nil, language: String? = nil, ruleName: String? = nil, selectedText: String? = nil) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
         self.url = url
         self.language = language
-        self.profileName = profileName
+        self.ruleName = ruleName
         self.selectedText = selectedText
     }
+
+    @available(*, deprecated, renamed: "init(appName:bundleIdentifier:url:language:ruleName:selectedText:)")
+    public init(appName: String? = nil, bundleIdentifier: String? = nil, url: String? = nil, language: String? = nil, profileName: String?, selectedText: String? = nil) {
+        self.init(appName: appName, bundleIdentifier: bundleIdentifier, url: url, language: language, ruleName: profileName, selectedText: selectedText)
+    }
+
+    @available(*, deprecated, renamed: "ruleName")
+    public var profileName: String? { ruleName }
 }
 
 public protocol PostProcessorPlugin: TypeWhisperPlugin {
@@ -281,15 +289,50 @@ public enum MemoryType: String, Codable, Sendable, CaseIterable {
 public struct MemorySource: Codable, Sendable {
     public let appName: String?
     public let bundleIdentifier: String?
-    public let profileName: String?
+    public let ruleName: String?
     public let timestamp: Date
 
+    enum CodingKeys: String, CodingKey {
+        case appName
+        case bundleIdentifier
+        case ruleName
+        case profileName
+        case timestamp
+    }
+
     public init(appName: String? = nil, bundleIdentifier: String? = nil,
-                profileName: String? = nil, timestamp: Date = Date()) {
+                ruleName: String? = nil, timestamp: Date = Date()) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
-        self.profileName = profileName
+        self.ruleName = ruleName
         self.timestamp = timestamp
+    }
+
+    @available(*, deprecated, renamed: "init(appName:bundleIdentifier:ruleName:timestamp:)")
+    public init(appName: String? = nil, bundleIdentifier: String? = nil,
+                profileName: String?, timestamp: Date = Date()) {
+        self.init(appName: appName, bundleIdentifier: bundleIdentifier, ruleName: profileName, timestamp: timestamp)
+    }
+
+    @available(*, deprecated, renamed: "ruleName")
+    public var profileName: String? { ruleName }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        appName = try container.decodeIfPresent(String.self, forKey: .appName)
+        bundleIdentifier = try container.decodeIfPresent(String.self, forKey: .bundleIdentifier)
+        ruleName = try container.decodeIfPresent(String.self, forKey: .ruleName)
+            ?? container.decodeIfPresent(String.self, forKey: .profileName)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(appName, forKey: .appName)
+        try container.encodeIfPresent(bundleIdentifier, forKey: .bundleIdentifier)
+        try container.encodeIfPresent(ruleName, forKey: .ruleName)
+        try container.encodeIfPresent(ruleName, forKey: .profileName)
+        try container.encode(timestamp, forKey: .timestamp)
     }
 }
 

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -32,11 +32,11 @@ private struct MockHostServices: HostServices {
     let activeAppBundleId: String? = "com.apple.Notes"
     let activeAppName: String? = "Notes"
     let eventBus: EventBusProtocol
-    let availableProfileNames: [String]
+    let availableRuleNames: [String]
 
-    init(eventBus: EventBusProtocol, availableProfileNames: [String]) {
+    init(eventBus: EventBusProtocol, availableRuleNames: [String]) {
         self.eventBus = eventBus
-        self.availableProfileNames = availableProfileNames
+        self.availableRuleNames = availableRuleNames
         self.pluginDataDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     }
 
@@ -91,21 +91,22 @@ private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin
 }
 
 final class ProtocolContractTests: XCTestCase {
-    func testHostServicesExposeProfilesSecretsAndDefaults() throws {
-        let host = MockHostServices(eventBus: MockEventBus(), availableProfileNames: ["Work", "Docs"])
+    func testHostServicesExposeRulesSecretsAndDefaults() throws {
+        let host = MockHostServices(eventBus: MockEventBus(), availableRuleNames: ["Work", "Docs"])
 
         try host.storeSecret(key: "apiKey", value: "secret")
         host.setUserDefault("value", forKey: "sample")
 
         XCTAssertEqual(host.loadSecret(key: "apiKey"), "secret")
         XCTAssertEqual(host.userDefault(forKey: "sample") as? String, "value")
+        XCTAssertEqual(host.availableRuleNames, ["Work", "Docs"])
         XCTAssertEqual(host.availableProfileNames, ["Work", "Docs"])
         XCTAssertEqual(host.activeAppName, "Notes")
     }
 
     func testTranscriptionPluginUsesDefaultStreamingFallback() async throws {
         let plugin = MockTranscriptionPlugin()
-        let host = MockHostServices(eventBus: MockEventBus(), availableProfileNames: ["Work"])
+        let host = MockHostServices(eventBus: MockEventBus(), availableRuleNames: ["Work"])
         plugin.activate(host: host)
 
         let result = try await plugin.transcribe(
@@ -120,7 +121,7 @@ final class ProtocolContractTests: XCTestCase {
         )
 
         XCTAssertEqual(result.text, "transcribed")
-        XCTAssertEqual(plugin.host?.availableProfileNames, ["Work"])
+        XCTAssertEqual(plugin.host?.availableRuleNames, ["Work"])
         XCTAssertNil(plugin.settingsView)
 
         plugin.deactivate()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -100,7 +100,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(notFoundResponse.status, 404)
     }
 
-    func testAPIHandlersExposeStatusHistoryAndProfiles() async throws {
+    func testAPIHandlersExposeStatusHistoryAndRules() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?
         defer {
@@ -135,13 +135,17 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let history = try Self.jsonObject(
             await router.route(HTTPRequest(method: "GET", path: "/v1/history", queryParams: [:], headers: [:], body: Data()))
         )
-        let profiles = try Self.jsonObject(
+        let rules = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "GET", path: "/v1/rules", queryParams: [:], headers: [:], body: Data()))
+        )
+        let legacyProfiles = try Self.jsonObject(
             await router.route(HTTPRequest(method: "GET", path: "/v1/profiles", queryParams: [:], headers: [:], body: Data()))
         )
 
         XCTAssertEqual(status["status"] as? String, "no_model")
         XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 1)
-        XCTAssertEqual((profiles["profiles"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
+        XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
+        XCTAssertEqual((legacyProfiles["profiles"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
     }
 
     @MainActor
@@ -293,7 +297,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
-        XCTAssertEqual(context.dictationViewModel.activeProfileName, "Docs")
+        XCTAssertEqual(context.dictationViewModel.activeRuleName, "Docs")
 
         await fulfillment(of: [selectedTextCaptured], timeout: 1.0)
     }

--- a/TypeWhisperTests/ProfileServiceTests.swift
+++ b/TypeWhisperTests/ProfileServiceTests.swift
@@ -40,4 +40,34 @@ final class ProfileServiceTests: XCTestCase {
         )
         XCTAssertEqual(fallbackMatch?.name, "URL Only")
     }
+
+    @MainActor
+    func testRuleMatchDetailsExplainPriorityWinsWithinSameTier() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = ProfileService(appSupportDirectory: appSupportDirectory)
+
+        service.addProfile(
+            name: "Docs Low",
+            urlPatterns: ["docs.github.com"],
+            priority: 1
+        )
+        service.addProfile(
+            name: "Docs High",
+            urlPatterns: ["docs.github.com"],
+            priority: 9
+        )
+
+        let match = service.matchRule(
+            bundleIdentifier: "com.apple.Safari",
+            url: "https://docs.github.com/en/get-started"
+        )
+
+        XCTAssertEqual(match?.profile.name, "Docs High")
+        XCTAssertEqual(match?.kind, .websiteOnly)
+        XCTAssertTrue(match?.wonByPriority == true)
+        XCTAssertEqual(match?.matchedDomain, "docs.github.com")
+        XCTAssertEqual(match?.competingProfileCount, 1)
+    }
 }


### PR DESCRIPTION
## Summary
- reframe profiles as rules across the app, HTTP API, plugin SDK, and docs while keeping compatibility aliases in place
- replace the old profile editor with a three-step guided rule wizard and simplify the rules overview/editing flow
- add clearer active-rule explainability, safer deletion, and drag-and-drop ordering for rule priority

## Why
The existing profile UI was hard to understand because context matching, behavior overrides, and advanced options were mixed together. This change makes the model easier to reason about as rules: when context X is detected, TypeWhisper uses behavior Y.

## User impact
- settings now use the term `Regel` instead of `Profil`
- creating or editing a rule is now a guided three-step flow
- rules can be reordered directly in the overview via drag and drop
- public consumers can move to `/v1/rules` and `rules` fields while legacy profile aliases continue to work for now

## Validation
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/5d09/typewhisper-mac`
- `xcodebuild test -project /Users/marco/.codex/worktrees/5d09/typewhisper-mac/TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/ProfileServiceTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -quiet`
- `swift test` in `TypeWhisperPluginSDK`