### PR TITLE
Support side-aware modifier hotkeys

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -215,7 +215,7 @@ final class ManagedAppWindowOpener {
     }
 
     private func forceActivateCurrentApplication(_ application: NSRunningApplication) {
-        application.activate(options: [.activateIgnoringOtherApps])
+        application.activate()
         NSApp.activate(ignoringOtherApps: true)
     }
 }

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -15,7 +15,7 @@ extension UserDefaults {
 }
 
 extension Notification.Name {
-    static let openSettingsFromDock = Notification.Name("openSettingsFromDock")
+    static let openManagedAppWindow = Notification.Name("openManagedAppWindow")
 }
 
 enum DockIconBehavior: String, CaseIterable {
@@ -88,7 +88,6 @@ struct TypeWhisperApp: App {
             EmptyView()
         } else {
             SettingsView()
-                .background(SettingsWindowBridge())
                 .sheet(isPresented: $showWelcomeSheet) {
                     WelcomeSheet()
                 }
@@ -130,35 +129,94 @@ struct TypeWhisperApp: App {
     }
 }
 
-// MARK: - Settings Window Bridge
+@MainActor
+final class ActivationSourceTracker {
+    static let shared = ActivationSourceTracker()
 
-/// Captures the `openWindow` environment action from the SwiftUI scene context
-/// and stores it statically so AppDelegate can open the settings window from Dock clicks.
-private struct SettingsWindowBridge: View {
-    @Environment(\.openWindow) private var openWindow
+    private(set) var lastExternalApplication: NSRunningApplication?
 
-    var body: some View {
-        Color.clear
-            .frame(width: 0, height: 0)
-            .onAppear {
-                SettingsWindowOpener.shared.openWindow = openWindow
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .openSettingsFromDock)) { _ in
-                openWindow(id: "settings")
-            }
+    func recordActivation(_ application: NSRunningApplication?) {
+        guard let application else { return }
+        if application.processIdentifier == NSRunningApplication.current.processIdentifier {
+            return
+        }
+        lastExternalApplication = application
     }
 }
 
-/// Stores the `openWindow` action captured from SwiftUI scene context.
 @MainActor
-final class SettingsWindowOpener {
-    static let shared = SettingsWindowOpener()
+final class ManagedAppWindowOpener {
+    static let shared = ManagedAppWindowOpener()
+
     var openWindow: OpenWindowAction?
 
-    func openSettings() {
+    func open(id: String) {
+        let sourceApplication = sourceApplicationForActivation()
         NSApp.setActivationPolicy(.regular)
-        NSApp.activate()
-        openWindow?(id: "settings")
+
+        if let existingWindow = managedWindow(id: id) {
+            reopenExistingWindow(existingWindow, sourceApplication: sourceApplication)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                self.reopenExistingWindow(existingWindow, sourceApplication: sourceApplication)
+            }
+            return
+        }
+
+        if let openWindow {
+            openWindow(id: id)
+        } else {
+            NotificationCenter.default.post(
+                name: .openManagedAppWindow,
+                object: nil,
+                userInfo: ["id": id]
+            )
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            guard let window = self.managedWindow(id: id) else { return }
+            self.reopenExistingWindow(window, sourceApplication: sourceApplication)
+        }
+    }
+
+    private func sourceApplicationForActivation() -> NSRunningApplication? {
+        ActivationSourceTracker.shared.lastExternalApplication
+            ?? NSWorkspace.shared.frontmostApplication
+    }
+
+    private func managedWindow(id: String) -> NSWindow? {
+        NSApp.windows.first(where: {
+            $0.identifier?.rawValue.localizedCaseInsensitiveContains(id) == true
+        })
+    }
+
+    private func reopenExistingWindow(_ window: NSWindow, sourceApplication: NSRunningApplication?) {
+        NSApp.unhide(nil)
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+        requestActivation(from: sourceApplication)
+    }
+
+    private func requestActivation(from sourceApplication: NSRunningApplication?) {
+        let currentApplication = NSRunningApplication.current
+
+        guard let sourceApplication,
+              sourceApplication.processIdentifier != currentApplication.processIdentifier else {
+            forceActivateCurrentApplication(currentApplication)
+            return
+        }
+
+        let activated = currentApplication.activate(from: sourceApplication)
+        if !activated {
+            forceActivateCurrentApplication(currentApplication)
+        }
+    }
+
+    private func forceActivateCurrentApplication(_ application: NSRunningApplication) {
+        application.activate(options: [.activateIgnoringOtherApps])
+        NSApp.activate(ignoringOtherApps: true)
     }
 }
 
@@ -170,6 +228,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var translationHostWindow: NSWindow?
     private var menuBarIconObserver: NSKeyValueObservation?
     private var dockIconBehaviorObserver: NSKeyValueObservation?
+    private var appActivationObserver: NSObjectProtocol?
     private var hasInteractiveForegroundContent = false
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
@@ -251,6 +310,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             }
         }
 
+        appActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { notification in
+            let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            Task { @MainActor in
+                ActivationSourceTracker.shared.recordActivation(application)
+            }
+        }
+
         // Observe settings window lifecycle
         NotificationCenter.default.addObserver(
             self,
@@ -280,25 +350,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     private func openSettingsWindow() {
-        NSApp.setActivationPolicy(.regular)
-        NSApp.activate()
-
-        // Try existing window first (SwiftUI keeps it after close)
-        if let window = NSApp.windows.first(where: {
-            $0.identifier?.rawValue.localizedCaseInsensitiveContains("settings") == true
-        }) {
-            window.makeKeyAndOrderFront(nil)
-            return
-        }
-
-        // Fall back to stored openWindow action from SwiftUI scene
-        if SettingsWindowOpener.shared.openWindow != nil {
-            SettingsWindowOpener.shared.openSettings()
-            return
-        }
-
-        // Last resort: post notification for bridge view
-        NotificationCenter.default.post(name: .openSettingsFromDock, object: nil)
+        ManagedAppWindowOpener.shared.open(id: "settings")
     }
 
     private func handleIncomingURL(_ url: URL) {
@@ -312,10 +364,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     private func isManagedWindow(_ window: NSWindow) -> Bool {
-        guard let id = window.identifier?.rawValue else { return false }
-        return id.localizedCaseInsensitiveContains("settings")
-            || id.localizedCaseInsensitiveContains("history")
-            || id.localizedCaseInsensitiveContains("errors")
+        if let identifier = window.identifier?.rawValue.lowercased() {
+            if identifier.contains("settings") || identifier.contains("history") || identifier.contains("errors") {
+                return true
+            }
+        }
+
+        let title = window.title
+        return title == String(localized: "Settings")
+            || title == String(localized: "History")
+            || title == String(localized: "Error Log")
     }
 
     private var hasVisibleManagedWindow: Bool {
@@ -329,7 +387,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
 
         if activate {
-            NSApp.activate(ignoringOtherApps: true)
+            NSApp.activate()
         }
     }
 

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1062,6 +1062,16 @@
         }
       }
     },
+    "App visibility" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Sichtbarkeit"
+          }
+        }
+      }
+    },
     "App-aware formatting" : {
       "localizations" : {
         "de" : {
@@ -2212,6 +2222,37 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anzeige"
+          }
+        }
+      }
+    },
+    "Dock icon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock-Symbol"
+          }
+        }
+      }
+    },
+    "Dock icon only while a window is open" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock-Symbol nur bei geöffnetem Fenster"
+          }
+        }
+      }
+    },
+    "Dock icon when menu bar icon is hidden" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock-Symbol bei ausgeblendetem Menüleistensymbol"
           }
         }
       }
@@ -3447,6 +3488,17 @@
         }
       }
     },
+    "Keep visible" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichtbar lassen"
+          }
+        }
+      }
+    },
     "Language" : {
       "localizations" : {
         "de" : {
@@ -3779,7 +3831,18 @@
         }
       }
     },
+    "Menu bar icon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menüleistensymbol"
+          }
+        }
+      }
+    },
     "Menu bar icon hidden" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -4525,6 +4588,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nur bei Aktivität"
+          }
+        }
+      }
+    },
+    "Only while a window is open" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur solange ein Fenster geöffnet ist"
           }
         }
       }
@@ -6503,6 +6577,7 @@
       }
     },
     "Show menu bar icon" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -7082,6 +7157,17 @@
         }
       }
     },
+    "This setting applies only when the menu bar icon is hidden." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Einstellung gilt nur, wenn das Menüleistensymbol ausgeblendet ist."
+          }
+        }
+      }
+    },
     "This Week" : {
       "localizations" : {
         "de" : {
@@ -7497,6 +7583,16 @@
         }
       }
     },
+    "TypeWhisper hides both icons until a window opens. To reopen Settings later, launch TypeWhisper from Spotlight or the Applications folder." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper blendet beide Symbole aus, bis wieder ein Fenster geöffnet wird. Um die Einstellungen später erneut zu öffnen, starte TypeWhisper über Spotlight oder den Programme-Ordner."
+          }
+        }
+      }
+    },
     "TypeWhisper is free for personal use. If you'd like to support development, grab a supporter license for a Discord role and an in-app badge." : {
       "localizations" : {
         "de" : {
@@ -7525,6 +7621,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TypeWhisper kann jetzt in jeder App verwendet werden."
+          }
+        }
+      }
+    },
+    "TypeWhisper stays accessible via the Dock icon." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper bleibt über das Dock-Symbol erreichbar."
+          }
+        }
+      }
+    },
+    "TypeWhisper stays in the menu bar and hides its Dock icon while no window is open." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper bleibt in der Menüleiste und blendet sein Dock-Symbol aus, solange kein Fenster geöffnet ist."
           }
         }
       }
