### PR TITLE
fix: avoid clipboard history writes when preserving clipboard

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -10,9 +10,14 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhis
 /// Inserts transcribed text into the active application via clipboard + simulated Cmd+V.
 @MainActor
 final class TextInsertionService {
+    typealias FocusedTextSnapshot = (value: String?, selectedText: String?, selectedRange: NSRange?)
+
     var accessibilityGrantedOverride: Bool?
     var pasteboardProvider: () -> NSPasteboard = { .general }
     var focusedTextFieldOverride: (() -> Bool)?
+    var focusedTextElementOverride: (() -> AXUIElement?)?
+    var focusedTextStateOverride: ((AXUIElement) -> FocusedTextSnapshot?)?
+    var insertTextAtOverride: ((AXUIElement, String) -> Bool)?
     var pasteSimulatorOverride: (() -> Void)?
     var returnSimulatorOverride: (() -> Void)?
     var captureActiveAppOverride: (() -> (name: String?, bundleId: String?, url: String?))?
@@ -279,6 +284,9 @@ enum InsertionResult {
 
     /// Returns the focused text element (even without selection), for later insertion.
     func getFocusedTextElement() -> AXUIElement? {
+        if let focusedTextElementOverride {
+            return focusedTextElementOverride()
+        }
         guard isAccessibilityGranted else { return nil }
 
         let systemWide = AXUIElementCreateSystemWide()
@@ -304,12 +312,40 @@ enum InsertionResult {
 
     /// Inserts text at the cursor position of a previously captured AXUIElement.
     func insertTextAt(element: AXUIElement, text: String) -> Bool {
+        if let insertTextAtOverride {
+            return insertTextAtOverride(element, text)
+        }
+
         let result = AXUIElementSetAttributeValue(
             element,
             kAXSelectedTextAttribute as CFString,
             text as CFTypeRef
         )
         return result == .success
+    }
+
+    /// Inserts via Accessibility only when we can verify that the focused text state changed.
+    /// This avoids silently dropping text in apps that report AX success but ignore the write.
+    func insertTextAtAndVerifyChange(element: AXUIElement, text: String) -> Bool {
+        guard let initialState = captureFocusedTextState(for: element) else {
+            return false
+        }
+        guard insertTextAt(element: element, text: text),
+              let currentState = captureFocusedTextState(for: element) else {
+            return false
+        }
+        return Self.focusedTextDidChange(
+            from: (
+                value: initialState.value,
+                selectedText: initialState.selectedText,
+                selectedRange: initialState.selectedRange
+            ),
+            to: (
+                value: currentState.value,
+                selectedText: currentState.selectedText,
+                selectedRange: currentState.selectedRange
+            )
+        )
     }
 
     /// Saves all current clipboard contents for later restoration.
@@ -358,6 +394,17 @@ enum InsertionResult {
         }
 
         let hadFocusedTextField = autoEnter && hasFocusedTextField()
+
+        if preserveClipboard,
+           let focusedElement = getFocusedTextElement(),
+           insertTextAtAndVerifyChange(element: focusedElement, text: text) {
+            if hadFocusedTextField {
+                try? await Task.sleep(for: .milliseconds(50))
+                simulateReturn()
+            }
+            return .pasted
+        }
+
         let pasteboard = pasteboardProvider()
         let savedItems = preserveClipboard ? saveClipboard(from: pasteboard) : []
 
@@ -594,7 +641,17 @@ enum InsertionResult {
     }
 
     private func captureFocusedTextState(for element: AXUIElement) -> FocusedTextState? {
-        FocusedTextState(
+        if let focusedTextStateOverride {
+            guard let snapshot = focusedTextStateOverride(element) else { return nil }
+            return FocusedTextState(
+                element: element,
+                value: snapshot.value,
+                selectedText: snapshot.selectedText,
+                selectedRange: snapshot.selectedRange
+            )
+        }
+
+        return FocusedTextState(
             element: element,
             value: stringAttribute(kAXValueAttribute as CFString, from: element),
             selectedText: stringAttribute(kAXSelectedTextAttribute as CFString, from: element),

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -371,6 +371,72 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testPreserveClipboardAvoidsPasteboardWhenVerifiedAccessibilityInsertionSucceeds() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { element }
+
+        var stateReadCount = 0
+        service.focusedTextStateOverride = { _ in
+            defer { stateReadCount += 1 }
+            if stateReadCount == 0 {
+                return (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+            }
+            return (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+        }
+
+        var insertedText: String?
+        service.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        var didSimulatePaste = false
+        service.pasteSimulatorOverride = {
+            didSimulatePaste = true
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+
+        _ = try await service.insertText("Hello", preserveClipboard: true)
+
+        XCTAssertEqual(insertedText, "Hello")
+        XCTAssertFalse(didSimulatePaste)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
+    @MainActor
+    func testPreserveClipboardFallsBackToPasteboardWhenVerifiedAccessibilityInsertionFails() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { element }
+        service.focusedTextStateOverride = { _ in
+            (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+        }
+        service.insertTextAtOverride = { _, _ in true }
+
+        var didSimulatePaste = false
+        service.pasteSimulatorOverride = {
+            didSimulatePaste = true
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+
+        _ = try await service.insertText("Hello", preserveClipboard: true)
+
+        XCTAssertTrue(didSimulatePaste)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
+    @MainActor
     func testApiStartRecording_startsAudioBeforeDeferredSelectedTextCapture() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?


### PR DESCRIPTION
## Summary

Closes #251.

When `Preserve clipboard content` is enabled, TypeWhisper now prefers a verified Accessibility insertion path before touching the global pasteboard.

This avoids creating transient clipboard writes in apps where direct text insertion works, which should prevent TypeWhisper dictation text from showing up in clipboard history in the common/native text-field case.

Also adds regression coverage for:
- verified AX insertion without pasteboard mutation
- fallback to the existing pasteboard path when AX insertion cannot be verified

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

Automated verification:
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- `swift test --package-path TypeWhisperPluginSDK`

Local app verification:
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --clean --run /Users/marco/Projects/typewhisper-mac`
