### PR TITLE
Add double-escape cancel confirmation

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -5291,6 +5291,16 @@
         }
       }
     },
+    "Press Esc again to cancel recording" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drücke Esc erneut, um die Aufnahme abzubrechen"
+          }
+        }
+      }
+    },
     "Processing..." : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -167,7 +167,8 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
-    private var recordingCancelWarningResetTask: Task<Void, Never>?
+    private var recordingCancelWarningResetWorkItem: DispatchWorkItem?
+    private var recordingCancelWarningResetToken = UUID()
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -188,7 +189,7 @@ final class DictationViewModel: ObservableObject {
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
-    private var recordingCancelWarningDuration: Duration = .seconds(2)
+    private var recordingCancelWarningDuration: TimeInterval = 2
 
     init(
         audioRecordingService: AudioRecordingService,
@@ -403,6 +404,7 @@ final class DictationViewModel: ObservableObject {
 
     isolated deinit {
         recordingTimer?.invalidate()
+        recordingCancelWarningResetWorkItem?.cancel()
     }
 
     private func beginDictationSession(id: UUID) {
@@ -530,19 +532,28 @@ final class DictationViewModel: ObservableObject {
 
     private func showRecordingCancelWarning() {
         recordingCancelWarningMessage = String(localized: "Press Esc again to cancel recording")
-        recordingCancelWarningResetTask?.cancel()
-        let duration = recordingCancelWarningDuration
-        recordingCancelWarningResetTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: duration)
-            guard let self, !Task.isCancelled else { return }
+        recordingCancelWarningResetWorkItem?.cancel()
+
+        let resetToken = UUID()
+        recordingCancelWarningResetToken = resetToken
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.recordingCancelWarningResetToken == resetToken else { return }
             self.recordingCancelWarningMessage = nil
-            self.recordingCancelWarningResetTask = nil
+            self.recordingCancelWarningResetWorkItem = nil
         }
+
+        recordingCancelWarningResetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + recordingCancelWarningDuration,
+            execute: workItem
+        )
     }
 
     private func clearRecordingCancelWarning() {
-        recordingCancelWarningResetTask?.cancel()
-        recordingCancelWarningResetTask = nil
+        recordingCancelWarningResetToken = UUID()
+        recordingCancelWarningResetWorkItem?.cancel()
+        recordingCancelWarningResetWorkItem = nil
         recordingCancelWarningMessage = nil
     }
 
@@ -1114,7 +1125,7 @@ final class DictationViewModel: ObservableObject {
     }
 
 #if DEBUG
-    func setRecordingCancelWarningDurationForTesting(_ duration: Duration) {
+    func setRecordingCancelWarningDurationForTesting(_ duration: TimeInterval) {
         recordingCancelWarningDuration = duration
     }
 #endif

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -56,13 +56,7 @@ final class DictationViewModel: ObservableObject {
         case error(String)
     }
 
-    @Published var state: State = .idle {
-        didSet {
-            if state != .recording {
-                clearRecordingCancelWarning()
-            }
-        }
-    }
+    @Published var state: State = .idle
     @Published var audioLevel: Float = 0
     @Published var recordingDuration: TimeInterval = 0
     @Published var hotkeyMode: HotkeyService.HotkeyMode?
@@ -166,7 +160,7 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
-    private var recordingCancelWarningShownAt: Date?
+    @Published private var recordingCancelWarningShownAt: Date?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -450,6 +444,14 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func setupBindings() {
+        $state
+            .removeDuplicates()
+            .sink { [weak self] newState in
+                guard let self, newState != .recording else { return }
+                self.clearRecordingCancelWarning()
+            }
+            .store(in: &cancellables)
+
         hotkeyService.onDictationStart = { [weak self] in
             self?.startRecording()
         }
@@ -535,7 +537,6 @@ final class DictationViewModel: ObservableObject {
 
     private func showRecordingCancelWarning(at date: Date) {
         recordingCancelWarningShownAt = date
-        objectWillChange.send()
     }
 
     private func isRecordingCancelWarningActive(referenceDate: Date) -> Bool {
@@ -546,7 +547,6 @@ final class DictationViewModel: ObservableObject {
     private func clearRecordingCancelWarning() {
         guard recordingCancelWarningShownAt != nil else { return }
         recordingCancelWarningShownAt = nil
-        objectWillChange.send()
     }
 
     private func cancelCurrentOperation() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -6,7 +6,6 @@ import os
 import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "DictationViewModel")
-private let recordingCancelWarningIcon = "exclamationmark.triangle.fill"
 
 struct DictationSessionTranscription: Sendable, Equatable {
     let text: String
@@ -167,8 +166,7 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
-    private var recordingCancelWarningResetTimer: Timer?
-    private var isAwaitingRecordingCancelConfirmation = false
+    private var recordingCancelWarningShownAt: Date?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -192,8 +190,8 @@ final class DictationViewModel: ObservableObject {
     private var recordingCancelWarningDuration: TimeInterval = 2
 
     var recordingCancelWarningMessage: String? {
-        guard state == .recording, actionFeedbackIcon == recordingCancelWarningIcon else { return nil }
-        return actionFeedbackMessage
+        guard state == .recording, isRecordingCancelWarningActive(referenceDate: Date()) else { return nil }
+        return String(localized: "Press Esc again to cancel recording")
     }
 
     init(
@@ -409,7 +407,6 @@ final class DictationViewModel: ObservableObject {
 
     isolated deinit {
         recordingTimer?.invalidate()
-        recordingCancelWarningResetTimer?.invalidate()
     }
 
     private func beginDictationSession(id: UUID) {
@@ -522,11 +519,12 @@ final class DictationViewModel: ObservableObject {
     func handleCancelHotkey() {
         switch state {
         case .recording:
-            if !isAwaitingRecordingCancelConfirmation {
-                showRecordingCancelWarning()
-            } else {
+            let now = Date()
+            if isRecordingCancelWarningActive(referenceDate: now) {
                 clearRecordingCancelWarning()
                 cancelCurrentOperation()
+            } else {
+                showRecordingCancelWarning(at: now)
             }
         case .processing:
             cancelCurrentOperation()
@@ -535,29 +533,20 @@ final class DictationViewModel: ObservableObject {
         }
     }
 
-    private func showRecordingCancelWarning() {
-        isAwaitingRecordingCancelConfirmation = true
-        actionFeedbackMessage = String(localized: "Press Esc again to cancel recording")
-        actionFeedbackIcon = recordingCancelWarningIcon
-        actionFeedbackIsError = false
-        actionDisplayDuration = recordingCancelWarningDuration
-        recordingCancelWarningResetTimer?.invalidate()
-        recordingCancelWarningResetTimer = Timer.scheduledTimer(withTimeInterval: recordingCancelWarningDuration, repeats: false) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.clearRecordingCancelWarning()
-            }
-        }
+    private func showRecordingCancelWarning(at date: Date) {
+        recordingCancelWarningShownAt = date
+        objectWillChange.send()
+    }
+
+    private func isRecordingCancelWarningActive(referenceDate: Date) -> Bool {
+        guard let shownAt = recordingCancelWarningShownAt else { return false }
+        return referenceDate.timeIntervalSince(shownAt) < recordingCancelWarningDuration
     }
 
     private func clearRecordingCancelWarning() {
-        isAwaitingRecordingCancelConfirmation = false
-        recordingCancelWarningResetTimer?.invalidate()
-        recordingCancelWarningResetTimer = nil
-        guard actionFeedbackIcon == recordingCancelWarningIcon else { return }
-        actionFeedbackMessage = nil
-        actionFeedbackIcon = nil
-        actionFeedbackIsError = false
-        actionDisplayDuration = 3.5
+        guard recordingCancelWarningShownAt != nil else { return }
+        recordingCancelWarningShownAt = nil
+        objectWillChange.send()
     }
 
     private func cancelCurrentOperation() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -6,6 +6,7 @@ import os
 import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "DictationViewModel")
+private let recordingCancelWarningIcon = "exclamationmark.triangle.fill"
 
 struct DictationSessionTranscription: Sendable, Equatable {
     let text: String
@@ -104,7 +105,6 @@ final class DictationViewModel: ObservableObject {
     @Published var actionFeedbackMessage: String?
     @Published var actionFeedbackIcon: String?
     @Published var actionFeedbackIsError: Bool = false
-    @Published var recordingCancelWarningMessage: String?
     @Published var activeAppIcon: NSImage?
     private var actionDisplayDuration: TimeInterval = 3.5
 
@@ -168,6 +168,7 @@ final class DictationViewModel: ObservableObject {
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
     private var recordingCancelWarningResetTimer: Timer?
+    private var isAwaitingRecordingCancelConfirmation = false
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -189,6 +190,11 @@ final class DictationViewModel: ObservableObject {
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
     private var recordingCancelWarningDuration: TimeInterval = 2
+
+    var recordingCancelWarningMessage: String? {
+        guard state == .recording, actionFeedbackIcon == recordingCancelWarningIcon else { return nil }
+        return actionFeedbackMessage
+    }
 
     init(
         audioRecordingService: AudioRecordingService,
@@ -516,7 +522,7 @@ final class DictationViewModel: ObservableObject {
     func handleCancelHotkey() {
         switch state {
         case .recording:
-            if recordingCancelWarningMessage == nil {
+            if !isAwaitingRecordingCancelConfirmation {
                 showRecordingCancelWarning()
             } else {
                 clearRecordingCancelWarning()
@@ -530,20 +536,28 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func showRecordingCancelWarning() {
-        recordingCancelWarningMessage = String(localized: "Press Esc again to cancel recording")
+        isAwaitingRecordingCancelConfirmation = true
+        actionFeedbackMessage = String(localized: "Press Esc again to cancel recording")
+        actionFeedbackIcon = recordingCancelWarningIcon
+        actionFeedbackIsError = false
+        actionDisplayDuration = recordingCancelWarningDuration
         recordingCancelWarningResetTimer?.invalidate()
         recordingCancelWarningResetTimer = Timer.scheduledTimer(withTimeInterval: recordingCancelWarningDuration, repeats: false) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.recordingCancelWarningMessage = nil
-                self?.recordingCancelWarningResetTimer = nil
+                self?.clearRecordingCancelWarning()
             }
         }
     }
 
     private func clearRecordingCancelWarning() {
+        isAwaitingRecordingCancelConfirmation = false
         recordingCancelWarningResetTimer?.invalidate()
         recordingCancelWarningResetTimer = nil
-        recordingCancelWarningMessage = nil
+        guard actionFeedbackIcon == recordingCancelWarningIcon else { return }
+        actionFeedbackMessage = nil
+        actionFeedbackIcon = nil
+        actionFeedbackIsError = false
+        actionDisplayDuration = 3.5
     }
 
     private func cancelCurrentOperation() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -167,8 +167,7 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
-    private var recordingCancelWarningResetWorkItem: DispatchWorkItem?
-    private var recordingCancelWarningResetToken = UUID()
+    private var recordingCancelWarningResetTimer: Timer?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -404,7 +403,7 @@ final class DictationViewModel: ObservableObject {
 
     isolated deinit {
         recordingTimer?.invalidate()
-        recordingCancelWarningResetWorkItem?.cancel()
+        recordingCancelWarningResetTimer?.invalidate()
     }
 
     private func beginDictationSession(id: UUID) {
@@ -532,28 +531,18 @@ final class DictationViewModel: ObservableObject {
 
     private func showRecordingCancelWarning() {
         recordingCancelWarningMessage = String(localized: "Press Esc again to cancel recording")
-        recordingCancelWarningResetWorkItem?.cancel()
-
-        let resetToken = UUID()
-        recordingCancelWarningResetToken = resetToken
-
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self, self.recordingCancelWarningResetToken == resetToken else { return }
-            self.recordingCancelWarningMessage = nil
-            self.recordingCancelWarningResetWorkItem = nil
+        recordingCancelWarningResetTimer?.invalidate()
+        recordingCancelWarningResetTimer = Timer.scheduledTimer(withTimeInterval: recordingCancelWarningDuration, repeats: false) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.recordingCancelWarningMessage = nil
+                self?.recordingCancelWarningResetTimer = nil
+            }
         }
-
-        recordingCancelWarningResetWorkItem = workItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + recordingCancelWarningDuration,
-            execute: workItem
-        )
     }
 
     private func clearRecordingCancelWarning() {
-        recordingCancelWarningResetToken = UUID()
-        recordingCancelWarningResetWorkItem?.cancel()
-        recordingCancelWarningResetWorkItem = nil
+        recordingCancelWarningResetTimer?.invalidate()
+        recordingCancelWarningResetTimer = nil
         recordingCancelWarningMessage = nil
     }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -56,7 +56,13 @@ final class DictationViewModel: ObservableObject {
         case error(String)
     }
 
-    @Published var state: State = .idle
+    @Published var state: State = .idle {
+        didSet {
+            if state != .recording {
+                clearRecordingCancelWarning()
+            }
+        }
+    }
     @Published var audioLevel: Float = 0
     @Published var recordingDuration: TimeInterval = 0
     @Published var hotkeyMode: HotkeyService.HotkeyMode?
@@ -98,6 +104,7 @@ final class DictationViewModel: ObservableObject {
     @Published var actionFeedbackMessage: String?
     @Published var actionFeedbackIcon: String?
     @Published var actionFeedbackIsError: Bool = false
+    @Published var recordingCancelWarningMessage: String?
     @Published var activeAppIcon: NSImage?
     private var actionDisplayDuration: TimeInterval = 3.5
 
@@ -160,6 +167,7 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
+    private var recordingCancelWarningResetTask: Task<Void, Never>?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -180,6 +188,7 @@ final class DictationViewModel: ObservableObject {
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
+    private var recordingCancelWarningDuration: Duration = .seconds(2)
 
     init(
         audioRecordingService: AudioRecordingService,
@@ -450,7 +459,7 @@ final class DictationViewModel: ObservableObject {
         }
 
         hotkeyService.onCancelPressed = { [weak self] in
-            self?.cancelCurrentOperation()
+            self?.handleCancelHotkey()
         }
 
         // Sync profile hotkeys whenever profiles change
@@ -503,6 +512,40 @@ final class DictationViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
+    func handleCancelHotkey() {
+        switch state {
+        case .recording:
+            if recordingCancelWarningMessage == nil {
+                showRecordingCancelWarning()
+            } else {
+                clearRecordingCancelWarning()
+                cancelCurrentOperation()
+            }
+        case .processing:
+            cancelCurrentOperation()
+        default:
+            break
+        }
+    }
+
+    private func showRecordingCancelWarning() {
+        recordingCancelWarningMessage = String(localized: "Press Esc again to cancel recording")
+        recordingCancelWarningResetTask?.cancel()
+        let duration = recordingCancelWarningDuration
+        recordingCancelWarningResetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: duration)
+            guard let self, !Task.isCancelled else { return }
+            self.recordingCancelWarningMessage = nil
+            self.recordingCancelWarningResetTask = nil
+        }
+    }
+
+    private func clearRecordingCancelWarning() {
+        recordingCancelWarningResetTask?.cancel()
+        recordingCancelWarningResetTask = nil
+        recordingCancelWarningMessage = nil
+    }
+
     private func cancelCurrentOperation() {
         let cancelledMessage = String(localized: "Cancelled")
 
@@ -545,6 +588,7 @@ final class DictationViewModel: ObservableObject {
         transcriptionTask = nil
         insertingResetTask?.cancel()
         insertingResetTask = nil
+        clearRecordingCancelWarning()
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
         urlResolutionTask?.cancel()
@@ -759,6 +803,7 @@ final class DictationViewModel: ObservableObject {
 
     private func stopDictation() {
         guard state == .recording, !isStopInFlight else { return }
+        clearRecordingCancelWarning()
         isStopInFlight = true
         Task {
             await finalizeStopDictation()
@@ -1053,6 +1098,7 @@ final class DictationViewModel: ObservableObject {
         lastStreamingParams = nil
         isStopInFlight = false
         activeDictationSessionID = nil
+        clearRecordingCancelWarning()
         state = .idle
         partialText = ""
         recordingStartTime = nil
@@ -1066,6 +1112,12 @@ final class DictationViewModel: ObservableObject {
         actionFeedbackIsError = false
         actionDisplayDuration = 3.5
     }
+
+#if DEBUG
+    func setRecordingCancelWarningDurationForTesting(_ duration: Duration) {
+        recordingCancelWarningDuration = duration
+    }
+#endif
 
     private func applyRuleMatch(
         _ match: RuleMatchResult?,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -398,10 +398,6 @@ final class DictationViewModel: ObservableObject {
         return nil
     }
 
-    isolated deinit {
-        recordingTimer?.invalidate()
-    }
-
     private func beginDictationSession(id: UUID) {
         activeDictationSessionID = id
         storeDictationSession(DictationSessionSnapshot(id: id, status: .recording, transcription: nil, error: nil))

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -160,7 +160,7 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
-    @Published private var recordingCancelWarningShownAt: Date?
+    @Published private(set) var recordingCancelWarningActive: Bool = false
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
@@ -181,10 +181,9 @@ final class DictationViewModel: ObservableObject {
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
-    private var recordingCancelWarningDuration: TimeInterval = 2
 
     var recordingCancelWarningMessage: String? {
-        guard state == .recording, isRecordingCancelWarningActive(referenceDate: Date()) else { return nil }
+        guard state == .recording, recordingCancelWarningActive else { return nil }
         return String(localized: "Press Esc again to cancel recording")
     }
 
@@ -444,14 +443,6 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func setupBindings() {
-        $state
-            .removeDuplicates()
-            .sink { [weak self] newState in
-                guard let self, newState != .recording else { return }
-                self.clearRecordingCancelWarning()
-            }
-            .store(in: &cancellables)
-
         hotkeyService.onDictationStart = { [weak self] in
             self?.startRecording()
         }
@@ -521,12 +512,11 @@ final class DictationViewModel: ObservableObject {
     func handleCancelHotkey() {
         switch state {
         case .recording:
-            let now = Date()
-            if isRecordingCancelWarningActive(referenceDate: now) {
-                clearRecordingCancelWarning()
+            if recordingCancelWarningActive {
+                recordingCancelWarningActive = false
                 cancelCurrentOperation()
             } else {
-                showRecordingCancelWarning(at: now)
+                recordingCancelWarningActive = true
             }
         case .processing:
             cancelCurrentOperation()
@@ -535,18 +525,8 @@ final class DictationViewModel: ObservableObject {
         }
     }
 
-    private func showRecordingCancelWarning(at date: Date) {
-        recordingCancelWarningShownAt = date
-    }
-
-    private func isRecordingCancelWarningActive(referenceDate: Date) -> Bool {
-        guard let shownAt = recordingCancelWarningShownAt else { return false }
-        return referenceDate.timeIntervalSince(shownAt) < recordingCancelWarningDuration
-    }
-
     private func clearRecordingCancelWarning() {
-        guard recordingCancelWarningShownAt != nil else { return }
-        recordingCancelWarningShownAt = nil
+        recordingCancelWarningActive = false
     }
 
     private func cancelCurrentOperation() {
@@ -1115,12 +1095,6 @@ final class DictationViewModel: ObservableObject {
         actionFeedbackIsError = false
         actionDisplayDuration = 3.5
     }
-
-#if DEBUG
-    func setRecordingCancelWarningDurationForTesting(_ duration: TimeInterval) {
-        recordingCancelWarningDuration = duration
-    }
-#endif
 
     private func applyRuleMatch(
         _ match: RuleMatchResult?,

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -39,13 +39,18 @@ struct MinimalIndicatorView: View {
         return viewModel.actionFeedbackMessage
     }
 
+    private var recordingCancelWarningMessage: String? {
+        guard viewModel.state == .recording else { return nil }
+        return viewModel.recordingCancelWarningMessage
+    }
+
     private var errorMessage: String? {
         guard case let .error(message) = viewModel.state else { return nil }
         return message
     }
 
     private var showsExpandedMessage: Bool {
-        actionFeedbackMessage != nil || errorMessage != nil
+        recordingCancelWarningMessage != nil || actionFeedbackMessage != nil || errorMessage != nil
     }
 
     private var currentWidth: CGFloat {
@@ -97,6 +102,10 @@ struct MinimalIndicatorView: View {
         }
 
     private var accessibilityLabel: String {
+        if let message = recordingCancelWarningMessage {
+            return message
+        }
+
         if let message = actionFeedbackMessage {
             return message
         }
@@ -122,6 +131,12 @@ struct MinimalIndicatorView: View {
                     text: message,
                     icon: "xmark.circle.fill",
                     iconColor: .red
+                )
+            } else if let message = recordingCancelWarningMessage {
+                compactMessage(
+                    text: message,
+                    icon: "exclamationmark.triangle.fill",
+                    iconColor: .yellow
                 )
             } else if let message = actionFeedbackMessage {
                 compactMessage(

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -28,6 +28,10 @@ struct NotchIndicatorView: View {
         viewModel.state == .inserting && viewModel.actionFeedbackMessage != nil
     }
 
+    private var hasRecordingCancelWarning: Bool {
+        viewModel.state == .recording && viewModel.recordingCancelWarningMessage != nil
+    }
+
     private var hasProcessingPhase: Bool {
         viewModel.state == .processing && viewModel.processingPhase != nil
     }
@@ -45,6 +49,7 @@ struct NotchIndicatorView: View {
     }
 
     private var expansionMode: NotchExpansionMode {
+        if hasRecordingCancelWarning { return .feedback }
         if transcriptBodyVisible { return .transcript }
         if hasActionFeedback { return .feedback }
         if hasProcessingPhase { return .processing }
@@ -71,6 +76,9 @@ struct NotchIndicatorView: View {
     }
 
     private var expandedBodyHeight: CGFloat {
+        if hasRecordingCancelWarning {
+            return feedbackBodyHeight
+        }
         if hasTranscriptSection {
             return transcriptBodyHeight
         }
@@ -156,6 +164,9 @@ struct NotchIndicatorView: View {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
+            if let warning = viewModel.recordingCancelWarningMessage {
+                return warning
+            }
             return String(localized: "Recording")
         case .processing:
             return String(localized: "Processing transcription")
@@ -188,7 +199,15 @@ struct NotchIndicatorView: View {
 
     @ViewBuilder
     private var expandedBodyContent: some View {
-        if hasTranscriptSection {
+        if hasRecordingCancelWarning {
+            IndicatorActionFeedback(
+                message: viewModel.recordingCancelWarningMessage ?? "",
+                icon: "exclamationmark.triangle.fill",
+                isError: false,
+                iconColor: .yellow,
+                contentPadding: contentPadding
+            )
+        } else if hasTranscriptSection {
             IndicatorExpandableText(
                 text: viewModel.partialText,
                 sizing: sizing,
@@ -207,6 +226,7 @@ struct NotchIndicatorView: View {
                 message: viewModel.actionFeedbackMessage ?? "",
                 icon: viewModel.actionFeedbackIcon,
                 isError: viewModel.actionFeedbackIsError,
+                iconColor: nil,
                 contentPadding: contentPadding
             )
         } else {

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -19,15 +19,20 @@ struct OverlayIndicatorView: View {
         viewModel.state == .inserting && viewModel.actionFeedbackMessage != nil
     }
 
+    private var hasRecordingCancelWarning: Bool {
+        viewModel.state == .recording && viewModel.recordingCancelWarningMessage != nil
+    }
+
     private var showTranscriptPreview: Bool {
         viewModel.indicatorTranscriptPreviewEnabled && !suppressStreamingText
     }
 
     private var isExpanded: Bool {
-        textExpanded || hasActionFeedback
+        textExpanded || hasActionFeedback || hasRecordingCancelWarning
     }
 
     private var currentWidth: CGFloat {
+        if hasRecordingCancelWarning { return max(closedWidth, 340) }
         if textExpanded { return max(closedWidth, 400) }
         if hasActionFeedback { return max(closedWidth, 340) }
         return closedWidth
@@ -98,7 +103,15 @@ struct OverlayIndicatorView: View {
 
     @ViewBuilder
     private var expandableContent: some View {
-        if isTop {
+        if hasRecordingCancelWarning {
+            IndicatorActionFeedback(
+                message: viewModel.recordingCancelWarningMessage ?? "",
+                icon: "exclamationmark.triangle.fill",
+                isError: false,
+                iconColor: .yellow,
+                contentPadding: contentPadding
+            )
+        } else if isTop {
             // Top position: text expands downward, action feedback below text
             if viewModel.state == .recording, showTranscriptPreview {
                 IndicatorExpandableText(
@@ -122,6 +135,7 @@ struct OverlayIndicatorView: View {
                     message: viewModel.actionFeedbackMessage ?? "",
                     icon: viewModel.actionFeedbackIcon,
                     isError: viewModel.actionFeedbackIsError,
+                    iconColor: nil,
                     contentPadding: contentPadding
                 )
             }
@@ -132,6 +146,7 @@ struct OverlayIndicatorView: View {
                     message: viewModel.actionFeedbackMessage ?? "",
                     icon: viewModel.actionFeedbackIcon,
                     isError: viewModel.actionFeedbackIsError,
+                    iconColor: nil,
                     contentPadding: contentPadding
                 )
                 Divider().background(Color.white.opacity(0.1))

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -232,12 +232,13 @@ struct IndicatorActionFeedback: View {
     let message: String
     let icon: String?
     let isError: Bool
+    let iconColor: Color?
     let contentPadding: CGFloat
 
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: icon ?? (isError ? "xmark.circle.fill" : "checkmark.circle.fill"))
-                .foregroundStyle(isError ? .red : .green)
+                .foregroundStyle(iconColor ?? (isError ? .red : .green))
                 .font(.system(size: 16))
                 .accessibilityHidden(true)
             Text(message)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1930,7 +1930,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.dictationViewModel.recordingCancelWarningMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
         )
-        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
+        )
     }
 
     @MainActor
@@ -1980,7 +1983,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.dictationViewModel.recordingCancelWarningMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
         )
-        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
+        )
     }
 
     @MainActor

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1930,10 +1930,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.dictationViewModel.recordingCancelWarningMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
         )
-        XCTAssertEqual(
-            context.dictationViewModel.actionFeedbackMessage,
-            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
-        )
+        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
     }
 
     @MainActor
@@ -1983,10 +1980,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.dictationViewModel.recordingCancelWarningMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
         )
-        XCTAssertEqual(
-            context.dictationViewModel.actionFeedbackMessage,
-            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
-        )
+        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
     }
 
     @MainActor

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1958,32 +1958,6 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testHandleCancelHotkey_secondEscapeAfterExpiryRequiresConfirmationAgain() async throws {
-        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
-        var dictationContext: DictationContext?
-        defer {
-            dictationContext = nil
-            TestSupport.remove(appSupportDirectory)
-        }
-
-        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
-        let context = try XCTUnwrap(dictationContext)
-        context.dictationViewModel.state = .recording
-        context.dictationViewModel.setRecordingCancelWarningDurationForTesting(0.05)
-
-        context.dictationViewModel.handleCancelHotkey()
-        try await Task.sleep(for: .milliseconds(120))
-        context.dictationViewModel.handleCancelHotkey()
-
-        XCTAssertEqual(context.dictationViewModel.state, .recording)
-        XCTAssertEqual(
-            context.dictationViewModel.recordingCancelWarningMessage,
-            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
-        )
-        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
-    }
-
-    @MainActor
     func testHandleCancelHotkey_processingStillCancelsImmediately() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1969,7 +1969,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
         context.dictationViewModel.state = .recording
-        context.dictationViewModel.setRecordingCancelWarningDurationForTesting(.milliseconds(50))
+        context.dictationViewModel.setRecordingCancelWarningDurationForTesting(0.05)
 
         context.dictationViewModel.handleCancelHotkey()
         try await Task.sleep(for: .milliseconds(120))

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1909,6 +1909,121 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(plugin.selectedModelId, "alpha")
     }
+
+    @MainActor
+    func testHandleCancelHotkey_firstEscapeDuringRecordingShowsWarningWithoutCancelling() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.state = .recording
+
+        context.dictationViewModel.handleCancelHotkey()
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertEqual(
+            context.dictationViewModel.recordingCancelWarningMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
+        )
+        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
+    }
+
+    @MainActor
+    func testHandleCancelHotkey_secondEscapeDuringRecordingCancels() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.state = .recording
+
+        context.dictationViewModel.handleCancelHotkey()
+        context.dictationViewModel.handleCancelHotkey()
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertNil(context.dictationViewModel.recordingCancelWarningMessage)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Cancelled")
+        )
+    }
+
+    @MainActor
+    func testHandleCancelHotkey_secondEscapeAfterExpiryRequiresConfirmationAgain() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.state = .recording
+        context.dictationViewModel.setRecordingCancelWarningDurationForTesting(.milliseconds(50))
+
+        context.dictationViewModel.handleCancelHotkey()
+        try await Task.sleep(for: .milliseconds(120))
+        context.dictationViewModel.handleCancelHotkey()
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertEqual(
+            context.dictationViewModel.recordingCancelWarningMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
+        )
+        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
+    }
+
+    @MainActor
+    func testHandleCancelHotkey_processingStillCancelsImmediately() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.state = .processing
+
+        context.dictationViewModel.handleCancelHotkey()
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertNil(context.dictationViewModel.recordingCancelWarningMessage)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Cancelled")
+        )
+    }
+
+    @MainActor
+    func testRecordingCancelWarningClearsWhenStateLeavesRecording() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.state = .recording
+
+        context.dictationViewModel.handleCancelHotkey()
+        context.dictationViewModel.state = .processing
+
+        XCTAssertNil(context.dictationViewModel.recordingCancelWarningMessage)
+    }
 }
 
 final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {
@@ -1936,6 +2051,22 @@ final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {
 }
 
 final class HotkeyServiceCompatibilityTests: XCTestCase {
+    @MainActor
+    func testEscapeKeyStillInvokesCancelHandlerWithoutSuppression() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        var cancelCount = 0
+        service.onCancelPressed = {
+            cancelCount += 1
+        }
+
+        let escape = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+
+        XCTAssertFalse(service.processEventForTesting(escape, source: .monitor))
+        XCTAssertEqual(cancelCount, 1)
+    }
+
     @MainActor
     func testMonitorFallbackStartsToggleHotkey() throws {
         let service = HotkeyService()


### PR DESCRIPTION
## Summary
- Add a two-step Esc confirmation before cancelling an active recording.
- Show a recording warning in all indicators and localize the new message.
- Keep immediate Esc cancellation for processing and preserve existing cancel behavior.

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_firstEscapeDuringRecordingShowsWarningWithoutCancelling -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_secondEscapeDuringRecordingCancels -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_secondEscapeAfterExpiryRequiresConfirmationAgain -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_processingStillCancelsImmediately -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testRecordingCancelWarningClearsWhenStateLeavesRecording -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests/testEscapeKeyStillInvokesCancelHandlerWithoutSuppression`
- Result: 6/6 selected tests passed

Closes #246