@@ -8284,11 +8400,34 @@
       }
     },
     "When hidden, the app is accessible via the Dock icon." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wenn ausgeblendet, ist die App über das Dock-Symbol erreichbar."
+          }
+        }
+      }
+    },
+    "When hidden, the app stays accessible via the Dock icon." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn ausgeblendet, bleibt die App über das Dock-Symbol erreichbar."
+          }
+        }
+      }
+    },
+    "When hidden, the Dock icon only appears while a TypeWhisper window is open. To reopen Settings later, launch TypeWhisper again from Spotlight or the Applications folder." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn ausgeblendet, erscheint das Dock-Symbol nur, solange ein TypeWhisper-Fenster geöffnet ist. Um die Einstellungen später erneut zu öffnen, starte TypeWhisper erneut über Spotlight oder den Programme-Ordner."
           }
         }
       }
@@ -8362,6 +8501,7 @@
       }
     },
     "You can access TypeWhisper settings via the Dock icon." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -8445,136 +8585,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deine Worte erscheinen sofort als Text."
-          }
-        }
-      }
-    },
-    "Dock icon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dock-Symbol"
-          }
-        }
-      }
-    },
-    "App visibility" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Sichtbarkeit"
-          }
-        }
-      }
-    },
-    "Dock icon when menu bar icon is hidden" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dock-Symbol bei ausgeblendetem Menüleistensymbol"
-          }
-        }
-      }
-    },
-    "Keep visible" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sichtbar lassen"
-          }
-        }
-      }
-    },
-    "Only while a window is open" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur solange ein Fenster geöffnet ist"
-          }
-        }
-      }
-    },
-    "Menu bar icon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menüleistensymbol"
-          }
-        }
-      }
-    },
-    "Dock icon only while a window is open" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dock-Symbol nur bei geöffnetem Fenster"
-          }
-        }
-      }
-    },
-    "When hidden, the app stays accessible via the Dock icon." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn ausgeblendet, bleibt die App über das Dock-Symbol erreichbar."
-          }
-        }
-      }
-    },
-    "TypeWhisper stays in the menu bar and hides its Dock icon while no window is open." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TypeWhisper bleibt in der Menüleiste und blendet sein Dock-Symbol aus, solange kein Fenster geöffnet ist."
-          }
-        }
-      }
-    },
-    "TypeWhisper stays accessible via the Dock icon." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TypeWhisper bleibt über das Dock-Symbol erreichbar."
-          }
-        }
-      }
-    },
-    "TypeWhisper hides both icons until a window opens. To reopen Settings later, launch TypeWhisper from Spotlight or the Applications folder." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TypeWhisper blendet beide Symbole aus, bis wieder ein Fenster geöffnet wird. Um die Einstellungen später erneut zu öffnen, starte TypeWhisper über Spotlight oder den Programme-Ordner."
-          }
-        }
-      }
-    },
-    "This setting applies only when the menu bar icon is hidden." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Einstellung gilt nur, wenn das Menüleistensymbol ausgeblendet ist."
-          }
-        }
-      }
-    },
-    "When hidden, the Dock icon only appears while a TypeWhisper window is open. To reopen Settings later, launch TypeWhisper again from Spotlight or the Applications folder." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn ausgeblendet, erscheint das Dock-Symbol nur, solange ein TypeWhisper-Fenster geöffnet ist. Um die Einstellungen später erneut zu öffnen, starte TypeWhisper erneut über Spotlight oder den Programme-Ordner."
           }
         }
       }

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -7,10 +7,54 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioDeviceService")
 
+enum AudioInputDeviceCompatibilityIssue: Sendable, Equatable {
+    case cannotSetDevice
+    case invalidInputFormat
+    case engineStartFailed
+
+    var badgeText: String {
+        localizedAppText("Not compatible", de: "Nicht kompatibel")
+    }
+
+    var detailText: String {
+        switch self {
+        case .cannotSetDevice, .invalidInputFormat, .engineStartFailed:
+            return localizedAppText(
+                "This microphone can't be used by TypeWhisper for preview or recording.",
+                de: "Dieses Mikrofon kann von TypeWhisper nicht für Test oder Aufnahme verwendet werden."
+            )
+        }
+    }
+}
+
+enum AudioInputDeviceCompatibility: Sendable, Equatable {
+    case unknown
+    case compatible
+    case incompatible(AudioInputDeviceCompatibilityIssue)
+}
+
+enum SelectedInputDeviceError: LocalizedError, Sendable, Equatable {
+    case unavailable
+    case incompatible(AudioInputDeviceCompatibilityIssue)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return localizedAppText(
+                "Selected input device is no longer available.",
+                de: "Das ausgewählte Eingabegerät ist nicht mehr verfügbar."
+            )
+        case .incompatible(let issue):
+            return issue.detailText
+        }
+    }
+}
+
 struct AudioInputDevice: Identifiable, Equatable {
     let deviceID: AudioDeviceID
     let name: String
     let uid: String
+    var compatibility: AudioInputDeviceCompatibility = .unknown
 
     var id: String { uid }
 }
@@ -20,18 +64,26 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     @Published var inputDevices: [AudioInputDevice] = []
     @Published var selectedDeviceUID: String? {
         didSet {
-            if selectedDeviceUID != oldValue {
-                UserDefaults.standard.set(selectedDeviceUID, forKey: UserDefaultsKeys.selectedInputDeviceUID)
-            }
+            guard selectedDeviceUID != oldValue else { return }
+            handleSelectedDeviceSelectionChange(from: oldValue, to: selectedDeviceUID)
         }
     }
     @Published var disconnectedDeviceName: String?
     @Published var isPreviewActive: Bool = false
     @Published var previewAudioLevel: Float = 0
     @Published var previewRawLevel: Float = 0
+    @Published private(set) var previewError: SelectedInputDeviceError?
+
+    var hasMicrophonePermissionOverride: Bool?
+    var audioDeviceIDResolverOverride: ((String) -> AudioDeviceID?)?
+    var selectionValidationOverride: ((AudioDeviceID?) throws -> Void)?
+    var startPreviewOverride: ((AudioDeviceID?) throws -> Void)?
 
     var selectedDeviceID: AudioDeviceID? {
         guard let uid = selectedDeviceUID else { return nil }
+        if let audioDeviceIDResolverOverride {
+            return audioDeviceIDResolverOverride(uid)
+        }
         return audioDeviceID(fromUID: uid)
     }
 
@@ -45,29 +97,56 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private let previewRecoveryQueue = DispatchQueue(label: "com.typewhisper.preview-recovery", qos: .userInitiated)
     private let previewRecoveryCoordinator = AudioEngineRecoveryCoordinator()
     private var activePreviewDeviceID: AudioDeviceID?
+    private var compatibilityCache: [String: AudioInputDeviceCompatibility] = [:]
+    private var isApplyingValidatedSelection = false
+    private var isInitializingSelection = false
 
