### PR TITLE
fix: infinite engine restart loop on recording start

### DIFF
--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -119,6 +119,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private var _hasExplicitDeviceSelection = false
 
     private var audioEngine: AVAudioEngine?
+    private var installedTapFormat: AVAudioFormat?
     private var configChangeObserver: NSObjectProtocol?
     private var sampleBuffer: [Float] = []
     private var _peakRawAudioLevel: Float = 0
@@ -345,8 +346,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
         }
 
-        let engine: AVAudioEngine? = engineLock.withLock { audioEngine }
+        let (engine, expected): (AVAudioEngine?, AVAudioFormat?) = engineLock.withLock {
+            (audioEngine, installedTapFormat)
+        }
         guard isRecording, let engine else { return }
+
+        let live = engine.inputNode.outputFormat(forBus: 0)
+        if let expected,
+           live.sampleRate == expected.sampleRate,
+           live.channelCount == expected.channelCount { return }
 
         logger.warning("Audio engine configuration changed during recording, restarting engine")
 
@@ -483,6 +491,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let engineStartTime = CFAbsoluteTimeGetCurrent()
         do {
             try engine.start()
+            engineLock.withLock { installedTapFormat = tapFormat }
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
             logger.info("\(label, privacy: .public) audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
         } catch {


### PR DESCRIPTION
## Summary

On USB mics whose native channel count differs from the tap format (e.g.
2ch stereo device with a 1ch mono tap), Core Audio's AUHAL renegotiates
the input bus to match the tap *after* `engine.start()` returns, firing
an `AVAudioEngineConfigurationChange` notification.

`performScheduledRecovery` treats that notification as a real device
change and tears down + recreates the engine. The fresh engine repeats
the same renegotiation, producing an infinite restart loop that only
exits when the user releases the record hotkey.

## Fix

Stash the installed tap format after `engine.start()`. On a
configuration-change notification, compare the live input format against
the stashed format and return early when they match — that's the benign
post-start renegotiation. Real device/format changes (sample-rate flip,
device swap) still fall through to the existing restart path.

## Verification

Hollyland USB mic, MacBook Pro M4, sound feedback on:

| metric         | before | after  |
| -------------- | ------ | ------ |
| restart cycles | ∞      | 0      |
| totalStartMs   | ~900ms | 190ms  |

## Test plan

- [ ] Start recording on a USB mic with mismatched native/tap channel counts — no restart loop, capture begins promptly.
- [ ] Unplug the mic mid-recording — engine still tears down and surfaces the real device change (benign guard doesn't swallow legitimate events).
- [ ] Start recording on the built-in mic — no regression.