### PR TITLE
fix: harden recording recovery during Bluetooth route changes

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
+		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
 		E5A1B2C3D4F5061728394A5B /* NotchIndicatorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */; };
@@ -382,6 +383,9 @@
 		BB00000000000000000031 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
 		BB00000000000000000032 /* TextInsertionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInsertionService.swift; sourceTree = "<group>"; };
 		BB00000000000000000033 /* DictationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationViewModel.swift; sourceTree = "<group>"; };
+		BB00000000000000000350 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
+		BB00000000000000000351 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
+		BB00000000000000000352 /* TypeWhisper-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TypeWhisper-Bridging-Header.h"; sourceTree = "<group>"; };
 		BB00000000000000000040 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		BB00000000000000000041 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		BB00000000000000000042 /* APIRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRouter.swift; sourceTree = "<group>"; };
@@ -1022,6 +1026,7 @@
 			children = (
 				BB00000000000000000093 /* main.swift */,
 				BB00000000000000000001 /* TypeWhisperApp.swift */,
+				BB00000000000000000352 /* TypeWhisper-Bridging-Header.h */,
 				BB00000000000000000002 /* ServiceContainer.swift */,
 				BB00000000000000000070 /* UpdateChecker.swift */,
 				BB00000000000000000119 /* UserDefaultsKeys.swift */,
@@ -1054,6 +1059,8 @@
 				BB00000000000000000009 /* ModelManagerService.swift */,
 				BB00000000000000000010 /* AudioFileService.swift */,
 				BB00000000000000000030 /* AudioRecordingService.swift */,
+				BB00000000000000000350 /* ObjCExceptionCatcher.h */,
+				BB00000000000000000351 /* ObjCExceptionCatcher.m */,
 				BB00000000000000000220 /* AudioPlaybackService.swift */,
 				BB00000000000000000031 /* HotkeyService.swift */,
 				BB00000000000000000196 /* IndicatorCoordinator.swift */,
@@ -2797,6 +2804,7 @@
 				AA00000000000000000016 /* FileTranscriptionView.swift in Sources */,
 				AA00000000000000000017 /* SettingsView.swift in Sources */,
 				AA00000000000000000030 /* AudioRecordingService.swift in Sources */,
+				AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */,
 				AA00000000000000000230 /* AudioPlaybackService.swift in Sources */,
 				AA00000000000000000031 /* HotkeyService.swift in Sources */,
 				AA00000000000000000032 /* TextInsertionService.swift in Sources */,
@@ -3391,6 +3399,7 @@
 				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev;
 				PRODUCT_NAME = TypeWhisper;
+				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 6.0;
@@ -3419,6 +3428,7 @@
 				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac;
 				PRODUCT_NAME = TypeWhisper;
+				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 6.0;

