### PR TITLE
Add multi-release registry support and incremental live transcription

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -239,7 +239,6 @@ jobs:
           with open("/tmp/gh-pages/plugins.json", "r") as f:
               registry = json.load(f)
 
-          plugin_name = "$PLUGIN_NAME"
           version = "$PLUGIN_VERSION"
           size = int("$ZIP_SIZE")
           download_url = "$DOWNLOAD_URL"
@@ -253,41 +252,86 @@ jobs:
           with open(src_manifest) as mf:
               manifest = json.load(mf)
 
-          def sync_registry_fields(plugin):
+          registry["schemaVersion"] = max(int(registry.get("schemaVersion", 1)), 2)
+
+          def version_key(value):
+              return tuple(int(part) for part in value.split("."))
+
+          def sync_plugin_metadata(plugin):
               plugin["id"] = manifest["id"]
               plugin["name"] = manifest["name"]
-              plugin["version"] = version
-              plugin["minHostVersion"] = manifest.get("minHostVersion", plugin.get("minHostVersion", "0.9.0"))
               plugin["author"] = manifest.get("author", plugin.get("author", "TypeWhisper"))
               plugin["description"] = manifest.get("description", plugin.get("description", ""))
               plugin["descriptions"] = manifest.get("descriptions", plugin.get("descriptions", {}))
               plugin["category"] = manifest.get("category", plugin.get("category", "utility"))
-              plugin["size"] = size
-              plugin["downloadURL"] = download_url
+              plugin["downloadCount"] = plugin.get("downloadCount", 0)
 
-              optional_fields = [
-                  "minOSVersion",
-                  "supportedArchitectures",
-                  "iconSystemName",
-                  "requiresAPIKey",
-              ]
-              for field in optional_fields:
+              for field in ["iconSystemName", "requiresAPIKey"]:
                   if field in manifest and manifest[field] is not None:
                       plugin[field] = manifest[field]
                   else:
                       plugin.pop(field, None)
 
+              for legacy_field in [
+                  "version",
+                  "minHostVersion",
+                  "minOSVersion",
+                  "supportedArchitectures",
+                  "size",
+                  "downloadURL",
+              ]:
+                  plugin.pop(legacy_field, None)
+
+          def build_release():
+              release = {
+                  "version": version,
+                  "minHostVersion": manifest.get("minHostVersion", "0.9.0"),
+                  "size": size,
+                  "downloadURL": download_url,
+              }
+              for field in ["minOSVersion", "supportedArchitectures"]:
+                  if field in manifest and manifest[field] is not None:
+                      release[field] = manifest[field]
+              return release
+
+          def migrate_legacy_release(plugin):
+              if plugin.get("releases"):
+                  return plugin["releases"]
+
+              version_value = plugin.get("version")
+              min_host = plugin.get("minHostVersion")
+              size_value = plugin.get("size")
+              download_value = plugin.get("downloadURL")
+              if not all([version_value, min_host, size_value, download_value]):
+                  return []
+
+              legacy = {
+                  "version": version_value,
+                  "minHostVersion": min_host,
+                  "size": size_value,
+                  "downloadURL": download_value,
+              }
+              for field in ["minOSVersion", "supportedArchitectures"]:
+                  if field in plugin and plugin[field] is not None:
+                      legacy[field] = plugin[field]
+              return [legacy]
+
           updated = False
           for plugin in registry["plugins"]:
-              if plugin_name in plugin["id"]:
-                  sync_registry_fields(plugin)
+              if plugin["id"] == manifest["id"]:
+                  sync_plugin_metadata(plugin)
+                  releases = migrate_legacy_release(plugin)
+                  releases = [release for release in releases if release.get("version") != version]
+                  releases.append(build_release())
+                  plugin["releases"] = sorted(releases, key=lambda release: version_key(release["version"]), reverse=True)
                   updated = True
-                  print(f"Updated {plugin['id']} to v{version}")
+                  print(f"Updated {plugin['id']} release set with v{version}")
                   break
 
           if not updated:
               new_entry = {}
-              sync_registry_fields(new_entry)
+              sync_plugin_metadata(new_entry)
+              new_entry["releases"] = [build_release()]
               registry["plugins"].append(new_entry)
               print(f"Added new plugin {manifest['id']} v{version}")
 

--- a/.github/workflows/update-plugin-downloads.yml
+++ b/.github/workflows/update-plugin-downloads.yml
@@ -35,14 +35,18 @@ jobs:
           with open("/tmp/releases.json") as f:
               releases = json.load(f)
 
-          # Sum download counts per plugin across all versions
+          # Sum download counts per plugin across all versions and track per-release counts.
           counts = {}
+          release_counts = {}
           for release in releases:
               tag = release.get("tag_name", "")
-              m = re.match(r"^plugin-(.+)-v\d", tag)
+              m = re.match(r"^plugin-(.+)-v(\d+(?:\.\d+)+)$", tag)
               if not m:
                   continue
               plugin_name = m.group(1)
+              version = m.group(2)
+              total = sum(asset.get("download_count", 0) for asset in release.get("assets", []))
+              release_counts[(plugin_name, version)] = total
               for asset in release.get("assets", []):
                   counts[plugin_name] = counts.get(plugin_name, 0) + asset.get("download_count", 0)
 
@@ -59,6 +63,17 @@ jobs:
                           plugin["downloadCount"] = count
                           changed = True
                           print(f"{pid}: {old} -> {count}")
+
+                      for release in plugin.get("releases", []):
+                          version = release.get("version")
+                          if not version:
+                              continue
+                          release_old = release.get("downloadCount", 0)
+                          release_new = release_counts.get((name, version), 0)
+                          if release_old != release_new:
+                              release["downloadCount"] = release_new
+                              changed = True
+                              print(f"{pid}@{version}: {release_old} -> {release_new}")
                       break
 
           if changed:

--- a/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -9,7 +9,7 @@ import os
 
 @available(macOS 26, *)
 @objc(SpeechAnalyzerPlugin)
-final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
+final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.speechanalyzer"
     static let pluginName = "Apple Speech"
 
@@ -173,6 +173,24 @@ final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, PluginSet
             text: text.trimmingCharacters(in: .whitespacesAndNewlines),
             detectedLanguage: locale.language.languageCode?.identifier
         )
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        guard let locale = currentLocale else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        if translate {
+            throw PluginTranscriptionError.apiError("Apple Speech does not support translation")
+        }
+
+        let session = SpeechAnalyzerLiveSession(locale: locale, onProgress: onProgress)
+        try await session.start()
+        return session
     }
 
     // MARK: - Model Management