-    init() {
+    private var hasMicrophonePermission: Bool {
+        if let hasMicrophonePermissionOverride {
+            return hasMicrophonePermissionOverride
+        }
+        return AVAudioApplication.shared.recordPermission == .granted
+    }
+
+    var selectedDevice: AudioInputDevice? {
+        guard let selectedDeviceUID else { return nil }
+        return inputDevices.first(where: { $0.uid == selectedDeviceUID })
+    }
+
+    var selectedDeviceCompatibility: AudioInputDeviceCompatibility? {
+        selectedDevice?.compatibility
+    }
+
+    var selectedDeviceStatusMessage: String? {
+        guard let selectedDevice else { return nil }
+        switch selectedDevice.compatibility {
+        case .incompatible(let issue):
+            return "\(selectedDevice.name): \(issue.detailText)"
+        case .unknown, .compatible:
+            return nil
+        }
+    }
+
+    init(initialInputDevices: [AudioInputDevice]? = nil, monitorDeviceChanges: Bool = true, probeCompatibilities: Bool = false) {
+        isInitializingSelection = true
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
-        inputDevices = listInputDevices()
-        installDeviceListener()
+        inputDevices = applyCompatibilityCache(to: initialInputDevices ?? listInputDevices())
+        if monitorDeviceChanges {
+            installDeviceListener()
+        }
+        if probeCompatibilities, let selectedDeviceUID {
+            compatibilityCache[selectedDeviceUID] = .unknown
+        }
 
-        deviceChangeSubject
-            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
-            .sink { [weak self] in
-                self?.handleDeviceChange()
-            }
-            .store(in: &cancellables)
-
-        $selectedDeviceUID
-            .removeDuplicates()
-            .dropFirst()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self, self.isPreviewActive else { return }
-                self.stopPreview()
-                self.startPreview()
-            }
-            .store(in: &cancellables)
+        if monitorDeviceChanges {
+            deviceChangeSubject
+                .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                .sink { [weak self] in
+                    self?.handleDeviceChange()
+                }
+                .store(in: &cancellables)
+        }
+        isInitializingSelection = false
     }
 
     deinit {
@@ -80,14 +159,33 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     func startPreview() {
         guard !isPreviewActive else { return }
-        guard AVAudioApplication.shared.recordPermission == .granted else {
+        previewError = nil
+        guard hasMicrophonePermission else {
             logger.warning("Microphone permission not granted, cannot start preview")
             return
         }
 
-        let engine = AVAudioEngine()
         let preferredDeviceID = selectedDeviceID
+        if let selectionError = selectedInputDeviceError(for: preferredDeviceID) {
+            previewError = selectionError
+            return
+        }
 
+        if let startPreviewOverride {
+            do {
+                try startPreviewOverride(preferredDeviceID)
+                isPreviewActive = true
+            } catch let error as SelectedInputDeviceError {
+                previewError = error
+                isPreviewActive = false
+            } catch {
+                previewError = selectedDeviceUID == nil ? nil : .incompatible(.engineStartFailed)
+                isPreviewActive = false
+            }
+            return
+        }
+
+        let engine = AVAudioEngine()
         previewLock.withLock {
             previewEngine = engine
             activePreviewDeviceID = preferredDeviceID
@@ -97,6 +195,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         do {
             try startPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: "preview")
+            if selectedDeviceUID != nil {
+                markSelectedDeviceCompatibility(.compatible)
+            }
 
             if previewRecoveryCoordinator.finishStartingSuccessfully() == .performImmediateRecovery {
                 logger.warning("Preview engine configuration changed while starting, restarting with fresh input format")
@@ -105,8 +206,18 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             }
 
             isPreviewActive = true
+        } catch let error as SelectedInputDeviceError {
+            if case .incompatible(let issue) = error {
+                markSelectedDeviceCompatibility(.incompatible(issue))
+            }
+            previewError = error
+            cleanupAfterFailedPreviewStart(engine)
         } catch {
             logger.error("Failed to start preview engine: \(error.localizedDescription)")
+            if selectedDeviceUID != nil {
+                markSelectedDeviceCompatibility(.incompatible(.engineStartFailed))
+                previewError = .incompatible(.engineStartFailed)
+            }
             cleanupAfterFailedPreviewStart(engine)
         }
     }
@@ -126,6 +237,15 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         isPreviewActive = false
         previewAudioLevel = 0
         previewRawLevel = 0
+    }
+
+    func displayName(for device: AudioInputDevice) -> String {
+        switch device.compatibility {
+        case .incompatible(let issue):
+            return "\(device.name) (\(issue.badgeText))"
+        case .unknown, .compatible:
+            return device.name
+        }
     }
 
     private func processPreviewBuffer(_ buffer: AVAudioPCMBuffer) {
@@ -206,6 +326,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 return
             } catch {
                 guard AudioEngineRecoveryPolicy.isRetryable(error: error) else {
+                    if preferredDeviceID != nil {
+                        throw SelectedInputDeviceError.incompatible(.engineStartFailed)
+                    }
                     throw error
                 }
 
@@ -214,7 +337,16 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             }
         }
 
-        try configureAndStartPreviewEngine(engine, preferredDeviceID: preferredDeviceID, label: label)
+        do {
+            try configureAndStartPreviewEngine(engine, preferredDeviceID: preferredDeviceID, label: label)
+        } catch let error as SelectedInputDeviceError {
+            throw error
+        } catch {
+            if preferredDeviceID != nil {
+                throw SelectedInputDeviceError.incompatible(.engineStartFailed)
+            }
+            throw error
+        }
     }
 
     private func restartPreviewEngineWithRecovery(
@@ -232,21 +364,13 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         label: String
     ) throws {
         if let preferredDeviceID {
-            if !setInputDevice(preferredDeviceID, on: engine, label: label) {
-                logger.error("Failed to set \(label, privacy: .public) input device (\(preferredDeviceID)), falling back to system default")
-            }
+            try configureExplicitInputDevice(preferredDeviceID, on: engine, label: label)
         }
 
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
         logger.info("\(label, privacy: .public) input format: sampleRate=\(format.sampleRate), channels=\(format.channelCount)")
-        guard format.sampleRate > 0, format.channelCount > 0 else {
-            throw NSError(
-                domain: "AudioDeviceService",
-                code: 0,
-                userInfo: [NSLocalizedDescriptionKey: "No audio input available for preview"]
-            )
-        }
+        try validateInputFormat(format, for: preferredDeviceID)
 
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
             self?.processPreviewBuffer(buffer)
@@ -459,8 +583,12 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     private func handleDeviceChange() {
         let oldDevices = inputDevices
-        let newDevices = listInputDevices()
+        let newDevices = applyCompatibilityCache(to: listInputDevices())
         inputDevices = newDevices
+        compatibilityCache = compatibilityCache.filter { uid, _ in
+            newDevices.contains(where: { $0.uid == uid })
+        }
+        inputDevices = applyCompatibilityCache(to: newDevices)
 
         if let uid = selectedDeviceUID,
            !newDevices.contains(where: { $0.uid == uid }) {
@@ -477,7 +605,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
                 guard let currentUID = self.selectedDeviceUID, currentUID == uid else { return }
 
-                let refreshedDevices = self.listInputDevices()
+                let refreshedDevices = self.applyCompatibilityCache(to: self.listInputDevices())
                 if refreshedDevices.contains(where: { $0.uid == uid }) {
                     logger.info("Device reappeared after reconfiguration: \(deviceName ?? uid)")
                     self.inputDevices = refreshedDevices
@@ -493,6 +621,120 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             // Selected device still present - cancel any pending disconnect verification
             disconnectVerificationTask?.cancel()
             disconnectVerificationTask = nil
+        }
+    }
+
+    private func applyCompatibilityCache(to devices: [AudioInputDevice]) -> [AudioInputDevice] {
+        devices.map { device in
+            var device = device
+            device.compatibility = compatibilityCache[device.uid] ?? device.compatibility
+            return device
+        }
+    }
+
+    func markSelectedDeviceCompatibility(_ compatibility: AudioInputDeviceCompatibility) {
+        guard let selectedDeviceUID else { return }
+        compatibilityCache[selectedDeviceUID] = compatibility
+        inputDevices = applyCompatibilityCache(to: inputDevices)
+    }
+
+    private func handleSelectedDeviceSelectionChange(from oldValue: String?, to newValue: String?) {
+        if isInitializingSelection {
+            return
+        }
+
+        if isApplyingValidatedSelection {
+            persistSelectedDeviceUID()
+            return
+        }
+
+        previewError = nil
+
+        guard let newValue else {
+            persistSelectedDeviceUID()
+            if isPreviewActive {
+                stopPreview()
+                startPreview()
+            }
+            return
+        }
+
+        do {
+            try validateDeviceSelection(uid: newValue)
+            compatibilityCache[newValue] = .compatible
+            inputDevices = applyCompatibilityCache(to: inputDevices)
+            persistSelectedDeviceUID()
+
+            if isPreviewActive {
+                stopPreview()
+                startPreview()
+            }
+        } catch let error as SelectedInputDeviceError {
+            if case .incompatible(let issue) = error {
+                compatibilityCache[newValue] = .incompatible(issue)
+                inputDevices = applyCompatibilityCache(to: inputDevices)
+            }
+            previewError = error
+            revertSelectedDeviceUID(to: oldValue)
+        } catch {
+            compatibilityCache[newValue] = .incompatible(.engineStartFailed)
+            inputDevices = applyCompatibilityCache(to: inputDevices)
+            previewError = .incompatible(.engineStartFailed)
+            revertSelectedDeviceUID(to: oldValue)
+        }
+    }
+
+    private func validateDeviceSelection(uid: String) throws {
+        guard let deviceID = audioDeviceIDResolverOverride?(uid) ?? audioDeviceID(fromUID: uid) else {
+            throw SelectedInputDeviceError.unavailable
+        }
+
+        if let selectionValidationOverride {
+            try selectionValidationOverride(deviceID)
+            return
+        }
+
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+
+        do {
+            try configureExplicitInputDevice(deviceID, on: engine, label: "selection")
+            let format = inputNode.outputFormat(forBus: 0)
+            try validateInputFormat(format, for: deviceID)
+            inputNode.installTap(onBus: 0, bufferSize: 256, format: format) { _, _ in }
+            defer {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+            }
+            try engine.start()
+        } catch let error as SelectedInputDeviceError {
+            throw error
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            engine.stop()
+            throw SelectedInputDeviceError.incompatible(.engineStartFailed)
+        }
+    }
+
+    private func revertSelectedDeviceUID(to value: String?) {
+        isApplyingValidatedSelection = true
+        selectedDeviceUID = value
+        isApplyingValidatedSelection = false
+    }
+
+    private func persistSelectedDeviceUID() {
+        UserDefaults.standard.set(selectedDeviceUID, forKey: UserDefaultsKeys.selectedInputDeviceUID)
+    }
+
+    private func selectedInputDeviceError(for preferredDeviceID: AudioDeviceID?) -> SelectedInputDeviceError? {
+        guard let selectedDeviceUID else { return nil }
+        guard preferredDeviceID != nil else { return .unavailable }
+
+        switch compatibilityCache[selectedDeviceUID] ?? selectedDevice?.compatibility ?? .unknown {
+        case .incompatible(let issue):
+            return .incompatible(issue)
+        case .unknown, .compatible:
+            return nil
         }
     }
 }
@@ -544,6 +786,29 @@ func setInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine, label: 
 
     deviceHelperLogger.info("[\(label)] Input device set and verified: \(deviceID)")
     return true
+}
+
+func configureExplicitInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine, label: String) throws {
+    guard AudioDeviceService.isInputDeviceAvailable(deviceID) else {
+        throw SelectedInputDeviceError.unavailable
+    }
+
+    guard setInputDevice(deviceID, on: engine, label: label) else {
+        throw SelectedInputDeviceError.incompatible(.cannotSetDevice)
+    }
+}
+
+func validateInputFormat(_ format: AVAudioFormat, for preferredDeviceID: AudioDeviceID?) throws {
+    guard format.sampleRate > 0, format.channelCount > 0 else {
+        if preferredDeviceID != nil {
+            throw SelectedInputDeviceError.incompatible(.invalidInputFormat)
+        }
+        throw NSError(
+            domain: "AudioDeviceService",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "No audio input available for preview"]
+        )
+    }
 }
 
 private func audioStatusString(_ status: OSStatus) -> String {

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -67,6 +67,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     enum AudioRecordingError: LocalizedError {
         case microphonePermissionDenied
         case noMicrophoneDetected
+        case selectedInputDeviceUnavailable
+        case selectedInputDeviceIncompatible(AudioInputDeviceCompatibilityIssue)
         case engineStartFailed(String)
         case noAudioData
 
@@ -76,6 +78,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                 "Microphone permission denied. Please grant access in System Settings."
             case .noMicrophoneDetected:
                 String(localized: "No mic detected.")
+            case .selectedInputDeviceUnavailable:
+                SelectedInputDeviceError.unavailable.errorDescription
+            case .selectedInputDeviceIncompatible(let issue):
+                SelectedInputDeviceError.incompatible(issue).errorDescription
             case .engineStartFailed(let detail):
                 "Failed to start audio engine: \(detail)"
             case .noAudioData:
@@ -97,8 +103,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         get { configLock.withLock { _selectedDeviceID } }
         set { configLock.withLock { _selectedDeviceID = newValue } }
     }
+    var hasExplicitDeviceSelection: Bool {
+        get { configLock.withLock { _hasExplicitDeviceSelection } }
+        set { configLock.withLock { _hasExplicitDeviceSelection = newValue } }
+    }
 
     private var _selectedDeviceID: AudioDeviceID?
+    private var _hasExplicitDeviceSelection = false
 
     private var audioEngine: AVAudioEngine?
     private var configChangeObserver: NSObjectProtocol?
@@ -341,14 +352,20 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func startEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+        let explicitDeviceSelected = hasExplicitDeviceSelection
         for (attempt, delay) in AudioEngineRecoveryPolicy.retryBackoff.enumerated() {
             do {
                 try configureAndStartEngine(engine, label: label)
                 return
+            } catch let error as SelectedInputDeviceError {
+                throw mapSelectedInputDeviceError(error)
             } catch let error as AudioRecordingError {
                 throw error
             } catch {
                 guard AudioEngineRecoveryPolicy.isRetryable(error: error) else {
+                    if explicitDeviceSelected {
+                        throw AudioRecordingError.selectedInputDeviceIncompatible(.engineStartFailed)
+                    }
                     throw AudioRecordingError.engineStartFailed(error.localizedDescription)
                 }
 
@@ -359,9 +376,14 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         do {
             try configureAndStartEngine(engine, label: label)
+        } catch let error as SelectedInputDeviceError {
+            throw mapSelectedInputDeviceError(error)
         } catch let error as AudioRecordingError {
             throw error
         } catch {
+            if explicitDeviceSelected {
+                throw AudioRecordingError.selectedInputDeviceIncompatible(.engineStartFailed)
+            }
             throw AudioRecordingError.engineStartFailed(error.localizedDescription)
         }
     }
@@ -374,18 +396,14 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func configureAndStartEngine(_ engine: AVAudioEngine, label: String) throws {
         // Set the input device before reading the format so each retry sees fresh hardware state.
         if let deviceID = selectedDeviceID {
-            if !setInputDevice(deviceID, on: engine, label: label) {
-                logger.error("Failed to set \(label, privacy: .public) input device (\(deviceID)), falling back to system default")
-            }
+            try configureExplicitInputDevice(deviceID, on: engine, label: label)
         }
 
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
         logger.info("\(label, privacy: .public) input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
 
-        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            throw AudioRecordingError.noMicrophoneDetected
-        }
+        try validateRecordingInputFormat(inputFormat)
 
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -448,9 +466,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             return
         }
 
-        if let selectedDeviceID {
+        if hasExplicitDeviceSelection {
+            guard let selectedDeviceID else {
+                throw AudioRecordingError.selectedInputDeviceUnavailable
+            }
             guard AudioDeviceService.isInputDeviceAvailable(selectedDeviceID) else {
-                throw AudioRecordingError.noMicrophoneDetected
+                throw AudioRecordingError.selectedInputDeviceUnavailable
             }
             return
         }
@@ -539,5 +560,24 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let samples = sampleBuffer
         sampleBuffer.removeAll()
         return samples
+    }
+
+    private func validateRecordingInputFormat(_ format: AVAudioFormat) throws {
+        do {
+            try validateInputFormat(format, for: hasExplicitDeviceSelection ? selectedDeviceID : nil)
+        } catch let error as SelectedInputDeviceError {
+            throw mapSelectedInputDeviceError(error)
+        } catch {
+            throw AudioRecordingError.noMicrophoneDetected
+        }
+    }
+
+    private func mapSelectedInputDeviceError(_ error: SelectedInputDeviceError) -> AudioRecordingError {
+        switch error {
+        case .unavailable:
+            return .selectedInputDeviceUnavailable
+        case .incompatible(let issue):
+            return .selectedInputDeviceIncompatible(issue)
+        }
     }
 }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -7,6 +7,7 @@ import os
 struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
     let keyCode: UInt16
     let modifierFlags: UInt
+    let deviceModifierFlags: UInt
     let isFn: Bool
     let isDoubleTap: Bool
     /// nil = keyboard hotkey; 0..N = mouse button number (macOS convention: 2=middle, 3=back, 4=forward)
@@ -34,9 +35,16 @@ struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
         return .bareKey
     }
 