--- a/TypeWhisper/Services/AudioEngineRecoverySupport.swift
+++ b/TypeWhisper/Services/AudioEngineRecoverySupport.swift
@@ -19,6 +19,11 @@ enum AudioEngineRecoveryPolicy {
 
     static func isRetryable(error: Error) -> Bool {
         let nsError = error as NSError
+        if nsError.domain == AudioEngineRecoveryErrorDomains.avfException
+            || nsError.domain == AudioEngineRecoveryErrorDomains.transientFormatMismatch {
+            return true
+        }
+
         let detail = nsError.localizedDescription
         return isRetryable(detail: detail, osStatus: extractOSStatus(from: error))
     }
@@ -46,6 +51,16 @@ enum AudioEngineRecoveryPolicy {
         if detail.contains("-10877") { return kAudioUnitErr_InvalidElement }
         return nil
     }
+}
+
+enum AudioEngineRecoveryErrorDomains {
+    static let avfException = "com.typewhisper.AVFException"
+    static let transientFormatMismatch = "com.typewhisper.AudioRecordingRecovery"
+}
+
+enum AudioEngineRecoveryErrorUserInfoKeys {
+    static let exceptionName = "NSExceptionName"
+    static let exceptionUserInfo = "NSExceptionUserInfo"
 }
 
 final class AudioEngineRecoveryCoordinator: @unchecked Sendable {

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -32,6 +32,13 @@ final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
 
 /// Captures microphone audio via AVAudioEngine and converts to 16kHz mono Float32 samples.
 final class AudioRecordingService: ObservableObject, @unchecked Sendable {
+    private let recoveryNotificationQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "com.typewhisper.audio-recovery.notifications"
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
+
     enum StopPolicy {
         case immediate
         case finalizeShortSpeech(
@@ -128,6 +135,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     static let targetSampleRate: Double = 16000
     private static let captureTapFrames: AVAudioFrameCount = 1024
     private static let engineTeardownRetentionInterval: TimeInterval = 0.3
+
+    init() {
+        recoveryNotificationQueue.underlyingQueue = recoveryQueue
+    }
 
     var peakRawAudioLevel: Float {
         bufferLock.lock()
@@ -236,7 +247,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
             if recoveryCoordinator.finishStartingSuccessfully() == .performImmediateRecovery {
                 logger.warning("Audio engine configuration changed while recording was starting, restarting with fresh input format")
-                try restartEngineWithRecovery(engine, label: "recording-startup")
+                guard let currentEngine = engineLock.withLock({ audioEngine }) else {
+                    throw AudioRecordingError.engineStartFailed("Recording engine disappeared during startup recovery")
+                }
+                try restartEngineWithRecovery(currentEngine, label: "recording-startup")
                 scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
             }
 
@@ -338,7 +352,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         configChangeObserver = NotificationCenter.default.addObserver(
             forName: .AVAudioEngineConfigurationChange,
             object: engine,
-            queue: nil
+            queue: recoveryNotificationQueue
         ) { [weak self] _ in
             self?.handleConfigurationChangeNotification()
         }
@@ -389,8 +403,18 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func restartEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+        guard let replacementEngine = replaceAudioEngineForRecoveryIfNeeded(engine) else { return }
+
+        installConfigurationObserver(for: replacementEngine)
         teardownEngine(engine)
-        try startEngineWithRecovery(engine, label: label)
+        engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+
+        do {
+            try startEngineWithRecovery(replacementEngine, label: label)
+        } catch {
+            cleanupAfterFailedStart(replacementEngine)
+            throw error
+        }
     }
 
     private func configureAndStartEngine(_ engine: AVAudioEngine, label: String) throws {
@@ -414,14 +438,32 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.engineStartFailed("Cannot create target audio format")
         }
 
-        let tapFormat = Self.monoTapFormat(for: inputFormat)
+        let currentInputFormat = inputNode.outputFormat(forBus: 0)
+        try validateTapInstallationPreconditions(expected: inputFormat, current: currentInputFormat)
+
+        let tapFormat = Self.monoTapFormat(for: currentInputFormat)
 
         guard let converter = AVAudioConverter(from: tapFormat, to: targetFormat) else {
             throw AudioRecordingError.engineStartFailed("Cannot create audio converter")
         }
 
-        inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
-            self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
+        inputNode.removeTap(onBus: 0)
+
+        do {
+            _ = try ObjCExceptionCatcher.catching {
+                inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
+                    self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
+                }
+            }
+        } catch {
+            let tapError = error as NSError? ?? NSError(
+                domain: AudioEngineRecoveryErrorDomains.avfException,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "installTap raised NSException"]
+            )
+            let exceptionName = tapError.userInfo[AudioEngineRecoveryErrorUserInfoKeys.exceptionName] as? String ?? "NSException"
+            logger.error("\(label, privacy: .public) installTap raised \(exceptionName, privacy: .public): \(tapError.localizedDescription, privacy: .public)")
+            throw tapError
         }
 
         let engineStartTime = CFAbsoluteTimeGetCurrent()
@@ -439,6 +481,17 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func teardownEngine(_ engine: AVAudioEngine) {
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+    }
+
+    @discardableResult
+    private func replaceAudioEngineForRecoveryIfNeeded(_ engine: AVAudioEngine) -> AVAudioEngine? {
+        let replacementEngine = AVAudioEngine()
+        let didReplace = engineLock.withLock { () -> Bool in
+            guard audioEngine === engine else { return false }
+            audioEngine = replacementEngine
+            return true
+        }
+        return didReplace ? replacementEngine : nil
     }
 
     private func cleanupAfterFailedStart(_ engine: AVAudioEngine) {
@@ -580,4 +633,47 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             return .selectedInputDeviceIncompatible(issue)
         }
     }
+
+    private func validateTapInstallationPreconditions(expected: AVAudioFormat, current: AVAudioFormat) throws {
+        let currentSampleRate = current.sampleRate
+        let currentChannelCount = current.channelCount
+        let matchesExpected = currentSampleRate == expected.sampleRate && currentChannelCount == expected.channelCount
+
+        guard currentSampleRate > 0, currentChannelCount > 0, matchesExpected else {
+            throw Self.makeTransientFormatMismatchError(expected: expected, current: current)
+        }
+    }
+
+    static func makeTransientFormatMismatchError(expected: AVAudioFormat, current: AVAudioFormat) -> NSError {
+        NSError(
+            domain: AudioEngineRecoveryErrorDomains.transientFormatMismatch,
+            code: 0,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Format mismatch before installTap: expected \(expected.sampleRate) Hz/\(expected.channelCount) ch, got \(current.sampleRate) Hz/\(current.channelCount) ch"
+            ]
+        )
+    }
 }
