### PR TITLE
fix: harden audio recovery during Bluetooth route changes

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -35,6 +35,14 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return audioDeviceID(fromUID: uid)
     }
 
+    /// Used to avoid start-sound playback while macOS is still stabilizing a Bluetooth output route.
+    var isBluetoothOutputActive: Bool {
+        guard let deviceID = defaultOutputDeviceID() else { return false }
+        guard let transportType = transportType(for: deviceID) else { return false }
+        return transportType == kAudioDeviceTransportTypeBluetooth
+            || transportType == kAudioDeviceTransportTypeBluetoothLE
+    }
+
     private var listenerBlock: AudioObjectPropertyListenerBlock?
     private var previewEngine: AVAudioEngine?
     private var previewConfigChangeObserver: NSObjectProtocol?
@@ -43,8 +51,10 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private var disconnectVerificationTask: Task<Void, Never>?
     private let previewLock = NSLock()
     private let previewRecoveryQueue = DispatchQueue(label: "com.typewhisper.preview-recovery", qos: .userInitiated)
+    private let previewTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.preview-engine-teardown")
     private let previewRecoveryCoordinator = AudioEngineRecoveryCoordinator()
     private var activePreviewDeviceID: AudioDeviceID?
+    private static let previewTeardownRetentionInterval: TimeInterval = 0.3
 
     init() {
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -122,6 +132,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
         if let engine {
             teardownPreviewEngine(engine)
+            previewTeardownRetainer.retain(engine, for: Self.previewTeardownRetentionInterval)
         }
         isPreviewActive = false
         previewAudioLevel = 0
@@ -222,8 +233,25 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         preferredDeviceID: AudioDeviceID?,
         label: String
     ) throws {
+        let replacementEngine = AVAudioEngine()
+        let shouldReplace = previewLock.withLock { () -> Bool in
+            guard previewEngine === engine else { return false }
+            previewEngine = replacementEngine
+            activePreviewDeviceID = preferredDeviceID
+            return true
+        }
+        guard shouldReplace else { return }
+
+        installPreviewConfigurationObserver(for: replacementEngine)
         teardownPreviewEngine(engine)
-        try startPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: label)
+        previewTeardownRetainer.retain(engine, for: Self.previewTeardownRetentionInterval)
+
+        do {
+            try startPreviewEngineWithRecovery(replacementEngine, preferredDeviceID: preferredDeviceID, label: label)
+        } catch {
+            cleanupAfterFailedPreviewStart(replacementEngine)
+            throw error
+        }
     }
 
     private func configureAndStartPreviewEngine(
@@ -276,6 +304,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             }
         }
         teardownPreviewEngine(engine)
+        previewTeardownRetainer.retain(engine, for: Self.previewTeardownRetentionInterval)
         isPreviewActive = false
         previewAudioLevel = 0
         previewRawLevel = 0
@@ -376,6 +405,33 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     }
 
     private func isAggregateDevice(_ deviceID: AudioDeviceID) -> Bool {
+        guard let transportType = transportType(for: deviceID) else { return false }
+        return transportType == kAudioDeviceTransportTypeAggregate
+            || transportType == kAudioDeviceTransportTypeVirtual
+    }
+
+    private func defaultOutputDeviceID() -> AudioDeviceID? {
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0, nil,
+            &size,
+            &deviceID
+        )
+
+        guard status == noErr, deviceID != 0 else { return nil }
+        return deviceID
+    }
+
+    private func transportType(for deviceID: AudioDeviceID) -> UInt32? {
         var transportType: UInt32 = 0
         var size = UInt32(MemoryLayout<UInt32>.size)
         var address = AudioObjectPropertyAddress(
@@ -384,9 +440,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             mElement: kAudioObjectPropertyElementMain
         )
         let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transportType)
