### PR TITLE
Fix Gemini model discovery and prompt fallback handling

### DIFF
--- a/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -8,6 +8,21 @@ import TypeWhisperPluginSDK
 final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gemini"
     static let pluginName = "Gemini"
+    private static let cachedLLMModelsKey = "fetchedLLMModels.v2"
+    private static let legacyCachedLLMModelsKey = "fetchedLLMModels"
+    private static let selectedLLMModelKey = "selectedLLMModel"
+    private static let compatibleModelsEndpoint = "https://generativelanguage.googleapis.com/v1beta/openai/models"
+    private static let modelIdPrefix = "models/"
+    private static let excludedCompatibleModelTokens = [
+        "embedding",
+        "-image",
+        "tts",
+        "live",
+        "audio",
+        "robotics",
+        "computer-use",
+        "deep-research",
+    ]
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -26,12 +41,14 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     func activate(host: HostServices) {
         self.host = host
         _apiKey = host.loadSecret(key: "api-key")
-        if let data = host.userDefault(forKey: "fetchedLLMModels") as? Data,
+        if let data = host.userDefault(forKey: Self.cachedLLMModelsKey) as? Data,
            let models = try? JSONDecoder().decode([GeminiFetchedModel].self, from: data) {
             _fetchedLLMModels = models
         }
-        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
-            ?? supportedModels.first?.id
+        host.setUserDefault(nil, forKey: Self.legacyCachedLLMModelsKey)
+        _selectedLLMModelId = host.userDefault(forKey: Self.selectedLLMModelKey) as? String
+        normalizeSelectedModel()
+        refreshCompatibleModelsIfNeeded()
     }
 
     func deactivate() {
@@ -48,9 +65,9 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     private static let fallbackLLMModels: [PluginModelInfo] = [
-        PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
-        PluginModelInfo(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro"),
-        PluginModelInfo(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite"),
+        PluginModelInfo(id: "gemini-flash-latest", displayName: "Gemini Flash Latest"),
+        PluginModelInfo(id: "gemini-pro-latest", displayName: "Gemini Pro Latest"),
+        PluginModelInfo(id: "gemini-flash-lite-latest", displayName: "Gemini Flash-Lite Latest"),
     ]
 
     var supportedModels: [PluginModelInfo] {
@@ -75,7 +92,7 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
 
     func selectLLMModel(_ modelId: String) {
         _selectedLLMModelId = modelId
-        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+        host?.setUserDefault(modelId, forKey: Self.selectedLLMModelKey)
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
@@ -112,11 +129,11 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     func validateApiKey(_ key: String) async -> Bool {
-        guard !key.isEmpty else { return false }
-        // Validate by listing models
-        guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models?key=\(key)") else { return false }
+        guard !key.isEmpty,
+              let url = URL(string: Self.compatibleModelsEndpoint) else { return false }
 
         var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 10
 
         do {
@@ -131,54 +148,105 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     fileprivate func setFetchedLLMModels(_ models: [GeminiFetchedModel]) {
         _fetchedLLMModels = models
         if let data = try? JSONEncoder().encode(models) {
-            host?.setUserDefault(data, forKey: "fetchedLLMModels")
+            host?.setUserDefault(data, forKey: Self.cachedLLMModelsKey)
         }
+        host?.setUserDefault(nil, forKey: Self.legacyCachedLLMModelsKey)
+        normalizeSelectedModel()
         host?.notifyCapabilitiesChanged()
     }
 
     fileprivate func fetchLLMModels() async -> [GeminiFetchedModel] {
         guard let apiKey = _apiKey, !apiKey.isEmpty,
-              let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models?key=\(apiKey)&pageSize=100") else { return [] }
+              let url = URL(string: Self.compatibleModelsEndpoint) else { return [] }
 
         var request = URLRequest(url: url)
-        request.timeoutInterval = 10
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
 
         do {
             let (data, response) = try await PluginHTTPClient.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return [] }
-
-            struct ModelsResponse: Decodable {
-                let models: [GeminiAPIModel]
-            }
-
-            let decoded = try JSONDecoder().decode(ModelsResponse.self, from: data)
-            return decoded.models
-                .filter { Self.isLLMModel($0) }
-                .map { model in
-                    let id = model.name.hasPrefix("models/") ? String(model.name.dropFirst(7)) : model.name
-                    return GeminiFetchedModel(id: id, displayName: model.displayName)
-                }
-                .sorted { $0.id < $1.id }
+            return try Self.decodeCompatibleLLMModels(from: data)
         } catch {
             return []
         }
     }
 
-    nonisolated private static func isLLMModel(_ model: GeminiAPIModel) -> Bool {
-        guard let methods = model.supportedGenerationMethods,
-              methods.contains("generateContent") else { return false }
-        let id = model.name.hasPrefix("models/") ? String(model.name.dropFirst(7)) : model.name
-        return id.hasPrefix("gemini-")
+    nonisolated static func decodeCompatibleLLMModels(from data: Data) throws -> [GeminiFetchedModel] {
+        let decoded = try JSONDecoder().decode(GeminiCompatibleModelsResponse.self, from: data)
+        var seenIds = Set<String>()
+
+        return decoded.data
+            .compactMap { model -> GeminiFetchedModel? in
+                let normalizedId = normalizedCompatibleModelId(model.id)
+                guard isCompatibleChatModelId(normalizedId),
+                      seenIds.insert(normalizedId).inserted else { return nil }
+                return GeminiFetchedModel(id: normalizedId, displayName: model.displayName)
+            }
+            .sorted { $0.id < $1.id }
+    }
+
+    nonisolated private static func normalizedCompatibleModelId(_ id: String) -> String {
+        guard id.hasPrefix(modelIdPrefix) else { return id }
+        return String(id.dropFirst(modelIdPrefix.count))
+    }
+
+    nonisolated private static func isCompatibleChatModelId(_ id: String) -> Bool {
+        guard id.hasPrefix("gemini-") else { return false }
+        return !excludedCompatibleModelTokens.contains { id.contains($0) }
+    }
+
+    private func normalizeSelectedModel() {
+        let supportedIds = Set(supportedModels.map(\.id))
+        guard !supportedIds.isEmpty else {
+            _selectedLLMModelId = nil
+            return
+        }
+
+        if let selectedModelId = _selectedLLMModelId,
+           supportedIds.contains(selectedModelId) {
+            return
+        }
+
+        let fallbackModelId = supportedModels.first?.id
+        _selectedLLMModelId = fallbackModelId
+        if let fallbackModelId {
+            host?.setUserDefault(fallbackModelId, forKey: Self.selectedLLMModelKey)
+        }
+    }
+
+    private func refreshCompatibleModelsIfNeeded() {
+        guard _fetchedLLMModels.isEmpty,
+              _apiKey?.isEmpty == false else { return }
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            let models = await self.fetchLLMModels()
+            guard !models.isEmpty else { return }
+
+            await MainActor.run {
+                self.setFetchedLLMModels(models)
+            }
+        }
     }
 }
 
-// MARK: - API Model (for decoding Gemini API response)
+// MARK: - OpenAI-Compatible Models API
 
-private struct GeminiAPIModel: Decodable {
-    let name: String
+private struct GeminiCompatibleModelsResponse: Decodable {
+    let data: [GeminiCompatibleModel]
+}
+
+private struct GeminiCompatibleModel: Decodable {
+    let id: String
     let displayName: String?
-    let supportedGenerationMethods: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+    }
 }
 
 // MARK: - Fetched Model
@@ -310,6 +378,9 @@ private struct GeminiSettingsView: View {
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             fetchedLLMModels = plugin._fetchedLLMModels
+            if plugin.isAvailable, fetchedLLMModels.isEmpty {
+                refreshLLMModels()
+            }
         }
     }
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
+		F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000141 /* GeminiPlugin.swift */; };
 		A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000001 /* SystemTTSPlugin.swift */; };
 		A10000000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000002 /* manifest.json */; };
 		A10000000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000044 /* TypeWhisperPluginSDK */; };
