### PR TITLE
fix: support Fn press/release hotkey strategies

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -106,6 +106,11 @@ final class HotkeyService: ObservableObject {
         case toggle
     }
 
+    private enum FnTriggerMode {
+        case pressThenRelease
+        case releaseOnly
+    }
+
     @Published private(set) var currentMode: HotkeyMode?
 
     var onDictationStart: (() -> Void)?
@@ -454,12 +459,18 @@ final class HotkeyService: ObservableObject {
         // Global slots
         for slotType in HotkeySlotType.allCases {
             guard var state = slots[slotType], let hotkey = state.hotkey else { continue }
+            let fnTriggerMode: FnTriggerMode = slotType == .toggle ? .releaseOnly : .pressThenRelease
             if shouldSuppressForCapsLockOrigin(event, hotkey: hotkey, keyWasDown: state.keyWasDown) {
                 state.resetTransientState()
                 slots[slotType] = state
                 continue
             }
-            let (keyDown, keyUp, isMatch) = processKeyEvent(event, hotkey: hotkey, state: &state)
+            let (keyDown, keyUp, isMatch) = processKeyEvent(
+                event,
+                hotkey: hotkey,
+                state: &state,
+                fnTriggerMode: fnTriggerMode
+            )
             slots[slotType] = state
             if isMatch { shouldSuppress = true }
             dispatchGlobalMatch(
@@ -484,7 +495,12 @@ final class HotkeyService: ObservableObject {
                                   modifierWasDown: pState.modifierWasDown, keyWasDown: pState.keyWasDown,
                                   mouseButtonWasDown: pState.mouseButtonWasDown,
                                   lastTapUpTime: pState.lastTapUpTime, tapCount: pState.tapCount)
-            let (keyDown, keyUp, isMatch) = processKeyEvent(event, hotkey: pState.hotkey, state: &state)
+            let (keyDown, keyUp, isMatch) = processKeyEvent(
+                event,
+                hotkey: pState.hotkey,
+                state: &state,
+                fnTriggerMode: .pressThenRelease
+            )
             pState.fnWasDown = state.fnWasDown
             pState.fnComboKeyPressed = state.fnComboKeyPressed
             pState.modifierWasDown = state.modifierWasDown
@@ -640,9 +656,12 @@ final class HotkeyService: ObservableObject {
         case modifierRelease // Modifiers no longer match, but key is still physically down
     }
 
-    /// Processes a key event against a hotkey, updating state booleans.
-    /// Returns (keyDown, keyUp, shouldSuppress) flags.
-    private func processKeyEvent(_ event: NSEvent, hotkey: UnifiedHotkey, state: inout SlotState) -> (keyDown: Bool, keyUp: Bool, shouldSuppress: Bool) {
+    private func processKeyEvent(
+        _ event: NSEvent,
+        hotkey: UnifiedHotkey,
+        state: inout SlotState,
+        fnTriggerMode: FnTriggerMode
+    ) -> (keyDown: Bool, keyUp: Bool, shouldSuppress: Bool) {
         // Mouse button hotkeys - self-contained path (no modifier interplay)
         if hotkey.kind == .mouseButton {
             guard event.type == .otherMouseDown || event.type == .otherMouseUp else {
@@ -684,33 +703,68 @@ final class HotkeyService: ObservableObject {
             return (false, false, false)
         }
 
-        // Fn hotkeys fire on release to avoid conflicts with Fn+key combos
-        // (e.g. Fn+Backspace = forward delete, Fn+Arrow = page navigation)
+        // Fn hotkeys can run in two modes:
+        // - releaseOnly: keep current toggle behavior (start on release)
+        // - pressThenRelease: Hybrid/PTT/profiles should start on press and stop on release
         if hotkey.kind == .fn {
-            if state.fnWasDown && event.type == .keyDown {
-                state.fnComboKeyPressed = true
-                return (false, false, false)
-            }
-            guard event.type == .flagsChanged else { return (false, false, false) }
-            let fnDown = event.modifierFlags.contains(.function)
-            if fnDown, !state.fnWasDown {
-                state.fnWasDown = true
+            switch fnTriggerMode {
+            case .pressThenRelease:
+                if state.fnWasDown && event.type == .keyDown {
+                    state.fnComboKeyPressed = true
+                    return (false, false, false)
+                }
+
+                guard event.type == .flagsChanged else {
+                    return (false, false, false)
+                }
+
+                let fnDown = event.modifierFlags.contains(.function)
+                if fnDown, !state.fnWasDown {
+                    state.fnWasDown = true
+                    state.fnComboKeyPressed = false
+                    return (true, false, true)
+                }
+                guard !fnDown, state.fnWasDown else {
+                    return (false, false, false)
+                }
+                state.fnWasDown = false
+                let wasComboed = state.fnComboKeyPressed
                 state.fnComboKeyPressed = false
-                return (false, false, false)
+                if wasComboed { return (false, false, false) }
+                if hotkey.isDoubleTap {
+                    return (false, false, true)
+                }
+                return (false, true, true)
+
+            case .releaseOnly:
+                if state.fnWasDown && event.type == .keyDown {
+                    state.fnComboKeyPressed = true
+                    return (false, false, false)
+                }
+                guard event.type == .flagsChanged else { return (false, false, false) }
+                let fnDown = event.modifierFlags.contains(.function)
+                if fnDown, !state.fnWasDown {
+                    state.fnWasDown = true
+                    state.fnComboKeyPressed = false
+                    return (false, false, false)
+                }
+                guard !fnDown, state.fnWasDown else { return (false, false, false) }
+                state.fnWasDown = false
+                let wasComboed = state.fnComboKeyPressed
+                state.fnComboKeyPressed = false
+                if wasComboed { return (false, false, false) }
+                guard hotkey.isDoubleTap else { return (true, false, true) }
+                if state.tapCount == 1,
+                   let lastUp = state.lastTapUpTime,
+                   Date().timeIntervalSince(lastUp) < Self.doubleTapThreshold {
+                    state.tapCount = 0
+                    state.lastTapUpTime = nil
+                    return (true, false, true)
+                }
+                state.tapCount = 1
+                state.lastTapUpTime = Date()
+                return (false, false, true)
             }
-            guard !fnDown, state.fnWasDown else { return (false, false, false) }
-            state.fnWasDown = false
-            let wasComboed = state.fnComboKeyPressed
-            state.fnComboKeyPressed = false
-            if wasComboed { return (false, false, false) }
-            guard hotkey.isDoubleTap else { return (true, false, true) }
-            if state.tapCount == 1, let lastUp = state.lastTapUpTime,
-               Date().timeIntervalSince(lastUp) < Self.doubleTapThreshold {
-                state.tapCount = 0; state.lastTapUpTime = nil
-                return (true, false, true)
-            }
-            state.tapCount = 1; state.lastTapUpTime = Date()
-            return (false, false, true)
         }
 
         let result = detectKeyEvent(

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1348,6 +1348,101 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testMonitorFallbackStartsPushToTalkOnFnPress() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(fnHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeFnEvent(isDown: true)
+        let keyUp = try makeFnEvent(isDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testMonitorFallbackStartsHybridOnFnPress() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(fnHotkey(), for: .hybrid)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeFnEvent(isDown: true)
+        let keyUp = try makeFnEvent(isDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .toggle)
+    }
+
+    @MainActor
+    func testMonitorFallbackStartsHybridLongPressAndStopsAfterRelease() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(fnHotkey(), for: .hybrid)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeFnEvent(isDown: true)
+        let keyUp = try makeFnEvent(isDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        try await Task.sleep(nanoseconds: 1_150_000_000)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertEqual(startCount, 1)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testMonitorFallbackToggleFnStillWorksOnRelease() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(fnHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { startCount += 1 }
+
+        let keyDown = try makeFnEvent(isDown: true)
+        let keyUp = try makeFnEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
     private func spaceHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
             keyCode: 0x31,
@@ -1383,6 +1478,15 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
     }
 
+    @MainActor
+    private func fnHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x00,
+            modifierFlags: 0,
+            isFn: true
+        )
+    }
+
     private func makeKeyboardEvent(
         keyCode: UInt16,
         keyDown: Bool,
@@ -1412,6 +1516,13 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
                 isARepeat: false,
                 keyCode: keyCode
             )
+        )
+    }
+
+    private func makeFnEvent(isDown: Bool) throws -> NSEvent {
+        try makeFlagsChangedEvent(
+            keyCode: 0x3F,
+            modifierFlags: isDown ? [.function] : []
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add Fn hotkey mode-specific trigger semantics in `HotkeyService`.
- Push-to-talk and hybrid Fn hotkeys now start on Fn press and behave correctly for press/release stopping semantics.
- Toggle Fn hotkeys remain on-release behavior.
- Extended `HotkeyServiceCompatibilityTests` with Fn helper and coverage for push-to-talk, hybrid, and toggle scenarios.

Closes #310

## Test Coverage
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Result: **Passed** (152 tests, 0 failures)
- `bash scripts/check_first_party_warnings.sh test.log`
  - Result: **No first-party warnings**
- `swift test --package-path TypeWhisperPluginSDK`
  - Result: **Passed** (20 tests, 0 failures)
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Result: **Passed**
- `bash scripts/check_first_party_warnings.sh build.log`
  - Result: **No first-party warnings**

## Pre-Landing Review
- Manual review run against `origin/main..HEAD` included:
  - `git diff --check origin/main...HEAD` for whitespace/syntax hygiene
- No functional issues identified in this pass.

## Test plan
- [x] App test suite passes
- [x] Plugin SDK tests pass
- [x] Release-style app build passes
- [x] First-party warning checks pass
- [x] PR created with summary and verification evidence
