### PR TITLE
feat: redesign the licensing settings flow

### DIFF
--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -163,6 +163,27 @@ enum AppConstants {
         static let checkoutURLSupporterGold = "https://buy.polar.sh/polar_cl_FpojMlLmyF73gOqpXLihSE0lNYnoQoaMxGp724IIor4"
     }
 
+    enum Website {
+        private static var localeSegment: String {
+            let preferred = UserDefaults.standard.string(forKey: UserDefaultsKeys.preferredAppLanguage)
+                ?? Bundle.main.preferredLocalizations.first
+                ?? Locale.preferredLanguages.first
+                ?? "en"
+            return preferred.hasPrefix("de") ? "de" : "en"
+        }
+
+        private static let rootURL = "https://www.typewhisper.com"
+        static let licensingEmailURL = URL(string: "mailto:licensing@typewhisper.com")!
+
+        static var pricingURL: URL {
+            URL(string: "\(rootURL)/\(localeSegment)/pricing/")!
+        }
+
+        static var teamContactURL: URL {
+            URL(string: "\(rootURL)/\(localeSegment)/business/") ?? licensingEmailURL
+        }
+    }
+
     // MARK: - Discord Claim Service
     enum DiscordClaim {
         static let defaultBaseURLString = "http://127.0.0.1:8787"

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -104,12 +104,14 @@ enum UserDefaultsKeys {
     static let watchFolderModel = "watchFolderModel"
 
     // MARK: - Licensing
+    static let usageIntent = "usageIntent"
     static let userType = "userType"
     static let licenseStatus = "licenseStatus"
     static let licenseTier = "licenseTier"
     static let lastLicenseValidation = "lastLicenseValidation"
     static let licenseIsLifetime = "licenseIsLifetime"
     static let welcomeSheetShown = "welcomeSheetShown"
+    static let workUsagePromptDismissed = "workUsagePromptDismissed"
 
     // MARK: - Supporter
     static let supporterTier = "supporterTier"

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -3,27 +3,39 @@ import Foundation
 import Security
 import os
 
-enum LicenseUserType: String {
+enum UsageIntent: String, CaseIterable, Sendable {
+    case personalOSS
+    case workSolo
+    case team
+    case enterprise
+}
+
+enum LicenseUserType: String, Sendable {
     case privateUser = "private"
     case business = "business"
 }
 
-enum LicenseStatus: String {
+enum LicenseStatus: String, Sendable {
     case unlicensed
     case active = "polar_active"
     case expired = "polar_expired"
 }
 
-enum LicenseTier: String {
+enum LicenseTier: String, Sendable {
     case individual
     case team
     case enterprise
 }
 
-enum SupporterTier: String, CaseIterable {
+enum SupporterTier: String, CaseIterable, Sendable {
     case bronze
     case silver
     case gold
+}
+
+enum ActivatedEntitlement: Equatable, Sendable {
+    case commercial(tier: LicenseTier, isLifetime: Bool)
+    case supporter(tier: SupporterTier)
 }
 
 struct PolarActivationResponse: Codable {
@@ -34,17 +46,27 @@ struct PolarValidationResponse: Codable {
     let id: String
     let status: String
     let expiresAt: String?
+    let benefitId: String?
     let benefit: PolarBenefit?
 
     enum CodingKeys: String, CodingKey {
         case id, status
         case expiresAt = "expires_at"
+        case benefitId = "benefit_id"
         case benefit
     }
 
     struct PolarBenefit: Codable {
         let id: String
         let description: String?
+    }
+
+    var resolvedBenefitID: String? {
+        benefit?.id ?? benefitId
+    }
+
+    var resolvedBenefitDescription: String? {
+        benefit?.description
     }
 }
 
@@ -53,28 +75,106 @@ struct PolarErrorResponse: Codable {
     let type: String?
 }
 
+typealias LicenseDataTransport = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+private struct KnownPolarBenefit<Value: Sendable>: Sendable {
+    let id: String
+    let name: String
+    let value: Value
+}
+
+private let knownPolarCommercialBenefits: [KnownPolarBenefit<LicenseTier>] = [
+    KnownPolarBenefit(
+        id: "a4c0b152-0b91-4588-b8f8-779870affba9",
+        name: "Individual Business License",
+        value: .individual
+    ),
+    KnownPolarBenefit(
+        id: "4eb5fa60-ed43-475d-a9b1-c837e67307e5",
+        name: "Lifetime Business License",
+        value: .individual
+    ),
+    KnownPolarBenefit(
+        id: "5138b20a-57ba-48aa-a664-2139cd6df0de",
+        name: "Team Business License",
+        value: .team
+    ),
+    KnownPolarBenefit(
+        id: "afc8fac1-0e8f-4bb7-a1bc-60c8250b9923",
+        name: "Lifetime Team Business License",
+        value: .team
+    ),
+    KnownPolarBenefit(
+        id: "40b82917-f74e-4cc3-8165-937f1f47b294",
+        name: "Enterprise Business License",
+        value: .enterprise
+    ),
+    KnownPolarBenefit(
+        id: "1857c2ed-3f80-4a8a-93c7-c1d67e02db2e",
+        name: "Lifetime Enterprise Business License",
+        value: .enterprise
+    ),
+]
+
+private let knownPolarSupporterBenefits: [KnownPolarBenefit<SupporterTier>] = [
+    KnownPolarBenefit(
+        id: "d3eef5ed-bc8c-469d-809b-79fdfe5fc8e8",
+        name: "Supporter Bronze License",
+        value: .bronze
+    ),
+    KnownPolarBenefit(
+        id: "9ca12e41-b407-4368-9745-76b72ff2c7c2",
+        name: "Supporter Silver License",
+        value: .silver
+    ),
+    KnownPolarBenefit(
+        id: "0c695b7a-2f3a-4797-81c7-1410dbb76cc2",
+        name: "Supporter Gold License",
+        value: .gold
+    ),
+]
+
+private let polarCommercialBenefitIDs = Dictionary(
+    uniqueKeysWithValues: knownPolarCommercialBenefits.map { ($0.id, $0.value) }
+)
+
+private let polarSupporterBenefitIDs = Dictionary(
+    uniqueKeysWithValues: knownPolarSupporterBenefits.map { ($0.id, $0.value) }
+)
+
+private let knownPolarBenefitNames = Dictionary(
+    uniqueKeysWithValues:
+        knownPolarCommercialBenefits.map { ($0.id, $0.name) } +
+        knownPolarSupporterBenefits.map { ($0.id, $0.name) }
+)
+
 @MainActor
 final class LicenseService: ObservableObject {
     nonisolated(unsafe) static var shared: LicenseService!
 
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "LicenseService")
-    private let keychainKeyPrefix = AppConstants.keychainServicePrefix
     private let validationInterval: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     private let supporterValidationInterval: TimeInterval = 30 * 24 * 60 * 60 // 30 days
+    private let defaults: UserDefaults
+    private let dataTransport: LicenseDataTransport
+    private let keychainServiceName: String
 
     // MARK: - Published state (Business)
 
-    @Published var userType: LicenseUserType? {
-        didSet { UserDefaults.standard.set(userType?.rawValue, forKey: UserDefaultsKeys.userType) }
+    @Published var usageIntent: UsageIntent {
+        didSet {
+            defaults.set(usageIntent.rawValue, forKey: UserDefaultsKeys.usageIntent)
+            defaults.set(Self.legacyUserType(for: usageIntent).rawValue, forKey: UserDefaultsKeys.userType)
+        }
     }
     @Published var licenseStatus: LicenseStatus {
-        didSet { UserDefaults.standard.set(licenseStatus.rawValue, forKey: UserDefaultsKeys.licenseStatus) }
+        didSet { defaults.set(licenseStatus.rawValue, forKey: UserDefaultsKeys.licenseStatus) }
     }
     @Published var licenseTier: LicenseTier? {
-        didSet { UserDefaults.standard.set(licenseTier?.rawValue, forKey: UserDefaultsKeys.licenseTier) }
+        didSet { defaults.set(licenseTier?.rawValue, forKey: UserDefaultsKeys.licenseTier) }
     }
     @Published var licenseIsLifetime: Bool {
-        didSet { UserDefaults.standard.set(licenseIsLifetime, forKey: UserDefaultsKeys.licenseIsLifetime) }
+        didSet { defaults.set(licenseIsLifetime, forKey: UserDefaultsKeys.licenseIsLifetime) }
     }
     @Published var isActivating = false
     @Published var activationError: String?
@@ -83,14 +183,20 @@ final class LicenseService: ObservableObject {
     // MARK: - Published state (Supporter)
 
     @Published var supporterTier: SupporterTier? {
-        didSet { UserDefaults.standard.set(supporterTier?.rawValue, forKey: UserDefaultsKeys.supporterTier) }
+        didSet { defaults.set(supporterTier?.rawValue, forKey: UserDefaultsKeys.supporterTier) }
     }
     @Published var supporterStatus: LicenseStatus {
-        didSet { UserDefaults.standard.set(supporterStatus.rawValue, forKey: UserDefaultsKeys.supporterStatus) }
+        didSet { defaults.set(supporterStatus.rawValue, forKey: UserDefaultsKeys.supporterStatus) }
     }
     @Published var isSupporterActivating = false
     @Published var supporterActivationError: String?
     @Published var supporterDeactivationError: String?
+
+    private enum ExpectedEntitlementKind {
+        case any
+        case commercial
+        case supporter
+    }
 
     var isSupporter: Bool { supporterStatus == .active && supporterTier != nil }
     var supporterClaimProof: SupporterClaimProof? {
@@ -106,43 +212,60 @@ final class LicenseService: ObservableObject {
     }
 
     var needsWelcomeSheet: Bool {
-        !UserDefaults.standard.bool(forKey: UserDefaultsKeys.welcomeSheetShown)
+        !defaults.bool(forKey: UserDefaultsKeys.welcomeSheetShown)
     }
 
     var shouldShowReminder: Bool {
-        userType == .business && licenseStatus != .active
+        requiresCommercialLicense && licenseStatus != .active
+    }
+
+    var requiresCommercialLicense: Bool {
+        usageIntent != .personalOSS
+    }
+
+    var shouldShowWorkUsagePrompt: Bool {
+        usageIntent == .personalOSS && licenseStatus != .active
     }
 
     // MARK: - Init
 
-    init() {
-        // Business license state
-        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.userType) {
-            self.userType = LicenseUserType(rawValue: raw)
-        } else {
-            self.userType = nil
+    init(
+        defaults: UserDefaults = .standard,
+        keychainServiceName: String = AppConstants.keychainServicePrefix + "license",
+        dataTransport: @escaping LicenseDataTransport = { request in
+            try await URLSession.shared.data(for: request)
         }
-        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.licenseStatus),
+    ) {
+        self.defaults = defaults
+        self.keychainServiceName = keychainServiceName
+        self.dataTransport = dataTransport
+
+        let migratedUsageIntent = Self.migrateUsageIntent(defaults: defaults)
+
+        // Business license state
+        self.usageIntent = migratedUsageIntent
+
+        if let raw = defaults.string(forKey: UserDefaultsKeys.licenseStatus),
            let status = LicenseStatus(rawValue: raw) {
             self.licenseStatus = status
         } else {
             self.licenseStatus = .unlicensed
         }
-        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.licenseTier) {
+        if let raw = defaults.string(forKey: UserDefaultsKeys.licenseTier) {
             self.licenseTier = LicenseTier(rawValue: raw)
         } else {
             self.licenseTier = nil
         }
-        self.licenseIsLifetime = UserDefaults.standard.bool(forKey: UserDefaultsKeys.licenseIsLifetime)
+        self.licenseIsLifetime = defaults.bool(forKey: UserDefaultsKeys.licenseIsLifetime)
 
         // Supporter state
-        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.supporterStatus),
+        if let raw = defaults.string(forKey: UserDefaultsKeys.supporterStatus),
            let status = LicenseStatus(rawValue: raw) {
             self.supporterStatus = status
         } else {
             self.supporterStatus = .unlicensed
         }
-        if let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.supporterTier) {
+        if let raw = defaults.string(forKey: UserDefaultsKeys.supporterTier) {
             self.supporterTier = SupporterTier(rawValue: raw)
         } else {
             self.supporterTier = nil
@@ -152,38 +275,64 @@ final class LicenseService: ObservableObject {
     // MARK: - Welcome Sheet
 
     func markWelcomeSheetShown() {
-        UserDefaults.standard.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+    }
+
+    func setUsageIntent(_ intent: UsageIntent) {
+        usageIntent = intent
+        markWelcomeSheetShown()
     }
 
     func setUserType(_ type: LicenseUserType) {
-        userType = type
-        markWelcomeSheetShown()
+        let mappedIntent: UsageIntent = switch type {
+        case .privateUser:
+            .personalOSS
+        case .business:
+            .workSolo
+        }
+        setUsageIntent(mappedIntent)
     }
 
     // MARK: - Polar License Key
 
-    func activateLicenseKey(_ key: String) async {
+    func activateAnyKey(_ key: String) async -> ActivatedEntitlement? {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return nil }
+
         isActivating = true
         activationError = nil
         deactivationError = nil
+        supporterActivationError = nil
+        supporterDeactivationError = nil
+        defer { isActivating = false }
 
         do {
-            let response = try await polarActivate(key: key)
-            saveLicenseToKeychain(key: key, activationId: response.id)
-            licenseStatus = .active
-            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
+            let entitlement = try await activateKey(trimmedKey, expecting: .any)
+            logger.info("Universal key activation succeeded")
+            return entitlement
+        } catch {
+            activationError = error.localizedDescription
+            logger.error("Universal key activation failed: \(error)")
+            return nil
+        }
+    }
 
-            // Detect lifetime vs subscription
-            let validation = try? await polarValidate(key: key, activationId: response.id)
-            licenseIsLifetime = validation?.expiresAt == nil
+    func activateLicenseKey(_ key: String) async {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
 
-            logger.info("License activated via Polar (activation: \(response.id), lifetime: \(self.licenseIsLifetime))")
+        isActivating = true
+        activationError = nil
+        deactivationError = nil
+        defer { isActivating = false }
+
+        do {
+            _ = try await activateKey(trimmedKey, expecting: .commercial)
+            logger.info("Commercial key activated via Polar")
         } catch {
             activationError = error.localizedDescription
             logger.error("License activation failed: \(error)")
         }
-
-        isActivating = false
     }
 
     func validateLicense() async {
@@ -194,15 +343,25 @@ final class LicenseService: ObservableObject {
             if response.status == "granted" {
                 licenseStatus = .active
                 licenseIsLifetime = response.expiresAt == nil
-                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
+                licenseTier = Self.inferLicenseTier(
+                    benefitID: response.resolvedBenefitID,
+                    benefitDescription: response.resolvedBenefitDescription
+                )
+                defaults.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
                 logger.info("License validation successful (lifetime: \(self.licenseIsLifetime))")
             } else {
                 licenseStatus = .expired
+                licenseTier = nil
                 logger.warning("License revoked or disabled (status: \(response.status))")
             }
         } catch {
-            logger.error("License validation failed: \(error)")
-            // Keep current status on network errors - don't downgrade offline users
+            if Self.isPolarResourceMissing(error) {
+                logger.warning("Stored license activation no longer exists on Polar; clearing local license state")
+                clearLicenseState()
+            } else {
+                logger.error("License validation failed: \(error)")
+                // Keep current status on network errors - don't downgrade offline users
+            }
         }
     }
 
@@ -220,7 +379,7 @@ final class LicenseService: ObservableObject {
             return
         }
 
-        guard let lastValidation = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastLicenseValidation) as? Date else {
+        guard let lastValidation = defaults.object(forKey: UserDefaultsKeys.lastLicenseValidation) as? Date else {
             await validateLicense()
             return
         }
@@ -237,44 +396,36 @@ final class LicenseService: ObservableObject {
             try await polarDeactivate(key: key, activationId: activationId)
             logger.info("License deactivated on Polar")
 
-            removeLicenseFromKeychain()
-            licenseStatus = .unlicensed
-            licenseTier = nil
-            licenseIsLifetime = false
-            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastLicenseValidation)
+            clearLicenseState()
         } catch {
-            deactivationError = error.localizedDescription
-            logger.error("Polar deactivation failed: \(error)")
+            if Self.isPolarResourceMissing(error) {
+                logger.warning("License activation was already missing on Polar during deactivation; clearing local state")
+                clearLicenseState()
+            } else {
+                deactivationError = error.localizedDescription
+                logger.error("Polar deactivation failed: \(error)")
+            }
         }
     }
 
     // MARK: - Supporter License
 
     func activateSupporterKey(_ key: String) async {
+        let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
         isSupporterActivating = true
         supporterActivationError = nil
         supporterDeactivationError = nil
+        defer { isSupporterActivating = false }
 
         do {
-            let response = try await polarActivate(key: key)
-            saveSupporterToKeychain(key: key, activationId: response.id)
-            supporterStatus = .active
-            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
-
-            // Detect tier from benefit description
-            if let validation = try? await polarValidate(key: key, activationId: response.id) {
-                supporterTier = supporterTier(from: validation.benefit?.description)
-            } else {
-                supporterTier = .bronze
-            }
-
-            logger.info("Supporter activated via Polar (activation: \(response.id), tier: \(self.supporterTier?.rawValue ?? "unknown"))")
+            _ = try await activateKey(trimmedKey, expecting: .supporter)
+            logger.info("Supporter key activated via Polar")
         } catch {
             supporterActivationError = error.localizedDescription
             logger.error("Supporter activation failed: \(error)")
         }
-
-        isSupporterActivating = false
     }
 
     func validateSupporterIfNeeded() async {
@@ -292,7 +443,7 @@ final class LicenseService: ObservableObject {
             return
         }
 
-        guard let lastValidation = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastSupporterValidation) as? Date else {
+        guard let lastValidation = defaults.object(forKey: UserDefaultsKeys.lastSupporterValidation) as? Date else {
             await validateSupporter(key: key, activationId: activationId)
             return
         }
@@ -306,8 +457,11 @@ final class LicenseService: ObservableObject {
             let response = try await polarValidate(key: key, activationId: activationId)
             if response.status == "granted" {
                 supporterStatus = .active
-                supporterTier = supporterTier(from: response.benefit?.description)
-                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
+                supporterTier = Self.inferSupporterTier(
+                    benefitID: response.resolvedBenefitID,
+                    benefitDescription: response.resolvedBenefitDescription
+                ) ?? .bronze
+                defaults.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
                 logger.info("Supporter validation successful")
             } else {
                 supporterStatus = .expired
@@ -316,7 +470,12 @@ final class LicenseService: ObservableObject {
                 logger.warning("Supporter revoked or disabled (status: \(response.status))")
             }
         } catch {
-            logger.error("Supporter validation failed: \(error)")
+            if Self.isPolarResourceMissing(error) {
+                logger.warning("Stored supporter activation no longer exists on Polar; clearing local supporter state")
+                clearSupporterState()
+            } else {
+                logger.error("Supporter validation failed: \(error)")
+            }
         }
     }
 
@@ -328,22 +487,180 @@ final class LicenseService: ObservableObject {
             try await polarDeactivate(key: key, activationId: activationId)
             logger.info("Supporter deactivated on Polar")
 
-            removeSupporterFromKeychain()
-            supporterStatus = .unlicensed
-            supporterTier = nil
-            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastSupporterValidation)
-            SupporterDiscordService.shared?.handleSupporterEntitlementRemoved()
+            clearSupporterState()
         } catch {
-            supporterDeactivationError = error.localizedDescription
-            logger.error("Supporter deactivation failed: \(error)")
+            if Self.isPolarResourceMissing(error) {
+                logger.warning("Supporter activation was already missing on Polar during deactivation; clearing local state")
+                clearSupporterState()
+            } else {
+                supporterDeactivationError = error.localizedDescription
+                logger.error("Supporter deactivation failed: \(error)")
+            }
         }
     }
 
-    private func supporterTier(from benefitDescription: String?) -> SupporterTier {
-        guard let description = benefitDescription?.lowercased() else { return .bronze }
-        if description.contains("gold") { return .gold }
-        if description.contains("silver") { return .silver }
+    private func activateKey(_ key: String, expecting expectedEntitlement: ExpectedEntitlementKind) async throws -> ActivatedEntitlement {
+        let response = try await polarActivate(key: key)
+
+        do {
+            let validation = try await polarValidate(key: key, activationId: response.id)
+            guard validation.status == "granted" else {
+                throw LicenseError.activationFailed(
+                    localizedAppText(
+                        "This entitlement is not active.",
+                        de: "Dieses Entitlement ist nicht aktiv."
+                    )
+                )
+            }
+
+            let benefitID = validation.resolvedBenefitID
+            let benefitDescription = validation.resolvedBenefitDescription
+
+            if let supporterTier = Self.inferSupporterTier(benefitID: benefitID, benefitDescription: benefitDescription) {
+                guard expectedEntitlement != .commercial else {
+                    throw LicenseError.activationFailed(
+                        localizedAppText(
+                            "This key belongs to a supporter tier, not a commercial license.",
+                            de: "Dieser Schlüssel gehört zu einem Supporter-Tier, nicht zu einer kommerziellen Lizenz."
+                        )
+                    )
+                }
+
+                applySupporterActivation(
+                    key: key,
+                    activationId: response.id,
+                    tier: supporterTier
+                )
+                return .supporter(tier: supporterTier)
+            }
+
+            if let licenseTier = Self.inferLicenseTier(benefitID: benefitID, benefitDescription: benefitDescription) {
+                guard expectedEntitlement != .supporter else {
+                    throw LicenseError.activationFailed(
+                        localizedAppText(
+                            "This key belongs to a commercial license, not a supporter tier.",
+                            de: "Dieser Schlüssel gehört zu einer kommerziellen Lizenz, nicht zu einem Supporter-Tier."
+                        )
+                    )
+                }
+
+                let isLifetime = validation.expiresAt == nil
+                applyCommercialActivation(
+                    key: key,
+                    activationId: response.id,
+                    tier: licenseTier,
+                    isLifetime: isLifetime
+                )
+                return .commercial(tier: licenseTier, isLifetime: isLifetime)
+            }
+
+            let normalizedBenefitID = Self.normalizeBenefitIdentifier(benefitID)
+            let benefitName = normalizedBenefitID.flatMap { knownPolarBenefitNames[$0] } ?? benefitDescription ?? "unknown"
+            logger.error(
+                "Unknown Polar entitlement during activation (benefitID: \(benefitID ?? "nil"), benefitName: \(benefitName))"
+            )
+
+            throw LicenseError.activationFailed(
+                localizedAppText(
+                    "This key could not be matched to a known TypeWhisper entitlement.",
+                    de: "Dieser Schlüssel konnte keinem bekannten TypeWhisper-Entitlement zugeordnet werden."
+                )
+            )
+        } catch {
+            try? await polarDeactivate(key: key, activationId: response.id)
+            throw error
+        }
+    }
+
+    nonisolated static func inferLicenseTier(benefitID: String?, benefitDescription: String?) -> LicenseTier? {
+        if let normalizedBenefitID = normalizeBenefitIdentifier(benefitID),
+           let tier = polarCommercialBenefitIDs[normalizedBenefitID] {
+            return tier
+        }
+
+        let haystack = [benefitID, benefitDescription]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+
+        guard !haystack.isEmpty else { return nil }
+
+        if haystack.contains("enterprise") || haystack.contains("unlimited device") {
+            return .enterprise
+        }
+        if haystack.contains("team") || haystack.contains("10 device") || haystack.contains("small teams") {
+            return .team
+        }
+        if haystack.contains("individual") || haystack.contains("single-seat") || haystack.contains("single seat") ||
+            haystack.contains("freelancer") || haystack.contains("2 device") {
+            return .individual
+        }
+
+        return nil
+    }
+
+    nonisolated static func inferSupporterTier(benefitID: String?, benefitDescription: String?) -> SupporterTier? {
+        if let normalizedBenefitID = normalizeBenefitIdentifier(benefitID),
+           let tier = polarSupporterBenefitIDs[normalizedBenefitID] {
+            return tier
+        }
+
+        let haystack = [benefitID, benefitDescription]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+
+        guard haystack.contains("supporter") ||
+                haystack.contains("bronze") ||
+                haystack.contains("silver") ||
+                haystack.contains("gold") else {
+            return nil
+        }
+
+        if haystack.contains("gold") { return .gold }
+        if haystack.contains("silver") { return .silver }
         return .bronze
+    }
+
+    nonisolated private static func normalizeBenefitIdentifier(_ benefitID: String?) -> String? {
+        let normalized = benefitID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        guard let normalized, !normalized.isEmpty else { return nil }
+        return normalized
+    }
+
+    private static func migrateUsageIntent(defaults: UserDefaults) -> UsageIntent {
+        if let raw = defaults.string(forKey: UserDefaultsKeys.usageIntent),
+           let intent = UsageIntent(rawValue: raw) {
+            defaults.set(legacyUserType(for: intent).rawValue, forKey: UserDefaultsKeys.userType)
+            return intent
+        }
+
+        let migrated: UsageIntent
+        if let raw = defaults.string(forKey: UserDefaultsKeys.userType),
+           let legacy = LicenseUserType(rawValue: raw) {
+            migrated = switch legacy {
+            case .privateUser:
+                .personalOSS
+            case .business:
+                .workSolo
+            }
+        } else {
+            migrated = .personalOSS
+        }
+
+        defaults.set(migrated.rawValue, forKey: UserDefaultsKeys.usageIntent)
+        defaults.set(legacyUserType(for: migrated).rawValue, forKey: UserDefaultsKeys.userType)
+        return migrated
+    }
+
+    private static func legacyUserType(for intent: UsageIntent) -> LicenseUserType {
+        switch intent {
+        case .personalOSS:
+            .privateUser
+        case .workSolo, .team, .enterprise:
+            .business
+        }
     }
 
     // MARK: - Polar API
@@ -372,7 +689,7 @@ final class LicenseService: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await withRetry { try await URLSession.shared.data(for: request) }
+        let (data, response) = try await withRetry { try await dataTransport(request) }
         guard let httpResponse = response as? HTTPURLResponse else {
             throw LicenseError.networkError
         }
@@ -380,8 +697,7 @@ final class LicenseService: ObservableObject {
         if httpResponse.statusCode == 200 {
             return try JSONDecoder().decode(PolarActivationResponse.self, from: data)
         } else {
-            let errorResponse = try? JSONDecoder().decode(PolarErrorResponse.self, from: data)
-            throw LicenseError.activationFailed(errorResponse?.detail ?? "HTTP \(httpResponse.statusCode)")
+            throw LicenseError.activationFailed(Self.polarErrorDetail(from: data, statusCode: httpResponse.statusCode))
         }
     }
 
@@ -398,7 +714,7 @@ final class LicenseService: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await withRetry { try await URLSession.shared.data(for: request) }
+        let (data, response) = try await withRetry { try await dataTransport(request) }
         guard let httpResponse = response as? HTTPURLResponse else {
             throw LicenseError.networkError
         }
@@ -406,7 +722,10 @@ final class LicenseService: ObservableObject {
         if httpResponse.statusCode == 200 {
             return try JSONDecoder().decode(PolarValidationResponse.self, from: data)
         } else {
-            throw LicenseError.validationFailed("HTTP \(httpResponse.statusCode)")
+            throw LicenseError.validationFailed(
+                statusCode: httpResponse.statusCode,
+                detail: Self.polarErrorDetail(from: data, statusCode: httpResponse.statusCode)
+            )
         }
     }
 
@@ -423,17 +742,31 @@ final class LicenseService: ObservableObject {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (_, response) = try await withRetry { try await URLSession.shared.data(for: request) }
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200 ... 299).contains(httpResponse.statusCode) else {
-            throw LicenseError.deactivationFailed
+        let (data, response) = try await withRetry { try await dataTransport(request) }
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LicenseError.networkError
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            throw LicenseError.deactivationFailed(
+                statusCode: httpResponse.statusCode,
+                detail: Self.polarErrorDetail(from: data, statusCode: httpResponse.statusCode)
+            )
         }
     }
 
     // MARK: - Keychain
 
-    private var keychainService: String { keychainKeyPrefix + "license" }
+    private var keychainService: String { keychainServiceName }
     private var hasStoredLicense: Bool { loadLicenseFromKeychain() != nil }
+
+    private func clearLicenseState() {
+        removeLicenseFromKeychain()
+        licenseStatus = .unlicensed
+        licenseTier = nil
+        licenseIsLifetime = false
+        defaults.removeObject(forKey: UserDefaultsKeys.lastLicenseValidation)
+    }
 
     private func saveLicenseToKeychain(key: String, activationId: String) {
         let data = "\(key)|\(activationId)".data(using: .utf8)!
@@ -478,6 +811,20 @@ final class LicenseService: ObservableObject {
             kSecAttrAccount as String: "polar-license",
         ]
         SecItemDelete(query as CFDictionary)
+    }
+
+    private func applyCommercialActivation(
+        key: String,
+        activationId: String,
+        tier: LicenseTier,
+        isLifetime: Bool
+    ) {
+        saveLicenseToKeychain(key: key, activationId: activationId)
+        licenseStatus = .active
+        licenseTier = tier
+        licenseIsLifetime = isLifetime
+        usageIntent = Self.usageIntent(for: tier)
+        defaults.set(Date(), forKey: UserDefaultsKeys.lastLicenseValidation)
     }
 
     // MARK: - Supporter Keychain
@@ -526,6 +873,48 @@ final class LicenseService: ObservableObject {
         ]
         SecItemDelete(query as CFDictionary)
     }
+
+    private func clearSupporterState() {
+        removeSupporterFromKeychain()
+        supporterStatus = .unlicensed
+        supporterTier = nil
+        defaults.removeObject(forKey: UserDefaultsKeys.lastSupporterValidation)
+        SupporterDiscordService.shared?.handleSupporterEntitlementRemoved()
+    }
+
+    private func applySupporterActivation(
+        key: String,
+        activationId: String,
+        tier: SupporterTier
+    ) {
+        saveSupporterToKeychain(key: key, activationId: activationId)
+        supporterStatus = .active
+        supporterTier = tier
+        defaults.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
+    }
+
+    private static func usageIntent(for tier: LicenseTier) -> UsageIntent {
+        switch tier {
+        case .individual:
+            .workSolo
+        case .team:
+            .team
+        case .enterprise:
+            .enterprise
+        }
+    }
+
+    private static func polarErrorDetail(from data: Data, statusCode: Int) -> String {
+        let errorResponse = try? JSONDecoder().decode(PolarErrorResponse.self, from: data)
+        return errorResponse?.detail ?? errorResponse?.type ?? "HTTP \(statusCode)"
+    }
+
+    private static func isPolarResourceMissing(_ error: Error) -> Bool {
+        guard let licenseError = error as? LicenseError else {
+            return false
+        }
+        return licenseError.isResourceMissing
+    }
 }
 
 // MARK: - Errors
@@ -533,8 +922,17 @@ final class LicenseService: ObservableObject {
 enum LicenseError: LocalizedError {
     case networkError
     case activationFailed(String)
-    case validationFailed(String)
-    case deactivationFailed
+    case validationFailed(statusCode: Int, detail: String)
+    case deactivationFailed(statusCode: Int, detail: String)
+
+    var isResourceMissing: Bool {
+        switch self {
+        case .validationFailed(let statusCode, _), .deactivationFailed(let statusCode, _):
+            statusCode == 404
+        case .networkError, .activationFailed:
+            false
+        }
+    }
 
     var errorDescription: String? {
         switch self {
@@ -542,10 +940,13 @@ enum LicenseError: LocalizedError {
             return String(localized: "Network error. Please check your internet connection.")
         case .activationFailed(let detail):
             return String(localized: "Activation failed: \(detail)")
-        case .validationFailed(let detail):
+        case .validationFailed(_, let detail):
             return String(localized: "Validation failed: \(detail)")
-        case .deactivationFailed:
-            return String(localized: "Deactivation failed. Please try again.")
+        case .deactivationFailed(_, let detail):
+            if detail.isEmpty {
+                return String(localized: "Deactivation failed. Please try again.")
+            }
+            return String(localized: "Deactivation failed: \(detail)")
         }
     }
 }

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -1,9 +1,12 @@
+import AppKit
 import SwiftUI
 import Charts
 
 struct HomeSettingsView: View {
     @ObservedObject private var viewModel = HomeViewModel.shared
     @ObservedObject private var dictation = DictationViewModel.shared
+    @ObservedObject private var license = LicenseService.shared
+    @AppStorage(UserDefaultsKeys.workUsagePromptDismissed) private var workUsagePromptDismissed = false
 
     var body: some View {
         if viewModel.showSetupWizard {
@@ -37,6 +40,10 @@ struct HomeSettingsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
+                    if license.shouldShowWorkUsagePrompt && !workUsagePromptDismissed {
+                        workUsageCard
+                    }
+
                     // Row 1: Stats grid or Getting Started
                     if viewModel.hasAnyTranscriptions {
                         statsGrid
@@ -89,6 +96,57 @@ struct HomeSettingsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private var workUsageCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(localizedAppText("Using TypeWhisper at work?", de: "Nutzt du TypeWhisper beruflich?"))
+                        .font(.headline)
+                    Text(localizedAppText(
+                        "Commercial pricing, lifetime options, and the team story are clearer on the website.",
+                        de: "Kommerzielle Preise, Lifetime-Optionen und die Team-Story sind auf der Website klarer erklärt."
+                    ))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button {
+                    workUsagePromptDismissed = true
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    NSWorkspace.shared.open(AppConstants.Website.pricingURL)
+                } label: {
+                    Label(localizedAppText("See pricing on the website", de: "Preise auf der Website ansehen"), systemImage: "globe")
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(localizedAppText("Not now", de: "Später")) {
+                    workUsagePromptDismissed = true
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.2), lineWidth: 1)
+        )
     }
 
     // MARK: - Time Period Picker

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct LicenseSettingsView: View {
@@ -6,26 +7,31 @@ struct LicenseSettingsView: View {
         SupporterDiscordService.shared ?? SupporterDiscordService(licenseService: LicenseService.shared)
 
     @State private var licenseKeyInput = ""
-    @State private var supporterKeyInput = ""
+    @State private var activationNotice: String?
 
-    private var isPrivateUser: Bool {
-        license.userType == .privateUser
+    private let planColumns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+    private let planDescriptionMinHeight: CGFloat = 52
+
+    private var shouldShowCommercialSection: Bool {
+        license.requiresCommercialLicense || license.licenseStatus == .active
     }
 
     var body: some View {
-        Form {
-            userTypeSection
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                planSelectionSection
 
-            if isPrivateUser {
-                privateStatusSection
+                if shouldShowCommercialSection {
+                    commercialSection
+                }
+
                 supporterSection
-            } else {
-                businessSection
+
+                sharedActivationSection
             }
+            .padding(20)
         }
-        .formStyle(.grouped)
-        .padding()
-        .frame(minWidth: 500, minHeight: 300)
+        .frame(minWidth: 560, minHeight: 360)
         .task(id: "\(license.supporterStatus.rawValue)-\(license.supporterTier?.rawValue ?? "none")") {
             if license.isSupporter {
                 await supporterDiscord.refreshStatusIfNeeded()
@@ -35,193 +41,340 @@ struct LicenseSettingsView: View {
         }
     }
 
-    // MARK: - User Type
+    private var planSelectionSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(localizedAppText("Choose the plan that fits.", de: "Wähle den passenden Plan."))
+                .font(.headline)
 
-    private var userTypeSection: some View {
-        Section(String(localized: "User Type")) {
-            Picker(String(localized: "I use TypeWhisper"), selection: Binding(
-                get: { license.userType ?? .privateUser },
-                set: { license.setUserType($0) }
-            )) {
-                Text(String(localized: "Personal / OSS")).tag(LicenseUserType.privateUser)
-                Text(String(localized: "Proprietary")).tag(LicenseUserType.business)
+            Text(localizedAppText(
+                "Everything stays on this page. Pick the plan that matches how you use TypeWhisper.",
+                de: "Alles bleibt auf dieser Seite. Wähle den Plan, der zu deiner Nutzung von TypeWhisper passt."
+            ))
+            .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: planColumns, spacing: 12) {
+                planSelectionButton(
+                    title: localizedAppText("Private & OSS", de: "Privat & OSS"),
+                    price: localizedAppText("Free", de: "Kostenlos"),
+                    description: localizedAppText(
+                        "For personal use and GPL-compatible open-source work.",
+                        de: "Für private Nutzung und GPL-kompatible Open-Source-Arbeit."
+                    ),
+                    systemImage: "checkmark.circle",
+                    selected: license.usageIntent == .personalOSS && license.licenseTier != .enterprise,
+                    accent: .green
+                ) {
+                    license.setUsageIntent(.personalOSS)
+                }
+
+                planSelectionButton(
+                    title: localizedAppText("Individual", de: "Einzelnutzer"),
+                    price: localizedAppText("from 5 EUR/mo", de: "ab 5 EUR/Monat"),
+                    description: localizedAppText(
+                        "One person using TypeWhisper professionally on up to 2 devices.",
+                        de: "Eine Person nutzt TypeWhisper beruflich auf bis zu 2 Geräten."
+                    ),
+                    systemImage: "briefcase",
+                    selected: license.usageIntent == .workSolo && license.licenseTier != .enterprise,
+                    accent: .accentColor
+                ) {
+                    license.setUsageIntent(.workSolo)
+                }
+
+                planSelectionButton(
+                    title: "Team",
+                    price: localizedAppText("from 19 EUR/mo", de: "ab 19 EUR/Monat"),
+                    description: localizedAppText(
+                        "Small teams, up to 10 devices, and the clearest future path for sync and sharing.",
+                        de: "Kleine Teams, bis zu 10 Geräte und der klarste spätere Pfad für Sync und Sharing."
+                    ),
+                    systemImage: "person.3",
+                    selected: license.usageIntent == .team && license.licenseTier != .enterprise,
+                    accent: .accentColor
+                ) {
+                    license.setUsageIntent(.team)
+                }
+
+                planSelectionButton(
+                    title: localizedAppText("Enterprise", de: "Unternehmensplan"),
+                    price: localizedAppText("from 99 EUR/mo", de: "ab 99 EUR/Monat"),
+                    description: localizedAppText(
+                        "Company-wide rollout, procurement, and compliance-heavy setups.",
+                        de: "Firmenweiter Rollout, Beschaffung und Setups mit hohen Compliance-Anforderungen."
+                    ),
+                    systemImage: "building.2",
+                    selected: license.usageIntent == .enterprise || license.licenseTier == .enterprise,
+                    accent: .orange
+                ) {
+                    license.setUsageIntent(.enterprise)
+                }
             }
-            .pickerStyle(.segmented)
+        }
+    }
 
-            Text(String(localized: "Personal use and GPL-compliant open-source use are free. Proprietary or otherwise non-GPL-compliant use requires a commercial license."))
-                .font(.caption)
+    private var sharedActivationSection: some View {
+        PanelCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(localizedAppText("Already have a key?", de: "Bereits einen Schlüssel?"))
+                    .font(.headline)
+
+                Text(localizedAppText(
+                    "Enter any TypeWhisper key here. The app automatically detects whether it is Supporter, Individual, Team, or Enterprise.",
+                    de: "Gib hier einen beliebigen TypeWhisper-Schlüssel ein. Die App erkennt automatisch, ob es ein Supporter-, Einzelnutzer-, Team- oder Unternehmensschlüssel ist."
+                ))
                 .foregroundStyle(.secondary)
-        }
-    }
-
-    // MARK: - Private
-
-    private var privateStatusSection: some View {
-        Section(String(localized: "License Status")) {
-            Label(String(localized: "Free for personal and GPL-compliant open-source use"), systemImage: "checkmark.circle")
-                .foregroundStyle(.green)
-        }
-    }
-
-    // MARK: - Business
-
-    @ViewBuilder
-    private var businessSection: some View {
-        Section(String(localized: "License Status")) {
-            businessStatusView
-        }
-
-        if license.licenseStatus == .active {
-            Section(String(localized: "Manage")) {
-                Button {
-                    if let url = URL(string: AppConstants.Polar.customerPortalURL) {
-                        NSWorkspace.shared.open(url)
-                    }
-                } label: {
-                    Label(String(localized: "Manage Subscription"), systemImage: "arrow.up.right.square")
-                }
-
-                Text(String(localized: "Opens the Polar.sh customer portal where you can manage your subscription, update payment methods, or cancel."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Button(String(localized: "Deactivate License on This Mac"), role: .destructive) {
-                    Task { await license.deactivateLicense() }
-                }
-
-                Text(String(localized: "Removes the license from this device. You can reactivate it on another Mac."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if let error = license.deactivationError {
-                    Label(error, systemImage: "exclamationmark.triangle")
-                        .foregroundStyle(.red)
-                        .font(.caption)
-                }
-            }
-        } else {
-            Section(String(localized: "Purchase a License")) {
-                Text(String(localized: "Monthly Subscription"))
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-
-                HStack(spacing: 16) {
-                    businessTierButton(tier: .individual, price: "5", suffix: String(localized: "EUR/mo"), url: AppConstants.Polar.checkoutURLIndividual)
-                    businessTierButton(tier: .team, price: "19", suffix: String(localized: "EUR/mo"), url: AppConstants.Polar.checkoutURLTeam)
-                    businessTierButton(tier: .enterprise, price: "99", suffix: String(localized: "EUR/mo"), url: AppConstants.Polar.checkoutURLEnterprise)
-                }
-
-                Text(String(localized: "Lifetime (one-time)"))
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-
-                HStack(spacing: 16) {
-                    businessTierButton(tier: .individual, price: "99", suffix: String(localized: "EUR"), url: AppConstants.Polar.checkoutURLIndividualLifetime)
-                    businessTierButton(tier: .team, price: "299", suffix: String(localized: "EUR"), url: AppConstants.Polar.checkoutURLTeamLifetime)
-                    businessTierButton(tier: .enterprise, price: "999", suffix: String(localized: "EUR"), url: AppConstants.Polar.checkoutURLEnterpriseLifetime)
-                }
-
-                Text(String(localized: "Pay-what-you-want starting at the listed price. Click a tier to open the checkout page."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
                 keyActivationField(
                     input: $licenseKeyInput,
                     isActivating: license.isActivating,
                     error: license.activationError
                 ) {
-                    await license.activateLicenseKey(licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines))
+                    await activateDetectedKey()
                 }
+
+                if let activationNotice {
+                    Label(activationNotice, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+
+                Button {
+                    openURL(URL(string: AppConstants.Polar.customerPortalURL))
+                } label: {
+                    Label(localizedAppText("Manage Purchases", de: "Käufe verwalten"), systemImage: "arrow.up.right.square")
+                }
+                .buttonStyle(.link)
+                .modifier(PointingHandCursorModifier())
+
+                Text(localizedAppText(
+                    "Use this if you already bought a commercial or supporter license and want to manage it in Polar.",
+                    de: "Nutze das, wenn du bereits eine kommerzielle oder Supporter-Lizenz gekauft hast und sie in Polar verwalten möchtest."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
         }
     }
 
     @ViewBuilder
-    private var businessStatusView: some View {
-        switch license.licenseStatus {
-        case .active:
-            HStack {
-                Label(String(localized: "Licensed"), systemImage: "checkmark.seal.fill")
-                    .foregroundStyle(.green)
-                if let tier = license.licenseTier {
-                    let lifetimeLabel = license.licenseIsLifetime ? String(localized: ", Lifetime") : ""
-                    Text("(\(businessTierDisplayName(tier))\(lifetimeLabel))")
+    private var commercialSection: some View {
+        if license.licenseStatus == .active {
+            activeCommercialSection
+        } else {
+            inactiveCommercialSection
+        }
+    }
+
+    private var inactiveCommercialSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            PanelCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(localizedAppText("Pricing in short", de: "Preise im Überblick"))
+                        .font(.headline)
+
+                    if let selectedCommercialTier {
+                        HStack(alignment: .top, spacing: 12) {
+                            purchaseOptionCard(
+                                eyebrow: localizedAppText("Flexible", de: "Flexibel"),
+                                title: localizedAppText("Monthly subscription", de: "Monatsabo"),
+                                pricing: commercialPurchaseOptionCopy(for: selectedCommercialTier, cadence: .monthly),
+                                description: monthlyPurchaseDescription(for: selectedCommercialTier),
+                                systemImage: "calendar",
+                                accent: .accentColor
+                            ) {
+                                openURL(selectedCommercialMonthlyURL)
+                            }
+
+                            purchaseOptionCard(
+                                eyebrow: localizedAppText("One-time purchase", de: "Einmalkauf"),
+                                title: localizedAppText("Lifetime", de: "Dauerlizenz"),
+                                pricing: commercialPurchaseOptionCopy(for: selectedCommercialTier, cadence: .lifetime),
+                                description: lifetimePurchaseDescription(for: selectedCommercialTier),
+                                systemImage: "infinity",
+                                accent: Color(red: 0.96, green: 0.69, blue: 0.22),
+                                badge: localizedAppText("Best Value", de: "Bestes Angebot"),
+                                emphasized: true
+                            ) {
+                                openURL(selectedCommercialLifetimeURL)
+                            }
+                        }
+
+                        Text(localizedAppText(
+                            "Monthly is recurring. Lifetime is a one-time purchase for the same tier.",
+                            de: "Das Monatsabo ist wiederkehrend. Die Dauerlizenz ist ein einmaliger Kauf für dasselbe Paket."
+                        ))
+                        .font(.caption)
                         .foregroundStyle(.secondary)
+
+                        pricingWebsiteLink
+                    }
                 }
             }
-        case .expired:
-            Label(String(localized: "License expired or revoked"), systemImage: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-        case .unlicensed:
-            Label(String(localized: "No active commercial license"), systemImage: "key")
-                .foregroundStyle(.secondary)
+
+            PanelCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label(commercialStatusTitle, systemImage: commercialStatusSymbol)
+                        .foregroundStyle(commercialStatusColor)
+                        .font(.headline)
+
+                    Text(commercialStatusDescription)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
+    }
+
+    private var activeCommercialSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            PanelCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Label(localizedAppText("Licensed", de: "Lizenziert"), systemImage: "checkmark.seal.fill")
+                            .foregroundStyle(.green)
+                            .font(.headline)
+
+                        if let tier = license.licenseTier {
+                            Text(activeTierLabel(for: tier))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Text(activeCommercialDescription)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            PanelCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(localizedAppText("Manage this Mac and your subscription", de: "Diesen Mac und dein Abo verwalten"))
+                        .font(.headline)
+
+                    pricingWebsiteLink
+
+                    actionButton(title: localizedAppText("Manage Subscription", de: "Abo verwalten"), systemImage: "arrow.up.right.square") {
+                        openURL(URL(string: AppConstants.Polar.customerPortalURL))
+                    }
+
+                    Text(localizedAppText(
+                        "Opens the Polar.sh customer portal where you can manage your subscription, update payment methods, or cancel.",
+                        de: "Öffnet das Polar.sh-Kundenportal, in dem du dein Abo verwalten, Zahlungsmethoden aktualisieren oder kündigen kannst."
+                    ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    actionButton(title: localizedAppText("Deactivate License on This Mac", de: "Lizenz auf diesem Mac deaktivieren"), systemImage: "trash", role: .destructive) {
+                        Task { await license.deactivateLicense() }
+                    }
+
+                    Text(localizedAppText(
+                        "Removes the license from this device. You can reactivate it on another Mac.",
+                        de: "Entfernt die Lizenz von diesem Gerät. Du kannst sie auf einem anderen Mac erneut aktivieren."
+                    ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let error = license.deactivationError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+    }
+
+    private var pricingWebsiteLink: some View {
+        Button {
+            openURL(AppConstants.Website.pricingURL)
+        } label: {
+            Label(
+                localizedAppText(
+                    "View full pricing and FAQs on the website",
+                    de: "Vollständige Preise und FAQ auf der Website"
+                ),
+                systemImage: "globe"
+            )
+        }
+        .buttonStyle(.link)
+        .modifier(PointingHandCursorModifier())
     }
 
     // MARK: - Supporter
 
-    @ViewBuilder
     private var supporterSection: some View {
-        if license.isSupporter, let tier = license.supporterTier {
-            Section(String(localized: "Supporter Status")) {
-                HStack {
-                    SupporterBadgeView(tier: tier)
-                    Spacer()
-                }
+        PanelCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(localizedAppText("Supporter", de: "Supporter"))
+                    .font(.headline)
 
-                supporterDiscordSection(tier: tier)
+                Text(supporterDescriptionText)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                Button {
-                    if let url = URL(string: AppConstants.Polar.customerPortalURL) {
-                        NSWorkspace.shared.open(url)
+                if license.isSupporter, let tier = license.supporterTier {
+                    HStack {
+                        SupporterBadgeView(tier: tier)
+                        Spacer()
                     }
-                } label: {
-                    Label(String(localized: "Manage Purchase"), systemImage: "arrow.up.right.square")
-                }
 
-                Button(String(localized: "Deactivate Supporter License"), role: .destructive) {
-                    Task { await license.deactivateSupporterLicense() }
-                }
+                    supporterDiscordSection(tier: tier)
 
-                if let error = license.supporterDeactivationError {
-                    Label(error, systemImage: "exclamationmark.triangle")
-                        .foregroundStyle(.red)
-                        .font(.caption)
-                }
-            }
-        } else {
-            Section(String(localized: "Support TypeWhisper")) {
-                Text(String(localized: "TypeWhisper is free for personal use. If you'd like to support development, grab a supporter license for a Discord role and an in-app badge."))
+                    HStack(spacing: 10) {
+                        actionButton(title: localizedAppText("Manage Purchase", de: "Kauf verwalten"), systemImage: "arrow.up.right.square") {
+                            openURL(URL(string: AppConstants.Polar.customerPortalURL))
+                        }
+
+                        actionButton(
+                            title: localizedAppText("Deactivate Supporter License", de: "Supporter-Lizenz deaktivieren"),
+                            systemImage: "trash",
+                            role: .destructive
+                        ) {
+                            Task { await license.deactivateSupporterLicense() }
+                        }
+                    }
+
+                    if let error = license.supporterDeactivationError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                    }
+                } else {
+                    Text(localizedAppText(
+                        "If you already bought a supporter key, enter it above. GitHub Sponsors can still be claimed on the web.",
+                        de: "Wenn du bereits einen Supporter-Schlüssel gekauft hast, gib ihn oben ein. GitHub Sponsors kannst du weiter im Web bestätigen."
+                    ))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                HStack(spacing: 16) {
+                    actionButton(
+                        title: localizedAppText("Claim GitHub Sponsors status on the web", de: "GitHub-Sponsors-Status im Web bestätigen"),
+                        systemImage: "link"
+                    ) {
+                        openURL(supporterDiscord.githubSponsorsURL)
+                    }
+                }
+
+                HStack(spacing: 12) {
                     supporterTierButton(tier: .bronze, price: "10")
                     supporterTierButton(tier: .silver, price: "25")
                     supporterTierButton(tier: .gold, price: "50")
-                }
-                .padding(.vertical, 4)
-
-                Button {
-                    NSWorkspace.shared.open(supporterDiscord.githubSponsorsURL)
-                } label: {
-                    Label("Claim GitHub Sponsors status on the web", systemImage: "link")
-                }
-
-                keyActivationField(
-                    input: $supporterKeyInput,
-                    isActivating: license.isSupporterActivating,
-                    error: license.supporterActivationError
-                ) {
-                    await license.activateSupporterKey(supporterKeyInput.trimmingCharacters(in: .whitespacesAndNewlines))
                 }
             }
         }
     }
 
     // MARK: - Shared Key Activation
+
+    private var supporterDescriptionText: String {
+        localizedAppText(
+            "Supporter status is personal and optional. It can exist alongside Private & OSS, Individual, Team, or Enterprise, but it never replaces a commercial license.",
+            de: "Supporter-Status ist persönlich und optional. Er kann neben Privat & OSS, Einzelnutzer, Team oder Unternehmensplan bestehen, ersetzt aber nie eine kommerzielle Lizenz."
+        )
+    }
 
     @ViewBuilder
     private func keyActivationField(
@@ -230,16 +383,11 @@ struct LicenseSettingsView: View {
         error: String?,
         action: @escaping () async -> Void
     ) -> some View {
-        Text(String(localized: "Already have a key?"))
-            .font(.caption.bold())
-            .foregroundStyle(.secondary)
-            .textCase(.uppercase)
-
         HStack {
-            TextField(String(localized: "TYPEWHISPER-xxxx-xxxx"), text: input)
+            TextField(localizedAppText("TYPEWHISPER-xxxx-xxxx", de: "TYPEWHISPER-xxxx-xxxx"), text: input)
                 .textFieldStyle(.roundedBorder)
 
-            Button(String(localized: "Activate")) {
+            Button(localizedAppText("Activate", de: "Aktivieren")) {
                 Task { await action() }
             }
             .disabled(input.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isActivating)
@@ -264,68 +412,80 @@ struct LicenseSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             switch supporterDiscord.claimStatus.state {
             case .unavailable, .unlinked:
-                Label("Discord not connected", systemImage: "person.crop.circle.badge.xmark")
+                Label(localizedAppText("Discord not connected", de: "Discord nicht verbunden"), systemImage: "person.crop.circle.badge.xmark")
                     .foregroundStyle(.secondary)
 
-                Text("Connect Discord to claim your \(supporterTierDisplayName(tier)) supporter status in the community server.")
+                Text(localizedAppText(
+                    "Connect Discord to claim your \(supporterTierDisplayName(tier)) supporter status in the community server.",
+                    de: "Verbinde Discord, um deinen \(supporterTierDisplayName(tier))-Supporter-Status im Community-Server zu bestätigen."
+                ))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                actionButton(title: "Connect Discord", systemImage: "person.crop.circle.badge.plus") {
-                    await openClaimURL(await supporterDiscord.createClaimSession())
+                actionButton(title: localizedAppText("Connect Discord", de: "Discord verbinden"), systemImage: "person.crop.circle.badge.plus") {
+                    Task { await openClaimURL(await supporterDiscord.createClaimSession()) }
                 }
             case .pending:
-                Label("Claim in progress", systemImage: "clock.badge")
+                Label(localizedAppText("Claim in progress", de: "Bestätigung läuft"), systemImage: "clock.badge")
                     .foregroundStyle(.orange)
 
-                Text("Finish the Discord authorization flow in your browser, then refresh the status here.")
+                Text(localizedAppText(
+                    "Finish the Discord authorization flow in your browser, then refresh the status here.",
+                    de: "Schließe den Discord-Autorisierungsablauf im Browser ab und aktualisiere den Status dann hier."
+                ))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                actionButton(title: "Reconnect Discord", systemImage: "arrow.clockwise.circle") {
-                    await openClaimURL(await supporterDiscord.reconnect())
+                actionButton(title: localizedAppText("Reconnect Discord", de: "Discord erneut verbinden"), systemImage: "arrow.clockwise.circle") {
+                    Task { await openClaimURL(await supporterDiscord.reconnect()) }
                 }
 
-                actionButton(title: "Refresh Discord Status", systemImage: "arrow.clockwise") {
-                    await supporterDiscord.refreshClaimStatus()
+                actionButton(title: localizedAppText("Refresh Discord Status", de: "Discord-Status aktualisieren"), systemImage: "arrow.clockwise") {
+                    Task { await supporterDiscord.refreshClaimStatus() }
                 }
             case .linked:
-                Label("Discord connected", systemImage: "checkmark.seal.fill")
+                Label(localizedAppText("Discord connected", de: "Discord verbunden"), systemImage: "checkmark.seal.fill")
                     .foregroundStyle(.green)
 
                 if let username = supporterDiscord.claimStatus.discordUsername {
-                    Text("Linked account: \(username)")
+                    Text(localizedAppText("Linked account: \(username)", de: "Verknüpftes Konto: \(username)"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
 
                 if !supporterDiscord.claimStatus.linkedRoles.isEmpty {
-                    Text("Active roles: \(supporterDiscord.claimStatus.linkedRoles.joined(separator: ", "))")
+                    Text(localizedAppText(
+                        "Active roles: \(supporterDiscord.claimStatus.linkedRoles.joined(separator: ", "))",
+                        de: "Aktive Rollen: \(supporterDiscord.claimStatus.linkedRoles.joined(separator: ", "))"
+                    ))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
 
-                actionButton(title: "Refresh Discord Status", systemImage: "arrow.clockwise") {
-                    await supporterDiscord.refreshClaimStatus()
+                actionButton(title: localizedAppText("Refresh Discord Status", de: "Discord-Status aktualisieren"), systemImage: "arrow.clockwise") {
+                    Task { await supporterDiscord.refreshClaimStatus() }
                 }
 
-                actionButton(title: "Reconnect Discord", systemImage: "link.badge.plus") {
-                    await openClaimURL(await supporterDiscord.reconnect())
+                actionButton(title: localizedAppText("Reconnect Discord", de: "Discord erneut verbinden"), systemImage: "link.badge.plus") {
+                    Task { await openClaimURL(await supporterDiscord.reconnect()) }
                 }
             case .failed:
-                Label("Discord claim failed", systemImage: "exclamationmark.triangle.fill")
+                Label(localizedAppText("Discord claim failed", de: "Discord-Bestätigung fehlgeschlagen"), systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.red)
 
-                Text(supporterDiscord.claimStatus.errorMessage ?? "The Discord claim service returned an unknown error.")
+                Text(supporterDiscord.claimStatus.errorMessage ?? localizedAppText(
+                    "The Discord claim service returned an unknown error.",
+                    de: "Der Discord-Bestätigungsdienst hat einen unbekannten Fehler zurückgegeben."
+                ))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                actionButton(title: "Retry Discord Claim", systemImage: "arrow.clockwise.circle") {
-                    await openClaimURL(await supporterDiscord.reconnect())
+                actionButton(title: localizedAppText("Retry Discord Claim", de: "Discord-Bestätigung erneut versuchen"), systemImage: "arrow.clockwise.circle") {
+                    Task { await openClaimURL(await supporterDiscord.reconnect()) }
                 }
 
-                actionButton(title: "Refresh Discord Status", systemImage: "arrow.clockwise") {
-                    await supporterDiscord.refreshClaimStatus()
+                actionButton(title: localizedAppText("Refresh Discord Status", de: "Discord-Status aktualisieren"), systemImage: "arrow.clockwise") {
+                    Task { await supporterDiscord.refreshClaimStatus() }
                 }
             }
 
@@ -343,93 +503,353 @@ struct LicenseSettingsView: View {
         }
     }
 
+    private func planSelectionButton(
+        title: String,
+        price: String,
+        description: String,
+        systemImage: String,
+        selected: Bool,
+        accent: Color,
+        trailingLabel: String? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            action()
+        } label: {
+            planSummaryCard(
+                title: title,
+                price: price,
+                description: description,
+                systemImage: systemImage,
+                selected: selected,
+                accent: accent,
+                trailingLabel: trailingLabel
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func planSummaryCard(
+        title: String,
+        price: String,
+        description: String,
+        systemImage: String,
+        selected: Bool,
+        accent: Color,
+        trailingLabel: String? = nil
+    ) -> some View {
+        PlanSelectionCardView(
+            title: title,
+            price: price,
+            description: description,
+            systemImage: systemImage,
+            selected: selected,
+            accent: accent,
+            trailingLabel: trailingLabel,
+            descriptionMinHeight: planDescriptionMinHeight
+        )
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private func purchaseOptionCard(
+        eyebrow: String,
+        title: String,
+        pricing: CommercialPurchaseOptionCopy,
+        description: String,
+        systemImage: String,
+        accent: Color,
+        badge: String? = nil,
+        emphasized: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        PurchaseOptionCardView(
+            eyebrow: eyebrow,
+            title: title,
+            pricing: pricing,
+            description: description,
+            systemImage: systemImage,
+            accent: accent,
+            badge: badge,
+            emphasized: emphasized,
+            action: action
+        )
+    }
+
+    @ViewBuilder
     private func actionButton(
         title: String,
         systemImage: String,
-        action: @escaping () async -> Void
+        prominent: Bool = false,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
     ) -> some View {
-        Button {
-            Task { await action() }
-        } label: {
+        let button = Button(role: role, action: action) {
             Label(title, systemImage: systemImage)
+                .frame(maxWidth: .infinity)
         }
-        .disabled(supporterDiscord.isWorking)
+
+        if prominent {
+            button.buttonStyle(.borderedProminent)
+        } else {
+            button.buttonStyle(.bordered)
+        }
     }
 
-    private func openClaimURL(_ url: URL?) async {
+    private var commercialStatusTitle: String {
+        switch license.licenseStatus {
+        case .active:
+            return localizedAppText("Licensed", de: "Lizenziert")
+        case .expired:
+            return localizedAppText("License expired or revoked", de: "Lizenz abgelaufen oder widerrufen")
+        case .unlicensed:
+            return localizedAppText("No active commercial license", de: "Keine aktive kommerzielle Lizenz")
+        }
+    }
+
+    private var commercialStatusDescription: String {
+        switch license.usageIntent {
+        case .personalOSS:
+            return ""
+        case .workSolo:
+            return localizedAppText(
+                "Professional solo usage needs a commercial license. Individual covers one person on up to 2 devices.",
+                de: "Berufliche Einzel-Nutzung braucht eine kommerzielle Lizenz. Der Einzelnutzer-Plan deckt eine Person auf bis zu 2 Geräten ab."
+            )
+        case .team:
+            return localizedAppText(
+                "Team usage needs Team or Enterprise. Team covers up to 10 devices under one commercial plan.",
+                de: "Team-Nutzung braucht den Team- oder Unternehmensplan. Team deckt bis zu 10 Geräte unter einer kommerziellen Lizenz ab."
+            )
+        case .enterprise:
+            return localizedAppText(
+                "Enterprise covers company-wide rollout, procurement, and unlimited devices.",
+                de: "Der Unternehmensplan deckt firmenweiten Rollout, Beschaffung und unbegrenzt viele Geräte ab."
+            )
+        }
+    }
+
+    private var commercialStatusSymbol: String {
+        switch license.licenseStatus {
+        case .active:
+            "checkmark.seal.fill"
+        case .expired:
+            "exclamationmark.triangle.fill"
+        case .unlicensed:
+            "briefcase"
+        }
+    }
+
+    private var commercialStatusColor: Color {
+        switch license.licenseStatus {
+        case .active:
+            .green
+        case .expired:
+            .orange
+        case .unlicensed:
+            .accentColor
+        }
+    }
+
+    private var activeCommercialDescription: String {
+        if let tier = license.licenseTier {
+            switch tier {
+            case .individual:
+                return localizedAppText(
+                    "This Mac is covered for professional single-seat usage on up to 2 devices.",
+                    de: "Dieser Mac ist für berufliche Einzel-Nutzung auf bis zu 2 Geräten abgedeckt."
+                )
+            case .team:
+                return localizedAppText(
+                    "This Mac is covered by a team license for up to 10 devices.",
+                    de: "Dieser Mac ist durch eine Team-Lizenz für bis zu 10 Geräte abgedeckt."
+                )
+            case .enterprise:
+                return localizedAppText(
+                    "This Mac is covered by an enterprise license for company-wide rollout and unlimited devices.",
+                    de: "Dieser Mac ist durch eine Unternehmenslizenz für firmenweiten Rollout und unbegrenzt viele Geräte abgedeckt."
+                )
+            }
+        }
+
+        return localizedAppText(
+            "This Mac has an active commercial license.",
+            de: "Dieser Mac hat eine aktive kommerzielle Lizenz."
+        )
+    }
+
+    private func monthlyPurchaseDescription(for tier: LicenseTier) -> String {
+        switch tier {
+        case .individual:
+            return localizedAppText(
+                "Professional single-seat access for up to 2 devices with recurring billing.",
+                de: "Beruflicher Einzelzugang für bis zu 2 Geräte mit wiederkehrender Abrechnung."
+            )
+        case .team:
+            return localizedAppText(
+                "Keeps a team of up to 10 devices covered with a recurring plan.",
+                de: "Deckt ein Team mit bis zu 10 Geräten über einen wiederkehrenden Plan ab."
+            )
+        case .enterprise:
+            return localizedAppText(
+                "Recurring company-wide plan for rollout, procurement, and unlimited devices.",
+                de: "Wiederkehrender firmenweiter Plan für Rollout, Beschaffung und unbegrenzt viele Geräte."
+            )
+        }
+    }
+
+    private func lifetimePurchaseDescription(for tier: LicenseTier) -> String {
+        switch tier {
+        case .individual:
+            return localizedAppText(
+                "One payment for the same 2-device Individual tier, with no monthly renewal.",
+                de: "Eine Zahlung für dasselbe Einzelnutzer-Paket mit 2 Geräten, ohne monatliche Verlängerung."
+            )
+        case .team:
+            return localizedAppText(
+                "One payment for the same Team tier with up to 10 devices and no renewal cycle.",
+                de: "Eine Zahlung für dasselbe Team-Paket mit bis zu 10 Geräten und ohne Verlängerungszyklus."
+            )
+        case .enterprise:
+            return localizedAppText(
+                "One payment for the same Enterprise rollout tier with unlimited devices.",
+                de: "Eine Zahlung für dasselbe Unternehmens-Paket mit unbegrenzt vielen Geräten."
+            )
+        }
+    }
+
+    private var selectedCommercialTier: LicenseTier? {
+        switch license.usageIntent {
+        case .personalOSS:
+            return nil
+        case .workSolo:
+            return .individual
+        case .team:
+            return .team
+        case .enterprise:
+            return .enterprise
+        }
+    }
+
+    private var selectedCommercialMonthlyURL: URL? {
+        guard let tier = selectedCommercialTier else { return nil }
+
+        let urlString: String = switch tier {
+        case .individual:
+            AppConstants.Polar.checkoutURLIndividual
+        case .team:
+            AppConstants.Polar.checkoutURLTeam
+        case .enterprise:
+            AppConstants.Polar.checkoutURLEnterprise
+        }
+
+        return URL(string: urlString)
+    }
+
+    private var selectedCommercialLifetimeURL: URL? {
+        guard let tier = selectedCommercialTier else { return nil }
+
+        let urlString: String = switch tier {
+        case .individual:
+            AppConstants.Polar.checkoutURLIndividualLifetime
+        case .team:
+            AppConstants.Polar.checkoutURLTeamLifetime
+        case .enterprise:
+            AppConstants.Polar.checkoutURLEnterpriseLifetime
+        }
+
+        return URL(string: urlString)
+    }
+
+    @MainActor
+    private func activateDetectedKey() async {
+        activationNotice = nil
+
+        let trimmedKey = licenseKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        if let activatedEntitlement = await license.activateAnyKey(trimmedKey) {
+            licenseKeyInput = ""
+            activationNotice = activationSuccessText(for: activatedEntitlement)
+        }
+    }
+
+    private func activationSuccessText(for entitlement: ActivatedEntitlement) -> String {
+        switch entitlement {
+        case .commercial(let tier, let isLifetime):
+            let lifetimeSuffix = isLifetime
+                ? localizedAppText(" (Lifetime)", de: " (Dauerlizenz)")
+                : ""
+            return localizedAppText(
+                "Detected commercial key: \(businessTierDisplayName(tier))\(lifetimeSuffix).",
+                de: "Kommerzieller Schlüssel erkannt: \(businessTierDisplayName(tier))\(lifetimeSuffix)."
+            )
+        case .supporter(let tier):
+            return localizedAppText(
+                "Detected supporter key: \(supporterTierDisplayName(tier)).",
+                de: "Supporter-Schlüssel erkannt: \(supporterTierDisplayName(tier))."
+            )
+        }
+    }
+
+    private func activeTierLabel(for tier: LicenseTier) -> String {
+        let lifetimeSuffix = license.licenseIsLifetime ? localizedAppText(", Lifetime", de: ", Dauerlizenz") : ""
+        return "(\(businessTierDisplayName(tier))\(lifetimeSuffix))"
+    }
+
+    private func openURL(_ url: URL?) {
         guard let url else { return }
         NSWorkspace.shared.open(url)
     }
 
-    private func businessTierButton(tier: LicenseTier, price: String, suffix: String, url: String) -> some View {
-        Button {
-            if let checkoutURL = URL(string: url) {
-                NSWorkspace.shared.open(checkoutURL)
-            }
-        } label: {
-            VStack(spacing: 4) {
-                Text(businessTierDisplayName(tier))
-                    .font(.caption.bold())
-                Text(businessTierFeature(tier))
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                Text(String(localized: "from \(price) \(suffix)"))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 8)
-        }
-        .buttonStyle(.bordered)
+    private func openClaimURL(_ url: URL?) async {
+        openURL(url)
     }
 
-    private func businessTierDisplayName(_ tier: LicenseTier) -> String {
-        switch tier {
-        case .individual: return "Individual"
-        case .team: return "Team"
-        case .enterprise: return "Enterprise"
-        }
-    }
-
-    private func businessTierFeature(_ tier: LicenseTier) -> String {
-        switch tier {
-        case .individual: return String(localized: "2 devices")
-        case .team: return String(localized: "10 devices")
-        case .enterprise: return String(localized: "Unlimited devices")
-        }
-    }
-
+    @ViewBuilder
     private func supporterTierButton(tier: SupporterTier, price: String) -> some View {
-        Button {
+        let isCurrentTier = license.isSupporter && license.supporterTier == tier
+
+        let button = Button {
             let url: String = switch tier {
             case .bronze: AppConstants.Polar.checkoutURLSupporterBronze
             case .silver: AppConstants.Polar.checkoutURLSupporterSilver
             case .gold: AppConstants.Polar.checkoutURLSupporterGold
             }
-            if let checkoutURL = URL(string: url) {
-                NSWorkspace.shared.open(checkoutURL)
-            }
+            openURL(URL(string: url))
         } label: {
-            VStack(spacing: 4) {
+            VStack(spacing: 6) {
                 Image(systemName: supporterTierIcon(tier))
                     .foregroundStyle(supporterTierColor(tier))
                 Text(supporterTierDisplayName(tier))
                     .font(.caption.bold())
-                Text(String(localized: "\(price) EUR"))
+                Text("\(price) EUR")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 8)
+            .padding(.vertical, 10)
         }
-        .buttonStyle(.bordered)
+
+        if isCurrentTier {
+            button.buttonStyle(.borderedProminent)
+        } else {
+            button.buttonStyle(.bordered)
+        }
+    }
+
+    private func businessTierDisplayName(_ tier: LicenseTier) -> String {
+        switch tier {
+        case .individual: return localizedAppText("Individual", de: "Einzelnutzer")
+        case .team: return localizedAppText("Team", de: "Team")
+        case .enterprise: return localizedAppText("Enterprise", de: "Unternehmensplan")
+        }
     }
 
     private func supporterTierDisplayName(_ tier: SupporterTier) -> String {
         switch tier {
-        case .bronze: return "Bronze"
-        case .silver: return "Silver"
-        case .gold: return "Gold"
+        case .bronze: return localizedAppText("Bronze", de: "Bronze")
+        case .silver: return localizedAppText("Silver", de: "Silber")
+        case .gold: return localizedAppText("Gold", de: "Gold")
         }
     }
 
@@ -447,5 +867,325 @@ struct LicenseSettingsView: View {
         case .silver: return Color(red: 0.753, green: 0.753, blue: 0.753)
         case .gold: return Color(red: 1.0, green: 0.843, blue: 0.0)
         }
+    }
+}
+
+enum CommercialPurchaseCadence {
+    case monthly
+    case lifetime
+}
+
+struct CommercialPurchaseOptionCopy: Equatable {
+    let price: String
+    let billingLabel: String
+    let detail: String
+}
+
+func commercialPurchaseOptionCopy(for tier: LicenseTier, cadence: CommercialPurchaseCadence) -> CommercialPurchaseOptionCopy {
+    switch (tier, cadence) {
+    case (.individual, .monthly):
+        CommercialPurchaseOptionCopy(
+            price: "5 EUR",
+            billingLabel: localizedAppText("per month", de: "pro Monat"),
+            detail: localizedAppText("Lower upfront cost", de: "Geringerer Einstiegspreis")
+        )
+    case (.individual, .lifetime):
+        CommercialPurchaseOptionCopy(
+            price: "99 EUR",
+            billingLabel: localizedAppText("one-time", de: "einmalig"),
+            detail: localizedAppText("Pay once, keep this tier", de: "Einmal zahlen, dieses Tier behalten")
+        )
+    case (.team, .monthly):
+        CommercialPurchaseOptionCopy(
+            price: "19 EUR",
+            billingLabel: localizedAppText("per month", de: "pro Monat"),
+            detail: localizedAppText("Recurring billing", de: "Wiederkehrende Abrechnung")
+        )
+    case (.team, .lifetime):
+        CommercialPurchaseOptionCopy(
+            price: "299 EUR",
+            billingLabel: localizedAppText("one-time", de: "einmalig"),
+            detail: localizedAppText("Pay once, keep this tier", de: "Einmal zahlen, dieses Tier behalten")
+        )
+    case (.enterprise, .monthly):
+        CommercialPurchaseOptionCopy(
+            price: "99 EUR",
+            billingLabel: localizedAppText("per month", de: "pro Monat"),
+            detail: localizedAppText("Recurring billing", de: "Wiederkehrende Abrechnung")
+        )
+    case (.enterprise, .lifetime):
+        CommercialPurchaseOptionCopy(
+            price: "999 EUR",
+            billingLabel: localizedAppText("one-time", de: "einmalig"),
+            detail: localizedAppText("Pay once, keep this tier", de: "Einmal zahlen, dieses Tier behalten")
+        )
+    }
+}
+
+private struct PanelCard<Content: View>: View {
+    let selected: Bool
+    let accent: Color
+    @ViewBuilder let content: Content
+
+    init(
+        selected: Bool = false,
+        accent: Color = .accentColor,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.selected = selected
+        self.accent = accent
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(selected ? accent.opacity(0.8) : Color.primary.opacity(0.08), lineWidth: selected ? 1.5 : 1)
+            )
+    }
+}
+
+private struct PurchaseOptionCardView: View {
+    let eyebrow: String
+    let title: String
+    let pricing: CommercialPurchaseOptionCopy
+    let description: String
+    let systemImage: String
+    let accent: Color
+    let badge: String?
+    let emphasized: Bool
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            ZStack(alignment: .topTrailing) {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(
+                                LinearGradient(
+                                    colors: emphasized
+                                        ? [accent.opacity(isHovering ? 0.25 : 0.22), accent.opacity(isHovering ? 0.08 : 0.05), .clear]
+                                        : [accent.opacity(isHovering ? 0.17 : 0.14), accent.opacity(isHovering ? 0.06 : 0.04), .clear],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            )
+                    }
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(
+                                accent.opacity(emphasized
+                                    ? (isHovering ? 0.56 : 0.45)
+                                    : (isHovering ? 0.34 : 0.22)
+                                ),
+                                lineWidth: isHovering ? 1.2 : 1
+                            )
+                    }
+
+                if emphasized {
+                    Circle()
+                        .fill(accent.opacity(isHovering ? 0.15 : 0.12))
+                        .frame(width: 84, height: 84)
+                        .blur(radius: isHovering ? 18 : 16)
+                        .offset(x: 16, y: -12)
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 10) {
+                            HStack(alignment: .top, spacing: 12) {
+                                ZStack {
+                                    Circle()
+                                        .fill(accent.opacity(emphasized ? 0.2 : 0.13))
+                                        .frame(width: 34, height: 34)
+
+                                    Image(systemName: systemImage)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(accent)
+                                }
+
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(eyebrow)
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(accent)
+
+                                    Text(title)
+                                        .font(.headline)
+                                        .foregroundStyle(.primary)
+                                }
+                            }
+
+                            Text(description)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer(minLength: 8)
+
+                        VStack(alignment: .trailing, spacing: 6) {
+                            Text(pricing.price)
+                                .font(.system(size: 28, weight: .bold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(.primary)
+
+                            Text(pricing.billingLabel)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(accent)
+                        }
+                        .padding(.top, 22)
+                    }
+
+                    Text(pricing.detail)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(emphasized ? accent : .secondary)
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, minHeight: 152, alignment: .leading)
+
+                if let badge {
+                    Text(badge)
+                        .font(.caption2.weight(.bold))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(accent.opacity(0.18))
+                        )
+                        .foregroundStyle(accent)
+                        .padding(12)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .offset(y: isHovering ? -1 : 0)
+            .shadow(
+                color: accent.opacity(emphasized
+                    ? (isHovering ? 0.14 : 0.10)
+                    : (isHovering ? 0.08 : 0.04)
+                ),
+                radius: emphasized ? (isHovering ? 10 : 8) : (isHovering ? 6 : 4),
+                y: isHovering ? 4 : (emphasized ? 3 : 1)
+            )
+            .animation(.easeOut(duration: 0.14), value: isHovering)
+        }
+        .buttonStyle(.plain)
+        .modifier(PointingHandCursorModifier())
+        .onHover { hovering in
+            isHovering = hovering
+        }
+    }
+}
+
+private struct PlanSelectionCardView: View {
+    let title: String
+    let price: String
+    let description: String
+    let systemImage: String
+    let selected: Bool
+    let accent: Color
+    let trailingLabel: String?
+    let descriptionMinHeight: CGFloat
+
+    @State private var isHovering = false
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: selected
+                                    ? [accent.opacity(isHovering ? 0.10 : 0.08), accent.opacity(isHovering ? 0.04 : 0.02), .clear]
+                                    : [accent.opacity(isHovering ? 0.05 : 0.0), .clear, .clear],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(
+                            selected
+                                ? accent.opacity(isHovering ? 0.92 : 0.80)
+                                : accent.opacity(isHovering ? 0.28 : 0.08),
+                            lineWidth: selected ? (isHovering ? 1.8 : 1.5) : (isHovering ? 1.2 : 1)
+                        )
+                }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top) {
+                    Label(title, systemImage: systemImage)
+                        .font(.headline)
+                    Spacer()
+                    if selected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(accent)
+                    } else if let trailingLabel {
+                        Text(trailingLabel)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(accent)
+                    }
+                }
+
+                Text(price)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, minHeight: descriptionMinHeight, alignment: .topLeading)
+            }
+            .padding(16)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .offset(y: isHovering ? -1 : 0)
+        .shadow(
+            color: (selected ? accent : .black).opacity(isHovering ? 0.12 : 0.05),
+            radius: isHovering ? 7 : 4,
+            y: isHovering ? 4 : 1
+        )
+        .animation(.easeOut(duration: 0.14), value: isHovering)
+        .modifier(PointingHandCursorModifier())
+        .onHover { hovering in
+            isHovering = hovering
+        }
+    }
+}
+
+private struct PointingHandCursorModifier: ViewModifier {
+    @State private var isHovering = false
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                guard hovering != isHovering else { return }
+                isHovering = hovering
+
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .onDisappear {
+                guard isHovering else { return }
+                NSCursor.pop()
+                isHovering = false
+            }
     }
 }

--- a/TypeWhisper/Views/WelcomeSheet.swift
+++ b/TypeWhisper/Views/WelcomeSheet.swift
@@ -13,32 +13,83 @@ struct WelcomeSheet: View {
             Text(String(localized: "Welcome to TypeWhisper!"))
                 .font(.title2.bold())
 
-            Text(String(localized: "TypeWhisper is open source.\nPersonal use and GPL-compliant open-source use are free.\nProprietary or otherwise non-GPL-compliant use requires a commercial license."))
+            Text(localizedAppText(
+                "Choose the scenario closest to you. You can change it later in Settings > License.",
+                de: "Wähle den Fall, der dir am nächsten kommt. Du kannst ihn später unter Einstellungen > Lizenz ändern."
+            ))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
-            HStack(spacing: 16) {
-                Button {
-                    license.setUserType(.privateUser)
-                    dismiss()
-                } label: {
-                    Label(String(localized: "Personal or open source"), systemImage: "person")
-                        .frame(maxWidth: .infinity)
-                }
-                .controlSize(.large)
+            VStack(spacing: 12) {
+                welcomeChoiceButton(
+                    intent: .personalOSS,
+                    title: localizedAppText("Private & OSS", de: "Privat & OSS"),
+                    description: localizedAppText(
+                        "Personal use and GPL-compatible open-source work stay free.",
+                        de: "Private Nutzung und GPL-kompatible Open-Source-Arbeit bleiben kostenlos."
+                    ),
+                    systemImage: "person"
+                )
 
-                Button {
-                    license.setUserType(.business)
-                    dismiss()
-                } label: {
-                    Label(String(localized: "Proprietary use"), systemImage: "building.2")
-                        .frame(maxWidth: .infinity)
-                }
-                .controlSize(.large)
-                .buttonStyle(.borderedProminent)
+                welcomeChoiceButton(
+                    intent: .workSolo,
+                    title: localizedAppText("At work, solo", de: "Beruflich allein"),
+                    description: localizedAppText(
+                        "Freelance work, day job usage, or closed-source projects for one person.",
+                        de: "Freelance-Arbeit, Nutzung im Job oder Closed-Source-Projekte für eine Person."
+                    ),
+                    systemImage: "briefcase"
+                )
+
+                welcomeChoiceButton(
+                    intent: .team,
+                    title: localizedAppText("With a team", de: "Mit Team"),
+                    description: localizedAppText(
+                        "Shared rollout, multiple devices, and team-wide usage.",
+                        de: "Gemeinsamer Rollout, mehrere Geräte und Team-Nutzung."
+                    ),
+                    systemImage: "person.3"
+                )
             }
         }
         .padding(32)
-        .frame(width: 440)
+        .frame(width: 520)
+    }
+
+    private func welcomeChoiceButton(
+        intent: UsageIntent,
+        title: String,
+        description: String,
+        systemImage: String
+    ) -> some View {
+        Button {
+            license.setUsageIntent(intent)
+            dismiss()
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.title3)
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                    Text(description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import XCTest
 @testable import TypeWhisper
 
@@ -154,6 +155,343 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(service.claimStatus.linkedRoles, ["Supporter Gold"])
     }
 
+    @MainActor
+    func testLicenseServiceMigratesLegacyPrivateUserTypeToPersonalOSS() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("private", forKey: UserDefaultsKeys.userType)
+
+        let service = LicenseService(defaults: defaults)
+
+        XCTAssertEqual(service.usageIntent, .personalOSS)
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.usageIntent), UsageIntent.personalOSS.rawValue)
+    }
+
+    @MainActor
+    func testLicenseServiceMigratesLegacyBusinessUserTypeToWorkSolo() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("business", forKey: UserDefaultsKeys.userType)
+
+        let service = LicenseService(defaults: defaults)
+
+        XCTAssertEqual(service.usageIntent, .workSolo)
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.usageIntent), UsageIntent.workSolo.rawValue)
+    }
+
+    func testLicenseTierInferenceMapsKnownPolarBenefitIDs() {
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "a4c0b152-0b91-4588-b8f8-779870affba9",
+                benefitDescription: "Individual Business License"
+            ),
+            .individual
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "4eb5fa60-ed43-475d-a9b1-c837e67307e5",
+                benefitDescription: "Lifetime Business License"
+            ),
+            .individual
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "5138b20a-57ba-48aa-a664-2139cd6df0de",
+                benefitDescription: "Team Business License"
+            ),
+            .team
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "afc8fac1-0e8f-4bb7-a1bc-60c8250b9923",
+                benefitDescription: "Lifetime Team Business License"
+            ),
+            .team
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "40b82917-f74e-4cc3-8165-937f1f47b294",
+                benefitDescription: "Enterprise Business License"
+            ),
+            .enterprise
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "1857c2ed-3f80-4a8a-93c7-c1d67e02db2e",
+                benefitDescription: "Lifetime Enterprise Business License"
+            ),
+            .enterprise
+        )
+    }
+
+    func testLicenseTierInferenceReturnsNilForUnknownBenefit() {
+        XCTAssertNil(
+            LicenseService.inferLicenseTier(benefitID: "benefit_custom", benefitDescription: "Custom internal grant")
+        )
+    }
+
+    func testLicenseTierInferenceFallsBackToLegacyDescriptionMatching() {
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "legacy-benefit",
+                benefitDescription: "Freelancer single-seat license for 2 devices"
+            ),
+            .individual
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "legacy-benefit",
+                benefitDescription: "Small teams up to 10 devices"
+            ),
+            .team
+        )
+        XCTAssertEqual(
+            LicenseService.inferLicenseTier(
+                benefitID: "legacy-benefit",
+                benefitDescription: "Unlimited devices and priority support"
+            ),
+            .enterprise
+        )
+    }
+
+    func testSupporterTierInferenceMapsKnownPolarBenefitIDs() {
+        XCTAssertEqual(
+            LicenseService.inferSupporterTier(
+                benefitID: "0c695b7a-2f3a-4797-81c7-1410dbb76cc2",
+                benefitDescription: "Supporter Gold License"
+            ),
+            .gold
+        )
+        XCTAssertEqual(
+            LicenseService.inferSupporterTier(
+                benefitID: "9ca12e41-b407-4368-9745-76b72ff2c7c2",
+                benefitDescription: "Supporter Silver License"
+            ),
+            .silver
+        )
+        XCTAssertEqual(
+            LicenseService.inferSupporterTier(
+                benefitID: "d3eef5ed-bc8c-469d-809b-79fdfe5fc8e8",
+                benefitDescription: "Supporter Bronze License"
+            ),
+            .bronze
+        )
+    }
+
+    func testSupporterTierInferenceFallsBackToLegacyDescriptionMatching() {
+        XCTAssertEqual(
+            LicenseService.inferSupporterTier(
+                benefitID: "legacy-supporter",
+                benefitDescription: "Gold supporter"
+            ),
+            .gold
+        )
+        XCTAssertEqual(
+            LicenseService.inferSupporterTier(
+                benefitID: "legacy-supporter",
+                benefitDescription: "Silver supporter"
+            ),
+            .silver
+        )
+        XCTAssertEqual(
+            LicenseService.inferSupporterTier(
+                benefitID: "legacy-supporter",
+                benefitDescription: "Bronze supporter"
+            ),
+            .bronze
+        )
+    }
+
+    func testCommercialPurchaseOptionCopyMapsPriceAndBillingLabels() {
+        XCTAssertEqual(
+            commercialPurchaseOptionCopy(for: .individual, cadence: .monthly),
+            CommercialPurchaseOptionCopy(
+                price: "5 EUR",
+                billingLabel: localizedAppText("per month", de: "pro Monat"),
+                detail: localizedAppText("Lower upfront cost", de: "Geringerer Einstiegspreis")
+            )
+        )
+
+        XCTAssertEqual(
+            commercialPurchaseOptionCopy(for: .team, cadence: .lifetime),
+            CommercialPurchaseOptionCopy(
+                price: "299 EUR",
+                billingLabel: localizedAppText("one-time", de: "einmalig"),
+                detail: localizedAppText("Pay once, keep this tier", de: "Einmal zahlen, dieses Tier behalten")
+            )
+        )
+
+        XCTAssertEqual(
+            commercialPurchaseOptionCopy(for: .enterprise, cadence: .monthly),
+            CommercialPurchaseOptionCopy(
+                price: "99 EUR",
+                billingLabel: localizedAppText("per month", de: "pro Monat"),
+                detail: localizedAppText("Recurring billing", de: "Wiederkehrende Abrechnung")
+            )
+        )
+    }
+
+    @MainActor
+    func testActivateAnyKeyRoutesCommercialBenefitIntoCommercialState() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let keychainServiceName = "TypeWhisperTests.Universal.\(UUID().uuidString)"
+        defer {
+            Self.deleteKeychainValue(service: keychainServiceName, account: "polar-license")
+            Self.deleteKeychainValue(service: keychainServiceName, account: "polar-supporter")
+        }
+
+        let service = LicenseService(
+            defaults: defaults,
+            keychainServiceName: keychainServiceName,
+            dataTransport: { request in
+                switch request.url?.path {
+                case "/v1/customer-portal/license-keys/activate":
+                    let body = #"{"id":"activation-123"}"#
+                    return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+                case "/v1/customer-portal/license-keys/validate":
+                    let body = #"{"id":"activation-123","status":"granted","expires_at":null,"benefit_id":"40b82917-f74e-4cc3-8165-937f1f47b294"}"#
+                    return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+                default:
+                    XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                    let body = #"{"detail":"unexpected"}"#
+                    return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 500))
+                }
+            }
+        )
+
+        let entitlement = await service.activateAnyKey("TYPEWHISPER-ENT-123")
+
+        XCTAssertEqual(entitlement, .commercial(tier: .enterprise, isLifetime: true))
+        XCTAssertEqual(service.licenseStatus, .active)
+        XCTAssertEqual(service.licenseTier, .enterprise)
+        XCTAssertEqual(service.usageIntent, .enterprise)
+        XCTAssertTrue(service.licenseIsLifetime)
+        XCTAssertEqual(
+            Self.loadKeychainValue(service: keychainServiceName, account: "polar-license"),
+            "TYPEWHISPER-ENT-123|activation-123"
+        )
+        XCTAssertNil(Self.loadKeychainValue(service: keychainServiceName, account: "polar-supporter"))
+    }
+
+    @MainActor
+    func testActivateAnyKeyRoutesSupporterBenefitIntoSupporterState() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let keychainServiceName = "TypeWhisperTests.Universal.\(UUID().uuidString)"
+        defer {
+            Self.deleteKeychainValue(service: keychainServiceName, account: "polar-license")
+            Self.deleteKeychainValue(service: keychainServiceName, account: "polar-supporter")
+        }
+
+        let service = LicenseService(
+            defaults: defaults,
+            keychainServiceName: keychainServiceName,
+            dataTransport: { request in
+                switch request.url?.path {
+                case "/v1/customer-portal/license-keys/activate":
+                    let body = #"{"id":"activation-999"}"#
+                    return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+                case "/v1/customer-portal/license-keys/validate":
+                    let body = #"{"id":"activation-999","status":"granted","expires_at":"2027-01-01T00:00:00Z","benefit_id":"0c695b7a-2f3a-4797-81c7-1410dbb76cc2"}"#
+                    return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+                default:
+                    XCTFail("Unexpected request path: \(request.url?.path ?? "nil")")
+                    let body = #"{"detail":"unexpected"}"#
+                    return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 500))
+                }
+            }
+        )
+
+        let entitlement = await service.activateAnyKey("TYPEWHISPER-SUP-999")
+
+        XCTAssertEqual(entitlement, .supporter(tier: .gold))
+        XCTAssertEqual(service.supporterStatus, .active)
+        XCTAssertEqual(service.supporterTier, .gold)
+        XCTAssertEqual(service.licenseStatus, .unlicensed)
+        XCTAssertNil(service.licenseTier)
+        XCTAssertEqual(
+            Self.loadKeychainValue(service: keychainServiceName, account: "polar-supporter"),
+            "TYPEWHISPER-SUP-999|activation-999"
+        )
+        XCTAssertNil(Self.loadKeychainValue(service: keychainServiceName, account: "polar-license"))
+    }
+
+    @MainActor
+    func testSupporterDeactivationClearsLocalStateWhenPolarActivationIsMissing() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let keychainServiceName = "TypeWhisperTests.Supporter.\(UUID().uuidString)"
+        defer { Self.deleteKeychainValue(service: keychainServiceName, account: "polar-supporter") }
+
+        Self.storeKeychainValue(
+            "supporter-key|activation-123",
+            service: keychainServiceName,
+            account: "polar-supporter"
+        )
+
+        let service = LicenseService(
+            defaults: defaults,
+            keychainServiceName: keychainServiceName,
+            dataTransport: { request in
+                XCTAssertEqual(request.url?.path, "/v1/customer-portal/license-keys/deactivate")
+                let body = #"{"error":"ResourceNotFound","detail":"Not found"}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 404))
+            }
+        )
+
+        service.supporterStatus = .active
+        service.supporterTier = .bronze
+        defaults.set(Date(), forKey: UserDefaultsKeys.lastSupporterValidation)
+
+        await service.deactivateSupporterLicense()
+
+        XCTAssertEqual(service.supporterStatus, .unlicensed)
+        XCTAssertNil(service.supporterTier)
+        XCTAssertNil(service.supporterDeactivationError)
+        XCTAssertNil(defaults.object(forKey: UserDefaultsKeys.lastSupporterValidation))
+        XCTAssertNil(Self.loadKeychainValue(service: keychainServiceName, account: "polar-supporter"))
+    }
+
+    @MainActor
+    func testSupporterValidationClearsLocalStateWhenPolarActivationIsMissing() async throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let keychainServiceName = "TypeWhisperTests.Supporter.\(UUID().uuidString)"
+        defer { Self.deleteKeychainValue(service: keychainServiceName, account: "polar-supporter") }
+
+        Self.storeKeychainValue(
+            "supporter-key|activation-123",
+            service: keychainServiceName,
+            account: "polar-supporter"
+        )
+
+        let service = LicenseService(
+            defaults: defaults,
+            keychainServiceName: keychainServiceName,
+            dataTransport: { request in
+                XCTAssertEqual(request.url?.path, "/v1/customer-portal/license-keys/validate")
+                let body = #"{"error":"ResourceNotFound","detail":"Not found"}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 404))
+            }
+        )
+
+        service.supporterStatus = .active
+        service.supporterTier = .gold
+        defaults.set(Date.distantPast, forKey: UserDefaultsKeys.lastSupporterValidation)
+
+        await service.validateSupporterIfNeeded()
+
+        XCTAssertEqual(service.supporterStatus, .unlicensed)
+        XCTAssertNil(service.supporterTier)
+        XCTAssertNil(defaults.object(forKey: UserDefaultsKeys.lastSupporterValidation))
+        XCTAssertNil(Self.loadKeychainValue(service: keychainServiceName, account: "polar-supporter"))
+    }
+
     private func makeIsolatedDefaults() throws -> (UserDefaults, String) {
         let suiteName = "TypeWhisperTests.SupporterDiscord.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -165,5 +503,44 @@ final class CLISupportTests: XCTestCase {
 
     private static func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func storeKeychainValue(_ value: String, service: String, account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = Data(value.utf8)
+        XCTAssertEqual(SecItemAdd(addQuery as CFDictionary, nil), errSecSuccess)
+    }
+
+    private static func loadKeychainValue(service: String, account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func deleteKeychainValue(service: String, account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
     }
 }


### PR DESCRIPTION
## Summary
- redesign the in-app licensing page into a plan-first flow with clearer commercial and supporter states
- add usage-intent persistence, universal Polar key activation, and benefit ID based entitlement mapping
- polish the settings UI with localized copy, website FAQ links, plan card hover states, and targeted regression tests

## Testing
- xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/CLISupportTests