### PR TITLE
fix: stabilize localized macOS test expectations

### DIFF
--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -677,7 +677,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
         _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
-        XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, "No mic detected.")
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "No mic detected.")
+        )
     }
 
     @MainActor

--- a/TypeWhisperTests/SoundServiceTests.swift
+++ b/TypeWhisperTests/SoundServiceTests.swift
@@ -3,22 +3,35 @@ import XCTest
 
 final class SoundServiceTests: XCTestCase {
     func testSoundEventKeysHaveGermanLocalizationsInCatalog() throws {
-        XCTAssertEqual(SoundEvent.recordingStarted.displayName, "Recording started")
-        XCTAssertEqual(try localizedCatalogValue(for: "Recording started", language: "de"), "Aufnahme gestartet")
+        XCTAssertEqual(
+            SoundEvent.recordingStarted.displayName,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Recording started")
+        )
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Recording started", language: "de"), "Aufnahme gestartet")
 
-        XCTAssertEqual(SoundEvent.transcriptionSuccess.displayName, "Transcription success")
-        XCTAssertEqual(try localizedCatalogValue(for: "Transcription success", language: "de"), "Transkription erfolgreich")
+        XCTAssertEqual(
+            SoundEvent.transcriptionSuccess.displayName,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Transcription success")
+        )
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Transcription success", language: "de"), "Transkription erfolgreich")
     }
 
     func testAccessibilityAndSpeechFeedbackKeysHaveGermanLocalizationsInCatalog() throws {
-        XCTAssertEqual(try localizedCatalogValue(for: "Recording started", language: "de"), "Aufnahme gestartet")
-        XCTAssertEqual(try localizedCatalogValue(for: "Prompt complete", language: "de"), "Prompt abgeschlossen")
-        XCTAssertEqual(try localizedCatalogValue(for: "Processing prompt", language: "de"), "Verarbeite Prompt")
-        XCTAssertEqual(try localizedCatalogValue(for: "Processing prompt: %@", language: "de"), "Verarbeite Prompt: %@")
-        XCTAssertEqual(try localizedCatalogValue(for: "Error: %@", language: "de"), "Fehler: %@")
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Recording started", language: "de"), "Aufnahme gestartet")
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Prompt complete", language: "de"), "Prompt abgeschlossen")
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Processing prompt", language: "de"), "Verarbeite Prompt")
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Processing prompt: %@", language: "de"), "Verarbeite Prompt: %@")
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Error: %@", language: "de"), "Fehler: %@")
         XCTAssertEqual(
-            try localizedCatalogValue(for: "Transcription complete, %lld words", language: "de"),
+            try TestSupport.localizedCatalogValue(for: "Transcription complete, %lld words", language: "de"),
             "Transkription abgeschlossen, %lld Wörter"
+        )
+    }
+
+    func testCatalogLookupFallsBackToSourceStringWhenPreferredLanguageHasNoTranslation() throws {
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(for: "Recording started", preferredLanguages: ["en-US"]),
+            "Recording started"
         )
     }
 
@@ -93,14 +106,4 @@ final class SoundServiceTests: XCTestCase {
         }
     }
 
-    private func localizedCatalogValue(for key: String, language: String) throws -> String {
-        let data = try Data(contentsOf: TestSupport.repoRoot.appendingPathComponent("TypeWhisper/Resources/Localizable.xcstrings"))
-        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        let strings = try XCTUnwrap(object["strings"] as? [String: Any])
-        let entry = try XCTUnwrap(strings[key] as? [String: Any], "Missing catalog entry for key: \(key)")
-        let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any], "Missing localizations for key: \(key)")
-        let languageEntry = try XCTUnwrap(localizations[language] as? [String: Any], "Missing \(language) localization for key: \(key)")
-        let stringUnit = try XCTUnwrap(languageEntry["stringUnit"] as? [String: Any], "Missing stringUnit for key: \(key)")
-        return try XCTUnwrap(stringUnit["value"] as? String, "Missing localized value for key: \(key)")
-    }
 }

