### PR TITLE
Add dictation session IDs to API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,17 @@ curl -X PUT "http://localhost:8978/v1/profiles/toggle?id=<uuid>"
 ### Dictation Control
 
 ```bash
-# Start dictation
+# Start dictation (returns session id)
 curl -X POST http://localhost:8978/v1/dictation/start
 
-# Stop dictation
+# Stop dictation (returns same session id)
 curl -X POST http://localhost:8978/v1/dictation/stop
 
-# Check dictation status
+# Check whether dictation is currently recording
 curl http://localhost:8978/v1/dictation/status
+
+# Fetch status/result for a specific dictation session
+curl "http://localhost:8978/v1/dictation/transcription?id=<uuid>"
 ```
 
 ## CLI Tool

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -90,6 +90,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     var hasMicrophonePermissionOverride: Bool?
     var inputAvailabilityOverride: ((AudioDeviceID?) -> Bool)?
     var startRecordingOverride: (() throws -> Void)?
+    var stopRecordingOverride: ((StopPolicy) async -> [Float])?
 
     /// CoreAudio device ID to use for recording. nil = system default input.
     var selectedDeviceID: AudioDeviceID? {
@@ -236,6 +237,16 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     func stopRecording(policy: StopPolicy) async -> [Float] {
+        if let stopRecordingOverride {
+            let samples = await stopRecordingOverride(policy)
+            setLastStopGraceCaptureApplied(false)
+            DispatchQueue.main.async { [weak self] in
+                self?.isRecording = false
+                self?.audioLevel = 0
+            }
+            return samples
+        }
+
         // Atomically claim the engine - only the first concurrent caller proceeds
         let engine: AVAudioEngine? = engineLock.withLock {
             let e = audioEngine

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -31,6 +31,7 @@ final class APIHandlers: @unchecked Sendable {
         router.register("POST", "/v1/dictation/start", handler: handleStartDictation)
         router.register("POST", "/v1/dictation/stop", handler: handleStopDictation)
         router.register("GET", "/v1/dictation/status", handler: handleDictationStatus)
+        router.register("GET", "/v1/dictation/transcription", handler: handleDictationTranscription)
     }
 
     // MARK: - POST /v1/transcribe
@@ -430,10 +431,17 @@ final class APIHandlers: @unchecked Sendable {
             guard !dictationViewModel.isRecording else {
                 return .error(status: 409, message: "Already recording")
             }
-            dictationViewModel.apiStartRecording()
 
-            struct StartResponse: Encodable { let status: String }
-            return .json(StartResponse(status: "recording"))
+            let id = dictationViewModel.apiStartRecording()
+            if let session = dictationViewModel.apiDictationSession(id: id), session.status == .failed {
+                return .error(status: 409, message: session.error ?? "Failed to start dictation")
+            }
+
+            struct StartResponse: Encodable {
+                let id: String
+                let status: String
+            }
+            return .json(StartResponse(id: id.uuidString, status: "recording"))
         }
     }
 
@@ -445,10 +453,15 @@ final class APIHandlers: @unchecked Sendable {
             guard dictationViewModel.isRecording else {
                 return .error(status: 409, message: "Not recording")
             }
-            dictationViewModel.apiStopRecording()
+            guard let id = dictationViewModel.apiStopRecording() else {
+                return .error(status: 500, message: "Missing active dictation session")
+            }
 
-            struct StopResponse: Encodable { let status: String }
-            return .json(StopResponse(status: "stopped"))
+            struct StopResponse: Encodable {
+                let id: String
+                let status: String
+            }
+            return .json(StopResponse(id: id.uuidString, status: "stopped"))
         }
     }
 
@@ -459,6 +472,66 @@ final class APIHandlers: @unchecked Sendable {
         return await MainActor.run {
             struct DictationStatusResponse: Encodable { let is_recording: Bool }
             return .json(DictationStatusResponse(is_recording: dictationViewModel.isRecording))
+        }
+    }
+
+    // MARK: - GET /v1/dictation/transcription
+
+    private func handleDictationTranscription(_ request: HTTPRequest) async -> HTTPResponse {
+        guard let idString = request.queryParams["id"],
+              let uuid = UUID(uuidString: idString) else {
+            return .error(status: 400, message: "Missing or invalid 'id' query parameter")
+        }
+
+        let dictationViewModel = self.dictationViewModel
+        return await MainActor.run {
+            guard let session = dictationViewModel.apiDictationSession(id: uuid) else {
+                return .error(status: 404, message: "Dictation session not found")
+            }
+
+            struct DictationTranscriptionPayload: Encodable {
+                let text: String
+                let raw_text: String
+                let timestamp: Date
+                let app_name: String?
+                let app_bundle_id: String?
+                let app_url: String?
+                let duration: Double
+                let language: String?
+                let engine: String
+                let model: String?
+                let words_count: Int
+            }
+
+            struct DictationTranscriptionResponse: Encodable {
+                let id: String
+                let status: String
+                let transcription: DictationTranscriptionPayload?
+                let error: String?
+            }
+
+            let transcription = session.transcription.map {
+                DictationTranscriptionPayload(
+                    text: $0.text,
+                    raw_text: $0.rawText,
+                    timestamp: $0.timestamp,
+                    app_name: $0.appName,
+                    app_bundle_id: $0.appBundleIdentifier,
+                    app_url: $0.appURL,
+                    duration: $0.duration,
+                    language: $0.language,
+                    engine: $0.engine,
+                    model: $0.model,
+                    words_count: $0.wordsCount
+                )
+            }
+
+            return .json(DictationTranscriptionResponse(
+                id: session.id.uuidString,
+                status: session.status.rawValue,
+                transcription: transcription,
+                error: session.error
+            ))
         }
     }
 

--- a/TypeWhisper/Services/HistoryService.swift
+++ b/TypeWhisper/Services/HistoryService.swift
@@ -51,6 +51,7 @@ final class HistoryService: ObservableObject {
     }
 
     func addRecord(
+        id: UUID = UUID(),
         rawText: String,
         finalText: String,
         appName: String?,
@@ -73,7 +74,7 @@ final class HistoryService: ObservableObject {
             logger.warning("Skipping history record: invalid duration \(durationSeconds)")
             return
         }
-        let recordId = UUID()
+        let recordId = id
         var audioFileName: String?
 
         if let samples = audioSamples, !samples.isEmpty {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -7,6 +7,34 @@ import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "DictationViewModel")
 
+struct DictationSessionTranscription: Sendable, Equatable {
+    let text: String
+    let rawText: String
+    let timestamp: Date
+    let appName: String?
+    let appBundleIdentifier: String?
+    let appURL: String?
+    let duration: Double
+    let language: String?
+    let engine: String
+    let model: String?
+    let wordsCount: Int
+}
+
+struct DictationSessionSnapshot: Sendable, Equatable {
+    enum Status: String, Sendable {
+        case recording
+        case processing
+        case completed
+        case failed
+    }
+
+    let id: UUID
+    let status: Status
+    let transcription: DictationSessionTranscription?
+    let error: String?
+}
+
 /// Orchestrates the dictation flow: recording → transcription → text insertion.
 @MainActor
 final class DictationViewModel: ObservableObject {
@@ -132,6 +160,10 @@ final class DictationViewModel: ObservableObject {
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     private var isStopInFlight = false
+    private var activeDictationSessionID: UUID?
+    private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
+    private var dictationSessionOrder: [UUID] = []
+    private let maxTrackedDictationSessions = 100
 
     init(
         audioRecordingService: AudioRecordingService,
@@ -293,16 +325,87 @@ final class DictationViewModel: ObservableObject {
         state == .recording
     }
 
-    func apiStartRecording() {
-        startRecording()
+    func apiStartRecording() -> UUID {
+        let sessionID = UUID()
+        startRecording(sessionID: sessionID)
+        return sessionID
     }
 
-    func apiStopRecording() {
+    func apiStopRecording() -> UUID? {
+        let sessionID = activeDictationSessionID
         stopDictation()
+        return sessionID
+    }
+
+    func apiDictationSession(id: UUID) -> DictationSessionSnapshot? {
+        if let session = dictationSessions[id] {
+            return session
+        }
+        if let record = historyService.records.first(where: { $0.id == id }) {
+            return DictationSessionSnapshot(
+                id: id,
+                status: .completed,
+                transcription: DictationSessionTranscription(
+                    text: record.finalText,
+                    rawText: record.rawText,
+                    timestamp: record.timestamp,
+                    appName: record.appName,
+                    appBundleIdentifier: record.appBundleIdentifier,
+                    appURL: record.appURL,
+                    duration: record.durationSeconds,
+                    language: record.language,
+                    engine: record.engineUsed,
+                    model: record.modelUsed,
+                    wordsCount: record.wordsCount
+                ),
+                error: nil
+            )
+        }
+        return nil
     }
 
     isolated deinit {
         recordingTimer?.invalidate()
+    }
+
+    private func beginDictationSession(id: UUID) {
+        activeDictationSessionID = id
+        storeDictationSession(DictationSessionSnapshot(id: id, status: .recording, transcription: nil, error: nil))
+    }
+
+    private func markActiveDictationSessionProcessingIfNeeded() {
+        guard let sessionID = activeDictationSessionID else { return }
+        storeDictationSession(DictationSessionSnapshot(id: sessionID, status: .processing, transcription: nil, error: nil))
+    }
+
+    private func completeDictationSession(id: UUID, transcription: DictationSessionTranscription) {
+        storeDictationSession(DictationSessionSnapshot(id: id, status: .completed, transcription: transcription, error: nil))
+        if activeDictationSessionID == id {
+            activeDictationSessionID = nil
+        }
+    }
+
+    private func failDictationSession(id: UUID, error: String) {
+        storeDictationSession(DictationSessionSnapshot(id: id, status: .failed, transcription: nil, error: error))
+        if activeDictationSessionID == id {
+            activeDictationSessionID = nil
+        }
+    }
+
+    private func cancelActiveDictationSessionIfNeeded(message: String = String(localized: "Cancelled")) {
+        guard let sessionID = activeDictationSessionID else { return }
+        failDictationSession(id: sessionID, error: message)
+    }
+
+    private func storeDictationSession(_ session: DictationSessionSnapshot) {
+        dictationSessions[session.id] = session
+        dictationSessionOrder.removeAll { $0 == session.id }
+        dictationSessionOrder.append(session.id)
+
+        while dictationSessionOrder.count > maxTrackedDictationSessions {
+            let removedID = dictationSessionOrder.removeFirst()
+            dictationSessions.removeValue(forKey: removedID)
+        }
     }
 
     private func setupBindings() {
@@ -358,9 +461,11 @@ final class DictationViewModel: ObservableObject {
                 Task {
                     _ = await self.audioRecordingService.stopRecording(policy: .immediate)
                 }
+                let errorMessage = String(localized: "Microphone disconnected")
+                self.cancelActiveDictationSessionIfNeeded(message: errorMessage)
                 self.hotkeyService.cancelDictation()
                 self.showNotchFeedback(
-                    message: String(localized: "Microphone disconnected"),
+                    message: errorMessage,
                     icon: "mic.slash",
                     duration: 3.0,
                     isError: true,
@@ -371,6 +476,8 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func cancelCurrentOperation() {
+        let cancelledMessage = String(localized: "Cancelled")
+
         switch state {
         case .recording:
             guard !isStopInFlight else { return }
@@ -380,18 +487,20 @@ final class DictationViewModel: ObservableObject {
             Task {
                 _ = await audioRecordingService.stopRecording(policy: .immediate)
             }
+            cancelActiveDictationSessionIfNeeded(message: cancelledMessage)
             hotkeyService.cancelDictation()
-            showNotchFeedback(message: String(localized: "Cancelled"), icon: "xmark.circle", duration: 1.5)
+            showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
         case .processing:
+            cancelActiveDictationSessionIfNeeded(message: cancelledMessage)
             transcriptionTask?.cancel()
             transcriptionTask = nil
-            showNotchFeedback(message: String(localized: "Cancelled"), icon: "xmark.circle", duration: 1.5)
+            showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
         default:
             break
         }
     }
 
-    private func startRecording(forcedProfileId: UUID? = nil) {
+    private func startRecording(forcedProfileId: UUID? = nil, sessionID: UUID = UUID()) {
         let startTimestamp = CFAbsoluteTimeGetCurrent()
 
         // Dismiss prompt palette if active
@@ -400,17 +509,10 @@ final class DictationViewModel: ObservableObject {
         // Cancel auto-unload timer to prevent unloading during recording
         modelManager.cancelAutoUnloadTimer()
 
-        guard canDictate else {
-            showError(TranscriptionEngineError.modelNotLoaded.localizedDescription, category: "recording")
-            return
-        }
-
-        guard audioRecordingService.hasMicrophonePermission else {
-            showError("Microphone permission required.", category: "recording")
-            return
-        }
-
         // Cancel any pending transcription from a previous recording
+        if transcriptionTask != nil {
+            cancelActiveDictationSessionIfNeeded()
+        }
         transcriptionTask?.cancel()
         transcriptionTask = nil
         insertingResetTask?.cancel()
@@ -421,6 +523,21 @@ final class DictationViewModel: ObservableObject {
         urlResolutionTask = nil
 
         self.forcedProfileId = forcedProfileId
+        beginDictationSession(id: sessionID)
+
+        guard canDictate else {
+            let errorMessage = TranscriptionEngineError.modelNotLoaded.localizedDescription
+            failDictationSession(id: sessionID, error: errorMessage)
+            showError(errorMessage, category: "recording")
+            return
+        }
+
+        guard audioRecordingService.hasMicrophonePermission else {
+            let errorMessage = "Microphone permission required."
+            failDictationSession(id: sessionID, error: errorMessage)
+            showError(errorMessage, category: "recording")
+            return
+        }
 
         // Match profile: forced profile or app-based matching
         let activeApp = textInsertionService.captureActiveApp()
@@ -493,6 +610,7 @@ final class DictationViewModel: ObservableObject {
             }
             accessibilityAnnouncementService.announceError(errorMessage)
             speechFeedbackService.announceEvent(.error(reason: errorMessage))
+            failDictationSession(id: sessionID, error: errorMessage)
             showError(errorMessage, category: "recording")
             hotkeyService.cancelDictation()
         }
@@ -615,6 +733,8 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func finalizeStopDictation() async {
+        let sessionID = activeDictationSessionID
+
         audioDuckingService.restoreAudio()
         mediaPlaybackService.resumeIfWePaused()
         streamingHandler.stop()
@@ -648,16 +768,24 @@ final class DictationViewModel: ObservableObject {
 
         switch decision {
         case .discardTooShort:
+            let errorMessage = String(localized: "Too short, hold the hotkey a bit longer")
+            if let sessionID {
+                failDictationSession(id: sessionID, error: errorMessage)
+            }
             showNotchFeedback(
-                message: String(localized: "Too short, hold the hotkey a bit longer"),
+                message: errorMessage,
                 icon: "waveform.badge.exclamationmark",
                 duration: 1.8
             )
             return
         case .discardNoSpeech:
             logger.info("Peak level too low (\(String(format: "%.4f", peakLevel))) - no speech detected")
+            let errorMessage = String(localized: "No speech detected")
+            if let sessionID {
+                failDictationSession(id: sessionID, error: errorMessage)
+            }
             showNotchFeedback(
-                message: String(localized: "No speech detected"),
+                message: errorMessage,
                 icon: "mic.slash",
                 duration: 2.0
             )
@@ -678,6 +806,7 @@ final class DictationViewModel: ObservableObject {
 
         state = .processing
         processingPhase = String(localized: "Transcribing...")
+        markActiveDictationSessionProcessingIfNeeded()
 
         transcriptionTask = Task {
             do {
@@ -707,8 +836,12 @@ final class DictationViewModel: ObservableObject {
                 var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else {
                     logger.info("Transcription returned empty text (duration: \(String(format: "%.2f", result.duration))s, engine: \(result.engineUsed))")
+                    let errorMessage = String(localized: "No speech recognized")
+                    if let sessionID {
+                        failDictationSession(id: sessionID, error: errorMessage)
+                    }
                     showNotchFeedback(
-                        message: String(localized: "No speech recognized"),
+                        message: errorMessage,
                         icon: "text.magnifyingglass",
                         duration: 2.0
                     )
@@ -776,6 +909,7 @@ final class DictationViewModel: ObservableObject {
 
                 if UserDefaults.standard.object(forKey: UserDefaultsKeys.historyEnabled) as? Bool ?? true {
                     historyService.addRecord(
+                        id: sessionID ?? UUID(),
                         rawText: result.text,
                         finalText: text,
                         appName: activeApp.name,
@@ -806,6 +940,22 @@ final class DictationViewModel: ObservableObject {
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                 let wordCount = text.split(separator: " ").count
                 let detectedLang = result.detectedLanguage ?? language
+                let completedTranscription = DictationSessionTranscription(
+                    text: text,
+                    rawText: result.text,
+                    timestamp: Date(),
+                    appName: activeApp.name,
+                    appBundleIdentifier: activeApp.bundleId,
+                    appURL: activeApp.url,
+                    duration: audioDuration,
+                    language: detectedLang,
+                    engine: result.engineUsed,
+                    model: modelDisplayName,
+                    wordsCount: wordCount
+                )
+                if let sessionID {
+                    completeDictationSession(id: sessionID, transcription: completedTranscription)
+                }
                 accessibilityAnnouncementService.announceTranscriptionComplete(wordCount: wordCount)
                 speechFeedbackService.announceEvent(.transcriptionComplete(text: text, language: detectedLang))
                 lastTranscribedText = text
@@ -826,6 +976,9 @@ final class DictationViewModel: ObservableObject {
                     appName: capturedActiveApp?.name,
                     bundleIdentifier: capturedActiveApp?.bundleId
                 )))
+                if let sessionID {
+                    failDictationSession(id: sessionID, error: error.localizedDescription)
+                }
                 accessibilityAnnouncementService.announceError(error.localizedDescription)
                 speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
                 showError(error.localizedDescription, category: "transcription")
@@ -835,6 +988,7 @@ final class DictationViewModel: ObservableObject {
                 activeAppIcon = nil
                 activeProfileName = nil
             }
+            self.transcriptionTask = nil
         }
     }
 
@@ -861,6 +1015,7 @@ final class DictationViewModel: ObservableObject {
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
         isStopInFlight = false
+        activeDictationSessionID = nil
         state = .idle
         partialText = ""
         recordingStartTime = nil

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -62,12 +62,26 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let router: APIRouter
         let historyService: HistoryService
         let profileService: ProfileService
+        let dictationViewModel: DictationViewModel
+        let audioRecordingService: AudioRecordingService
+        let textInsertionService: TextInsertionService
         private let retainedObjects: [AnyObject]
 
-        init(router: APIRouter, historyService: HistoryService, profileService: ProfileService, retainedObjects: [AnyObject]) {
+        init(
+            router: APIRouter,
+            historyService: HistoryService,
+            profileService: ProfileService,
+            dictationViewModel: DictationViewModel,
+            audioRecordingService: AudioRecordingService,
+            textInsertionService: TextInsertionService,
+            retainedObjects: [AnyObject]
+        ) {
             self.router = router
             self.historyService = historyService
             self.profileService = profileService
+            self.dictationViewModel = dictationViewModel
+            self.audioRecordingService = audioRecordingService
+            self.textInsertionService = textInsertionService
             self.retainedObjects = retainedObjects
         }
     }
@@ -167,6 +181,107 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(status["status"] as? String, "no_model")
         XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 1)
         XCTAssertEqual((profiles["profiles"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
+    }
+
+    func testDictationStartReturnsConflictWhenRecordingCannotStart() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let response = await router.route(
+            HTTPRequest(method: "POST", path: "/v1/dictation/start", queryParams: [:], headers: [:], body: Data())
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 409)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, TranscriptionEngineError.modelNotLoaded.localizedDescription)
+    }
+
+    func testDictationEndpointsReturnSessionIDAndCompletedTranscription() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+
+        await MainActor.run {
+            apiContext.audioRecordingService.hasMicrophonePermissionOverride = true
+            apiContext.audioRecordingService.inputAvailabilityOverride = { _ in true }
+            apiContext.audioRecordingService.startRecordingOverride = {}
+            apiContext.audioRecordingService.stopRecordingOverride = { _ in
+                Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+            }
+            apiContext.textInsertionService.accessibilityGrantedOverride = true
+            apiContext.textInsertionService.captureActiveAppOverride = {
+                ("Notes", "com.apple.Notes", nil)
+            }
+            apiContext.textInsertionService.selectedTextOverride = { nil }
+            apiContext.textInsertionService.pasteSimulatorOverride = {}
+        }
+
+        let start = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "POST", path: "/v1/dictation/start", queryParams: [:], headers: [:], body: Data()))
+        )
+        let startID = try XCTUnwrap(start["id"] as? String)
+        XCTAssertEqual(start["status"] as? String, "recording")
+        XCTAssertNotNil(UUID(uuidString: startID))
+
+        await MainActor.run {
+            apiContext.dictationViewModel.partialText = "transcribed"
+        }
+
+        let stop = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "POST", path: "/v1/dictation/stop", queryParams: [:], headers: [:], body: Data()))
+        )
+        XCTAssertEqual(stop["id"] as? String, startID)
+        XCTAssertEqual(stop["status"] as? String, "stopped")
+
+        var completedResponse: [String: Any]?
+        for _ in 0..<40 {
+            let response = try Self.jsonObject(
+                await router.route(
+                    HTTPRequest(
+                        method: "GET",
+                        path: "/v1/dictation/transcription",
+                        queryParams: ["id": startID],
+                        headers: [:],
+                        body: Data()
+                    )
+                )
+            )
+            if response["status"] as? String == "completed" {
+                completedResponse = response
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        let completedPayload = try XCTUnwrap(completedResponse)
+        XCTAssertEqual(completedPayload["id"] as? String, startID)
+        XCTAssertEqual(completedPayload["status"] as? String, "completed")
+
+        let transcription = try XCTUnwrap(completedPayload["transcription"] as? [String: Any])
+        XCTAssertEqual(transcription["text"] as? String, "transcribed")
+        XCTAssertEqual(transcription["raw_text"] as? String, "transcribed")
+        XCTAssertEqual(transcription["app_name"] as? String, "Notes")
+        XCTAssertEqual(transcription["app_bundle_id"] as? String, "com.apple.Notes")
+        XCTAssertEqual(transcription["words_count"] as? Int, 1)
+
+        let recordID = await MainActor.run { apiContext.historyService.records.first?.id.uuidString }
+        XCTAssertEqual(recordID, startID)
     }
 
     @MainActor
@@ -281,7 +396,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             return "Already selected"
         }
 
-        context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
         XCTAssertEqual(events, ["capture_app", "start_audio"])
@@ -315,7 +430,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             return nil
         }
 
-        context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
         XCTAssertEqual(context.dictationViewModel.activeProfileName, "Docs")
@@ -353,7 +468,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             events.append("start_audio")
         }
 
-        context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(Array(events.prefix(3)), ["capture_app", "start_audio", "pause_media"])
     }
@@ -466,7 +581,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         dictationViewModel.soundFeedbackEnabled = false
         dictationViewModel.spokenFeedbackEnabled = false
 
-        dictationViewModel.apiStartRecording()
+        _ = dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(dictationViewModel.state, .inserting)
         XCTAssertEqual(
@@ -489,7 +604,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         context.audioRecordingService.hasMicrophonePermissionOverride = true
         context.audioRecordingService.inputAvailabilityOverride = { _ in false }
 
-        context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
         XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, "No mic detected.")
@@ -508,7 +623,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let context = try XCTUnwrap(dictationContext)
         context.audioRecordingService.hasMicrophonePermissionOverride = false
 
-        context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
         XCTAssertEqual(
@@ -571,10 +686,30 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    private static func makeAPIContext(appSupportDirectory: URL) -> APIContext {
+    private static func makeAPIContext(appSupportDirectory: URL, withMockTranscriptionPlugin: Bool = false) -> APIContext {
+        EventBus.shared = EventBus()
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
 
         let modelManager = ModelManagerService()
+        if withMockTranscriptionPlugin {
+            let mockPlugin = MockTranscriptionPlugin()
+            let manifest = PluginManifest(
+                id: "com.typewhisper.mock.transcription",
+                name: "Mock Transcription",
+                version: "1.0.0",
+                principalClass: "APIRouterMockTranscriptionPlugin"
+            )
+            PluginManager.shared.loadedPlugins = [
+                LoadedPlugin(
+                    manifest: manifest,
+                    instance: mockPlugin,
+                    bundle: Bundle.main,
+                    sourceURL: appSupportDirectory,
+                    isEnabled: true
+                )
+            ]
+            modelManager.selectProvider(mockPlugin.providerId)
+        }
         let audioFileService = AudioFileService()
         let audioRecordingService = AudioRecordingService()
         let hotkeyService = HotkeyService()
@@ -632,6 +767,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
             router: router,
             historyService: historyService,
             profileService: profileService,
+            dictationViewModel: dictationViewModel,
+            audioRecordingService: audioRecordingService,
+            textInsertionService: textInsertionService,
             retainedObjects: [
                 PluginManager.shared,
                 modelManager,


### PR DESCRIPTION
Closes #262

## Summary
- return a stable dictation session UUID from `/v1/dictation/start` and `/v1/dictation/stop`
- add `/v1/dictation/transcription?id=<uuid>` to poll a specific dictation session and fetch the final transcript
- keep history IDs aligned with dictation session IDs so completed sessions remain addressable
- preserve backward compatibility for existing clients like the Raycast extension by leaving `/v1/dictation/status` unchanged

## Local verification
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- manual API smoke test against the local dev app:
  - `POST /v1/dictation/start` returned a UUID
  - `POST /v1/dictation/stop` returned the same UUID
  - `GET /v1/dictation/transcription?id=<uuid>` progressed from `processing` to `completed`
  - `GET /v1/history?limit=1` returned the same UUID as the completed session
