### PR TITLE
fix: limit spoken feedback to transcription readback

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -5476,12 +5476,12 @@
         }
       }
     },
-    "Reads back the transcribed text via speech synthesis after each dictation." : {
+    "Reads back the final transcribed text after each dictation using the selected speech provider. Recording, error, and prompt announcements are only spoken through VoiceOver accessibility announcements." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Liest den transkribierten Text nach jeder Diktation per Sprachsynthese vor."
+            "value" : "Liest den finalen transkribierten Text nach jeder Diktation über den ausgewählten Sprachprovider vor. Aufnahme-, Fehler- und Prompt-Ansagen werden nur über die VoiceOver-Bedienungshilfen gesprochen."
           }
         }
       }

--- a/TypeWhisper/Services/SpeechFeedbackService.swift
+++ b/TypeWhisper/Services/SpeechFeedbackService.swift
@@ -39,34 +39,11 @@ private final class PendingTTSPlaybackSession: TTSPlaybackSession, @unchecked Se
     }
 }
 
-enum SpeechFeedbackEvent {
-    case recordingStarted
-    case transcriptionComplete(text: String, language: String?)
-    case error(reason: String)
-    case promptProcessing
-    case promptComplete
-
-    var request: TTSSpeakRequest? {
-        switch self {
-        case .recordingStarted:
-            return TTSSpeakRequest(text: String(localized: "Recording"), purpose: .status)
-        case .transcriptionComplete(let text, let language):
-            guard !text.isEmpty else { return nil }
-            return TTSSpeakRequest(text: text, language: language, purpose: .transcription)
-        case .error(let reason):
-            return TTSSpeakRequest(text: String(localized: "Error: \(reason)"), purpose: .status)
-        case .promptProcessing:
-            return TTSSpeakRequest(text: String(localized: "Processing prompt"), purpose: .status)
-        case .promptComplete:
-            return TTSSpeakRequest(text: String(localized: "Prompt complete"), purpose: .status)
-        }
-    }
-}
-
 @MainActor
 final class SpeechFeedbackService: ObservableObject {
     private let defaults: UserDefaults
     private let providerResolver: @MainActor () -> [any TTSProviderPlugin]
+    private let isVoiceOverEnabled: @MainActor () -> Bool
 
     private var playbackSession: (any TTSPlaybackSession)?
     private var speakTask: Task<Void, Never>?
@@ -105,19 +82,21 @@ final class SpeechFeedbackService: ObservableObject {
 
     init(
         defaults: UserDefaults = .standard,
-        providerResolver: @escaping @MainActor () -> [any TTSProviderPlugin] = { PluginManager.shared.ttsProviders }
+        providerResolver: @escaping @MainActor () -> [any TTSProviderPlugin] = { PluginManager.shared.ttsProviders },
+        isVoiceOverEnabled: @escaping @MainActor () -> Bool = { NSWorkspace.shared.isVoiceOverEnabled }
     ) {
         self.defaults = defaults
         self.providerResolver = providerResolver
+        self.isVoiceOverEnabled = isVoiceOverEnabled
         self.spokenFeedbackEnabled = defaults.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
         self.selectedProviderId = defaults.string(forKey: UserDefaultsKeys.spokenFeedbackProviderId) ?? ""
     }
 
-    func announceEvent(_ event: SpeechFeedbackEvent) {
+    func speakAutomaticTranscription(text: String, language: String?) {
         guard spokenFeedbackEnabled else { return }
-        guard !NSWorkspace.shared.isVoiceOverEnabled else { return }
-        guard let request = event.request else { return }
-        speak(request)
+        guard !isVoiceOverEnabled() else { return }
+        guard !text.isEmpty else { return }
+        speak(TTSSpeakRequest(text: text, language: language, purpose: .transcription))
     }
 
     func readBack(text: String, language: String?) {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -247,8 +247,7 @@ final class DictationViewModel: ObservableObject {
             promptActionService: promptActionService,
             promptProcessingService: promptProcessingService,
             soundService: soundService,
-            accessibilityAnnouncementService: accessibilityAnnouncementService,
-            speechFeedbackService: speechFeedbackService
+            accessibilityAnnouncementService: accessibilityAnnouncementService
         )
         self.settingsHandler = DictationSettingsHandler(
             hotkeyService: hotkeyService,
@@ -599,7 +598,6 @@ final class DictationViewModel: ObservableObject {
             // would otherwise make the hold appear as "long press" → PTT stop.
             hotkeyService.resetKeyDownTime()
             accessibilityAnnouncementService.announceRecordingStarted()
-            speechFeedbackService.announceEvent(.recordingStarted)
             partialText = ""
             isStopInFlight = false
             recordingStartTime = Date()
@@ -635,7 +633,6 @@ final class DictationViewModel: ObservableObject {
                 errorMessage = error.localizedDescription
             }
             accessibilityAnnouncementService.announceError(errorMessage)
-            speechFeedbackService.announceEvent(.error(reason: errorMessage))
             failDictationSession(id: sessionID, error: errorMessage)
             showError(errorMessage, category: "recording")
             hotkeyService.cancelDictation()
@@ -999,7 +996,7 @@ final class DictationViewModel: ObservableObject {
                     completeDictationSession(id: sessionID, transcription: completedTranscription)
                 }
                 accessibilityAnnouncementService.announceTranscriptionComplete(wordCount: wordCount)
-                speechFeedbackService.announceEvent(.transcriptionComplete(text: text, language: detectedLang))
+                speechFeedbackService.speakAutomaticTranscription(text: text, language: detectedLang)
                 lastTranscribedText = text
                 lastTranscriptionLanguage = detectedLang
 
@@ -1022,7 +1019,6 @@ final class DictationViewModel: ObservableObject {
                     failDictationSession(id: sessionID, error: error.localizedDescription)
                 }
                 accessibilityAnnouncementService.announceError(error.localizedDescription)
-                speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
                 showError(error.localizedDescription, category: "transcription")
                 clearActiveRuleState()
                 capturedActiveApp = nil

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -31,7 +31,6 @@ final class PromptPaletteHandler {
     private let promptProcessingService: PromptProcessingService
     private let soundService: SoundService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
-    private let speechFeedbackService: SpeechFeedbackService
 
     var onShowNotchFeedback: ((String, String, TimeInterval, Bool, String?) -> Void)?
     var onShowError: ((String) -> Void)?
@@ -47,15 +46,13 @@ final class PromptPaletteHandler {
         promptActionService: PromptActionService,
         promptProcessingService: PromptProcessingService,
         soundService: SoundService,
-        accessibilityAnnouncementService: AccessibilityAnnouncementService,
-        speechFeedbackService: SpeechFeedbackService
+        accessibilityAnnouncementService: AccessibilityAnnouncementService
     ) {
         self.textInsertionService = textInsertionService
         self.promptActionService = promptActionService
         self.promptProcessingService = promptProcessingService
         self.soundService = soundService
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
-        self.speechFeedbackService = speechFeedbackService
     }
 
     func hide() {
@@ -126,7 +123,6 @@ final class PromptPaletteHandler {
                     let message = "Please select or copy some text first."
                     soundService.play(.error, enabled: soundFeedbackEnabled)
                     self.accessibilityAnnouncementService.announceError(message)
-                    self.speechFeedbackService.announceEvent(.error(reason: message))
                     self.onShowNotchFeedback?(message, "xmark.circle.fill", 2.5, true, "prompt")
                     self.onShowError?(message)
                 }
@@ -164,7 +160,6 @@ final class PromptPaletteHandler {
 
         onShowNotchFeedback?(action.name + "...", "ellipsis.circle", 30, false, nil)
         accessibilityAnnouncementService.announcePromptProcessing(action.name)
-        speechFeedbackService.announceEvent(.promptProcessing)
 
         Task { [weak self] in
             guard let self else { return }
@@ -190,7 +185,6 @@ final class PromptPaletteHandler {
                     )
                     soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                     self.accessibilityAnnouncementService.announcePromptComplete()
-                    self.speechFeedbackService.announceEvent(.promptComplete)
                     let feedback = getActionFeedback?() ?? (message: nil, icon: nil, duration: 3.5)
                     onShowNotchFeedback?(
                         feedback.0 ?? "Done",
@@ -239,7 +233,6 @@ final class PromptPaletteHandler {
 
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                 self.accessibilityAnnouncementService.announcePromptComplete()
-                self.speechFeedbackService.announceEvent(.promptComplete)
                 let feedbackMessage: String
                 let feedbackIcon: String
                 if insertionOutcome == .failed && preserveClipboard {
@@ -257,7 +250,6 @@ final class PromptPaletteHandler {
                 guard !Task.isCancelled else { return }
                 soundService.play(.error, enabled: soundFeedbackEnabled)
                 self.accessibilityAnnouncementService.announceError(error.localizedDescription)
-                self.speechFeedbackService.announceEvent(.error(reason: error.localizedDescription))
                 onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "prompt")
             }
         }

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -131,7 +131,7 @@ struct AdvancedSettingsView: View {
 
                 Toggle(String(localized: "Spoken feedback"), isOn: $dictation.spokenFeedbackEnabled)
 
-                Text(String(localized: "Speaks transcribed text and spoken status feedback through the selected speech provider."))
+                Text(String(localized: "Reads back the final transcribed text after each dictation using the selected speech provider. Recording, error, and prompt announcements are only spoken through VoiceOver accessibility announcements."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -99,6 +99,52 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterMockTTSPlugin)
+    private final class MockTTSProviderPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.tts" }
+        static var pluginName: String { "Mock TTS" }
+
+        private let requestsLock = NSLock()
+        private var requests: [TTSSpeakRequest] = []
+        var onSpeak: ((TTSSpeakRequest) -> Void)?
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "mock-tts" }
+        var providerDisplayName: String { "Mock TTS" }
+        var isConfigured: Bool { true }
+        var availableVoices: [PluginVoiceInfo] { [] }
+        var selectedVoiceId: String? { nil }
+        var settingsSummary: String? { "Mock Summary" }
+        var recordedRequests: [TTSSpeakRequest] {
+            requestsLock.withLock { requests }
+        }
+
+        func selectVoice(_ voiceId: String?) {}
+
+        func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+            requestsLock.withLock {
+                requests.append(request)
+            }
+            onSpeak?(request)
+            return MockTTSPlaybackSession()
+        }
+    }
+
+    private final class MockTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+        var isActive: Bool = true
+        var onFinish: (@Sendable () -> Void)?
+
+        func stop() {
+            guard isActive else { return }
+            isActive = false
+            onFinish?()
+        }
+    }
+
     private final class APIContext: @unchecked Sendable {
         let router: APIRouter
         let historyService: HistoryService
@@ -107,6 +153,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
         let textInsertionService: TextInsertionService
+        let ttsProvider: MockTTSProviderPlugin
         private let retainedObjects: [AnyObject]
 
         init(
@@ -117,6 +164,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictationViewModel: DictationViewModel,
             audioRecordingService: AudioRecordingService,
             textInsertionService: TextInsertionService,
+            ttsProvider: MockTTSProviderPlugin,
             retainedObjects: [AnyObject]
         ) {
             self.router = router
@@ -126,6 +174,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
             self.textInsertionService = textInsertionService
+            self.ttsProvider = ttsProvider
             self.retainedObjects = retainedObjects
         }
     }
@@ -501,6 +550,86 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         let recordID = await MainActor.run { apiContext.historyService.records.first?.id.uuidString }
         XCTAssertEqual(recordID, startID)
+    }
+
+    func testDictationEndpointsSpeakCompletedTranscriptionOnly() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+        let ttsExpectation = expectation(description: "tts speak called")
+
+        await MainActor.run {
+            apiContext.ttsProvider.onSpeak = { request in
+                if request.purpose == .transcription {
+                    ttsExpectation.fulfill()
+                }
+            }
+            apiContext.dictationViewModel.spokenFeedbackEnabled = true
+            apiContext.audioRecordingService.hasMicrophonePermissionOverride = true
+            apiContext.audioRecordingService.inputAvailabilityOverride = { _ in true }
+            apiContext.audioRecordingService.startRecordingOverride = {}
+            apiContext.audioRecordingService.stopRecordingOverride = { _ in
+                Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+            }
+            apiContext.textInsertionService.accessibilityGrantedOverride = true
+            apiContext.textInsertionService.captureActiveAppOverride = {
+                ("Notes", "com.apple.Notes", nil)
+            }
+            apiContext.textInsertionService.selectedTextOverride = { nil }
+            apiContext.textInsertionService.pasteSimulatorOverride = {}
+        }
+
+        let start = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "POST", path: "/v1/dictation/start", queryParams: [:], headers: [:], body: Data()))
+        )
+        let startID = try XCTUnwrap(start["id"] as? String)
+        let initialRequestsAreEmpty = await MainActor.run { apiContext.ttsProvider.recordedRequests.isEmpty }
+        XCTAssertTrue(initialRequestsAreEmpty)
+
+        await MainActor.run {
+            apiContext.dictationViewModel.partialText = "transcribed"
+        }
+
+        _ = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "POST", path: "/v1/dictation/stop", queryParams: [:], headers: [:], body: Data()))
+        )
+
+        var completedResponse: [String: Any]?
+        for _ in 0..<40 {
+            let response = try Self.jsonObject(
+                await router.route(
+                    HTTPRequest(
+                        method: "GET",
+                        path: "/v1/dictation/transcription",
+                        queryParams: ["id": startID],
+                        headers: [:],
+                        body: Data()
+                    )
+                )
+            )
+            if response["status"] as? String == "completed" {
+                completedResponse = response
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        _ = try XCTUnwrap(completedResponse)
+        await fulfillment(of: [ttsExpectation], timeout: 1.0)
+
+        let requests = await MainActor.run { apiContext.ttsProvider.recordedRequests }
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.purpose, .transcription)
+        XCTAssertEqual(requests.first?.text, "transcribed")
     }
 
     @MainActor
@@ -896,6 +1025,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.dictationViewModel.actionFeedbackMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "No mic detected.")
         )
+        XCTAssertTrue(context.ttsProvider.recordedRequests.isEmpty)
     }
 
     @MainActor
@@ -918,6 +1048,51 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.dictationViewModel.actionFeedbackMessage,
             "Microphone permission required."
         )
+        XCTAssertTrue(context.ttsProvider.recordedRequests.isEmpty)
+    }
+
+    @MainActor
+    func testApiStartRecording_doesNotSpeakStatusFeedback() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.spokenFeedbackEnabled = true
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.textInsertionService.captureActiveAppOverride = { ("Notes", nil, nil) }
+        context.textInsertionService.selectedTextOverride = { nil }
+
+        _ = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertTrue(context.ttsProvider.recordedRequests.isEmpty)
+    }
+
+    @MainActor
+    func testApiStartRecordingError_doesNotSpeakStatusFeedback() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.spokenFeedbackEnabled = true
+        context.audioRecordingService.hasMicrophonePermissionOverride = false
+
+        _ = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertTrue(context.ttsProvider.recordedRequests.isEmpty)
     }
 
     @MainActor
@@ -1074,6 +1249,24 @@ final class APIRouterAndHandlersTests: XCTestCase {
     private static func makeAPIContext(appSupportDirectory: URL, withMockTranscriptionPlugin: Bool = false) -> APIContext {
         EventBus.shared = EventBus()
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        let ttsProvider = MockTTSProviderPlugin()
+        let ttsManifest = PluginManifest(
+            id: "com.typewhisper.mock.tts",
+            name: "Mock TTS",
+            version: "1.0.0",
+            principalClass: "APIRouterMockTTSPlugin",
+            category: "tts"
+        )
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: ttsManifest,
+                instance: ttsProvider,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
 
         let modelManager = ModelManagerService()
         if withMockTranscriptionPlugin {
@@ -1084,7 +1277,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 version: "1.0.0",
                 principalClass: "APIRouterMockTranscriptionPlugin"
             )
-            PluginManager.shared.loadedPlugins = [
+            PluginManager.shared.loadedPlugins.append(
                 LoadedPlugin(
                     manifest: manifest,
                     instance: mockPlugin,
@@ -1092,7 +1285,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                     sourceURL: appSupportDirectory,
                     isEnabled: true
                 )
-            ]
+            )
             modelManager.selectProvider(mockPlugin.providerId)
         }
         let audioFileService = AudioFileService()
@@ -1157,8 +1350,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictationViewModel: dictationViewModel,
             audioRecordingService: audioRecordingService,
             textInsertionService: textInsertionService,
+            ttsProvider: ttsProvider,
             retainedObjects: [
                 PluginManager.shared,
+                ttsProvider,
                 modelManager,
                 audioFileService,
                 audioRecordingService,
@@ -1190,6 +1385,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let audioRecordingService: AudioRecordingService
         let textInsertionService: TextInsertionService
         let profileService: ProfileService
+        let ttsProvider: MockTTSProviderPlugin
         private let retainedObjects: [AnyObject]
 
         init(
@@ -1197,12 +1393,14 @@ final class APIRouterAndHandlersTests: XCTestCase {
             audioRecordingService: AudioRecordingService,
             textInsertionService: TextInsertionService,
             profileService: ProfileService,
+            ttsProvider: MockTTSProviderPlugin,
             retainedObjects: [AnyObject]
         ) {
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
             self.textInsertionService = textInsertionService
             self.profileService = profileService
+            self.ttsProvider = ttsProvider
             self.retainedObjects = retainedObjects
         }
     }
@@ -1216,13 +1414,28 @@ final class APIRouterAndHandlersTests: XCTestCase {
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
 
         let mockPlugin = MockTranscriptionPlugin()
+        let ttsProvider = MockTTSProviderPlugin()
         let manifest = PluginManifest(
             id: "com.typewhisper.mock.transcription",
             name: "Mock Transcription",
             version: "1.0.0",
             principalClass: "APIRouterMockTranscriptionPlugin"
         )
+        let ttsManifest = PluginManifest(
+            id: "com.typewhisper.mock.tts",
+            name: "Mock TTS",
+            version: "1.0.0",
+            principalClass: "APIRouterMockTTSPlugin",
+            category: "tts"
+        )
         PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: ttsManifest,
+                instance: ttsProvider,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ),
             LoadedPlugin(
                 manifest: manifest,
                 instance: mockPlugin,
@@ -1286,6 +1499,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             audioRecordingService: audioRecordingService,
             textInsertionService: textInsertionService,
             profileService: profileService,
+            ttsProvider: ttsProvider,
             retainedObjects: [
                 EventBus.shared,
                 PluginManager.shared,
@@ -1304,6 +1518,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 promptProcessingService,
                 appFormatterService,
                 speechFeedbackService,
+                ttsProvider,
                 accessibilityAnnouncementService,
                 errorLogService,
                 settingsViewModel,

--- a/TypeWhisperTests/SpeechFeedbackServiceTests.swift
+++ b/TypeWhisperTests/SpeechFeedbackServiceTests.swift
@@ -72,7 +72,7 @@ final class SpeechFeedbackServiceTests: XCTestCase {
     }
 
     @MainActor
-    func testAnnounceEventUsesSelectedProvider() async {
+    func testAutomaticTranscriptionUsesSelectedProvider() async {
         let provider = MockTTSProvider()
         let speakExpectation = expectation(description: "provider speak called")
         provider.onSpeak = { _ in speakExpectation.fulfill() }
@@ -80,12 +80,12 @@ final class SpeechFeedbackServiceTests: XCTestCase {
 
         service.spokenFeedbackEnabled = true
         service.selectedProviderId = provider.providerId
-        service.announceEvent(.promptComplete)
+        service.speakAutomaticTranscription(text: "transcribed text", language: "en")
         await fulfillment(of: [speakExpectation], timeout: 1.0)
 
         XCTAssertEqual(provider.requests.count, 1)
-        XCTAssertEqual(provider.requests.first?.purpose, .status)
-        XCTAssertEqual(provider.requests.first?.text, String(localized: "Prompt complete"))
+        XCTAssertEqual(provider.requests.first?.purpose, .transcription)
+        XCTAssertEqual(provider.requests.first?.text, "transcribed text")
         XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.spokenFeedbackProviderId), provider.providerId)
     }
 
@@ -120,12 +120,38 @@ final class SpeechFeedbackServiceTests: XCTestCase {
 
         service.spokenFeedbackEnabled = true
         service.selectedProviderId = "missing"
-        service.announceEvent(.recordingStarted)
+        service.speakAutomaticTranscription(text: "transcribed text", language: "en")
         await fulfillment(of: [speakExpectation], timeout: 1.0)
 
         XCTAssertEqual(provider.requests.count, 1)
         XCTAssertEqual(service.effectiveProviderId, provider.providerId)
         XCTAssertEqual(service.selectedProviderDisplayName, provider.providerDisplayName)
         XCTAssertEqual(service.currentSettingsSummary, provider.settingsSummary)
+    }
+
+    @MainActor
+    func testAutomaticTranscriptionSkipsVoiceOver() async {
+        let provider = MockTTSProvider()
+        let service = SpeechFeedbackService(
+            defaults: defaults,
+            providerResolver: { [provider] in [provider] },
+            isVoiceOverEnabled: { true }
+        )
+
+        service.spokenFeedbackEnabled = true
+        service.speakAutomaticTranscription(text: "transcribed text", language: "en")
+
+        XCTAssertTrue(provider.requests.isEmpty)
+    }
+
+    @MainActor
+    func testAutomaticTranscriptionSkipsEmptyText() async {
+        let provider = MockTTSProvider()
+        let service = SpeechFeedbackService(defaults: defaults) { [provider] in [provider] }
+
+        service.spokenFeedbackEnabled = true
+        service.speakAutomaticTranscription(text: "", language: "en")
+
+        XCTAssertTrue(provider.requests.isEmpty)
     }
 }


### PR DESCRIPTION
Fixes #308

## Summary
**Spoken feedback host policy**
- Limit automatic spoken feedback to completed dictation transcriptions and manual readback.
- Remove event-based spoken feedback for recording start, errors, and prompt lifecycle events.
- Keep VoiceOver accessibility announcements unchanged.

**UI copy**
- Update the Advanced Settings spoken feedback description to match the new behavior.
- Update localized strings, including the German translation.

**Regression coverage**
- Update `SpeechFeedbackServiceTests` for automatic transcription, VoiceOver suppression, empty-text suppression, and provider fallback.
- Extend `APIRouterAndHandlersTests` to assert that dictation start and error paths do not speak status feedback, and that only completed transcriptions trigger TTS.

## Test Coverage
All new code paths have test coverage.

## Pre-Landing Review
No issues found.

## Design Review
No dedicated design review run. Frontend change is limited to settings copy in Advanced Settings.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
No plan file detected.

## Verification Results
- Automated: `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/SpeechFeedbackServiceTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests` passed.
- Manual live check: rebuilt and ran the dev app, enabled spoken feedback, exercised the real dictation flow through the local API server, and verified that recording start does not trigger `/usr/bin/say` while the completed transcription still does.

## Test plan
- [x] Primary verification command passed
- [x] Fresh verification rerun completed after final code changes
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/SpeechFeedbackServiceTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
