### PR TITLE
Add app visibility picker for menu bar and Dock

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -7,10 +7,36 @@ extension UserDefaults {
     @objc dynamic var showMenuBarIcon: Bool {
         bool(forKey: UserDefaultsKeys.showMenuBarIcon)
     }
+
+    @objc dynamic var dockIconBehaviorWhenMenuBarHidden: String {
+        string(forKey: UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden)
+            ?? DockIconBehavior.keepVisible.rawValue
+    }
 }
 
 extension Notification.Name {
     static let openSettingsFromDock = Notification.Name("openSettingsFromDock")
+}
+
+enum DockIconBehavior: String, CaseIterable {
+    case keepVisible
+    case onlyWhileWindowOpen
+}
+
+enum DockIconVisibility {
+    static func shouldShowDockIcon(
+        showMenuBarIcon: Bool,
+        dockIconBehavior: DockIconBehavior,
+        hasVisibleManagedWindow: Bool,
+        hasInteractiveForegroundContent: Bool = false
+    ) -> Bool {
+        if hasVisibleManagedWindow || hasInteractiveForegroundContent {
+            return true
+        }
+
+        guard !showMenuBarIcon else { return false }
+        return dockIconBehavior == .keepVisible
+    }
 }
 
 struct TypeWhisperApp: App {
@@ -143,19 +169,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var indicatorCoordinator: IndicatorCoordinator?
     private var translationHostWindow: NSWindow?
     private var menuBarIconObserver: NSKeyValueObservation?
+    private var dockIconBehaviorObserver: NSKeyValueObservation?
+    private var hasInteractiveForegroundContent = false
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
     var updateChecker: UpdateChecker {
         .sparkle(updaterController.updater)
     }
 
-    private var isMenuBarIconHidden: Bool {
-        !UserDefaults.standard.bool(forKey: UserDefaultsKeys.showMenuBarIcon)
+    private var showMenuBarIconPreference: Bool {
+        UserDefaults.standard.object(forKey: UserDefaultsKeys.showMenuBarIcon) as? Bool ?? true
+    }
+
+    private var dockIconBehaviorPreference: DockIconBehavior {
+        DockIconBehavior(rawValue: UserDefaults.standard.dockIconBehaviorWhenMenuBarHidden) ?? .keepVisible
+    }
+
+    private var shouldShowDockIcon: Bool {
+        DockIconVisibility.shouldShowDockIcon(
+            showMenuBarIcon: showMenuBarIconPreference,
+            dockIconBehavior: dockIconBehaviorPreference,
+            hasVisibleManagedWindow: hasVisibleManagedWindow,
+            hasInteractiveForegroundContent: hasInteractiveForegroundContent
+        )
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: [
             UserDefaultsKeys.showMenuBarIcon: true,
+            UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden: DockIconBehavior.keepVisible.rawValue,
             UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue
         ])
 
@@ -164,11 +206,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
 
         UpdateChecker.shared = updateChecker
-
-        // If menu bar icon is hidden, show dock icon immediately
-        if isMenuBarIconHidden {
-            NSApp.setActivationPolicy(.regular)
-        }
+        applyActivationPolicy()
 
         let coordinator = IndicatorCoordinator()
         coordinator.startObserving()
@@ -178,13 +216,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         if #available(macOS 15, *), let ts = ServiceContainer.shared.translationService as? TranslationService {
             translationHostWindow = TranslationHostWindow(translationService: ts)
             ts.setInteractiveHostMode = { [weak self] enabled in
-                (self?.translationHostWindow as? TranslationHostWindow)?.setInteractiveMode(enabled)
-                if enabled {
-                    NSApp.setActivationPolicy(.regular)
-                    NSApp.activate(ignoringOtherApps: true)
-                } else if self?.shouldRevertToAccessory == true {
-                    NSApp.setActivationPolicy(.accessory)
-                }
+                guard let self else { return }
+                (self.translationHostWindow as? TranslationHostWindow)?.setInteractiveMode(enabled)
+                self.hasInteractiveForegroundContent = enabled
+                self.applyActivationPolicy(activate: enabled)
             }
         }
         #endif
@@ -204,17 +239,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             }
         }
 
