### PR TITLE
fix: suppress modifier hotkeys during Universal Control transfer

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -4,6 +4,19 @@ import Carbon.HIToolbox
 import Combine
 import os
 
+private typealias NotifyHandler = @convention(block) (Int32) -> Void
+
+@_silgen_name("notify_register_dispatch")
+private func notify_register_dispatch(
+    _ name: UnsafePointer<CChar>,
+    _ outToken: UnsafeMutablePointer<Int32>,
+    _ queue: DispatchQueue,
+    _ handler: @escaping NotifyHandler
+) -> UInt32
+
+@_silgen_name("notify_cancel")
+private func notify_cancel(_ token: Int32) -> UInt32
+
 struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
     let keyCode: UInt16
     let modifierFlags: UInt
@@ -167,8 +180,20 @@ final class HotkeyService: ObservableObject {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var recentEventTapDispatches: [HotkeyDispatchKey: Date] = [:]
+    private var keyboardIsLocal = true
+    private var universalControlTransferSourceToken: Int32 = -1
+    private var universalControlTransferDestinationToken: Int32 = -1
 
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "HotkeyService")
+
+    deinit {
+        if universalControlTransferSourceToken >= 0 {
+            _ = notify_cancel(universalControlTransferSourceToken)
+        }
+        if universalControlTransferDestinationToken >= 0 {
+            _ = notify_cancel(universalControlTransferDestinationToken)
+        }
+    }
 
     // Modifier keyCodes that generate flagsChanged instead of keyDown/keyUp
     nonisolated static let modifierKeyCodes: Set<UInt16> = [
@@ -184,6 +209,7 @@ final class HotkeyService: ObservableObject {
 
     func setup() {
         loadHotkeys()
+        setupUniversalControlObservers()
         setupMonitor()
     }
 
@@ -338,6 +364,39 @@ final class HotkeyService: ObservableObject {
             runLoopSource = nil
         }
         recentEventTapDispatches.removeAll()
+
+    }
+
+    private func tearDownUniversalControlObservers() {
+        if universalControlTransferSourceToken >= 0 {
+            _ = notify_cancel(universalControlTransferSourceToken)
+            universalControlTransferSourceToken = -1
+        }
+        if universalControlTransferDestinationToken >= 0 {
+            _ = notify_cancel(universalControlTransferDestinationToken)
+            universalControlTransferDestinationToken = -1
+        }
+    }
+
+    private func setupUniversalControlObservers() {
+        guard universalControlTransferSourceToken < 0, universalControlTransferDestinationToken < 0 else {
+            return
+        }
+
+        // Modifier-only hotkeys use flagsChanged events. Under Universal Control those
+        // still reach the source Mac even after keyboard focus moved to another Mac.
+        // These notifications let us suppress modifier-only hotkeys on the source Mac.
+        "com.apple.universalcontrol.transfer-source".withCString { name in
+            _ = notify_register_dispatch(name, &universalControlTransferSourceToken, .main) { [weak self] _ in
+                self?.keyboardIsLocal = false
+            }
+        }
+
+        "com.apple.universalcontrol.transfer-destination".withCString { name in
+            _ = notify_register_dispatch(name, &universalControlTransferDestinationToken, .main) { [weak self] _ in
+                self?.keyboardIsLocal = true
+            }
+        }
     }
 
     func suspendMonitoring() {
@@ -436,6 +495,7 @@ final class HotkeyService: ObservableObject {
         // Global slots
         for slotType in HotkeySlotType.allCases {
             guard var state = slots[slotType], let hotkey = state.hotkey else { continue }
+            if shouldIgnoreNonLocalModifierHotkey(hotkey) { continue }
             let (keyDown, keyUp, isMatch) = processKeyEvent(event, hotkey: hotkey, state: &state)
             slots[slotType] = state
             if isMatch { shouldSuppress = true }
@@ -451,6 +511,7 @@ final class HotkeyService: ObservableObject {
         // Profile slots
         for profileId in Array(profileSlots.keys) {
             guard var pState = profileSlots[profileId] else { continue }
+            if shouldIgnoreNonLocalModifierHotkey(pState.hotkey) { continue }
             var state = SlotState(hotkey: pState.hotkey, fnWasDown: pState.fnWasDown,
                                   fnComboKeyPressed: pState.fnComboKeyPressed,
                                   modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown,
@@ -476,6 +537,17 @@ final class HotkeyService: ObservableObject {
         }
 
         return shouldSuppress
+    }
+
+    private func shouldIgnoreNonLocalModifierHotkey(_ hotkey: UnifiedHotkey) -> Bool {
+        guard !keyboardIsLocal else { return false }
+
+        switch hotkey.kind {
+        case .modifierOnly, .modifierCombo, .fn:
+            return true
+        case .keyWithModifiers, .bareKey, .mouseButton:
+            return false
+        }
     }
 
     private func dispatchGlobalMatch(
@@ -572,6 +644,10 @@ final class HotkeyService: ObservableObject {
 #if DEBUG
     func setHotkeyForTesting(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
         slots[slotType] = SlotState(hotkey: hotkey)
+    }
+
+    func setKeyboardLocalForTesting(_ isLocal: Bool) {
+        keyboardIsLocal = isLocal
     }
 
     @discardableResult

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -680,6 +680,42 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
 final class HotkeyServiceCompatibilityTests: XCTestCase {
     @MainActor
+    func testModifierOnlyHotkeyIsIgnoredWhenKeyboardIsRemote() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(optionHotkey(), for: .toggle)
+        service.setKeyboardLocalForTesting(false)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let optionDown = try makeModifierEvent(keyCode: 0x3A, modifierFlags: [.option])
+        XCTAssertFalse(service.processEventForTesting(optionDown, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testKeyWithModifiersStillWorksWhenKeyboardIsRemote() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
+        service.setKeyboardLocalForTesting(false)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
     func testMonitorFallbackStartsToggleHotkey() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -751,6 +787,10 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
     }
 
+    private func optionHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(keyCode: 0x3A, modifierFlags: 0, isFn: false)
+    }
+
     private func makeKeyboardEvent(keyCode: UInt16, keyDown: Bool) throws -> NSEvent {
         let flags: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
         let event = try XCTUnwrap(
@@ -758,5 +798,22 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
         event.flags = flags
         return try XCTUnwrap(NSEvent(cgEvent: event))
+    }
+
+    private func makeModifierEvent(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) throws -> NSEvent {
+        try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .flagsChanged,
+                location: .zero,
+                modifierFlags: modifierFlags,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "",
+                charactersIgnoringModifiers: "",
+                isARepeat: false,
+                keyCode: keyCode
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary
- track Universal Control keyboard transfer notifications so modifier-only hotkeys are ignored while the keyboard focus is remote
- keep normal key-with-modifier hotkeys working and preserve the observer lifecycle across monitor rebuilds
- add compatibility tests for the remote-keyboard suppression behavior

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests`