### PR TITLE
fix(audio): bounded recovery + terminal error propagation

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -36,6 +36,7 @@ enum AudioInputDeviceCompatibility: Sendable, Equatable {
 enum SelectedInputDeviceError: LocalizedError, Sendable, Equatable {
     case unavailable
     case incompatible(AudioInputDeviceCompatibilityIssue)
+    case routingConflict
 
     var errorDescription: String? {
         switch self {
@@ -46,6 +47,11 @@ enum SelectedInputDeviceError: LocalizedError, Sendable, Equatable {
             )
         case .incompatible(let issue):
             return issue.detailText
+        case .routingConflict:
+            return localizedAppText(
+                "The selected microphone conflicts with your current audio routing. Disconnect Bluetooth or choose a different input.",
+                de: "Das ausgewählte Mikrofon kollidiert mit deiner aktuellen Audio-Route. Trenne Bluetooth oder wähle ein anderes Eingabegerät."
+            )
         }
     }
 }
@@ -60,6 +66,19 @@ struct AudioInputDevice: Identifiable, Equatable {
 }
 
 final class AudioDeviceService: ObservableObject, @unchecked Sendable {
+    /// Serial OperationQueue used by the preview configuration-change
+    /// observer. Its `underlyingQueue` is set to `previewRecoveryQueue` in
+    /// `init` so that `AVAudioEngineConfigurationChange` notifications are
+    /// serialized onto the same queue the recovery coordinator runs on,
+    /// preserving the thread-confinement invariants of
+    /// `AudioEngineRecoveryCoordinator`. Mirrors the pattern used by
+    /// `AudioRecordingService.recoveryNotificationQueue`.
+    private let previewNotificationQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "com.typewhisper.preview-recovery.notifications"
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
 
     @Published var inputDevices: [AudioInputDevice] = []
     @Published var selectedDeviceUID: String? {
@@ -96,6 +115,12 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private let previewLock = NSLock()
     private let previewRecoveryQueue = DispatchQueue(label: "com.typewhisper.preview-recovery", qos: .userInitiated)
     private let previewRecoveryCoordinator = AudioEngineRecoveryCoordinator()
+    /// Retains the outgoing preview `AVAudioEngine` for a short interval after
+    /// teardown so CoreAudio's internal callbacks cannot outlive the object
+    /// they still reference. Mirrors `AudioRecordingService.engineTeardownRetainer`.
+    /// See issue #332.
+    private let previewEngineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.preview-engine-teardown")
+    private static let previewEngineTeardownRetentionInterval: TimeInterval = 0.3
     private var activePreviewDeviceID: AudioDeviceID?
     private var compatibilityCache: [String: AudioInputDeviceCompatibility] = [:]
     private var isApplyingValidatedSelection = false
@@ -127,7 +152,12 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
     }
 
-    init(initialInputDevices: [AudioInputDevice]? = nil, monitorDeviceChanges: Bool = true, probeCompatibilities: Bool = false) {
+    init(
+        initialInputDevices: [AudioInputDevice]? = nil,
+        monitorDeviceChanges: Bool = true,
+        probeCompatibilities: Bool = false
+    ) {
+        previewNotificationQueue.underlyingQueue = previewRecoveryQueue
         isInitializingSelection = true
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         inputDevices = applyCompatibilityCache(to: initialInputDevices ?? listInputDevices())
@@ -233,6 +263,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
         if let engine {
             teardownPreviewEngine(engine)
+            previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
         }
         isPreviewActive = false
         previewAudioLevel = 0
@@ -270,10 +301,15 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     }
 
     private func schedulePreviewRecoveryIfNeeded(_ action: AudioEngineRecoveryAction) {
-        guard case .schedule(let generation, let delay) = action else { return }
-
-        previewRecoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.performScheduledPreviewRecovery(generation: generation)
+        switch action {
+        case .none, .performImmediateRecovery:
+            return
+        case .schedule(let generation, let delay):
+            previewRecoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.performScheduledPreviewRecovery(generation: generation)
+            }
+        case .fail(let failure):
+            handlePreviewRecoveryFailure(failure)
         }
     }
 
@@ -297,12 +333,45 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func handlePreviewRecoveryFailure(_ failure: AudioEngineRecoveryFailure) {
+        let error: SelectedInputDeviceError
+        switch failure {
+        case .configurationChangeBurstLimitExceeded:
+            logger.error("Preview recovery circuit breaker tripped after repeated configuration changes")
+            error = .routingConflict
+        }
+
+        failActivePreviewDueToRecovery(error)
+    }
+
+    private func failActivePreviewDueToRecovery(_ error: SelectedInputDeviceError) {
+        previewRecoveryCoordinator.transitionToIdle()
+        removePreviewConfigurationObserver()
+        let engine: AVAudioEngine? = previewLock.withLock {
+            let engine = previewEngine
+            previewEngine = nil
+            activePreviewDeviceID = nil
+            return engine
+        }
+        if let engine {
+            teardownPreviewEngine(engine)
+            previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isPreviewActive = false
+            self.previewAudioLevel = 0
+            self.previewRawLevel = 0
+            self.previewError = error
+        }
+    }
+
     private func installPreviewConfigurationObserver(for engine: AVAudioEngine) {
         removePreviewConfigurationObserver()
         previewConfigChangeObserver = NotificationCenter.default.addObserver(
             forName: .AVAudioEngineConfigurationChange,
             object: engine,
-            queue: nil
+            queue: previewNotificationQueue
         ) { [weak self] _ in
             self?.handlePreviewConfigurationChangeNotification()
         }
@@ -357,8 +426,22 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         preferredDeviceID: AudioDeviceID?,
         label: String
     ) throws {
+        // Swap in a fresh AVAudioEngine instead of reusing the stuck one.
+        // Reusing the same engine after CoreAudio flagged its AUHAL mid-switch
+        // causes `AudioUnitSetProperty` to return 'nope'
+        // (kAudioHardwareIllegalOperationError). See issue #332.
+        guard let replacementEngine = replacePreviewAudioEngineForRecoveryIfNeeded(engine) else { return }
+
+        installPreviewConfigurationObserver(for: replacementEngine)
         teardownPreviewEngine(engine)
-        try startPreviewEngineWithRecovery(engine, preferredDeviceID: preferredDeviceID, label: label)
+        previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
+
+        do {
+            try startPreviewEngineWithRecovery(replacementEngine, preferredDeviceID: preferredDeviceID, label: label)
+        } catch {
+            cleanupAfterFailedPreviewStart(replacementEngine)
+            throw error
+        }
     }
 
     private func configureAndStartPreviewEngine(
@@ -375,11 +458,19 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         logger.info("\(label, privacy: .public) input format: sampleRate=\(format.sampleRate), channels=\(format.channelCount)")
         try validateInputFormat(format, for: preferredDeviceID)
 
+        // Re-read the format immediately before installTap and reject the
+        // install if it has drifted (e.g. Bluetooth flipping from A2DP to HFP
+        // between `configureExplicitInputDevice` and here). Mirrors
+        // `AudioRecordingService.validateTapInstallationPreconditions`.
+        // See issue #332.
+        let currentFormat = inputNode.outputFormat(forBus: 0)
+        try validatePreviewTapInstallationPreconditions(expected: format, current: currentFormat)
+
         // Wrap installTap so NSException (e.g. AVAudioSession incompatible format)
         // is converted into a Swift error instead of crashing the app. See K2.
         do {
             _ = try ObjCExceptionCatcher.catching {
-                inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+                inputNode.installTap(onBus: 0, bufferSize: 1024, format: currentFormat) { [weak self] buffer, _ in
                     self?.processPreviewBuffer(buffer)
                 }
             }
@@ -396,10 +487,43 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         do {
             try engine.start()
+            // Open the post-start quiescence window. Without this, the
+            // observer armed on this engine catches the config-change
+            // triggered by our own `AudioUnitSetProperty(...CurrentDevice)`
+            // write and schedules another restart — indefinitely.
+            // See issue #332.
+            previewRecoveryCoordinator.noteEngineStarted()
         } catch {
             inputNode.removeTap(onBus: 0)
             engine.stop()
             throw error
+        }
+    }
+
+    @discardableResult
+    private func replacePreviewAudioEngineForRecoveryIfNeeded(_ engine: AVAudioEngine) -> AVAudioEngine? {
+        let replacementEngine = AVAudioEngine()
+        let didReplace = previewLock.withLock { () -> Bool in
+            guard previewEngine === engine else { return false }
+            previewEngine = replacementEngine
+            return true
+        }
+        return didReplace ? replacementEngine : nil
+    }
+
+    private func validatePreviewTapInstallationPreconditions(expected: AVAudioFormat, current: AVAudioFormat) throws {
+        let currentSampleRate = current.sampleRate
+        let currentChannelCount = current.channelCount
+        let matchesExpected = currentSampleRate == expected.sampleRate && currentChannelCount == expected.channelCount
+
+        guard currentSampleRate > 0, currentChannelCount > 0, matchesExpected else {
+            throw NSError(
+                domain: AudioEngineRecoveryErrorDomains.transientFormatMismatch,
+                code: 0,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Format mismatch before preview installTap: expected \(expected.sampleRate) Hz/\(expected.channelCount) ch, got \(current.sampleRate) Hz/\(current.channelCount) ch"
+                ]
+            )
         }
     }
 
@@ -418,6 +542,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             }
         }
         teardownPreviewEngine(engine)