-        // Observe menu bar icon visibility changes
-        menuBarIconObserver = UserDefaults.standard.observe(
-            \.showMenuBarIcon, options: [.new]
-        ) { [weak self] _, change in
+        // Observe appearance preference changes
+        menuBarIconObserver = UserDefaults.standard.observe(\.showMenuBarIcon, options: [.new]) { [weak self] _, _ in
             Task { @MainActor in
-                let hidden = change.newValue == false
-                if hidden {
-                    NSApp.setActivationPolicy(.regular)
-                } else if self?.hasVisibleManagedWindow != true {
-                    NSApp.setActivationPolicy(.accessory)
-                }
+                self?.applyActivationPolicy()
+            }
+        }
+        dockIconBehaviorObserver = UserDefaults.standard.observe(\.dockIconBehaviorWhenMenuBarHidden, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.applyActivationPolicy()
             }
         }
 
@@ -289,27 +322,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         NSApp.windows.contains { isManagedWindow($0) && $0.isVisible }
     }
 
-    private var shouldRevertToAccessory: Bool {
-        !isMenuBarIconHidden && !hasVisibleManagedWindow
+    private func applyActivationPolicy(activate: Bool = false) {
+        let targetPolicy: NSApplication.ActivationPolicy = shouldShowDockIcon ? .regular : .accessory
+        if NSApp.activationPolicy() != targetPolicy {
+            NSApp.setActivationPolicy(targetPolicy)
+        }
+
+        if activate {
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 
     @objc nonisolated private func windowDidBecomeKey(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
-        DispatchQueue.main.async { [self] in
-            guard isManagedWindow(window), window.isVisible else { return }
-            NSApp.setActivationPolicy(.regular)
-            NSApp.activate()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isManagedWindow(window), window.isVisible else { return }
+            self.applyActivationPolicy(activate: true)
         }
     }
 
     @objc nonisolated private func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
-        // Only go back to accessory if menu bar icon is visible and no other managed window is open
         DispatchQueue.main.async { [weak self] in
-            guard self?.isManagedWindow(window) == true else { return }
-            if self?.shouldRevertToAccessory == true {
-                NSApp.setActivationPolicy(.accessory)
-            }
+            guard let self, self.isManagedWindow(window) else { return }
+            self.applyActivationPolicy()
         }
     }
 

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -65,6 +65,7 @@ enum UserDefaultsKeys {
 
     // MARK: - Appearance
     static let showMenuBarIcon = "showMenuBarIcon"
+    static let dockIconBehaviorWhenMenuBarHidden = "dockIconBehaviorWhenMenuBarHidden"
     static let menuBarIconHiddenAlertShown = "menuBarIconHiddenAlertShown"
 
     // MARK: - Memory

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -8448,6 +8448,136 @@
           }
         }
       }
