### PR TITLE
feat(api,cli): per-request STT engine/model selection (#317)

### DIFF
--- a/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/Plugins/GranitePlugin/GranitePlugin.swift
@@ -57,6 +57,17 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsC
             .map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
     }
 
+    var availableModels: [PluginModelInfo] {
+        Self.availableModels.map { def in
+            PluginModelInfo(
+                id: def.id,
+                displayName: def.displayName,
+                sizeDescription: def.sizeDescription,
+                loaded: def.id == loadedModelId
+            )
+        }
+    }
+
     var supportedLanguages: [String] {
         ["en", "fr", "de", "es", "pt", "ja"]
     }

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -73,6 +73,17 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCap
             .map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
     }
 
+    var availableModels: [PluginModelInfo] {
+        Self.availableModels.map { def in
+            PluginModelInfo(
+                id: def.id,
+                displayName: def.displayName,
+                sizeDescription: def.sizeDescription,
+                loaded: def.id == loadedModelId
+            )
+        }
+    }
+
     var supportedLanguages: [String] {
         [
             "af", "am", "ar", "az", "be", "bg", "bn", "bs", "ca", "cs",

--- a/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -59,6 +59,18 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Dict
             .map { PluginModelInfo(id: $0.id, displayName: $0.displayName, sizeDescription: "System-managed", languageCount: 1) }
     }
 
+    var availableModels: [PluginModelInfo] {
+        cachedModels.map { def in
+            PluginModelInfo(
+                id: def.id,
+                displayName: def.displayName,
+                sizeDescription: "System-managed",
+                languageCount: 1,
+                loaded: def.id == loadedModelId
+            )
+        }
+    }
+
     var selectedModelId: String? { loadedModelId }
 
     func selectModel(_ modelId: String) {

--- a/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -73,6 +73,17 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsC
             .map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
     }
 
+    var availableModels: [PluginModelInfo] {
+        Self.availableModels.map { def in
+            PluginModelInfo(
+                id: def.id,
+                displayName: def.displayName,
+                sizeDescription: def.sizeDescription,
+                loaded: def.id == loadedModelId
+            )
+        }
+    }
+
     var supportedLanguages: [String] {
         [
             "en", "fr", "es", "pt", "de", "nl", "it", "hi",

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -50,6 +50,18 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             .map { PluginModelInfo(id: $0.id, displayName: $0.displayName, sizeDescription: $0.sizeDescription, languageCount: 99) }
     }
 
+    var availableModels: [PluginModelInfo] {
+        Self.availableModels.map { def in
+            PluginModelInfo(
+                id: def.id,
+                displayName: def.displayName,
+                sizeDescription: def.sizeDescription,
+                languageCount: 99,
+                loaded: def.id == loadedModelId
+            )
+        }
+    }
+
     var selectedModelId: String? { _selectedModelId }
 
     func selectModel(_ modelId: String) {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -52,13 +52,6 @@ final class APIHandlers: @unchecked Sendable {
     // MARK: - POST /v1/transcribe
 
     private func handleTranscribe(_ request: HTTPRequest) async -> HTTPResponse {
-        // Note: Don't pre-check isModelReady here - let transcribe() handle auto-restore
-        // for models that were auto-unloaded but can be re-loaded.
-        let hasEngine = await modelManager.selectedProviderId != nil
-        guard hasEngine else {
-            return .error(status: 503, message: "No engine selected. Select an engine in TypeWhisper first.")
-        }
-
         let audioData: Data
         var fileExtension = "wav"
         var language: String?
@@ -67,6 +60,8 @@ final class APIHandlers: @unchecked Sendable {
         var targetLanguage: String?
         var responseFormat = "json"
         var requestPrompt: String?
+        var engineOverride: String?
+        var modelOverride: String?
 
         let contentType = request.headers["content-type"] ?? ""
 
@@ -120,6 +115,18 @@ final class APIHandlers: @unchecked Sendable {
                !val.isEmpty {
                 requestPrompt = val
             }
+
+            if let enginePart = parts.first(where: { $0.name == "engine" }),
+               let val = String(data: enginePart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !val.isEmpty {
+                engineOverride = val
+            }
+
+            if let modelPart = parts.first(where: { $0.name == "model" }),
+               let val = String(data: modelPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !val.isEmpty {
+                modelOverride = val
+            }
         } else if !request.body.isEmpty {
             audioData = request.body
             fileExtension = extensionFromMIME(contentType)
@@ -139,6 +146,14 @@ final class APIHandlers: @unchecked Sendable {
                !prompt.isEmpty {
                 requestPrompt = prompt
             }
+            if let engine = request.headers["x-engine"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !engine.isEmpty {
+                engineOverride = engine
+            }
+            if let model = request.headers["x-model"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !model.isEmpty {
+                modelOverride = model
+            }
         } else {
             return .error(status: 400, message: "No audio data provided")
         }
@@ -149,6 +164,23 @@ final class APIHandlers: @unchecked Sendable {
 
         if language != nil, !languageHints.isEmpty {
             return .error(status: 400, message: "Use either 'language' or 'language_hint', not both")
+        }
+
+        let awaitDownload = (request.queryParams["await_download"] == "1")
+
+        let resolvedOverride: ResolvedOverride
+        switch await resolveEngineModelOverride(engine: engineOverride, model: modelOverride, awaitDownload: awaitDownload) {
+        case .use(let value):
+            resolvedOverride = value
+        case .reject(let response):
+            return response
+        }
+
+        if resolvedOverride.engineId == nil {
+            let hasEngine = await modelManager.selectedProviderId != nil
+            guard hasEngine else {
+                return .error(status: 503, message: "No engine selected. Select an engine in TypeWhisper first.")
+            }
         }
 
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".\(fileExtension)")
@@ -172,6 +204,8 @@ final class APIHandlers: @unchecked Sendable {
                 audioSamples: samples,
                 languageSelection: languageSelection,
                 task: task,
+                engineOverrideId: resolvedOverride.engineId,
+                cloudModelOverride: resolvedOverride.modelId,
                 prompt: prompt
             )
 
@@ -212,7 +246,10 @@ final class APIHandlers: @unchecked Sendable {
                 #endif
             }
 
-            let modelId = await modelManager.selectedModelId
+            let modelId = await resolveResponseModelId(
+                override: resolvedOverride,
+                engineUsed: result.engineUsed
+            )
 
             if responseFormat == "verbose_json" {
                 struct SegmentEntry: Encodable {
@@ -266,6 +303,104 @@ final class APIHandlers: @unchecked Sendable {
         } catch {
             return .error(status: 500, message: "Transcription failed: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: - Engine/Model Override Resolution
+
+    private struct ResolvedOverride {
+        let engineId: String?
+        let modelId: String?
+    }
+
+    private enum OverrideResolution {
+        case use(ResolvedOverride)
+        case reject(HTTPResponse)
+    }
+
+    /// Resolve per-request `engine` / `model` overrides against the full set of loaded
+    /// transcription plugins. Implements the matrix from issue #317:
+    ///
+    /// - both nil -> use GUI selection
+    /// - engine only -> use that engine's default model
+    /// - model only -> infer engine by scanning `availableModels` across all engines
+    /// - both set   -> use as-is
+    ///
+    /// Also enforces configuration: an unconfigured engine returns 409 by default (to
+    /// distinguish "typo" from "needs setup") unless the caller passed `?await_download=1`,
+    /// in which case the usual `triggerRestoreModel` retry path is allowed to run.
+    @MainActor
+    private func resolveEngineModelOverride(
+        engine: String?,
+        model: String?,
+        awaitDownload: Bool
+    ) -> OverrideResolution {
+        if engine == nil, model == nil {
+            return .use(ResolvedOverride(engineId: nil, modelId: nil))
+        }
+
+        let engines = PluginManager.shared.transcriptionEngines
+
+        let resolvedEngineId: String?
+        if let engine {
+            guard let match = engines.first(where: { $0.providerId == engine }) else {
+                return .reject(.error(status: 400, message: "Unknown engine '\(engine)'"))
+            }
+            resolvedEngineId = match.providerId
+        } else if let model {
+            let matches = engines.filter { engine in
+                engine.availableModels.contains(where: { $0.id == model })
+            }
+            if matches.isEmpty {
+                return .reject(.error(status: 400, message: "Unknown model '\(model)'"))
+            }
+            if matches.count > 1 {
+                let engineIds = matches.map { $0.providerId }.joined(separator: ", ")
+                return .reject(.error(
+                    status: 400,
+                    message: "Ambiguous model id '\(model)' -- matches engines: \(engineIds). Specify 'engine' too."
+                ))
+            }
+            resolvedEngineId = matches[0].providerId
+        } else {
+            resolvedEngineId = nil
+        }
+
+        if let engineId = resolvedEngineId,
+           let model,
+           let plugin = engines.first(where: { $0.providerId == engineId }) {
+            let ids = Set(plugin.availableModels.map { $0.id })
+            if !ids.isEmpty, !ids.contains(model) {
+                return .reject(.error(
+                    status: 400,
+                    message: "Model '\(model)' is not offered by engine '\(engineId)'"
+                ))
+            }
+        }
+
+        if let engineId = resolvedEngineId,
+           let plugin = engines.first(where: { $0.providerId == engineId }),
+           !plugin.isConfigured,
+           !awaitDownload {
+            return .reject(.error(
+                status: 409,
+                message: "Engine '\(engineId)' is not configured (missing API key or downloaded weights). Pass ?await_download=1 to wait for restore."
+            ))
+        }
+
+        return .use(ResolvedOverride(engineId: resolvedEngineId, modelId: model))
+    }
+
+    @MainActor
+    private func resolveResponseModelId(override: ResolvedOverride, engineUsed: String) -> String? {
+        if let modelId = override.modelId { return modelId }
+        if let engineId = override.engineId,
+           let plugin = PluginManager.shared.transcriptionEngine(for: engineId) {
+            return plugin.selectedModelId
+        }
+        if let plugin = PluginManager.shared.transcriptionEngine(for: engineUsed) {
+            return plugin.selectedModelId
+        }
+        return nil
     }
 
     private func mergedPrompt(requestPrompt: String?, dictionaryPrompt: String?) -> String? {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -312,6 +312,8 @@ final class APIHandlers: @unchecked Sendable {
             let language_count: Int
             let status: String
             let selected: Bool
+            let downloaded: Bool?
+            let loaded: Bool?
         }
 
         let selectedProviderId = modelManager.selectedProviderId
@@ -319,7 +321,7 @@ final class APIHandlers: @unchecked Sendable {
 
         for engine in PluginManager.shared.transcriptionEngines {
             let isSelected = engine.providerId == selectedProviderId
-            for model in engine.transcriptionModels {
+            for model in engine.availableModels {
                 models.append(ModelEntry(
                     id: model.id,
                     engine: engine.providerId,
@@ -327,7 +329,9 @@ final class APIHandlers: @unchecked Sendable {
                     size_description: model.sizeDescription,
                     language_count: model.languageCount,
                     status: engine.isConfigured ? "ready" : "not_configured",
-                    selected: isSelected && engine.selectedModelId == model.id
+                    selected: isSelected && engine.selectedModelId == model.id,
+                    downloaded: model.downloaded,
+                    loaded: model.loaded
                 ))
             }
         }

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -280,6 +280,7 @@ final class APIHandlers: @unchecked Sendable {
 
     private func handleStatus(_ request: HTTPRequest) async -> HTTPResponse {
         let providerId = await modelManager.selectedProviderId
+        let modelId = await modelManager.selectedModelId
         let isReady = await modelManager.isModelReady
         let supportsStreaming = await modelManager.supportsStreaming
         let supportsTranslation = await modelManager.supportsTranslation
@@ -287,6 +288,7 @@ final class APIHandlers: @unchecked Sendable {
         struct StatusResponse: Encodable {
             let status: String
             let engine: String?
+            let model: String?
             let supports_streaming: Bool
             let supports_translation: Bool
         }
@@ -294,6 +296,7 @@ final class APIHandlers: @unchecked Sendable {
         let response = StatusResponse(
             status: isReady ? "ready" : "no_model",
             engine: providerId,
+            model: modelId,
             supports_streaming: supportsStreaming,
             supports_translation: supportsTranslation
         )

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -171,6 +171,36 @@ final class ModelManagerService: ObservableObject {
 
     // MARK: - Transcription
 
+    /// Apply a one-shot cloud model override without persisting the default.
+    ///
+    /// Returns the model id that should be restored after the transcription call completes
+    /// (nil means "no restore needed" -- either no override was applied or the plugin had no
+    /// previous selection to restore to). Callers must pair this with `restoreCloudModelOverride`
+    /// inside a `defer` so the original selection is restored even on throw.
+    private func applyCloudModelOverride(
+        plugin: any TranscriptionEnginePlugin,
+        override: String?
+    ) -> String? {
+        guard let override else { return nil }
+        let previousId = plugin.selectedModelId
+        // If the plugin had no previous selection we can't express "unselect" through the SDK,
+        // so the override stays in place. For configured plugins selectedModelId is normally set.
+        guard let previousId, previousId != override else {
+            if previousId != override { plugin.selectModel(override) }
+            return nil
+        }
+        plugin.selectModel(override)
+        return previousId
+    }
+
+    private func restoreCloudModelOverride(
+        plugin: any TranscriptionEnginePlugin,
+        previousId: String?
+    ) {
+        guard let previousId else { return }
+        plugin.selectModel(previousId)
+    }
+
     func createLiveTranscriptionSession(
         language: String?,
         task: TranscriptionTask,
@@ -210,9 +240,8 @@ final class ModelManagerService: ObservableObject {
             throw TranscriptionEngineError.modelNotLoaded
         }
 
-        if let modelId = cloudModelOverride {
-            plugin.selectModel(modelId)
-        }
+        let overrideRestoreId = applyCloudModelOverride(plugin: plugin, override: cloudModelOverride)
+        defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         guard let livePlugin = plugin as? LiveTranscriptionCapablePlugin else {
             return nil
@@ -298,9 +327,8 @@ final class ModelManagerService: ObservableObject {
             throw TranscriptionEngineError.modelNotLoaded
         }
 
-        if let modelId = cloudModelOverride {
-            plugin.selectModel(modelId)
-        }
+        let overrideRestoreId = applyCloudModelOverride(plugin: plugin, override: cloudModelOverride)
+        defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         let startTime = CFAbsoluteTimeGetCurrent()
         let wavData = WavEncoder.encode(audioSamples)
@@ -376,9 +404,8 @@ final class ModelManagerService: ObservableObject {
             throw TranscriptionEngineError.modelNotLoaded
         }
 
-        if let modelId = cloudModelOverride {
-            plugin.selectModel(modelId)
-        }
+        let overrideRestoreId = applyCloudModelOverride(plugin: plugin, override: cloudModelOverride)
+        defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         let startTime = CFAbsoluteTimeGetCurrent()
         let wavData = WavEncoder.encode(audioSamples)

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -141,11 +141,13 @@ final class ModelManagerService: ObservableObject {
               let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else { return nil }
 
         if let modelId = cloudModelOverride,
-           let model = plugin.transcriptionModels.first(where: { $0.id == modelId }) {
+           let model = plugin.availableModels.first(where: { $0.id == modelId })
+            ?? plugin.transcriptionModels.first(where: { $0.id == modelId }) {
             return model.displayName
         }
         if let selectedId = plugin.selectedModelId,
-           let model = plugin.transcriptionModels.first(where: { $0.id == selectedId }) {
+           let model = plugin.availableModels.first(where: { $0.id == selectedId })
+            ?? plugin.transcriptionModels.first(where: { $0.id == selectedId }) {
             return model.displayName
         }
         return plugin.providerDisplayName

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -59,12 +59,25 @@ public final class PluginModelInfo: @unchecked Sendable {
     public let displayName: String
     public let sizeDescription: String
     public let languageCount: Int
+    /// Whether the model's weights are available locally (nil when the plugin does not report this).
+    public let downloaded: Bool?
+    /// Whether the model is currently loaded into memory (nil when the plugin does not report this).
+    public let loaded: Bool?
 
-    public init(id: String, displayName: String, sizeDescription: String = "", languageCount: Int = 0) {
+    public init(
+        id: String,
+        displayName: String,
+        sizeDescription: String = "",
+        languageCount: Int = 0,
+        downloaded: Bool? = nil,
+        loaded: Bool? = nil
+    ) {
         self.id = id
         self.displayName = displayName
         self.sizeDescription = sizeDescription
         self.languageCount = languageCount
+        self.downloaded = downloaded
+        self.loaded = loaded
     }
 }
 
@@ -283,6 +296,12 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var providerDisplayName: String { get }
     var isConfigured: Bool { get }
     var transcriptionModels: [PluginModelInfo] { get }
+    /// Full catalogue this engine can select from, including variants not currently
+    /// downloaded or loaded. Default implementation returns `transcriptionModels`, so
+    /// existing plugins keep their current behaviour. Plugins that hide un-loaded
+    /// variants from `transcriptionModels` (to keep the GUI model picker quiet) should
+    /// override this to surface the full catalogue to API consumers like /v1/models.
+    var availableModels: [PluginModelInfo] { get }
     var selectedModelId: String? { get }
     func selectModel(_ modelId: String)
     var supportsTranslation: Bool { get }
@@ -292,6 +311,10 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var supportedLanguages: [String] { get }
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?,
                     onProgress: @Sendable @escaping (String) -> Bool) async throws -> PluginTranscriptionResult
+}
+
+public extension TranscriptionEnginePlugin {
+    var availableModels: [PluginModelInfo] { transcriptionModels }
 }
 
 public protocol LiveTranscriptionCapablePlugin: TranscriptionEnginePlugin {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1590,6 +1590,273 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testTranscribeRejectsUnknownEngineOverride() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        MockTranscriptionPlugin.reset()
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: true
+        )
+
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let boundary = "TestBoundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"engine\"\r\n\r\n".data(using: .utf8)!)
+        body.append("nonexistent-engine\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        )
+
+        XCTAssertEqual(response.status, 400)
+        let json = try Self.jsonObject(response)
+        let message = (json["error"] as? [String: Any])?["message"] as? String ?? ""
+        XCTAssertTrue(message.contains("Unknown engine"), "Expected 'Unknown engine' in message, got: \(message)")
+    }
+
+    @MainActor
+    func testTranscribeRejectsUnknownModelOverride() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        MockTranscriptionPlugin.reset()
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: true
+        )
+
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let boundary = "TestBoundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\n".data(using: .utf8)!)
+        body.append("definitely-not-a-real-model\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        )
+
+        XCTAssertEqual(response.status, 400)
+        let json = try Self.jsonObject(response)
+        let message = (json["error"] as? [String: Any])?["message"] as? String ?? ""
+        XCTAssertTrue(message.contains("Unknown model"), "Expected 'Unknown model' in message, got: \(message)")
+    }
+
+    @MainActor
+    func testTranscribeRejectsAmbiguousModelOverride() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        MockTranscriptionPlugin.reset()
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: true
+        )
+
+        // Add a second plugin that advertises the same model id "tiny", making it ambiguous.
+        let configurable = ConfigurableTranscriptionPlugin()
+        configurable.currentModelId = "tiny"
+        configurable.configured = true
+        let configurableManifest = PluginManifest(
+            id: "com.typewhisper.mock.configurable-transcription",
+            name: "Configurable Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterConfigurableTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins.append(
+            LoadedPlugin(
+                manifest: configurableManifest,
+                instance: configurable,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        )
+
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let boundary = "TestBoundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\n".data(using: .utf8)!)
+        body.append("tiny\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        )
+
+        XCTAssertEqual(response.status, 400)
+        let json = try Self.jsonObject(response)
+        let message = (json["error"] as? [String: Any])?["message"] as? String ?? ""
+        XCTAssertTrue(message.contains("Ambiguous"), "Expected 'Ambiguous' in message, got: \(message)")
+    }
+
+    @MainActor
+    func testTranscribeRejectsUnconfiguredEngineOverrideWithConflict() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        MockTranscriptionPlugin.reset()
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: true
+        )
+
+        let configurable = ConfigurableTranscriptionPlugin()
+        configurable.configured = false
+        let configurableManifest = PluginManifest(
+            id: "com.typewhisper.mock.configurable-transcription",
+            name: "Configurable Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterConfigurableTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins.append(
+            LoadedPlugin(
+                manifest: configurableManifest,
+                instance: configurable,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        )
+
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let boundary = "TestBoundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"engine\"\r\n\r\n".data(using: .utf8)!)
+        body.append("configurable-mock\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        )
+
+        XCTAssertEqual(response.status, 409)
+        let json = try Self.jsonObject(response)
+        let message = (json["error"] as? [String: Any])?["message"] as? String ?? ""
+        XCTAssertTrue(message.contains("not configured"), "Expected 'not configured' in message, got: \(message)")
+    }
+
+    @MainActor
+    func testTranscribeWithEngineOverrideRoutesToOverrideEngine() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        MockTranscriptionPlugin.reset()
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: true
+        )
+
+        let configurable = ConfigurableTranscriptionPlugin()
+        configurable.configured = true
+        configurable.currentModelId = "alpha"
+        let configurableManifest = PluginManifest(
+            id: "com.typewhisper.mock.configurable-transcription",
+            name: "Configurable Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterConfigurableTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins.append(
+            LoadedPlugin(
+                manifest: configurableManifest,
+                instance: configurable,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        )
+
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let boundary = "TestBoundary-\(UUID().uuidString)"
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"engine\"\r\n\r\n".data(using: .utf8)!)
+        body.append("configurable-mock\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = try Self.jsonObject(await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        ))
+
+        XCTAssertEqual(response["engine"] as? String, "configurable-mock")
+        XCTAssertEqual(response["model"] as? String, "alpha")
+        XCTAssertEqual(response["text"] as? String, "transcribed")
+    }
+
+    @MainActor
     func testTranscribeWithoutOverrideLeavesSelectionUntouched() async throws {
         let selectedEngineKey = UserDefaultsKeys.selectedEngine
         let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1532,6 +1532,116 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let object = try JSONSerialization.jsonObject(with: response.body)
         return try XCTUnwrap(object as? [String: Any])
     }
+
+    @MainActor
+    func testCloudModelOverrideDoesNotPersistPluginDefault() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = ConfigurableTranscriptionPlugin()
+        plugin.currentModelId = "alpha"
+        plugin.configured = true
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.configurable-transcription",
+            name: "Configurable Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterConfigurableTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        XCTAssertEqual(plugin.selectedModelId, "alpha")
+
+        _ = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            language: nil,
+            task: .transcribe,
+            engineOverrideId: nil,
+            cloudModelOverride: "beta",
+            prompt: nil
+        )
+
+        XCTAssertEqual(plugin.selectedModelId, "alpha", "cloudModelOverride must not persist the plugin's default model")
+    }
+
+    @MainActor
+    func testTranscribeWithoutOverrideLeavesSelectionUntouched() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = ConfigurableTranscriptionPlugin()
+        plugin.currentModelId = "alpha"
+        plugin.configured = true
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.configurable-transcription",
+            name: "Configurable Mock Transcription",
+            version: "1.0.0",
+            principalClass: "APIRouterConfigurableTranscriptionPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        _ = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            language: nil,
+            task: .transcribe,
+            engineOverrideId: nil,
+            cloudModelOverride: nil,
+            prompt: nil
+        )
+
+        XCTAssertEqual(plugin.selectedModelId, "alpha")
+    }
 }
 
 final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {

--- a/typewhisper-cli/CLIClient.swift
+++ b/typewhisper-cli/CLIClient.swift
@@ -57,7 +57,16 @@ struct CLIClient {
         try await get("/v1/models")
     }
 
-    func transcribe(fileURL: URL?, language: String?, languageHints: [String], task: String?, targetLanguage: String?) async throws -> Data {
+    func transcribe(
+        fileURL: URL?,
+        language: String?,
+        languageHints: [String],
+        task: String?,
+        targetLanguage: String?,
+        engine: String? = nil,
+        model: String? = nil,
+        awaitDownload: Bool = false
+    ) async throws -> Data {
         let audioData: Data
         let filename: String
 
@@ -100,10 +109,20 @@ struct CLIClient {
         if let targetLanguage {
             body.appendFormField("target_language", value: targetLanguage, boundary: boundary)
         }
+        if let engine {
+            body.appendFormField("engine", value: engine, boundary: boundary)
+        }
+        if let model {
+            body.appendFormField("model", value: model, boundary: boundary)
+        }
 
         body.append("--\(boundary)--\r\n")
 
-        let url = URL(string: "\(baseURL)/v1/transcribe")!
+        var transcribePath = "/v1/transcribe"
+        if awaitDownload {
+            transcribePath += "?await_download=1"
+        }
+        let url = URL(string: "\(baseURL)\(transcribePath)")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")

--- a/typewhisper-cli/main.swift
+++ b/typewhisper-cli/main.swift
@@ -12,6 +12,9 @@ var positionalArgs = [String]()
 var languageOptions = CLITranscribeLanguageOptions()
 var task: String?
 var translateTo: String?
+var engineOverride: String?
+var modelOverride: String?
+var awaitDownload = false
 
 var argIterator = args.makeIterator()
 while let arg = argIterator.next() {
@@ -56,6 +59,20 @@ while let arg = argIterator.next() {
             exit(1)
         }
         translateTo = next
+    case "--engine":
+        guard let next = argIterator.next() else {
+            printError("Error: --engine requires a value.")
+            exit(1)
+        }
+        engineOverride = next
+    case "--model":
+        guard let next = argIterator.next() else {
+            printError("Error: --model requires a value.")
+            exit(1)
+        }
+        modelOverride = next
+    case "--await-download":
+        awaitDownload = true
     default:
         // Ignore Apple/Xcode internal flags (e.g. -NSDocumentRevisionsDebugMode)
         if arg.hasPrefix("-NS") || arg.hasPrefix("-Apple") {
@@ -109,7 +126,10 @@ do {
             language: languageOptions.language,
             languageHints: languageOptions.languageHints,
             task: task,
-            targetLanguage: translateTo
+            targetLanguage: translateTo,
+            engine: engineOverride,
+            model: modelOverride,
+            awaitDownload: awaitDownload
         )
         print(OutputFormatter.formatTranscription(data, json: jsonOutput))
 
@@ -151,12 +171,18 @@ func printUsage() {
           --language-hint <code>  Repeatable language hint for auto-detection
           --task <task>        transcribe (default) or translate
           --translate-to <code>  Target language for translation
+          --engine <id>        Override the engine for this request (e.g. groq, qwen3)
+          --model <id>         Override the model for this request (e.g. whisper-large-v3-turbo)
+          --await-download     Wait for an engine to restore/download its model instead of failing with 409
 
         Examples:
           typewhisper status
           typewhisper transcribe recording.wav
           typewhisper transcribe recording.wav --language de --json
           typewhisper transcribe recording.wav --language-hint de --language-hint en
+          typewhisper transcribe recording.wav --model whisper-large-v3-turbo
+          typewhisper transcribe recording.wav --engine groq
+          typewhisper transcribe recording.wav --engine groq --model whisper-large-v3-turbo
           typewhisper transcribe - < audio.wav
           cat audio.wav | typewhisper transcribe -
         """


### PR DESCRIPTION
## Summary

Implements [Issue #317](https://github.com/TypeWhisper/typewhisper-mac/issues/317) — per-request STT model selection via CLI + HTTP API — in four atomic commits:

- **P0.1 `fix: prevent cloudModelOverride from persisting plugin default`**
  `cloudModelOverride` no longer leaks into `UserDefaults` via `plugin.selectModel`. Introduced save/restore helpers in `ModelManagerService` so the per-request override is applied around the transcribe/live-session call and reverted via `defer`, even on error. Covers all three call sites (batch, streaming, live session).

- **P0.2 `feat(plugin-sdk): add availableModels with default fallback`**
  Additive, non-breaking SDK change: new `TranscriptionEnginePlugin.availableModels` (default = `transcriptionModels`) plus optional `PluginModelInfo.downloaded` / `.loaded`. Opt-in overrides in `Qwen3Plugin`, `WhisperKitPlugin`, `GranitePlugin`, `VoxtralPlugin`, `SpeechAnalyzerPlugin` so `/v1/models` returns the full catalogue — including variants not currently loaded/downloaded — while the GUI's `transcriptionModels` stays filtered. `resolvedModelDisplayName` now also looks up `availableModels` so profiles with a `cloudModelOverride` on non-loaded models still get the right name.

- **P1 `feat(api): include model in /v1/status`**
  `StatusResponse` now carries `model` (= `modelManager.selectedModelId`). The CLI's `OutputFormatter` already reads the key, so `typewhisper status` now prints `Ready - <engine> (<model>)` automatically.

- **P2 `feat(api,cli): per-request engine/model override for /v1/transcribe`**
  Adds `engine` + `model` override fields on `POST /v1/transcribe` (multipart + `x-engine` / `x-model` headers). Implements the full resolution matrix (both nil, engine only, model only, both set) with a dedicated `resolveEngineModelOverride` helper:
  - unknown engine → `400`
  - unknown model → `400`
  - model matches multiple engines → `400` ambiguous
  - engine not configured → `409` (opt-in retry via `?await_download=1` falls back to the existing `triggerRestoreModel` path)
  - successful routing reports the resolved `engine` + `model` in the JSON response.

  CLI gets `--engine`, `--model`, and `--await-download` flags with updated `--help` / examples; `CLIClient.transcribe` forwards them as multipart form fields / query param.

## Test Plan

- [x] Built and ran locally (`build-typewhisper-mac-dev.sh --run`, rebuilt `GroqPlugin`, `OpenAIPlugin`, `WhisperKitPlugin` against the new SDK)
- [x] Tested the changed functionality manually against the running dev app:
  - `GET /v1/status` now returns `{"engine":"groq","model":"whisper-large-v3-turbo",…}`
  - `GET /v1/models` returns the full catalogue per engine
  - `typewhisper transcribe jfk.wav --model whisper-large-v3 --json` → response reports `"model":"whisper-large-v3"`, `/v1/status` still reports `whisper-large-v3-turbo` (P0.1 leak fix confirmed)
  - `--engine groq`, `--engine groq --model whisper-large-v3`, and default (no override) all succeed
  - `--engine doesnotexist` → `400 Unknown engine`
  - `--model doesnotexist` → `400 Unknown model`
- [x] No regressions in existing features — full XCTest suite (183 tests) green; added new tests:
  - `testCloudModelOverrideDoesNotPersistPluginDefault`
  - `testTranscribeWithoutOverrideLeavesSelectionUntouched`
  - `testTranscribeRejectsUnknownEngineOverride`
  - `testTranscribeRejectsUnknownModelOverride`
  - `testTranscribeRejectsAmbiguousModelOverride`
  - `testTranscribeRejectsUnconfiguredEngineOverrideWithConflict`
  - `testTranscribeWithEngineOverrideRoutesToOverrideEngine`

Closes #317.

Made with [Cursor](https://cursor.com)