+        previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
         isPreviewActive = false
         previewAudioLevel = 0
         previewRawLevel = 0
@@ -862,3 +987,31 @@ private func audioStatusString(_ status: OSStatus) -> String {
     }
     return "\(status)"
 }
+
+#if DEBUG
+extension AudioDeviceService {
+    @discardableResult
+    func testingReplacePreviewEngineForRecoveryIfNeeded(_ engine: AVAudioEngine) -> AVAudioEngine? {
+        replacePreviewAudioEngineForRecoveryIfNeeded(engine)
+    }
+
+    func testingSetPreviewEngine(_ engine: AVAudioEngine?, activeDeviceID: AudioDeviceID? = nil) {
+        previewLock.withLock {
+            previewEngine = engine
+            activePreviewDeviceID = activeDeviceID
+        }
+    }
+
+    func testingCurrentPreviewEngine() -> AVAudioEngine? {
+        previewLock.withLock { previewEngine }
+    }
+
+    func testingCurrentPreviewDeviceID() -> AudioDeviceID? {
+        previewLock.withLock { activePreviewDeviceID }
+    }
+
+    func testingValidatePreviewTapInstallationPreconditions(expected: AVAudioFormat, current: AVAudioFormat) throws {
+        try validatePreviewTapInstallationPreconditions(expected: expected, current: current)
+    }
+}
+#endif