+
+#if DEBUG
+extension AudioRecordingService {
+    @discardableResult
+    func testingReplaceAudioEngineForRecoveryIfNeeded(_ engine: AVAudioEngine) -> AVAudioEngine? {
+        replaceAudioEngineForRecoveryIfNeeded(engine)
+    }
+
+    func testingSetAudioEngine(_ engine: AVAudioEngine?) {
+        engineLock.withLock {
+            audioEngine = engine
+        }
+    }
+
+    func testingCurrentAudioEngine() -> AVAudioEngine? {
+        engineLock.withLock { audioEngine }
+    }
+
+    func testingValidateTapInstallationPreconditions(expected: AVAudioFormat, current: AVAudioFormat) throws {
+        try validateTapInstallationPreconditions(expected: expected, current: current)
+    }
+}
+#endif

--- a/TypeWhisper/Services/ObjCExceptionCatcher.h
+++ b/TypeWhisper/Services/ObjCExceptionCatcher.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjCExceptionCatcher : NSObject
+
++ (BOOL)catching:(void (NS_NOESCAPE ^)(void))tryBlock error:(NSError * _Nullable * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TypeWhisper/Services/ObjCExceptionCatcher.m
+++ b/TypeWhisper/Services/ObjCExceptionCatcher.m
@@ -1,0 +1,23 @@
+#import "ObjCExceptionCatcher.h"
+
+@implementation ObjCExceptionCatcher
+
++ (BOOL)catching:(void (NS_NOESCAPE ^)(void))tryBlock error:(NSError * _Nullable * _Nullable)error {
+    @try {
+        tryBlock();
+        return YES;
+    } @catch (NSException *exception) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:@"com.typewhisper.AVFException"
+                                         code:0
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: exception.reason ?: exception.name ?: @"NSException",
+                                         @"NSExceptionName": exception.name ?: @"",
+                                         @"NSExceptionUserInfo": exception.userInfo ?: @{},
+                                     }];
+        }
+        return NO;
+    }
+}
+
+@end

--- a/TypeWhisper/TypeWhisper-Bridging-Header.h
+++ b/TypeWhisper/TypeWhisper-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "Services/ObjCExceptionCatcher.h"

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1,4 +1,5 @@
 import AudioToolbox
+import AVFoundation
 import XCTest
 @testable import TypeWhisper
 
@@ -13,10 +14,37 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertFalse(AudioEngineRecoveryPolicy.isRetryable(error: permissionError))
     }
 
