### PR TITLE
fix: show script/region variants in language pickers

### DIFF
--- a/TypeWhisper/Services/TranslationService.swift
+++ b/TypeWhisper/Services/TranslationService.swift
@@ -246,7 +246,7 @@ final class TranslationService: ObservableObject {
             "nl", "pl", "pt", "ru", "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant",
         ]
         return codes.compactMap { code in
-            let name = Locale.current.localizedString(forLanguageCode: code) ?? code
+            let name = Locale.current.localizedString(forIdentifier: code) ?? code
             return (code: code, name: name)
         }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }()
@@ -314,12 +314,12 @@ final class TranslationService: ObservableObject {
             map[foldLanguageToken(code)] = code
 
             for locale in helperLocales {
-                if let localized = locale.localizedString(forLanguageCode: code) {
+                if let localized = locale.localizedString(forIdentifier: code) {
                     map[foldLanguageToken(localized)] = code
                 }
             }
 
-            if let autonym = Locale(identifier: code).localizedString(forLanguageCode: code) {
+            if let autonym = Locale(identifier: code).localizedString(forIdentifier: code) {
                 map[foldLanguageToken(autonym)] = code
             }
         }

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -24,7 +24,7 @@ func localizedAppLanguageName(for code: String) -> String {
     }
 
     let locale = Locale(identifier: preferredAppLanguageCode())
-    return locale.localizedString(forLanguageCode: code) ?? code
+    return locale.localizedString(forIdentifier: code) ?? code
 }
 
 func localizedAppOrSeparator() -> String {

--- a/TypeWhisper/ViewModels/SettingsViewModel.swift
+++ b/TypeWhisper/ViewModels/SettingsViewModel.swift
@@ -60,7 +60,7 @@ final class SettingsViewModel: ObservableObject {
             }
         }
         return codes.map { code in
-            let name = Locale.current.localizedString(forLanguageCode: code) ?? code
+            let name = Locale.current.localizedString(forIdentifier: code) ?? code
             return (code: code, name: name)
         }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -119,7 +119,7 @@ struct FileTranscriptionView: View {
                         if !languages.isEmpty {
                             Divider()
                             ForEach(languages, id: \.self) { code in
-                                Text(Locale.current.localizedString(forLanguageCode: code) ?? code)
+                                Text(Locale.current.localizedString(forIdentifier: code) ?? code)
                                     .tag(code)
                             }
                         }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -11,6 +11,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         static var pluginId: String { "com.typewhisper.mock.transcription" }
         static var pluginName: String { "Mock Transcription" }
 
+        var languages: [String] = []
+
         required override init() {}
 
         func activate(host: HostServices) {}
@@ -23,6 +25,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         var selectedModelId: String? { "tiny" }
         func selectModel(_ modelId: String) {}
         var supportsTranslation: Bool { false }
+        var supportedLanguages: [String] { languages }
 
         func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
             PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
@@ -756,6 +759,52 @@ final class APIRouterAndHandlersTests: XCTestCase {
         await fulfillment(of: [propagation], timeout: 1.0)
 
         XCTAssertEqual(modelManager.selectedProviderId, plugin.providerId)
+    }
+
+    @MainActor
+    func testTranslationTargetLanguagesKeepScriptVariantsDistinct() {
+        guard #available(macOS 15.0, *) else { return }
+
+        let namesByCode = Dictionary(uniqueKeysWithValues: TranslationService.availableTargetLanguages.map { ($0.code, $0.name) })
+
+        XCTAssertNotEqual(namesByCode["zh-Hans"], namesByCode["zh-Hant"])
+    }
+
+    func testLocalizedAppLanguageNameKeepsScriptVariantsDistinct() {
+        XCTAssertNotEqual(localizedAppLanguageName(for: "zh-Hans"), localizedAppLanguageName(for: "zh-Hant"))
+    }
+
+    @MainActor
+    func testSettingsViewModelAvailableLanguagesKeepsRegionalAndScriptVariantsDistinct() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockTranscriptionPlugin()
+        plugin.languages = ["zh-Hans", "zh-Hant", "pt-BR", "pt-PT"]
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.transcription",
+            name: "Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterMockTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let settingsViewModel = SettingsViewModel(modelManager: ModelManagerService())
+        let namesByCode = Dictionary(uniqueKeysWithValues: settingsViewModel.availableLanguages.map { ($0.code, $0.name) })
+
+        XCTAssertNotEqual(namesByCode["zh-Hans"], namesByCode["zh-Hant"])
+        XCTAssertNotEqual(namesByCode["pt-BR"], namesByCode["pt-PT"])
     }
 
     @MainActor


### PR DESCRIPTION
## TL;DR

Language pickers now distinguish regional and script variants of the same base language — Chinese (Simplified vs Traditional), Portuguese (Brazil vs Portugal), English (US vs UK vs AU), etc. — instead of collapsing them into a single ambiguous entry.

## Summary

`Locale.localizedString(forLanguageCode:)` only inspects the ISO 639-1 base code and silently drops script (`-Hans`/`-Hant`) and region (`-BR`/`-GB`) suffixes. As a result, in the Translation target picker, both `zh-Hans` and `zh-Hant` render as plain **"Chinese"** — users cannot tell Simplified from Traditional. The same collapse affects every other picker where the code list contains suffixed BCP-47 identifiers.

## Change

Switch six call sites to `Locale.localizedString(forIdentifier:)`, which respects the full BCP-47 identifier. `SpeechAnalyzerPlugin.swift:185` already uses this API for exactly this reason, so the fix just brings the remaining call sites in line.

### Visible surfaces (four call sites)

| File | Surface | Codes that render correctly after this fix |
|---|---|---|
| `TypeWhisper/Services/TranslationService.swift:249` | General → Translation target picker | `zh-Hans`, `zh-Hant` (declared in `availableTargetLanguages`) |
| `TypeWhisper/ViewModels/ProfilesViewModel.swift:27` | Profile description text (e.g. "with translation to Chinese, Traditional") | Same as above, plus any `inputLanguage` fed from plugin data |
| `TypeWhisper/ViewModels/SettingsViewModel.swift:63` | General → Spoken Language picker | `pt-BR`, `pt-PT`, `zh-CN`, `zh-TW`, `en-AU`, `en-GB`, `pa-Guru-IN`, etc. declared by DeepgramPlugin and GoogleCloudSTTPlugin |
| `TypeWhisper/Views/FileTranscriptionView.swift:122` | File Transcription per-engine language picker | Same as above |

### Internal consistency (two call sites)

`TranslationService.swift:317` and `:322` are inside `languageAliasMap` construction and iterate over `Locale.LanguageCode.isoLanguageCodes` — pure ISO base codes where both APIs return identical results today. Switched for file-wide consistency so the next time that map ingests a script/region-qualified code it doesn't silently collapse.

## Before / After

The app currently supports English and Deutsch as UI languages, so names render in one of those:

| Input code | Before | After (en) | After (de) |
|---|---|---|---|
| `zh-Hans` | Chinese | Chinese, Simplified | Chinesisch, vereinfacht |
| `zh-Hant` | Chinese | Chinese, Traditional | Chinesisch, traditionell |
| `pt-BR` | Portuguese | Portuguese (Brazil) | Portugiesisch (Brasilien) |
| `en-GB` | English | British English | Britisches Englisch |
| `pa-Guru-IN` | Punjabi | Punjabi (Gurmukhi, India) | Pandschabi (Gurmukhi, Indien) |

## Test plan

- [x] Debug build succeeds (`xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug build`)
- [x] Full test suite passes (`xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS'`) — 113 tests, 0 failures
- [x] General → Translation target picker shows "Chinese, Simplified" and "Chinese, Traditional" as distinct entries
- [x] Profile description text including a translation target renders the correct script variant
- [ ] With DeepgramPlugin or GoogleCloudSTTPlugin enabled, General → Spoken Language picker distinguishes `pt-BR` vs `pt-PT`, `zh-CN` vs `zh-TW`, `en-US` vs `en-GB`, etc.
- [ ] With the same plugins enabled, File Transcription per-engine language picker distinguishes the same variants

## Notes

This is a prerequisite for adding `zh-Hans` / `zh-Hant` to transcription plugin `supportedLanguages` (e.g. Groq) — a follow-up change. Without this fix, adding script variants to a plugin would make the Spoken Language picker show two indistinguishable "Chinese" entries.