### PR TITLE
Add multilingual language hints and improve language selection UI

### DIFF
--- a/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -73,7 +73,7 @@ private struct GladiaLiveSession: Sendable {
 }
 
 @objc(GladiaPlugin)
-final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gladia"
     static let pluginName = "Gladia"
 
@@ -143,6 +143,32 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
 
     func transcribe(
         audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        return try await transcribeREST(
+            audio: audio,
+            language: languageSelection.requestedLanguage,
+            languageHints: resolvedLanguageHints(
+                requestedLanguage: languageSelection.requestedLanguage,
+                languageHints: languageSelection.languageHints
+            ),
+            modelId: modelId,
+            apiKey: apiKey,
+            prompt: prompt
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
         language: String?,
         translate: Bool,
         prompt: String?,
@@ -176,9 +202,52 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         }
     }
 
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let effectiveHints = resolvedLanguageHints(
+            requestedLanguage: languageSelection.requestedLanguage,
+            languageHints: languageSelection.languageHints
+        )
+
+        do {
+            return try await transcribeWebSocket(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                languageHints: effectiveHints,
+                modelId: modelId,
+                prompt: prompt,
+                apiKey: apiKey,
+                onProgress: onProgress
+            )
+        } catch {
+            logger.warning("Live transcription failed, falling back to REST: \(error.localizedDescription)")
+            return try await transcribeREST(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                languageHints: effectiveHints,
+                modelId: modelId,
+                apiKey: apiKey,
+                prompt: prompt
+            )
+        }
+    }
+
     private func transcribeREST(
         audio: AudioData,
         language: String?,
+        languageHints: [String] = [],
         modelId: String,
         apiKey: String,
         prompt: String?
@@ -187,6 +256,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         let resultURL = try await submitPreRecorded(
             audioURL: audioURL,
             language: language,
+            languageHints: languageHints,
             modelId: modelId,
             apiKey: apiKey,
             prompt: prompt
@@ -246,6 +316,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     private func submitPreRecorded(
         audioURL: String,
         language: String?,
+        languageHints: [String] = [],
         modelId: String,
         apiKey: String,
         prompt: String?
@@ -262,10 +333,11 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             body["model"] = modelId
         }
 
-        if let language, !language.isEmpty {
+        let effectiveHints = resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
+        if !effectiveHints.isEmpty {
             body["language_config"] = [
-                "languages": [language],
-                "code_switching": false,
+                "languages": effectiveHints,
+                "code_switching": effectiveHints.count > 1,
             ]
         }
         if let customVocabulary = Self.customVocabularyConfig(prompt: prompt) {
@@ -353,6 +425,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     private func transcribeWebSocket(
         audio: AudioData,
         language: String?,
+        languageHints: [String] = [],
         modelId: String,
         prompt: String?,
         apiKey: String,
@@ -360,6 +433,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     ) async throws -> PluginTranscriptionResult {
         let liveSession = try await createLiveSession(
             language: language,
+            languageHints: languageHints,
             modelId: modelId,
             apiKey: apiKey,
             prompt: prompt
@@ -469,6 +543,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
 
     private func createLiveSession(
         language: String?,
+        languageHints: [String] = [],
         modelId: String,
         apiKey: String,
         prompt: String?
@@ -490,10 +565,11 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             ],
         ]
 
-        if let language, !language.isEmpty {
+        let effectiveHints = resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
+        if !effectiveHints.isEmpty {
             body["language_config"] = [
-                "languages": [language],
-                "code_switching": false,
+                "languages": effectiveHints,
+                "code_switching": effectiveHints.count > 1,
             ]
         }
         if let customVocabulary = Self.customVocabularyConfig(prompt: prompt) {
@@ -692,6 +768,16 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             "vocabulary": vocabulary,
             "default_intensity": 0.7,
         ]
+    }
+
+    private func resolvedLanguageHints(requestedLanguage: String?, languageHints: [String]) -> [String] {
+        if !languageHints.isEmpty {
+            return languageHints
+        }
+        if let requestedLanguage, !requestedLanguage.isEmpty {
+            return [requestedLanguage]
+        }
+        return []
     }
 
     fileprivate func validateApiKey(_ key: String) async -> Bool {

--- a/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -67,7 +67,7 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(SonioxPlugin)
-final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.soniox"
     static let pluginName = "Soniox"
 
@@ -138,6 +138,31 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         )
     }
 
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let effectiveHints = resolvedLanguageHints(
+            requestedLanguage: languageSelection.requestedLanguage,
+            languageHints: languageSelection.languageHints
+        )
+
+        return try await transcribeREST(
+            audio: audio,
+            language: languageSelection.requestedLanguage,
+            languageHints: effectiveHints,
+            translate: translate,
+            apiKey: apiKey,
+            prompt: prompt
+        )
+    }
+
     // MARK: - Transcription (WebSocket Streaming)
 
     func transcribe(
@@ -171,11 +196,55 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         }
     }
 
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let effectiveHints = resolvedLanguageHints(
+            requestedLanguage: languageSelection.requestedLanguage,
+            languageHints: languageSelection.languageHints
+        )
+
+        do {
+            return try await transcribeWebSocket(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                languageHints: effectiveHints,
+                translate: translate,
+                modelId: modelId,
+                prompt: prompt,
+                apiKey: apiKey,
+                onProgress: onProgress
+            )
+        } catch {
+            logger.warning("WebSocket streaming failed, falling back to REST: \(error.localizedDescription)")
+            return try await transcribeREST(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                languageHints: effectiveHints,
+                translate: translate,
+                apiKey: apiKey,
+                prompt: prompt
+            )
+        }
+    }
+
     // MARK: - WebSocket Implementation
 
     private func transcribeWebSocket(
         audio: AudioData,
         language: String?,
+        languageHints: [String] = [],
         translate: Bool,
         modelId: String,
         prompt: String?,
@@ -199,8 +268,9 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             "enable_endpoint_detection": true,
         ]
 
-        if let language, !language.isEmpty {
-            config["language_hints"] = [language]
+        let effectiveHints = resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
+        if !effectiveHints.isEmpty {
+            config["language_hints"] = effectiveHints
         }
 
         if translate {
@@ -333,6 +403,7 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     private func transcribeREST(
         audio: AudioData,
         language: String?,
+        languageHints: [String] = [],
         translate: Bool,
         apiKey: String,
         prompt: String?
@@ -341,6 +412,7 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         let transcriptionId = try await createTranscription(
             fileId: fileId,
             language: language,
+            languageHints: languageHints,
             translate: translate,
             apiKey: apiKey,
             prompt: prompt
@@ -396,6 +468,7 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     private func createTranscription(
         fileId: String,
         language: String?,
+        languageHints: [String] = [],
         translate: Bool,
         apiKey: String,
         prompt: String?
@@ -409,8 +482,9 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             "model": "stt-async-v4",
         ]
 
-        if let language, !language.isEmpty {
-            body["language_hints"] = [language]
+        let effectiveHints = resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
+        if !effectiveHints.isEmpty {
+            body["language_hints"] = effectiveHints
         }
 
         if translate {
@@ -457,6 +531,16 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
         guard !terms.isEmpty else { return nil }
         return ["terms": terms]
+    }
+
+    private func resolvedLanguageHints(requestedLanguage: String?, languageHints: [String]) -> [String] {
+        if !languageHints.isEmpty {
+            return languageHints
+        }
+        if let requestedLanguage, !requestedLanguage.isEmpty {
+            return [requestedLanguage]
+        }
+        return []
     }
 
     private func pollUntilCompleted(id: String, apiKey: String) async throws {

--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ curl http://localhost:8978/v1/status
 curl -X POST http://localhost:8978/v1/transcribe \
   -F "file=@recording.wav" \
   -F "language=en"
+
+curl -X POST http://localhost:8978/v1/transcribe \
+  -F "file=@recording.wav" \
+  -F "language_hint=de" \
+  -F "language_hint=en"
 ```
 
 ```json
@@ -248,7 +253,8 @@ curl -X POST http://localhost:8978/v1/transcribe \
 ```
 
 Optional parameters:
-- `language` - ISO 639-1 code (e.g., `en`, `de`). Omit for auto-detection.
+- `language` - ISO 639-1 code (e.g., `en`, `de`). Omit for full auto-detection.
+- `language_hint` - Repeatable language hint for restricted auto-detection. Do not combine with `language`.
 - `task` - `transcribe` (default) or `translate` (translates to English, WhisperKit only).
 - `target_language` - ISO 639-1 code for translation target language (e.g., `es`, `fr`). Uses Apple Translate.
 
@@ -329,6 +335,7 @@ typewhisper transcribe file.wav # Transcribe an audio file
 | `--port <N>` | Server port (default: auto-detect) |
 | `--json` | Output as JSON |
 | `--language <code>` | Source language (e.g. `en`, `de`) |
+| `--language-hint <code>` | Repeatable language hint for restricted auto-detection |
 | `--task <task>` | `transcribe` (default) or `translate` |
 | `--translate-to <code>` | Target language for translation |
 
@@ -337,6 +344,9 @@ typewhisper transcribe file.wav # Transcribe an audio file
 ```bash
 # Transcribe with language and JSON output
 typewhisper transcribe recording.wav --language de --json
+
+# Restrict auto-detection to a shortlist
+typewhisper transcribe recording.wav --language-hint de --language-hint en
 
 # Pipe audio from stdin
 cat audio.wav | typewhisper transcribe -
@@ -357,7 +367,7 @@ Rules let you configure transcription settings per application or website. For e
 - **github.com** - English language (matches in any browser)
 - **docs.google.com** - German language, translate to English
 
-Create rules in Settings > Regeln. Assign apps and/or URL patterns, set language/task/engine overrides, assign a custom prompt for automatic post-processing, optionally configure a manual rule shortcut, enable auto-submit (automatically sends text in chat apps), and adjust priority. URL patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`. The domain autocomplete suggests domains from your transcription history.
+Create rules in Settings > Regeln. Assign apps and/or URL patterns, set language/task/engine overrides, assign a custom prompt for automatic post-processing, optionally configure a manual rule shortcut, enable auto-submit (automatically sends text in chat apps), and adjust priority. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. URL patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`. The domain autocomplete suggests domains from your transcription history.
 
 When you start dictating, TypeWhisper matches the active app and browser URL against your rules with the following priority:
 1. **App + URL match** - highest specificity (e.g. Chrome + github.com)

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -158,7 +158,10 @@ final class ServiceContainer: ObservableObject {
             promptProcessingService: promptProcessingService
         )
         audioRecorderViewModel = AudioRecorderViewModel(recorderService: audioRecorderService, modelManager: modelManagerService, dictionaryService: dictionaryService)
-        watchFolderViewModel = WatchFolderViewModel(watchFolderService: watchFolderService)
+        watchFolderViewModel = WatchFolderViewModel(
+            watchFolderService: watchFolderService,
+            modelManager: modelManagerService
+        )
 
         // Set shared references
         FileTranscriptionViewModel._shared = fileTranscriptionViewModel

--- a/TypeWhisper/Models/Profile.swift
+++ b/TypeWhisper/Models/Profile.swift
@@ -34,6 +34,15 @@ final class Profile {
         }
     }
 
+    var inputLanguageSelection: LanguageSelection {
+        get {
+            LanguageSelection(storedValue: inputLanguage, nilBehavior: .inheritGlobal)
+        }
+        set {
+            inputLanguage = newValue.storedValue(nilBehavior: .inheritGlobal)
+        }
+    }
+
     init(
         id: UUID = UUID(),
         name: String,

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -62,6 +62,7 @@ final class APIHandlers: @unchecked Sendable {
         let audioData: Data
         var fileExtension = "wav"
         var language: String?
+        var languageHints: [String] = []
         var task: TranscriptionTask = .transcribe
         var targetLanguage: String?
         var responseFormat = "json"
@@ -91,6 +92,11 @@ final class APIHandlers: @unchecked Sendable {
                 language = val
             }
 
+            languageHints = parts
+                .filter { $0.name == "language_hint" }
+                .compactMap { String(data: $0.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+
             if let taskPart = parts.first(where: { $0.name == "task" }),
                let val = String(data: taskPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                let parsed = TranscriptionTask(rawValue: val) {
@@ -118,6 +124,10 @@ final class APIHandlers: @unchecked Sendable {
             audioData = request.body
             fileExtension = extensionFromMIME(contentType)
             language = request.headers["x-language"]
+            languageHints = request.headers["x-language-hints"]?
+                .split(separator: ",")
+                .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty } ?? []
             if let taskStr = request.headers["x-task"], let parsed = TranscriptionTask(rawValue: taskStr) {
                 task = parsed
             }
@@ -137,6 +147,10 @@ final class APIHandlers: @unchecked Sendable {
             return .error(status: 400, message: "Empty audio data")
         }
 
+        if language != nil, !languageHints.isEmpty {
+            return .error(status: 400, message: "Use either 'language' or 'language_hint', not both")
+        }
+
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".\(fileExtension)")
 
         do {
@@ -146,9 +160,17 @@ final class APIHandlers: @unchecked Sendable {
             let samples = try await audioFileService.loadAudioSamples(from: tempURL)
             let dictionaryPrompt = await MainActor.run { dictionaryService.getTermsForPrompt() }
             let prompt = mergedPrompt(requestPrompt: requestPrompt, dictionaryPrompt: dictionaryPrompt)
+            let languageSelection: LanguageSelection
+            if !languageHints.isEmpty {
+                languageSelection = LanguageSelection.auto.withSelectedCodes(languageHints, nilBehavior: .auto)
+            } else if let language {
+                languageSelection = .exact(language)
+            } else {
+                languageSelection = .auto
+            }
             let result = try await modelManager.transcribe(
                 audioSamples: samples,
-                language: language,
+                languageSelection: languageSelection,
                 task: task,
                 prompt: prompt
             )
@@ -465,6 +487,8 @@ final class APIHandlers: @unchecked Sendable {
                 let bundle_identifiers: [String]
                 let url_patterns: [String]
                 let input_language: String?
+                let language_mode: String
+                let language_hints: [String]
                 let translation_target_language: String?
             }
 
@@ -474,14 +498,27 @@ final class APIHandlers: @unchecked Sendable {
             }
 
             let entries = profileService.profiles.map { profile in
-                RuleEntry(
+                let selection = profile.inputLanguageSelection
+                let legacyInputLanguage: String?
+                switch selection {
+                case .auto:
+                    legacyInputLanguage = "auto"
+                case .exact(let code):
+                    legacyInputLanguage = code
+                case .inheritGlobal, .hints:
+                    legacyInputLanguage = nil
+                }
+
+                return RuleEntry(
                     id: profile.id.uuidString,
                     name: profile.name,
                     is_enabled: profile.isEnabled,
                     priority: profile.priority,
                     bundle_identifiers: profile.bundleIdentifiers,
                     url_patterns: profile.urlPatterns,
-                    input_language: profile.inputLanguage,
+                    input_language: legacyInputLanguage,
+                    language_mode: selection.mode.rawValue,
+                    language_hints: selection.selectedCodes,
                     translation_target_language: profile.translationTargetLanguage
                 )
             }

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -179,6 +179,24 @@ final class ModelManagerService: ObservableObject {
         prompt: String? = nil,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> LiveTranscriptionSessionHandle? {
+        try await createLiveTranscriptionSession(
+            languageSelection: language.map(LanguageSelection.exact) ?? .auto,
+            task: task,
+            engineOverrideId: engineOverrideId,
+            cloudModelOverride: cloudModelOverride,
+            prompt: prompt,
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: LanguageSelection,
+        task: TranscriptionTask,
+        engineOverrideId: String? = nil,
+        cloudModelOverride: String? = nil,
+        prompt: String? = nil,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> LiveTranscriptionSessionHandle? {
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
               let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
@@ -200,12 +218,24 @@ final class ModelManagerService: ObservableObject {
             return nil
         }
 
-        let session = try await livePlugin.createLiveTranscriptionSession(
-            language: language,
-            translate: task == .translate,
-            prompt: prompt,
-            onProgress: onProgress
-        )
+        let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
+        let session: any LiveTranscriptionSession
+        if !runtimeSelection.languageHints.isEmpty,
+           let hintPlugin = livePlugin as? LiveLanguageHintTranscriptionCapablePlugin {
+            session = try await hintPlugin.createLiveTranscriptionSession(
+                languageSelection: runtimeSelection,
+                translate: task == .translate,
+                prompt: prompt,
+                onProgress: onProgress
+            )
+        } else {
+            session = try await livePlugin.createLiveTranscriptionSession(
+                language: runtimeSelection.requestedLanguage,
+                translate: task == .translate,
+                prompt: prompt,
+                onProgress: onProgress
+            )
+        }
         return LiveTranscriptionSessionHandle(providerId: providerId, session: session)
     }
 
@@ -232,6 +262,24 @@ final class ModelManagerService: ObservableObject {
     func transcribe(
         audioSamples: [Float],
         language: String?,
+        task: TranscriptionTask,
+        engineOverrideId: String? = nil,
+        cloudModelOverride: String? = nil,
+        prompt: String? = nil
+    ) async throws -> TranscriptionResult {
+        try await transcribe(
+            audioSamples: audioSamples,
+            languageSelection: language.map(LanguageSelection.exact) ?? .auto,
+            task: task,
+            engineOverrideId: engineOverrideId,
+            cloudModelOverride: cloudModelOverride,
+            prompt: prompt
+        )
+    }
+
+    func transcribe(
+        audioSamples: [Float],
+        languageSelection: LanguageSelection,
         task: TranscriptionTask,
         engineOverrideId: String? = nil,
         cloudModelOverride: String? = nil,
@@ -264,10 +312,11 @@ final class ModelManagerService: ObservableObject {
             duration: audioDuration
         )
 
-        let result = try await plugin.transcribe(
+        let result = try await transcribeWithResolvedLanguageSelection(
+            plugin: plugin,
             audio: audio,
-            language: language,
-            translate: task == .translate,
+            languageSelection: runtimeLanguageSelection(for: languageSelection, plugin: plugin),
+            task: task,
             prompt: prompt
         )
 
@@ -288,6 +337,26 @@ final class ModelManagerService: ObservableObject {
     func transcribe(
         audioSamples: [Float],
         language: String?,
+        task: TranscriptionTask,
+        engineOverrideId: String? = nil,
+        cloudModelOverride: String? = nil,
+        prompt: String? = nil,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> TranscriptionResult {
+        try await transcribe(
+            audioSamples: audioSamples,
+            languageSelection: language.map(LanguageSelection.exact) ?? .auto,
+            task: task,
+            engineOverrideId: engineOverrideId,
+            cloudModelOverride: cloudModelOverride,
+            prompt: prompt,
+            onProgress: onProgress
+        )
+    }
+
+    func transcribe(
+        audioSamples: [Float],
+        languageSelection: LanguageSelection,
         task: TranscriptionTask,
         engineOverrideId: String? = nil,
         cloudModelOverride: String? = nil,
@@ -321,24 +390,14 @@ final class ModelManagerService: ObservableObject {
             duration: audioDuration
         )
 
-        let result: PluginTranscriptionResult
-        if plugin.supportsStreaming {
-            result = try await plugin.transcribe(
-                audio: audio,
-                language: language,
-                translate: task == .translate,
-                prompt: prompt,
-                onProgress: onProgress
-            )
-        } else {
-            result = try await plugin.transcribe(
-                audio: audio,
-                language: language,
-                translate: task == .translate,
-                prompt: prompt
-            )
-            let _ = onProgress(result.text)
-        }
+        let result = try await transcribeWithResolvedLanguageSelection(
+            plugin: plugin,
+            audio: audio,
+            languageSelection: runtimeLanguageSelection(for: languageSelection, plugin: plugin),
+            task: task,
+            prompt: prompt,
+            onProgress: onProgress
+        )
 
         let processingTime = CFAbsoluteTimeGetCurrent() - startTime
 
@@ -389,6 +448,95 @@ final class ModelManagerService: ObservableObject {
         let sel = NSSelectorFromString("triggerAutoUnload")
         guard nsPlugin.responds(to: sel) else { return }
         nsPlugin.perform(sel)
+    }
+
+    private func runtimeLanguageSelection(
+        for languageSelection: LanguageSelection,
+        plugin: TranscriptionEnginePlugin
+    ) -> PluginLanguageSelection {
+        if case .hints(let requestedCodes) = languageSelection,
+           requestedCodes.count > 1,
+           !pluginSupportsLanguageHints(plugin) {
+            return PluginLanguageSelection()
+        }
+
+        let normalizedSelection = languageSelection.normalizedForSupportedLanguages(plugin.supportedLanguages)
+        switch normalizedSelection {
+        case .exact(let code):
+            return PluginLanguageSelection(requestedLanguage: code)
+        case .hints(let codes):
+            return PluginLanguageSelection(languageHints: codes)
+        case .inheritGlobal, .auto:
+            return PluginLanguageSelection()
+        }
+    }
+
+    private func pluginSupportsLanguageHints(_ plugin: TranscriptionEnginePlugin) -> Bool {
+        plugin is LanguageHintTranscriptionEnginePlugin || plugin is LiveLanguageHintTranscriptionCapablePlugin
+    }
+
+    private func transcribeWithResolvedLanguageSelection(
+        plugin: TranscriptionEnginePlugin,
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        task: TranscriptionTask,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        if !languageSelection.languageHints.isEmpty,
+           let hintPlugin = plugin as? LanguageHintTranscriptionEnginePlugin {
+            return try await hintPlugin.transcribe(
+                audio: audio,
+                languageSelection: languageSelection,
+                translate: task == .translate,
+                prompt: prompt
+            )
+        }
+
+        return try await plugin.transcribe(
+            audio: audio,
+            language: languageSelection.requestedLanguage,
+            translate: task == .translate,
+            prompt: prompt
+        )
+    }
+
+    private func transcribeWithResolvedLanguageSelection(
+        plugin: TranscriptionEnginePlugin,
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        task: TranscriptionTask,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        if !languageSelection.languageHints.isEmpty,
+           let hintPlugin = plugin as? LanguageHintTranscriptionEnginePlugin {
+            return try await hintPlugin.transcribe(
+                audio: audio,
+                languageSelection: languageSelection,
+                translate: task == .translate,
+                prompt: prompt,
+                onProgress: onProgress
+            )
+        }
+
+        if plugin.supportsStreaming {
+            return try await plugin.transcribe(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                translate: task == .translate,
+                prompt: prompt,
+                onProgress: onProgress
+            )
+        }
+
+        let result = try await plugin.transcribe(
+            audio: audio,
+            language: languageSelection.requestedLanguage,
+            translate: task == .translate,
+            prompt: prompt
+        )
+        let _ = onProgress(result.text)
+        return result
     }
 
     /// Trigger model restore via ObjC dispatch (avoids Swift protocol witness table issues

--- a/TypeWhisper/Services/WatchFolderService.swift
+++ b/TypeWhisper/Services/WatchFolderService.swift
@@ -187,7 +187,7 @@ final class WatchFolderService: ObservableObject {
             let samples = try await audioFileService.loadAudioSamples(from: url)
             let result = try await modelManagerService.transcribe(
                 audioSamples: samples,
-                language: overrides.language,
+                languageSelection: overrides.languageSelection,
                 task: .transcribe,
                 engineOverrideId: overrides.engineId,
                 cloudModelOverride: overrides.modelId

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -24,7 +24,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private struct FinalTranscriptionRequest {
         let outputURL: URL
         let buffer: [Float]
-        let language: String?
+        let languageSelection: LanguageSelection
         let task: TranscriptionTask
         let providerId: String?
         let modelId: String?
@@ -70,7 +70,7 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var transcriptionEnabled: Bool {
         didSet { UserDefaults.standard.set(transcriptionEnabled, forKey: UserDefaultsKeys.recorderTranscriptionEnabled) }
     }
-    @Published var selectedLanguage: String? = nil
+    @Published var languageSelection: LanguageSelection = .auto
     @Published var selectedTask: TranscriptionTask = .transcribe
     @Published var recordings: [RecordingItem] = []
     @Published var errorMessage: String?
@@ -81,6 +81,7 @@ final class AudioRecorderViewModel: ObservableObject {
     var activeModelName: String? { modelManager.activeModelName }
     var isModelReady: Bool { modelManager.isModelReady }
     var supportsTranslation: Bool { modelManager.supportsTranslation }
+    var selectedLanguage: String? { languageSelection.requestedLanguage }
 
     private let recorderService: AudioRecorderService
     private let modelManager: ModelManagerService
@@ -220,7 +221,7 @@ final class AudioRecorderViewModel: ObservableObject {
                 finalTranscriptionRequest = FinalTranscriptionRequest(
                     outputURL: url,
                     buffer: recorderService.getCurrentBuffer(),
-                    language: selectedLanguage,
+                    languageSelection: languageSelection,
                     task: selectedTask,
                     providerId: modelManager.selectedProviderId,
                     modelId: modelManager.selectedModelId,
@@ -354,7 +355,7 @@ final class AudioRecorderViewModel: ObservableObject {
         streamingHandler.start(
             engineOverrideId: providerId,
             selectedProviderId: modelManager.selectedProviderId,
-            language: selectedLanguage,
+            languageSelection: languageSelection,
             task: task,
             cloudModelOverride: nil,
             allowLiveTranscription: true,
@@ -398,7 +399,7 @@ final class AudioRecorderViewModel: ObservableObject {
             } else {
                 try await modelManager.transcribe(
                     audioSamples: buffer,
-                    language: request.language,
+                    languageSelection: request.languageSelection,
                     task: effectiveTask,
                     engineOverrideId: request.providerId,
                     cloudModelOverride: request.modelId,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -594,7 +594,7 @@ final class DictationViewModel: ObservableObject {
             streamingHandler.start(
                 engineOverrideId: effectiveEngineOverrideId,
                 selectedProviderId: modelManager.selectedProviderId,
-                language: effectiveLanguage,
+                languageSelection: effectiveLanguageSelection,
                 task: effectiveTask,
                 cloudModelOverride: effectiveCloudModelOverride,
                 allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0,
@@ -697,11 +697,21 @@ final class DictationViewModel: ObservableObject {
         }
     }
 
-    private var effectiveLanguage: String? {
+    private var effectiveLanguageSelection: LanguageSelection {
         if let profileLang = matchedProfile?.inputLanguage {
-            return profileLang == "auto" ? nil : profileLang
+            let profileSelection = LanguageSelection(
+                storedValue: profileLang,
+                nilBehavior: .inheritGlobal
+            )
+            if profileSelection != .inheritGlobal {
+                return profileSelection
+            }
         }
-        return settingsViewModel.selectedLanguage
+        return settingsViewModel.languageSelection
+    }
+
+    private var effectiveLanguage: String? {
+        effectiveLanguageSelection.requestedLanguage
     }
 
     private var effectiveTask: TranscriptionTask {
@@ -833,7 +843,8 @@ final class DictationViewModel: ObservableObject {
                 await urlResolutionTask?.value
 
                 let activeApp = capturedActiveApp ?? textInsertionService.captureActiveApp()
-                let language = effectiveLanguage
+                let languageSelection = effectiveLanguageSelection
+                let language = languageSelection.requestedLanguage
                 let task = effectiveTask
                 let engineOverride = effectiveEngineOverrideId
                 let cloudModelOverride = effectiveCloudModelOverride
@@ -845,7 +856,7 @@ final class DictationViewModel: ObservableObject {
                 } else {
                     try await modelManager.transcribe(
                         audioSamples: samples,
-                        language: language,
+                        languageSelection: languageSelection,
                         task: task,
                         engineOverrideId: engineOverride,
                         cloudModelOverride: cloudModelOverride,

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -41,7 +41,7 @@ final class FileTranscriptionViewModel: ObservableObject {
     @Published var showFilePickerFromMenu = false
     @Published var batchState: BatchState = .idle
     @Published var currentIndex: Int = 0
-    @Published var selectedLanguage: String? = nil
+    @Published var languageSelection: LanguageSelection = .auto
     @Published var selectedTask: TranscriptionTask = .transcribe
 
     private let modelManager: ModelManagerService
@@ -131,7 +131,7 @@ final class FileTranscriptionViewModel: ObservableObject {
 
             let result = try await modelManager.transcribe(
                 audioSamples: samples,
-                language: selectedLanguage,
+                languageSelection: languageSelection,
                 task: selectedTask,
                 engineOverrideId: nil,
                 cloudModelOverride: nil

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -27,8 +27,135 @@ func localizedAppLanguageName(for code: String) -> String {
     return locale.localizedString(forIdentifier: code) ?? code
 }
 
+func localizedAppLanguageFlag(for code: String) -> String? {
+    guard code != "auto" else { return nil }
+
+    let components = NSLocale.components(fromLocaleIdentifier: code)
+    let regionKey = NSLocale.Key.countryCode.rawValue
+    let scriptKey = NSLocale.Key.scriptCode.rawValue
+    let languageKey = NSLocale.Key.languageCode.rawValue
+
+    if let region = components[regionKey]?.uppercased(),
+       region.count == 2 {
+        return emojiFlag(forRegionCode: region)
+    }
+
+    // Script-only variants like zh-Hans / zh-Hant should not get a country flag.
+    if components[scriptKey] != nil {
+        return nil
+    }
+
+    guard let languageCode = components[languageKey]?.lowercased() else {
+        return nil
+    }
+
+    let inferredRegionByLanguage = [
+        "ar": "SA",
+        "cs": "CZ",
+        "da": "DK",
+        "de": "DE",
+        "en": "US",
+        "el": "GR",
+        "es": "ES",
+        "fi": "FI",
+        "fr": "FR",
+        "he": "IL",
+        "hi": "IN",
+        "hu": "HU",
+        "id": "ID",
+        "it": "IT",
+        "ja": "JP",
+        "ko": "KR",
+        "nl": "NL",
+        "no": "NO",
+        "pl": "PL",
+        "ro": "RO",
+        "ru": "RU",
+        "sv": "SE",
+        "th": "TH",
+        "tr": "TR",
+        "uk": "UA",
+        "vi": "VN",
+        "zh": "CN"
+    ]
+
+    guard let inferredRegion = inferredRegionByLanguage[languageCode] else {
+        return nil
+    }
+
+    return emojiFlag(forRegionCode: inferredRegion)
+}
+
+func localizedAppLanguageBadgeText(for code: String) -> String {
+    let components = NSLocale.components(fromLocaleIdentifier: code)
+    let languageKey = NSLocale.Key.languageCode.rawValue
+    guard let languageCode = components[languageKey], !languageCode.isEmpty else {
+        return code.uppercased()
+    }
+
+    if code.contains("-") {
+        return code.uppercased()
+    }
+
+    return languageCode.uppercased()
+}
+
+private func emojiFlag(forRegionCode regionCode: String) -> String? {
+    let normalized = regionCode.uppercased()
+    guard normalized.count == 2 else { return nil }
+
+    let base: UInt32 = 127397
+    var scalars = String.UnicodeScalarView()
+
+    for scalar in normalized.unicodeScalars {
+        guard let regionalIndicator = UnicodeScalar(base + scalar.value) else {
+            return nil
+        }
+        scalars.append(regionalIndicator)
+    }
+
+    return String(scalars)
+}
+
+func localizedAppLanguageNames(for codes: [String]) -> [String] {
+    codes.map(localizedAppLanguageName(for:))
+}
+
+func localizedAppLanguageList(_ codes: [String]) -> String {
+    let names = localizedAppLanguageNames(for: codes)
+    guard let first = names.first else { return "" }
+    if names.count == 1 { return first }
+    if names.count == 2 {
+        return "\(first)\(localizedAppOrSeparator())\(names[1])"
+    }
+    let allButLast = names.dropLast().joined(separator: ", ")
+    return "\(allButLast),\(localizedAppText(" and ", de: " und "))\(names[names.count - 1])"
+}
+
 func localizedAppOrSeparator() -> String {
     localizedAppText(" or ", de: " oder ")
+}
+
+func featuredAppLanguageRank(for code: String) -> Int? {
+    let components = NSLocale.components(fromLocaleIdentifier: code)
+    let languageKey = NSLocale.Key.languageCode.rawValue
+    guard let languageCode = components[languageKey]?.lowercased() else {
+        return nil
+    }
+
+    let featuredLanguageOrder = [
+        "de",
+        "en",
+        "fr",
+        "es",
+        "zh",
+        "hi",
+        "ar",
+        "pt",
+        "ja"
+    ]
+
+    return featuredLanguageOrder.firstIndex(of: languageCode)
 }
 
 struct InstalledApp: Identifiable, Hashable {
@@ -496,9 +623,23 @@ final class ProfilesViewModel: ObservableObject {
             parts.append(localizedAppText("the prompt “\(action.name)”", de: "den Prompt „\(action.name)“"))
         }
 
-        if let lang = inputLanguage {
-            let languageName = localizedAppLanguageName(for: lang)
+        let languageSelection = LanguageSelection(storedValue: inputLanguage, nilBehavior: .inheritGlobal)
+        switch languageSelection {
+        case .inheritGlobal:
+            break
+        case .auto:
+            parts.append(localizedAppText("with auto-detect", de: "mit automatischer Erkennung"))
+        case .exact(let code):
+            let languageName = localizedAppLanguageName(for: code)
             parts.append(localizedAppText("with \(languageName)", de: "mit \(languageName)"))
+        case .hints(let codes):
+            let languageList = localizedAppLanguageList(codes)
+            parts.append(
+                localizedAppText(
+                    "with auto-detect between \(languageList)",
+                    de: "mit automatischer Erkennung zwischen \(languageList)"
+                )
+            )
         }
 
         if translationEnabled == false {

--- a/TypeWhisper/ViewModels/SettingsViewModel.swift
+++ b/TypeWhisper/ViewModels/SettingsViewModel.swift
@@ -1,6 +1,174 @@
 import Foundation
 import Combine
 
+enum LanguageSelectionNilBehavior: Sendable {
+    case inheritGlobal
+    case auto
+}
+
+enum LanguageSelectionMode: String, Sendable {
+    case inheritGlobal = "inherit"
+    case auto
+    case exact
+    case multiple
+}
+
+enum LanguageSelection: Equatable, Sendable {
+    case inheritGlobal
+    case auto
+    case exact(String)
+    case hints([String])
+
+    init(storedValue rawValue: String?, nilBehavior: LanguageSelectionNilBehavior) {
+        guard let rawValue else {
+            self = nilBehavior == .inheritGlobal ? .inheritGlobal : .auto
+            return
+        }
+
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            self = nilBehavior == .inheritGlobal ? .inheritGlobal : .auto
+            return
+        }
+
+        if trimmed.caseInsensitiveCompare("auto") == .orderedSame {
+            self = .auto
+            return
+        }
+
+        if let data = trimmed.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            let normalized = Self.normalizedCodes(decoded)
+            switch normalized.count {
+            case 0:
+                self = nilBehavior == .inheritGlobal ? .inheritGlobal : .auto
+            case 1:
+                self = .exact(normalized[0])
+            default:
+                self = .hints(normalized)
+            }
+            return
+        }
+
+        self = .exact(trimmed)
+    }
+
+    var mode: LanguageSelectionMode {
+        switch self {
+        case .inheritGlobal:
+            return .inheritGlobal
+        case .auto:
+            return .auto
+        case .exact:
+            return .exact
+        case .hints:
+            return .multiple
+        }
+    }
+
+    var requestedLanguage: String? {
+        switch self {
+        case .exact(let code):
+            return code
+        case .inheritGlobal, .auto, .hints:
+            return nil
+        }
+    }
+
+    var selectedCodes: [String] {
+        switch self {
+        case .exact(let code):
+            return [code]
+        case .hints(let codes):
+            return Self.normalizedCodes(codes)
+        case .inheritGlobal, .auto:
+            return []
+        }
+    }
+
+    var isRestrictingDetection: Bool {
+        switch self {
+        case .exact, .hints:
+            return true
+        case .inheritGlobal, .auto:
+            return false
+        }
+    }
+
+    func storedValue(nilBehavior: LanguageSelectionNilBehavior) -> String? {
+        switch self {
+        case .inheritGlobal:
+            return nilBehavior == .inheritGlobal ? nil : "auto"
+        case .auto:
+            return "auto"
+        case .exact(let code):
+            return code
+        case .hints(let codes):
+            let normalized = Self.normalizedCodes(codes)
+            switch normalized.count {
+            case 0:
+                return nilBehavior == .inheritGlobal ? nil : "auto"
+            case 1:
+                return normalized[0]
+            default:
+                guard let data = try? JSONEncoder().encode(normalized),
+                      let encoded = String(data: data, encoding: .utf8) else {
+                    return normalized.joined(separator: ",")
+                }
+                return encoded
+            }
+        }
+    }
+
+    func withSelectedCodes(_ codes: [String], nilBehavior: LanguageSelectionNilBehavior) -> LanguageSelection {
+        let normalized = Self.normalizedCodes(codes)
+        switch normalized.count {
+        case 0:
+            return nilBehavior == .inheritGlobal ? .inheritGlobal : .auto
+        case 1:
+            return .exact(normalized[0])
+        default:
+            return .hints(normalized)
+        }
+    }
+
+    func normalizedForSupportedLanguages(_ supportedLanguages: [String]) -> LanguageSelection {
+        let supportedSet = Set(supportedLanguages)
+        guard !supportedSet.isEmpty else {
+            switch self {
+            case .hints(let codes):
+                return withSelectedCodes(codes, nilBehavior: .auto)
+            default:
+                return self
+            }
+        }
+
+        switch self {
+        case .exact(let code):
+            return supportedSet.contains(code) ? .exact(code) : .auto
+        case .hints(let codes):
+            let filtered = codes.filter { supportedSet.contains($0) }
+            return withSelectedCodes(filtered, nilBehavior: .auto)
+        case .inheritGlobal, .auto:
+            return self
+        }
+    }
+
+    private static func normalizedCodes(_ codes: [String]) -> [String] {
+        var seen = Set<String>()
+        var normalized: [String] = []
+
+        for rawCode in codes {
+            let code = rawCode.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !code.isEmpty else { continue }
+            guard seen.insert(code).inserted else { continue }
+            normalized.append(code)
+        }
+
+        return normalized
+    }
+}
+
 @MainActor
 final class SettingsViewModel: ObservableObject {
     nonisolated(unsafe) static var _shared: SettingsViewModel?
@@ -11,9 +179,12 @@ final class SettingsViewModel: ObservableObject {
         return instance
     }
 
-    @Published var selectedLanguage: String? {
+    @Published var languageSelection: LanguageSelection {
         didSet {
-            UserDefaults.standard.set(selectedLanguage, forKey: UserDefaultsKeys.selectedLanguage)
+            UserDefaults.standard.set(
+                languageSelection.storedValue(nilBehavior: .auto),
+                forKey: UserDefaultsKeys.selectedLanguage
+            )
         }
     }
     @Published var selectedTask: TranscriptionTask {
@@ -36,11 +207,18 @@ final class SettingsViewModel: ObservableObject {
 
     init(modelManager: ModelManagerService) {
         self.modelManager = modelManager
-        self.selectedLanguage = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedLanguage)
+        self.languageSelection = LanguageSelection(
+            storedValue: UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedLanguage),
+            nilBehavior: .auto
+        )
         self.selectedTask = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedTask)
             .flatMap { TranscriptionTask(rawValue: $0) } ?? .transcribe
         self.translationEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.translationEnabled)
         self.translationTargetLanguage = UserDefaults.standard.string(forKey: UserDefaultsKeys.translationTargetLanguage) ?? "en"
+    }
+
+    var selectedLanguage: String? {
+        languageSelection.requestedLanguage
     }
 
     func observePluginManager() {

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -37,7 +37,7 @@ final class StreamingHandler {
     func start(
         engineOverrideId: String?,
         selectedProviderId: String?,
-        language: String?,
+        languageSelection: LanguageSelection,
         task: TranscriptionTask,
         cloudModelOverride: String?,
         allowLiveTranscription: Bool,
@@ -65,7 +65,7 @@ final class StreamingHandler {
             let progressText = self.progressText
 
             if let handle = try? await self.modelManager.createLiveTranscriptionSession(
-                language: language,
+                languageSelection: languageSelection,
                 task: task,
                 engineOverrideId: engineOverrideId,
                 cloudModelOverride: cloudModelOverride,
@@ -118,7 +118,7 @@ final class StreamingHandler {
                         let confirmed = self.confirmedStreamingText
                         let result = try await self.modelManager.transcribe(
                             audioSamples: buffer,
-                            language: language,
+                            languageSelection: languageSelection,
                             task: task,
                             engineOverrideId: engineOverrideId,
                             cloudModelOverride: cloudModelOverride,

--- a/TypeWhisper/ViewModels/WatchFolderViewModel.swift
+++ b/TypeWhisper/ViewModels/WatchFolderViewModel.swift
@@ -24,8 +24,13 @@ final class WatchFolderViewModel: ObservableObject {
     @Published var autoStartOnLaunch: Bool = false {
         didSet { UserDefaults.standard.set(autoStartOnLaunch, forKey: UserDefaultsKeys.watchFolderAutoStart) }
     }
-    @Published var language: String? {
-        didSet { UserDefaults.standard.set(language, forKey: UserDefaultsKeys.watchFolderLanguage) }
+    @Published var languageSelection: LanguageSelection = .auto {
+        didSet {
+            UserDefaults.standard.set(
+                languageSelection.storedValue(nilBehavior: .auto),
+                forKey: UserDefaultsKeys.watchFolderLanguage
+            )
+        }
     }
     @Published var selectedEngine: String? {
         didSet {
@@ -35,9 +40,9 @@ final class WatchFolderViewModel: ObservableObject {
             selectedModel = nil
             guard let selectedEngine,
                   let engine = PluginManager.shared.transcriptionEngine(for: selectedEngine) else { return }
-            let supported = engine.supportedLanguages.sorted()
-            if let lang = language, !supported.isEmpty, !supported.contains(lang) {
-                language = nil
+            let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
+            if normalized != languageSelection {
+                languageSelection = normalized
             }
         }
     }
@@ -50,11 +55,11 @@ final class WatchFolderViewModel: ObservableObject {
     struct TranscriptionOverrides {
         let engineId: String?
         let modelId: String?
-        let language: String?
+        let languageSelection: LanguageSelection
     }
 
     var transcriptionOverrides: TranscriptionOverrides {
-        TranscriptionOverrides(engineId: selectedEngine, modelId: selectedModel, language: language)
+        TranscriptionOverrides(engineId: selectedEngine, modelId: selectedModel, languageSelection: languageSelection)
     }
 
     var availableEngines: [TranscriptionEnginePlugin] {
@@ -62,7 +67,7 @@ final class WatchFolderViewModel: ObservableObject {
     }
 
     var resolvedEngine: TranscriptionEnginePlugin? {
-        let engineId = selectedEngine ?? ServiceContainer.shared.modelManagerService.selectedProviderId
+        let engineId = selectedEngine ?? modelManager.selectedProviderId
         guard let engineId else { return nil }
         return PluginManager.shared.transcriptionEngine(for: engineId)
     }
@@ -73,10 +78,15 @@ final class WatchFolderViewModel: ObservableObject {
     }
 
     let watchFolderService: WatchFolderService
+    private let modelManager: ModelManagerService
     private var cancellables = Set<AnyCancellable>()
 
-    init(watchFolderService: WatchFolderService) {
+    init(
+        watchFolderService: WatchFolderService,
+        modelManager: ModelManagerService
+    ) {
         self.watchFolderService = watchFolderService
+        self.modelManager = modelManager
         loadSettings()
         isInitialized = true
 
@@ -147,7 +157,10 @@ final class WatchFolderViewModel: ObservableObject {
         outputFormat = UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderOutputFormat) ?? "md"
         deleteSourceFiles = UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderDeleteSource)
         autoStartOnLaunch = UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderAutoStart)
-        language = UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderLanguage)
+        languageSelection = LanguageSelection(
+            storedValue: UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderLanguage),
+            nilBehavior: .auto
+        )
         selectedEngine = UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderEngine)
         selectedModel = UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderModel)
 
@@ -169,10 +182,25 @@ final class WatchFolderViewModel: ObservableObject {
     }
 
     func reconcileSelectionWithAvailablePlugins() {
-        guard let selectedEngine else { return }
-        guard PluginManager.shared.transcriptionEngine(for: selectedEngine) == nil else { return }
-        self.selectedEngine = nil
-        selectedModel = nil
+        if let selectedEngine {
+            guard let engine = PluginManager.shared.transcriptionEngine(for: selectedEngine) else {
+                self.selectedEngine = nil
+                selectedModel = nil
+                return
+            }
+            let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
+            if normalized != languageSelection {
+                languageSelection = normalized
+            }
+            return
+        }
+
+        if let engine = resolvedEngine {
+            let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
+            if normalized != languageSelection {
+                languageSelection = normalized
+            }
+        }
     }
 
     private func resolveWatchFolderURL() -> URL? {

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -189,14 +189,21 @@ struct AudioRecorderView: View {
                         }
                     }
 
-                    // Language picker
-                    Picker(String(localized: "recorder.language"), selection: $viewModel.selectedLanguage) {
-                        Text(String(localized: "Auto-detect")).tag(nil as String?)
-                        Divider()
-                        ForEach(SettingsViewModel.shared.availableLanguages, id: \.code) { lang in
-                            Text(lang.name).tag(lang.code as String?)
+                    let languageOptions: [(code: String, name: String)] = {
+                        guard let providerId = selectedProvider,
+                              let engine = pluginManager.transcriptionEngine(for: providerId),
+                              !engine.supportedLanguages.isEmpty else {
+                            return SettingsViewModel.shared.availableLanguages
                         }
-                    }
+                        return engine.supportedLanguages
+                            .map { ($0, Locale.current.localizedString(forIdentifier: $0) ?? $0) }
+                            .sorted { $0.1.localizedCaseInsensitiveCompare($1.1) == .orderedAscending }
+                    }()
+
+                    LanguageSelectionEditor(
+                        selection: $viewModel.languageSelection,
+                        availableLanguages: languageOptions
+                    )
                     .disabled(isEditingLocked)
 
                     // Task picker (transcribe/translate)

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -110,20 +110,11 @@ struct FileTranscriptionView: View {
                         }
                     }
 
-                    Picker(String(localized: "watchFolder.language"), selection: Binding(
-                        get: { watchFolder.language ?? "__auto__" },
-                        set: { watchFolder.language = $0 == "__auto__" ? nil : $0 }
-                    )) {
-                        Text(String(localized: "watchFolder.language.auto")).tag("__auto__")
-                        let languages = watchFolder.selectedEngineSupportedLanguages
-                        if !languages.isEmpty {
-                            Divider()
-                            ForEach(languages, id: \.self) { code in
-                                Text(Locale.current.localizedString(forIdentifier: code) ?? code)
-                                    .tag(code)
-                            }
-                        }
-                    }
+                    LanguageSelectionEditor(
+                        selection: $watchFolder.languageSelection,
+                        availableLanguages: watchFolder.selectedEngineSupportedLanguages
+                            .map { ($0, Locale.current.localizedString(forIdentifier: $0) ?? $0) }
+                    )
                 }
 
                 Section(String(localized: "watchFolder.settings")) {
@@ -394,65 +385,72 @@ struct FileTranscriptionView: View {
 
     @ViewBuilder
     private var controls: some View {
-        HStack {
-            Button(String(localized: "Add Files...")) {
-                showFilePicker = true
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .disabled(viewModel.batchState == .processing)
+        VStack(alignment: .leading, spacing: 12) {
+            LanguageSelectionEditor(
+                selection: $viewModel.languageSelection,
+                availableLanguages: SettingsViewModel.shared.availableLanguages
+            )
 
-            if viewModel.supportsTranslation {
-                Picker(String(localized: "Task"), selection: $viewModel.selectedTask) {
-                    ForEach(TranscriptionTask.allCases) { task in
-                        Text(task.displayName).tag(task)
+            HStack {
+                Button(String(localized: "Add Files...")) {
+                    showFilePicker = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(viewModel.batchState == .processing)
+
+                if viewModel.supportsTranslation {
+                    Picker(String(localized: "Task"), selection: $viewModel.selectedTask) {
+                        ForEach(TranscriptionTask.allCases) { task in
+                            Text(task.displayName).tag(task)
+                        }
                     }
+                    .frame(width: 180)
+                    .controlSize(.small)
                 }
-                .frame(width: 180)
-                .controlSize(.small)
-            }
 
-            Spacer()
+                Spacer()
 
-            if viewModel.hasResults {
-                Menu(String(localized: "Export All")) {
-                    Button(String(localized: "Copy All Text")) { viewModel.copyAllText() }
-                    Divider()
-                    Button(String(localized: "Export All as SRT")) { viewModel.exportAllSubtitles(format: .srt) }
-                    Button(String(localized: "Export All as VTT")) { viewModel.exportAllSubtitles(format: .vtt) }
+                if viewModel.hasResults {
+                    Menu(String(localized: "Export All")) {
+                        Button(String(localized: "Copy All Text")) { viewModel.copyAllText() }
+                        Divider()
+                        Button(String(localized: "Export All as SRT")) { viewModel.exportAllSubtitles(format: .srt) }
+                        Button(String(localized: "Export All as VTT")) { viewModel.exportAllSubtitles(format: .vtt) }
+                    }
+                    .controlSize(.small)
                 }
-                .controlSize(.small)
-            }
 
-            if viewModel.batchState == .processing {
-                HStack(spacing: 6) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
-                        .font(.caption)
-                        .monospacedDigit()
+                if viewModel.batchState == .processing {
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
+                            .font(.caption)
+                            .monospacedDigit()
+                    }
+                } else {
+                    Button {
+                        viewModel.transcribeAll()
+                    } label: {
+                        Label(String(localized: "Transcribe All"), systemImage: "waveform")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(!viewModel.canTranscribe)
                 }
-            } else {
+
                 Button {
-                    viewModel.transcribeAll()
+                    viewModel.reset()
                 } label: {
-                    Label(String(localized: "Transcribe All"), systemImage: "waveform")
+                    Image(systemName: "trash")
+                        .foregroundStyle(.red)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .disabled(!viewModel.canTranscribe)
+                .buttonStyle(.plain)
+                .disabled(viewModel.batchState == .processing)
+                .help(String(localized: "Clear All"))
+                .accessibilityLabel(String(localized: "Clear All"))
             }
-
-            Button {
-                viewModel.reset()
-            } label: {
-                Image(systemName: "trash")
-                    .foregroundStyle(.red)
-            }
-            .buttonStyle(.plain)
-            .disabled(viewModel.batchState == .processing)
-            .help(String(localized: "Clear All"))
-            .accessibilityLabel(String(localized: "Clear All"))
         }
     }
 

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -73,13 +73,10 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section(String(localized: "Spoken Language")) {
-                Picker(String(localized: "Spoken language"), selection: $settings.selectedLanguage) {
-                    Text(String(localized: "Auto-detect")).tag(nil as String?)
-                    Divider()
-                    ForEach(settings.availableLanguages, id: \.code) { lang in
-                        Text(lang.name).tag(lang.code as String?)
-                    }
-                }
+                LanguageSelectionEditor(
+                    selection: $settings.languageSelection,
+                    availableLanguages: settings.availableLanguages
+                )
 
                 Text(String(localized: "The language being spoken. Setting this explicitly improves accuracy."))
                     .font(.caption)
@@ -258,5 +255,299 @@ struct GeneralSettingsView: View {
             // Revert toggle on failure
             launchAtLogin = SMAppService.mainApp.status == .enabled
         }
+    }
+}
+
+struct LanguageSelectionEditor: View {
+    private enum SelectionMode: Hashable {
+        case inheritGlobal
+        case auto
+        case restricted
+    }
+
+    @Binding var selection: LanguageSelection
+    let availableLanguages: [(code: String, name: String)]
+    var nilBehavior: LanguageSelectionNilBehavior = .auto
+    var inheritTitle: String? = nil
+    var autoTitle: String = "Auto-detect all languages"
+    var restrictedTitle: String = "Restrict detection to selected languages"
+
+    @State private var isPickerPresented = false
+    @State private var searchQuery = ""
+    @State private var pendingRestrictedSelection = false
+
+    private var mode: SelectionMode {
+        if pendingRestrictedSelection {
+            return .restricted
+        }
+
+        switch selection {
+        case .inheritGlobal:
+            return .inheritGlobal
+        case .auto:
+            return .auto
+        case .exact, .hints:
+            return .restricted
+        }
+    }
+
+    private var filteredLanguages: [(code: String, name: String)] {
+        guard !searchQuery.isEmpty else { return availableLanguages }
+        return availableLanguages.filter {
+            $0.name.localizedCaseInsensitiveContains(searchQuery) || $0.code.localizedCaseInsensitiveContains(searchQuery)
+        }
+    }
+
+    private var featuredLanguages: [(code: String, name: String)] {
+        let rankedLanguages: [(rank: Int, language: (code: String, name: String))] = filteredLanguages.compactMap { language in
+                guard let rank = featuredAppLanguageRank(for: language.code) else { return nil }
+                return (rank: rank, language: language)
+            }
+        return rankedLanguages.sorted {
+                if $0.rank != $1.rank { return $0.rank < $1.rank }
+                return $0.language.name.localizedCaseInsensitiveCompare($1.language.name) == .orderedAscending
+            }
+            .map(\.language)
+    }
+
+    private var nonFeaturedLanguages: [(code: String, name: String)] {
+        let featuredCodes = Set(featuredLanguages.map(\.code))
+        return filteredLanguages.filter { !featuredCodes.contains($0.code) }
+    }
+
+    private var showsFeaturedSection: Bool {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !featuredLanguages.isEmpty
+    }
+
+    private var selectedCodes: [String] {
+        selection.selectedCodes
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let inheritTitle {
+                modeButton(
+                    title: inheritTitle,
+                    subtitle: "Use the global spoken language setting for this context.",
+                    mode: .inheritGlobal
+                )
+            }
+
+            modeButton(
+                title: autoTitle,
+                subtitle: "Let the engine detect the spoken language without restrictions.",
+                mode: .auto
+            )
+
+            modeButton(
+                title: restrictedTitle,
+                subtitle: "Improve detection by limiting it to one or more expected languages.",
+                mode: .restricted
+            )
+
+            if mode == .restricted {
+                HStack(spacing: 8) {
+                    Button {
+                        isPickerPresented = true
+                    } label: {
+                        Label(selectedCodes.isEmpty ? "Select languages" : "Selected: \(selectedCodes.count)", systemImage: "plus.circle")
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if selectedCodes.isEmpty {
+                    Text("No languages selected yet.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    FlowLayout(spacing: 2) {
+                        ForEach(selectedCodes, id: \.self) { code in
+                            LanguageChip(
+                                code: code,
+                                title: localizedAppLanguageName(for: code),
+                                removeAction: { removeCode(code) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        .popover(isPresented: $isPickerPresented, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Search languages", text: $searchQuery)
+                    .textFieldStyle(.roundedBorder)
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        if showsFeaturedSection {
+                            ForEach(featuredLanguages, id: \.code) { language in
+                                languageRow(language)
+                            }
+
+                            if !nonFeaturedLanguages.isEmpty {
+                                Divider()
+                                    .padding(.vertical, 4)
+                            }
+                        }
+
+                        ForEach(showsFeaturedSection ? nonFeaturedLanguages : filteredLanguages, id: \.code) { language in
+                            languageRow(language)
+                        }
+                    }
+                }
+                .frame(width: 320, height: 240)
+            }
+            .padding(10)
+        }
+    }
+
+    private func modeButton(title: String, subtitle: String, mode targetMode: SelectionMode) -> some View {
+        Button {
+            setMode(targetMode)
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: mode == targetMode ? "largecircle.fill.circle" : "circle")
+                    .foregroundStyle(mode == targetMode ? Color.accentColor : Color.secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func setMode(_ newMode: SelectionMode) {
+        switch newMode {
+        case .inheritGlobal:
+            pendingRestrictedSelection = false
+            selection = .inheritGlobal
+        case .auto:
+            pendingRestrictedSelection = false
+            selection = .auto
+        case .restricted:
+            if selectedCodes.isEmpty {
+                pendingRestrictedSelection = true
+                isPickerPresented = true
+            } else {
+                pendingRestrictedSelection = false
+                applySelection(for: selectedCodes)
+            }
+        }
+    }
+
+    private func toggleCode(_ code: String) {
+        var codes = selectedCodes
+        if let index = codes.firstIndex(of: code) {
+            codes.remove(at: index)
+        } else {
+            codes.append(code)
+        }
+        applySelection(for: codes)
+    }
+
+    private func removeCode(_ code: String) {
+        applySelection(for: selectedCodes.filter { $0 != code })
+    }
+
+    private func applySelection(for codes: [String]) {
+        guard !codes.isEmpty else {
+            pendingRestrictedSelection = true
+            selection = .auto
+            return
+        }
+        pendingRestrictedSelection = false
+        selection = selection.withSelectedCodes(codes, nilBehavior: .auto)
+    }
+
+    private func languageRow(_ language: (code: String, name: String)) -> some View {
+        let isSelected = selectedCodes.contains(language.code)
+
+        return Button {
+            toggleCode(language.code)
+        } label: {
+            HStack(alignment: .center, spacing: 10) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .frame(width: 16)
+                LanguageLeadingVisual(code: language.code)
+                Text(language.name)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(language.code.uppercased())
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct LanguageChip: View {
+    let code: String
+    let title: String
+    let removeAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            LanguageLeadingVisual(code: code)
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+            Button(action: removeAction) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.leading, 7)
+        .padding(.trailing, 9)
+        .padding(.vertical, 4)
+        .background {
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(Color.primary.opacity(0.055))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        }
+    }
+}
+
+struct LanguageLeadingVisual: View {
+    let code: String
+
+    var body: some View {
+        let flag = localizedAppLanguageFlag(for: code)
+        let symbolText = flag ?? localizedAppLanguageBadgeText(for: code)
+        let usesMonogram = flag == nil
+
+        Text(symbolText)
+            .font(usesMonogram ? .caption2.weight(.semibold) : .body)
+            .foregroundStyle(usesMonogram ? .secondary : .primary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.75)
+            .frame(width: 26, height: 16)
+            .background {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.primary.opacity(0.045))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.07), lineWidth: 1)
+            }
+            .accessibilityLabel(localizedAppLanguageName(for: code))
     }
 }

--- a/TypeWhisper/Views/ProfilesSettingsView.swift
+++ b/TypeWhisper/Views/ProfilesSettingsView.swift
@@ -803,18 +803,21 @@ private struct RuleBehaviorStep: View {
                         title: localizedAppText("Spoken Language", de: "Gesprochene Sprache"),
                         description: localizedAppText("Which language TypeWhisper should expect in this context.", de: "Welche Sprache TypeWhisper in diesem Kontext erwarten soll.")
                     ) {
-                        Picker(localizedAppText("Spoken Language", de: "Gesprochene Sprache"), selection: $viewModel.editorInputLanguage) {
-                            Text(localizedAppText("Global Setting", de: "Globale Einstellung")).tag(nil as String?)
-                            Divider()
-                            Text(localizedAppText("Auto-Detect", de: "Automatisch erkennen")).tag("auto" as String?)
-                            Divider()
-                            ForEach(viewModel.settingsViewModel.availableLanguages, id: \.code) { lang in
-                                Text(lang.name).tag(lang.code as String?)
-                            }
-                        }
+                        LanguageSelectionEditor(
+                            selection: Binding(
+                                get: {
+                                    LanguageSelection(
+                                        storedValue: viewModel.editorInputLanguage,
+                                        nilBehavior: .inheritGlobal
+                                    )
+                                },
+                                set: { viewModel.editorInputLanguage = $0.storedValue(nilBehavior: .inheritGlobal) }
+                            ),
+                            availableLanguages: viewModel.settingsViewModel.availableLanguages,
+                            nilBehavior: .inheritGlobal,
+                            inheritTitle: localizedAppText("Global Setting", de: "Globale Einstellung")
+                        )
                     }
-                    .pickerStyle(.menu)
-                    .labelsHidden()
 
                     #if canImport(Translation)
                     if #available(macOS 15, *) {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -208,6 +208,16 @@ public struct PluginTranscriptionResult: Sendable {
     }
 }
 
+public struct PluginLanguageSelection: Sendable, Equatable {
+    public let requestedLanguage: String?
+    public let languageHints: [String]
+
+    public init(requestedLanguage: String? = nil, languageHints: [String] = []) {
+        self.requestedLanguage = requestedLanguage
+        self.languageHints = languageHints
+    }
+}
+
 public enum DictionaryTermsSupport: String, Sendable, CaseIterable {
     case supported
     case requiresPluginSetting
@@ -291,6 +301,49 @@ public protocol LiveTranscriptionCapablePlugin: TranscriptionEnginePlugin {
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> any LiveTranscriptionSession
+}
+
+public protocol LanguageHintTranscriptionEnginePlugin: TranscriptionEnginePlugin {
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult
+
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult
+}
+
+public protocol LiveLanguageHintTranscriptionCapablePlugin: LiveTranscriptionCapablePlugin {
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession
+}
+
+public extension LanguageHintTranscriptionEnginePlugin {
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt
+        )
+    }
 }
 
 public extension TranscriptionEnginePlugin {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7,18 +7,26 @@ import TypeWhisperPluginSDK
 
 final class APIRouterAndHandlersTests: XCTestCase {
     @objc(APIRouterMockTranscriptionPlugin)
-    private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.transcription" }
         static var pluginName: String { "Mock Transcription" }
         private static let promptLock = NSLock()
         nonisolated(unsafe) private static var _lastPrompt: String?
+        nonisolated(unsafe) private static var _lastLanguageSelection = PluginLanguageSelection()
 
         static var lastPrompt: String? {
             promptLock.withLock { _lastPrompt }
         }
 
+        static var lastLanguageSelection: PluginLanguageSelection {
+            promptLock.withLock { _lastLanguageSelection }
+        }
+
         static func reset() {
-            promptLock.withLock { _lastPrompt = nil }
+            promptLock.withLock {
+                _lastPrompt = nil
+                _lastLanguageSelection = PluginLanguageSelection()
+            }
         }
 
         var languages: [String] = []
@@ -38,8 +46,27 @@ final class APIRouterAndHandlersTests: XCTestCase {
         var supportedLanguages: [String] { languages }
 
         func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
-            Self.promptLock.withLock { Self._lastPrompt = prompt }
+            Self.promptLock.withLock {
+                Self._lastPrompt = prompt
+                Self._lastLanguageSelection = PluginLanguageSelection(requestedLanguage: language)
+            }
             return PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+
+        func transcribe(
+            audio: AudioData,
+            languageSelection: PluginLanguageSelection,
+            translate: Bool,
+            prompt: String?
+        ) async throws -> PluginTranscriptionResult {
+            Self.promptLock.withLock {
+                Self._lastPrompt = prompt
+                Self._lastLanguageSelection = languageSelection
+            }
+            return PluginTranscriptionResult(
+                text: "transcribed",
+                detectedLanguage: languageSelection.requestedLanguage ?? languageSelection.languageHints.first
+            )
         }
     }
 
@@ -178,6 +205,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.profileService.addProfile(
                 name: "Docs",
                 urlPatterns: ["docs.github.com"],
+                inputLanguage: #"["de","en"]"#,
                 priority: 1
             )
             return context
@@ -201,6 +229,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(status["status"] as? String, "no_model")
         XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 1)
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
+        XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["language_mode"] as? String, "multiple")
+        XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["language_hints"] as? [String], ["de", "en"])
+        XCTAssertNil((rules["rules"] as? [[String: Any]])?.first?["input_language"] as? String)
         XCTAssertEqual((legacyProfiles["profiles"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
     }
 
@@ -293,6 +324,82 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(response["text"] as? String, "transcribed")
         XCTAssertEqual(MockTranscriptionPlugin.lastPrompt, "TypeWhisper, WhisperKit")
+    }
+
+    func testTranscribeEndpointAcceptsRepeatedLanguageHints() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let boundary = "TestBoundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        for hint in ["de", "en"] {
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"language_hint\"\r\n\r\n".data(using: .utf8)!)
+            body.append("\(hint)\r\n".data(using: .utf8)!)
+        }
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "transcribed")
+        XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.languageHints, ["de", "en"])
+        XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
+    }
+
+    func testTranscribeEndpointRejectsMixedLanguageAndHints() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let response = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-language": "de",
+                    "x-language-hints": "en,nl"
+                ],
+                body: WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 400)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Use either 'language' or 'language_hint', not both")
     }
 
     func testDictationStartReturnsConflictWhenRecordingCannotStart() async throws {
@@ -877,6 +984,57 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
     func testLocalizedAppLanguageNameKeepsScriptVariantsDistinct() {
         XCTAssertNotEqual(localizedAppLanguageName(for: "zh-Hans"), localizedAppLanguageName(for: "zh-Hant"))
+    }
+
+    func testLocalizedAppLanguageFlagUsesDefaultsAndRegionOverrides() {
+        XCTAssertEqual(localizedAppLanguageFlag(for: "en"), "🇺🇸")
+        XCTAssertEqual(localizedAppLanguageFlag(for: "en-GB"), "🇬🇧")
+        XCTAssertEqual(localizedAppLanguageFlag(for: "en-US"), "🇺🇸")
+        XCTAssertEqual(localizedAppLanguageFlag(for: "zh"), "🇨🇳")
+        XCTAssertNil(localizedAppLanguageFlag(for: "zh-Hans"))
+    }
+
+    func testFeaturedAppLanguageRankPromotesCommonLanguages() {
+        XCTAssertEqual(featuredAppLanguageRank(for: "de"), 0)
+        XCTAssertEqual(featuredAppLanguageRank(for: "en"), 1)
+        XCTAssertEqual(featuredAppLanguageRank(for: "fr"), 2)
+        XCTAssertEqual(featuredAppLanguageRank(for: "es"), 3)
+        XCTAssertEqual(featuredAppLanguageRank(for: "zh-Hans"), 4)
+        XCTAssertNil(featuredAppLanguageRank(for: "cs"))
+    }
+
+    func testLanguageSelectionCodecSupportsLegacyAndHintValues() {
+        XCTAssertEqual(LanguageSelection(storedValue: nil, nilBehavior: .auto), .auto)
+        XCTAssertEqual(LanguageSelection(storedValue: nil, nilBehavior: .inheritGlobal), .inheritGlobal)
+        XCTAssertEqual(LanguageSelection(storedValue: "auto", nilBehavior: .auto), .auto)
+        XCTAssertEqual(LanguageSelection(storedValue: "de", nilBehavior: .auto), .exact("de"))
+        XCTAssertEqual(
+            LanguageSelection(storedValue: #"["de","en"]"#, nilBehavior: .auto),
+            .hints(["de", "en"])
+        )
+    }
+
+    func testProfileLanguageSelectionPersistsHintListsWithoutSchemaChanges() {
+        let profile = Profile(name: "Hints")
+        profile.inputLanguageSelection = .hints(["de", "en"])
+
+        XCTAssertEqual(profile.inputLanguage, #"["de","en"]"#)
+        XCTAssertEqual(profile.inputLanguageSelection, .hints(["de", "en"]))
+    }
+
+    func testLanguageSelectionNormalizesAgainstSupportedLanguages() {
+        XCTAssertEqual(
+            LanguageSelection.hints(["de", "en", "nl"]).normalizedForSupportedLanguages(["de", "nl"]),
+            .hints(["de", "nl"])
+        )
+        XCTAssertEqual(
+            LanguageSelection.hints(["de", "en"]).normalizedForSupportedLanguages(["de"]),
+            .exact("de")
+        )
+        XCTAssertEqual(
+            LanguageSelection.hints(["de", "en"]).normalizedForSupportedLanguages(["fr"]),
+            .auto
+        )
     }
 
     @MainActor

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -24,6 +24,14 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(PortDiscovery.discoverPort(dev: true, applicationSupportDirectory: applicationSupportRoot), PortDiscovery.defaultPort)
     }
 
+    func testCLITranscribeLanguageOptionsRejectMixedExactAndHintFlags() {
+        let options = CLITranscribeLanguageOptions(language: "de", languageHints: ["en", "nl"])
+        XCTAssertEqual(
+            options.validationError(),
+            "Error: --language and --language-hint cannot be used together."
+        )
+    }
+
     @MainActor
     func testSupporterDiscordCreateClaimSessionPersistsPendingStatus() async throws {
         let (defaults, suiteName) = try makeIsolatedDefaults()

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -200,7 +200,10 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
             audioFileService: AudioFileService(),
             modelManagerService: ModelManagerService()
         )
-        let viewModel = WatchFolderViewModel(watchFolderService: watchFolderService)
+        let viewModel = WatchFolderViewModel(
+            watchFolderService: watchFolderService,
+            modelManager: ModelManagerService()
+        )
         viewModel.reconcileSelectionWithAvailablePlugins()
 
         XCTAssertNil(viewModel.selectedEngine)

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -28,6 +28,40 @@ final class StreamingHandlerTests: XCTestCase {
         }
     }
 
+    private final class MockHintPlugin: NSObject, LanguageHintTranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.hints" }
+        static var pluginName: String { "Mock Hints" }
+
+        var providerId: String { "mock-hints" }
+        var providerDisplayName: String { "Mock Hints" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { false }
+        var supportedLanguages: [String] { ["de", "en", "nl"] }
+        private(set) var lastSelection = PluginLanguageSelection()
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            XCTFail("Legacy language API should not be used when hints are available")
+            return PluginTranscriptionResult(text: "", detectedLanguage: language)
+        }
+
+        func transcribe(
+            audio: AudioData,
+            languageSelection: PluginLanguageSelection,
+            translate: Bool,
+            prompt: String?
+        ) async throws -> PluginTranscriptionResult {
+            lastSelection = languageSelection
+            return PluginTranscriptionResult(text: "hinted", detectedLanguage: languageSelection.languageHints.first)
+        }
+    }
+
     private final class MockLivePlugin: NSObject, LiveTranscriptionCapablePlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.live" }
         static var pluginName: String { "Mock Live" }
@@ -68,6 +102,63 @@ final class StreamingHandlerTests: XCTestCase {
             prompt: String?,
             onProgress: @Sendable @escaping (String) -> Bool
         ) async throws -> any LiveTranscriptionSession {
+            await session.setOnProgress(onProgress)
+            return session
+        }
+    }
+
+    private final class MockHintLivePlugin: NSObject, LiveLanguageHintTranscriptionCapablePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.live-hints" }
+        static var pluginName: String { "Mock Live Hints" }
+
+        var providerId: String { "mock-live-hints" }
+        var providerDisplayName: String { "Mock Live Hints" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { true }
+        var supportedLanguages: [String] { ["de", "en"] }
+        let session = MockLiveSession()
+        private(set) var lastSelection = PluginLanguageSelection()
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            XCTFail("Batch transcribe should not be used for the live-session path")
+            return PluginTranscriptionResult(text: "", detectedLanguage: language)
+        }
+
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> PluginTranscriptionResult {
+            XCTFail("Legacy streaming should not be used for the hint-aware live-session path")
+            return PluginTranscriptionResult(text: "", detectedLanguage: language)
+        }
+
+        func createLiveTranscriptionSession(
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> any LiveTranscriptionSession {
+            XCTFail("Legacy live-session API should not be used when hint-aware API exists")
+            return session
+        }
+
+        func createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> any LiveTranscriptionSession {
+            lastSelection = languageSelection
             await session.setOnProgress(onProgress)
             return session
         }
@@ -138,7 +229,7 @@ final class StreamingHandlerTests: XCTestCase {
         handler.start(
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
-            language: "en",
+            languageSelection: .exact("en"),
             task: .transcribe,
             cloudModelOverride: nil,
             allowLiveTranscription: true,
@@ -187,7 +278,7 @@ final class StreamingHandlerTests: XCTestCase {
         handler.start(
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
-            language: "en",
+            languageSelection: .exact("en"),
             task: .transcribe,
             cloudModelOverride: nil,
             allowLiveTranscription: false,
@@ -254,7 +345,7 @@ final class StreamingHandlerTests: XCTestCase {
         handler.start(
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
-            language: "en",
+            languageSelection: .exact("en"),
             task: .transcribe,
             cloudModelOverride: nil,
             allowLiveTranscription: true,
@@ -270,5 +361,121 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertEqual(result?.text, "finished")
         let recorded = await plugin.session.recordedChunks()
         XCTAssertEqual(recorded, chunks.map(\.count))
+    }
+
+    func testModelManagerUsesHintAwarePluginWhenMultipleHintsAreSelected() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockHintPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.hints",
+                    name: "Mock Hints",
+                    version: "1.0.0",
+                    principalClass: "MockHintPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        _ = try await modelManager.transcribe(
+            audioSamples: Array(repeating: 0.25, count: 16_000),
+            languageSelection: .hints(["de", "en"]),
+            task: .transcribe
+        )
+
+        XCTAssertEqual(plugin.lastSelection.languageHints, ["de", "en"])
+        XCTAssertNil(plugin.lastSelection.requestedLanguage)
+    }
+
+    func testModelManagerFallsBackToAutoDetectForLegacyPluginsWithMultipleHints() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockBatchPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.batch",
+                    name: "Mock Batch",
+                    version: "1.0.0",
+                    principalClass: "MockBatchPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: Array(repeating: 0.25, count: 16_000),
+            languageSelection: .hints(["de", "en"]),
+            task: .transcribe
+        )
+
+        XCTAssertNil(result.detectedLanguage)
+    }
+
+    func testStreamingHandlerUsesHintAwareLiveSessionWhenAvailable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockHintLivePlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.live-hints",
+                    name: "Mock Live Hints",
+                    version: "1.0.0",
+                    principalClass: "MockHintLivePlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            streamPromptProvider: { "" },
+            bufferProvider: { [] },
+            bufferDeltaProvider: { _ in (Array(repeating: 0.1, count: 4000), 4000) },
+            bufferedDurationProvider: { 0.25 }
+        )
+
+        handler.start(
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .hints(["de", "en"]),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { false }
+        )
+
+        try await Task.sleep(for: .milliseconds(150))
+        _ = await handler.finish()
+
+        XCTAssertEqual(plugin.lastSelection.languageHints, ["de", "en"])
+        XCTAssertNil(plugin.lastSelection.requestedLanguage)
     }
 }

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -53,7 +53,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - `typewhisper status`
 - `typewhisper models`
 - `typewhisper transcribe`
-- Flags: `--port`, `--json`, `--language`, `--task`, `--translate-to`
+- Flags: `--port`, `--json`, `--language`, `--language-hint`, `--task`, `--translate-to`
 
 ### Plugin SDK
 

--- a/typewhisper-cli/CLIClient.swift
+++ b/typewhisper-cli/CLIClient.swift
@@ -57,7 +57,7 @@ struct CLIClient {
         try await get("/v1/models")
     }
 
-    func transcribe(fileURL: URL?, language: String?, task: String?, targetLanguage: String?) async throws -> Data {
+    func transcribe(fileURL: URL?, language: String?, languageHints: [String], task: String?, targetLanguage: String?) async throws -> Data {
         let audioData: Data
         let filename: String
 
@@ -90,6 +90,9 @@ struct CLIClient {
         // Optional fields
         if let language {
             body.appendFormField("language", value: language, boundary: boundary)
+        }
+        for languageHint in languageHints {
+            body.appendFormField("language_hint", value: languageHint, boundary: boundary)
         }
         if let task {
             body.appendFormField("task", value: task, boundary: boundary)

--- a/typewhisper-cli/PortDiscovery.swift
+++ b/typewhisper-cli/PortDiscovery.swift
@@ -17,3 +17,15 @@ enum PortDiscovery {
         return port
     }
 }
+
+struct CLITranscribeLanguageOptions: Equatable {
+    var language: String?
+    var languageHints: [String] = []
+
+    func validationError() -> String? {
+        if language != nil, !languageHints.isEmpty {
+            return "Error: --language and --language-hint cannot be used together."
+        }
+        return nil
+    }
+}

--- a/typewhisper-cli/main.swift
+++ b/typewhisper-cli/main.swift
@@ -9,7 +9,7 @@ var command: String?
 var positionalArgs = [String]()
 
 // Transcribe options
-var language: String?
+var languageOptions = CLITranscribeLanguageOptions()
 var task: String?
 var translateTo: String?
 
@@ -37,7 +37,13 @@ while let arg = argIterator.next() {
             printError("Error: --language requires a value.")
             exit(1)
         }
-        language = next
+        languageOptions.language = next
+    case "--language-hint":
+        guard let next = argIterator.next() else {
+            printError("Error: --language-hint requires a value.")
+            exit(1)
+        }
+        languageOptions.languageHints.append(next)
     case "--task":
         guard let next = argIterator.next() else {
             printError("Error: --task requires a value.")
@@ -68,6 +74,11 @@ while let arg = argIterator.next() {
     }
 }
 
+if let validationError = languageOptions.validationError() {
+    printError(validationError)
+    exit(1)
+}
+
 guard let command else {
     printUsage()
     exit(1)
@@ -95,7 +106,8 @@ do {
         }
         let data = try await client.transcribe(
             fileURL: fileURL,
-            language: language,
+            language: languageOptions.language,
+            languageHints: languageOptions.languageHints,
             task: task,
             targetLanguage: translateTo
         )
@@ -136,6 +148,7 @@ func printUsage() {
 
         Transcribe options:
           --language <code>    Source language (e.g. en, de)
+          --language-hint <code>  Repeatable language hint for auto-detection
           --task <task>        transcribe (default) or translate
           --translate-to <code>  Target language for translation
 
@@ -143,6 +156,7 @@ func printUsage() {
           typewhisper status
           typewhisper transcribe recording.wav
           typewhisper transcribe recording.wav --language de --json
+          typewhisper transcribe recording.wav --language-hint de --language-hint en
           typewhisper transcribe - < audio.wav
           cat audio.wav | typewhisper transcribe -
         """


### PR DESCRIPTION
## Summary

Closes #312

- add a shared `LanguageSelection` model with backward-compatible persistence for auto, exact language, and multi-language hint selections
- extend the macOS app, local HTTP API, CLI, and plugin SDK to pass multi-language hints end to end, with Soniox and Gladia using real hint payloads and legacy engines falling back to auto-detect
- replace the old single-language pickers with a reusable multi-select editor across settings, rules, recorder, file transcription, and watch folders
- polish the language picker UI with featured languages, compact one-line rows, tighter chips, curated flag defaults, and an empty restricted state instead of auto-selecting the first language
- fix the startup crash caused by watch-folder initialization reaching shared services too early

## Test Plan

- [x] Built and ran locally
- [ ] Tested the changed functionality manually
- [x] No regressions in existing features
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/StreamingHandlerTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/CLISupportTests`
