### PR TITLE
feat: add TTS providers for spoken feedback

### DIFF
--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -13,6 +13,7 @@ TypeWhisper supports external plugins as macOS `.bundle` files. Place compiled b
 | `TypeWhisperPlugin` | Base protocol, event observation | No |
 | `PostProcessorPlugin` | Transform text in the pipeline | Yes (processed text) |
 | `LLMProviderPlugin` | Add custom LLM providers | Yes (LLM response) |
+| `TTSProviderPlugin` | Add text-to-speech providers for spoken feedback and readback | Yes (playback session) |
 | `TranscriptionEnginePlugin` | Custom transcription engines | Yes (transcription result) |
 | `ActionPlugin` | Route LLM output to custom actions (e.g. create Linear issues) | Yes (action result) |
 
@@ -49,6 +50,8 @@ Plugins can subscribe to events without modifying the transcription pipeline:
     "principalClass": "MyPluginClassName"
 }
 ```
+
+`category` may be one of `transcription`, `tts`, `llm`, `post-processor`, `action`, `memory`, or `utility`.
 
 ### Host Services
 

--- a/Plugins/SystemTTSPlugin/SystemTTSPlugin.swift
+++ b/Plugins/SystemTTSPlugin/SystemTTSPlugin.swift
@@ -1,0 +1,269 @@
+import AppKit
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+import os
+
+private enum SystemTTSPluginDefaultsKey {
+    static let voiceId = "voiceId"
+    static let rateWPM = "rateWPM"
+}
+
+private enum SystemTTSPluginError: LocalizedError {
+    case unavailable
+    case processLaunchFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "System voice is unavailable."
+        case .processLaunchFailed:
+            return "System voice playback could not be started."
+        }
+    }
+}
+
+private final class SystemTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    private struct State {
+        var isActive = true
+        var onFinish: (@Sendable () -> Void)?
+    }
+
+    private let process: Process
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(process: Process) {
+        self.process = process
+        process.terminationHandler = { [weak self] _ in
+            self?.finish()
+        }
+    }
+
+    var isActive: Bool {
+        state.withLock { $0.isActive }
+    }
+
+    var onFinish: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onFinish } }
+        set {
+            let shouldNotify = state.withLock { state in
+                state.onFinish = newValue
+                return !state.isActive
+            }
+            if shouldNotify {
+                newValue?()
+            }
+        }
+    }
+
+    func stop() {
+        if process.isRunning {
+            process.terminate()
+        }
+        finish()
+    }
+
+    private func finish() {
+        let callback: (@Sendable () -> Void)? = state.withLock { state in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        callback?()
+    }
+}
+
+@objc(SystemTTSPlugin)
+final class SystemTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.tts.system"
+    static let pluginName = "System Voice"
+
+    private let logger = Logger(subsystem: "com.typewhisper.tts.system", category: "Plugin")
+    private var host: HostServices?
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    var providerId: String { "systemTTS" }
+    var providerDisplayName: String { String(localized: "System Voice") }
+    var isConfigured: Bool { host != nil }
+
+    var availableVoices: [PluginVoiceInfo] {
+        NSSpeechSynthesizer.availableVoices.compactMap { voiceIdentifier in
+            let attributes = NSSpeechSynthesizer.attributes(forVoice: voiceIdentifier)
+            let voiceID = voiceIdentifier.rawValue
+            let displayName = attributes[.name] as? String ?? voiceID
+            let localeIdentifier = attributes[.localeIdentifier] as? String
+            return PluginVoiceInfo(id: voiceID, displayName: displayName, localeIdentifier: localeIdentifier)
+        }
+        .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+
+    var selectedVoiceId: String? {
+        host?.userDefault(forKey: SystemTTSPluginDefaultsKey.voiceId) as? String
+    }
+
+    var selectedRateWPM: Int? {
+        if let value = host?.userDefault(forKey: SystemTTSPluginDefaultsKey.rateWPM) as? Int {
+            return value
+        }
+        if let value = host?.userDefault(forKey: SystemTTSPluginDefaultsKey.rateWPM) as? Double {
+            return Int(value)
+        }
+        return nil
+    }
+
+    var settingsSummary: String? {
+        let voiceLabel = if let voice = selectedVoice {
+            voice.displayName
+        } else {
+            String(localized: "System Default")
+        }
+
+        let rateLabel = if let rate = selectedRateWPM {
+            String(localized: "\(rate) WPM")
+        } else {
+            String(localized: "System Default")
+        }
+
+        return String(localized: "Voice: \(voiceLabel) • Speed: \(rateLabel)")
+    }
+
+    nonisolated var settingsView: AnyView? {
+        AnyView(SystemTTSSettingsView(plugin: self))
+    }
+
+    func selectVoice(_ voiceId: String?) {
+        host?.setUserDefault(voiceId, forKey: SystemTTSPluginDefaultsKey.voiceId)
+    }
+
+    func selectRate(_ rateWPM: Int?) {
+        host?.setUserDefault(rateWPM, forKey: SystemTTSPluginDefaultsKey.rateWPM)
+    }
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        guard host != nil else {
+            throw SystemTTSPluginError.unavailable
+        }
+
+        let process = Process()
+        let inputPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        process.arguments = sayArguments()
+        process.standardInput = inputPipe
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        let session = SystemTTSPlaybackSession(process: process)
+
+        do {
+            try process.run()
+            if let data = request.text.data(using: .utf8) {
+                inputPipe.fileHandleForWriting.write(data)
+            }
+            inputPipe.fileHandleForWriting.closeFile()
+            return session
+        } catch {
+            logger.error("Failed to launch say: \(error.localizedDescription)")
+            inputPipe.fileHandleForWriting.closeFile()
+            throw SystemTTSPluginError.processLaunchFailed
+        }
+    }
+
+    private var selectedVoice: PluginVoiceInfo? {
+        guard let selectedVoiceId else { return nil }
+        return availableVoices.first { $0.id == selectedVoiceId }
+    }
+
+    private func sayArguments() -> [String] {
+        var arguments: [String] = []
+        if let selectedVoiceId, !selectedVoiceId.isEmpty {
+            arguments.append(contentsOf: ["-v", selectedVoiceId])
+        }
+        if let selectedRateWPM {
+            arguments.append(contentsOf: ["-r", String(selectedRateWPM)])
+        }
+        arguments.append(contentsOf: ["-f", "-"])
+        return arguments
+    }
+}
+
+private struct SystemTTSSettingsView: View {
+    let plugin: SystemTTSPlugin
+
+    @State private var selectedVoiceId: String?
+    @State private var rateWPM: Double
+
+    init(plugin: SystemTTSPlugin) {
+        self.plugin = plugin
+        _selectedVoiceId = State(initialValue: plugin.selectedVoiceId)
+        _rateWPM = State(initialValue: Double(plugin.selectedRateWPM ?? 175))
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker(String(localized: "Voice"), selection: Binding(
+                    get: { selectedVoiceId },
+                    set: { newValue in
+                        selectedVoiceId = newValue
+                        plugin.selectVoice(newValue)
+                    }
+                )) {
+                    Text(String(localized: "System Default")).tag(Optional<String>.none)
+                    ForEach(plugin.availableVoices, id: \.id) { voice in
+                        Text(voice.displayName).tag(Optional(voice.id))
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(String(localized: "Speed"))
+                        Spacer()
+                        if plugin.selectedRateWPM == nil {
+                            Text(String(localized: "System Default"))
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("\(Int(rateWPM)) WPM")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                    }
+
+                    Slider(
+                        value: Binding(
+                            get: { rateWPM },
+                            set: { newValue in
+                                let rounded = round(newValue / 5) * 5
+                                rateWPM = rounded
+                                plugin.selectRate(Int(rounded))
+                            }
+                        ),
+                        in: 100...300,
+                        step: 5
+                    )
+
+                    Button(String(localized: "Use System Default Speed")) {
+                        rateWPM = 175
+                        plugin.selectRate(nil)
+                    }
+                    .font(.caption)
+                }
+            } footer: {
+                Text(String(localized: "Uses macOS text-to-speech via the built-in system voice."))
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .frame(minWidth: 420, minHeight: 220)
+    }
+}

--- a/Plugins/SystemTTSPlugin/manifest.json
+++ b/Plugins/SystemTTSPlugin/manifest.json
@@ -1,0 +1,11 @@
+{
+  "id": "com.typewhisper.tts.system",
+  "name": "System Voice",
+  "version": "1.0.0",
+  "minHostVersion": "1.0.0",
+  "minOSVersion": "14.0",
+  "author": "TypeWhisper",
+  "principalClass": "SystemTTSPlugin",
+  "iconSystemName": "speaker.wave.2.fill",
+  "category": "tts"
+}

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
+		A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000001 /* SystemTTSPlugin.swift */; };
+		A10000000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000002 /* manifest.json */; };
+		A10000000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000044 /* TypeWhisperPluginSDK */; };
+		A10000000000000000000004 /* SystemTTSPlugin.bundle in Embed Built-in Plugins */ = {isa = PBXBuildFile; fileRef = B10000000000000000000003 /* SystemTTSPlugin.bundle */; };
+		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
@@ -324,6 +329,13 @@
 			remoteGlobalIDString = DD00000000000000000014;
 			remoteInfo = TypeWhisperWidgetExtension;
 		};
+		H10000000000000000000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE00000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D10000000000000000000001;
+			remoteInfo = SystemTTSPlugin;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -360,6 +372,17 @@
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F10000000000000000000004 /* Embed Built-in Plugins */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				A10000000000000000000004 /* SystemTTSPlugin.bundle in Embed Built-in Plugins */,
+			);
+			name = "Embed Built-in Plugins";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -369,6 +392,7 @@
 		7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoundServiceTests.swift; sourceTree = "<group>"; };
 		AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationShortSpeechTests.swift; sourceTree = "<group>"; };
 		8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPRequestParserTests.swift; sourceTree = "<group>"; };
+		B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackServiceTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000001 /* TypeWhisperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeWhisperApp.swift; sourceTree = "<group>"; };
 		BB00000000000000000002 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
 		BB00000000000000000005 /* TranscriptionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionResult.swift; sourceTree = "<group>"; };
@@ -558,6 +582,9 @@
 		BB00000000000000000229 /* FileMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMemoryPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000230 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000231 /* FileMemoryPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FileMemoryPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		B10000000000000000000001 /* SystemTTSPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTTSPlugin.swift; sourceTree = "<group>"; };
+		B10000000000000000000002 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		B10000000000000000000003 /* SystemTTSPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SystemTTSPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000232 /* OpenAIVectorMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIVectorMemoryPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000233 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenAIVectorMemoryPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -840,6 +867,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F10000000000000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000003 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000120 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -992,6 +1027,7 @@
 				CC00000000000000000033 /* GranitePlugin */,
 				CC00000000000000000034 /* CloudflareASRPlugin */,
 				CC00000000000000000035 /* FileMemoryPlugin */,
+				C10000000000000000000001 /* SystemTTSPlugin */,
 				CC00000000000000000036 /* OpenAIVectorMemoryPlugin */,
 				CC00000000000000000037 /* FireworksPlugin */,
 				CC00000000000000000038 /* CerebrasPlugin */,
@@ -1462,6 +1498,16 @@
 			path = Plugins/FileMemoryPlugin;
 			sourceTree = "<group>";
 		};
+		C10000000000000000000001 /* SystemTTSPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				B10000000000000000000001 /* SystemTTSPlugin.swift */,
+				B10000000000000000000002 /* manifest.json */,
+			);
+			name = SystemTTSPlugin;
+			path = Plugins/SystemTTSPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000036 /* OpenAIVectorMemoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -1617,6 +1663,7 @@
 				BB00000000000000000224 /* GranitePlugin.bundle */,
 				BB00000000000000000227 /* CloudflareASRPlugin.bundle */,
 				BB00000000000000000231 /* FileMemoryPlugin.bundle */,
+				B10000000000000000000003 /* SystemTTSPlugin.bundle */,
 				BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */,
 				BB00000000000000000254 /* FireworksPlugin.bundle */,
 				BB00000000000000000257 /* CerebrasPlugin.bundle */,
@@ -1652,6 +1699,7 @@
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				F41BD305007A3A158038C75C /* ProfileServiceTests.swift */,
+				B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */,
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
 				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
@@ -1696,12 +1744,14 @@
 				FF00000000000000000004 /* CopyFiles */,
 				FF00000000000000000036 /* Embed Frameworks */,
 				FF00000000000000000081 /* Embed App Extensions */,
+				F10000000000000000000004 /* Embed Built-in Plugins */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				GG00000000000000000001 /* PBXTargetDependency */,
 				GG00000000000000000009 /* PBXTargetDependency */,
+				G10000000000000000000001 /* PBXTargetDependency */,
 			);
 			name = TypeWhisper;
 			packageProductDependencies = (
@@ -2134,6 +2184,26 @@
 			productReference = BB00000000000000000231 /* FileMemoryPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		D10000000000000000000001 /* SystemTTSPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F10000000000000000000005 /* Build configuration list for PBXNativeTarget "SystemTTSPlugin" */;
+			buildPhases = (
+				F10000000000000000000002 /* Sources */,
+				F10000000000000000000003 /* Frameworks */,
+				F10000000000000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SystemTTSPlugin;
+			packageProductDependencies = (
+				PP00000000000000000044 /* TypeWhisperPluginSDK */,
+			);
+			productName = SystemTTSPlugin;
+			productReference = B10000000000000000000003 /* SystemTTSPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000024 /* OpenAIVectorMemoryPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000122 /* Build configuration list for PBXNativeTarget "OpenAIVectorMemoryPlugin" */;
@@ -2393,6 +2463,9 @@
 					DD00000000000000000002 = {
 						CreatedOnToolsVersion = 16.0;
 					};
+					D10000000000000000000001 = {
+						CreatedOnToolsVersion = 16.0;
+					};
 				};
 			};
 			buildConfigurationList = FF00000000000000000020 /* Build configuration list for PBXProject "TypeWhisper" */;
@@ -2440,6 +2513,7 @@
 				DD00000000000000000021 /* GranitePlugin */,
 				DD00000000000000000022 /* CloudflareASRPlugin */,
 				DD00000000000000000023 /* FileMemoryPlugin */,
+				D10000000000000000000001 /* SystemTTSPlugin */,
 				DD00000000000000000024 /* OpenAIVectorMemoryPlugin */,
 				DD00000000000000000025 /* FireworksPlugin */,
 				DD00000000000000000026 /* CerebrasPlugin */,
@@ -2656,6 +2730,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F10000000000000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000002 /* manifest.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000121 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2787,6 +2869,7 @@
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
+				A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,
 				A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */,
@@ -2794,6 +2877,14 @@
 				76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */,
 				E2DA879FDEFA04FBD013E837 /* OutputFormatter.swift in Sources */,
 				BA68B1E282D5D714132FEA24 /* PortDiscovery.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F10000000000000000000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3208,6 +3299,11 @@
 			isa = PBXTargetDependency;
 			target = DD00000000000000000014 /* TypeWhisperWidgetExtension */;
 			targetProxy = HH00000000000000000009 /* PBXContainerItemProxy */;
+		};
+		G10000000000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D10000000000000000000001 /* SystemTTSPlugin */;
+			targetProxy = H10000000000000000000001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -4401,6 +4497,54 @@
 			};
 			name = Release;
 		};
+		X10000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "System Voice";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = SystemTTSPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.tts.system;
+				PRODUCT_NAME = SystemTTSPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		X10000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "System Voice";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = SystemTTSPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.tts.system;
+				PRODUCT_NAME = SystemTTSPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		XX00000000000000000097 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5192,6 +5336,15 @@
 			buildConfigurations = (
 				XX00000000000000000093 /* Debug */,
 				XX00000000000000000094 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F10000000000000000000005 /* Build configuration list for PBXNativeTarget "SystemTTSPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				X10000000000000000000001 /* Debug */,
+				X10000000000000000000002 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -80,6 +80,7 @@ enum UserDefaultsKeys {
 
     // MARK: - Accessibility
     static let spokenFeedbackEnabled = "spokenFeedbackEnabled"
+    static let spokenFeedbackProviderId = "spokenFeedbackProviderId"
 
     // MARK: - Plugin Registry
     static let pluginRegistryLastFetch = "pluginRegistryLastFetch"

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -159,6 +159,12 @@ final class PluginManager: ObservableObject {
             .compactMap { $0.instance as? LLMProviderPlugin }
     }
 
+    var ttsProviders: [TTSProviderPlugin] {
+        loadedPlugins
+            .filter { $0.isEnabled }
+            .compactMap { $0.instance as? TTSProviderPlugin }
+    }
+
     var transcriptionEngines: [TranscriptionEnginePlugin] {
         loadedPlugins
             .filter { $0.isEnabled }
@@ -185,6 +191,17 @@ final class PluginManager: ObservableObject {
         loadedPlugins.first {
             guard let engine = $0.instance as? TranscriptionEnginePlugin else { return false }
             return $0.isEnabled && engine.providerId == providerId
+        }
+    }
+
+    func ttsProvider(for providerId: String) -> TTSProviderPlugin? {
+        ttsProviders.first { $0.providerId == providerId }
+    }
+
+    func loadedTTSPlugin(for providerId: String) -> LoadedPlugin? {
+        loadedPlugins.first {
+            guard let provider = $0.instance as? TTSProviderPlugin else { return false }
+            return $0.isEnabled && provider.providerId == providerId
         }
     }
 

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -25,6 +25,7 @@ enum PluginDownloadError: LocalizedError {
 
 enum PluginCategory: String, CaseIterable {
     case transcription
+    case tts
     case llm
     case postProcessor = "post-processor"
     case action
@@ -34,6 +35,7 @@ enum PluginCategory: String, CaseIterable {
     var displayName: String {
         switch self {
         case .transcription: String(localized: "Transcription Engines")
+        case .tts: String(localized: "Text-to-Speech")
         case .llm: String(localized: "LLM Providers")
         case .postProcessor: String(localized: "Post-Processors")
         case .action: String(localized: "Actions")
@@ -45,6 +47,7 @@ enum PluginCategory: String, CaseIterable {
     var iconSystemName: String {
         switch self {
         case .transcription: "waveform"
+        case .tts: "speaker.wave.2.fill"
         case .llm: "brain"
         case .postProcessor: "arrow.triangle.2.circlepath"
         case .action: "bolt.fill"
@@ -56,11 +59,12 @@ enum PluginCategory: String, CaseIterable {
     var sortOrder: Int {
         switch self {
         case .transcription: 0
-        case .llm: 1
-        case .postProcessor: 2
-        case .action: 3
-        case .memory: 4
-        case .utility: 5
+        case .tts: 1
+        case .llm: 2
+        case .postProcessor: 3
+        case .action: 4
+        case .memory: 5
+        case .utility: 6
         }
     }
 }

--- a/TypeWhisper/Services/SpeechFeedbackService.swift
+++ b/TypeWhisper/Services/SpeechFeedbackService.swift
@@ -1,5 +1,43 @@
 import Foundation
 import AppKit
+import Combine
+import os
+import TypeWhisperPluginSDK
+
+private final class PendingTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    private struct State {
+        var isActive = true
+        var onFinish: (@Sendable () -> Void)?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var isActive: Bool {
+        state.withLock { $0.isActive }
+    }
+
+    var onFinish: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onFinish } }
+        set {
+            let shouldNotify = state.withLock { state in
+                state.onFinish = newValue
+                return !state.isActive
+            }
+            if shouldNotify {
+                newValue?()
+            }
+        }
+    }
+
+    func stop() {
+        let callback: (@Sendable () -> Void)? = state.withLock { state in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        callback?()
+    }
+}
 
 enum SpeechFeedbackEvent {
     case recordingStarted
@@ -8,46 +46,78 @@ enum SpeechFeedbackEvent {
     case promptProcessing
     case promptComplete
 
-    var message: String {
+    var request: TTSSpeakRequest? {
         switch self {
         case .recordingStarted:
-            return String(localized: "Recording")
-        case .transcriptionComplete:
-            return ""
+            return TTSSpeakRequest(text: String(localized: "Recording"), purpose: .status)
+        case .transcriptionComplete(let text, let language):
+            guard !text.isEmpty else { return nil }
+            return TTSSpeakRequest(text: text, language: language, purpose: .transcription)
         case .error(let reason):
-            return String(localized: "Error: \(reason)")
+            return TTSSpeakRequest(text: String(localized: "Error: \(reason)"), purpose: .status)
         case .promptProcessing:
-            return String(localized: "Processing prompt")
+            return TTSSpeakRequest(text: String(localized: "Processing prompt"), purpose: .status)
         case .promptComplete:
-            return String(localized: "Prompt complete")
+            return TTSSpeakRequest(text: String(localized: "Prompt complete"), purpose: .status)
         }
     }
 }
 
 @MainActor
-class SpeechFeedbackService {
-    private var sayProcess: Process?
+final class SpeechFeedbackService: ObservableObject {
+    private let defaults: UserDefaults
+    private let providerResolver: @MainActor () -> [any TTSProviderPlugin]
+
+    private var playbackSession: (any TTSPlaybackSession)?
+    private var speakTask: Task<Void, Never>?
 
     @Published var spokenFeedbackEnabled: Bool {
-        didSet { UserDefaults.standard.set(spokenFeedbackEnabled, forKey: UserDefaultsKeys.spokenFeedbackEnabled) }
+        didSet {
+            defaults.set(spokenFeedbackEnabled, forKey: UserDefaultsKeys.spokenFeedbackEnabled)
+        }
+    }
+
+    @Published var selectedProviderId: String {
+        didSet {
+            defaults.set(selectedProviderId, forKey: UserDefaultsKeys.spokenFeedbackProviderId)
+        }
     }
 
     var isSpeaking: Bool {
-        sayProcess?.isRunning ?? false
+        playbackSession?.isActive ?? false
     }
 
-    init() {
-        self.spokenFeedbackEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
+    var availableProviders: [(id: String, displayName: String)] {
+        providerResolver().map { ($0.providerId, $0.providerDisplayName) }
+    }
+
+    var effectiveProviderId: String? {
+        selectedProvider?.providerId
+    }
+
+    var selectedProviderDisplayName: String? {
+        selectedProvider?.providerDisplayName
+    }
+
+    var currentSettingsSummary: String? {
+        selectedProvider?.settingsSummary
+    }
+
+    init(
+        defaults: UserDefaults = .standard,
+        providerResolver: @escaping @MainActor () -> [any TTSProviderPlugin] = { PluginManager.shared.ttsProviders }
+    ) {
+        self.defaults = defaults
+        self.providerResolver = providerResolver
+        self.spokenFeedbackEnabled = defaults.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
+        self.selectedProviderId = defaults.string(forKey: UserDefaultsKeys.spokenFeedbackProviderId) ?? ""
     }
 
     func announceEvent(_ event: SpeechFeedbackEvent) {
         guard spokenFeedbackEnabled else { return }
         guard !NSWorkspace.shared.isVoiceOverEnabled else { return }
-        if case .transcriptionComplete(let text, _) = event {
-            speak(text)
-        } else {
-            speak(event.message)
-        }
+        guard let request = event.request else { return }
+        speak(request)
     }
 
     func readBack(text: String, language: String?) {
@@ -55,29 +125,64 @@ class SpeechFeedbackService {
             stopSpeaking()
             return
         }
-        speak(text)
+        speak(TTSSpeakRequest(text: text, language: language, purpose: .manualReadback))
     }
 
     func stopSpeaking() {
-        sayProcess?.terminate()
-        sayProcess = nil
+        speakTask?.cancel()
+        speakTask = nil
+        playbackSession?.stop()
+        playbackSession = nil
     }
 
-    private func speak(_ text: String) {
+    private var selectedProvider: TTSProviderPlugin? {
+        let providers = providerResolver()
+        if let exact = providers.first(where: { $0.providerId == selectedProviderId }) {
+            return exact
+        }
+        if let configured = providers.first(where: { $0.isConfigured }) {
+            return configured
+        }
+        return providers.first
+    }
+
+    private func speak(_ request: TTSSpeakRequest) {
         stopSpeaking()
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
-        process.arguments = ["--", text]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        process.terminationHandler = { [weak self] _ in
-            DispatchQueue.main.async { self?.sayProcess = nil }
+        guard let provider = selectedProvider else { return }
+        let pendingSession = PendingTTSPlaybackSession()
+        let pendingSessionID = ObjectIdentifier(pendingSession as AnyObject)
+        setPlaybackSession(pendingSession)
+
+        speakTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let session = try await provider.speak(request)
+                if Task.isCancelled {
+                    session.stop()
+                    return
+                }
+                self.setPlaybackSession(session)
+            } catch {
+                if let activeSession = self.playbackSession,
+                   ObjectIdentifier(activeSession as AnyObject) == pendingSessionID {
+                    self.playbackSession = nil
+                }
+            }
+            self.speakTask = nil
         }
-        do {
-            try process.run()
-            sayProcess = process
-        } catch {
-            sayProcess = nil
+    }
+
+    private func setPlaybackSession(_ session: any TTSPlaybackSession) {
+        let sessionID = ObjectIdentifier(session as AnyObject)
+        session.onFinish = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                if let activeSession = self.playbackSession,
+                   ObjectIdentifier(activeSession as AnyObject) == sessionID {
+                    self.playbackSession = nil
+                }
+            }
         }
+        playbackSession = session
     }
 }

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -6,6 +6,8 @@ struct AdvancedSettingsView: View {
     @ObservedObject private var promptProcessingService = ServiceContainer.shared.promptProcessingService
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
     @ObservedObject private var dictation = DictationViewModel.shared
+    @ObservedObject private var speechFeedbackService = ServiceContainer.shared.speechFeedbackService
+    @ObservedObject private var pluginManager = PluginManager.shared
     @State private var cliInstalled = false
     @State private var cliSymlinkTarget = ""
     @State private var raycastInstalled = false
@@ -129,9 +131,36 @@ struct AdvancedSettingsView: View {
 
                 Toggle(String(localized: "Spoken feedback"), isOn: $dictation.spokenFeedbackEnabled)
 
-                Text(String(localized: "Reads back the transcribed text via speech synthesis after each dictation."))
+                Text(String(localized: "Speaks transcribed text and spoken status feedback through the selected speech provider."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                if dictation.spokenFeedbackEnabled, !speechFeedbackService.availableProviders.isEmpty {
+                    let providerSelection = Binding(
+                        get: { speechFeedbackService.effectiveProviderId ?? speechFeedbackService.selectedProviderId },
+                        set: { speechFeedbackService.selectedProviderId = $0 }
+                    )
+
+                    Picker(String(localized: "Speech Provider"), selection: providerSelection) {
+                        ForEach(speechFeedbackService.availableProviders, id: \.id) { provider in
+                            Text(provider.displayName).tag(provider.id)
+                        }
+                    }
+
+                    if let summary = speechFeedbackService.currentSettingsSummary {
+                        Text(summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let activeProviderId = speechFeedbackService.effectiveProviderId,
+                       let plugin = pluginManager.loadedTTSPlugin(for: activeProviderId),
+                       plugin.instance.settingsView != nil {
+                        Button(String(localized: "Configure Voice & Speed…")) {
+                            PluginSettingsWindowManager.shared.present(plugin)
+                        }
+                    }
+                }
             }
 
             // MARK: - History

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -127,9 +127,11 @@ struct PluginSettingsView: View {
             return PluginCategory(rawValue: regPlugin.category) ?? .utility
         }
         if plugin.instance is TranscriptionEnginePlugin { return .transcription }
+        if plugin.instance is TTSProviderPlugin { return .tts }
         if plugin.instance is LLMProviderPlugin { return .llm }
         if plugin.instance is PostProcessorPlugin { return .postProcessor }
         if plugin.instance is ActionPlugin { return .action }
+        if plugin.instance is MemoryStoragePlugin { return .memory }
         return .utility
     }
 

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -1,6 +1,6 @@
 # TypeWhisper Plugin SDK
 
-Build plugins for [TypeWhisper](https://github.com/TypeWhisper/typewhisper-mac) to add transcription engines, LLM providers, post-processors, and custom actions.
+Build plugins for [TypeWhisper](https://github.com/TypeWhisper/typewhisper-mac) to add transcription engines, text-to-speech providers, LLM providers, post-processors, and custom actions.
 
 ## Quick Start
 
@@ -162,6 +162,54 @@ let result = try await helper.process(
     apiKey: apiKey, model: "my-model",
     systemPrompt: systemPrompt, userText: userText
 )
+```
+
+### TTSProviderPlugin
+
+Add a text-to-speech provider for spoken feedback and manual readback.
+
+```swift
+@objc(MyTTSProvider)
+final class MyTTSProvider: NSObject, TTSProviderPlugin, @unchecked Sendable {
+    static let pluginId = "com.yourname.mytts"
+    static let pluginName = "My TTS"
+
+    private var host: HostServices?
+
+    required override init() { super.init() }
+    func activate(host: HostServices) { self.host = host }
+    func deactivate() { host = nil }
+
+    var providerId: String { "my-tts" }
+    var providerDisplayName: String { "My TTS" }
+    var isConfigured: Bool { true }
+    var availableVoices: [PluginVoiceInfo] {
+        [PluginVoiceInfo(id: "default", displayName: "Default Voice")]
+    }
+    var selectedVoiceId: String? { nil }
+    func selectVoice(_ voiceId: String?) {}
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        // request.text     - text to speak
+        // request.language - optional language hint
+        // request.purpose  - .status, .transcription, or .manualReadback
+        MyPlaybackSession()
+    }
+}
+```
+
+`TTSPlaybackSession` must keep track of active playback so TypeWhisper can stop or replace it:
+
+```swift
+final class MyPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    var isActive: Bool = true
+    var onFinish: (@Sendable () -> Void)?
+
+    func stop() {
+        isActive = false
+        onFinish?()
+    }
+}
 ```
 
 ### PostProcessorPlugin
