### PR TITLE
Refactor Qwen3 context bias formatting

### DIFF
--- a/Plugins/Qwen3Plugin/Qwen3ContextBiasFormatter.swift
+++ b/Plugins/Qwen3Plugin/Qwen3ContextBiasFormatter.swift
@@ -1,0 +1,10 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+enum Qwen3ContextBiasFormatter {
+    static func format(prompt: String?) -> String {
+        let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
+        guard !terms.isEmpty else { return "" }
+        return "Technical terms: \(terms.joined(separator: ", "))."
+    }
+}

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -275,7 +275,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCap
     }
 
     private static func contextBiasString(from prompt: String?) -> String {
-        PluginDictionaryTerms.terms(fromPrompt: prompt).joined(separator: " ")
+        Qwen3ContextBiasFormatter.format(prompt: prompt)
     }
 
     private static func generate(

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
+		C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
 		91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */; };
 		91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */; };
@@ -89,6 +90,7 @@
 		AA00000000000000000096 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000096 /* KeychainService.swift */; };
 		AA00000000000000000102 /* AudioDeviceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000102 /* AudioDeviceService.swift */; };
 		AA00000000000000000320 /* AudioEngineRecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000320 /* AudioEngineRecoverySupport.swift */; };
+		AA00000000000000000321 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
 		AA00000000000000000103 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000103 /* main.swift */; };
 		AA00000000000000000104 /* CLIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000104 /* CLIClient.swift */; };
 		AA00000000000000000105 /* PortDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000105 /* PortDiscovery.swift */; };
@@ -477,6 +479,7 @@
 		BB00000000000000000150 /* Qwen3Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Qwen3Plugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000151 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000152 /* PluginRegistryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginRegistryService.swift; sourceTree = "<group>"; };
+		BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Qwen3ContextBiasFormatter.swift; sourceTree = "<group>"; };
 		BB00000000000000000153 /* WhisperKitPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WhisperKitPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000154 /* WhisperKitPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperKitPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000155 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1290,6 +1293,7 @@
 		CC00000000000000000020 /* Qwen3Plugin */ = {
 			isa = PBXGroup;
 			children = (
+				BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */,
 				BB00000000000000000150 /* Qwen3Plugin.swift */,
 				BB00000000000000000151 /* manifest.json */,
 				BB00000000000000000167 /* Localizable.xcstrings */,
@@ -2784,6 +2788,7 @@
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
 				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
+				C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
@@ -2972,6 +2977,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA00000000000000000321 /* Qwen3ContextBiasFormatter.swift in Sources */,
 				AA00000000000000000154 /* Qwen3Plugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -48,6 +48,34 @@ final class PluginManifestValidationTests: XCTestCase {
     }
 }
 
+final class Qwen3PluginContextFormattingTests: XCTestCase {
+    func testQwen3ContextFormatterReturnsEmptyStringForNilPrompt() throws {
+        XCTAssertEqual(Qwen3ContextBiasFormatter.format(prompt: nil), "")
+    }
+
+    func testQwen3ContextFormatterWrapsSingleTerm() throws {
+        XCTAssertEqual(
+            Qwen3ContextBiasFormatter.format(prompt: "Qwen3"),
+            "Technical terms: Qwen3."
+        )
+    }
+
+    func testQwen3ContextFormatterWrapsMultipleTermsAsCommaSeparatedSentence() throws {
+        XCTAssertEqual(
+            Qwen3ContextBiasFormatter.format(prompt: "Qwen3, MLX, LoRA"),
+            "Technical terms: Qwen3, MLX, LoRA."
+        )
+    }
+
+    func testQwen3ContextFormatterPreservesNormalizedAndDeduplicatedTerms() throws {
+        let prompt = PluginDictionaryTerms.prompt(from: [" Kubernetes ", "MLX", "mlx", "TypeWhisper"])
+        XCTAssertEqual(
+            Qwen3ContextBiasFormatter.format(prompt: prompt),
+            "Technical terms: Kubernetes, MLX, TypeWhisper."
+        )
+    }
+}
+
 @MainActor
 final class PluginArchitectureCompatibilityTests: XCTestCase {
     private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Closes #321
- Format Qwen3 dictionary terms as `Technical terms: ...` instead of a space-joined token list.
- Extract the formatter into a small shared helper so the Qwen3 plugin logic stays minimal and testable.
- Add regression tests for empty, single-term, multi-term, and normalized/deduplicated prompt inputs.

## Testing
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/Qwen3PluginContextFormattingTests test -quiet`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/Qwen3PluginContextFormattingTests -only-testing:TypeWhisperTests/DictionaryServiceTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests test -quiet`