--- a/TypeWhisper/Services/AudioEngineRecoverySupport.swift
+++ b/TypeWhisper/Services/AudioEngineRecoverySupport.swift
@@ -6,10 +6,23 @@ enum AudioEngineRecoveryAction: Equatable {
     case none
     case performImmediateRecovery
     case schedule(generation: UInt64, delay: TimeInterval)
+    case fail(AudioEngineRecoveryFailure)
+}
+
+enum AudioEngineRecoveryFailure: Equatable {
+    case configurationChangeBurstLimitExceeded
 }
 
 enum AudioEngineRecoveryPolicy {
     static let configurationDebounce: TimeInterval = 0.15
+    // Real BT-default/headset repros continue posting self-induced config
+    // changes ~700ms after each successful restart, so the filter needs to
+    // cover more than the initial engine.start() call itself. We defer a
+    // single recovery until this window expires instead of immediately
+    // re-entering the startup path.
+    static let configurationChangeQuiescence: TimeInterval = 1.0
+    static let configurationChangeBurstWindow: TimeInterval = 5.0
+    static let configurationChangeBurstLimit = 4
 
     /// Backoff schedule used by the asynchronous observer-based recovery path,
     /// which runs on a dedicated dispatch queue. Blocking sleeps here are
@@ -79,6 +92,29 @@ enum AudioEngineRecoveryErrorUserInfoKeys {
     static let exceptionUserInfo = "NSExceptionUserInfo"
 }
 
+final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
+    private final class RetainedObjectBox: @unchecked Sendable {
+        let object: Object
+
+        init(_ object: Object) {
+            self.object = object
+        }
+    }
+
+    private let queue: DispatchQueue
+
+    init(label: String, qos: DispatchQoS = .utility) {
+        queue = DispatchQueue(label: label, qos: qos)
+    }
+
+    func retain(_ object: Object, for duration: TimeInterval) {
+        let retainedObject = RetainedObjectBox(object)
+        queue.asyncAfter(deadline: .now() + duration) {
+            withExtendedLifetime(retainedObject) {}
+        }
+    }
+}
+
 final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
     private enum LifecycleState {
         case idle
@@ -91,9 +127,16 @@ final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
         var pendingConfigurationChange = false
         var recoveryInFlight = false
         var generation: UInt64 = 0
+        var lastEngineStartTimestamp: TimeInterval?
+        var scheduledRecoveryTimestamps: [TimeInterval] = []
     }
 
+    private let now: @Sendable () -> TimeInterval
     private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(now: @escaping @Sendable () -> TimeInterval = { Date().timeIntervalSinceReferenceDate }) {
+        self.now = now
+    }
 
     func beginStarting() {
         state.withLock { state in
@@ -101,6 +144,14 @@ final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
             state.pendingConfigurationChange = false
             state.recoveryInFlight = false
             state.generation &+= 1
+            state.lastEngineStartTimestamp = nil
+            state.scheduledRecoveryTimestamps.removeAll(keepingCapacity: false)
+        }
+    }
+
+    func noteEngineStarted() {
+        state.withLock { state in
+            state.lastEngineStartTimestamp = now()
         }
     }
 
@@ -131,8 +182,7 @@ final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
                     return .none
                 }
 
-                state.generation &+= 1
-                return .schedule(generation: state.generation, delay: AudioEngineRecoveryPolicy.configurationDebounce)
+                return makeScheduledRecoveryAction(for: &state)
             }
         }
     }
@@ -159,8 +209,7 @@ final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
                 return .none
             }
 
-            state.generation &+= 1
-            return .schedule(generation: state.generation, delay: AudioEngineRecoveryPolicy.configurationDebounce)
+            return makeScheduledRecoveryAction(for: &state)
         }
     }
 
@@ -170,6 +219,35 @@ final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
             state.pendingConfigurationChange = false
             state.recoveryInFlight = false
             state.generation &+= 1
+            state.lastEngineStartTimestamp = nil
+            state.scheduledRecoveryTimestamps.removeAll(keepingCapacity: false)
         }
+    }
+
+    private func makeScheduledRecoveryAction(for state: inout State) -> AudioEngineRecoveryAction {
+        pruneScheduledRecoveryTimestamps(in: &state)
+        if state.scheduledRecoveryTimestamps.count >= AudioEngineRecoveryPolicy.configurationChangeBurstLimit - 1 {
+            state.pendingConfigurationChange = false
+            return .fail(.configurationChangeBurstLimitExceeded)
+        }
+
+        state.generation &+= 1
+        state.scheduledRecoveryTimestamps.append(now())
+        return .schedule(generation: state.generation, delay: recoveryDelay(for: state))
+    }
+
+    private func recoveryDelay(for state: State) -> TimeInterval {
+        guard let lastEngineStartTimestamp = state.lastEngineStartTimestamp else {
+            return AudioEngineRecoveryPolicy.configurationDebounce
+        }
+
+        let elapsedSinceStart = now() - lastEngineStartTimestamp
+        let remainingQuiescence = AudioEngineRecoveryPolicy.configurationChangeQuiescence - elapsedSinceStart
+        return max(AudioEngineRecoveryPolicy.configurationDebounce, remainingQuiescence)
+    }
+
+    private func pruneScheduledRecoveryTimestamps(in state: inout State) {
+        let cutoff = now() - AudioEngineRecoveryPolicy.configurationChangeBurstWindow
+        state.scheduledRecoveryTimestamps.removeAll { $0 < cutoff }
     }
 }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -7,29 +7,6 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioRecordingService")
 
