### PR TITLE
fix: restore Apple Speech model on app launch

### DIFF
--- a/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -27,8 +27,10 @@ final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, PluginSet
 
     func activate(host: HostServices) {
         self.host = host
-        Task { await populateModels() }
-        Task { await restoreLoadedModel() }
+        Task {
+            await populateModels()
+            await restoreLoadedModel()
+        }
     }
 
     func deactivate() {
@@ -245,6 +247,10 @@ final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, PluginSet
     }
 
     func restoreLoadedModel() async {
+        if cachedModels.isEmpty {
+            await populateModels()
+        }
+
         guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
               let modelDef = cachedModels.first(where: { $0.id == savedId }) else {
             return


### PR DESCRIPTION
Closes #275

## Summary
- serialize `populateModels()` and `restoreLoadedModel()` during `SpeechAnalyzerPlugin.activate(host:)`
- make `restoreLoadedModel()` repopulate `cachedModels` before looking up the persisted model id
- fixes the startup race where Apple Speech could come back as "unloaded" after relaunch even though a model had been loaded before

## Local verification
- Built and installed the plugin with:
  - `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run SpeechAnalyzerPlugin /Users/marco/Projects/typewhisper-mac`
- Relaunched the dev app and verified via local API:
  - `GET http://127.0.0.1:8978/v1/models`
  - result included `engine: speechAnalyzer`, `id: speechanalyzer-de_DE`, `status: ready`, `selected: true`
- Ran `swift test --package-path TypeWhisperPluginSDK` ✅
- Ran app tests with `xcodebuild test ...` ⚠️
  - unrelated pre-existing localized-string test failures
  - tracked in #277

## Notes
- No frontend changes
- No docs changes required for this fix