+    func testRetryableErrorClassification_matchesObjCExceptionAndFormatMismatchDomains() {
+        let avfException = NSError(
+            domain: AudioEngineRecoveryErrorDomains.avfException,
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "required condition is false"]
+        )
+        let transientFormatMismatch = NSError(
+            domain: AudioEngineRecoveryErrorDomains.transientFormatMismatch,
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "Format mismatch before installTap"]
+        )
+
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: avfException))
+        XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: transientFormatMismatch))
+    }
+
     func testRetryableErrorClassification_matchesKnownLogMessages() {
         XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "Failed to create tap, config change pending!", osStatus: nil))
         XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(detail: "Format mismatch: input hw 24000 Hz, client format 48000 Hz", osStatus: nil))
         XCTAssertFalse(AudioEngineRecoveryPolicy.isRetryable(detail: "Microphone permission denied", osStatus: nil))
+    }
+
+    func testObjCExceptionCatcher_convertsNSExceptionIntoNSError() {
+        XCTAssertThrowsError(try ObjCExceptionCatcher.catching {
+            _ = NSArray().object(at: 1)
+        }) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, AudioEngineRecoveryErrorDomains.avfException)
+            XCTAssertEqual(nsError.userInfo[AudioEngineRecoveryErrorUserInfoKeys.exceptionName] as? String, NSExceptionName.rangeException.rawValue)
+            XCTAssertFalse(nsError.localizedDescription.isEmpty)
+        }
     }
 
     func testConfigurationChangeDuringStart_triggersImmediateRecoveryOnceStartSucceeds() {
@@ -67,6 +95,17 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
 
         XCTAssertNotEqual(generation, followUpGeneration)
         XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationDebounce)
+    }
+
+    func testTransientFormatMismatchError_describesMismatch() throws {
+        let expected = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+        let current = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 0, channels: 0, interleaved: false))
+
+        let error = AudioRecordingService.makeTransientFormatMismatchError(expected: expected, current: current)
+
+        XCTAssertEqual(error.domain, AudioEngineRecoveryErrorDomains.transientFormatMismatch)
+        XCTAssertTrue(error.localizedDescription.contains("expected 48000.0 Hz/1 ch"))
+        XCTAssertTrue(error.localizedDescription.contains("got 0.0 Hz/0 ch"))
     }
 }
 
@@ -241,5 +280,29 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertNoThrow(try service.startRecording())
         XCTAssertTrue(didReachStartOverride)
         XCTAssertTrue(service.isRecording)
+    }
+
+    func testRecoveryEngineSwap_replacesStoredEngineInstance() {
+        let service = AudioRecordingService()
+        let originalEngine = AVAudioEngine()
+
+        service.testingSetAudioEngine(originalEngine)
+        let replacementEngine = service.testingReplaceAudioEngineForRecoveryIfNeeded(originalEngine)
+
+        XCTAssertNotNil(replacementEngine)
+        XCTAssertTrue(service.testingCurrentAudioEngine() === replacementEngine)
+        XCTAssertFalse(service.testingCurrentAudioEngine() === originalEngine)
+    }
+
+    func testTapPreconditions_throwRetryableMismatchWhenFormatChangesImmediately() throws {
+        let service = AudioRecordingService()
+        let expected = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+        let current = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 24_000, channels: 1, interleaved: false))
+
+        XCTAssertThrowsError(try service.testingValidateTapInstallationPreconditions(expected: expected, current: current)) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, AudioEngineRecoveryErrorDomains.transientFormatMismatch)
+            XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: nsError))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the recording recovery path with a fresh `AVAudioEngine` on configuration changes
- catch Objective-C `installTap` exceptions and treat them as retryable recovery failures instead of crashing
- revalidate the input format immediately before installing the tap and add regression tests for the new recovery paths

## Why
Bluetooth and AirPods route changes could trigger an uncaught `NSException` from `AVAudioNode.installTap`, causing a fatal crash on the audio recovery queue. The recording path now downgrades that failure into controlled recovery or a normal recording error.

## Impact
Recording should no longer terminate the app when AVFAudio throws during route churn. Users may still see a failed restart if CoreAudio never settles, but the process should stay alive.

## Validation
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests -only-testing:TypeWhisperTests/AudioRecordingServiceSelectedDeviceTests`

## Manual testing needed
- AirPods / Bluetooth profile switching while dictating
- Bluetooth off/on during recording
- Hot-swapping between Bluetooth and USB input devices

Refs #293