-final class DelayedReleaseRetainer<Object: AnyObject>: @unchecked Sendable {
-    private final class RetainedObjectBox: @unchecked Sendable {
-        let object: Object
-
-        init(_ object: Object) {
-            self.object = object
-        }
-    }
-
-    private let queue: DispatchQueue
-
-    init(label: String, qos: DispatchQoS = .utility) {
-        queue = DispatchQueue(label: label, qos: qos)
-    }
-
-    func retain(_ object: Object, for duration: TimeInterval) {
-        let retainedObject = RetainedObjectBox(object)
-        queue.asyncAfter(deadline: .now() + duration) {
-            withExtendedLifetime(retainedObject) {}
-        }
-    }
-}
-
 /// Captures microphone audio via AVAudioEngine and converts to 16kHz mono Float32 samples.
 final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let recoveryNotificationQueue: OperationQueue = {
@@ -76,6 +53,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         case noMicrophoneDetected
         case selectedInputDeviceUnavailable
         case selectedInputDeviceIncompatible(AudioInputDeviceCompatibilityIssue)
+        case audioRoutingConflict
         case engineStartFailed(String)
         case noAudioData
 
@@ -89,6 +67,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                 SelectedInputDeviceError.unavailable.errorDescription
             case .selectedInputDeviceIncompatible(let issue):
                 SelectedInputDeviceError.incompatible(issue).errorDescription
+            case .audioRoutingConflict:
+                localizedAppText(
+                    "The selected microphone conflicts with your current audio routing. Disconnect Bluetooth or choose a different input.",
+                    de: "Das ausgewählte Mikrofon kollidiert mit deiner aktuellen Audio-Route. Trenne Bluetooth oder wähle ein anderes Eingabegerät."
+                )
             case .engineStartFailed(let detail):
                 "Failed to start audio engine: \(detail)"
             case .noAudioData:
@@ -100,6 +83,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     @Published private(set) var isRecording = false
     @Published private(set) var audioLevel: Float = 0
     @Published private(set) var rawAudioLevel: Float = 0
+    /// Set when the recovery coordinator gives up (e.g. burst circuit breaker
+    /// trips). The view model observes this and surfaces the error to the UI,
+    /// tears down the session, and resumes any paused media / restores ducking.
+    /// Reset to nil at the start of each `startRecording`.
+    @Published private(set) var recoveryError: AudioRecordingError?
     var hasMicrophonePermissionOverride: Bool?
     var inputAvailabilityOverride: ((AudioDeviceID?) -> Bool)?
     var startRecordingOverride: (() throws -> Void)?
@@ -234,6 +222,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.microphonePermissionDenied
         }
 
+        // Clear any terminal-recovery error from a previous session so the
+        // view model doesn't see a stale failure on the first buffer update.
+        recoveryError = nil
+
         try validateRecordingInputAvailability()
 
         if let startRecordingOverride {
@@ -247,6 +239,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         clearRecordingBuffer()
+
         let engine = AVAudioEngine()
         engineLock.withLock { audioEngine = engine }
         recoveryCoordinator.beginStarting()
@@ -332,10 +325,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func scheduleRecoveryIfNeeded(_ action: AudioEngineRecoveryAction) {
-        guard case .schedule(let generation, let delay) = action else { return }
-
-        recoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.performScheduledRecovery(generation: generation)
+        switch action {
+        case .none, .performImmediateRecovery:
+            return
+        case .schedule(let generation, let delay):
+            recoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.performScheduledRecovery(generation: generation)
+            }
+        case .fail(let failure):
+            handleRecoveryFailure(failure)
         }
     }
 
@@ -354,6 +352,43 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             try restartEngineWithRecovery(engine, label: "config-change")
         } catch {
             logger.error("Failed to restart audio engine after configuration change: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleRecoveryFailure(_ failure: AudioEngineRecoveryFailure) {
+        let error: AudioRecordingError
+        switch failure {
+        case .configurationChangeBurstLimitExceeded:
+            logger.error("Audio engine recovery circuit breaker tripped after repeated configuration changes")
+            if hasExplicitDeviceSelection {
+                error = .audioRoutingConflict
+            } else {
+                error = .engineStartFailed("Audio engine kept restarting after repeated configuration changes")
+            }
+        }
+
+        failActiveRecordingDueToRecovery(error)
+    }
+
+    private func failActiveRecordingDueToRecovery(_ error: AudioRecordingError) {
+        recoveryCoordinator.transitionToIdle()
+        removeConfigurationObserver()
+        let engine: AVAudioEngine? = engineLock.withLock {
+            let engine = audioEngine
+            audioEngine = nil
+            return engine
+        }
+        if let engine {
+            teardownEngine(engine)
+            engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        }
+        clearRecordingBuffer()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.recoveryError = error
+            self.isRecording = false
+            self.audioLevel = 0
+            self.rawAudioLevel = 0
         }
     }
 
@@ -483,6 +518,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engineStartTime = CFAbsoluteTimeGetCurrent()
         do {
             try engine.start()
+            // Open the post-start quiescence window so configuration-change
+            // notifications caused by our own AudioUnitSetProperty / start
+            // sequence (Bluetooth A2DP↔HFP renegotiation) are deferred
+            // instead of driving an infinite restart loop. See issue #332.
+            recoveryCoordinator.noteEngineStarted()
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
             logger.info("\(label, privacy: .public) audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
         } catch {
@@ -639,12 +679,21 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Clears the terminal-recovery error after a downstream observer has
+    /// handled it. Called from `DictationViewModel` once the session is
+    /// unwound so the @Published value doesn't linger for later bindings.
+    func clearRecoveryError() {
+        recoveryError = nil
+    }
+
     private func mapSelectedInputDeviceError(_ error: SelectedInputDeviceError) -> AudioRecordingError {
         switch error {
         case .unavailable:
             return .selectedInputDeviceUnavailable
         case .incompatible(let issue):
             return .selectedInputDeviceIncompatible(issue)
+        case .routingConflict:
+            return .audioRoutingConflict
         }
     }
 

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -106,7 +106,24 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private var _selectedDeviceID: AudioDeviceID?
     private var _hasExplicitDeviceSelection = false
 
+    private struct StartupConfigurationChangeGuard {
+        let engineID: ObjectIdentifier
+        let expectedSampleRate: Double
+        let expectedChannelCount: AVAudioChannelCount
+
+        init(engine: AVAudioEngine, expectedTapFormat: AVAudioFormat) {
+            engineID = ObjectIdentifier(engine)
+            expectedSampleRate = expectedTapFormat.sampleRate
+            expectedChannelCount = expectedTapFormat.channelCount
+        }
+
+        func matches(_ liveFormat: AVAudioFormat) -> Bool {
+            liveFormat.sampleRate == expectedSampleRate && liveFormat.channelCount == expectedChannelCount
+        }
+    }
+
     private var audioEngine: AVAudioEngine?
+    private var startupConfigurationChangeGuard: StartupConfigurationChangeGuard?
     private var configChangeObserver: NSObjectProtocol?
     private var sampleBuffer: [Float] = []
     private var _peakRawAudioLevel: Float = 0
@@ -241,7 +258,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         clearRecordingBuffer()
 
         let engine = AVAudioEngine()
-        engineLock.withLock { audioEngine = engine }
+        engineLock.withLock {
+            audioEngine = engine
+            startupConfigurationChangeGuard = nil
+        }
         recoveryCoordinator.beginStarting()
         installConfigurationObserver(for: engine)
 
@@ -249,11 +269,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             try startEngineWithRecovery(engine, label: "recording")
 
             if recoveryCoordinator.finishStartingSuccessfully() == .performImmediateRecovery {
-                logger.warning("Audio engine configuration changed while recording was starting, restarting with fresh input format")
                 guard let currentEngine = engineLock.withLock({ audioEngine }) else {
                     throw AudioRecordingError.engineStartFailed("Recording engine disappeared during startup recovery")
                 }
-                try restartEngineWithRecovery(currentEngine, label: "recording-startup")
+                if consumeStartupConfigurationChangeGuardIfNeeded(for: currentEngine) {
+                    logger.info("Ignoring benign post-start audio engine configuration change after tap renegotiation")
+                } else {
+                    logger.warning("Audio engine configuration changed while recording was starting, restarting with fresh input format")
+                    try restartEngineWithRecovery(currentEngine, label: "recording-startup")
+                }
                 scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
             }
 
@@ -279,6 +303,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engine: AVAudioEngine? = engineLock.withLock {
             let e = audioEngine
             audioEngine = nil
+            startupConfigurationChangeGuard = nil
             return e
         }
         guard let engine else { return [] }
@@ -346,6 +371,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engine: AVAudioEngine? = engineLock.withLock { audioEngine }
         guard isRecording, let engine else { return }
 
+        if consumeStartupConfigurationChangeGuardIfNeeded(for: engine) {
+            logger.info("Ignoring benign post-start audio engine configuration change after tap renegotiation")
+            return
+        }
+
         logger.warning("Audio engine configuration changed during recording, restarting engine")
 
         do {
@@ -376,6 +406,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engine: AVAudioEngine? = engineLock.withLock {
             let engine = audioEngine
             audioEngine = nil
+            startupConfigurationChangeGuard = nil
             return engine
         }
         if let engine {
@@ -518,6 +549,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engineStartTime = CFAbsoluteTimeGetCurrent()
         do {
             try engine.start()
+            armStartupConfigurationChangeGuard(for: engine, expectedTapFormat: tapFormat)
             // Open the post-start quiescence window so configuration-change
             // notifications caused by our own AudioUnitSetProperty / start
             // sequence (Bluetooth A2DP↔HFP renegotiation) are deferred
@@ -543,6 +575,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let didReplace = engineLock.withLock { () -> Bool in
             guard audioEngine === engine else { return false }
             audioEngine = replacementEngine
+            startupConfigurationChangeGuard = nil
             return true
         }
         return didReplace ? replacementEngine : nil
@@ -554,6 +587,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         engineLock.withLock {
             if audioEngine === engine {
                 audioEngine = nil
+            }
+            if startupConfigurationChangeGuard?.engineID == ObjectIdentifier(engine) {
+                startupConfigurationChangeGuard = nil
             }
         }
         teardownEngine(engine)
@@ -697,6 +733,34 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func armStartupConfigurationChangeGuard(for engine: AVAudioEngine, expectedTapFormat: AVAudioFormat) {
+        engineLock.withLock {
+            startupConfigurationChangeGuard = StartupConfigurationChangeGuard(engine: engine, expectedTapFormat: expectedTapFormat)
+        }
+    }
+
+    private func consumeStartupConfigurationChangeGuardIfNeeded(for engine: AVAudioEngine) -> Bool {
+        let engineID = ObjectIdentifier(engine)
+        let shouldInspectLiveFormat = engineLock.withLock {
+            startupConfigurationChangeGuard?.engineID == engineID
+        }
+        guard shouldInspectLiveFormat else { return false }
+        return consumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: engine.inputNode.outputFormat(forBus: 0))
+    }
+
+    private func consumeStartupConfigurationChangeGuardIfMatching(for engine: AVAudioEngine, liveFormat: AVAudioFormat) -> Bool {
+        let engineID = ObjectIdentifier(engine)
+        let guardState: StartupConfigurationChangeGuard? = engineLock.withLock {
+            guard let guardState = startupConfigurationChangeGuard, guardState.engineID == engineID else {
+                return nil
+            }
+            startupConfigurationChangeGuard = nil
+            return guardState
+        }
+        guard let guardState else { return false }
+        return guardState.matches(liveFormat)
+    }
+
     private func validateTapInstallationPreconditions(expected: AVAudioFormat, current: AVAudioFormat) throws {
         let currentSampleRate = current.sampleRate
         let currentChannelCount = current.channelCount
@@ -737,6 +801,14 @@ extension AudioRecordingService {
 
     func testingValidateTapInstallationPreconditions(expected: AVAudioFormat, current: AVAudioFormat) throws {
         try validateTapInstallationPreconditions(expected: expected, current: current)
+    }
+
+    func testingArmStartupConfigurationChangeGuard(for engine: AVAudioEngine, expectedTapFormat: AVAudioFormat) {
+        armStartupConfigurationChangeGuard(for: engine, expectedTapFormat: expectedTapFormat)
+    }
+
+    func testingConsumeStartupConfigurationChangeGuardIfMatching(for engine: AVAudioEngine, liveFormat: AVAudioFormat) -> Bool {
+        consumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: liveFormat)
     }
 }
 #endif

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -473,6 +473,38 @@ final class DictationViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // When the recovery coordinator's circuit breaker gives up mid-session,
+        // `AudioRecordingService` publishes the terminal error here. Surface
+        // it to the UI and unwind the dictation session cleanly — restore
+        // ducking, resume media, stop streaming, cancel the session.
+        audioRecordingService.$recoveryError
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                guard let self else { return }
+                // Always drain the publisher so `recoveryError` never lingers
+                // on `AudioRecordingService`, even when the session is no
+                // longer active (stop-in-flight, already processed, etc.).
+                defer { self.audioRecordingService.clearRecoveryError() }
+                guard self.state == .recording, !self.isStopInFlight else { return }
+                self.metadataCaptureTask?.cancel()
+                self.metadataCaptureTask = nil
+                self.urlResolutionTask?.cancel()
+                self.urlResolutionTask = nil
+                self.lastStreamingParams = nil
+                self.audioDuckingService.restoreAudio()
+                self.mediaPlaybackService.resumeIfWePaused()
+                self.streamingHandler.stop()
+                self.stopRecordingTimer()
+
+                let errorMessage = error.localizedDescription
+                self.accessibilityAnnouncementService.announceError(errorMessage)
+                self.cancelActiveDictationSessionIfNeeded(message: errorMessage)
+                self.hotkeyService.cancelDictation()
+                self.showError(errorMessage, category: "recording")
+            }
+            .store(in: &cancellables)
+
         hotkeyService.$currentMode
             .dropFirst()
             .receive(on: DispatchQueue.main)

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -3,6 +3,10 @@ import AVFoundation
 import XCTest
 @testable import TypeWhisper
 
+private final class TestClock: @unchecked Sendable {
+    var now: TimeInterval = 0
+}
+
 final class AudioEngineRecoverySupportTests: XCTestCase {
     func testRetryableErrorClassification_matchesKnownAudioUnitCodes() {
         let formatError = NSError(domain: NSOSStatusErrorDomain, code: Int(kAudioUnitErr_FormatNotSupported))
@@ -56,6 +60,18 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertEqual(coordinator.finishRecovery(), .none)
     }
 
+    func testConfigurationChangeWithinQuiescenceWindow_preservesStartupRecoveryPath() {
+        let clock = TestClock()
+        let coordinator = AudioEngineRecoveryCoordinator(now: { clock.now })
+
+        coordinator.beginStarting()
+        coordinator.noteEngineStarted()
+        clock.now += 0.1
+
+        XCTAssertEqual(coordinator.noteConfigurationChange(), .none)
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .performImmediateRecovery)
+    }
+
     func testMultipleConfigurationChanges_coalesceToLatestScheduledGeneration() {
         let coordinator = AudioEngineRecoveryCoordinator()
 
@@ -95,6 +111,69 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
 
         XCTAssertNotEqual(generation, followUpGeneration)
         XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationDebounce)
+    }
+
+    func testSelfTriggeredConfigurationChangeWithinQuiescenceWindow_isDeferredWhileRunning() {
+        let clock = TestClock()
+        let coordinator = AudioEngineRecoveryCoordinator(now: { clock.now })
+
+        coordinator.beginStarting()
+        coordinator.noteEngineStarted()
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .none)
+
+        clock.now += 0.1
+        guard case .schedule(_, let delay) = coordinator.noteConfigurationChange() else {
+            return XCTFail("Expected deferred recovery schedule")
+        }
+
+        XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationChangeQuiescence - 0.1, accuracy: 0.0001)
+    }
+
+    func testSelfTriggeredConfigurationChangeWithinQuiescenceWindow_isDeferredDuringScheduledRecovery() {
+        let clock = TestClock()
+        let coordinator = AudioEngineRecoveryCoordinator(now: { clock.now })
+
+        coordinator.beginStarting()
+        coordinator.noteEngineStarted()
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .none)
+
+        clock.now = 1
+        guard case .schedule(let generation, _) = coordinator.noteConfigurationChange() else {
+            return XCTFail("Expected scheduled recovery")
+        }
+
+        XCTAssertTrue(coordinator.beginScheduledRecovery(generation: generation))
+
+        coordinator.noteEngineStarted()
+        clock.now += 0.1
+        XCTAssertEqual(coordinator.noteConfigurationChange(), .none)
+        guard case .schedule(_, let delay) = coordinator.finishRecovery() else {
+            return XCTFail("Expected deferred follow-up recovery")
+        }
+        XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationChangeQuiescence - 0.1, accuracy: 0.0001)
+    }
+
+    func testRecoveryCoordinator_stopsAfterRestartLoopThreshold() {
+        let clock = TestClock()
+        let coordinator = AudioEngineRecoveryCoordinator(now: { clock.now })
+
+        coordinator.beginStarting()
+        coordinator.noteEngineStarted()
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .none)
+        clock.now += AudioEngineRecoveryPolicy.configurationChangeQuiescence + 0.1
+
+        for attempt in 0..<(AudioEngineRecoveryPolicy.configurationChangeBurstLimit - 1) {
+            guard case .schedule(let generation, let delay) = coordinator.noteConfigurationChange() else {
+                return XCTFail("Expected scheduled recovery for attempt \(attempt + 1)")
+            }
+            XCTAssertEqual(delay, AudioEngineRecoveryPolicy.configurationDebounce)
+            XCTAssertTrue(coordinator.beginScheduledRecovery(generation: generation))
+            XCTAssertEqual(coordinator.finishRecovery(), .none)
+
+            clock.now += 0.2
+        }
+
+        XCTAssertEqual(coordinator.noteConfigurationChange(), .fail(.configurationChangeBurstLimitExceeded))
     }
 
     func testTransientFormatMismatchError_describesMismatch() throws {
@@ -220,6 +299,39 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(service.selectedDeviceUID, "display-mic")
         XCTAssertEqual(service.selectedDevice?.uid, "display-mic")
         XCTAssertNotNil(service.selectedDeviceStatusMessage)
+    }
+
+    func testPreviewRecoveryEngineSwap_replacesStoredEngineInstance() {
+        let service = AudioDeviceService(
+            initialInputDevices: [],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+        let originalEngine = AVAudioEngine()
+
+        service.testingSetPreviewEngine(originalEngine, activeDeviceID: AudioDeviceID(42))
+        let replacementEngine = service.testingReplacePreviewEngineForRecoveryIfNeeded(originalEngine)
+
+        XCTAssertNotNil(replacementEngine)
+        XCTAssertTrue(service.testingCurrentPreviewEngine() === replacementEngine)
+        XCTAssertFalse(service.testingCurrentPreviewEngine() === originalEngine)
+        XCTAssertEqual(service.testingCurrentPreviewDeviceID(), AudioDeviceID(42))
+    }
+
+    func testPreviewTapPreconditions_throwRetryableMismatchWhenFormatChangesImmediately() throws {
+        let service = AudioDeviceService(
+            initialInputDevices: [],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+        let expected = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+        let current = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 24_000, channels: 1, interleaved: false))
+
+        XCTAssertThrowsError(try service.testingValidatePreviewTapInstallationPreconditions(expected: expected, current: current)) { error in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.domain, AudioEngineRecoveryErrorDomains.transientFormatMismatch)
+            XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: nsError))
+        }
     }
 }
 

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -417,4 +417,47 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
             XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: nsError))
         }
     }
+
+    func testStartupConfigurationChangeGuard_ignoresOnlyFirstMatchingChangeForSameEngine() throws {
+        let service = AudioRecordingService()
+        let engine = AVAudioEngine()
+        let matchingFormat = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+
+        service.testingArmStartupConfigurationChangeGuard(for: engine, expectedTapFormat: matchingFormat)
+
+        XCTAssertTrue(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: matchingFormat))
+        XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: matchingFormat))
+    }
+
+    func testStartupConfigurationChangeGuard_doesNotIgnoreMatchingFormatOnDifferentEngine() throws {
+        let service = AudioRecordingService()
+        let expectedEngine = AVAudioEngine()
+        let otherEngine = AVAudioEngine()
+        let matchingFormat = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+
+        service.testingArmStartupConfigurationChangeGuard(for: expectedEngine, expectedTapFormat: matchingFormat)
+
+        XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: otherEngine, liveFormat: matchingFormat))
+        XCTAssertTrue(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: expectedEngine, liveFormat: matchingFormat))
+    }
+
+    func testStartupConfigurationChangeGuard_doesNotIgnoreMatchingFormatWithoutPendingState() throws {
+        let service = AudioRecordingService()
+        let engine = AVAudioEngine()
+        let matchingFormat = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+
+        XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: matchingFormat))
+    }
+
+    func testStartupConfigurationChangeGuard_mismatchDoesNotIgnoreAndConsumesSingleUseState() throws {
+        let service = AudioRecordingService()
+        let engine = AVAudioEngine()
+        let expectedFormat = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 1, interleaved: false))
+        let mismatchedFormat = try XCTUnwrap(AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000, channels: 2, interleaved: false))
+
+        service.testingArmStartupConfigurationChangeGuard(for: engine, expectedTapFormat: expectedFormat)
+
+        XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: mismatchedFormat))
+        XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: expectedFormat))
+    }
 }


### PR DESCRIPTION
## Summary

Part of #332 (formerly closed by this PR, now split per maintainer review). This PR is the **bounded-recovery / terminal-error-propagation** slice. The routing/format-correctness work (`SystemDefaultInputOverride`, `hardwareInputFormat`, skip-if-default) has been moved to a follow-up PR so the silent best-effort CoreAudio-write class @SeoFood was flagging can be audited end-to-end on its own.

Coordinator + error-propagation design adopted verbatim from @SeoFood's reference branch [`seofood/issue-332-bounded-audio-recovery`](https://github.com/TypeWhisper/typewhisper-mac/tree/seofood/issue-332-bounded-audio-recovery); credited via `Co-authored-by:` on the commit.

## What's in this PR

- **`AudioEngineRecoveryCoordinator` — action-based bounded recovery.** Post-start quiescence window defers rather than drops follow-up recoveries; sliding-window burst circuit breaker returns a `.fail` action from `noteConfigurationChange` / `finishRecovery` when restart attempts exceed threshold. Callers dispatch on the action.
- **`AudioEngineRecoveryAction.fail(AudioEngineRecoveryFailure)`** — terminal failure surfaces through the existing action-dispatch path, no boolean side channel.
- **`handleRecoveryFailure` / `handlePreviewRecoveryFailure`** + **`failActiveRecordingDueToRecovery` / `failActivePreviewDueToRecovery`** — unwind the active session cleanly on circuit-breaker failure.
- **`@Published recoveryError`** on `AudioRecordingService`, observed by `DictationViewModel.$recoveryError` sink — surfaces terminal failures to the UI and cleanly tears down the dictation session (restore ducking, resume media, stop streaming, cancel the active session).
- **`DelayedReleaseRetainer`** moved to `AudioEngineRecoverySupport.swift` so the preview path can use it without duplication. Retains torn-down engines briefly through CoreAudio's internal teardown callbacks.
- **PR #301 hardening ported to the preview path**: fresh-engine swap via `replacePreviewAudioEngineForRecoveryIfNeeded`, `validatePreviewTapInstallationPreconditions` before `installTap`.
- **Tests**: `TestClock`-driven quiescence-defer tests, burst-limit-trip test, preview engine-swap test, preview tap-preconditions test.

## Deferred to the follow-up routing PR

After a full silent-write-class audit:
- `SystemDefaultInputOverride` + selection-time / init-time / rollback `apply()` semantics
- `hardwareInputFormat(for:)` HAL format probe (root cause #2 from the original PR description)
- Skip-if-already-default optimization in `configureAndStartEngine` / `configureAndStartPreviewEngine`
- `AggregateInputDevice.destroyOrphans` migration helper
- `mediaPlaybackService.resumeIfWePaused()` gaps in cancel/disconnect paths (to land as a separate tiny bugfix PR)

## Test Plan

- [x] `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests -only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests -only-testing:TypeWhisperTests/AudioRecordingServiceSelectedDeviceTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_pausesMediaAfterAudioStart` → 24/24 pass.
- [x] Built locally (Debug) on macOS 26.4.1 (M1 Pro).

## Scope change note

This PR no longer closes #332 on its own — it stops the self-sustaining restart loop and surfaces terminal failures to the UI, but the empty-transcript (format-cache) and BT/default-input (routing-write) root causes will be addressed in the follow-up PR.