### PR TITLE
fix: align language picker search with app locale

### DIFF
--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -27,6 +27,50 @@ func localizedAppLanguageName(for code: String) -> String {
     return locale.localizedString(forIdentifier: code) ?? code
 }
 
+struct LocalizedAppLanguageOption: Equatable {
+    let code: String
+    let name: String
+}
+
+func localizedAppLanguageOptions(for codes: [String]) -> [LocalizedAppLanguageOption] {
+    codes.map { code in
+        LocalizedAppLanguageOption(code: code, name: localizedAppLanguageName(for: code))
+    }
+}
+
+func localizedAppLanguageSearchTerms(for code: String, preferredDisplayName: String? = nil) -> [String] {
+    var terms: [String] = []
+
+    if let preferredDisplayName {
+        appendLanguageSearchTerm(preferredDisplayName, to: &terms)
+    }
+
+    appendLanguageSearchTerm(code, to: &terms)
+    appendLanguageSearchTerm(localizedAppLanguageName(for: code), to: &terms)
+
+    let locales = [
+        Locale.current,
+        Locale(identifier: "en"),
+        Locale(identifier: code)
+    ]
+
+    for locale in locales {
+        appendLanguageSearchTerm(locale.localizedString(forIdentifier: code), to: &terms)
+    }
+
+    return terms
+}
+
+private func appendLanguageSearchTerm(_ value: String?, to terms: inout [String]) {
+    guard let value else { return }
+
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    guard !terms.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) else { return }
+
+    terms.append(trimmed)
+}
+
 func localizedAppLanguageFlag(for code: String) -> String? {
     guard code != "auto" else { return nil }
 

--- a/TypeWhisper/ViewModels/SettingsViewModel.swift
+++ b/TypeWhisper/ViewModels/SettingsViewModel.swift
@@ -237,10 +237,9 @@ final class SettingsViewModel: ObservableObject {
                 codes.insert(code)
             }
         }
-        return codes.map { code in
-            let name = Locale.current.localizedString(forIdentifier: code) ?? code
-            return (code: code, name: name)
-        }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        return localizedAppLanguageOptions(for: Array(codes))
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .map { (code: $0.code, name: $0.name) }
     }
 
     var supportsTranslation: Bool {

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -198,9 +198,9 @@ struct AudioRecorderView: View {
                               !engine.supportedLanguages.isEmpty else {
                             return SettingsViewModel.shared.availableLanguages
                         }
-                        return engine.supportedLanguages
-                            .map { ($0, Locale.current.localizedString(forIdentifier: $0) ?? $0) }
-                            .sorted { $0.1.localizedCaseInsensitiveCompare($1.1) == .orderedAscending }
+                        return localizedAppLanguageOptions(for: engine.supportedLanguages)
+                            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                            .map { (code: $0.code, name: $0.name) }
                     }()
 
                     LanguageSelectionEditor(

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -112,8 +112,9 @@ struct FileTranscriptionView: View {
 
                     LanguageSelectionEditor(
                         selection: $watchFolder.languageSelection,
-                        availableLanguages: watchFolder.selectedEngineSupportedLanguages
-                            .map { ($0, Locale.current.localizedString(forIdentifier: $0) ?? $0) }
+                        availableLanguages: localizedAppLanguageOptions(for: watchFolder.selectedEngineSupportedLanguages)
+                            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                            .map { (code: $0.code, name: $0.name) }
                     )
                 }
 

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -287,7 +287,8 @@ struct LanguageSelectionEditor: View {
     private var filteredLanguages: [(code: String, name: String)] {
         guard !searchQuery.isEmpty else { return availableLanguages }
         return availableLanguages.filter {
-            $0.name.localizedCaseInsensitiveContains(searchQuery) || $0.code.localizedCaseInsensitiveContains(searchQuery)
+            localizedAppLanguageSearchTerms(for: $0.code, preferredDisplayName: $0.name)
+                .contains(where: { $0.localizedCaseInsensitiveContains(searchQuery) })
         }
     }
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -111,3 +111,39 @@ final class DockIconVisibilityTests: XCTestCase {
         )
     }
 }
+
+final class LanguageLocalizationTests: XCTestCase {
+    private var originalPreferredAppLanguage: String?
+
+    override func setUp() {
+        super.setUp()
+        originalPreferredAppLanguage = UserDefaults.standard.string(forKey: UserDefaultsKeys.preferredAppLanguage)
+    }
+
+    override func tearDown() {
+        if let originalPreferredAppLanguage {
+            UserDefaults.standard.set(originalPreferredAppLanguage, forKey: UserDefaultsKeys.preferredAppLanguage)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.preferredAppLanguage)
+        }
+        super.tearDown()
+    }
+
+    func testLocalizedAppLanguageOptionsFollowPreferredAppLanguage() {
+        UserDefaults.standard.set("en", forKey: UserDefaultsKeys.preferredAppLanguage)
+
+        let options = localizedAppLanguageOptions(for: ["de", "en"])
+
+        XCTAssertEqual(options.map(\.code), ["de", "en"])
+        XCTAssertEqual(options.map(\.name), ["German", "English"])
+    }
+
+    func testLanguageSearchTermsIncludeEnglishAliasForEnglish() {
+        UserDefaults.standard.set("de", forKey: UserDefaultsKeys.preferredAppLanguage)
+
+        let searchTerms = localizedAppLanguageSearchTerms(for: "en")
+
+        XCTAssertTrue(searchTerms.contains(where: { $0.localizedCaseInsensitiveContains("english") }))
+        XCTAssertTrue(searchTerms.contains(where: { $0.localizedCaseInsensitiveContains("englisch") }))
+    }
+}


### PR DESCRIPTION
## Summary
- align spoken-language picker labels with the app language instead of the macOS system locale
- expand picker search matching so mixed locale setups still find languages like \`english\` and \`englisch\`
- add regression coverage for localized language labels and search aliases

## Verification
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh \"$(pwd)\"`

## Pre-Landing Review
- No issues found.

## Docs / TODOs
- No documentation or TODO updates were required for this bug fix.