### PR TITLE
chore: recreate build-release before logging

### DIFF
--- a/scripts/build-release-local.sh
+++ b/scripts/build-release-local.sh
@@ -22,6 +22,7 @@ echo ""
 
 # Clean previous build
 rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
 
 # Resolve packages
 echo "--- Resolving Swift packages ---"


### PR DESCRIPTION
## Summary
- recreate `build-release/` immediately after cleanup so `tee "$BUILD_DIR/build.log"` cannot fail on a missing directory

## Testing
- `bash -n scripts/build-release-local.sh`