@@ -2848,6 +2849,7 @@
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
+				F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */,
 				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
 				C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -188,6 +188,7 @@ final class ServiceContainer: ObservableObject {
         TermPackRegistryService.shared = termPackRegistryService
 
         modelManagerService.observePluginManager()
+        promptProcessingService.observePluginManager()
         settingsViewModel.observePluginManager()
         watchFolderViewModel.observePluginManager()
     }

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import TypeWhisperPluginSDK
 import os.log
 
@@ -7,7 +8,16 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhis
 @MainActor
 class PromptProcessingService: ObservableObject {
     @Published var selectedProviderId: String {
-        didSet { UserDefaults.standard.set(selectedProviderId, forKey: "llmProviderType") }
+        didSet {
+            let normalized = normalizeProviderId(selectedProviderId)
+            guard normalized == selectedProviderId else {
+                selectedProviderId = normalized
+                return
+            }
+
+            UserDefaults.standard.set(selectedProviderId, forKey: "llmProviderType")
+            normalizeSelectedCloudModelIfNeeded(for: selectedProviderId)
+        }
     }
     @Published var selectedCloudModel: String {
         didSet { UserDefaults.standard.set(selectedCloudModel, forKey: "llmCloudModel") }
@@ -15,6 +25,7 @@ class PromptProcessingService: ObservableObject {
 
     weak var memoryService: MemoryService?
     private var appleIntelligenceProvider: LLMProvider?
+    private var cancellables = Set<AnyCancellable>()
 
     static let appleIntelligenceId = "appleIntelligence"
 
@@ -89,6 +100,17 @@ class PromptProcessingService: ObservableObject {
         }
     }
 
+    func observePluginManager() {
+        PluginManager.shared.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.validateSelectionAfterPluginLoad()
+                self.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
     /// Validate and fix selectedProviderId and selectedCloudModel after plugins are loaded.
     /// Called from ServiceContainer after scanAndLoadPlugins().
     func validateSelectionAfterPluginLoad() {
@@ -98,12 +120,7 @@ class PromptProcessingService: ObservableObject {
             selectedProviderId = normalized
         }
 
-        // Validate cloud model against available models for the selected provider
-        let models = modelsForProvider(selectedProviderId)
-        if !models.isEmpty && !models.contains(where: { $0.id == selectedCloudModel }) {
-            let pluginPreferred = (PluginManager.shared.llmProvider(for: selectedProviderId) as? LLMModelSelectable)?.preferredModelId as? String
-            selectedCloudModel = pluginPreferred ?? models.first?.id ?? ""
-        }
+        normalizeSelectedCloudModelIfNeeded(for: selectedProviderId)
     }
 
     func process(prompt: String, text: String, providerOverride: String? = nil, cloudModelOverride: String? = nil, skipMemoryInjection: Bool = false) async throws -> String {
@@ -116,7 +133,7 @@ class PromptProcessingService: ObservableObject {
             }
         }
 
-        let effectiveId = providerOverride ?? selectedProviderId
+        let effectiveId = normalizeProviderId(providerOverride ?? selectedProviderId)
 
         if effectiveId == Self.appleIntelligenceId {
             guard let provider = appleIntelligenceProvider, provider.isAvailable else {
@@ -136,8 +153,13 @@ class PromptProcessingService: ObservableObject {
             throw LLMError.noApiKey
         }
 
-        let preferred = (plugin as? LLMModelSelectable)?.preferredModelId as? String
-        let model = cloudModelOverride ?? preferred ?? (selectedCloudModel.isEmpty ? nil : selectedCloudModel)
+        normalizeSelectedCloudModelIfNeeded(for: effectiveId)
+        let requestedModel = cloudModelOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = resolvedModelId(
+            for: effectiveId,
+            requestedModel: requestedModel?.isEmpty == false ? requestedModel : nil,
+            persistGlobalSelection: false
+        )
         logger.info("Processing prompt with plugin \(effectiveId)")
         let result = try await plugin.process(
             systemPrompt: effectivePrompt,
@@ -146,5 +168,49 @@ class PromptProcessingService: ObservableObject {
         )
         logger.info("Prompt processing complete, result length: \(result.count)")
         return result
+    }
+
+    private func normalizeSelectedCloudModelIfNeeded(for providerId: String) {
+        guard providerId != Self.appleIntelligenceId else { return }
+        _ = resolvedModelId(
+            for: providerId,
+            requestedModel: selectedCloudModel.isEmpty ? nil : selectedCloudModel,
+            persistGlobalSelection: true
+        )
+    }
+
+    private func resolvedModelId(
+        for providerId: String,
+        requestedModel: String?,
+        persistGlobalSelection: Bool
+    ) -> String? {
+        let models = modelsForProvider(providerId)
+        guard !models.isEmpty else { return requestedModel }
+
+        let validIds = Set(models.map(\.id))
+        if let requestedModel,
+           validIds.contains(requestedModel) {
+            return requestedModel
+        }
+
+        let preferredModelId = (PluginManager.shared.llmProvider(for: providerId) as? LLMModelSelectable)?.preferredModelId as? String
+        let fallbackModelId: String?
+        if let preferredModelId,
+           validIds.contains(preferredModelId) {
+            fallbackModelId = preferredModelId
+        } else if !selectedCloudModel.isEmpty,
+                  validIds.contains(selectedCloudModel) {
+            fallbackModelId = selectedCloudModel
+        } else {
+            fallbackModelId = models.first?.id
+        }
+
+        if persistGlobalSelection,
+           let fallbackModelId,
+           selectedCloudModel != fallbackModelId {
+            selectedCloudModel = fallbackModelId
+        }
+
+        return fallbackModelId
     }
 }

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -67,6 +67,9 @@ struct PromptActionsSettingsView: View {
         } message: {
             Text(viewModel.error ?? "")
         }
+        .onAppear {
+            processingService.validateSelectionAfterPluginLoad()
+        }
     }
 
     // MARK: - Provider Section
@@ -277,10 +280,17 @@ struct ModelPickerView: View {
                 }
             }
             .onAppear {
-                if selection.isEmpty || !models.contains(where: { $0.id == selection }) {
-                    selection = models.first?.id ?? ""
-                }
+                ensureValidSelection()
             }
+            .onChange(of: models.map(\.id)) {
+                ensureValidSelection()
+            }
+        }
+    }
+
+    private func ensureValidSelection() {
+        if selection.isEmpty || !models.contains(where: { $0.id == selection }) {
+            selection = models.first?.id ?? ""
         }
     }
 }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -6,6 +6,37 @@ import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class APIRouterAndHandlersTests: XCTestCase {
+    @objc(APIRouterMockLLMProviderPlugin)
+    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.llm" }
+        static var pluginName: String { "Mock LLM" }
+
+        private let requestLock = NSLock()
+        var models: [PluginModelInfo] = []
+        var responseText = "processed"
+        nonisolated(unsafe) private var _lastRequestedModel: String?
+
+        var lastRequestedModel: String? {
+            requestLock.withLock { _lastRequestedModel }
+        }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerName: String { "Gemini" }
+        var isAvailable: Bool { true }
+        var supportedModels: [PluginModelInfo] { models }
+
+        func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+            requestLock.withLock {
+                _lastRequestedModel = model
+            }
+            return responseText
+        }
+    }
+
     @objc(APIRouterMockTranscriptionPlugin)
     private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.transcription" }