+    },
+    "Dock icon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock-Symbol"
+          }
+        }
+      }
+    },
+    "App visibility" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Sichtbarkeit"
+          }
+        }
+      }
+    },
+    "Dock icon when menu bar icon is hidden" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock-Symbol bei ausgeblendetem Menüleistensymbol"
+          }
+        }
+      }
+    },
+    "Keep visible" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichtbar lassen"
+          }
+        }
+      }
+    },
+    "Only while a window is open" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur solange ein Fenster geöffnet ist"
+          }
+        }
+      }
+    },
+    "Menu bar icon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menüleistensymbol"
+          }
+        }
+      }
+    },
+    "Dock icon only while a window is open" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock-Symbol nur bei geöffnetem Fenster"
+          }
+        }
+      }
+    },
+    "When hidden, the app stays accessible via the Dock icon." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn ausgeblendet, bleibt die App über das Dock-Symbol erreichbar."
+          }
+        }
+      }
+    },
+    "TypeWhisper stays in the menu bar and hides its Dock icon while no window is open." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper bleibt in der Menüleiste und blendet sein Dock-Symbol aus, solange kein Fenster geöffnet ist."
+          }
+        }
+      }
+    },
+    "TypeWhisper stays accessible via the Dock icon." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper bleibt über das Dock-Symbol erreichbar."
+          }
+        }
+      }
+    },
+    "TypeWhisper hides both icons until a window opens. To reopen Settings later, launch TypeWhisper from Spotlight or the Applications folder." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper blendet beide Symbole aus, bis wieder ein Fenster geöffnet wird. Um die Einstellungen später erneut zu öffnen, starte TypeWhisper über Spotlight oder den Programme-Ordner."
+          }
+        }
+      }
+    },
+    "This setting applies only when the menu bar icon is hidden." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Einstellung gilt nur, wenn das Menüleistensymbol ausgeblendet ist."
+          }
+        }
+      }
+    },
+    "When hidden, the Dock icon only appears while a TypeWhisper window is open. To reopen Settings later, launch TypeWhisper again from Spotlight or the Applications folder." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn ausgeblendet, erscheint das Dock-Symbol nur, solange ein TypeWhisper-Fenster geöffnet ist. Um die Einstellungen später erneut zu öffnen, starte TypeWhisper erneut über Spotlight oder den Programme-Ordner."
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -61,6 +61,7 @@ private struct DiagnosticsReport: Encodable {
         let soundFeedbackEnabled: Bool
         let spokenFeedbackEnabled: Bool
         let showMenuBarIcon: Bool
+        let dockIconBehaviorWhenMenuBarHidden: String
         let watchFolderAutoStart: Bool
         let setupWizardCompleted: Bool
         let preferredAppLanguage: String?
@@ -194,6 +195,7 @@ final class ErrorLogService: ObservableObject {
                 soundFeedbackEnabled: defaults.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true,
                 spokenFeedbackEnabled: defaults.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled),
                 showMenuBarIcon: defaults.object(forKey: UserDefaultsKeys.showMenuBarIcon) as? Bool ?? true,
+                dockIconBehaviorWhenMenuBarHidden: defaults.string(forKey: UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden) ?? DockIconBehavior.keepVisible.rawValue,
                 watchFolderAutoStart: defaults.bool(forKey: UserDefaultsKeys.watchFolderAutoStart),
                 setupWizardCompleted: defaults.bool(forKey: UserDefaultsKeys.setupWizardCompleted),
                 preferredAppLanguage: defaults.string(forKey: UserDefaultsKeys.preferredAppLanguage)

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -2,6 +2,12 @@ import SwiftUI
 import ServiceManagement
 
 struct GeneralSettingsView: View {
+    private enum AppVisibilityMode: String, CaseIterable {
+        case menuBar
+        case dock
+        case dockWhileWindowOpen
+    }
+
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var appLanguage: String = {
         if let lang = UserDefaults.standard.string(forKey: UserDefaultsKeys.preferredAppLanguage) {
@@ -10,8 +16,8 @@ struct GeneralSettingsView: View {
         return Locale.preferredLanguages.first?.hasPrefix("de") == true ? "de" : "en"
     }()
     @State private var showRestartAlert = false
-    @State private var showMenuBarIconHiddenAlert = false
     @AppStorage(UserDefaultsKeys.showMenuBarIcon) private var showMenuBarIcon = true
+    @AppStorage(UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden) private var dockIconBehaviorRawValue = DockIconBehavior.keepVisible.rawValue
     @AppStorage(UserDefaultsKeys.showRecorderTab) private var showRecorderTab = false
     @ObservedObject private var pluginManager = PluginManager.shared
     @ObservedObject private var settings = SettingsViewModel.shared
@@ -23,6 +29,45 @@ struct GeneralSettingsView: View {
 
     private var supportsPositionSelection: Bool {
         dictation.indicatorStyle == .overlay || dictation.indicatorStyle == .minimal
+    }
+
+    private var dockIconBehavior: DockIconBehavior {
+        get { DockIconBehavior(rawValue: dockIconBehaviorRawValue) ?? .keepVisible }
+        nonmutating set { dockIconBehaviorRawValue = newValue.rawValue }
+    }
+
+    private var appVisibilityMode: AppVisibilityMode {
+        get {
+            if showMenuBarIcon {
+                return .menuBar
+            }
+
+            return dockIconBehavior == .keepVisible ? .dock : .dockWhileWindowOpen
+        }
+        nonmutating set {
+            switch newValue {
+            case .menuBar:
+                showMenuBarIcon = true
+                dockIconBehavior = .keepVisible
+            case .dock:
+                showMenuBarIcon = false
+                dockIconBehavior = .keepVisible
+            case .dockWhileWindowOpen:
+                showMenuBarIcon = false
+                dockIconBehavior = .onlyWhileWindowOpen
+            }
+        }
+    }
+
+    private var appVisibilityDescription: LocalizedStringKey {
+        switch appVisibilityMode {
+        case .menuBar:
+            "TypeWhisper stays in the menu bar and hides its Dock icon while no window is open."
+        case .dock:
+            "TypeWhisper stays accessible via the Dock icon."
+        case .dockWhileWindowOpen:
+            "TypeWhisper hides both icons until a window opens. To reopen Settings later, launch TypeWhisper from Spotlight or the Applications folder."
+        }
     }
 
     var body: some View {
@@ -85,18 +130,16 @@ struct GeneralSettingsView: View {
             }
 
             Section(String(localized: "Appearance")) {
-                Toggle(String(localized: "Show menu bar icon"), isOn: $showMenuBarIcon)
-                    .onChange(of: showMenuBarIcon) { _, newValue in
-                        if !newValue {
-                            let alertShown = UserDefaults.standard.bool(forKey: UserDefaultsKeys.menuBarIconHiddenAlertShown)
-                            if !alertShown {
-                                showMenuBarIconHiddenAlert = true
-                                UserDefaults.standard.set(true, forKey: UserDefaultsKeys.menuBarIconHiddenAlertShown)
-                            }
-                        }
-                    }
+                Picker(String(localized: "App visibility"), selection: Binding(
+                    get: { appVisibilityMode },
+                    set: { appVisibilityMode = $0 }
+                )) {
+                    Text(String(localized: "Menu bar icon")).tag(AppVisibilityMode.menuBar)
+                    Text(String(localized: "Dock icon")).tag(AppVisibilityMode.dock)
+                    Text(String(localized: "Dock icon only while a window is open")).tag(AppVisibilityMode.dockWhileWindowOpen)
+                }
 
-                Text(String(localized: "When hidden, the app is accessible via the Dock icon."))
+                Text(appVisibilityDescription)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -181,11 +224,6 @@ struct GeneralSettingsView: View {
             Button(String(localized: "Later"), role: .cancel) {}
         } message: {
             Text(String(localized: "The language change will take effect after restarting TypeWhisper."))
-        }
-        .alert(String(localized: "Menu bar icon hidden"), isPresented: $showMenuBarIconHiddenAlert) {
-            Button(String(localized: "OK"), role: .cancel) {}
-        } message: {
-            Text(String(localized: "You can access TypeWhisper settings via the Dock icon."))
         }
     }
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -58,3 +58,56 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
         XCTAssertEqual(DictationViewModel.loadIndicatorStyle(defaults: defaults), .notch)
     }
 }
+
+final class DockIconVisibilityTests: XCTestCase {
+    func testDockIconStaysHiddenWhenMenuBarIconIsVisibleAndNoWindowIsOpen() {
+        XCTAssertFalse(
+            DockIconVisibility.shouldShowDockIcon(
+                showMenuBarIcon: true,
+                dockIconBehavior: .keepVisible,
+                hasVisibleManagedWindow: false
+            )
+        )
+    }
+
+    func testDockIconStaysVisibleWhenMenuBarIconIsHiddenAndBehaviorKeepsItVisible() {
+        XCTAssertTrue(
+            DockIconVisibility.shouldShowDockIcon(
+                showMenuBarIcon: false,
+                dockIconBehavior: .keepVisible,
+                hasVisibleManagedWindow: false
+            )
+        )
+    }
+
+    func testDockIconStaysHiddenWhenMenuBarIconIsHiddenAndBehaviorRequiresWindow() {
+        XCTAssertFalse(
+            DockIconVisibility.shouldShowDockIcon(
+                showMenuBarIcon: false,
+                dockIconBehavior: .onlyWhileWindowOpen,
+                hasVisibleManagedWindow: false
+            )
+        )
+    }
+
+    func testDockIconAppearsWhileManagedWindowIsVisibleEvenWhenBehaviorRequiresWindow() {
+        XCTAssertTrue(
+            DockIconVisibility.shouldShowDockIcon(
+                showMenuBarIcon: false,
+                dockIconBehavior: .onlyWhileWindowOpen,
+                hasVisibleManagedWindow: true
+            )
+        )
+    }
+
+    func testDockIconAppearsForInteractiveForegroundContent() {
+        XCTAssertTrue(
+            DockIconVisibility.shouldShowDockIcon(
+                showMenuBarIcon: true,
+                dockIconBehavior: .onlyWhileWindowOpen,
+                hasVisibleManagedWindow: false,
+                hasInteractiveForegroundContent: true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
This replaces the old separate menu bar / Dock controls with a single **App visibility** picker.

It adds three modes:
- **Menu bar icon**
- **Dock icon**
- **Dock icon only while a window is open**

It also updates activation policy handling, diagnostics, tests, and localized strings to match the new behavior.

Closes #274

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/DockIconVisibilityTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
