### PR TITLE
fix: improve text insertion for remote sessions and terminals

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -12,6 +12,7 @@ enum UserDefaultsKeys {
     static let soundError = "soundError"
     static let indicatorStyle = "indicatorStyle"
     static let indicatorTranscriptPreviewEnabled = "indicatorTranscriptPreviewEnabled"
+    static let copyFinalTextToClipboard = "copyFinalTextToClipboard"
     static let preserveClipboard = "preserveClipboard"
     static let mediaPauseEnabled = "mediaPauseEnabled"
 

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -10,16 +10,28 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhis
 /// Inserts transcribed text into the active application via clipboard + simulated Cmd+V.
 @MainActor
 final class TextInsertionService {
+    private let syntheticPastePreferredBundleIdentifiers: Set<String> = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "com.github.wez.wezterm",
+        "dev.warp.Warp-Stable",
+        "dev.warp.WarpPreview",
+        "com.mitchellh.ghostty"
+    ]
+
     var accessibilityGrantedOverride: Bool?
+    var remoteSessionOverride: Bool?
     var pasteboardProvider: () -> NSPasteboard = { .general }
     var focusedTextFieldOverride: (() -> Bool)?
     var pasteSimulatorOverride: (() -> Void)?
     var returnSimulatorOverride: (() -> Void)?
     var captureActiveAppOverride: (() -> (name: String?, bundleId: String?, url: String?))?
     var selectedTextOverride: (() -> String?)?
+    var directInsertOverride: ((String) -> Bool)?
 
-enum InsertionResult {
+    enum InsertionResult {
         case pasted
+        case copiedOnly
     }
 
     enum TextInsertionError: LocalizedError {
@@ -38,6 +50,25 @@ enum InsertionResult {
 
     var isAccessibilityGranted: Bool {
         accessibilityGrantedOverride ?? AXIsProcessTrusted()
+    }
+
+    func isRemoteSession() -> Bool {
+        if let remoteSessionOverride {
+            return remoteSessionOverride
+        }
+
+        if let sessionDictionary = CGSessionCopyCurrentDictionary() as? [String: Any] {
+            let onConsole = (sessionDictionary["kCGSSessionOnConsoleKey"] as? Int ?? 1) != 0
+            if !onConsole {
+                return true
+            }
+        }
+
+        return NSScreen.screens.contains { screen in
+            let name = screen.localizedName.lowercased()
+            return name.contains("screen sharing")
+                || (name.contains("virtual display") && name.contains("sharing"))
+        }
     }
 
     func requestAccessibilityPermission() {
@@ -345,6 +376,7 @@ enum InsertionResult {
 
     func insertText(
         _ text: String,
+        copyToClipboard: Bool = false,
         preserveClipboard: Bool = false,
         autoEnter: Bool = false
     ) async throws -> InsertionResult {
@@ -355,24 +387,61 @@ enum InsertionResult {
         let hadFocusedTextField = autoEnter && hasFocusedTextField()
         let pasteboard = pasteboardProvider()
         let savedItems = preserveClipboard ? saveClipboard(from: pasteboard) : []
+        let remoteSession = isRemoteSession()
+        let preferSyntheticPaste = !remoteSession && shouldPreferSyntheticPasteForFrontmostApp()
+        let insertionResult: InsertionResult
 
-        // Set transcribed text on clipboard and simulate Cmd+V.
-        // Text stays on clipboard as fallback if no text field is focused.
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-        simulatePaste()
+        if copyToClipboard {
+            copyTextToClipboard(text, to: pasteboard)
+        }
 
-        if preserveClipboard {
+        if !preferSyntheticPaste && insertTextDirectly(text) {
+            insertionResult = .pasted
+        } else if remoteSession {
+            if !copyToClipboard {
+                copyTextToClipboard(text, to: pasteboard)
+            }
+            insertionResult = .copiedOnly
+        } else {
+            // Set transcribed text on clipboard and simulate Cmd+V.
+            // Text stays on clipboard as fallback if no text field is focused.
+            if !copyToClipboard {
+                copyTextToClipboard(text, to: pasteboard)
+            }
+            simulatePaste()
+            insertionResult = .pasted
+        }
+
+        if preserveClipboard && insertionResult == .pasted && !copyToClipboard {
             try? await Task.sleep(for: .milliseconds(200))
             restoreClipboard(savedItems, to: pasteboard)
         }
 
-        if hadFocusedTextField {
+        if hadFocusedTextField && insertionResult == .pasted && !remoteSession {
             try? await Task.sleep(for: .milliseconds(50))
             simulateReturn()
         }
 
-        return .pasted
+        return insertionResult
+    }
+
+    func copyTextToClipboard(_ text: String, to pasteboard: NSPasteboard = .general) {
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    private func insertTextDirectly(_ text: String) -> Bool {
+        if let directInsertOverride {
+            return directInsertOverride(text)
+        }
+
+        guard let element = getFocusedTextElement() else { return false }
+        return insertTextAt(element: element, text: text)
+    }
+
+    private func shouldPreferSyntheticPasteForFrontmostApp() -> Bool {
+        guard let bundleId = captureActiveApp().bundleId else { return false }
+        return syntheticPastePreferredBundleIdentifiers.contains(bundleId)
     }
 
     func focusedElementPosition() -> CGPoint? {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -50,6 +50,9 @@ final class DictationViewModel: ObservableObject {
     @Published var preserveClipboard: Bool {
         didSet { UserDefaults.standard.set(preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard) }
     }
+    @Published var copyFinalTextToClipboard: Bool {
+        didSet { UserDefaults.standard.set(copyFinalTextToClipboard, forKey: UserDefaultsKeys.copyFinalTextToClipboard) }
+    }
     @Published var mediaPauseEnabled: Bool {
         didSet { UserDefaults.standard.set(mediaPauseEnabled, forKey: UserDefaultsKeys.mediaPauseEnabled) }
     }
@@ -202,6 +205,7 @@ final class DictationViewModel: ObservableObject {
         self.audioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2
         self.soundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true
         self.indicatorTranscriptPreviewEnabled = Self.loadIndicatorTranscriptPreviewEnabled()
+        self.copyFinalTextToClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.copyFinalTextToClipboard)
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
         self.spokenFeedbackEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
@@ -750,16 +754,24 @@ final class DictationViewModel: ObservableObject {
                         activeApp: activeApp, language: language, originalText: result.text
                     )
                 } else {
-                    _ = try await textInsertionService.insertText(
+                    let insertionResult = try await textInsertionService.insertText(
                         text,
+                        copyToClipboard: copyFinalTextToClipboard,
                         preserveClipboard: preserveClipboard,
                         autoEnter: self.matchedProfile?.autoEnterEnabled == true
                     )
-                    EventBus.shared.emit(.textInserted(TextInsertedPayload(
-                        text: text,
-                        appName: activeApp.name,
-                        bundleIdentifier: activeApp.bundleId
-                    )))
+                    if insertionResult == .pasted {
+                        EventBus.shared.emit(.textInserted(TextInsertedPayload(
+                            text: text,
+                            appName: activeApp.name,
+                            bundleIdentifier: activeApp.bundleId
+                        )))
+                    } else {
+                        actionFeedbackMessage = String(localized: "Copied to clipboard")
+                        actionFeedbackIcon = "doc.on.clipboard.fill"
+                        actionFeedbackIsError = false
+                        actionDisplayDuration = 2.5
+                    }
                 }
 
                 let modelDisplayName = modelManager.resolvedModelDisplayName(

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -314,6 +314,12 @@ struct RecordingSettingsView: View {
             }
 
             Section(String(localized: "Clipboard")) {
+                Toggle(String(localized: "Copy final transcription to clipboard"), isOn: $dictation.copyFinalTextToClipboard)
+
+                Text(String(localized: "Always puts the final transcription on your clipboard before any insertion attempt. Useful for remote sessions like Screen Sharing. Overrides clipboard preservation for the new transcription."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 Toggle(String(localized: "Preserve clipboard content"), isOn: $dictation.preserveClipboard)
 
                 Text(String(localized: "Restores your clipboard after text insertion. Without this, your clipboard contains the transcribed text after dictation."))

--- a/TypeWhisperTests/TextInsertionServiceTests.swift
+++ b/TypeWhisperTests/TextInsertionServiceTests.swift
@@ -1,0 +1,141 @@
+import AppKit
+import XCTest
+@testable import TypeWhisper
+
+final class TextInsertionServiceTests: XCTestCase {
+    @MainActor
+    func testRemoteSessionUsesDirectInsertAndSkipsSyntheticPaste() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        service.accessibilityGrantedOverride = true
+        service.remoteSessionOverride = true
+        service.pasteboardProvider = { pasteboard }
+
+        var pasted = false
+        service.pasteSimulatorOverride = { pasted = true }
+        service.directInsertOverride = { text in
+            XCTAssertEqual(text, "Hello remote")
+            return true
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("old", forType: .string)
+
+        let result = try await service.insertText("Hello remote", preserveClipboard: true)
+
+        XCTAssertEqual(result, .pasted)
+        XCTAssertFalse(pasted)
+        XCTAssertEqual(pasteboard.string(forType: .string), "old")
+    }
+
+    @MainActor
+    func testRemoteSessionFallsBackToClipboardOnly() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        service.accessibilityGrantedOverride = true
+        service.remoteSessionOverride = true
+        service.pasteboardProvider = { pasteboard }
+
+        var pasted = false
+        service.pasteSimulatorOverride = { pasted = true }
+        service.directInsertOverride = { _ in false }
+
+        let result = try await service.insertText("Clipboard fallback", preserveClipboard: true)
+
+        XCTAssertEqual(result, .copiedOnly)
+        XCTAssertFalse(pasted)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Clipboard fallback")
+    }
+
+    @MainActor
+    func testLocalSessionKeepsClipboardPastePath() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        service.accessibilityGrantedOverride = true
+        service.remoteSessionOverride = false
+        service.pasteboardProvider = { pasteboard }
+
+        var pasted = false
+        service.pasteSimulatorOverride = { pasted = true }
+        service.directInsertOverride = { _ in false }
+
+        let result = try await service.insertText("Local paste")
+
+        XCTAssertEqual(result, .pasted)
+        XCTAssertTrue(pasted)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Local paste")
+    }
+
+    @MainActor
+    func testLocalSessionPrefersDirectInsertWhenAvailable() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        service.accessibilityGrantedOverride = true
+        service.remoteSessionOverride = false
+        service.pasteboardProvider = { pasteboard }
+
+        var pasted = false
+        service.pasteSimulatorOverride = { pasted = true }
+        service.directInsertOverride = { text in
+            XCTAssertEqual(text, "AX first")
+            return true
+        }
+
+        let result = try await service.insertText("AX first")
+
+        XCTAssertEqual(result, .pasted)
+        XCTAssertFalse(pasted)
+        XCTAssertNil(pasteboard.string(forType: .string))
+    }
+
+    @MainActor
+    func testTerminalAppsPreferSyntheticPasteOverDirectInsert() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        service.accessibilityGrantedOverride = true
+        service.remoteSessionOverride = false
+        service.pasteboardProvider = { pasteboard }
+        service.captureActiveAppOverride = { ("iTerm2", "com.googlecode.iterm2", nil) }
+
+        var pasted = false
+        service.pasteSimulatorOverride = { pasted = true }
+        service.directInsertOverride = { _ in
+            XCTFail("Direct insert should be skipped for terminal apps")
+            return false
+        }
+
+        let result = try await service.insertText("echo hello")
+
+        XCTAssertEqual(result, .pasted)
+        XCTAssertTrue(pasted)
+        XCTAssertEqual(pasteboard.string(forType: .string), "echo hello")
+    }
+
+    @MainActor
+    func testCopyToClipboardPersistsWhenDirectInsertSucceeds() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+
+        service.accessibilityGrantedOverride = true
+        service.remoteSessionOverride = false
+        service.pasteboardProvider = { pasteboard }
+        service.directInsertOverride = { _ in true }
+
+        pasteboard.clearContents()
+        pasteboard.setString("old", forType: .string)
+
+        let result = try await service.insertText(
+            "Clipboard first",
+            copyToClipboard: true,
+            preserveClipboard: true
+        )
+
+        XCTAssertEqual(result, .pasted)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Clipboard first")
+    }
+}


### PR DESCRIPTION
## Summary
- add a clipboard option for always copying the final transcription and only emit `textInserted` when insertion actually pastes
- prefer direct Accessibility insertion locally, fall back to clipboard-only behavior in remote sessions, and force synthetic paste for terminal apps where AX insertion is unreliable
- surface clipboard-only fallback in the UI and add focused unit coverage for the local, remote, and terminal insertion paths

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/TextInsertionServiceTests`