### PR TITLE
Fix plugin SDK compatibility handling

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -295,6 +295,7 @@ jobs:
               release = {
                   "version": version,
                   "minHostVersion": manifest.get("minHostVersion", "0.9.0"),
+                  "sdkCompatibilityVersion": manifest.get("sdkCompatibilityVersion"),
                   "size": size,
                   "downloadURL": download_url,
               }
@@ -309,6 +310,7 @@ jobs:
 
               version_value = plugin.get("version")
               min_host = plugin.get("minHostVersion")
+              sdk_compat = plugin.get("sdkCompatibilityVersion")
               size_value = plugin.get("size")
               download_value = plugin.get("downloadURL")
               if not all([version_value, min_host, size_value, download_value]):
@@ -317,6 +319,7 @@ jobs:
               legacy = {
                   "version": version_value,
                   "minHostVersion": min_host,
+                  "sdkCompatibilityVersion": sdk_compat,
                   "size": size_value,
                   "downloadURL": download_value,
               }
@@ -328,6 +331,10 @@ jobs:
           def sync_legacy_fields(plugin, release):
               plugin["version"] = release["version"]
               plugin["minHostVersion"] = release["minHostVersion"]
+              if release.get("sdkCompatibilityVersion") is not None:
+                  plugin["sdkCompatibilityVersion"] = release["sdkCompatibilityVersion"]
+              else:
+                  plugin.pop("sdkCompatibilityVersion", None)
               plugin["size"] = release["size"]
               plugin["downloadURL"] = release["downloadURL"]
 

--- a/Plugins/AssemblyAIPlugin/manifest.json
+++ b/Plugins/AssemblyAIPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "AssemblyAI",
     "version": "1.0.4",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via AssemblyAI API with real-time WebSocket streaming. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "AssemblyAIPlugin"
+    "principalClass": "AssemblyAIPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/CerebrasPlugin/manifest.json
+++ b/Plugins/CerebrasPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Cerebras",
     "version": "1.0.1",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Ultra-fast LLM inference via Cerebras API. Up to 3,000 tokens/sec. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "llm",
     "iconSystemName": "bolt.fill",
-    "requiresAPIKey": true,
-    "principalClass": "CerebrasPlugin"
+    "principalClass": "CerebrasPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/ClaudePlugin/manifest.json
+++ b/Plugins/ClaudePlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Claude",
     "version": "1.0.0",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "LLM provider via Anthropic Claude API. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "llm",
     "iconSystemName": "brain.head.profile",
-    "requiresAPIKey": true,
-    "principalClass": "ClaudePlugin"
+    "principalClass": "ClaudePlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/CloudflareASRPlugin/manifest.json
+++ b/Plugins/CloudflareASRPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Cloudflare ASR",
     "version": "1.0.0",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "yunluyl",
     "description": "OpenAI-compatible transcription through a Cloudflare tunnel with service token authentication. Credentials stored in macOS Keychain.",

--- a/Plugins/CoherePlugin/manifest.json
+++ b/Plugins/CoherePlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Cohere",
     "version": "1.0.0",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via Cohere Transcribe API. State-of-the-art accuracy across 14 languages. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "CoherePlugin"
+    "principalClass": "CoherePlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/DeepgramPlugin/manifest.json
+++ b/Plugins/DeepgramPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Deepgram",
     "version": "1.0.4",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via Deepgram API with real-time WebSocket streaming. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "DeepgramPlugin"
+    "principalClass": "DeepgramPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/ElevenLabsPlugin/manifest.json
+++ b/Plugins/ElevenLabsPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "ElevenLabs",
     "version": "1.0.0",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via ElevenLabs Scribe API with real-time WebSocket streaming.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "ElevenLabsPlugin"
+    "principalClass": "ElevenLabsPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/FileMemoryPlugin/manifest.json
+++ b/Plugins/FileMemoryPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "File Memory",
     "version": "1.0.0",
     "minHostVersion": "0.14.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Store memories as local JSON files with text-based search. Fully offline, no API key required.",

--- a/Plugins/FireworksPlugin/manifest.json
+++ b/Plugins/FireworksPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Fireworks AI",
     "version": "1.0.1",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription and LLM via Fireworks AI. Streaming transcription, fast inference, requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "flame.fill",
-    "requiresAPIKey": true,
-    "principalClass": "FireworksPlugin"
+    "principalClass": "FireworksPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/GeminiPlugin/manifest.json
+++ b/Plugins/GeminiPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Gemini",
     "version": "1.0.12",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "LLM provider via Google Gemini API. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "llm",
     "iconSystemName": "sparkles",
-    "requiresAPIKey": true,
-    "principalClass": "GeminiPlugin"
+    "principalClass": "GeminiPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/Gemma4Plugin/manifest.json
+++ b/Plugins/Gemma4Plugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Gemma 4",
     "version": "1.0.1",
     "minHostVersion": "0.11.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Local LLM powered by Google Gemma 4 on Apple Silicon via MLX. No API key required.",

--- a/Plugins/GladiaPlugin/manifest.json
+++ b/Plugins/GladiaPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Gladia",
     "version": "1.0.0",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via Gladia Solaria API with real-time WebSocket streaming.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "GladiaPlugin"
+    "principalClass": "GladiaPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/GoogleCloudSTTPlugin/manifest.json
+++ b/Plugins/GoogleCloudSTTPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Google Cloud Speech-to-Text",
     "version": "1.0.0",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via Google Cloud Speech-to-Text using a service-account JSON key. Handles long recordings by chunking audio into multiple recognize requests.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "globe.badge.chevron.backward",
-    "requiresAPIKey": true,
-    "principalClass": "GoogleCloudSTTPlugin"
+    "principalClass": "GoogleCloudSTTPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/Plugins/GranitePlugin/GranitePlugin.swift
@@ -9,7 +9,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(GranitePlugin)
-final class GranitePlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.granite"
     static let pluginName = "Granite Speech"
 

--- a/Plugins/GranitePlugin/manifest.json
+++ b/Plugins/GranitePlugin/manifest.json
@@ -3,8 +3,11 @@
     "name": "Granite Speech",
     "version": "1.0.2",
     "minHostVersion": "1.2.1",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
-    "supportedArchitectures": ["arm64"],
+    "supportedArchitectures": [
+        "arm64"
+    ],
     "author": "TypeWhisper",
     "description": "Local speech-to-text and translation by IBM, powered by MLX on Apple Silicon. 6 languages with bidirectional translation.",
     "descriptions": {

--- a/Plugins/GroqPlugin/manifest.json
+++ b/Plugins/GroqPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Groq",
     "version": "1.0.15",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription and LLM via Groq API. Fast inference, requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "bolt.fill",
-    "requiresAPIKey": true,
-    "principalClass": "GroqPlugin"
+    "principalClass": "GroqPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/LinearPlugin/manifest.json
+++ b/Plugins/LinearPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Linear",
     "version": "1.0.10",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Create Linear issues from transcribed or processed text. Requires a Linear API key.",
@@ -11,6 +12,6 @@
     },
     "category": "action",
     "iconSystemName": "list.bullet.rectangle",
-    "requiresAPIKey": true,
-    "principalClass": "LinearPlugin"
+    "principalClass": "LinearPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/LiveTranscriptPlugin/manifest.json
+++ b/Plugins/LiveTranscriptPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Live Transcript",
     "version": "1.0.3",
     "minHostVersion": "1.1.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Show a floating live transcript window during recording.",

--- a/Plugins/ObsidianPlugin/manifest.json
+++ b/Plugins/ObsidianPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Obsidian",
     "version": "1.0.0",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Save transcriptions to your Obsidian vault as Markdown notes. Supports daily notes, frontmatter, and auto-export.",

--- a/Plugins/OpenAICompatiblePlugin/manifest.json
+++ b/Plugins/OpenAICompatiblePlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "OpenAI Compatible",
     "version": "1.0.10",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Connect to any OpenAI-compatible API server for transcription and LLM. Works with Ollama, LM Studio, vLLM, and more.",

--- a/Plugins/OpenAIPlugin/manifest.json
+++ b/Plugins/OpenAIPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "OpenAI / ChatGPT",
     "version": "1.1.1",
     "minHostVersion": "1.2.2",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription plus OpenAI/ChatGPT prompts. Use an API key or ChatGPT login.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "brain",
-    "requiresAPIKey": false,
-    "principalClass": "OpenAIPlugin"
+    "principalClass": "OpenAIPlugin",
+    "requiresAPIKey": false
 }

--- a/Plugins/OpenAIVectorMemoryPlugin/manifest.json
+++ b/Plugins/OpenAIVectorMemoryPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "OpenAI Vector Memory",
     "version": "1.0.0",
     "minHostVersion": "0.14.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Store and search memories using the OpenAI Vector Store API with semantic embeddings.",

--- a/Plugins/OpenRouterPlugin/manifest.json
+++ b/Plugins/OpenRouterPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "OpenRouter",
     "version": "1.0.1",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Access 300+ LLMs from OpenAI, Anthropic, Meta, Google and more via OpenRouter. Shows model pricing and account balance. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "llm",
     "iconSystemName": "globe",
-    "requiresAPIKey": true,
-    "principalClass": "OpenRouterPlugin"
+    "principalClass": "OpenRouterPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/ParakeetPlugin/manifest.json
+++ b/Plugins/ParakeetPlugin/manifest.json
@@ -3,8 +3,11 @@
     "name": "Parakeet",
     "version": "1.2.4",
     "minHostVersion": "1.2.1",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
-    "supportedArchitectures": ["arm64"],
+    "supportedArchitectures": [
+        "arm64"
+    ],
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by NVIDIA Parakeet TDT. Fast and accurate, 25 languages.",
     "descriptions": {

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 

--- a/Plugins/Qwen3Plugin/manifest.json
+++ b/Plugins/Qwen3Plugin/manifest.json
@@ -3,8 +3,11 @@
     "name": "Qwen3 ASR",
     "version": "1.0.16",
     "minHostVersion": "1.2.1",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
-    "supportedArchitectures": ["arm64"],
+    "supportedArchitectures": [
+        "arm64"
+    ],
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by MLX on Apple Silicon. 30 languages, no API key required.",
     "descriptions": {

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -44,6 +44,7 @@ Plugins can subscribe to events without modifying the transcription pipeline:
     "name": "My Plugin",
     "version": "1.0.0",
     "minHostVersion": "1.0.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": ["arm64"],
     "author": "Your Name",

--- a/Plugins/ScriptPlugin/manifest.json
+++ b/Plugins/ScriptPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Script Runner",
     "version": "1.1.0",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Post-process transcribed text through custom shell scripts. Pass text via stdin, get results via stdout.",

--- a/Plugins/SonioxPlugin/manifest.json
+++ b/Plugins/SonioxPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Soniox",
     "version": "1.0.0",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via Soniox API with real-time WebSocket streaming and translation support. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "SonioxPlugin"
+    "principalClass": "SonioxPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -9,7 +9,7 @@ import os
 
 @available(macOS 26, *)
 @objc(SpeechAnalyzerPlugin)
-final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.speechanalyzer"
     static let pluginName = "Apple Speech"
 

--- a/Plugins/SpeechAnalyzerPlugin/manifest.json
+++ b/Plugins/SpeechAnalyzerPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Apple Speech",
     "version": "1.0.9",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "26.0",
     "author": "TypeWhisper",
     "description": "On-device speech recognition using Apple's Speech framework. Requires macOS 26+, streaming support.",

--- a/Plugins/SpeechmaticsPlugin/manifest.json
+++ b/Plugins/SpeechmaticsPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Speechmatics",
     "version": "1.0.0",
     "minHostVersion": "0.12.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Cloud transcription via Speechmatics API with real-time WebSocket streaming. Requires API key.",
@@ -11,6 +12,6 @@
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",
-    "requiresAPIKey": true,
-    "principalClass": "SpeechmaticsPlugin"
+    "principalClass": "SpeechmaticsPlugin",
+    "requiresAPIKey": true
 }

--- a/Plugins/SystemTTSPlugin/manifest.json
+++ b/Plugins/SystemTTSPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "System Voice",
     "version": "1.0.0",
     "minHostVersion": "1.3.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Text-to-speech via the built-in macOS AVSpeechSynthesizer voices for spoken feedback.",
@@ -11,6 +12,6 @@
     },
     "category": "tts",
     "iconSystemName": "speaker.wave.2.fill",
-    "requiresAPIKey": false,
-    "principalClass": "SystemTTSPlugin"
+    "principalClass": "SystemTTSPlugin",
+    "requiresAPIKey": false
 }

--- a/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -9,7 +9,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(VoxtralPlugin)
-final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.voxtral"
     static let pluginName = "Voxtral"
 

--- a/Plugins/VoxtralPlugin/manifest.json
+++ b/Plugins/VoxtralPlugin/manifest.json
@@ -3,8 +3,11 @@
     "name": "Voxtral",
     "version": "1.0.6",
     "minHostVersion": "1.2.1",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
-    "supportedArchitectures": ["arm64"],
+    "supportedArchitectures": [
+        "arm64"
+    ],
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by Voxtral MLX on Apple Silicon. Fast and accurate.",
     "descriptions": {

--- a/Plugins/WebhookPlugin/manifest.json
+++ b/Plugins/WebhookPlugin/manifest.json
@@ -3,6 +3,7 @@
     "name": "Webhook Notifications",
     "version": "1.0.9",
     "minHostVersion": "0.9.0",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Send transcribed or processed text to any webhook URL via HTTP POST.",

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -6,7 +6,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(WhisperKitPlugin)
-final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.whisperkit"
     static let pluginName = "WhisperKit"
 

--- a/Plugins/WhisperKitPlugin/manifest.json
+++ b/Plugins/WhisperKitPlugin/manifest.json
@@ -3,8 +3,11 @@
     "name": "WhisperKit",
     "version": "1.0.16",
     "minHostVersion": "1.2.1",
+    "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
-    "supportedArchitectures": ["arm64"],
+    "supportedArchitectures": [
+        "arm64"
+    ],
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by WhisperKit. 7 model sizes, 99 languages, streaming support.",
     "descriptions": {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -322,7 +322,7 @@ final class APIHandlers: @unchecked Sendable {
     ///
     /// - both nil -> use GUI selection
     /// - engine only -> use that engine's default model
-    /// - model only -> infer engine by scanning `availableModels` across all engines
+    /// - model only -> infer engine by scanning the model catalog across all engines
     /// - both set   -> use as-is
     ///
     /// Also enforces configuration: an unconfigured engine returns 409 by default (to
@@ -348,7 +348,7 @@ final class APIHandlers: @unchecked Sendable {
             resolvedEngineId = match.providerId
         } else if let model {
             let matches = engines.filter { engine in
-                engine.availableModels.contains(where: { $0.id == model })
+                engine.modelCatalog.contains(where: { $0.id == model })
             }
             if matches.isEmpty {
                 return .reject(.error(status: 400, message: "Unknown model '\(model)'"))
@@ -368,7 +368,7 @@ final class APIHandlers: @unchecked Sendable {
         if let engineId = resolvedEngineId,
            let model,
            let plugin = engines.first(where: { $0.providerId == engineId }) {
-            let ids = Set(plugin.availableModels.map { $0.id })
+            let ids = Set(plugin.modelCatalog.map { $0.id })
             if !ids.isEmpty, !ids.contains(model) {
                 return .reject(.error(
                     status: 400,
@@ -459,7 +459,7 @@ final class APIHandlers: @unchecked Sendable {
 
         for engine in PluginManager.shared.transcriptionEngines {
             let isSelected = engine.providerId == selectedProviderId
-            for model in engine.availableModels {
+            for model in engine.modelCatalog {
                 models.append(ModelEntry(
                     id: model.id,
                     engine: engine.providerId,

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -141,12 +141,12 @@ final class ModelManagerService: ObservableObject {
               let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else { return nil }
 
         if let modelId = cloudModelOverride,
-           let model = plugin.availableModels.first(where: { $0.id == modelId })
+           let model = plugin.modelCatalog.first(where: { $0.id == modelId })
             ?? plugin.transcriptionModels.first(where: { $0.id == modelId }) {
             return model.displayName
         }
         if let selectedId = plugin.selectedModelId,
-           let model = plugin.availableModels.first(where: { $0.id == selectedId })
+           let model = plugin.modelCatalog.first(where: { $0.id == selectedId })
             ?? plugin.transcriptionModels.first(where: { $0.id == selectedId }) {
             return model.displayName
         }

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -217,6 +217,13 @@ final class PluginManager: ObservableObject {
         manifest.isCompatibleWithCurrentEnvironment
     }
 
+    func isManifestSDKCompatible(_ manifest: PluginManifest, isBundled: Bool) -> Bool {
+        PluginSDKCompatibility.isCompatible(
+            manifestVersion: manifest.sdkCompatibilityVersion,
+            isBundled: isBundled
+        )
+    }
+
     init(appSupportDirectory: URL = AppConstants.appSupportDirectory) {
         self.pluginsDirectory = appSupportDirectory
             .appendingPathComponent("Plugins", isDirectory: true)
@@ -263,6 +270,7 @@ final class PluginManager: ObservableObject {
 
     func loadPlugin(at url: URL) throws {
         let manifestURL = url.appendingPathComponent("Contents/Resources/manifest.json")
+        let isBundledSource = Bundle.main.builtInPlugInsURL.map { url.path.hasPrefix($0.path) } ?? false
         let data: Data
         do {
             data = try Data(contentsOf: manifestURL)
@@ -288,6 +296,17 @@ final class PluginManager: ObservableObject {
             ) ?? "is not compatible with this Mac"
             logger.info(
                 "Skipping plugin \(manifest.id, privacy: .public) on \(architecture, privacy: .public): \(reason, privacy: .public)"
+            )
+            return
+        }
+
+        if !isManifestSDKCompatible(manifest, isBundled: isBundledSource) {
+            let reason = PluginSDKCompatibility.incompatibilityReason(
+                manifestVersion: manifest.sdkCompatibilityVersion,
+                isBundled: isBundledSource
+            ) ?? "is not compatible with this TypeWhisper build"
+            logger.info(
+                "Skipping plugin \(manifest.id, privacy: .public): \(reason, privacy: .public)"
             )
             return
         }
@@ -347,9 +366,8 @@ final class PluginManager: ObservableObject {
             isEnabled = stored
         } else {
             // Auto-enable bundled plugins on first encounter
-            let isBundled = Bundle.main.builtInPlugInsURL.map { url.path.hasPrefix($0.path) } ?? false
-            isEnabled = isBundled
-            if isBundled {
+            isEnabled = isBundledSource
+            if isBundledSource {
                 UserDefaults.standard.set(true, forKey: enabledKey)
             }
         }

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -76,6 +76,7 @@ struct RegistryPlugin: Codable, Identifiable {
     let name: String
     let version: String
     let minHostVersion: String
+    let sdkCompatibilityVersion: String?
     let minOSVersion: String?
     let supportedArchitectures: [String]?
     let author: String
@@ -108,6 +109,7 @@ struct RegistryPlugin: Codable, Identifiable {
 struct RegistryPluginRelease: Decodable, Equatable {
     let version: String
     let minHostVersion: String
+    let sdkCompatibilityVersion: String?
     let minOSVersion: String?
     let supportedArchitectures: [String]?
     let size: Int64
@@ -117,10 +119,12 @@ struct RegistryPluginRelease: Decodable, Equatable {
 
     func isCompatible(
         withAppVersion appVersion: String,
+        sdkCompatibilityVersion: String,
         currentOSVersion: OperatingSystemVersion,
         architecture: String
     ) -> Bool {
         PluginRegistryService.compareVersions(minHostVersion, appVersion) != .orderedDescending
+            && self.sdkCompatibilityVersion == sdkCompatibilityVersion
             && PluginCompatibility.isCompatible(
                 minOSVersion: minOSVersion,
                 supportedArchitectures: supportedArchitectures,
@@ -133,6 +137,7 @@ struct RegistryPluginRelease: Decodable, Equatable {
 private struct LegacyRegistryRelease: Decodable {
     let version: String?
     let minHostVersion: String?
+    let sdkCompatibilityVersion: String?
     let minOSVersion: String?
     let supportedArchitectures: [String]?
     let size: Int64?
@@ -165,6 +170,7 @@ struct RegistryPluginEntry: Decodable {
         case releases
         case version
         case minHostVersion
+        case sdkCompatibilityVersion
         case minOSVersion
         case supportedArchitectures
         case size
@@ -201,10 +207,11 @@ struct RegistryPluginEntry: Decodable {
             return
         }
 
-        releases = [
+            releases = [
             RegistryPluginRelease(
                 version: version,
                 minHostVersion: minHostVersion,
+                sdkCompatibilityVersion: legacy.sdkCompatibilityVersion,
                 minOSVersion: legacy.minOSVersion,
                 supportedArchitectures: legacy.supportedArchitectures,
                 size: size,
@@ -217,6 +224,7 @@ struct RegistryPluginEntry: Decodable {
 
     func resolvedPlugin(
         appVersion: String,
+        sdkCompatibilityVersion: String,
         currentOSVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
         architecture: String = RuntimeArchitecture.current
     ) -> RegistryPlugin? {
@@ -224,6 +232,7 @@ struct RegistryPluginEntry: Decodable {
             .filter {
                 $0.isCompatible(
                     withAppVersion: appVersion,
+                    sdkCompatibilityVersion: sdkCompatibilityVersion,
                     currentOSVersion: currentOSVersion,
                     architecture: architecture
                 )
@@ -239,6 +248,7 @@ struct RegistryPluginEntry: Decodable {
             name: name,
             version: compatibleRelease.version,
             minHostVersion: compatibleRelease.minHostVersion,
+            sdkCompatibilityVersion: compatibleRelease.sdkCompatibilityVersion,
             minOSVersion: compatibleRelease.minOSVersion,
             supportedArchitectures: compatibleRelease.supportedArchitectures,
             author: author,
@@ -302,12 +312,14 @@ struct PluginRegistryResponse: Decodable {
 
     func resolvedPlugins(
         appVersion: String,
+        sdkCompatibilityVersion: String,
         currentOSVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
         architecture: String = RuntimeArchitecture.current
     ) -> [RegistryPlugin] {
         plugins.compactMap {
             $0.resolvedPlugin(
                 appVersion: appVersion,
+                sdkCompatibilityVersion: sdkCompatibilityVersion,
                 currentOSVersion: currentOSVersion,
                 architecture: architecture
             )
@@ -390,7 +402,10 @@ final class PluginRegistryService: ObservableObject {
             let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
 
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
-            registry = response.resolvedPlugins(appVersion: appVersion)
+            registry = response.resolvedPlugins(
+                appVersion: appVersion,
+                sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion
+            )
             lastFetchDate = Date()
             fetchState = .loaded
             logger.info("Fetched \(self.registry.count) plugin(s) from registry")

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -22,6 +22,7 @@ Create `Contents/Resources/manifest.json` in your bundle:
   "name": "My Plugin",
   "version": "1.0.0",
   "minHostVersion": "1.0.0",
+  "sdkCompatibilityVersion": "v1",
   "minOSVersion": "14.0",
   "author": "Your Name",
   "principalClass": "MyPlugin"
@@ -31,6 +32,7 @@ Create `Contents/Resources/manifest.json` in your bundle:
 - `id` - Unique reverse-domain identifier
 - `principalClass` - Must match `@objc(ClassName)` on your plugin class
 - `minHostVersion` - Minimum TypeWhisper version required
+- `sdkCompatibilityVersion` - Must match `PluginSDKCompatibility.currentVersion` for marketplace/external plugins
 - `minOSVersion` - Minimum macOS version required (plugin is skipped on older systems)
 
 ### 3. Implement the Plugin
@@ -120,6 +122,21 @@ final class MyTranscriptionEngine: NSObject, TranscriptionEnginePlugin, @uncheck
         // audio.duration  - TimeInterval
         let text = "transcribed text"
         return PluginTranscriptionResult(text: text)
+    }
+}
+```
+
+If your engine exposes a wider selectable catalog than its currently loaded
+`transcriptionModels`, add the optional `TranscriptionModelCatalogProviding`
+conformance:
+
+```swift
+extension MyTranscriptionEngine: TranscriptionModelCatalogProviding {
+    var availableModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: "small", displayName: "Small"),
+            PluginModelInfo(id: "large", displayName: "Large")
+        ]
     }
 }
 ```
@@ -443,6 +460,7 @@ let wavData = PluginWavEncoder.encode(samples, sampleRate: 16000)
 | `name` | Yes | Display name |
 | `version` | Yes | Semver string (e.g. `1.0.0`) |
 | `minHostVersion` | No | Minimum TypeWhisper version (e.g. `1.0.0`) |
+| `sdkCompatibilityVersion` | No | Exact plugin SDK compatibility line. Marketplace/external plugins must match `PluginSDKCompatibility.currentVersion`. |
 | `minOSVersion` | No | Minimum macOS version (e.g. `14.0`, `26.0`). Plugin is skipped on older systems. |
 | `author` | No | Author name |
 | `principalClass` | Yes | Objective-C class name, must match `@objc(Name)` |
@@ -466,6 +484,7 @@ Registry entry format:
   "name": "My Plugin",
   "version": "1.0.0",
   "minHostVersion": "1.0.0",
+  "sdkCompatibilityVersion": "v1",
   "minOSVersion": "14.0",
   "author": "Your Name",
   "description": "What your plugin does.",

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
@@ -5,6 +5,7 @@ public struct PluginManifest: Codable, Equatable, Sendable {
     public let name: String
     public let version: String
     public let minHostVersion: String?
+    public let sdkCompatibilityVersion: String?
     public let minOSVersion: String?
     public let supportedArchitectures: [String]?
     public let author: String?
@@ -18,6 +19,7 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         name: String,
         version: String,
         minHostVersion: String? = nil,
+        sdkCompatibilityVersion: String? = nil,
         minOSVersion: String? = nil,
         supportedArchitectures: [String]? = nil,
         author: String? = nil,
@@ -30,6 +32,7 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         self.name = name
         self.version = version
         self.minHostVersion = minHostVersion
+        self.sdkCompatibilityVersion = sdkCompatibilityVersion
         self.minOSVersion = minOSVersion
         self.supportedArchitectures = supportedArchitectures
         self.author = author

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -296,12 +296,6 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var providerDisplayName: String { get }
     var isConfigured: Bool { get }
     var transcriptionModels: [PluginModelInfo] { get }
-    /// Full catalogue this engine can select from, including variants not currently
-    /// downloaded or loaded. Default implementation returns `transcriptionModels`, so
-    /// existing plugins keep their current behaviour. Plugins that hide un-loaded
-    /// variants from `transcriptionModels` (to keep the GUI model picker quiet) should
-    /// override this to surface the full catalogue to API consumers like /v1/models.
-    var availableModels: [PluginModelInfo] { get }
     var selectedModelId: String? { get }
     func selectModel(_ modelId: String)
     var supportsTranslation: Bool { get }
@@ -313,8 +307,39 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
                     onProgress: @Sendable @escaping (String) -> Bool) async throws -> PluginTranscriptionResult
 }
 
+/// Optional model-catalog extension for engines that expose a broader model list than
+/// their currently active `transcriptionModels`. Kept separate to preserve binary
+/// compatibility with existing transcription plugins.
+public protocol TranscriptionModelCatalogProviding: TranscriptionEnginePlugin {
+    var availableModels: [PluginModelInfo] { get }
+}
+
 public extension TranscriptionEnginePlugin {
-    var availableModels: [PluginModelInfo] { transcriptionModels }
+    var modelCatalog: [PluginModelInfo] {
+        (self as? any TranscriptionModelCatalogProviding)?.availableModels ?? transcriptionModels
+    }
+}
+
+public enum PluginSDKCompatibility {
+    /// Opaque compatibility line for plugin ABI/protocol contracts. Bump only when the
+    /// host and marketplace plugins must be rebuilt together against a new SDK contract.
+    public static let currentVersion = "v1"
+
+    public static func isCompatible(manifestVersion: String?, isBundled: Bool) -> Bool {
+        guard !isBundled else { return true }
+        return manifestVersion == currentVersion
+    }
+
+    public static func incompatibilityReason(manifestVersion: String?, isBundled: Bool) -> String? {
+        guard !isBundled else { return nil }
+        guard let manifestVersion else {
+            return "missing sdkCompatibilityVersion (expected \(currentVersion))"
+        }
+        guard manifestVersion == currentVersion else {
+            return "requires sdkCompatibilityVersion \(currentVersion) (found \(manifestVersion))"
+        }
+        return nil
+    }
 }
 
 public protocol LiveTranscriptionCapablePlugin: TranscriptionEnginePlugin {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
@@ -10,6 +10,7 @@ final class PluginManifestTests: XCTestCase {
               "name": "Mock Plugin",
               "version": "1.2.3",
               "minHostVersion": "1.0.0",
+              "sdkCompatibilityVersion": "v1",
               "minOSVersion": "14.0",
               "author": "TypeWhisper",
               "principalClass": "MockPlugin"
@@ -26,6 +27,7 @@ final class PluginManifestTests: XCTestCase {
                 name: "Mock Plugin",
                 version: "1.2.3",
                 minHostVersion: "1.0.0",
+                sdkCompatibilityVersion: "v1",
                 minOSVersion: "14.0",
                 author: "TypeWhisper",
                 principalClass: "MockPlugin"
@@ -49,5 +51,23 @@ final class PluginManifestTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
+    }
+
+    func testPluginManifestDecodesSDKCompatibilityVersionWhenPresent() throws {
+        let data = Data(
+            """
+            {
+              "id": "com.typewhisper.mock",
+              "name": "Mock Plugin",
+              "version": "1.2.3",
+              "sdkCompatibilityVersion": "v1",
+              "principalClass": "MockPlugin"
+            }
+            """.utf8
+        )
+
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, "v1")
     }
 }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -114,6 +114,35 @@ private final class MockDictionaryTermsPlugin: NSObject, TranscriptionEnginePlug
     }
 }
 
+@objc(MockCatalogTranscriptionPlugin)
+private final class MockCatalogTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.catalog"
+    static let pluginName = "Mock Catalog"
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    var providerId: String { "mock-catalog" }
+    var providerDisplayName: String { "Mock Catalog" }
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] { [PluginModelInfo(id: "tiny", displayName: "Tiny")] }
+    var availableModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: "tiny", displayName: "Tiny"),
+            PluginModelInfo(id: "large", displayName: "Large")
+        ]
+    }
+    var selectedModelId: String? { "tiny" }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "ok", detectedLanguage: language)
+    }
+}
+
 private final class MockTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
     var isActive = true
     var onFinish: (@Sendable () -> Void)?
@@ -214,6 +243,15 @@ final class ProtocolContractTests: XCTestCase {
 
         XCTAssertFalse(legacyPlugin is any DictionaryTermsCapabilityProviding)
         XCTAssertEqual(capabilityPlugin.dictionaryTermsSupport, .requiresPluginSetting)
+    }
+
+    func testTranscriptionModelCatalogProtocolIsOptional() {
+        let legacyPlugin = MockTranscriptionPlugin()
+        let catalogPlugin = MockCatalogTranscriptionPlugin()
+
+        XCTAssertFalse(legacyPlugin is any TranscriptionModelCatalogProviding)
+        XCTAssertEqual(legacyPlugin.modelCatalog.map(\.id), ["tiny"])
+        XCTAssertEqual(catalogPlugin.modelCatalog.map(\.id), ["tiny", "large"])
     }
 
     func testTTSPluginCanPersistVoiceAndReceiveSpeakRequest() async throws {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -99,6 +99,37 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterCatalogTranscriptionPlugin)
+    private final class CatalogTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.catalog-transcription" }
+        static var pluginName: String { "Catalog Mock Transcription" }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "catalog-mock" }
+        var providerDisplayName: String { "Catalog Mock" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] {
+            [PluginModelInfo(id: "tiny", displayName: "Tiny")]
+        }
+        var availableModels: [PluginModelInfo] {
+            [
+                PluginModelInfo(id: "tiny", displayName: "Tiny"),
+                PluginModelInfo(id: "large", displayName: "Large")
+            ]
+        }
+        var selectedModelId: String? { "tiny" }
+        func selectModel(_ modelId: String) {}
+        var supportsTranslation: Bool { false }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
     @objc(APIRouterMockTTSPlugin)
     private final class MockTTSProviderPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.tts" }
@@ -1796,6 +1827,63 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let json = try Self.jsonObject(response)
         let message = (json["error"] as? [String: Any])?["message"] as? String ?? ""
         XCTAssertTrue(message.contains("not configured"), "Expected 'not configured' in message, got: \(message)")
+    }
+
+    @MainActor
+    func testModelsEndpointUsesExpandedCatalogOnlyForCatalogProvidingPlugins() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let legacyPlugin = MockTranscriptionPlugin()
+        let catalogPlugin = CatalogTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.transcription",
+                    name: "Mock Transcription",
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterMockTranscriptionPlugin"
+                ),
+                instance: legacyPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ),
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.catalog-transcription",
+                    name: "Catalog Mock Transcription",
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterCatalogTranscriptionPlugin"
+                ),
+                instance: catalogPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(method: "GET", path: "/v1/models", queryParams: [:], headers: [:], body: Data())
+        )
+        let json = try Self.jsonObject(response)
+        let models = try XCTUnwrap(json["models"] as? [[String: Any]])
+
+        let legacyIds = models
+            .filter { ($0["engine"] as? String) == legacyPlugin.providerId }
+            .compactMap { $0["id"] as? String }
+        let catalogIds = models
+            .filter { ($0["engine"] as? String) == catalogPlugin.providerId }
+            .compactMap { $0["id"] as? String }
+
+        XCTAssertEqual(legacyIds, ["tiny"])
+        XCTAssertEqual(catalogIds.sorted(), ["large", "tiny"])
     }
 
     @MainActor

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -24,6 +24,11 @@ final class PluginManifestValidationTests: XCTestCase {
             XCTAssertFalse(manifest.name.isEmpty, manifestURL.lastPathComponent)
             XCTAssertFalse(manifest.principalClass.isEmpty, manifestURL.lastPathComponent)
             XCTAssertNotNil(manifest.minHostVersion, manifestURL.lastPathComponent)
+            XCTAssertEqual(
+                manifest.sdkCompatibilityVersion,
+                PluginSDKCompatibility.currentVersion,
+                manifestURL.lastPathComponent
+            )
 
             let range = NSRange(location: 0, length: manifest.version.utf16.count)
             XCTAssertEqual(versionPattern.firstMatch(in: manifest.version, range: range)?.range, range, manifest.version)
@@ -122,12 +127,45 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
         XCTAssertTrue(manager.isManifestCompatible(manifest))
     }
 
+    func testExternalPluginsRequireExactSDKCompatibilityVersionWhileBundledPluginsAreExempt() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let matchingManifest = PluginManifest(
+            id: "com.typewhisper.mock.sdk-match",
+            name: "SDK Match",
+            version: "1.0.0",
+            sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+            principalClass: "MockPlugin"
+        )
+        let missingManifest = PluginManifest(
+            id: "com.typewhisper.mock.sdk-missing",
+            name: "SDK Missing",
+            version: "1.0.0",
+            principalClass: "MockPlugin"
+        )
+        let mismatchedManifest = PluginManifest(
+            id: "com.typewhisper.mock.sdk-mismatch",
+            name: "SDK Mismatch",
+            version: "1.0.0",
+            sdkCompatibilityVersion: "v999",
+            principalClass: "MockPlugin"
+        )
+
+        XCTAssertTrue(manager.isManifestSDKCompatible(matchingManifest, isBundled: false))
+        XCTAssertFalse(manager.isManifestSDKCompatible(missingManifest, isBundled: false))
+        XCTAssertFalse(manager.isManifestSDKCompatible(mismatchedManifest, isBundled: false))
+        XCTAssertTrue(manager.isManifestSDKCompatible(missingManifest, isBundled: true))
+    }
+
     func testRegistryPluginRejectsArm64OnlyEntryOnIntel() {
         let plugin = RegistryPlugin(
             id: "com.typewhisper.mock.arm64-only",
             name: "ARM64 Only",
             version: "1.0.0",
             minHostVersion: "1.0.0",
+            sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
             minOSVersion: "14.0",
             supportedArchitectures: ["arm64"],
             author: "TypeWhisper",

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -1,8 +1,11 @@
 import XCTest
+import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class PluginRegistryServiceTests: XCTestCase {
-    func testLegacyRegistryEntryDecodesIntoSingleRelease() throws {
+    private let sdkCompatibilityVersion = "v1"
+
+    func testLegacyRegistryEntryDoesNotResolveWithoutSDKCompatibilityVersion() throws {
         let data = Data(
             """
             {
@@ -25,15 +28,15 @@ final class PluginRegistryServiceTests: XCTestCase {
         )
 
         let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
-        let plugins = response.resolvedPlugins(appVersion: "1.2.3")
+        let plugins = response.resolvedPlugins(
+            appVersion: "1.2.3",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
 
-        XCTAssertEqual(plugins.count, 1)
-        XCTAssertEqual(plugins.first?.id, "com.typewhisper.legacy")
-        XCTAssertEqual(plugins.first?.version, "1.0.5")
-        XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/legacy.zip")
+        XCTAssertTrue(plugins.isEmpty)
     }
 
-    func testMultiReleaseRegistryChoosesNewestCompatibleRelease() throws {
+    func testMultiReleaseRegistryChoosesNewestCompatibleReleaseWithMatchingSDKCompatibilityVersion() throws {
         let data = Data(
             """
             {
@@ -50,12 +53,14 @@ final class PluginRegistryServiceTests: XCTestCase {
                     {
                       "version": "1.1.0",
                       "minHostVersion": "1.3.0",
+                      "sdkCompatibilityVersion": "v1",
                       "size": 20,
                       "downloadURL": "https://example.com/new.zip"
                     },
                     {
                       "version": "1.0.5",
                       "minHostVersion": "1.2.0",
+                      "sdkCompatibilityVersion": "v1",
                       "size": 10,
                       "downloadURL": "https://example.com/compatible.zip"
                     }
@@ -67,12 +72,60 @@ final class PluginRegistryServiceTests: XCTestCase {
         )
 
         let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
-        let plugins = response.resolvedPlugins(appVersion: "1.2.4")
+        let plugins = response.resolvedPlugins(
+            appVersion: "1.2.4",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
 
         XCTAssertEqual(plugins.count, 1)
         XCTAssertEqual(plugins.first?.version, "1.0.5")
         XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/compatible.zip")
         XCTAssertEqual(plugins.first?.downloadCount, 100)
+    }
+
+    func testMultiReleaseRegistryRejectsReleaseWithMismatchedSDKCompatibilityVersionAtSameHostVersion() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.multi",
+                  "name": "Multi Plugin",
+                  "author": "TypeWhisper",
+                  "description": "Multi-release entry",
+                  "category": "transcription",
+                  "releases": [
+                    {
+                      "version": "1.0.6",
+                      "minHostVersion": "1.2.2",
+                      "sdkCompatibilityVersion": "v2",
+                      "size": 12,
+                      "downloadURL": "https://example.com/mismatched.zip"
+                    },
+                    {
+                      "version": "1.0.5",
+                      "minHostVersion": "1.2.2",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 10,
+                      "downloadURL": "https://example.com/matching.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let plugins = response.resolvedPlugins(
+            appVersion: "1.2.2",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
+
+        XCTAssertEqual(plugins.count, 1)
+        XCTAssertEqual(plugins.first?.version, "1.0.5")
+        XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/matching.zip")
     }
 
     func testMultiReleaseRegistryFiltersIncompatibleReleasesByArchitectureAndOS() throws {
@@ -91,6 +144,7 @@ final class PluginRegistryServiceTests: XCTestCase {
                     {
                       "version": "1.2.0",
                       "minHostVersion": "1.0.0",
+                      "sdkCompatibilityVersion": "v1",
                       "minOSVersion": "15.0",
                       "supportedArchitectures": ["arm64"],
                       "size": 20,
@@ -99,6 +153,7 @@ final class PluginRegistryServiceTests: XCTestCase {
                     {
                       "version": "1.1.0",
                       "minHostVersion": "1.0.0",
+                      "sdkCompatibilityVersion": "v1",
                       "minOSVersion": "14.0",
                       "supportedArchitectures": ["x86_64"],
                       "size": 10,
@@ -115,6 +170,7 @@ final class PluginRegistryServiceTests: XCTestCase {
         let osVersion = OperatingSystemVersion(majorVersion: 14, minorVersion: 6, patchVersion: 0)
         let plugins = response.resolvedPlugins(
             appVersion: "1.2.4",
+            sdkCompatibilityVersion: sdkCompatibilityVersion,
             currentOSVersion: osVersion,
             architecture: "x86_64"
         )
@@ -157,10 +213,12 @@ final class PluginRegistryServiceTests: XCTestCase {
         )
 
         let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
-        let plugins = response.resolvedPlugins(appVersion: "1.2.3")
+        let plugins = response.resolvedPlugins(
+            appVersion: "1.2.3",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
 
         XCTAssertEqual(response.plugins.count, 1)
-        XCTAssertEqual(plugins.count, 1)
-        XCTAssertEqual(plugins.first?.id, "com.typewhisper.ok")
+        XCTAssertTrue(plugins.isEmpty)
     }
 }

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,6 +7,7 @@
 - `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
 - `bash scripts/check_first_party_warnings.sh build.log`
 - Review `README.md`, `SECURITY.md`, `docs/support-matrix.md`, `docs/release-readiness.md`, `Plugins/README.md`, and `TypeWhisperPluginSDK/README.md`
+- Confirm marketplace plugin manifests and registry releases carry the current `sdkCompatibilityVersion`
 - Confirm `MARKETING_VERSION = 1.3.0` across the app, CLI, and widgets
 - Prepare or refresh `docs/release-notes/1.3.0.md`
 - If you want to edit the notes directly on GitHub, create or update the draft release for `v1.3.0` before pushing the tag

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -27,6 +27,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Local HTTP API under `/v1/*` with per-request engine and model selection
 - `typewhisper` CLI with `--engine` and `--model` flags
 - Plugin SDK and plugin manifests, including TTS and streaming-dictionary hooks
+- Plugin SDK compatibility lines (`sdkCompatibilityVersion`) for marketplace releases
 - Widgets
 - Watch Folder
 


### PR DESCRIPTION
## Summary
- Add explicit `sdkCompatibilityVersion` handling to plugin manifests and registry releases
- Reject incompatible marketplace plugins before bundle load
- Move `availableModels` to optional `TranscriptionModelCatalogProviding` and update host call sites
- Update bundled manifests, release workflow, and docs for the new SDK compatibility contract

## Testing
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`