@@ -173,6 +204,64 @@ final class APIRouterAndHandlersTests: XCTestCase {
             guard isActive else { return }
             isActive = false
             onFinish?()
+        }
+    }
+
+    private final class MockEventBus: EventBusProtocol, @unchecked Sendable {
+        @discardableResult
+        func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID {
+            UUID()
+        }
+
+        func unsubscribe(id: UUID) {}
+    }
+
+    private final class MockHostServices: HostServices, @unchecked Sendable {
+        private var secrets: [String: String]
+        private var defaults: [String: Any]
+
+        let pluginDataDirectory: URL
+        let eventBus: EventBusProtocol = MockEventBus()
+        var activeAppBundleId: String?
+        var activeAppName: String?
+        var availableRuleNames: [String]
+        private(set) var capabilitiesChangedCount = 0
+        private(set) var streamingDisplayActiveValues: [Bool] = []
+
+        init(
+            pluginDataDirectory: URL,
+            secrets: [String: String] = [:],
+            defaults: [String: Any] = [:],
+            availableRuleNames: [String] = []
+        ) {
+            self.pluginDataDirectory = pluginDataDirectory
+            self.secrets = secrets
+            self.defaults = defaults
+            self.availableRuleNames = availableRuleNames
+        }
+
+        func storeSecret(key: String, value: String) throws {
+            secrets[key] = value
+        }
+
+        func loadSecret(key: String) -> String? {
+            secrets[key]
+        }
+
+        func userDefault(forKey key: String) -> Any? {
+            defaults[key]
+        }
+
+        func setUserDefault(_ value: Any?, forKey key: String) {
+            defaults[key] = value
+        }
+
+        func notifyCapabilitiesChanged() {
+            capabilitiesChangedCount += 1
+        }
+
+        func setStreamingDisplayActive(_ active: Bool) {
+            streamingDisplayActiveValues.append(active)
         }
     }
 