@@ -341,6 +359,82 @@ final class SpeechAnalyzerPlugin: NSObject, TranscriptionEnginePlugin, PluginSet
 
     var settingsView: AnyView? {
         AnyView(SpeechAnalyzerSettingsView(plugin: self))
+    }
+}
+
+@available(macOS 26, *)
+private actor SpeechAnalyzerLiveSession: LiveTranscriptionSession {
+    private let locale: Locale
+    private let onProgress: @Sendable (String) -> Bool
+    private let transcriber: SpeechTranscriber
+    private let analyzer: SpeechAnalyzer
+    private let stream: AsyncStream<AnalyzerInput>
+    private let continuation: AsyncStream<AnalyzerInput>.Continuation
+    private let resultTask: Task<String, Error>
+    private var didFinish = false
+
+    init(locale: Locale, onProgress: @escaping @Sendable (String) -> Bool) {
+        self.locale = locale
+        self.onProgress = onProgress
+        self.transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults],
+            attributeOptions: []
+        )
+        self.analyzer = SpeechAnalyzer(modules: [transcriber])
+        let streamParts = AsyncStream<AnalyzerInput>.makeStream()
+        self.stream = streamParts.stream
+        self.continuation = streamParts.continuation
+        self.resultTask = Task<String, Error> {
+            var fullText = ""
+            for try await result in transcriber.results {
+                let text = String(result.text.characters)
+                if result.isFinal {
+                    fullText += text
+                } else {
+                    let combined = fullText + text
+                    if !onProgress(combined) { break }
+                }
+            }
+            return fullText
+        }
+    }
+
+    func start() async throws {
+        try await analyzer.start(inputSequence: stream)
+    }
+
+    func appendAudio(samples: [Float]) async throws {
+        guard !didFinish, !samples.isEmpty else { return }
+        let buffer = await SpeechAnalyzerPlugin.prepareBuffer(samples, for: [transcriber])
+        continuation.yield(AnalyzerInput(buffer: buffer))
+    }
+
+    func finish() async throws -> PluginTranscriptionResult {
+        guard !didFinish else {
+            let text = try await resultTask.value
+            return PluginTranscriptionResult(
+                text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+                detectedLanguage: locale.language.languageCode?.identifier
+            )
+        }
+
+        didFinish = true
+        continuation.finish()
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
+        let text = try await resultTask.value
+
+        return PluginTranscriptionResult(
+            text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+            detectedLanguage: locale.language.languageCode?.identifier
+        )
+    }
+
+    func cancel() async {
+        didFinish = true
+        continuation.finish()
+        resultTask.cancel()
     }
 }
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
+		91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */; };
+		91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */; };
 		E5A1B2C3D4F5061728394A5B /* NotchIndicatorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */; };
 		E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */; };
 		3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
@@ -580,6 +582,8 @@
 		E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRouterAndHandlersTests.swift; sourceTree = "<group>"; };
 		E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TypeWhisperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationViewModelIndicatorSettingsTests.swift; sourceTree = "<group>"; };
+		91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginRegistryServiceTests.swift; sourceTree = "<group>"; };
+		91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingHandlerTests.swift; sourceTree = "<group>"; };
 		E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayout.swift; sourceTree = "<group>"; };
 		E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayoutTests.swift; sourceTree = "<group>"; };
 		E808D246301E36546EEB811F /* TestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestSupport.swift; sourceTree = "<group>"; };
@@ -1639,9 +1643,11 @@
 				8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */,
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
+				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				F41BD305007A3A158038C75C /* ProfileServiceTests.swift */,
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
+				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
 				05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */,
 			);
@@ -2772,9 +2778,11 @@
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
 				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
+				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,
 				A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */,
+				91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */,
 				204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */,
 				76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */,
 				E2DA879FDEFA04FBD013E837 /* OutputFormatter.swift in Sources */,

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -209,6 +209,22 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Returns audio appended since `sampleOffset` and the updated absolute offset.
+    func getBufferDelta(since sampleOffset: Int) -> (samples: [Float], nextOffset: Int) {
+        let micEnabled = self.micEnabled
+        let systemAudioEnabled = self.systemAudioEnabled
+        let micDuckingMode = self.micDuckingMode
+        return transcriptionBufferLock.withLock { state in
+            let buffer = state.mixedBuffer(
+                micEnabled: micEnabled,
+                systemAudioEnabled: systemAudioEnabled,
+                micDuckingMode: micDuckingMode
+            )
+            let clampedOffset = max(0, min(sampleOffset, buffer.count))
+            return (Array(buffer.dropFirst(clampedOffset)), buffer.count)
+        }
+    }
+
     /// Total duration of transcription buffer in seconds.
     var totalBufferDuration: TimeInterval {
         let micEnabled = self.micEnabled

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -181,6 +181,16 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         return Array(sampleBuffer.suffix(maxSamples))
     }
 