-        guard status == noErr else { return false }
-        return transportType == kAudioDeviceTransportTypeAggregate
-            || transportType == kAudioDeviceTransportTypeVirtual
+        guard status == noErr else { return nil }
+        return transportType
     }
 
     private func audioDeviceID(fromUID uid: String) -> AudioDeviceID? {
@@ -533,6 +588,26 @@ func setInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine, label: 
 
     deviceHelperLogger.info("[\(label)] Input device set and verified: \(deviceID)")
     return true
+}
+
+func currentInputDeviceID(on engine: AVAudioEngine) -> AudioDeviceID? {
+    guard let audioUnit = engine.inputNode.audioUnit else {
+        return nil
+    }
+
+    var deviceID = AudioDeviceID(0)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    let status = AudioUnitGetProperty(
+        audioUnit,
+        kAudioOutputUnitProperty_CurrentDevice,
+        kAudioUnitScope_Global,
+        0,
+        &deviceID,
+        &size
+    )
+
+    guard status == noErr, deviceID != 0 else { return nil }
+    return deviceID
 }
 
 private func audioStatusString(_ status: OSStatus) -> String {

--- a/TypeWhisper/Services/AudioEngineRecoverySupport.swift
+++ b/TypeWhisper/Services/AudioEngineRecoverySupport.swift
@@ -15,6 +15,8 @@ enum AudioEngineRecoveryPolicy {
     private static let retryableOSStatusCodes: Set<OSStatus> = [
         kAudioUnitErr_FormatNotSupported,
         kAudioUnitErr_InvalidElement,
+        // Seen during Bluetooth profile / route churn when CoreAudio asks us to retry.
+        35,
     ]
 
     static func isRetryable(error: Error) -> Bool {
@@ -33,6 +35,7 @@ enum AudioEngineRecoveryPolicy {
             || lowercasedDetail.contains("format mismatch")
             || lowercasedDetail.contains("error -10868")
             || lowercasedDetail.contains("error -10877")
+            || lowercasedDetail.contains("error 35")
     }
 
     static func extractOSStatus(from error: Error) -> OSStatus? {
@@ -44,6 +47,7 @@ enum AudioEngineRecoveryPolicy {
         let detail = nsError.localizedDescription
         if detail.contains("-10868") { return kAudioUnitErr_FormatNotSupported }
         if detail.contains("-10877") { return kAudioUnitErr_InvalidElement }
+        if detail.contains("error 35") { return 35 }
         return nil
     }
 }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -32,6 +32,12 @@ final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
 
 /// Captures microphone audio via AVAudioEngine and converts to 16kHz mono Float32 samples.
 final class AudioRecordingService: ObservableObject, @unchecked Sendable {
+    private struct InputConfigurationSnapshot {
+        let sampleRate: Double
+        let channelCount: AVAudioChannelCount
+        let deviceID: AudioDeviceID?
+    }
+
     enum StopPolicy {
         case immediate
         case finalizeShortSpeech(
@@ -94,6 +100,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private var _selectedDeviceID: AudioDeviceID?
+    private var startedInputConfiguration: InputConfigurationSnapshot?
 
     private var audioEngine: AVAudioEngine?
     private var configChangeObserver: NSObjectProtocol?
@@ -253,6 +260,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         setLastStopGraceCaptureApplied(graceApplied)
         recoveryCoordinator.transitionToIdle()
+        configLock.withLock {
+            startedInputConfiguration = nil
+        }
 
         removeConfigurationObserver()
         teardownEngine(engine)
@@ -295,6 +305,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         let engine: AVAudioEngine? = engineLock.withLock { audioEngine }
         guard isRecording, let engine else { return }
+
+        guard shouldRestartForConfigurationChange(using: engine) else {
+            logger.info("Audio engine configuration changed, but input configuration is unchanged. Skipping restart.")
+            return
+        }
 
         logger.warning("Audio engine configuration changed during recording, restarting engine")
 
@@ -350,8 +365,24 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func restartEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+        let replacementEngine = AVAudioEngine()
+        let shouldReplace = engineLock.withLock { () -> Bool in
+            guard audioEngine === engine else { return false }
+            audioEngine = replacementEngine
+            return true
+        }
+        guard shouldReplace else { return }
+
+        installConfigurationObserver(for: replacementEngine)
         teardownEngine(engine)
-        try startEngineWithRecovery(engine, label: label)
+        engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+
+        do {
+            try startEngineWithRecovery(replacementEngine, label: label)
+        } catch {
+            cleanupAfterFailedStart(replacementEngine)
+            throw error
+        }
     }
 
     private func configureAndStartEngine(_ engine: AVAudioEngine, label: String) throws {
@@ -392,6 +423,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engineStartTime = CFAbsoluteTimeGetCurrent()
         do {
             try engine.start()
+            recordStartedInputConfiguration(for: engine, inputFormat: inputFormat)
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
             logger.info("\(label, privacy: .public) audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
         } catch {
@@ -409,6 +441,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func cleanupAfterFailedStart(_ engine: AVAudioEngine) {
         recoveryCoordinator.transitionToIdle()
         removeConfigurationObserver()
+        configLock.withLock {
+            startedInputConfiguration = nil
+        }
         engineLock.withLock {
             if audioEngine === engine {
                 audioEngine = nil
@@ -502,5 +537,30 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let samples = sampleBuffer
         sampleBuffer.removeAll()
         return samples
+    }
+
+    private func recordStartedInputConfiguration(for engine: AVAudioEngine, inputFormat: AVAudioFormat) {
+        let actualDeviceID = currentInputDeviceID(on: engine) ?? selectedDeviceID
+        configLock.withLock {
+            startedInputConfiguration = InputConfigurationSnapshot(
+                sampleRate: inputFormat.sampleRate,
+                channelCount: inputFormat.channelCount,
+                deviceID: actualDeviceID
+            )
+        }
+    }
+
+    private func shouldRestartForConfigurationChange(using engine: AVAudioEngine) -> Bool {
+        let snapshot = configLock.withLock { startedInputConfiguration }
+        guard let snapshot else { return true }
+
+        let currentFormat = engine.inputNode.outputFormat(forBus: 0)
+        let currentDeviceID = currentInputDeviceID(on: engine) ?? selectedDeviceID
+
+        let sameSampleRate = currentFormat.sampleRate == snapshot.sampleRate
+        let sameChannelCount = currentFormat.channelCount == snapshot.channelCount
+        let sameDeviceID = currentDeviceID == snapshot.deviceID
+
+        return !(sameSampleRate && sameChannelCount && sameDeviceID)
     }
 }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -115,6 +115,7 @@ final class DictationViewModel: ObservableObject {
     private let errorLogService: ErrorLogService
     private let mediaPlaybackService: MediaPlaybackService
     private let postProcessingPipeline: PostProcessingPipeline
+    private var previewWasActiveBeforeRecording = false
     private var matchedProfile: Profile?
     private var forcedProfileId: UUID?
     private var capturedActiveApp: (name: String?, bundleId: String?, url: String?)?
@@ -439,9 +440,14 @@ final class DictationViewModel: ObservableObject {
         let immediateContextMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
 
         do {
-            // Play start sound BEFORE engine setup - AVAudioEngine reconfigures
-            // audio hardware (aggregate device) which disrupts NSSound playback.
-            soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
+            previewWasActiveBeforeRecording = audioDeviceService.isPreviewActive
+            if previewWasActiveBeforeRecording {
+                audioDeviceService.stopPreview()
+            }
+
+            if soundFeedbackEnabled && !audioDeviceService.isBluetoothOutputActive {
+                soundService.play(.recordingStarted, enabled: true)
+            }
             audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
             try audioRecordingService.startRecording()
             if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
@@ -478,6 +484,7 @@ final class DictationViewModel: ObservableObject {
                 "Recording started: immediateContextMs=\(String(format: "%.1f", immediateContextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
             )
         } catch {
+            restorePreviewIfNeeded()
             metadataCaptureTask?.cancel()
             metadataCaptureTask = nil
             urlResolutionTask?.cancel()
@@ -846,6 +853,7 @@ final class DictationViewModel: ObservableObject {
     func registerInitialProfileHotkeys() { settingsHandler.registerInitialProfileHotkeys() }
 
     private func resetDictationState() {
+        restorePreviewIfNeeded()
         errorResetTask?.cancel()
         insertingResetTask?.cancel()
         insertingResetTask = nil
@@ -868,6 +876,12 @@ final class DictationViewModel: ObservableObject {
         actionFeedbackIcon = nil
         actionFeedbackIsError = false
         actionDisplayDuration = 3.5
+    }
+
+    private func restorePreviewIfNeeded() {
+        guard previewWasActiveBeforeRecording else { return }
+        previewWasActiveBeforeRecording = false
+        audioDeviceService.startPreview()
     }
 
     // MARK: - Shared Helpers

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -6,16 +6,19 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
     func testRetryableErrorClassification_matchesKnownAudioUnitCodes() {
         let formatError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_FormatNotSupported))
         let invalidElementError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_InvalidElement))
+        let temporarilyUnavailableError = NSError(domain: NSOSStatusErrorDomain, code: 35)
         let permissionError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_Unauthorized))
 
         XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: formatError))
         XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: invalidElementError))
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: temporarilyUnavailableError))
         XCTAssertFalse(AudioEngineRecoveryPolicy.isRetryable(error: permissionError))
     }
 
     func testRetryableErrorClassification_matchesKnownLogMessages() {
         XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "Failed to create tap, config change pending!", osStatus: nil))
         XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "Format mismatch: input hw 24000 Hz, client format 48000 Hz", osStatus: nil))
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "StartIO failed with error 35", osStatus: nil))
         XCTAssertFalse(AudioEngineRecoveryPolicy.isRetryable(detail: "Microphone permission denied", osStatus: nil))
     }
 


### PR DESCRIPTION
## Summary
- replace stale `AVAudioEngine` instances during recovery instead of restarting torn-down engines in place
- suppress recording restarts when the input sample rate, channel count, and device id are unchanged across config-change notifications
- treat CoreAudio `error 35` as retryable and restore preview cleanly around recording start/stop, including Bluetooth output cases

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests`