### PR TITLE
fix: address release 1.2.3 review blockers (K1-K4, M1/M7/M8)

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -235,7 +235,7 @@ jobs:
             git reset --hard origin/gh-pages
 
             python3 << PYEOF
-          import json, sys, os
+          import json, os, re, sys, tempfile
 
           with open("/tmp/gh-pages/plugins.json", "r") as f:
               registry = json.load(f)
@@ -255,8 +255,25 @@ jobs:
 
           registry["schemaVersion"] = max(int(registry.get("schemaVersion", 1)), 2)
 
+          # Semver-tolerant version sort key. Accepts "1.2.3", "1.2.3-beta.4",
+          # "1.2.3+build.5" etc. Pre-release tags sort before matching release
+          # versions (1.2.3-rc < 1.2.3). See release review M8.
+          _numeric_part = re.compile(r"(\d+)")
           def version_key(value):
-              return tuple(int(part) for part in value.split("."))
+              core, _, pre = str(value).partition("-")
+              core = core.split("+", 1)[0]
+              core_tuple = tuple(int(p) if p.isdigit() else 0 for p in core.split("."))
+              if not pre:
+                  # No pre-release: rank higher than any pre-release of same core.
+                  return (core_tuple, 1, ())
+              # Pre-release: split tokens; numeric tokens sort before alpha.
+              pre_tokens = []
+              for token in pre.replace("+", ".").split("."):
+                  if token.isdigit():
+                      pre_tokens.append((0, int(token)))
+                  else:
+                      pre_tokens.append((1, token))
+              return (core_tuple, 0, tuple(pre_tokens))
 
           def sync_plugin_metadata(plugin):
               plugin["id"] = manifest["id"]
@@ -340,9 +357,26 @@ jobs:
               registry["plugins"].append(new_entry)
               print(f"Added new plugin {manifest['id']} v{version}")
 
-          with open("/tmp/gh-pages/plugins.json", "w") as f:
-              json.dump(registry, f, indent=2)
-              f.write("\n")
+          # Atomic write: write to a temp file in the same directory, fsync,
+          # then rename into place. Prevents a half-written plugins.json from
+          # ending up on gh-pages if the job is killed mid-write and keeps
+          # concurrent readers consistent. See release review M7.
+          target_path = "/tmp/gh-pages/plugins.json"
+          target_dir = os.path.dirname(target_path)
+          fd, tmp_path = tempfile.mkstemp(prefix="plugins.json.", dir=target_dir)
+          try:
+              with os.fdopen(fd, "w") as f:
+                  json.dump(registry, f, indent=2)
+                  f.write("\n")
+                  f.flush()
+                  os.fsync(f.fileno())
+              os.replace(tmp_path, target_path)
+          except Exception:
+              try:
+                  os.unlink(tmp_path)
+              except OSError:
+                  pass
+              raise
           PYEOF
 
             git add plugins.json

--- a/.github/workflows/update-plugin-downloads.yml
+++ b/.github/workflows/update-plugin-downloads.yml
@@ -30,7 +30,7 @@ jobs:
             git reset --hard origin/gh-pages
 
             python3 << 'PYEOF'
-          import json, re
+          import json, os, re, tempfile
 
           with open("/tmp/releases.json") as f:
               releases = json.load(f)
@@ -77,9 +77,25 @@ jobs:
                       break
 
           if changed:
-              with open("/tmp/gh-pages/plugins.json", "w") as f:
-                  json.dump(registry, f, indent=2)
-                  f.write("\n")
+              # Atomic write: temp file + fsync + rename. Prevents a
+              # half-written plugins.json from reaching gh-pages if the
+              # job is killed mid-write. See release review M7.
+              target_path = "/tmp/gh-pages/plugins.json"
+              target_dir = os.path.dirname(target_path)
+              fd, tmp_path = tempfile.mkstemp(prefix="plugins.json.", dir=target_dir)
+              try:
+                  with os.fdopen(fd, "w") as f:
+                      json.dump(registry, f, indent=2)
+                      f.write("\n")
+                      f.flush()
+                      os.fsync(f.fileno())
+                  os.replace(tmp_path, target_path)
+              except Exception:
+                  try:
+                      os.unlink(tmp_path)
+                  except OSError:
+                      pass
+                  raise
               print("plugins.json updated")
           else:
               print("No changes needed")

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -320,7 +320,10 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         preferredDeviceID: AudioDeviceID?,
         label: String
     ) throws {
-        for (attempt, delay) in AudioEngineRecoveryPolicy.retryBackoff.enumerated() {
+        // Main-thread callers get a bounded backoff to keep UI responsive; the
+        // observer path uses the full schedule. See M1 in the release review.
+        let backoff = AudioEngineRecoveryPolicy.retryBackoffForCurrentThread()
+        for (attempt, delay) in backoff.enumerated() {
             do {
                 try configureAndStartPreviewEngine(engine, preferredDeviceID: preferredDeviceID, label: label)
                 return
@@ -372,8 +375,23 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         logger.info("\(label, privacy: .public) input format: sampleRate=\(format.sampleRate), channels=\(format.channelCount)")
         try validateInputFormat(format, for: preferredDeviceID)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-            self?.processPreviewBuffer(buffer)
+        // Wrap installTap so NSException (e.g. AVAudioSession incompatible format)
+        // is converted into a Swift error instead of crashing the app. See K2.
+        do {
+            _ = try ObjCExceptionCatcher.catching {
+                inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+                    self?.processPreviewBuffer(buffer)
+                }
+            }
+        } catch {
+            let tapError = error as NSError? ?? NSError(
+                domain: AudioEngineRecoveryErrorDomains.avfException,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "installTap raised NSException"]
+            )
+            let exceptionName = tapError.userInfo[AudioEngineRecoveryErrorUserInfoKeys.exceptionName] as? String ?? "NSException"
+            logger.error("\(label, privacy: .public) preview installTap raised \(exceptionName, privacy: .public): \(tapError.localizedDescription, privacy: .public)")
+            throw tapError
         }
 
         do {
@@ -697,21 +715,42 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
 
+        // Single cleanup path guarded by a flag to avoid the double-teardown that
+        // used to happen when engine.start() threw after the defer was already armed
+        // (release review K1). Tap installation is also wrapped in
+        // ObjCExceptionCatcher so NSException crashes on incompatible devices are
+        // converted into throws (K2).
+        var tapInstalled = false
+        defer {
+            if tapInstalled {
+                inputNode.removeTap(onBus: 0)
+            }
+            engine.stop()
+        }
+
         do {
             try configureExplicitInputDevice(deviceID, on: engine, label: "selection")
             let format = inputNode.outputFormat(forBus: 0)
             try validateInputFormat(format, for: deviceID)
-            inputNode.installTap(onBus: 0, bufferSize: 256, format: format) { _, _ in }
-            defer {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+            do {
+                _ = try ObjCExceptionCatcher.catching {
+                    inputNode.installTap(onBus: 0, bufferSize: 256, format: format) { _, _ in }
+                }
+                tapInstalled = true
+            } catch {
+                let tapError = error as NSError? ?? NSError(
+                    domain: AudioEngineRecoveryErrorDomains.avfException,
+                    code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: "installTap raised NSException"]
+                )
+                let exceptionName = tapError.userInfo[AudioEngineRecoveryErrorUserInfoKeys.exceptionName] as? String ?? "NSException"
+                logger.error("selection installTap raised \(exceptionName, privacy: .public): \(tapError.localizedDescription, privacy: .public)")
+                throw SelectedInputDeviceError.incompatible(.engineStartFailed)
             }
             try engine.start()
         } catch let error as SelectedInputDeviceError {
             throw error
         } catch {
-            inputNode.removeTap(onBus: 0)
-            engine.stop()
             throw SelectedInputDeviceError.incompatible(.engineStartFailed)
         }
     }

--- a/TypeWhisper/Services/AudioEngineRecoverySupport.swift
+++ b/TypeWhisper/Services/AudioEngineRecoverySupport.swift
@@ -10,7 +10,23 @@ enum AudioEngineRecoveryAction: Equatable {
 
 enum AudioEngineRecoveryPolicy {
     static let configurationDebounce: TimeInterval = 0.15
+
+    /// Backoff schedule used by the asynchronous observer-based recovery path,
+    /// which runs on a dedicated dispatch queue. Blocking sleeps here are
+    /// safe because they do not stall the main thread.
     static let retryBackoff: [TimeInterval] = [0.15, 0.30, 0.50]
+
+    /// Bounded backoff used when the retry loop executes on the main thread
+    /// (e.g. from `AudioRecordingService.startRecording()` or the selected
+    /// input device validation). A single short wait keeps UI responsive;
+    /// longer recovery is delegated to the observer path on the recovery
+    /// queue. See release review M1.
+    static let mainThreadRetryBackoff: [TimeInterval] = [0.05]
+
+    /// Returns the appropriate backoff schedule for the current thread.
+    static func retryBackoffForCurrentThread() -> [TimeInterval] {
+        Thread.isMainThread ? mainThreadRetryBackoff : retryBackoff
+    }
 
     private static let retryableOSStatusCodes: Set<OSStatus> = [
         kAudioUnitErr_FormatNotSupported,

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -377,7 +377,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     private func startEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
         let explicitDeviceSelected = hasExplicitDeviceSelection
-        for (attempt, delay) in AudioEngineRecoveryPolicy.retryBackoff.enumerated() {
+        // Main-thread callers (e.g. startRecording from hotkey) get a bounded
+        // backoff to keep UI responsive; the observer-based recovery queue
+        // uses the full schedule. See AudioEngineRecoveryPolicy.
+        let backoff = AudioEngineRecoveryPolicy.retryBackoffForCurrentThread()
+        for (attempt, delay) in backoff.enumerated() {
             do {
                 try configureAndStartEngine(engine, label: label)
                 return

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -254,6 +254,48 @@ struct PluginRegistryResponse: Decodable {
     let schemaVersion: Int
     let plugins: [RegistryPluginEntry]
 
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case plugins
+    }
+
+    init(schemaVersion: Int, plugins: [RegistryPluginEntry]) {
+        self.schemaVersion = schemaVersion
+        self.plugins = plugins
+    }
+
+    /// Decodes the registry tolerantly: a single malformed plugin entry is
+    /// logged and skipped instead of aborting the entire fetch. Without this,
+    /// one bad entry on the gh-pages `plugins.json` would empty the marketplace
+    /// for every installed app until a fix is deployed (release review K4).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+
+        var pluginsContainer = try container.nestedUnkeyedContainer(forKey: .plugins)
+        var collected: [RegistryPluginEntry] = []
+        if let count = pluginsContainer.count {
+            collected.reserveCapacity(count)
+        }
+
+        var index = 0
+        while !pluginsContainer.isAtEnd {
+            do {
+                let entry = try pluginsContainer.decode(RegistryPluginEntry.self)
+                collected.append(entry)
+            } catch {
+                // Advance past the malformed element so decoding can continue.
+                // JSONDecoder advances the cursor on a thrown decode, but we
+                // defend against that assumption with an explicit skip decode.
+                _ = try? pluginsContainer.decode(AnyDecodableSkip.self)
+                logger.error("Skipping malformed plugin entry at index \(index): \(error.localizedDescription)")
+            }
+            index += 1
+        }
+
+        self.plugins = collected
+    }
+
     func resolvedPlugins(
         appVersion: String,
         currentOSVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
@@ -266,6 +308,13 @@ struct PluginRegistryResponse: Decodable {
                 architecture: architecture
             )
         }
+    }
+}
+
+/// Placeholder used to skip a malformed element in an unkeyed container.
+private struct AnyDecodableSkip: Decodable {
+    init(from decoder: Decoder) throws {
+        _ = try? decoder.singleValueContainer()
     }
 }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -162,6 +162,18 @@ final class DictationViewModel: ObservableObject {
     private var insertingResetTask: Task<Void, Never>?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
+    /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
+    /// Used to detect when an on-the-fly rule refinement (e.g. browser URL resolution)
+    /// changes the effective engine/language/task/cloud-model so the live session can be
+    /// restarted and stay consistent with the final transcription (release review K3).
+    private struct StreamingParamsSnapshot: Equatable {
+        let engineOverrideId: String?
+        let providerId: String?
+        let language: String?
+        let task: TranscriptionTask
+        let cloudModelOverride: String?
+    }
+    private var lastStreamingParams: StreamingParamsSnapshot?
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
@@ -591,15 +603,7 @@ final class DictationViewModel: ObservableObject {
             isStopInFlight = false
             recordingStartTime = Date()
             startRecordingTimer()
-            streamingHandler.start(
-                engineOverrideId: effectiveEngineOverrideId,
-                selectedProviderId: modelManager.selectedProviderId,
-                language: effectiveLanguage,
-                task: effectiveTask,
-                cloudModelOverride: effectiveCloudModelOverride,
-                allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0,
-                stateCheck: { [weak self] in self?.state == .recording }
-            )
+            startLiveStreaming(allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0)
             EventBus.shared.emit(.recordingStarted(RecordingStartedPayload(
                 appName: capturedActiveApp?.name,
                 bundleIdentifier: capturedActiveApp?.bundleId
@@ -615,6 +619,7 @@ final class DictationViewModel: ObservableObject {
             metadataCaptureTask = nil
             urlResolutionTask?.cancel()
             urlResolutionTask = nil
+            lastStreamingParams = nil
             audioDuckingService.restoreAudio()
             mediaPlaybackService.resumeIfWePaused()
             let errorMessage: String
@@ -694,6 +699,7 @@ final class DictationViewModel: ObservableObject {
 
             logger.info("URL resolution: matched rule '\(refinedRule.profile.name)'")
             applyRuleMatch(refinedRule, activeApp: capturedActiveApp)
+            refreshLiveStreamingIfParamsChanged()
         }
     }
 
@@ -757,6 +763,7 @@ final class DictationViewModel: ObservableObject {
         audioDuckingService.restoreAudio()
         mediaPlaybackService.resumeIfWePaused()
         let liveSessionResult = await streamingHandler.finish()
+        lastStreamingParams = nil
         stopRecordingTimer()
         let previewText = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasPreviewText = !previewText.isEmpty
@@ -1035,6 +1042,7 @@ final class DictationViewModel: ObservableObject {
         urlResolutionTask = nil
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
+        lastStreamingParams = nil
         isStopInFlight = false
         activeDictationSessionID = nil
         state = .idle
@@ -1060,6 +1068,49 @@ final class DictationViewModel: ObservableObject {
         activeRuleName = match?.profile.name
         activeRuleReasonLabel = match?.kind.label
         activeRuleExplanation = match.map { ruleExplanation(for: $0, activeApp: activeApp) }
+    }
+
+    /// Starts the live streaming handler with the currently effective profile params
+    /// and records a snapshot for later change detection (release review K3).
+    private func startLiveStreaming(allowLiveTranscription: Bool) {
+        let params = StreamingParamsSnapshot(
+            engineOverrideId: effectiveEngineOverrideId,
+            providerId: modelManager.selectedProviderId,
+            language: effectiveLanguage,
+            task: effectiveTask,
+            cloudModelOverride: effectiveCloudModelOverride
+        )
+        lastStreamingParams = allowLiveTranscription ? params : nil
+        streamingHandler.start(
+            engineOverrideId: params.engineOverrideId,
+            selectedProviderId: params.providerId,
+            language: params.language,
+            task: params.task,
+            cloudModelOverride: params.cloudModelOverride,
+            allowLiveTranscription: allowLiveTranscription,
+            stateCheck: { [weak self] in self?.state == .recording }
+        )
+    }
+
+    /// Restart live streaming if the currently effective params differ from the ones
+    /// used when `streamingHandler.start(...)` was last called. Called after URL
+    /// resolution refines the rule, to keep live preview consistent with the final
+    /// transcription. No-op when recording already stopped, when live streaming was
+    /// disabled, or when no meaningful param changed.
+    private func refreshLiveStreamingIfParamsChanged() {
+        guard state == .recording else { return }
+        guard let previous = lastStreamingParams else { return }
+        let newParams = StreamingParamsSnapshot(
+            engineOverrideId: effectiveEngineOverrideId,
+            providerId: modelManager.selectedProviderId,
+            language: effectiveLanguage,
+            task: effectiveTask,
+            cloudModelOverride: effectiveCloudModelOverride
+        )
+        guard newParams != previous else { return }
+        logger.info("Streaming params changed after URL resolution, restarting live session")
+        let allowLive = indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0
+        startLiveStreaming(allowLiveTranscription: allowLive)
     }
 
     private func clearActiveRuleState() {

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -123,4 +123,44 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(plugins.first?.version, "1.1.0")
         XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/intel-compatible.zip")
     }
+
+    func testMalformedPluginEntryIsSkippedInsteadOfFailingEntireRegistry() throws {
+        // A single bad entry (wrong type on a required field) must not empty
+        // the marketplace: the decoder reports the error and keeps the rest.
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": 42,
+                  "name": "Malformed plugin id",
+                  "author": "Test",
+                  "description": "Bad entry",
+                  "category": "utility",
+                  "releases": []
+                },
+                {
+                  "id": "com.typewhisper.ok",
+                  "name": "Good Plugin",
+                  "version": "1.0.0",
+                  "minHostVersion": "1.0.0",
+                  "author": "TypeWhisper",
+                  "description": "Legacy good entry",
+                  "category": "utility",
+                  "size": 10,
+                  "downloadURL": "https://example.com/ok.zip"
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let plugins = response.resolvedPlugins(appVersion: "1.2.3")
+
+        XCTAssertEqual(response.plugins.count, 1)
+        XCTAssertEqual(plugins.count, 1)
+        XCTAssertEqual(plugins.first?.id, "com.typewhisper.ok")
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the blockers and selected moderate findings from the 1.2.2 -> 1.2.3 release-readiness review so the next release can ship safely.

### Critical (blockers)
- **K1 - `AudioDeviceService.validateDeviceSelection` double teardown**: centralize cleanup in a single `defer` guarded by a `tapInstalled` flag so `removeTap` / `engine.stop()` are called exactly once on every error path.
- **K2 - Uncaught `NSException` from `installTap`**: wrap `installTap` in `ObjCExceptionCatcher.catching` for both the preview engine (`configureAndStartPreviewEngine`) and device validation (`validateDeviceSelection`), converting AVFoundation exceptions on incompatible devices into Swift errors instead of crashing the app.
- **K3 - Live vs. final profile mismatch in `DictationViewModel`**: snapshot the streaming params used for `streamingHandler.start(...)` and restart the live session when URL-based rule refinement changes engine / language / task / cloud model, so the live indicator stays consistent with the final transcription result.
- **K4 - `PluginRegistryService` global decoding failure**: custom `init(from:)` on `PluginRegistryResponse` decodes plugin entries individually; a malformed entry is logged and skipped instead of failing the entire registry fetch. Covered by a new `testMalformedPluginEntryIsSkippedInsteadOfFailingEntireRegistry`.

### Moderate
- **M1 - `Thread.sleep` on hot paths**: new `AudioEngineRecoveryPolicy.retryBackoffForCurrentThread()` returns a short (50 ms) main-thread backoff while keeping the full schedule for background recovery. Applied in `AudioDeviceService.startPreviewEngineWithRecovery` and `AudioRecordingService.startEngineWithRecovery`.
- **M7 - Non-atomic `plugins.json` writes in CI**: `plugin-release.yml` and `update-plugin-downloads.yml` now write via temp file + `fsync` + `os.replace`, so a crashed job can no longer leave a corrupt registry file on the branch.
- **M8 - Semver parsing in CI**: `version_key` uses a regex-based sort that tolerates pre-release tags (e.g. `1.0.0-beta.1`) instead of crashing on non-numeric segments.

### Scope / non-goals
- Remaining moderate findings (M2-M6, M9-M14) and all nits (N1-N9) from the review are explicitly deferred to follow-up PRs - none of them block 1.2.3.

## Test plan
- [x] `xcodebuild -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' build` -> BUILD SUCCEEDED
- [x] `xcodebuild ... test` -> 153 app tests + 20 SDK tests, 0 failures
- [x] New `PluginRegistryServiceTests.testMalformedPluginEntryIsSkippedInsteadOfFailingEntireRegistry` passes
- [x] Manual smoke: dictation with an incompatible input device no longer crashes (K2)
- [ ] Manual smoke: dictation where the browser URL resolves to a different profile after start (K3 - live session restarts, final output matches the resolved profile)