--- a/TypeWhisperTests/Support/TestSupport.swift
+++ b/TypeWhisperTests/Support/TestSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 enum TestSupport {
     static let repoRoot: URL = URL(fileURLWithPath: #filePath)
@@ -52,6 +53,44 @@ enum TestSupport {
         try FileManager.default.createDirectory(at: deferredCleanupRoot, withIntermediateDirectories: true)
     }
 
+    static func localizedCatalogValue(for key: String, language: String) throws -> String {
+        let localizations = try catalogLocalizations(for: key)
+        let languageEntry = try XCTUnwrap(
+            localizations[language] as? [String: Any],
+            "Missing \(language) localization for key: \(key)"
+        )
+        let stringUnit = try XCTUnwrap(
+            languageEntry["stringUnit"] as? [String: Any],
+            "Missing stringUnit for key: \(key)"
+        )
+        return try XCTUnwrap(
+            stringUnit["value"] as? String,
+            "Missing localized value for key: \(key)"
+        )
+    }
+
+    static func localizedCatalogValue(for key: String, preferredLanguages: [String]) throws -> String {
+        let localizations = try catalogLocalizations(for: key)
+
+        for language in normalizedLanguageCandidates(from: preferredLanguages) {
+            guard let languageEntry = localizations[language] as? [String: Any],
+                  let stringUnit = languageEntry["stringUnit"] as? [String: Any],
+                  let value = stringUnit["value"] as? String else {
+                continue
+            }
+            return value
+        }
+
+        return key
+    }
+
+    static func localizedCatalogValueForCurrentLocale(for key: String, bundle: Bundle = .main) throws -> String {
+        try localizedCatalogValue(
+            for: key,
+            preferredLanguages: bundle.preferredLocalizations + Locale.preferredLanguages
+        )
+    }
+
     private static func cleanupStaleDirectories() {
         let cutoff = Date().addingTimeInterval(-staleDirectoryLifetime)
         let resourceKeys: Set<URLResourceKey> = [.contentModificationDateKey]
@@ -70,5 +109,37 @@ enum TestSupport {
             guard modifiedAt < cutoff else { continue }
             try? FileManager.default.removeItem(at: directory)
         }
+    }
+
+    private static func catalogLocalizations(for key: String) throws -> [String: Any] {
+        let data = try Data(contentsOf: repoRoot.appendingPathComponent("TypeWhisper/Resources/Localizable.xcstrings"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let strings = try XCTUnwrap(object["strings"] as? [String: Any])
+        let entry = try XCTUnwrap(strings[key] as? [String: Any], "Missing catalog entry for key: \(key)")
+        return try XCTUnwrap(entry["localizations"] as? [String: Any], "Missing localizations for key: \(key)")
+    }
+
+    private static func normalizedLanguageCandidates(from identifiers: [String]) -> [String] {
+        var candidates: [String] = []
+        var seen = Set<String>()
+
+        func append(_ identifier: String) {
+            guard !identifier.isEmpty, seen.insert(identifier).inserted else { return }
+            candidates.append(identifier)
+        }
+
+        for identifier in identifiers {
+            append(identifier)
+
+            let normalized = identifier.replacingOccurrences(of: "_", with: "-")
+            append(normalized)
+
+            if let languageCode = normalized.split(separator: "-").first {
+                append(String(languageCode))
+            }
+        }
+
+        append("en")
+        return candidates
     }
 }


### PR DESCRIPTION
## Summary
**Test stability**
- make localized macOS test expectations resolve through `Localizable.xcstrings` instead of assuming English source strings
- fix the affected API router and sound service tests so they pass on German and other non-English macOS environments
- centralize catalog lookup helpers in `TypeWhisperTests/Support/TestSupport.swift`

Closes #277.

## Test Coverage
All changed code paths are covered by the existing XCTest suite.

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed, design review skipped.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN
Intent: fix pre-existing localized test failures on non-English macOS environments.
Delivered: locale-aware test assertions plus shared xcstrings lookup helpers in the test target.

## Plan Completion
No plan file detected.

## Verification Results
Not applicable for this macOS app change, localhost web verification skipped.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
- [x] Fresh verification rerun completed after final code changes