-    init(keyCode: UInt16, modifierFlags: UInt, isFn: Bool, isDoubleTap: Bool = false) {
+    init(
+        keyCode: UInt16,
+        modifierFlags: UInt,
+        deviceModifierFlags: UInt = 0,
+        isFn: Bool,
+        isDoubleTap: Bool = false
+    ) {
         self.keyCode = keyCode
         self.modifierFlags = modifierFlags
+        self.deviceModifierFlags = deviceModifierFlags
         self.isFn = isFn
         self.isDoubleTap = isDoubleTap
         self.mouseButton = nil
@@ -45,6 +53,7 @@ struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
     init(mouseButton: UInt16, isDoubleTap: Bool = false) {
         self.keyCode = 0
         self.modifierFlags = 0
+        self.deviceModifierFlags = 0
         self.isFn = false
         self.isDoubleTap = isDoubleTap
         self.mouseButton = mouseButton
@@ -55,6 +64,7 @@ struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         keyCode = try container.decode(UInt16.self, forKey: .keyCode)
         modifierFlags = try container.decode(UInt.self, forKey: .modifierFlags)
+        deviceModifierFlags = try container.decodeIfPresent(UInt.self, forKey: .deviceModifierFlags) ?? 0
         isFn = try container.decode(Bool.self, forKey: .isFn)
         isDoubleTap = try container.decodeIfPresent(Bool.self, forKey: .isDoubleTap) ?? false
         mouseButton = try container.decodeIfPresent(UInt16.self, forKey: .mouseButton)
@@ -80,6 +90,16 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
 /// Manages global hotkeys for dictation with three independent slots:
 /// hybrid (short=toggle, long=push-to-talk), push-to-talk, and toggle.
 final class HotkeyService: ObservableObject {
+    private struct DeviceModifierFamily {
+        let genericFlag: NSEvent.ModifierFlags
+        let mask: UInt
+        let leftFlag: UInt
+        let rightFlag: UInt
+        let genericSymbol: String
+        let leftSymbol: String
+        let rightSymbol: String
+    }
+
     enum HotkeyEventSource: Sendable {
         case eventTap
         case monitor
@@ -204,6 +224,58 @@ final class HotkeyService: ObservableObject {
         0x3E, // Right Control
     ]
 
+    nonisolated private static let leftControlDeviceModifierFlag: UInt = 0x00000001
+    nonisolated private static let leftShiftDeviceModifierFlag: UInt = 0x00000002
+    nonisolated private static let rightShiftDeviceModifierFlag: UInt = 0x00000004
+    nonisolated private static let leftCommandDeviceModifierFlag: UInt = 0x00000008
+    nonisolated private static let rightCommandDeviceModifierFlag: UInt = 0x00000010
+    nonisolated private static let leftOptionDeviceModifierFlag: UInt = 0x00000020
+    nonisolated private static let rightOptionDeviceModifierFlag: UInt = 0x00000040
+    nonisolated private static let rightControlDeviceModifierFlag: UInt = 0x00002000
+
+    nonisolated private static let deviceModifierFamilies: [DeviceModifierFamily] = [
+        DeviceModifierFamily(
+            genericFlag: .control,
+            mask: leftControlDeviceModifierFlag | rightControlDeviceModifierFlag,
+            leftFlag: leftControlDeviceModifierFlag,
+            rightFlag: rightControlDeviceModifierFlag,
+            genericSymbol: "⌃",
+            leftSymbol: "L⌃",
+            rightSymbol: "R⌃"
+        ),
+        DeviceModifierFamily(
+            genericFlag: .option,
+            mask: leftOptionDeviceModifierFlag | rightOptionDeviceModifierFlag,
+            leftFlag: leftOptionDeviceModifierFlag,
+            rightFlag: rightOptionDeviceModifierFlag,
+            genericSymbol: "⌥",
+            leftSymbol: "L⌥",
+            rightSymbol: "R⌥"
+        ),
+        DeviceModifierFamily(
+            genericFlag: .shift,
+            mask: leftShiftDeviceModifierFlag | rightShiftDeviceModifierFlag,
+            leftFlag: leftShiftDeviceModifierFlag,
+            rightFlag: rightShiftDeviceModifierFlag,
+            genericSymbol: "⇧",
+            leftSymbol: "L⇧",
+            rightSymbol: "R⇧"
+        ),
+        DeviceModifierFamily(
+            genericFlag: .command,
+            mask: leftCommandDeviceModifierFlag | rightCommandDeviceModifierFlag,
+            leftFlag: leftCommandDeviceModifierFlag,
+            rightFlag: rightCommandDeviceModifierFlag,
+            genericSymbol: "⌘",
+            leftSymbol: "L⌘",
+            rightSymbol: "R⌘"
+        ),
+    ]
+
+    nonisolated private static let supportedDeviceModifierFlags: UInt = deviceModifierFamilies.reduce(0) { partialResult, family in
+        partialResult | family.mask
+    }
+
     func setup() {
         loadHotkeys()
         setupMonitor()
@@ -228,12 +300,7 @@ final class HotkeyService: ObservableObject {
     func isHotkeyAssigned(_ hotkey: UnifiedHotkey, excluding: HotkeySlotType) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases where slotType != excluding {
             guard let existing = slots[slotType]?.hotkey else { continue }
-            if existing == hotkey { return slotType }
-            if existing.keyCode == hotkey.keyCode
-                && existing.modifierFlags == hotkey.modifierFlags
-                && existing.isFn == hotkey.isFn
-                && existing.mouseButton == hotkey.mouseButton
-                && existing.isDoubleTap != hotkey.isDoubleTap {
+            if Self.hotkeysConflict(existing, hotkey) {
                 return slotType
             }
         }
@@ -267,12 +334,7 @@ final class HotkeyService: ObservableObject {
 
     func isHotkeyAssignedToProfile(_ hotkey: UnifiedHotkey, excludingProfileId: UUID?) -> UUID? {
         for (id, state) in profileSlots where id != excludingProfileId {
-            if state.hotkey == hotkey { return id }
-            if state.hotkey.keyCode == hotkey.keyCode
-                && state.hotkey.modifierFlags == hotkey.modifierFlags
-                && state.hotkey.isFn == hotkey.isFn
-                && state.hotkey.mouseButton == hotkey.mouseButton
-                && state.hotkey.isDoubleTap != hotkey.isDoubleTap {
+            if Self.hotkeysConflict(state.hotkey, hotkey) {
                 return id
             }
         }
@@ -282,12 +344,7 @@ final class HotkeyService: ObservableObject {
     func isHotkeyAssignedToGlobalSlot(_ hotkey: UnifiedHotkey) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases {
             guard let existing = slots[slotType]?.hotkey else { continue }
-            if existing == hotkey { return slotType }
-            if existing.keyCode == hotkey.keyCode
-                && existing.modifierFlags == hotkey.modifierFlags
-                && existing.isFn == hotkey.isFn
-                && existing.mouseButton == hotkey.mouseButton
-                && existing.isDoubleTap != hotkey.isDoubleTap {
+            if Self.hotkeysConflict(existing, hotkey) {
                 return slotType
             }
         }
@@ -811,25 +868,36 @@ final class HotkeyService: ObservableObject {
         case .modifierCombo:
             guard event.type == .flagsChanged else { return .none }
             let requiredFlags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
-            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
-            let current = event.modifierFlags.intersection(relevantMask)
+            let current = Self.relevantModifierFlags(from: event.modifierFlags)
+            let currentDeviceFlags = Self.deviceSpecificModifierFlags(from: event.modifierFlags)
             let allDown = current.contains(requiredFlags)
-            if allDown, !modifierWasDown { return .down }
-            if !allDown, modifierWasDown {
+            let deviceMatch = Self.deviceModifierFlagsMatch(
+                requiredFlags: requiredFlags,
+                requiredDeviceFlags: hotkey.deviceModifierFlags,
+                currentDeviceFlags: currentDeviceFlags
+            )
+            let isActive = allDown && deviceMatch
+            if isActive, !modifierWasDown { return .down }
+            if !isActive, modifierWasDown {
                 // If the sentinel keyCode (0xFFFF) is used, we have no physical key to track.
                 // Otherwise, we'd need to track which modifiers are still down.
                 // For now, modifier-only combos don't have a 'base key'.
                 return .up
             }
-            if allDown, modifierWasDown { return .repeatDown }
+            if isActive, modifierWasDown { return .repeatDown }
 
         case .keyWithModifiers:
             let requiredFlags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
-            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
-            let currentRelevant = event.modifierFlags.intersection(relevantMask)
+            let currentRelevant = Self.relevantModifierFlags(from: event.modifierFlags)
+            let currentDeviceFlags = Self.deviceSpecificModifierFlags(from: event.modifierFlags)
+            let deviceMatch = Self.deviceModifierFlagsMatch(
+                requiredFlags: requiredFlags,
+                requiredDeviceFlags: hotkey.deviceModifierFlags,
+                currentDeviceFlags: currentDeviceFlags
+            )
 
             if event.type == .keyDown, event.keyCode == hotkey.keyCode {
-                if currentRelevant == requiredFlags {
+                if currentRelevant == requiredFlags && deviceMatch {
                     return keyWasDown ? .repeatDown : .down
                 } else if keyWasDown {
                     return .repeatDown // Modifiers released but key held -> still ours
@@ -837,7 +905,7 @@ final class HotkeyService: ObservableObject {
             } else if event.type == .keyUp, event.keyCode == hotkey.keyCode {
                 if keyWasDown { return .up }
             } else if event.type == .flagsChanged, keyWasDown {
-                if !currentRelevant.contains(requiredFlags) {
+                if !currentRelevant.contains(requiredFlags) || !deviceMatch {
                     return .modifierRelease
                 }
             }
@@ -964,11 +1032,7 @@ final class HotkeyService: ObservableObject {
         var parts: [String] = []
 
         let flags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
-        if flags.contains(.function) { parts.append("Fn") }
-        if flags.contains(.control) { parts.append("⌃") }
-        if flags.contains(.option) { parts.append("⌥") }
-        if flags.contains(.shift) { parts.append("⇧") }
-        if flags.contains(.command) { parts.append("⌘") }
+        parts.append(contentsOf: modifierDisplayParts(flags: flags, deviceFlags: hotkey.deviceModifierFlags))
 
         if hotkey.kind != .modifierCombo {
             parts.append(keyName(for: hotkey.keyCode))
@@ -991,10 +1055,10 @@ final class HotkeyService: ObservableObject {
         if let name = specialKeys[keyCode] { return name }
 
         let modifierNames: [UInt16: String] = [
-            0x37: "Left Command", 0x36: "Right Command",
-            0x38: "Left Shift", 0x3C: "Right Shift",
-            0x3A: "Left Option", 0x3D: "Right Option",
-            0x3B: "Left Control", 0x3E: "Right Control",
+            0x37: "L⌘", 0x36: "R⌘",
+            0x38: "L⇧", 0x3C: "R⇧",
+            0x3A: "L⌥", 0x3D: "R⌥",
+            0x3B: "L⌃", 0x3E: "R⌃",
         ]
         if let name = modifierNames[keyCode] { return name }
 
@@ -1066,6 +1130,77 @@ final class HotkeyService: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    nonisolated static func deviceSpecificModifierFlags(from modifierFlags: NSEvent.ModifierFlags) -> UInt {
+        modifierFlags.rawValue & supportedDeviceModifierFlags
+    }
+
+    private nonisolated static func relevantModifierFlags(from modifierFlags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        modifierFlags.intersection([.command, .option, .control, .shift, .function])
+    }
+
+    private nonisolated static func modifierDisplayParts(flags: NSEvent.ModifierFlags, deviceFlags: UInt) -> [String] {
+        var parts: [String] = []
+        if flags.contains(.function) {
+            parts.append("Fn")
+        }
+        for family in deviceModifierFamilies where flags.contains(family.genericFlag) {
+            let specificFlags = deviceFlags & family.mask
+            switch specificFlags {
+            case family.leftFlag:
+                parts.append(family.leftSymbol)
+            case family.rightFlag:
+                parts.append(family.rightSymbol)
+            default:
+                parts.append(family.genericSymbol)
+            }
+        }
+        return parts
+    }
+
+    private nonisolated static func deviceModifierFlagsMatch(
+        requiredFlags: NSEvent.ModifierFlags,
+        requiredDeviceFlags: UInt,
+        currentDeviceFlags: UInt
+    ) -> Bool {
+        guard requiredDeviceFlags != 0 else { return true }
+
+        for family in deviceModifierFamilies where requiredFlags.contains(family.genericFlag) {
+            let requiredSpecificFlags = requiredDeviceFlags & family.mask
+            if requiredSpecificFlags == 0 {
+                continue
+            }
+            if currentDeviceFlags & family.mask != requiredSpecificFlags {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private nonisolated static func hotkeysConflict(_ lhs: UnifiedHotkey, _ rhs: UnifiedHotkey) -> Bool {
+        guard lhs.isFn == rhs.isFn else { return false }
+        guard lhs.mouseButton == rhs.mouseButton else { return false }
+
+        if lhs.mouseButton != nil || lhs.isFn {
+            return true
+        }
+
+        guard lhs.keyCode == rhs.keyCode, lhs.modifierFlags == rhs.modifierFlags else {
+            return false
+        }
+
+        let genericFlags = NSEvent.ModifierFlags(rawValue: lhs.modifierFlags)
+        for family in deviceModifierFamilies where genericFlags.contains(family.genericFlag) {
+            let lhsSpecificFlags = lhs.deviceModifierFlags & family.mask
+            let rhsSpecificFlags = rhs.deviceModifierFlags & family.mask
+            if lhsSpecificFlags != 0, rhsSpecificFlags != 0, lhsSpecificFlags != rhsSpecificFlags {
+                return false
+            }
+        }
+
+        return true
+    }
 
     private static func modifierFlagForKeyCode(_ keyCode: UInt16) -> NSEvent.ModifierFlags? {
         switch keyCode {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -564,6 +564,7 @@ final class DictationViewModel: ObservableObject {
             // audio hardware (aggregate device) which disrupts NSSound playback.
             soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
             audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
+            audioRecordingService.hasExplicitDeviceSelection = audioDeviceService.selectedDeviceUID != nil
             try audioRecordingService.startRecording()
             if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
             if audioDuckingEnabled {
@@ -609,6 +610,10 @@ final class DictationViewModel: ObservableObject {
             if let recordingError = error as? AudioRecordingService.AudioRecordingError,
                case .noMicrophoneDetected = recordingError {
                 errorMessage = String(localized: "No mic detected.")
+            } else if let recordingError = error as? AudioRecordingService.AudioRecordingError,
+                      case .selectedInputDeviceIncompatible(let issue) = recordingError {
+                audioDeviceService.markSelectedDeviceCompatibility(.incompatible(issue))
+                errorMessage = recordingError.localizedDescription
             } else {
                 errorMessage = error.localizedDescription
             }

--- a/TypeWhisper/Views/HotkeyRecorderView.swift
+++ b/TypeWhisper/Views/HotkeyRecorderView.swift
@@ -9,7 +9,9 @@ struct HotkeyRecorderView: View {
 
     @State private var isRecording = false
     @State private var pendingModifiers: NSEvent.ModifierFlags = []
+    @State private var pendingDeviceModifierFlags: UInt = 0
     @State private var peakModifiers: NSEvent.ModifierFlags = []
+    @State private var peakDeviceModifierFlags: UInt = 0
     @State private var localMonitor: Any?
     @State private var globalMonitor: Any?
     @State private var modifierReleaseTimer: DispatchWorkItem?
@@ -83,13 +85,15 @@ struct HotkeyRecorderView: View {
     }
 
     private var pendingModifierString: String {
-        var parts: [String] = []
-        if pendingModifiers.contains(.function) { parts.append("Fn") }
-        if pendingModifiers.contains(.control) { parts.append("⌃") }
-        if pendingModifiers.contains(.option) { parts.append("⌥") }
-        if pendingModifiers.contains(.shift) { parts.append("⇧") }
-        if pendingModifiers.contains(.command) { parts.append("⌘") }
-        return parts.joined()
+        guard !pendingModifiers.isEmpty else { return "" }
+        return HotkeyService.displayName(
+            for: UnifiedHotkey(
+                keyCode: UnifiedHotkey.modifierComboKeyCode,
+                modifierFlags: pendingModifiers.rawValue,
+                deviceModifierFlags: pendingDeviceModifierFlags,
+                isFn: false
+            )
+        )
     }
 
     private func startRecording() {
@@ -99,7 +103,9 @@ struct HotkeyRecorderView: View {
         Self.activeRecorder = id
         isRecording = true
         pendingModifiers = []
+        pendingDeviceModifierFlags = 0
         peakModifiers = []
+        peakDeviceModifierFlags = 0
         ServiceContainer.shared.hotkeyService.suspendMonitoring()
 
         // Local monitor - can swallow events (return nil)
@@ -123,10 +129,12 @@ struct HotkeyRecorderView: View {
         if event.type == .flagsChanged {
             let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
             let current = event.modifierFlags.intersection(relevantMask)
+            let currentDeviceModifierFlags = HotkeyService.deviceSpecificModifierFlags(from: event.modifierFlags)
 
             // Track peak modifier set (most modifiers held simultaneously)
             if current.isSuperset(of: peakModifiers) {
                 peakModifiers = current
+                peakDeviceModifierFlags = currentDeviceModifierFlags
             }
 
             if current.isEmpty, !pendingModifiers.isEmpty {
@@ -136,7 +144,12 @@ struct HotkeyRecorderView: View {
                 // Build the candidate single-tap hotkey for this release
                 let candidateHotkey: UnifiedHotkey?
                 if peakCount > 1 {
-                    candidateHotkey = UnifiedHotkey(keyCode: UnifiedHotkey.modifierComboKeyCode, modifierFlags: peakModifiers.rawValue, isFn: false)
+                    candidateHotkey = UnifiedHotkey(
+                        keyCode: UnifiedHotkey.modifierComboKeyCode,
+                        modifierFlags: peakModifiers.rawValue,
+                        deviceModifierFlags: peakDeviceModifierFlags,
+                        isFn: false
+                    )
                 } else if peakModifiers.contains(.function) {
                     candidateHotkey = UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
                 } else if HotkeyService.modifierKeyCodes.contains(event.keyCode) {
@@ -151,7 +164,13 @@ struct HotkeyRecorderView: View {
                         // Second tap - finish as double-tap
                         doubleTapTimer?.cancel()
                         doubleTapTimer = nil
-                        let doubleTapHotkey = UnifiedHotkey(keyCode: candidate.keyCode, modifierFlags: candidate.modifierFlags, isFn: candidate.isFn, isDoubleTap: true)
+                        let doubleTapHotkey = UnifiedHotkey(
+                            keyCode: candidate.keyCode,
+                            modifierFlags: candidate.modifierFlags,
+                            deviceModifierFlags: candidate.deviceModifierFlags,
+                            isFn: candidate.isFn,
+                            isDoubleTap: true
+                        )
                         let work = DispatchWorkItem { [self] in
                             finishRecording(doubleTapHotkey)
                         }
@@ -173,12 +192,15 @@ struct HotkeyRecorderView: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
                     }
                     pendingModifiers = []
+                    pendingDeviceModifierFlags = 0
                     peakModifiers = []
+                    peakDeviceModifierFlags = 0
                     return true
                 }
             }
 
             pendingModifiers = current
+            pendingDeviceModifierFlags = currentDeviceModifierFlags
             return true
         }
 
@@ -226,8 +248,16 @@ struct HotkeyRecorderView: View {
 
             let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
             let modifiers = event.modifierFlags.intersection(relevantMask).rawValue
+            let deviceModifierFlags = HotkeyService.deviceSpecificModifierFlags(from: event.modifierFlags)
 
-            finishRecording(UnifiedHotkey(keyCode: event.keyCode, modifierFlags: modifiers, isFn: false))
+            finishRecording(
+                UnifiedHotkey(
+                    keyCode: event.keyCode,
+                    modifierFlags: modifiers,
+                    deviceModifierFlags: deviceModifierFlags,
+                    isFn: false
+                )
+            )
             return true
         }
 
@@ -246,7 +276,9 @@ struct HotkeyRecorderView: View {
         }
         isRecording = false
         pendingModifiers = []
+        pendingDeviceModifierFlags = 0
         peakModifiers = []
+        peakDeviceModifierFlags = 0
         removeMonitors()
         ServiceContainer.shared.hotkeyService.resumeMonitoring()
         onRecord(hotkey)
@@ -264,7 +296,9 @@ struct HotkeyRecorderView: View {
         }
         isRecording = false
         pendingModifiers = []
+        pendingDeviceModifierFlags = 0
         peakModifiers = []
+        peakDeviceModifierFlags = 0
         removeMonitors()
         ServiceContainer.shared.hotkeyService.resumeMonitoring()
     }

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -76,75 +76,69 @@ struct MenuBarView: View {
     @StateObject private var status = MenuBarState()
 
     var body: some View {
-        let _ = { SettingsWindowOpener.shared.openWindow = openWindow }()
+        Group {
+            let _ = { ManagedAppWindowOpener.shared.openWindow = openWindow }()
 
-        Label(status.statusText, systemImage: status.statusImage)
+            Label(status.statusText, systemImage: status.statusImage)
 
-        Divider()
+            Divider()
 
-        Button {
-            openWindow(id: "settings")
-            activateAppWindow("settings")
-        } label: {
-            Label(String(localized: "Settings..."), systemImage: "gear")
-        }
-        .keyboardShortcut(",")
-
-        Button {
-            openWindow(id: "history")
-            activateAppWindow("history")
-        } label: {
-            Label(String(localized: "History"), systemImage: "clock.arrow.circlepath")
-        }
-
-        Button {
-            openWindow(id: "errors")
-            activateAppWindow("errors")
-        } label: {
-            Label(String(localized: "Error Log"), systemImage: "exclamationmark.triangle")
-        }
-
-        Button {
-            openWindow(id: "settings")
-            activateAppWindow("settings")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                FileTranscriptionViewModel.shared.showFilePickerFromMenu = true
+            Button {
+                openManagedWindow("settings")
+            } label: {
+                Label(String(localized: "Settings..."), systemImage: "gear")
             }
-        } label: {
-            Label(String(localized: "Transcribe File..."), systemImage: "doc.text")
-        }
-        .disabled(!status.isModelReady)
+            .keyboardShortcut(",")
 
-        Button {
-            DictationViewModel.shared.readBackLastTranscription()
-        } label: {
-            Label(String(localized: "Read Back Last Transcription"), systemImage: "speaker.wave.2")
-        }
-        .keyboardShortcut("r", modifiers: [.command, .shift])
-        .disabled(DictationViewModel.shared.lastTranscribedText == nil)
+            Button {
+                openManagedWindow("history")
+            } label: {
+                Label(String(localized: "History"), systemImage: "clock.arrow.circlepath")
+            }
 
-        Button(String(localized: "Check for Updates...")) {
-            UpdateChecker.shared?.checkForUpdates()
-        }
-        .disabled(UpdateChecker.shared?.canCheckForUpdates() != true)
+            Button {
+                openManagedWindow("errors")
+            } label: {
+                Label(String(localized: "Error Log"), systemImage: "exclamationmark.triangle")
+            }
 
-        Divider()
+            Button {
+                openManagedWindow("settings")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    FileTranscriptionViewModel.shared.showFilePickerFromMenu = true
+                }
+            } label: {
+                Label(String(localized: "Transcribe File..."), systemImage: "doc.text")
+            }
+            .disabled(!status.isModelReady)
 
-        Button(String(localized: "Quit")) {
-            NSApplication.shared.terminate(nil)
+            Button {
+                DictationViewModel.shared.readBackLastTranscription()
+            } label: {
+                Label(String(localized: "Read Back Last Transcription"), systemImage: "speaker.wave.2")
+            }
+            .keyboardShortcut("r", modifiers: [.command, .shift])
+            .disabled(DictationViewModel.shared.lastTranscribedText == nil)
+
+            Button(String(localized: "Check for Updates...")) {
+                UpdateChecker.shared?.checkForUpdates()
+            }
+            .disabled(UpdateChecker.shared?.canCheckForUpdates() != true)
+
+            Divider()
+
+            Button(String(localized: "Quit")) {
+                NSApplication.shared.terminate(nil)
+            }
+            .keyboardShortcut("q")
         }
-        .keyboardShortcut("q")
+        .onReceive(NotificationCenter.default.publisher(for: .openManagedAppWindow)) { notification in
+            guard let id = notification.userInfo?["id"] as? String else { return }
+            openWindow(id: id)
+        }
     }
 
-    private func activateAppWindow(_ id: String) {
-        NSApp.setActivationPolicy(.regular)
-        DispatchQueue.main.async {
-            if let window = NSApp.windows.first(where: {
-                $0.identifier?.rawValue.localizedCaseInsensitiveContains(id) == true
-            }) {
-                window.makeKeyAndOrderFront(nil)
-            }
-            NSApp.activate()
-        }
+    private func openManagedWindow(_ id: String) {
+        ManagedAppWindowOpener.shared.open(id: id)
     }
 }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -404,8 +404,14 @@ struct RecordingSettingsView: View {
                     Text(String(localized: "System Default")).tag(nil as String?)
                     Divider()
                     ForEach(audioDevice.inputDevices) { device in
-                        Text(device.name).tag(device.uid as String?)
+                        Text(audioDevice.displayName(for: device)).tag(device.uid as String?)
                     }
+                }
+
+                if let message = audioDevice.selectedDeviceStatusMessage {
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
                 }
 
                 if audioDevice.isPreviewActive {
@@ -444,6 +450,12 @@ struct RecordingSettingsView: View {
                     }
                 }
                 .disabled(!audioDevice.isPreviewActive && dictation.needsMicPermission)
+
+                if let error = audioDevice.previewError {
+                    Label(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
 
                 if let name = audioDevice.disconnectedDeviceName {
                     Label(

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -230,8 +230,14 @@ struct SetupWizardView: View {
                     Text(String(localized: "System Default")).tag(nil as String?)
                     Divider()
                     ForEach(audioDevice.inputDevices) { device in
-                        Text(device.name).tag(device.uid as String?)
+                        Text(audioDevice.displayName(for: device)).tag(device.uid as String?)
                     }
+                }
+
+                if let message = audioDevice.selectedDeviceStatusMessage {
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
                 }
 
                 if audioDevice.isPreviewActive {
@@ -268,6 +274,12 @@ struct SetupWizardView: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+
+                if let error = audioDevice.previewError {
+                    Label(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             }
         }
     }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1241,6 +1241,194 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testLegacyModifierComboHotkeyMatchesBothSides() throws {
+        let rightComboEvent = try makeFlagsChangedEvent(
+            keyCode: 0x3D,
+            modifierFlags: modifierFlags([.command, .option], deviceFlags: rightCommandRightOptionDeviceFlags())
+        )
+        let leftComboEvent = try makeFlagsChangedEvent(
+            keyCode: 0x3A,
+            modifierFlags: modifierFlags([.command, .option], deviceFlags: leftCommandLeftOptionDeviceFlags())
+        )
+
+        let rightService = HotkeyService()
+        rightService.suspendMonitoring()
+        rightService.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
+
+        var rightStartCount = 0
+        rightService.onDictationStart = {
+            rightStartCount += 1
+        }
+
+        XCTAssertTrue(rightService.processEventForTesting(rightComboEvent, source: .monitor))
+        XCTAssertEqual(rightStartCount, 1)
+
+        let leftService = HotkeyService()
+        leftService.suspendMonitoring()
+        leftService.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
+
+        var leftStartCount = 0
+        leftService.onDictationStart = {
+            leftStartCount += 1
+        }
+
+        XCTAssertTrue(leftService.processEventForTesting(leftComboEvent, source: .monitor))
+        XCTAssertEqual(leftStartCount, 1)
+    }
+
+    @MainActor
+    func testRightSpecificModifierComboHotkeyRejectsLeftSide() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(rightCommandOptionComboHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let leftComboEvent = try makeFlagsChangedEvent(
+            keyCode: 0x3A,
+            modifierFlags: modifierFlags([.command, .option], deviceFlags: leftCommandLeftOptionDeviceFlags())
+        )
+        let rightComboEvent = try makeFlagsChangedEvent(
+            keyCode: 0x3D,
+            modifierFlags: modifierFlags([.command, .option], deviceFlags: rightCommandRightOptionDeviceFlags())
+        )
+
+        XCTAssertFalse(service.processEventForTesting(leftComboEvent, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(rightComboEvent, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testRightSpecificKeyWithModifiersHotkeyRejectsLeftCommand() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(rightCommandAHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+
+        let leftCommandKeyDown = try makeKeyboardEvent(
+            keyCode: 0x00,
+            keyDown: true,
+            flags: keyboardFlags([.maskCommand], deviceFlags: leftCommandDeviceFlag)
+        )
+        let rightCommandKeyDown = try makeKeyboardEvent(
+            keyCode: 0x00,
+            keyDown: true,
+            flags: keyboardFlags([.maskCommand], deviceFlags: rightCommandDeviceFlag)
+        )
+
+        XCTAssertFalse(service.processEventForTesting(leftCommandKeyDown, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(rightCommandKeyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testRightSpecificKeyWithModifiersStopsWhenMatchingSideChanges() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(rightCommandAHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = {
+            startCount += 1
+        }
+        service.onDictationStop = {
+            stopCount += 1
+        }
+
+        let keyDown = try makeKeyboardEvent(
+            keyCode: 0x00,
+            keyDown: true,
+            flags: keyboardFlags([.maskCommand], deviceFlags: rightCommandDeviceFlag)
+        )
+        let switchedSideEvent = try makeFlagsChangedEvent(
+            keyCode: 0x37,
+            modifierFlags: modifierFlags([.command], deviceFlags: leftCommandDeviceFlag)
+        )
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        XCTAssertTrue(service.processEventForTesting(switchedSideEvent, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testGenericAndSpecificHotkeysConflictButOppositeSidesDoNot() {
+        let genericService = HotkeyService()
+        genericService.suspendMonitoring()
+        genericService.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
+        XCTAssertEqual(genericService.isHotkeyAssigned(rightCommandOptionComboHotkey(), excluding: .hybrid), .toggle)
+
+        let specificService = HotkeyService()
+        specificService.suspendMonitoring()
+        specificService.setHotkeyForTesting(leftCommandOptionComboHotkey(), for: .toggle)
+        XCTAssertNil(specificService.isHotkeyAssigned(rightCommandOptionComboHotkey(), excluding: .hybrid))
+    }
+
+    @MainActor
+    func testProfileConflictUsesSameSideAwareOverlapRules() {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let genericProfileId = UUID()
+        service.registerProfileHotkeys([(id: genericProfileId, hotkey: commandOptionComboHotkey())])
+        XCTAssertEqual(service.isHotkeyAssignedToProfile(rightCommandOptionComboHotkey(), excludingProfileId: nil), genericProfileId)
+
+        let leftSpecificProfileId = UUID()
+        service.registerProfileHotkeys([(id: leftSpecificProfileId, hotkey: leftCommandOptionComboHotkey())])
+        XCTAssertNil(service.isHotkeyAssignedToProfile(rightCommandOptionComboHotkey(), excludingProfileId: nil))
+    }
+
+    func testUnifiedHotkeyDecodesLegacyPayloadWithoutDeviceModifierFlags() throws {
+        let legacyPayload = """
+        {"keyCode":\(UnifiedHotkey.modifierComboKeyCode),"modifierFlags":\(NSEvent.ModifierFlags([.command,.option]).rawValue),"isFn":false}
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(UnifiedHotkey.self, from: legacyPayload)
+
+        XCTAssertEqual(decoded.keyCode, UnifiedHotkey.modifierComboKeyCode)
+        XCTAssertEqual(decoded.modifierFlags, NSEvent.ModifierFlags([.command, .option]).rawValue)
+        XCTAssertEqual(decoded.deviceModifierFlags, 0)
+        XCTAssertFalse(decoded.isDoubleTap)
+    }
+
+    @MainActor
+    func testUnifiedHotkeyRoundTripsDeviceModifierFlags() throws {
+        let hotkey = rightCommandOptionComboHotkey()
+
+        let encoded = try JSONEncoder().encode(hotkey)
+        let decoded = try JSONDecoder().decode(UnifiedHotkey.self, from: encoded)
+
+        XCTAssertEqual(decoded, hotkey)
+        XCTAssertEqual(decoded.deviceModifierFlags, rightCommandRightOptionDeviceFlags())
+    }
+
+    @MainActor
+    func testDisplayNameShowsSpecificModifierSides() {
+        XCTAssertEqual(HotkeyService.displayName(for: rightCommandOptionComboHotkey()), "R⌥R⌘")
+        XCTAssertEqual(HotkeyService.displayName(for: rightCommandAHotkey()), "R⌘A")
+        XCTAssertEqual(
+            HotkeyService.displayName(for: UnifiedHotkey(keyCode: 0x36, modifierFlags: 0, isFn: false)),
+            "R⌘"
+        )
+    }
+
+    @MainActor
     private func spaceHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
             keyCode: 0x31,
@@ -1259,10 +1447,40 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    private func leftCommandOptionComboHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: UnifiedHotkey.modifierComboKeyCode,
+            modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            deviceModifierFlags: leftCommandLeftOptionDeviceFlags(),
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func rightCommandOptionComboHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: UnifiedHotkey.modifierComboKeyCode,
+            modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            deviceModifierFlags: rightCommandRightOptionDeviceFlags(),
+            isFn: false
+        )
+    }
+
+    @MainActor
     private func commandOptionAHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
             keyCode: 0x00,
             modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func rightCommandAHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x00,
+            modifierFlags: NSEvent.ModifierFlags([.command]).rawValue,
+            deviceModifierFlags: rightCommandDeviceFlag,
             isFn: false
         )
     }
@@ -1307,4 +1525,25 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
             )
         )
     }
+
+    private func modifierFlags(_ flags: NSEvent.ModifierFlags, deviceFlags: UInt) -> NSEvent.ModifierFlags {
+        NSEvent.ModifierFlags(rawValue: flags.rawValue | deviceFlags)
+    }
+
+    private func keyboardFlags(_ flags: CGEventFlags, deviceFlags: UInt) -> CGEventFlags {
+        CGEventFlags(rawValue: flags.rawValue | UInt64(deviceFlags))
+    }
+
+    private func leftCommandLeftOptionDeviceFlags() -> UInt {
+        leftCommandDeviceFlag | leftOptionDeviceFlag
+    }
+
+    private func rightCommandRightOptionDeviceFlags() -> UInt {
+        rightCommandDeviceFlag | rightOptionDeviceFlag
+    }
+
+    private let leftCommandDeviceFlag: UInt = 0x00000008
+    private let rightCommandDeviceFlag: UInt = 0x00000010
+    private let leftOptionDeviceFlag: UInt = 0x00000020
+    private let rightOptionDeviceFlag: UInt = 0x00000040
 }

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -69,3 +69,177 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationDebounce)
     }
 }
+
+final class AudioDeviceServiceCompatibilityTests: XCTestCase {
+    private var originalSelectedDeviceUID: Any?
+
+    override func setUp() {
+        super.setUp()
+        originalSelectedDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+    }
+
+    override func tearDown() {
+        if let originalSelectedDeviceUID {
+            UserDefaults.standard.set(originalSelectedDeviceUID, forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        }
+        super.tearDown()
+    }
+
+    func testStartPreview_selectedIncompatibleDeviceDoesNotActivatePreview() {
+        UserDefaults.standard.set("display-mic", forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let device = AudioInputDevice(
+            deviceID: AudioDeviceID(42),
+            name: "LG Ultrafine",
+            uid: "display-mic",
+            compatibility: .incompatible(.cannotSetDevice)
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [device],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.audioDeviceIDResolverOverride = { uid in
+            XCTAssertEqual(uid, "display-mic")
+            return AudioDeviceID(42)
+        }
+
+        service.startPreview()
+
+        XCTAssertFalse(service.isPreviewActive)
+        XCTAssertEqual(service.previewError, .incompatible(.cannotSetDevice))
+    }
+
+    func testSelectingIncompatibleDeviceRevertsToPreviousSelection() {
+        UserDefaults.standard.set("built-in", forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let devices = [
+            AudioInputDevice(deviceID: AudioDeviceID(1), name: "MacBook Pro Mic", uid: "built-in"),
+            AudioInputDevice(deviceID: AudioDeviceID(42), name: "LG Ultrafine", uid: "display-mic")
+        ]
+        let service = AudioDeviceService(
+            initialInputDevices: devices,
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "built-in": return AudioDeviceID(1)
+            case "display-mic": return AudioDeviceID(42)
+            default: return nil
+            }
+        }
+        service.selectionValidationOverride = { deviceID in
+            XCTAssertEqual(deviceID, AudioDeviceID(42))
+            throw SelectedInputDeviceError.incompatible(.cannotSetDevice)
+        }
+
+        service.selectedDeviceUID = "display-mic"
+
+        XCTAssertEqual(service.selectedDeviceUID, "built-in")
+        XCTAssertEqual(service.previewError, .incompatible(.cannotSetDevice))
+        let attemptedDevice = service.inputDevices.first(where: { $0.uid == "display-mic" })
+        XCTAssertEqual(attemptedDevice?.compatibility, .incompatible(.cannotSetDevice))
+    }
+
+    func testDisplayName_marksIncompatibleDevicesWithoutRemovingThem() {
+        let device = AudioInputDevice(
+            deviceID: AudioDeviceID(42),
+            name: "LG Ultrafine",
+            uid: "display-mic",
+            compatibility: .incompatible(.engineStartFailed)
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [device],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+
+        XCTAssertEqual(service.inputDevices.count, 1)
+        XCTAssertEqual(
+            service.displayName(for: device),
+            "LG Ultrafine (\(AudioInputDeviceCompatibilityIssue.engineStartFailed.badgeText))"
+        )
+    }
+
+    func testSavedSelectedIncompatibleDeviceRemainsSelected() {
+        UserDefaults.standard.set("display-mic", forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let device = AudioInputDevice(
+            deviceID: AudioDeviceID(42),
+            name: "LG Ultrafine",
+            uid: "display-mic",
+            compatibility: .incompatible(.invalidInputFormat)
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [device],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+
+        XCTAssertEqual(service.selectedDeviceUID, "display-mic")
+        XCTAssertEqual(service.selectedDevice?.uid, "display-mic")
+        XCTAssertNotNil(service.selectedDeviceStatusMessage)
+    }
+}
+
+final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
+    func testStartRecording_selectedUnavailableDeviceThrowsTypedError() {
+        let service = AudioRecordingService()
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = true
+        service.selectedDeviceID = nil
+
+        XCTAssertThrowsError(try service.startRecording()) { error in
+            guard case AudioRecordingService.AudioRecordingError.selectedInputDeviceUnavailable = error else {
+                return XCTFail("Expected selectedInputDeviceUnavailable, got \(error)")
+            }
+        }
+    }
+
+    func testStartRecording_explicitIncompatibleDeviceDoesNotFallbackToDefault() {
+        let service = AudioRecordingService()
+        var didReachStartOverride = false
+
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = true
+        service.selectedDeviceID = AudioDeviceID(42)
+        service.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertEqual(selectedDeviceID, AudioDeviceID(42))
+            return true
+        }
+        service.startRecordingOverride = {
+            didReachStartOverride = true
+            throw AudioRecordingService.AudioRecordingError.selectedInputDeviceIncompatible(.cannotSetDevice)
+        }
+
+        XCTAssertThrowsError(try service.startRecording()) { error in
+            guard case AudioRecordingService.AudioRecordingError.selectedInputDeviceIncompatible(.cannotSetDevice) = error else {
+                return XCTFail("Expected selectedInputDeviceIncompatible(.cannotSetDevice), got \(error)")
+            }
+        }
+        XCTAssertTrue(didReachStartOverride)
+        XCTAssertFalse(service.isRecording)
+    }
+
+    func testStartRecording_withoutExplicitSelectionStillAllowsDefaultInput() {
+        let service = AudioRecordingService()
+        var didReachStartOverride = false
+
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = false
+        service.selectedDeviceID = nil
+        service.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertNil(selectedDeviceID)
+            return true
+        }
+        service.startRecordingOverride = {
+            didReachStartOverride = true
+        }
+
+        XCTAssertNoThrow(try service.startRecording())
+        XCTAssertTrue(didReachStartOverride)
+        XCTAssertTrue(service.isRecording)
+    }
+}


### PR DESCRIPTION
## Summary
- add left/right-aware modifier storage for unified hotkeys while keeping legacy shortcuts generic
- update hotkey recording, matching, conflict detection, and display labels to respect modifier side
- expand hotkey compatibility tests for side-aware matching, release behavior, conflicts, and Codable compatibility

## Test Plan
- xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests
- manually verified that right Cmd + right Option can be recorded and does not trigger on left Cmd + left Option

Closes #286