@@ -421,7 +469,7 @@ Registry entry format:
   "minOSVersion": "14.0",
   "author": "Your Name",
   "description": "What your plugin does.",
-  "category": "transcription|llm|postprocessor|action",
+  "category": "transcription|tts|llm|post-processor|action|memory|utility",
   "size": 12345678,
   "downloadURL": "https://example.com/MyPlugin.zip",
   "iconSystemName": "star.fill"

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -355,6 +355,59 @@ public extension TranscriptionEnginePlugin {
     }
 }
 
+// MARK: - Text-to-Speech Provider Plugin
+
+public enum TTSPurpose: String, Sendable, Codable, CaseIterable {
+    case status
+    case transcription
+    case manualReadback
+}
+
+public struct TTSSpeakRequest: Sendable, Equatable {
+    public let text: String
+    public let language: String?
+    public let purpose: TTSPurpose
+
+    public init(text: String, language: String? = nil, purpose: TTSPurpose) {
+        self.text = text
+        self.language = language
+        self.purpose = purpose
+    }
+}
+
+public struct PluginVoiceInfo: Sendable, Equatable, Hashable {
+    public let id: String
+    public let displayName: String
+    public let localeIdentifier: String?
+
+    public init(id: String, displayName: String, localeIdentifier: String? = nil) {
+        self.id = id
+        self.displayName = displayName
+        self.localeIdentifier = localeIdentifier
+    }
+}
+
+public protocol TTSPlaybackSession: AnyObject, Sendable {
+    var isActive: Bool { get }
+    var onFinish: (@Sendable () -> Void)? { get set }
+    func stop()
+}
+
+public protocol TTSProviderPlugin: TypeWhisperPlugin {
+    var providerId: String { get }
+    var providerDisplayName: String { get }
+    var isConfigured: Bool { get }
+    var availableVoices: [PluginVoiceInfo] { get }
+    var selectedVoiceId: String? { get }
+    var settingsSummary: String? { get }
+    func selectVoice(_ voiceId: String?)
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession
+}
+
+public extension TTSProviderPlugin {
+    var settingsSummary: String? { nil }
+}
+
 // MARK: - Action Plugin
 
 public struct ActionContext: Sendable {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -114,6 +114,51 @@ private final class MockDictionaryTermsPlugin: NSObject, TranscriptionEnginePlug
     }
 }
 
