### PR TITLE
chore: add PR guard workflow and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Replace @SeoFood with your maintainer handle or a GitHub team, for example:
+# * @your-org/core-maintainers
+
+# Default: require maintainer review for everything.
+* @SeoFood
+
+# Critical paths called out explicitly for clarity.
+/.github/workflows/ @SeoFood
+/TypeWhisper/Services/ @SeoFood
+/TypeWhisper/ViewModels/ @SeoFood
+/TypeWhisperTests/ @SeoFood
+/TypeWhisperPluginSDK/ @SeoFood
+/Plugins/ @SeoFood

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,0 +1,126 @@
+name: PR Guard
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  author-policy:
+    name: Enforce PR author policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block non-allowlisted bots and multiple open PRs from external authors
+        uses: actions/github-script@v7
+        env:
+          # Repo variable, optional: comma-separated GitHub logins.
+          # Example: SeoFood,dependabot[bot],trusted-contributor
+          EXTRA_ALLOWLIST: ${{ vars.PR_GUARD_ALLOWLIST || '' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const association = pr.author_association;
+            const issueNumber = pr.number;
+            const marker = '<!-- pr-guard -->';
+
+            const defaultAllowlist = new Set([
+              'SeoFood'
+            ]);
+
+            const parseCsv = (value) =>
+              (value || '')
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter(Boolean);
+
+            for (const login of parseCsv(process.env.EXTRA_ALLOWLIST)) {
+              defaultAllowlist.add(login);
+            }
+
+            const isBot = author.endsWith('[bot]');
+            const isInternal = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+            const isAllowlisted = defaultAllowlist.has(author);
+
+            const upsertComment = async (body) => {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100
+              });
+
+              const existing = comments.find((comment) =>
+                comment.user?.type === 'Bot' && comment.body?.includes(marker)
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body
+              });
+            };
+
+            if (isAllowlisted || isInternal) {
+              core.info(`PR Guard: allowing ${author} (${association})`);
+              return;
+            }
+
+            if (isBot) {
+              await upsertComment([
+                marker,
+                `@${author} this repository blocks automated PRs from non-allowlisted bot accounts.`,
+                '',
+                'If this bot should be allowed, add it to the `PR_GUARD_ALLOWLIST` repository variable or the hardcoded allowlist in `.github/workflows/pr-guard.yml`.'
+              ].join('\n'));
+
+              core.setFailed(`PR Guard blocked non-allowlisted bot PR from ${author}`);
+              return;
+            }
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const otherOpenPRs = pulls.filter((openPR) =>
+              openPR.user?.login === author && openPR.number !== issueNumber
+            );
+
+            if (otherOpenPRs.length === 0) {
+              core.info(`PR Guard: ${author} has no other open PRs`);
+              return;
+            }
+
+            const firstOtherPR = otherOpenPRs[0];
+            await upsertComment([
+              marker,
+              `@${author} you already have another open PR in this repository: #${firstOtherPR.number}.`,
+              '',
+              'To keep review quality high, non-allowlisted external contributors may only have one open PR at a time.',
+              '',
+              `Please continue on #${firstOtherPR.number} first, or ask a maintainer to allowlist your account if multiple concurrent PRs are expected.`
+            ].join('\n'));
+
+            core.setFailed(
+              `PR Guard blocked ${author}: ${otherOpenPRs.length} other open PR(s) detected`
+            );


### PR DESCRIPTION
## Summary
- add a PR guard workflow that blocks non-allowlisted bot PRs and limits non-allowlisted external authors to one open PR at a time
- allow internal repo members automatically and support extra allowlisted logins via the `PR_GUARD_ALLOWLIST` repo variable
- add CODEOWNERS so maintainer review can be required for the full repo and explicit critical paths

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-guard.yml"); puts "YAML OK"'`
- reviewed generated workflow and CODEOWNERS contents locally

## Follow-up
- enable branch protection / rulesets so `Enforce PR author policy` is a required status check
- enable `Require review from Code Owners` for `main`
