### PR TITLE
Fix usage chart tooltip word label

### DIFF
--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -211,7 +211,7 @@ struct HomeSettingsView: View {
                     .overlay(alignment: .topLeading) {
                         if let hoveredDate, let point = viewModel.chartData.first(where: { Calendar.current.isDate($0.date, inSameDayAs: hoveredDate) }), point.wordCount > 0 {
                             VStack(spacing: 2) {
-                                Text("\(point.wordCount)")
+                                Text("\(point.wordCount) \(String(localized: "words"))")
                                     .font(.caption.bold())
                                     .monospacedDigit()
                                 Text(point.date.formatted(.dateTime.month(.abbreviated).day()))


### PR DESCRIPTION
## Summary
- add the localized `words` label to the activity chart tooltip on the Home dashboard
- keep the change scoped to the existing hover tooltip text only
- preserve existing view model and localization structure

## Verification
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`

Closes #247