+private final class MockTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    var isActive = true
+    var onFinish: (@Sendable () -> Void)?
+
+    func stop() {
+        isActive = false
+        onFinish?()
+    }
+}
+
+@objc(MockTTSPlugin)
+private final class MockTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.tts"
+    static let pluginName = "Mock TTS"
+
+    private(set) var host: HostServices?
+
+    required override init() {}
+
+    func activate(host: HostServices) {
+        self.host = host
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    var providerId: String { "mock-tts" }
+    var providerDisplayName: String { "Mock TTS" }
+    var isConfigured: Bool { true }
+    var availableVoices: [PluginVoiceInfo] { [PluginVoiceInfo(id: "default", displayName: "Default")] }
+    var selectedVoiceId: String? { host?.userDefault(forKey: "voice") as? String }
+    var settingsSummary: String? { "Default voice" }
+
+    func selectVoice(_ voiceId: String?) {
+        host?.setUserDefault(voiceId, forKey: "voice")
+    }
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        let session = MockTTSPlaybackSession()
+        host?.setUserDefault(request.text, forKey: "lastSpokenText")
+        return session
+    }
+}
+
 final class ProtocolContractTests: XCTestCase {
     func testHostServicesExposeRulesSecretsAndDefaults() throws {
         let host = MockHostServices(eventBus: MockEventBus(), availableRuleNames: ["Work", "Docs"])
@@ -169,6 +214,25 @@ final class ProtocolContractTests: XCTestCase {
 
         XCTAssertFalse(legacyPlugin is any DictionaryTermsCapabilityProviding)
         XCTAssertEqual(capabilityPlugin.dictionaryTermsSupport, .requiresPluginSetting)
+    }
+
+    func testTTSPluginCanPersistVoiceAndReceiveSpeakRequest() async throws {
+        let plugin = MockTTSPlugin()
+        let host = MockHostServices(eventBus: MockEventBus(), availableRuleNames: ["Work"])
+        plugin.activate(host: host)
+
+        plugin.selectVoice("default")
+        let session = try await plugin.speak(
+            TTSSpeakRequest(text: "Hello", language: "en", purpose: .manualReadback)
+        )
+
+        XCTAssertEqual(plugin.selectedVoiceId, "default")
+        XCTAssertEqual(plugin.settingsSummary, "Default voice")
+        XCTAssertEqual(host.userDefault(forKey: "lastSpokenText") as? String, "Hello")
+        XCTAssertTrue(session.isActive)
+
+        session.stop()
+        XCTAssertFalse(session.isActive)
     }
 
     func testPluginDictionaryTermsNormalizesPromptAndContextTokens() {

--- a/TypeWhisperTests/SpeechFeedbackServiceTests.swift
+++ b/TypeWhisperTests/SpeechFeedbackServiceTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+private final class MockTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    var isActive: Bool = true
+    var onFinish: (@Sendable () -> Void)?
+    private(set) var stopCallCount = 0
+    var onStop: (@Sendable () -> Void)?
+
+    func stop() {
+        guard isActive else { return }
+        isActive = false
+        stopCallCount += 1
+        onStop?()
+        onFinish?()
+    }
+}
+
+private final class MockTTSProvider: NSObject, TTSProviderPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.tts"
+    static let pluginName = "Mock TTS"
+
+    let providerId: String
+    let providerDisplayName: String
+    var isConfigured: Bool = true
+    var availableVoices: [PluginVoiceInfo] = []
+    var selectedVoiceId: String?
+    var settingsSummary: String? = "Mock Summary"
+    private(set) var requests: [TTSSpeakRequest] = []
+    let session = MockTTSPlaybackSession()
+    var onSpeak: (@Sendable (TTSSpeakRequest) -> Void)?
+
+    init(providerId: String = "mockTTS", providerDisplayName: String = "Mock TTS") {
+        self.providerId = providerId
+        self.providerDisplayName = providerDisplayName
+    }
+
+    required override init() {
+        self.providerId = "mockTTS"
+        self.providerDisplayName = "Mock TTS"
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func selectVoice(_ voiceId: String?) { selectedVoiceId = voiceId }
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        requests.append(request)
+        session.isActive = true
+        onSpeak?(request)
+        return session
+    }
+}
+
+@MainActor
+final class SpeechFeedbackServiceTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "SpeechFeedbackServiceTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testAnnounceEventUsesSelectedProvider() async {
+        let provider = MockTTSProvider()
+        let speakExpectation = expectation(description: "provider speak called")
+        provider.onSpeak = { _ in speakExpectation.fulfill() }
+        let service = SpeechFeedbackService(defaults: defaults) { [provider] in [provider] }
+
+        service.spokenFeedbackEnabled = true
+        service.selectedProviderId = provider.providerId
+        service.announceEvent(.promptComplete)
+        await fulfillment(of: [speakExpectation], timeout: 1.0)
+
+        XCTAssertEqual(provider.requests.count, 1)
+        XCTAssertEqual(provider.requests.first?.purpose, .status)
+        XCTAssertEqual(provider.requests.first?.text, String(localized: "Prompt complete"))
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.spokenFeedbackProviderId), provider.providerId)
+    }
+
+    func testReadBackStopsActiveSessionOnSecondInvocation() async {
+        let provider = MockTTSProvider()
+        let speakExpectation = expectation(description: "provider speak called")
+        let stopExpectation = expectation(description: "playback stopped")
+        provider.onSpeak = { _ in speakExpectation.fulfill() }
+        provider.session.onStop = { stopExpectation.fulfill() }
+        let service = SpeechFeedbackService(defaults: defaults) { [provider] in [provider] }
+
+        service.readBack(text: "Hello world", language: "en")
+        await fulfillment(of: [speakExpectation], timeout: 1.0)
+        XCTAssertEqual(provider.requests.count, 1)
+        XCTAssertTrue(service.isSpeaking)
+
+        service.readBack(text: "Hello world", language: "en")
+        await fulfillment(of: [stopExpectation], timeout: 1.0)
+
+        XCTAssertEqual(provider.requests.count, 1)
+        XCTAssertEqual(provider.session.stopCallCount, 1)
+        XCTAssertFalse(service.isSpeaking)
+    }
+
+    func testMissingSelectionFallsBackToAvailableProvider() async {
+        let provider = MockTTSProvider()
+        let speakExpectation = expectation(description: "fallback provider speak called")
+        provider.onSpeak = { _ in speakExpectation.fulfill() }
+        let service = SpeechFeedbackService(defaults: defaults) { [provider] in [provider] }
+
+        service.spokenFeedbackEnabled = true
+        service.selectedProviderId = "missing"
+        service.announceEvent(.recordingStarted)
+        await fulfillment(of: [speakExpectation], timeout: 1.0)
+
+        XCTAssertEqual(provider.requests.count, 1)
+        XCTAssertEqual(service.effectiveProviderId, provider.providerId)
+        XCTAssertEqual(service.selectedProviderDisplayName, provider.providerDisplayName)
+        XCTAssertEqual(service.currentSettingsSummary, provider.settingsSummary)
+    }
+}