+    /// Returns audio appended since `sampleOffset` and the updated absolute offset.
+    func getBufferDelta(since sampleOffset: Int) -> (samples: [Float], nextOffset: Int) {
+        bufferLock.lock()
+        defer { bufferLock.unlock() }
+
+        let clampedOffset = max(0, min(sampleOffset, sampleBuffer.count))
+        let samples = Array(sampleBuffer.dropFirst(clampedOffset))
+        return (samples, sampleBuffer.count)
+    }
+
     /// Total duration of the recorded audio in seconds.
     var totalBufferDuration: TimeInterval {
         bufferLock.lock()

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -27,6 +27,11 @@ enum TranscriptionEngineError: LocalizedError {
 
 @MainActor
 final class ModelManagerService: ObservableObject {
+    struct LiveTranscriptionSessionHandle: Sendable {
+        let providerId: String
+        let session: any LiveTranscriptionSession
+    }
+
     @Published private(set) var selectedProviderId: String?
 
     @Published var autoUnloadSeconds: Int {
@@ -113,6 +118,22 @@ final class ModelManagerService: ObservableObject {
         return plugin.supportsStreaming
     }
 
+    func supportsLiveTranscriptionSession(engineOverrideId: String? = nil) -> Bool {
+        guard let providerId = engineOverrideId ?? selectedProviderId,
+              let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
+            return false
+        }
+        return plugin is LiveTranscriptionCapablePlugin
+    }
+
+    func usesMeteredStreamingFallback(engineOverrideId: String? = nil) -> Bool {
+        guard let providerId = engineOverrideId ?? selectedProviderId,
+              let loadedPlugin = PluginManager.shared.loadedTranscriptionPlugin(for: providerId) else {
+            return false
+        }
+        return loadedPlugin.manifest.requiresAPIKey == true
+    }
+
     /// Resolve display name for a given engine/model override combination
     func resolvedModelDisplayName(engineOverrideId: String? = nil, cloudModelOverride: String? = nil) -> String? {
         let providerId = engineOverrideId ?? selectedProviderId
@@ -149,6 +170,64 @@ final class ModelManagerService: ObservableObject {
     }
 
     // MARK: - Transcription
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        task: TranscriptionTask,
+        engineOverrideId: String? = nil,
+        cloudModelOverride: String? = nil,
+        prompt: String? = nil,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> LiveTranscriptionSessionHandle? {
+        let providerId = engineOverrideId ?? selectedProviderId
+        guard let providerId,
+              let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
+            throw TranscriptionEngineError.modelNotLoaded
+        }
+
+        if !plugin.isConfigured {
+            await triggerRestoreModel(plugin)
+        }
+        guard plugin.isConfigured else {
+            throw TranscriptionEngineError.modelNotLoaded
+        }
+
+        if let modelId = cloudModelOverride {
+            plugin.selectModel(modelId)
+        }
+
+        guard let livePlugin = plugin as? LiveTranscriptionCapablePlugin else {
+            return nil
+        }
+
+        let session = try await livePlugin.createLiveTranscriptionSession(
+            language: language,
+            translate: task == .translate,
+            prompt: prompt,
+            onProgress: onProgress
+        )
+        return LiveTranscriptionSessionHandle(providerId: providerId, session: session)
+    }
+
+    func finishLiveTranscriptionSession(
+        _ handle: LiveTranscriptionSessionHandle,
+        bufferedDuration: Double
+    ) async throws -> TranscriptionResult {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let result = try await handle.session.finish()
+        let processingTime = CFAbsoluteTimeGetCurrent() - startTime
+
+        scheduleAutoUnloadIfNeeded()
+
+        return TranscriptionResult(
+            text: result.text,
+            detectedLanguage: result.detectedLanguage,
+            duration: bufferedDuration,
+            processingTime: processingTime,
+            engineUsed: handle.providerId,
+            segments: result.segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }
+        )
+    }
 
     func transcribe(
         audioSamples: [Float],

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -27,6 +27,7 @@ enum PluginCompatibility {
         isCompatible(
             minOSVersion: minOSVersion,
             supportedArchitectures: supportedArchitectures,
+            currentOSVersion: ProcessInfo.processInfo.operatingSystemVersion,
             architecture: RuntimeArchitecture.current
         )
     }
@@ -34,9 +35,10 @@ enum PluginCompatibility {
     static func isCompatible(
         minOSVersion: String?,
         supportedArchitectures: [String]?,
+        currentOSVersion: OperatingSystemVersion,
         architecture: String
     ) -> Bool {
-        if let minOSVersion, !isCompatibleWithCurrentOS(minOSVersion: minOSVersion) {
+        if let minOSVersion, !isCompatibleWithCurrentOS(minOSVersion: minOSVersion, currentOSVersion: currentOSVersion) {
             return false
         }
 
@@ -52,7 +54,10 @@ enum PluginCompatibility {
         supportedArchitectures: [String]?,
         architecture: String
     ) -> String? {
-        if let minOSVersion, !isCompatibleWithCurrentOS(minOSVersion: minOSVersion) {
+        if let minOSVersion, !isCompatibleWithCurrentOS(
+            minOSVersion: minOSVersion,
+            currentOSVersion: ProcessInfo.processInfo.operatingSystemVersion
+        ) {
             return "requires macOS \(minOSVersion)"
         }
 
@@ -67,14 +72,23 @@ enum PluginCompatibility {
         return "supports architectures \(supportedArchitectures.joined(separator: ", "))"
     }
 
-    private static func isCompatibleWithCurrentOS(minOSVersion: String) -> Bool {
+    private static func isCompatibleWithCurrentOS(
+        minOSVersion: String,
+        currentOSVersion: OperatingSystemVersion
+    ) -> Bool {
         let parts = minOSVersion.split(separator: ".").compactMap { Int($0) }
         let required = OperatingSystemVersion(
             majorVersion: parts.count > 0 ? parts[0] : 0,
             minorVersion: parts.count > 1 ? parts[1] : 0,
             patchVersion: parts.count > 2 ? parts[2] : 0
         )
-        return ProcessInfo.processInfo.isOperatingSystemAtLeast(required)
+        if currentOSVersion.majorVersion != required.majorVersion {
+            return currentOSVersion.majorVersion > required.majorVersion
+        }
+        if currentOSVersion.minorVersion != required.minorVersion {
+            return currentOSVersion.minorVersion > required.minorVersion
+        }
+        return currentOSVersion.patchVersion >= required.patchVersion
     }
 }
 
@@ -165,6 +179,13 @@ final class PluginManager: ObservableObject {
 
     func transcriptionEngine(for providerId: String) -> TranscriptionEnginePlugin? {
         transcriptionEngines.first { $0.providerId == providerId }
+    }
+
+    func loadedTranscriptionPlugin(for providerId: String) -> LoadedPlugin? {
+        loadedPlugins.first {
+            guard let engine = $0.instance as? TranscriptionEnginePlugin else { return false }
+            return $0.isEnabled && engine.providerId == providerId
+        }
     }
 
     func actionPlugin(for actionId: String) -> ActionPlugin? {

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -101,9 +101,172 @@ struct RegistryPlugin: Codable, Identifiable {
     }
 }
 
-struct PluginRegistryResponse: Codable {
+struct RegistryPluginRelease: Decodable, Equatable {
+    let version: String
+    let minHostVersion: String
+    let minOSVersion: String?
+    let supportedArchitectures: [String]?
+    let size: Int64
+    let downloadURL: String
+    let publishedAt: String?
+    let downloadCount: Int?
+
+    func isCompatible(
+        withAppVersion appVersion: String,
+        currentOSVersion: OperatingSystemVersion,
+        architecture: String
+    ) -> Bool {
+        PluginRegistryService.compareVersions(minHostVersion, appVersion) != .orderedDescending
+            && PluginCompatibility.isCompatible(
+                minOSVersion: minOSVersion,
+                supportedArchitectures: supportedArchitectures,
+                currentOSVersion: currentOSVersion,
+                architecture: architecture
+            )
+    }
+}
+
+private struct LegacyRegistryRelease: Decodable {
+    let version: String?
+    let minHostVersion: String?
+    let minOSVersion: String?
+    let supportedArchitectures: [String]?
+    let size: Int64?
+    let downloadURL: String?
+    let downloadCount: Int?
+}
+
+struct RegistryPluginEntry: Decodable {
+    let id: String
+    let name: String
+    let author: String
+    let description: String
+    let category: String
+    let iconSystemName: String?
+    let requiresAPIKey: Bool?
+    let descriptions: [String: String]?
+    let downloadCount: Int?
+    let releases: [RegistryPluginRelease]
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case author
+        case description
+        case category
+        case iconSystemName
+        case requiresAPIKey
+        case descriptions
+        case downloadCount
+        case releases
+        case version
+        case minHostVersion
+        case minOSVersion
+        case supportedArchitectures
+        case size
+        case downloadURL
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        author = try container.decode(String.self, forKey: .author)
+        description = try container.decode(String.self, forKey: .description)
+        category = try container.decode(String.self, forKey: .category)
+        iconSystemName = try container.decodeIfPresent(String.self, forKey: .iconSystemName)
+        requiresAPIKey = try container.decodeIfPresent(Bool.self, forKey: .requiresAPIKey)
+        descriptions = try container.decodeIfPresent([String: String].self, forKey: .descriptions)
+        downloadCount = try container.decodeIfPresent(Int.self, forKey: .downloadCount)
+
+        let decodedReleases = try container.decodeIfPresent([RegistryPluginRelease].self, forKey: .releases) ?? []
+        if !decodedReleases.isEmpty {
+            releases = decodedReleases
+            return
+        }
+
+        let legacy = try LegacyRegistryRelease(from: decoder)
+        guard
+            let version = legacy.version,
+            let minHostVersion = legacy.minHostVersion,
+            let size = legacy.size,
+            let downloadURL = legacy.downloadURL
+        else {
+            releases = []
+            return
+        }
+
+        releases = [
+            RegistryPluginRelease(
+                version: version,
+                minHostVersion: minHostVersion,
+                minOSVersion: legacy.minOSVersion,
+                supportedArchitectures: legacy.supportedArchitectures,
+                size: size,
+                downloadURL: downloadURL,
+                publishedAt: nil,
+                downloadCount: legacy.downloadCount
+            )
+        ]
+    }
+
+    func resolvedPlugin(
+        appVersion: String,
+        currentOSVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
+        architecture: String = RuntimeArchitecture.current
+    ) -> RegistryPlugin? {
+        let compatibleRelease = releases
+            .filter {
+                $0.isCompatible(
+                    withAppVersion: appVersion,
+                    currentOSVersion: currentOSVersion,
+                    architecture: architecture
+                )
+            }
+            .max { first, second in
+                PluginRegistryService.compareVersions(first.version, second.version) == .orderedAscending
+            }
+
+        guard let compatibleRelease else { return nil }
+
+        return RegistryPlugin(
+            id: id,
+            name: name,
+            version: compatibleRelease.version,
+            minHostVersion: compatibleRelease.minHostVersion,
+            minOSVersion: compatibleRelease.minOSVersion,
+            supportedArchitectures: compatibleRelease.supportedArchitectures,
+            author: author,
+            description: description,
+            category: category,
+            size: compatibleRelease.size,
+            downloadURL: compatibleRelease.downloadURL,
+            iconSystemName: iconSystemName,
+            requiresAPIKey: requiresAPIKey,
+            descriptions: descriptions,
+            downloadCount: compatibleRelease.downloadCount ?? downloadCount
+        )
+    }
+}
+
+struct PluginRegistryResponse: Decodable {
     let schemaVersion: Int
-    let plugins: [RegistryPlugin]
+    let plugins: [RegistryPluginEntry]
+
+    func resolvedPlugins(
+        appVersion: String,
+        currentOSVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
+        architecture: String = RuntimeArchitecture.current
+    ) -> [RegistryPlugin] {
+        plugins.compactMap {
+            $0.resolvedPlugin(
+                appVersion: appVersion,
+                currentOSVersion: currentOSVersion,
+                architecture: architecture
+            )
+        }
+    }
 }
 
 enum PluginInstallInfo {
@@ -145,7 +308,7 @@ final class PluginRegistryService: ObservableObject {
 
     // MARK: - Version Comparison
 
-    static func compareVersions(_ a: String, _ b: String) -> ComparisonResult {
+    nonisolated static func compareVersions(_ a: String, _ b: String) -> ComparisonResult {
         let partsA = a.split(separator: ".").compactMap { Int($0) }
         let partsB = b.split(separator: ".").compactMap { Int($0) }
         let count = max(partsA.count, partsB.count)
@@ -174,10 +337,7 @@ final class PluginRegistryService: ObservableObject {
             let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
 
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
-            registry = response.plugins.filter {
-                Self.compareVersions($0.minHostVersion, appVersion) != .orderedDescending
-                    && $0.isCompatibleWithCurrentEnvironment
-            }
+            registry = response.resolvedPlugins(appVersion: appVersion)
             lastFetchDate = Date()
             fetchState = .loaded
             logger.info("Fetched \(self.registry.count) plugin(s) from registry")

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -29,6 +29,7 @@ final class AudioRecorderViewModel: ObservableObject {
         let providerId: String?
         let modelId: String?
         let prompt: String?
+        let liveSessionResult: TranscriptionResult?
     }
 
     struct RecordingItem: Identifiable {
@@ -84,15 +85,29 @@ final class AudioRecorderViewModel: ObservableObject {
     private let recorderService: AudioRecorderService
     private let modelManager: ModelManagerService
     private let dictionaryService: DictionaryService
+    private let streamingHandler: StreamingHandler
     private var cancellables = Set<AnyCancellable>()
     private var currentOutputURL: URL?
-    private var streamingTask: Task<Void, Never>?
-    private var confirmedStreamingText = ""
 
     init(recorderService: AudioRecorderService, modelManager: ModelManagerService, dictionaryService: DictionaryService) {
         self.recorderService = recorderService
         self.modelManager = modelManager
         self.dictionaryService = dictionaryService
+        self.streamingHandler = StreamingHandler(
+            modelManager: modelManager,
+            streamPromptProvider: { [weak dictionaryService] in
+                dictionaryService?.getTermsForPrompt() ?? ""
+            },
+            bufferProvider: { [weak recorderService] in
+                recorderService?.getCurrentBuffer() ?? []
+            },
+            bufferDeltaProvider: { [weak recorderService] offset in
+                recorderService?.getBufferDelta(since: offset) ?? ([], offset)
+            },
+            bufferedDurationProvider: { [weak recorderService] in
+                recorderService?.totalBufferDuration ?? 0
+            }
+        )
 
         // Load saved preferences with defaults
         let defaults = UserDefaults.standard
@@ -135,6 +150,18 @@ final class AudioRecorderViewModel: ObservableObject {
 
         setupBindings()
         loadRecordings()
+
+        streamingHandler.onPartialTextUpdate = { [weak self] text in
+            guard let self else { return }
+            self.partialText = text
+            EventBus.shared.emit(.partialTranscriptionUpdate(PartialTranscriptionPayload(
+                text: text,
+                elapsedSeconds: self.duration
+            )))
+        }
+        streamingHandler.onStreamingStateChange = { [weak self] streaming in
+            self?.isTranscribing = streaming
+        }
     }
 
     private func setupBindings() {
@@ -158,7 +185,6 @@ final class AudioRecorderViewModel: ObservableObject {
         guard state == .idle else { return }
         errorMessage = nil
         partialText = ""
-        confirmedStreamingText = ""
         Task {
             do {
                 let url = try await recorderService.startRecording(
@@ -173,6 +199,8 @@ final class AudioRecorderViewModel: ObservableObject {
 
                 if transcriptionEnabled {
                     startStreamingTranscription()
+                } else {
+                    isTranscribing = false
                 }
             } catch {
                 errorMessage = error.localizedDescription
@@ -181,15 +209,14 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     func stopRecording() {
-        let wasTranscribing = streamingTask != nil
         let recordingDuration = duration
-        stopStreamingTranscription()
 
         Task {
+            let liveSessionResult = await streamingHandler.finish()
             let url = await recorderService.stopRecording()
 
             let finalTranscriptionRequest: FinalTranscriptionRequest?
-            if wasTranscribing, let url {
+            if transcriptionEnabled, let url {
                 finalTranscriptionRequest = FinalTranscriptionRequest(
                     outputURL: url,
                     buffer: recorderService.getCurrentBuffer(),
@@ -197,7 +224,8 @@ final class AudioRecorderViewModel: ObservableObject {
                     task: selectedTask,
                     providerId: modelManager.selectedProviderId,
                     modelId: modelManager.selectedModelId,
-                    prompt: dictionaryService.getTermsForPrompt()
+                    prompt: dictionaryService.getTermsForPrompt(),
+                    liveSessionResult: liveSessionResult
                 )
                 state = .finalizing
             } else {
@@ -322,66 +350,16 @@ final class AudioRecorderViewModel: ObservableObject {
             return
         }
 
-        isTranscribing = true
-        let pollInterval: Double = plugin.supportsStreaming ? 1.5 : 3.0
-        let streamPrompt = dictionaryService.getTermsForPrompt()
-        let language = selectedLanguage
-        // Fall back to transcribe if engine doesn't support translation
         let task = (selectedTask == .translate && !plugin.supportsTranslation) ? .transcribe : selectedTask
-
-        streamingTask = Task { [weak self] in
-            guard let self else { return }
-            try? await Task.sleep(for: .seconds(pollInterval))
-
-            while !Task.isCancelled, self.state == .recording {
-                let buffer = self.recorderService.getRecentBuffer(maxDuration: 3600)
-                let bufferDuration = Double(buffer.count) / 16000.0
-
-                if bufferDuration > 0.5 {
-                    do {
-                        let confirmed = self.confirmedStreamingText
-                        let result = try await self.modelManager.transcribe(
-                            audioSamples: buffer,
-                            language: language,
-                            task: task,
-                            engineOverrideId: nil,
-                            cloudModelOverride: nil,
-                            prompt: streamPrompt,
-                            onProgress: { [weak self] text in
-                                guard let self, !Task.isCancelled else { return false }
-                                let stable = StreamingHandler.stabilizeText(confirmed: confirmed, new: text)
-                                Task { @MainActor [weak self] in
-                                    guard let self else { return }
-                                    self.partialText = stable
-                                    EventBus.shared.emit(.partialTranscriptionUpdate(PartialTranscriptionPayload(
-                                        text: stable, elapsedSeconds: self.duration
-                                    )))
-                                }
-                                return true
-                            }
-                        )
-                        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !text.isEmpty {
-                            let stable = StreamingHandler.stabilizeText(confirmed: confirmed, new: text)
-                            self.partialText = stable
-                            self.confirmedStreamingText = stable
-                            EventBus.shared.emit(.partialTranscriptionUpdate(PartialTranscriptionPayload(
-                                text: stable, elapsedSeconds: self.duration
-                            )))
-                        }
-                    } catch {
-                        logger.warning("Streaming transcription error: \(error.localizedDescription)")
-                    }
-                }
-
-                try? await Task.sleep(for: .seconds(pollInterval))
-            }
-        }
-    }
-
-    private func stopStreamingTranscription() {
-        streamingTask?.cancel()
-        streamingTask = nil
+        streamingHandler.start(
+            engineOverrideId: providerId,
+            selectedProviderId: modelManager.selectedProviderId,
+            language: selectedLanguage,
+            task: task,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { [weak self] in self?.state == .recording }
+        )
     }
 
     private func runFinalTranscription(_ request: FinalTranscriptionRequest) async {
@@ -393,6 +371,12 @@ final class AudioRecorderViewModel: ObservableObject {
             // Use streaming result as final if buffer too short
             if !partialText.isEmpty {
                 saveTranscript(partialText, for: request.outputURL)
+            } else if let liveSessionResult = request.liveSessionResult {
+                let text = liveSessionResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    partialText = text
+                    saveTranscript(text, for: request.outputURL)
+                }
             }
             return
         }
@@ -409,14 +393,18 @@ final class AudioRecorderViewModel: ObservableObject {
         }
 
         do {
-            let result = try await modelManager.transcribe(
-                audioSamples: buffer,
-                language: request.language,
-                task: effectiveTask,
-                engineOverrideId: request.providerId,
-                cloudModelOverride: request.modelId,
-                prompt: request.prompt
-            )
+            let result = if let liveSessionResult = request.liveSessionResult {
+                liveSessionResult
+            } else {
+                try await modelManager.transcribe(
+                    audioSamples: buffer,
+                    language: request.language,
+                    task: effectiveTask,
+                    engineOverrideId: request.providerId,
+                    cloudModelOverride: request.modelId,
+                    prompt: request.prompt
+                )
+            }
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !text.isEmpty {
                 partialText = text

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -216,8 +216,18 @@ final class DictationViewModel: ObservableObject {
         )
         self.streamingHandler = StreamingHandler(
             modelManager: modelManager,
-            audioRecordingService: audioRecordingService,
-            dictionaryService: dictionaryService
+            streamPromptProvider: { [weak dictionaryService] in
+                dictionaryService?.getTermsForPrompt() ?? ""
+            },
+            bufferProvider: { [weak audioRecordingService] in
+                audioRecordingService?.getCurrentBuffer() ?? []
+            },
+            bufferDeltaProvider: { [weak audioRecordingService] offset in
+                audioRecordingService?.getBufferDelta(since: offset) ?? ([], offset)
+            },
+            bufferedDurationProvider: { [weak audioRecordingService] in
+                audioRecordingService?.totalBufferDuration ?? 0
+            }
         )
         self.promptPaletteHandler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
@@ -587,7 +597,8 @@ final class DictationViewModel: ObservableObject {
                 language: effectiveLanguage,
                 task: effectiveTask,
                 cloudModelOverride: effectiveCloudModelOverride,
-                stateCheck: { @MainActor [weak self] in self?.state ?? .idle }
+                allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0,
+                stateCheck: { [weak self] in self?.state == .recording }
             )
             EventBus.shared.emit(.recordingStarted(RecordingStartedPayload(
                 appName: capturedActiveApp?.name,
@@ -745,7 +756,7 @@ final class DictationViewModel: ObservableObject {
 
         audioDuckingService.restoreAudio()
         mediaPlaybackService.resumeIfWePaused()
-        streamingHandler.stop()
+        let liveSessionResult = await streamingHandler.finish()
         stopRecordingTimer()
         let previewText = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasPreviewText = !previewText.isEmpty
@@ -829,14 +840,18 @@ final class DictationViewModel: ObservableObject {
                 let translationTarget = effectiveTranslationTarget
                 let termsPrompt = dictionaryService.getTermsForPrompt()
 
-                let result = try await modelManager.transcribe(
-                    audioSamples: samples,
-                    language: language,
-                    task: task,
-                    engineOverrideId: engineOverride,
-                    cloudModelOverride: cloudModelOverride,
-                    prompt: termsPrompt
-                )
+                let result = if let liveSessionResult {
+                    liveSessionResult
+                } else {
+                    try await modelManager.transcribe(
+                        audioSamples: samples,
+                        language: language,
+                        task: task,
+                        engineOverrideId: engineOverride,
+                        cloudModelOverride: cloudModelOverride,
+                        prompt: termsPrompt
+                    )
+                }
 
                 // Bail out if a new recording started while we were transcribing
                 guard !Task.isCancelled else { return }

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -1,6 +1,5 @@
 import Foundation
 import os
-import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "StreamingHandler")
 
@@ -8,22 +7,31 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhis
 final class StreamingHandler {
     private var streamingTask: Task<Void, Never>?
     private var confirmedStreamingText = ""
+    private let progressText = OSAllocatedUnfairLock(initialState: "")
+    private var liveSessionHandle: ModelManagerService.LiveTranscriptionSessionHandle?
+    private var sampleCursor = 0
 
     private let modelManager: ModelManagerService
-    private let audioRecordingService: AudioRecordingService
-    private let dictionaryService: DictionaryService
+    private let streamPromptProvider: () -> String
+    private let bufferProvider: () -> [Float]
+    private let bufferDeltaProvider: (Int) -> (samples: [Float], nextOffset: Int)
+    private let bufferedDurationProvider: () -> Double
 
     var onPartialTextUpdate: ((String) -> Void)?
     var onStreamingStateChange: ((Bool) -> Void)?
 
     init(
         modelManager: ModelManagerService,
-        audioRecordingService: AudioRecordingService,
-        dictionaryService: DictionaryService
+        streamPromptProvider: @escaping () -> String,
+        bufferProvider: @escaping () -> [Float],
+        bufferDeltaProvider: @escaping (Int) -> (samples: [Float], nextOffset: Int),
+        bufferedDurationProvider: @escaping () -> Double
     ) {
         self.modelManager = modelManager
-        self.audioRecordingService = audioRecordingService
-        self.dictionaryService = dictionaryService
+        self.streamPromptProvider = streamPromptProvider
+        self.bufferProvider = bufferProvider
+        self.bufferDeltaProvider = bufferDeltaProvider
+        self.bufferedDurationProvider = bufferedDurationProvider
     }
 
     func start(
@@ -32,23 +40,77 @@ final class StreamingHandler {
         language: String?,
         task: TranscriptionTask,
         cloudModelOverride: String?,
-        stateCheck: @MainActor @escaping () -> DictationViewModel.State
+        allowLiveTranscription: Bool,
+        stateCheck: @escaping () -> Bool
     ) {
+        stop()
+
+        guard allowLiveTranscription else { return }
+
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
               let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else { return }
 
-        let pollInterval: Double = plugin.supportsStreaming ? 1.5 : 3.0
-
-        onStreamingStateChange?(true)
         confirmedStreamingText = ""
-        let streamPrompt = dictionaryService.getTermsForPrompt()
+        progressText.withLock { $0 = "" }
+        sampleCursor = 0
+        onStreamingStateChange?(true)
+
+        let streamPrompt = streamPromptProvider()
+        let pollInterval: Duration = plugin.supportsStreaming ? .milliseconds(350) : .seconds(3)
+        let shouldUseLegacyPolling = !modelManager.usesMeteredStreamingFallback(engineOverrideId: engineOverrideId)
+
         streamingTask = Task { [weak self] in
             guard let self else { return }
-            try? await Task.sleep(for: .seconds(pollInterval))
+            let progressText = self.progressText
 
-            while !Task.isCancelled, stateCheck() == .recording {
-                let buffer = self.audioRecordingService.getRecentBuffer(maxDuration: 3600)
+            if let handle = try? await self.modelManager.createLiveTranscriptionSession(
+                language: language,
+                task: task,
+                engineOverrideId: engineOverrideId,
+                cloudModelOverride: cloudModelOverride,
+                prompt: streamPrompt,
+                onProgress: { [weak self] text in
+                    guard let self else { return false }
+                    let confirmed = progressText.withLock { $0 }
+                    let stable = Self.stabilizeText(confirmed: confirmed, new: text)
+                    Task { @MainActor [weak self] in
+                        progressText.withLock { $0 = stable }
+                        self?.confirmedStreamingText = stable
+                        self?.onPartialTextUpdate?(stable)
+                    }
+                    return true
+                }
+            ) {
+                self.liveSessionHandle = handle
+
+                while !Task.isCancelled, stateCheck() {
+                    let delta = self.bufferDeltaProvider(self.sampleCursor)
+                    self.sampleCursor = delta.nextOffset
+
+                    if !delta.samples.isEmpty {
+                        do {
+                            try await handle.session.appendAudio(samples: delta.samples)
+                        } catch {
+                            logger.warning("Live transcription append failed: \(error.localizedDescription)")
+                            break
+                        }
+                    }
+
+                    try? await Task.sleep(for: pollInterval)
+                }
+                return
+            }
+
+            guard shouldUseLegacyPolling else {
+                self.onStreamingStateChange?(false)
+                return
+            }
+
+            try? await Task.sleep(for: pollInterval)
+
+            while !Task.isCancelled, stateCheck() {
+                let buffer = self.bufferProvider()
                 let bufferDuration = Double(buffer.count) / 16000.0
 
                 if bufferDuration > 0.5 {
@@ -81,16 +143,69 @@ final class StreamingHandler {
                     }
                 }
 
-                try? await Task.sleep(for: .seconds(pollInterval))
+                try? await Task.sleep(for: pollInterval)
             }
+        }
+    }
+
+    func finish() async -> TranscriptionResult? {
+        streamingTask?.cancel()
+        streamingTask = nil
+
+        guard let handle = liveSessionHandle else {
+            liveSessionHandle = nil
+            onStreamingStateChange?(false)
+            confirmedStreamingText = ""
+            progressText.withLock { $0 = "" }
+            sampleCursor = 0
+            return nil
+        }
+
+        let delta = bufferDeltaProvider(sampleCursor)
+        sampleCursor = delta.nextOffset
+
+        do {
+            if !delta.samples.isEmpty {
+                try await handle.session.appendAudio(samples: delta.samples)
+            }
+            let result = try await modelManager.finishLiveTranscriptionSession(
+                handle,
+                bufferedDuration: bufferedDurationProvider()
+            )
+            liveSessionHandle = nil
+            onStreamingStateChange?(false)
+            confirmedStreamingText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let finalText = confirmedStreamingText
+            progressText.withLock { $0 = finalText }
+            sampleCursor = 0
+            return result
+        } catch {
+            logger.warning("Finalizing live transcription failed: \(error.localizedDescription)")
+            await handle.session.cancel()
+            liveSessionHandle = nil
+            onStreamingStateChange?(false)
+            confirmedStreamingText = ""
+            progressText.withLock { $0 = "" }
+            sampleCursor = 0
+            return nil
         }
     }
 
     func stop() {
         streamingTask?.cancel()
         streamingTask = nil
+
+        if let handle = liveSessionHandle {
+            Task {
+                await handle.session.cancel()
+            }
+        }
+
+        liveSessionHandle = nil
         onStreamingStateChange?(false)
         confirmedStreamingText = ""
+        progressText.withLock { $0 = "" }
+        sampleCursor = 0
     }
 
     /// Keeps confirmed text stable and only appends new content.
@@ -99,10 +214,8 @@ final class StreamingHandler {
         guard !confirmed.isEmpty else { return new }
         guard !new.isEmpty else { return confirmed }
 
-        // Best case: new text starts with confirmed text
         if new.hasPrefix(confirmed) { return new }
 
-        // Find how far the texts match from the start
         let confirmedChars = Array(confirmed.unicodeScalars)
         let newChars = Array(new.unicodeScalars)
         var matchEnd = 0
@@ -114,14 +227,11 @@ final class StreamingHandler {
             }
         }
 
-        // If more than half matches, keep confirmed and append the new tail
         if matchEnd > confirmed.count / 2 {
             let newContent = String(new.unicodeScalars.dropFirst(matchEnd))
             return confirmed + newContent
         }
 
-        // Suffix-prefix overlap: new text starts with a suffix of confirmed
-        // (happens when the streaming window has shifted forward)
         let minOverlap = min(20, confirmedChars.count / 4)
         let maxShift = min(confirmedChars.count - minOverlap, 150)
         if maxShift > 0 {
@@ -134,7 +244,6 @@ final class StreamingHandler {
             }
         }
 
-        // Very different result - accept the new text to avoid freezing the preview
         return new
     }
 }

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -177,6 +177,16 @@ struct AudioRecorderView: View {
                             }
                             .disabled(isEditingLocked)
                         }
+
+                        if !modelManager.supportsLiveTranscriptionSession(engineOverrideId: providerId),
+                           modelManager.usesMeteredStreamingFallback(engineOverrideId: providerId) {
+                            Label(
+                                String(localized: "This engine avoids repeated live API calls and transcribes the full recording after you stop."),
+                                systemImage: "info.circle"
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
                     }
 
                     // Language picker

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -163,7 +163,7 @@ struct GeneralSettingsView: View {
                     Toggle(String(localized: "Show live transcript preview"), isOn: $dictation.indicatorTranscriptPreviewEnabled)
 
                     if !dictation.indicatorTranscriptPreviewEnabled {
-                        Text(String(localized: "When disabled, the indicator only shows recording status while transcription continues in the background."))
+                        Text(String(localized: "When disabled, TypeWhisper skips live transcript requests for the indicator and only runs the final transcription after you stop recording."))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -208,6 +208,12 @@ public struct PluginTranscriptionResult: Sendable {
     }
 }
 
+public protocol LiveTranscriptionSession: AnyObject, Sendable {
+    func appendAudio(samples: [Float]) async throws
+    func finish() async throws -> PluginTranscriptionResult
+    func cancel() async
+}
+
 public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var providerId: String { get }
     var providerDisplayName: String { get }
@@ -222,6 +228,15 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var supportedLanguages: [String] { get }
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?,
                     onProgress: @Sendable @escaping (String) -> Bool) async throws -> PluginTranscriptionResult
+}
+
+public protocol LiveTranscriptionCapablePlugin: TranscriptionEnginePlugin {
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession
 }
 
 public extension TranscriptionEnginePlugin {

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import TypeWhisper
+
+final class PluginRegistryServiceTests: XCTestCase {
+    func testLegacyRegistryEntryDecodesIntoSingleRelease() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 1,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.legacy",
+                  "name": "Legacy Plugin",
+                  "version": "1.0.5",
+                  "minHostVersion": "1.2.0",
+                  "author": "TypeWhisper",
+                  "description": "Legacy entry",
+                  "category": "utility",
+                  "size": 42,
+                  "downloadURL": "https://example.com/legacy.zip"
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let plugins = response.resolvedPlugins(appVersion: "1.2.3")
+
+        XCTAssertEqual(plugins.count, 1)
+        XCTAssertEqual(plugins.first?.id, "com.typewhisper.legacy")
+        XCTAssertEqual(plugins.first?.version, "1.0.5")
+        XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/legacy.zip")
+    }
+
+    func testMultiReleaseRegistryChoosesNewestCompatibleRelease() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.multi",
+                  "name": "Multi Plugin",
+                  "author": "TypeWhisper",
+                  "description": "Multi-release entry",
+                  "category": "transcription",
+                  "downloadCount": 100,
+                  "releases": [
+                    {
+                      "version": "1.1.0",
+                      "minHostVersion": "1.3.0",
+                      "size": 20,
+                      "downloadURL": "https://example.com/new.zip"
+                    },
+                    {
+                      "version": "1.0.5",
+                      "minHostVersion": "1.2.0",
+                      "size": 10,
+                      "downloadURL": "https://example.com/compatible.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let plugins = response.resolvedPlugins(appVersion: "1.2.4")
+
+        XCTAssertEqual(plugins.count, 1)
+        XCTAssertEqual(plugins.first?.version, "1.0.5")
+        XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/compatible.zip")
+        XCTAssertEqual(plugins.first?.downloadCount, 100)
+    }
+
+    func testMultiReleaseRegistryFiltersIncompatibleReleasesByArchitectureAndOS() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.arch",
+                  "name": "Architecture Plugin",
+                  "author": "TypeWhisper",
+                  "description": "Architecture-sensitive entry",
+                  "category": "transcription",
+                  "releases": [
+                    {
+                      "version": "1.2.0",
+                      "minHostVersion": "1.0.0",
+                      "minOSVersion": "15.0",
+                      "supportedArchitectures": ["arm64"],
+                      "size": 20,
+                      "downloadURL": "https://example.com/arm64-new.zip"
+                    },
+                    {
+                      "version": "1.1.0",
+                      "minHostVersion": "1.0.0",
+                      "minOSVersion": "14.0",
+                      "supportedArchitectures": ["x86_64"],
+                      "size": 10,
+                      "downloadURL": "https://example.com/intel-compatible.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let osVersion = OperatingSystemVersion(majorVersion: 14, minorVersion: 6, patchVersion: 0)
+        let plugins = response.resolvedPlugins(
+            appVersion: "1.2.4",
+            currentOSVersion: osVersion,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(plugins.count, 1)
+        XCTAssertEqual(plugins.first?.version, "1.1.0")
+        XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/intel-compatible.zip")
+    }
+}

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+@MainActor
+final class StreamingHandlerTests: XCTestCase {
+    private final class MockBatchPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.batch" }
+        static var pluginName: String { "Mock Batch" }
+
+        var providerId: String { "mock-batch" }
+        var providerDisplayName: String { "Mock Batch" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { false }
+        var supportedLanguages: [String] { ["en"] }
+        private(set) var transcribeCallCount = 0
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            transcribeCallCount += 1
+            return PluginTranscriptionResult(text: "final", detectedLanguage: language)
+        }
+    }
+
+    private final class MockLivePlugin: NSObject, LiveTranscriptionCapablePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.live" }
+        static var pluginName: String { "Mock Live" }
+
+        var providerId: String { "mock-live" }
+        var providerDisplayName: String { "Mock Live" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { true }
+        var supportedLanguages: [String] { ["en"] }
+        let session = MockLiveSession()
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            XCTFail("Batch transcribe should not be used for the live-session path")
+            return PluginTranscriptionResult(text: "", detectedLanguage: language)
+        }
+
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> PluginTranscriptionResult {
+            XCTFail("Legacy streaming should not be used for the live-session path")
+            return PluginTranscriptionResult(text: "", detectedLanguage: language)
+        }
+
+        func createLiveTranscriptionSession(
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> any LiveTranscriptionSession {
+            await session.setOnProgress(onProgress)
+            return session
+        }
+    }
+
+    private actor MockLiveSession: LiveTranscriptionSession {
+        private var appendedChunkSizes: [Int] = []
+        private var onProgress: (@Sendable (String) -> Bool)?
+
+        func setOnProgress(_ onProgress: @escaping @Sendable (String) -> Bool) {
+            self.onProgress = onProgress
+        }
+
+        func appendAudio(samples: [Float]) async throws {
+            appendedChunkSizes.append(samples.count)
+            _ = onProgress?("chunk-\(samples.count)")
+        }
+
+        func finish() async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "finished", detectedLanguage: "en")
+        }
+
+        func cancel() async {}
+
+        func recordedChunks() -> [Int] {
+            appendedChunkSizes
+        }
+    }
+
+    override func tearDown() {
+        PluginManager.shared = nil
+        super.tearDown()
+    }
+
+    func testMeteredBatchPluginSkipsIntermediateCalls() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockBatchPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.batch",
+                    name: "Mock Batch",
+                    version: "1.0.0",
+                    principalClass: "MockBatchPlugin",
+                    requiresAPIKey: true
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            streamPromptProvider: { "" },
+            bufferProvider: { Array(repeating: 0.5, count: 16_000) },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 1.0 }
+        )
+
+        handler.start(
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            language: "en",
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(700))
+        handler.stop()
+
+        XCTAssertEqual(plugin.transcribeCallCount, 0)
+    }
+
+    func testDisabledLiveTranscriptionPreventsAnyIntermediateWork() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockBatchPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.local",
+                    name: "Mock Local",
+                    version: "1.0.0",
+                    principalClass: "MockBatchPlugin",
+                    requiresAPIKey: false
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            streamPromptProvider: { "" },
+            bufferProvider: { Array(repeating: 0.5, count: 16_000) },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 1.0 }
+        )
+
+        handler.start(
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            language: "en",
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: false,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(700))
+        XCTAssertEqual(plugin.transcribeCallCount, 0)
+    }
+
+    func testLiveSessionConsumesOnlyIncrementalAudioDeltas() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockLivePlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.live",
+                    name: "Mock Live",
+                    version: "1.0.0",
+                    principalClass: "MockLivePlugin",
+                    requiresAPIKey: false
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let chunks = [
+            Array(repeating: Float(0.2), count: 4000),
+            Array(repeating: Float(0.3), count: 2500),
+            Array(repeating: Float(0.4), count: 1500),
+        ]
+        let indexLock = NSLock()
+        var index = 0
+        var nextOffset = 0
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            streamPromptProvider: { "" },
+            bufferProvider: { [] },
+            bufferDeltaProvider: { _ in
+                indexLock.lock()
+                defer { indexLock.unlock() }
+                guard index < chunks.count else {
+                    return ([], nextOffset)
+                }
+                let chunk = chunks[index]
+                index += 1
+                nextOffset += chunk.count
+                return (chunk, nextOffset)
+            },
+            bufferedDurationProvider: { 0.5 }
+        )
+
+        var activeChecks = 0
+        handler.start(
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            language: "en",
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: {
+                activeChecks += 1
+                return activeChecks <= 4
+            }
+        )
+
+        try await Task.sleep(for: .milliseconds(1200))
+        let result = await handler.finish()
+
+        XCTAssertEqual(result?.text, "finished")
+        let recorded = await plugin.session.recordedChunks()
+        XCTAssertEqual(recorded, chunks.map(\.count))
+    }
+}


### PR DESCRIPTION
## Summary
- add multi-release marketplace registry support with compatibility-based release selection
- migrate plugin release workflows to preserve compatible historical releases and track per-release downloads
- replace cumulative live transcription polling with incremental live-session streaming and batch-provider fallbacks

## Linked issues
- Closes #298
- Closes #300

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryServiceTests -only-testing:TypeWhisperTests/StreamingHandlerTests -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests`
