### PR TITLE
fix: stabilize macOS 14 settings sidebar layout

### DIFF
--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -87,6 +87,7 @@ struct HomeSettingsView: View {
                 .padding(.bottom)
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .frame(minWidth: 500, minHeight: 400)
     }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -281,12 +281,11 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
                     .tag(destination.tab)
             }
             .listStyle(.sidebar)
-            .navigationSplitViewColumnWidth(min: 220, ideal: 240, max: 280)
+            .navigationSplitViewColumnWidth(240)
         } detail: {
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .navigationSplitViewStyle(.balanced)
     }
 }
 


### PR DESCRIPTION
## Summary
- stabilize the macOS 14 settings sidebar by using a fixed split-view sidebar width
- remove the balanced split view style that caused visible layout hopping when the sidebar fades back in
- keep the Home dashboard anchored to the available detail area during layout changes

## Verification
- built and launched the dev app locally with `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- confirmed the Settings window opens successfully in the dev app after the change

Closes #272