--- a/TypeWhisperTests/SpeechFeedbackServiceTests.swift
+++ b/TypeWhisperTests/SpeechFeedbackServiceTests.swift
@@ -53,7 +53,6 @@ private final class MockTTSProvider: NSObject, TTSProviderPlugin, @unchecked Sen
     }
 }
 
-@MainActor
 final class SpeechFeedbackServiceTests: XCTestCase {
     private var defaults: UserDefaults!
     private var suiteName: String!
@@ -72,6 +71,7 @@ final class SpeechFeedbackServiceTests: XCTestCase {
         super.tearDown()
     }
 
+    @MainActor
     func testAnnounceEventUsesSelectedProvider() async {
         let provider = MockTTSProvider()
         let speakExpectation = expectation(description: "provider speak called")
@@ -89,6 +89,7 @@ final class SpeechFeedbackServiceTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.spokenFeedbackProviderId), provider.providerId)
     }
 
+    @MainActor
     func testReadBackStopsActiveSessionOnSecondInvocation() async {
         let provider = MockTTSProvider()
         let speakExpectation = expectation(description: "provider speak called")
@@ -110,6 +111,7 @@ final class SpeechFeedbackServiceTests: XCTestCase {
         XCTAssertFalse(service.isSpeaking)
     }
 
+    @MainActor
     func testMissingSelectionFallsBackToAvailableProvider() async {
         let provider = MockTTSProvider()
         let speakExpectation = expectation(description: "fallback provider speak called")


### PR DESCRIPTION
## Summary
- Closes #309 by replacing hardcoded `/usr/bin/say` speech feedback with a provider-based TTS platform
- add a bundled `SystemTTSPlugin` with configurable voice and speed, plus host-side provider selection in settings
- add SDK contracts, service tests, and plugin docs for the new `tts` plugin category
- lay the groundwork for #308 via `TTSPurpose`, without changing that issue's scope in this PR

## Testing
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh SystemTTSPlugin \"$(pwd)\"`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

## Review
- Pre-Landing Review: No issues found after auto-fixing the misleading spoken-feedback settings copy and the fallback provider picker state.
- Fresh verification rerun completed after final code changes.