@@ -1562,6 +1651,177 @@ final class APIRouterAndHandlersTests: XCTestCase {
     private static func jsonObject(_ response: HTTPResponse) throws -> [String: Any] {
         let object = try JSONSerialization.jsonObject(with: response.body)
         return try XCTUnwrap(object as? [String: Any])
+    }
+
+    @MainActor
+    func testPromptProcessingRepairsInvalidGlobalCloudModelBeforeRequest() async throws {
+        let providerKey = "llmProviderType"
+        let modelKey = "llmCloudModel"
+        let originalProvider = UserDefaults.standard.object(forKey: providerKey)
+        let originalModel = UserDefaults.standard.object(forKey: modelKey)
+        defer {
+            if let originalProvider {
+                UserDefaults.standard.set(originalProvider, forKey: providerKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: providerKey)
+            }
+            if let originalModel {
+                UserDefaults.standard.set(originalModel, forKey: modelKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: modelKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        UserDefaults.standard.set("Gemini", forKey: providerKey)
+        UserDefaults.standard.set("legacy-direct-model", forKey: modelKey)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.models = [
+            PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+            PluginModelInfo(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro")
+        ]
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.llm",
+            name: "Mock LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+        let result = try await service.process(prompt: "Fix grammar", text: "hello world")
+
+        XCTAssertEqual(result, "processed")
+        XCTAssertEqual(plugin.lastRequestedModel, "gemini-2.5-flash")
+        XCTAssertEqual(service.selectedCloudModel, "gemini-2.5-flash")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "gemini-2.5-flash")
+    }
+
+    @MainActor
+    func testPromptProcessingIgnoresInvalidPromptOverrideWithoutPersistingIt() async throws {
+        let providerKey = "llmProviderType"
+        let modelKey = "llmCloudModel"
+        let originalProvider = UserDefaults.standard.object(forKey: providerKey)
+        let originalModel = UserDefaults.standard.object(forKey: modelKey)
+        defer {
+            if let originalProvider {
+                UserDefaults.standard.set(originalProvider, forKey: providerKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: providerKey)
+            }
+            if let originalModel {
+                UserDefaults.standard.set(originalModel, forKey: modelKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: modelKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        UserDefaults.standard.set("Gemini", forKey: providerKey)
+        UserDefaults.standard.set("gemini-2.5-pro", forKey: modelKey)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.models = [
+            PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+            PluginModelInfo(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro")
+        ]
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.llm",
+            name: "Mock LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            cloudModelOverride: "legacy-direct-model"
+        )
+
+        XCTAssertEqual(result, "processed")
+        XCTAssertEqual(plugin.lastRequestedModel, "gemini-2.5-pro")
+        XCTAssertEqual(service.selectedCloudModel, "gemini-2.5-pro")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "gemini-2.5-pro")
+    }
+
+    @MainActor
+    func testGeminiPluginCompatibleModelDecodingNormalizesIdsAndFiltersToChatModels() throws {
+        let response = Data(
+            """
+            {
+              "object": "list",
+              "data": [
+                { "id": "models/gemini-2.5-pro", "object": "model", "display_name": "Gemini 2.5 Pro" },
+                { "id": "models/gemini-3-flash-preview", "object": "model", "display_name": "Gemini 3 Flash Preview" },
+                { "id": "models/gemini-2.5-flash-image", "object": "model", "display_name": "Nano Banana" },
+                { "id": "models/gemini-embedding-2-preview", "object": "model", "display_name": "Gemini Embedding 2 Preview" },
+                { "id": "models/gemini-2.5-flash-native-audio-latest", "object": "model", "display_name": "Gemini 2.5 Flash Native Audio Latest" },
+                { "id": "models/gemma-4-31b-it", "object": "model", "display_name": "Gemma 4 31B IT" }
+              ]
+            }
+            """.utf8
+        )
+
+        let models = try GeminiPlugin.decodeCompatibleLLMModels(from: response)
+
+        XCTAssertEqual(models.map(\.id), ["gemini-2.5-pro", "gemini-3-flash-preview"])
+        XCTAssertEqual(models.first?.displayName, "Gemini 2.5 Pro")
+        XCTAssertEqual(models.last?.displayName, "Gemini 3 Flash Preview")
+    }
+
+    @MainActor
+    func testGeminiPluginActivationIgnoresLegacyCacheAndRepairsInvalidSelection() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let legacyCache = try JSONEncoder().encode([
+            GeminiFetchedModel(id: "gemini-1.5-pro", displayName: "Gemini 1.5 Pro")
+        ])
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: [
+                "fetchedLLMModels": legacyCache,
+                "selectedLLMModel": "gemini-1.5-pro"
+            ]
+        )
+        let plugin = GeminiPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["gemini-flash-latest", "gemini-pro-latest", "gemini-flash-lite-latest"])
+        XCTAssertEqual(plugin.selectedLLMModelId, "gemini-flash-latest")
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "gemini-flash-latest")
     }
 
     @MainActor


### PR DESCRIPTION
Closes #336

## Summary
- switch Gemini model discovery and API key validation to the OpenAI-compatible Gemini models endpoint
- normalize `models/...` IDs from the Gemini response, refresh the cached model list automatically, and fall back to the current Gemini alias models when no fetched list is available
- repair stale global and prompt-specific Gemini model selections in prompt processing and add regression coverage for the broken path

## Root cause
The Gemini OpenAI-compatible `/v1beta/openai/models` endpoint returns model IDs prefixed with `models/`. Our decoder filtered for raw `gemini-...` IDs, so the fetched list was dropped and the plugin kept falling back to stale defaults. That left prompt requests sending invalid or outdated model IDs to `/v1beta/openai/chat/completions`, which produced the HTTP 400 reported in #336.

## Validation
- `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- `swift test --package-path /Users/marco/.codex/worktrees/c5f6/typewhisper-mac/TypeWhisperPluginSDK`
- `git diff --check`
