### PR TITLE
Upgrade local model infrastructure and add Gemma 4 support

### DIFF
--- a/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -2,22 +2,127 @@ import Foundation
 import SwiftUI
 import MLXVLM
 import MLXLMCommon
+import HuggingFace
 import Hub
+import Tokenizers
 import TypeWhisperPluginSDK
+
+private struct Gemma4HubDownloader: Downloader {
+    let client: HubClient
+    let modelsDirectory: URL
+
+    func download(
+        id: String,
+        revision: String?,
+        matching patterns: [String],
+        useLatest _: Bool,
+        progressHandler: @Sendable @escaping (Progress) -> Void
+    ) async throws -> URL {
+        guard let repoID = Repo.ID(rawValue: id) else {
+            throw Gemma4Plugin.DownloadError.invalidRepositoryID(id)
+        }
+
+        let destination = modelsDirectory.appendingPathComponent(id, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        return try await client.downloadSnapshot(
+            of: repoID,
+            to: destination,
+            revision: revision ?? "main",
+            matching: patterns,
+            progressHandler: { @MainActor progress in
+                progressHandler(progress)
+            }
+        )
+    }
+}
+
+private struct Gemma4TokenizerBridge: MLXLMCommon.Tokenizer {
+    let upstream: any Tokenizers.Tokenizer
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        upstream.convertTokenToId(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        upstream.convertIdToToken(id)
+    }
+
+    var bosToken: String? { upstream.bosToken }
+    var eosToken: String? { upstream.eosToken }
+    var unknownToken: String? { upstream.unknownToken }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        do {
+            return try upstream.applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext
+            )
+        } catch Tokenizers.TokenizerError.missingChatTemplate {
+            throw MLXLMCommon.TokenizerError.missingChatTemplate
+        }
+    }
+}
+
+private struct Gemma4TokenizerLoader: TokenizerLoader {
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let tokenizer = try await AutoTokenizer.from(modelFolder: directory)
+        return Gemma4TokenizerBridge(upstream: tokenizer)
+    }
+}
 
 // MARK: - Plugin Entry Point
 
 @objc(Gemma4Plugin)
-final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, PluginSettingsActivityReporting, @unchecked Sendable {
+final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gemma4"
     static let pluginName = "Gemma 4"
     static let defaultGenerationTemperature = 0.1
+    static let experimentalModelWarning = "Experimental. You can try it at your own risk."
+
+    enum DownloadError: LocalizedError {
+        case invalidRepositoryID(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidRepositoryID(let id):
+                return "Invalid Hugging Face repository ID: '\(id)'. Expected format 'namespace/name'."
+            }
+        }
+    }
 
     fileprivate var host: HostServices?
     fileprivate var _selectedLLMModelId: String?
     fileprivate var modelContainer: ModelContainer?
     fileprivate var loadedModelId: String?
     fileprivate var _generationTemperature: Double = 0.1
+    fileprivate var _hfToken: String?
+
+    private func modelsDirectory() -> URL {
+        host?.pluginDataDirectory.appendingPathComponent("models")
+            ?? FileManager.default.temporaryDirectory.appendingPathComponent("gemma4-models")
+    }
+
+    private func localModelDirectory(for repoId: String) -> URL {
+        modelsDirectory().appendingPathComponent(repoId, isDirectory: true)
+    }
+    fileprivate var downloadProgress: Double = 0
 
     var modelState: Gemma4ModelState = .notLoaded
 
@@ -27,10 +132,21 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
 
     func activate(host: HostServices) {
         self.host = host
-        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
-            ?? Self.availableModels.first?.id
+        let persistedSelection = host.userDefault(forKey: "selectedLLMModel") as? String
+        let sanitizedSelection = Self.sanitizedSelectedModelId(persistedSelection)
+        _selectedLLMModelId = sanitizedSelection
+        if sanitizedSelection != persistedSelection {
+            host.setUserDefault(sanitizedSelection, forKey: "selectedLLMModel")
+        }
+
+        let persistedLoadedModel = host.userDefault(forKey: "loadedModel") as? String
+        if let persistedLoadedModel, !Self.canRestoreLoadedModel(persistedLoadedModel) {
+            host.setUserDefault(nil, forKey: "loadedModel")
+        }
+
         _generationTemperature = host.userDefault(forKey: "generationTemperature") as? Double
             ?? Self.defaultGenerationTemperature
+        _hfToken = host.loadSecret(key: "hf-token")
 
         Task { await restoreLoadedModel(allowDownloads: false) }
     }
@@ -38,6 +154,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
     func deactivate() {
         modelContainer = nil
         loadedModelId = nil
+        downloadProgress = 0
         modelState = .notLoaded
         host = nil
     }
@@ -103,13 +220,34 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
     // MARK: - LLMModelSelectable
 
     func selectLLMModel(_ modelId: String) {
-        _selectedLLMModelId = modelId
-        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+        let sanitizedModelId = Self.sanitizedSelectedModelId(modelId)
+        _selectedLLMModelId = sanitizedModelId
+        host?.setUserDefault(sanitizedModelId, forKey: "selectedLLMModel")
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var preferredModelId: String? { _selectedLLMModelId }
+    var huggingFaceToken: String? { _hfToken }
+    var currentDownloadProgress: Double { downloadProgress }
 
     var generationTemperature: Double { _generationTemperature }
+
+    var requiresExternalCredentials: Bool { false }
+
+    var unavailableReason: String? {
+        if isAvailable { return nil }
+
+        if case .error(let message) = modelState,
+           !message.isEmpty {
+            return message
+        }
+
+        let bundle = Bundle(for: Gemma4Plugin.self)
+        return String(
+            localized: "Load a Gemma 4 model in Integrations before using it for prompts.",
+            bundle: bundle
+        )
+    }
 
     func setGenerationTemperature(_ temperature: Double) {
         let clamped = min(max(temperature, 0.0), 1.0)
@@ -117,34 +255,121 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
         host?.setUserDefault(clamped, forKey: "generationTemperature")
     }
 
+    func saveHuggingFaceToken(_ token: String) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        _hfToken = trimmed.isEmpty ? nil : trimmed
+        try? host?.storeSecret(key: "hf-token", value: trimmed)
+    }
+
+    func clearHuggingFaceToken() {
+        _hfToken = nil
+        try? host?.storeSecret(key: "hf-token", value: "")
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
+    }
+
+    func isModelDownloaded(_ modelDef: Gemma4ModelDef) -> Bool {
+        hasDownloadedModel(modelDef)
+    }
+
+    func beginModelLoad(for modelDef: Gemma4ModelDef, isAlreadyDownloaded: Bool) {
+        _selectedLLMModelId = modelDef.id
+        modelState = isAlreadyDownloaded ? .loading : .downloading
+        downloadProgress = isAlreadyDownloaded ? 0.8 : 0.02
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func cancelModelLoad() {
+        downloadProgress = 0
+        modelState = .notLoaded
+        host?.notifyCapabilitiesChanged()
+    }
+
     // MARK: - Model Management
 
     func loadModel(_ modelDef: Gemma4ModelDef) async throws {
-        modelState = .loading
+        try Task.checkCancellation()
+        let isAlreadyDownloaded = hasDownloadedModel(modelDef)
+        beginModelLoad(for: modelDef, isAlreadyDownloaded: isAlreadyDownloaded)
         do {
-            let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models")
-                ?? FileManager.default.temporaryDirectory
+            let token = _hfToken?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let modelsDir = modelsDirectory()
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
-            let hub = HubApi(downloadBase: modelsDir)
+            let hubClient = HubClient(
+                host: HubClient.defaultHost,
+                bearerToken: token?.isEmpty == false ? token : nil,
+                cache: HubCache(cacheDirectory: modelsDir)
+            )
+            let downloader = Gemma4HubDownloader(client: hubClient, modelsDirectory: modelsDir)
             let configuration = ModelConfiguration(
                 id: modelDef.repoId,
-                extraEOSTokens: ["<end_of_turn>"]
+                extraEOSTokens: ["<turn|>"]
             )
             let container = try await VLMModelFactory.shared.loadContainer(
-                hub: hub,
+                from: downloader,
+                using: Gemma4TokenizerLoader(),
                 configuration: configuration
-            )
+            ) { progress in
+                guard !Task.isCancelled else { return }
+                let fraction = max(0.0, min(progress.fractionCompleted, 1.0))
+                let mapped = 0.02 + fraction * 0.78
+                Task { @MainActor in
+                    self.downloadProgress = mapped
+                    if case .downloading = self.modelState {
+                        self.host?.notifyCapabilitiesChanged()
+                    }
+                }
+            }
 
+            try Task.checkCancellation()
+            modelState = .loading
+            downloadProgress = 0.9
             modelContainer = container
             loadedModelId = modelDef.id
             _selectedLLMModelId = modelDef.id
             host?.setUserDefault(modelDef.id, forKey: "selectedLLMModel")
             host?.setUserDefault(modelDef.id, forKey: "loadedModel")
+            downloadProgress = 1.0
             modelState = .ready(modelDef.id)
             host?.notifyCapabilitiesChanged()
         } catch {
-            modelState = .error(error.localizedDescription)
+            if error is CancellationError {
+                cancelModelLoad()
+                throw error
+            }
+            downloadProgress = 0
+            modelState = .error(Self.userFacingLoadErrorMessage(for: error, modelDef: modelDef))
             throw error
         }
     }
@@ -155,6 +380,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
     func unloadModel(clearPersistence: Bool = true) {
         modelContainer = nil
         loadedModelId = nil
+        downloadProgress = 0
         modelState = .notLoaded
         if clearPersistence {
             host?.setUserDefault(nil, forKey: "loadedModel")
@@ -163,15 +389,14 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
     }
 
     func deleteModelFiles(_ modelDef: Gemma4ModelDef) {
-        guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
-        let repo = Hub.Repo(id: modelDef.repoId)
-        let repoDir = HubApi(downloadBase: modelsDir).localRepoLocation(repo)
+        let repoDir = localModelDirectory(for: modelDef.repoId)
         try? FileManager.default.removeItem(at: repoDir)
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
         guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
-              let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
+              let modelDef = Self.modelDefinition(for: savedId) else {
+            host?.setUserDefault(nil, forKey: "loadedModel")
             return
         }
         guard allowDownloads || hasDownloadedModel(modelDef) else { return }
@@ -179,9 +404,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
     }
 
     private func hasDownloadedModel(_ modelDef: Gemma4ModelDef) -> Bool {
-        guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return false }
-        let repo = Hub.Repo(id: modelDef.repoId)
-        let repoDir = HubApi(downloadBase: modelsDir).localRepoLocation(repo)
+        let repoDir = localModelDirectory(for: modelDef.repoId)
 
         var isDirectory: ObjCBool = false
         return FileManager.default.fileExists(atPath: repoDir.path, isDirectory: &isDirectory)
@@ -194,6 +417,11 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
         switch modelState {
         case .notLoaded, .ready:
             return nil
+        case .downloading:
+            return PluginSettingsActivity(
+                message: "Downloading model",
+                progress: downloadProgress
+            )
         case .loading:
             return PluginSettingsActivity(message: "Preparing model")
         case .error(let message):
@@ -215,30 +443,86 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMModelSelectable, Plugi
             displayName: "Gemma 4 E2B (4-bit)",
             repoId: "mlx-community/gemma-4-e2b-it-4bit",
             sizeDescription: "~3.6 GB",
-            ramRequirement: "8 GB+"
+            ramRequirement: "8 GB+",
+            availability: .supported
         ),
         Gemma4ModelDef(
             id: "gemma-4-e4b-it-4bit",
             displayName: "Gemma 4 E4B (4-bit)",
             repoId: "mlx-community/gemma-4-e4b-it-4bit",
             sizeDescription: "~5.2 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            availability: .supported
         ),
         Gemma4ModelDef(
             id: "gemma-4-e4b-it-8bit",
             displayName: "Gemma 4 E4B (8-bit)",
             repoId: "mlx-community/gemma-4-e4b-it-8bit",
             sizeDescription: "~8 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            availability: .experimental(warning: experimentalModelWarning)
         ),
         Gemma4ModelDef(
             id: "gemma-4-26b-a4b-it-4bit",
             displayName: "Gemma 4 26B-A4B (4-bit, MoE)",
             repoId: "mlx-community/gemma-4-26b-a4b-it-4bit",
             sizeDescription: "~15.6 GB",
-            ramRequirement: "32 GB+"
+            ramRequirement: "32 GB+",
+            availability: .experimental(warning: experimentalModelWarning)
         ),
     ]
+
+    static var supportedModelDefinitions: [Gemma4ModelDef] {
+        availableModels.filter(\.isSupported)
+    }
+
+    static func modelDefinition(for id: String?) -> Gemma4ModelDef? {
+        guard let id else { return nil }
+        return availableModels.first(where: { $0.id == id })
+    }
+
+    static func sanitizedSelectedModelId(_ id: String?) -> String? {
+        guard let modelDef = modelDefinition(for: id) else {
+            return supportedModelDefinitions.first?.id
+        }
+        return modelDef.id
+    }
+
+    static func canRestoreLoadedModel(_ id: String) -> Bool {
+        modelDefinition(for: id) != nil
+    }
+
+    static func userFacingLoadErrorMessage(for error: Error, modelDef: Gemma4ModelDef) -> String {
+        if let pluginError = error as? Gemma4PluginError,
+           let description = pluginError.errorDescription {
+            return description
+        }
+
+        if let urlError = error as? URLError,
+           urlError.code == .timedOut {
+            let bundle = Bundle(for: Gemma4Plugin.self)
+            return String(
+                localized: "Download timed out while fetching Gemma 4 from Hugging Face. Please retry. Adding an optional HuggingFace token in this plugin can also increase download rate limits.",
+                bundle: bundle
+            )
+        }
+
+        let rawMessage = String(describing: error).lowercased()
+        if rawMessage.contains("unsupported model type")
+            || rawMessage.contains("model type gemma4 not supported") {
+            return unsupportedModelMessage(for: modelDef)
+        }
+
+        return error.localizedDescription
+    }
+
+    private static func unsupportedModelMessage(for modelDef: Gemma4ModelDef) -> String {
+        let supportedModels = supportedModelDefinitions.map(\.displayName).joined(separator: ", ")
+        if modelDef.isSupported {
+            return "Gemma 4 loading in this TypeWhisper release is limited to \(supportedModels). If loading still fails, update to the latest app build and try again."
+        }
+        return "\(modelDef.displayName) is experimental in this TypeWhisper release and may still fail to load. Recommended models: \(supportedModels)."
+    }
 }
 
 // MARK: - Model Types
@@ -249,6 +533,26 @@ struct Gemma4ModelDef: Identifiable {
     let repoId: String
     let sizeDescription: String
     let ramRequirement: String
+    let availability: Gemma4ModelAvailability
+
+    var isSupported: Bool {
+        if case .supported = availability {
+            return true
+        }
+        return false
+    }
+
+    var experimentalWarning: String? {
+        if case .experimental(let warning) = availability {
+            return warning
+        }
+        return nil
+    }
+}
+
+enum Gemma4ModelAvailability: Equatable {
+    case supported
+    case experimental(warning: String)
 }
 
 enum Gemma4PluginError: LocalizedError {
@@ -264,6 +568,7 @@ enum Gemma4PluginError: LocalizedError {
 
 enum Gemma4ModelState: Equatable {
     case notLoaded
+    case downloading
     case loading
     case ready(String)
     case error(String)
@@ -271,6 +576,7 @@ enum Gemma4ModelState: Equatable {
     static func == (lhs: Gemma4ModelState, rhs: Gemma4ModelState) -> Bool {
         switch (lhs, rhs) {
         case (.notLoaded, .notLoaded): true
+        case (.downloading, .downloading): true
         case (.loading, .loading): true
         case let (.ready(a), .ready(b)): a == b
         case let (.error(a), .error(b)): a == b

--- a/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -7,9 +7,26 @@ struct Gemma4SettingsView: View {
     @State private var modelState: Gemma4ModelState = .notLoaded
     @State private var selectedModelId: String = ""
     @State private var generationTemperature: Double = Gemma4Plugin.defaultGenerationTemperature
+    @State private var downloadProgress: Double = 0
+    @State private var hfTokenInput = ""
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
     @State private var isPolling = false
+    @State private var loadTask: Task<Void, Never>?
 
     private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    private var trimmedHfTokenInput: String {
+        hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var storedHfToken: String {
+        plugin.huggingFaceToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private var hasStoredHfToken: Bool {
+        !storedHfToken.isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -52,6 +69,62 @@ struct Gemma4SettingsView: View {
 
             Divider()
 
+            VStack(alignment: .leading, spacing: 10) {
+                Text("HuggingFace Token", bundle: bundle)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Text("Optional. Increases download rate limits. Free at huggingface.co/settings/tokens", bundle: bundle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    SecureField("hf_...", text: $hfTokenInput)
+                        .textFieldStyle(.roundedBorder)
+
+                    Button(String(localized: "Save", bundle: bundle)) {
+                        validateAndSaveHuggingFaceToken()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
+
+                    if hasStoredHfToken {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            hfTokenInput = ""
+                            tokenValidationResult = nil
+                            isValidatingToken = false
+                            plugin.clearHuggingFaceToken()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+
+                if isValidatingToken {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating token...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let tokenValidationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        Text(
+                            tokenValidationResult
+                                ? String(localized: "Valid HuggingFace Token", bundle: bundle)
+                                : String(localized: "Invalid HuggingFace Token", bundle: bundle)
+                        )
+                        .font(.caption)
+                        .foregroundStyle(tokenValidationResult ? .green : .red)
+                    }
+                }
+            }
+
+            Divider()
+
             VStack(alignment: .leading, spacing: 8) {
                 Text("Model", bundle: bundle)
                     .font(.subheadline)
@@ -61,6 +134,10 @@ struct Gemma4SettingsView: View {
                     modelRow(modelDef)
                 }
             }
+
+            Text("Gemma 4 E2B/E4B 4-bit models are recommended. Larger variants are experimental and may fail depending on hardware.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
             if case .error(let message) = modelState {
                 HStack(spacing: 4) {
@@ -77,6 +154,10 @@ struct Gemma4SettingsView: View {
             modelState = plugin.modelState
             selectedModelId = plugin.selectedLLMModelId ?? Gemma4Plugin.availableModels.first?.id ?? ""
             generationTemperature = plugin.generationTemperature
+            downloadProgress = plugin.currentDownloadProgress
+            if let token = plugin.huggingFaceToken, !token.isEmpty {
+                hfTokenInput = token
+            }
         }
         .task {
             if case .notLoaded = plugin.modelState {
@@ -88,12 +169,19 @@ struct Gemma4SettingsView: View {
         }
         .onReceive(pollTimer) { _ in
             guard isPolling else { return }
+            downloadProgress = plugin.currentDownloadProgress
             let pluginState = plugin.modelState
             if pluginState != .notLoaded {
                 modelState = pluginState
             }
             if case .ready = pluginState { isPolling = false }
             else if case .error = pluginState { isPolling = false }
+        }
+        .onChange(of: hfTokenInput) { _, newValue in
+            let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedValue != storedHfToken {
+                tokenValidationResult = nil
+            }
         }
     }
 
@@ -110,9 +198,29 @@ struct Gemma4SettingsView: View {
 
             Spacer()
 
-            if case .loading = modelState, selectedModelId == modelDef.id {
-                ProgressView()
+            if case .downloading = modelState, selectedModelId == modelDef.id {
+                HStack(spacing: 8) {
+                    ProgressView(value: downloadProgress)
+                        .frame(width: 80)
+                    Text("\(Int(downloadProgress * 100))%")
+                        .font(.caption)
+                        .monospacedDigit()
+                    Button(String(localized: "Cancel", bundle: bundle)) {
+                        cancelCurrentLoad()
+                    }
+                    .buttonStyle(.bordered)
                     .controlSize(.small)
+                }
+            } else if case .loading = modelState, selectedModelId == modelDef.id {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Button(String(localized: "Cancel", bundle: bundle)) {
+                        cancelCurrentLoad()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
             } else if case .ready(let loadedId) = modelState, loadedId == modelDef.id {
                 HStack(spacing: 8) {
                     Image(systemName: "checkmark.circle.fill")
@@ -125,22 +233,87 @@ struct Gemma4SettingsView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                 }
+            } else if let experimentalWarning = modelDef.experimentalWarning {
+                VStack(alignment: .trailing, spacing: 6) {
+                    Text("Experimental", bundle: bundle)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.orange)
+                    Text(LocalizedStringKey(experimentalWarning), bundle: bundle)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 220, alignment: .trailing)
+
+                    Button(String(localized: "Try anyway", bundle: bundle)) {
+                        startLoading(modelDef)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(modelState == .downloading || modelState == .loading)
+                }
             } else {
                 Button(String(localized: "Download & Load", bundle: bundle)) {
-                    selectedModelId = modelDef.id
-                    modelState = .loading
-                    isPolling = true
-                    Task {
-                        try? await plugin.loadModel(modelDef)
-                        isPolling = false
-                        modelState = plugin.modelState
-                    }
+                    startLoading(modelDef)
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
-                .disabled(modelState == .loading)
+                .disabled(modelState == .downloading || modelState == .loading)
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func startLoading(_ modelDef: Gemma4ModelDef) {
+        selectedModelId = modelDef.id
+        let alreadyDownloaded = plugin.isModelDownloaded(modelDef)
+        plugin.beginModelLoad(for: modelDef, isAlreadyDownloaded: alreadyDownloaded)
+        modelState = plugin.modelState
+        downloadProgress = plugin.currentDownloadProgress
+        isPolling = true
+        loadTask?.cancel()
+        loadTask = Task {
+            do {
+                try await plugin.loadModel(modelDef)
+            } catch is CancellationError {
+            } catch {
+            }
+
+            await MainActor.run {
+                isPolling = false
+                modelState = plugin.modelState
+                downloadProgress = plugin.currentDownloadProgress
+                loadTask = nil
+            }
+        }
+    }
+
+    private func cancelCurrentLoad() {
+        loadTask?.cancel()
+        loadTask = nil
+        isPolling = false
+        plugin.cancelModelLoad()
+        modelState = plugin.modelState
+        downloadProgress = plugin.currentDownloadProgress
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmedToken = trimmedHfTokenInput
+        guard !trimmedToken.isEmpty else { return }
+
+        isValidatingToken = true
+        tokenValidationResult = nil
+
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmedToken)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    hfTokenInput = trimmedToken
+                    plugin.saveHuggingFaceToken(trimmedToken)
+                }
+            }
+        }
     }
 }

--- a/Plugins/Gemma4Plugin/Localizable.xcstrings
+++ b/Plugins/Gemma4Plugin/Localizable.xcstrings
@@ -11,6 +11,46 @@
         }
       }
     },
+    "Cancel" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        }
+      }
+    },
+    "Download timed out while fetching Gemma 4 from Hugging Face. Please retry. Adding an optional HuggingFace token in this plugin can also increase download rate limits." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Download von Gemma 4 von Hugging Face hat zu lange gedauert. Bitte erneut versuchen. Ein optionaler HuggingFace-Token in diesem Plugin kann die Download-Rate-Limits erhoehen."
+          }
+        }
+      }
+    },
+    "HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HuggingFace Token"
+          }
+        }
+      }
+    },
+    "Load a Gemma 4 model in Integrations before using it for prompts." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lade zuerst ein Gemma-4-Modell in den Integrationen, bevor du es fuer Prompts verwendest."
+          }
+        }
+      }
+    },
     "Local LLM powered by Google Gemma 4 on Apple Silicon. No API key required." : {
       "localizations" : {
         "de" : {
@@ -27,6 +67,106 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modell"
+          }
+        }
+      }
+    },
+    "Invalid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Experimental" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentell"
+          }
+        }
+      }
+    },
+    "Experimental. You can try it at your own risk." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentell. Du kannst es auf eigene Gefahr ausprobieren."
+          }
+        }
+      }
+    },
+    "Valid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Validating token..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token wird geprüft..."
+          }
+        }
+      }
+    },
+    "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional. Erhoeht Download-Rate-Limits. Kostenlos unter huggingface.co/settings/tokens"
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern"
+          }
+        }
+      }
+    },
+    "Gemma 4 E2B/E4B 4-bit models are recommended. Larger variants are experimental and may fail depending on hardware." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gemma 4 E2B/E4B 4-bit Modelle sind empfohlen. Groessere Varianten sind experimentell und koennen je nach Hardware fehlschlagen."
+          }
+        }
+      }
+    },
+    "Try anyway" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trotzdem versuchen"
           }
         }
       }

--- a/Plugins/Gemma4Plugin/manifest.json
+++ b/Plugins/Gemma4Plugin/manifest.json
@@ -4,6 +4,9 @@
     "version": "1.0.1",
     "minHostVersion": "0.11.0",
     "sdkCompatibilityVersion": "v1",
+    "supportedArchitectures": [
+        "arm64"
+    ],
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
     "description": "Local LLM powered by Google Gemma 4 on Apple Silicon via MLX. No API key required.",

--- a/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/Plugins/GranitePlugin/GranitePlugin.swift
@@ -234,6 +234,49 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         AnyView(GraniteSettingsView(plugin: self))
     }
 
+    func setHuggingFaceToken(_ token: String) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        _hfToken = trimmed.isEmpty ? nil : trimmed
+        try? host?.storeSecret(key: "hf-token", value: trimmed)
+    }
+
+    func clearHuggingFaceToken() {
+        _hfToken = nil
+        try? host?.storeSecret(key: "hf-token", value: "")
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - Model Definitions
 
     static let availableModels: [GraniteModelDef] = [
@@ -315,8 +358,22 @@ private struct GraniteSettingsView: View {
     @State private var isPolling = false
     @State private var hfTokenInput = ""
     @State private var showHfToken = false
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
 
     private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    private var trimmedHfTokenInput: String {
+        hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var storedHfToken: String {
+        plugin._hfToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private var hasStoredHfToken: Bool {
+        !storedHfToken.isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -355,25 +412,44 @@ private struct GraniteSettingsView: View {
                     }
                     .buttonStyle(.borderless)
 
-                    if plugin._hfToken != nil, !plugin._hfToken!.isEmpty {
+                    if hasStoredHfToken {
                         Button(String(localized: "Remove", bundle: bundle)) {
                             hfTokenInput = ""
-                            plugin._hfToken = nil
-                            try? plugin.host?.storeSecret(key: "hf-token", value: "")
+                            tokenValidationResult = nil
+                            isValidatingToken = false
+                            plugin.clearHuggingFaceToken()
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                     }
 
                     Button(String(localized: "Save", bundle: bundle)) {
-                        let trimmed = hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else { return }
-                        plugin._hfToken = trimmed
-                        try? plugin.host?.storeSecret(key: "hf-token", value: trimmed)
+                        validateAndSaveHuggingFaceToken()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .disabled(hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
+                }
+
+                if isValidatingToken {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating token...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let tokenValidationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        Text(
+                            tokenValidationResult
+                                ? String(localized: "Valid HuggingFace Token", bundle: bundle)
+                                : String(localized: "Invalid HuggingFace Token", bundle: bundle)
+                        )
+                        .font(.caption)
+                        .foregroundStyle(tokenValidationResult ? .green : .red)
+                    }
                 }
             }
 
@@ -424,6 +500,12 @@ private struct GraniteSettingsView: View {
             if case .ready = pluginState { isPolling = false }
             else if case .error = pluginState { isPolling = false }
         }
+        .onChange(of: hfTokenInput) { _, newValue in
+            let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedValue != storedHfToken {
+                tokenValidationResult = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -471,5 +553,25 @@ private struct GraniteSettingsView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmedToken = trimmedHfTokenInput
+        guard !trimmedToken.isEmpty else { return }
+
+        isValidatingToken = true
+        tokenValidationResult = nil
+
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmedToken)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    plugin.setHuggingFaceToken(trimmedToken)
+                    hfTokenInput = trimmedToken
+                }
+            }
+        }
     }
 }

--- a/Plugins/GranitePlugin/Localizable.xcstrings
+++ b/Plugins/GranitePlugin/Localizable.xcstrings
@@ -41,6 +41,16 @@
         }
       }
     },
+    "Invalid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
     "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens" : {
       "localizations" : {
         "de" : {
@@ -67,6 +77,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Speichern"
+          }
+        }
+      }
+    },
+    "Valid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Validating token..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token wird geprüft..."
           }
         }
       }

--- a/Plugins/Qwen3Plugin/Localizable.xcstrings
+++ b/Plugins/Qwen3Plugin/Localizable.xcstrings
@@ -41,6 +41,16 @@
         }
       }
     },
+    "Invalid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
     "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens" : {
       "localizations" : {
         "de" : {
@@ -67,6 +77,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Speichern"
+          }
+        }
+      }
+    },
+    "Valid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Validating token..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token wird geprüft..."
           }
         }
       }

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -244,6 +244,49 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         AnyView(Qwen3SettingsView(plugin: self))
     }
 
+    func setHuggingFaceToken(_ token: String) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        _hfToken = trimmed.isEmpty ? nil : trimmed
+        try? host?.storeSecret(key: "hf-token", value: trimmed)
+    }
+
+    func clearHuggingFaceToken() {
+        _hfToken = nil
+        try? host?.storeSecret(key: "hf-token", value: "")
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - Model Definitions
 
     static let availableModels: [Qwen3ModelDef] = [
@@ -462,8 +505,22 @@ private struct Qwen3SettingsView: View {
     @State private var isPolling = false
     @State private var hfTokenInput = ""
     @State private var showHfToken = false
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
 
     private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    private var trimmedHfTokenInput: String {
+        hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var storedHfToken: String {
+        plugin._hfToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private var hasStoredHfToken: Bool {
+        !storedHfToken.isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -502,25 +559,44 @@ private struct Qwen3SettingsView: View {
                     }
                     .buttonStyle(.borderless)
 
-                    if plugin._hfToken != nil, !plugin._hfToken!.isEmpty {
+                    if hasStoredHfToken {
                         Button(String(localized: "Remove", bundle: bundle)) {
                             hfTokenInput = ""
-                            plugin._hfToken = nil
-                            try? plugin.host?.storeSecret(key: "hf-token", value: "")
+                            tokenValidationResult = nil
+                            isValidatingToken = false
+                            plugin.clearHuggingFaceToken()
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                     }
 
                     Button(String(localized: "Save", bundle: bundle)) {
-                        let trimmed = hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else { return }
-                        plugin._hfToken = trimmed
-                        try? plugin.host?.storeSecret(key: "hf-token", value: trimmed)
+                        validateAndSaveHuggingFaceToken()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .disabled(hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
+                }
+
+                if isValidatingToken {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating token...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let tokenValidationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        Text(
+                            tokenValidationResult
+                                ? String(localized: "Valid HuggingFace Token", bundle: bundle)
+                                : String(localized: "Invalid HuggingFace Token", bundle: bundle)
+                        )
+                        .font(.caption)
+                        .foregroundStyle(tokenValidationResult ? .green : .red)
+                    }
                 }
             }
 
@@ -573,6 +649,12 @@ private struct Qwen3SettingsView: View {
             if case .ready = pluginState { isPolling = false }
             else if case .error = pluginState { isPolling = false }
         }
+        .onChange(of: hfTokenInput) { _, newValue in
+            let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedValue != storedHfToken {
+                tokenValidationResult = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -620,5 +702,25 @@ private struct Qwen3SettingsView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmedToken = trimmedHfTokenInput
+        guard !trimmedToken.isEmpty else { return }
+
+        isValidatingToken = true
+        tokenValidationResult = nil
+
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmedToken)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    plugin.setHuggingFaceToken(trimmedToken)
+                    hfTokenInput = trimmedToken
+                }
+            }
+        }
     }
 }

--- a/Plugins/VoxtralPlugin/Localizable.xcstrings
+++ b/Plugins/VoxtralPlugin/Localizable.xcstrings
@@ -41,6 +41,16 @@
         }
       }
     },
+    "Invalid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
     "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens" : {
       "localizations" : {
         "de" : {
@@ -67,6 +77,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Speichern"
+          }
+        }
+      }
+    },
+    "Valid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Validating token..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token wird geprüft..."
           }
         }
       }

--- a/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -247,6 +247,49 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         AnyView(VoxtralSettingsView(plugin: self))
     }
 
+    func setHuggingFaceToken(_ token: String) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        _hfToken = trimmed.isEmpty ? nil : trimmed
+        try? host?.storeSecret(key: "hf-token", value: trimmed)
+    }
+
+    func clearHuggingFaceToken() {
+        _hfToken = nil
+        try? host?.storeSecret(key: "hf-token", value: "")
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - Model Definitions
 
     static let availableModels: [VoxtralModelDef] = [
@@ -322,8 +365,22 @@ private struct VoxtralSettingsView: View {
     @State private var isPolling = false
     @State private var hfTokenInput = ""
     @State private var showHfToken = false
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
 
     private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    private var trimmedHfTokenInput: String {
+        hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var storedHfToken: String {
+        plugin._hfToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private var hasStoredHfToken: Bool {
+        !storedHfToken.isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -362,25 +419,44 @@ private struct VoxtralSettingsView: View {
                     }
                     .buttonStyle(.borderless)
 
-                    if plugin._hfToken != nil, !plugin._hfToken!.isEmpty {
+                    if hasStoredHfToken {
                         Button(String(localized: "Remove", bundle: bundle)) {
                             hfTokenInput = ""
-                            plugin._hfToken = nil
-                            try? plugin.host?.storeSecret(key: "hf-token", value: "")
+                            tokenValidationResult = nil
+                            isValidatingToken = false
+                            plugin.clearHuggingFaceToken()
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                     }
 
                     Button(String(localized: "Save", bundle: bundle)) {
-                        let trimmed = hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else { return }
-                        plugin._hfToken = trimmed
-                        try? plugin.host?.storeSecret(key: "hf-token", value: trimmed)
+                        validateAndSaveHuggingFaceToken()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .disabled(hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
+                }
+
+                if isValidatingToken {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating token...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let tokenValidationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        Text(
+                            tokenValidationResult
+                                ? String(localized: "Valid HuggingFace Token", bundle: bundle)
+                                : String(localized: "Invalid HuggingFace Token", bundle: bundle)
+                        )
+                        .font(.caption)
+                        .foregroundStyle(tokenValidationResult ? .green : .red)
+                    }
                 }
             }
 
@@ -431,6 +507,12 @@ private struct VoxtralSettingsView: View {
             if case .ready = pluginState { isPolling = false }
             else if case .error = pluginState { isPolling = false }
         }
+        .onChange(of: hfTokenInput) { _, newValue in
+            let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedValue != storedHfToken {
+                tokenValidationResult = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -478,5 +560,25 @@ private struct VoxtralSettingsView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmedToken = trimmedHfTokenInput
+        guard !trimmedToken.isEmpty else { return }
+
+        isValidatingToken = true
+        tokenValidationResult = nil
+
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmedToken)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    plugin.setHuggingFaceToken(trimmedToken)
+                    hfTokenInput = trimmedToken
+                }
+            }
+        }
     }
 }

--- a/Plugins/WhisperKitPlugin/Localizable.xcstrings
+++ b/Plugins/WhisperKitPlugin/Localizable.xcstrings
@@ -11,6 +11,36 @@
         }
       }
     },
+    "HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Invalid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Load" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laden"
+          }
+        }
+      }
+    },
     "Loading model..." : {
       "localizations" : {
         "de" : {
@@ -51,12 +81,32 @@
         }
       }
     },
+    "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional. Erhöht Download-Ratenlimits. Kostenlos unter huggingface.co/settings/tokens"
+          }
+        }
+      }
+    },
     "Optimizing for Neural Engine..." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Optimierung für Neural Engine ..."
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
           }
         }
       }
@@ -71,12 +121,42 @@
         }
       }
     },
+    "Save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern"
+          }
+        }
+      }
+    },
     "Unload" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deaktivieren"
+          }
+        }
+      }
+    },
+    "Valid HuggingFace Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger HuggingFace-Token"
+          }
+        }
+      }
+    },
+    "Validating token..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token wird validiert ..."
           }
         }
       }

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -14,6 +14,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
     fileprivate var whisperKit: WhisperKit?
     fileprivate var loadedModelId: String?
     fileprivate var _selectedModelId: String?
+    fileprivate var _hfToken: String?
     fileprivate var modelState: WhisperModelState = .notLoaded
     fileprivate var downloadProgress: Double = 0
 
@@ -24,13 +25,17 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
     func activate(host: HostServices) {
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
-        Task { await restoreLoadedModel(allowDownloads: false) }
+        _hfToken = host.loadSecret(key: "hf-token")
+        // Do not eagerly restore on plugin activation. The host already has an
+        // on-demand restore path before transcription, and restoring here can
+        // leave the settings UI stuck in a long-running "Loading model..." state.
     }
 
     func deactivate() {
         whisperKit = nil
         loadedModelId = nil
         modelState = .notLoaded
+        _hfToken = nil
         host = nil
     }
 
@@ -269,7 +274,8 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
                 var lastProgress = 0.0
                 modelFolder = try await WhisperKit.download(
                     variant: modelDef.id,
-                    downloadBase: downloadBase
+                    downloadBase: downloadBase,
+                    token: _hfToken
                 ) { progress in
                     let fraction = progress.fractionCompleted
                     let mapped = 0.05 + fraction * 0.75
@@ -285,6 +291,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
 
             let config = WhisperKitConfig(
                 downloadBase: downloadBase,
+                modelToken: _hfToken,
                 modelFolder: modelFolder.path,
                 verbose: false,
                 logLevel: .error,
@@ -355,7 +362,20 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
 
     fileprivate func isModelDownloaded(_ modelDef: WhisperModelDef) -> Bool {
         let modelPath = resolvedModelPath(for: modelDef)
-        return FileManager.default.fileExists(atPath: modelPath.path)
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: modelPath.path) else { return false }
+
+        let requiredModelNames = [
+            "MelSpectrogram",
+            "AudioEncoder",
+            "TextDecoder",
+        ]
+
+        return requiredModelNames.allSatisfy { name in
+            let compiled = modelPath.appendingPathComponent("\(name).mlmodelc").path
+            let package = modelPath.appendingPathComponent("\(name).mlpackage").path
+            return fileManager.fileExists(atPath: compiled) || fileManager.fileExists(atPath: package)
+        }
     }
 
     /// Migrate models from old location (TypeWhisper/models/) to plugin data directory
@@ -425,6 +445,49 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
 
     var settingsView: AnyView? {
         AnyView(WhisperKitSettingsView(plugin: self))
+    }
+
+    func setHuggingFaceToken(_ token: String) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        _hfToken = trimmed.isEmpty ? nil : trimmed
+        try? host?.storeSecret(key: "hf-token", value: trimmed)
+    }
+
+    func clearHuggingFaceToken() {
+        _hfToken = nil
+        try? host?.storeSecret(key: "hf-token", value: "")
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Model Definitions
@@ -528,8 +591,24 @@ private struct WhisperKitSettingsView: View {
     @State private var downloadProgress: Double = 0
     @State private var activeModelId: String?
     @State private var isPolling = false
+    @State private var hfTokenInput = ""
+    @State private var showHfToken = false
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
 
     private let pollTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
+
+    private var trimmedHfTokenInput: String {
+        hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var storedHfToken: String {
+        plugin._hfToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private var hasStoredHfToken: Bool {
+        !storedHfToken.isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -539,6 +618,74 @@ private struct WhisperKitSettingsView: View {
             Text("Local speech-to-text using OpenAI Whisper via CoreML. 99+ languages, streaming, translation to English.", bundle: bundle)
                 .font(.callout)
                 .foregroundStyle(.secondary)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("HuggingFace Token", bundle: bundle)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Text("Optional. Increases download rate limits. Free at huggingface.co/settings/tokens", bundle: bundle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    if showHfToken {
+                        TextField("hf_...", text: $hfTokenInput)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        SecureField("hf_...", text: $hfTokenInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showHfToken.toggle()
+                    } label: {
+                        Image(systemName: showHfToken ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if hasStoredHfToken {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            hfTokenInput = ""
+                            tokenValidationResult = nil
+                            isValidatingToken = false
+                            plugin.clearHuggingFaceToken()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Button(String(localized: "Save", bundle: bundle)) {
+                        validateAndSaveHuggingFaceToken()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
+                }
+
+                if isValidatingToken {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating token...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let tokenValidationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        Text(
+                            tokenValidationResult
+                                ? String(localized: "Valid HuggingFace Token", bundle: bundle)
+                                : String(localized: "Invalid HuggingFace Token", bundle: bundle)
+                        )
+                        .font(.caption)
+                        .foregroundStyle(tokenValidationResult ? .green : .red)
+                    }
+                }
+            }
 
             Divider()
 
@@ -568,6 +715,9 @@ private struct WhisperKitSettingsView: View {
             modelState = plugin.modelState
             downloadProgress = plugin.downloadProgress
             activeModelId = plugin._selectedModelId
+            if let token = plugin._hfToken, !token.isEmpty {
+                hfTokenInput = token
+            }
             // If the plugin is mid-load (e.g., restoring on app launch), start polling
             if case .downloading = plugin.modelState { isPolling = true }
             else if case .loading = plugin.modelState { isPolling = true }
@@ -590,6 +740,12 @@ private struct WhisperKitSettingsView: View {
             }
             if case .ready = pluginState { isPolling = false }
             else if case .error = pluginState { isPolling = false }
+        }
+        .onChange(of: hfTokenInput) { _, newValue in
+            let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedValue != storedHfToken {
+                tokenValidationResult = nil
+            }
         }
     }
 
@@ -651,7 +807,12 @@ private struct WhisperKitSettingsView: View {
                     .font(.caption)
             }
         } else {
-            Button(String(localized: "Download & Load", bundle: bundle)) {
+            let isDownloaded = plugin.isModelDownloaded(modelDef)
+            Button(
+                isDownloaded
+                    ? String(localized: "Load", bundle: bundle)
+                    : String(localized: "Download & Load", bundle: bundle)
+            ) {
                 activeModelId = modelDef.id
                 modelState = .downloading
                 downloadProgress = 0.05
@@ -678,6 +839,26 @@ private struct WhisperKitSettingsView: View {
             String(localized: "Loading model...", bundle: bundle)
         default:
             String(localized: "Loading...", bundle: bundle)
+        }
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmedToken = trimmedHfTokenInput
+        guard !trimmedToken.isEmpty else { return }
+
+        isValidatingToken = true
+        tokenValidationResult = nil
+
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmedToken)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    plugin.setHuggingFaceToken(trimmedToken)
+                    hfTokenInput = trimmedToken
+                }
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 - **Custom prompts** - Process transcriptions (or any text) with LLM prompts. 8 presets included (Translate, Formal, Summarize, Fix Grammar, Email, List, Shorter, Explain). Standalone Prompt Palette via global hotkey - a floating panel for AI text processing independent of dictation
 - **LLM providers** - Apple Intelligence (macOS 26+), Groq, OpenAI / ChatGPT, Gemini, and OpenAI Compatible with per-prompt provider and model override
+- **Local prompt processing** - Gemma 4 via MLX runs on-device on Apple Silicon, with the current verified release path limited to the E2B/E4B 4-bit models
 - **Translation** - Translate transcriptions on-device using Apple Translate
 
 ### Personalization
@@ -174,6 +175,10 @@ If a fresh install still crashes immediately after these steps, please open an i
 - Apple Silicon (M1 or later) recommended
 - 8 GB RAM minimum, 16 GB+ recommended for larger models
 - Some features (Apple Translate, improved Settings UI) require macOS 15+. Apple Intelligence and SpeechAnalyzer require macOS 26+.
+
+## Gemma 4 Support
+
+TypeWhisper includes a bundled local Gemma 4 plugin powered by MLX for on-device prompt processing on Apple Silicon. In the current verified release path, Gemma 4 support is limited to the dense `E2B 4-bit` and `E4B 4-bit` variants; larger or unverified variants stay visible in the UI but remain disabled until they are validated end to end.
 
 ## Model Recommendations
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -19,6 +19,18 @@
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
+		C23000000000000000000003 /* Gemma4Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000295 /* Gemma4Plugin.swift */; };
+		C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000296 /* Gemma4SettingsView.swift */; };
+		C23000000000000000000005 /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000047 /* MLXVLM */; };
+		C23000000000000000000006 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000049 /* MLXLMCommon */; };
+		C23000000000000000000007 /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000048 /* Transformers */; };
+		C23000000000000000000008 /* Qwen3Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000150 /* Qwen3Plugin.swift */; };
+		C23000000000000000000009 /* VoxtralPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000191 /* VoxtralPlugin.swift */; };
+		C2300000000000000000000A /* GranitePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000221 /* GranitePlugin.swift */; };
+		C2300000000000000000000B /* MLXAudioSTT in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000012 /* MLXAudioSTT */; };
+		C2300000000000000000000C /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000013 /* MLXAudioCore */; };
+		C2300000000000000000000D /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000015 /* WhisperKit */; };
+		C2300000000000000000000E /* WhisperKitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000154 /* WhisperKitPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
 		91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */; };
 		91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */; };
@@ -665,6 +677,12 @@
 			files = (
 				1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */,
 				928A1F1B7A0D4C62A2B90761 /* TypeWhisperPluginSDK in Frameworks */,
+				C23000000000000000000005 /* MLXVLM in Frameworks */,
+				C23000000000000000000006 /* MLXLMCommon in Frameworks */,
+				C23000000000000000000007 /* Transformers in Frameworks */,
+				C2300000000000000000000B /* MLXAudioSTT in Frameworks */,
+				C2300000000000000000000C /* MLXAudioCore in Frameworks */,
+				C2300000000000000000000D /* WhisperKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1715,6 +1733,12 @@
 			name = TypeWhisperTests;
 			packageProductDependencies = (
 				PP00000000000000000034 /* TypeWhisperPluginSDK */,
+				PP00000000000000000047 /* MLXVLM */,
+				PP00000000000000000048 /* Transformers */,
+				PP00000000000000000049 /* MLXLMCommon */,
+				PP00000000000000000012 /* MLXAudioSTT */,
+				PP00000000000000000013 /* MLXAudioCore */,
+				PP00000000000000000015 /* WhisperKit */,
 			);
 			productName = TypeWhisperTests;
 			productReference = E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */;
@@ -2852,6 +2876,12 @@
 				F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */,
 				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
 				C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */,
+				C23000000000000000000008 /* Qwen3Plugin.swift in Sources */,
+				C23000000000000000000009 /* VoxtralPlugin.swift in Sources */,
+				C2300000000000000000000A /* GranitePlugin.swift in Sources */,
+				C2300000000000000000000E /* WhisperKitPlugin.swift in Sources */,
+				C23000000000000000000003 /* Gemma4Plugin.swift in Sources */,
+				C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
@@ -5453,8 +5483,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/argmaxinc/WhisperKit.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		RR00000000000000000002 /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
@@ -5477,8 +5507,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Blaizzy/mlx-audio-swift.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = 2685c640d4079641a01ef3489cacb684c34109fd;
 			};
 		};
 		RR00000000000000000007 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */ = {
@@ -5494,7 +5524,7 @@
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.30.6;
+				version = 3.31.3;
 			};
 		};
 		RR00000000000000000009 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
@@ -5697,6 +5727,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = RR00000000000000000009 /* XCRemoteSwiftPackageReference "swift-transformers" */;
 			productName = Transformers;
+		};
+		PP00000000000000000049 /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = RR00000000000000000008 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLMCommon;
 		};
 		PP00000000000000000046 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ca45e80ec679bf165d554e1f6a17ca9745134eaafba49495bd45eb0ff458cca6",
+  "originHash" : "16e1d8333637e2f35585a0446add22dac52bb3aaba40cfbfda0069ca7df2d27c",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -33,8 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "6f0d9ad27caf2ac45cc6ddf0fcb67d36055e0423"
+        "revision" : "2685c640d4079641a01ef3489cacb684c34109fd"
       }
     },
     {
@@ -42,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
-        "version" : "0.30.6"
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
       }
     },
     {
@@ -51,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "7e19e09027923d89ac47dd087d9627f610e5a91a",
-        "version" : "2.30.6"
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
       }
     },
     {
@@ -128,12 +127,21 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "573e5c9036c2f136b3a8a071da8e8907322403d0",
-        "version" : "1.1.6"
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
       }
     },
     {
@@ -141,8 +149,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/WhisperKit.git",
       "state" : {
-        "revision" : "664e1b5a65296cd957dfdf262cd120ca88f3b24b",
-        "version" : "0.15.0"
+        "branch" : "main",
+        "revision" : "80d96762fa727f816ffceab76a6529cd12c2726f"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/TypeWhisper/Services/LLM/LLMProvider.swift
+++ b/TypeWhisper/Services/LLM/LLMProvider.swift
@@ -26,6 +26,7 @@ protocol LLMProvider: Sendable {
 enum LLMError: LocalizedError {
     case notAvailable
     case providerError(String)
+    case providerNotReady(String)
     case inputTooLong
     case noProviderConfigured
     case noApiKey
@@ -36,6 +37,8 @@ enum LLMError: LocalizedError {
             "LLM provider is not available on this device."
         case .providerError(let message):
             "LLM error: \(message)"
+        case .providerNotReady(let message):
+            message
         case .inputTooLong:
             "Input text is too long for the selected provider."
         case .noProviderConfigured:

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -150,6 +150,12 @@ class PromptProcessingService: ObservableObject {
             throw LLMError.noProviderConfigured
         }
         guard plugin.isAvailable else {
+            if let setupStatus = plugin as? any LLMProviderSetupStatusProviding,
+               !setupStatus.requiresExternalCredentials {
+                throw LLMError.providerNotReady(
+                    setupStatus.unavailableReason ?? "This provider is not ready yet."
+                )
+            }
             throw LLMError.noApiKey
         }
 

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -198,6 +198,10 @@ struct ProviderStatusView: View {
     var onNavigateToIntegrations: (() -> Void)? = nil
 
     var body: some View {
+        let plugin = PluginManager.shared.llmProvider(for: providerId)
+        let setupStatus = plugin as? any LLMProviderSetupStatusProviding
+        let usesLocalSetup = setupStatus?.requiresExternalCredentials == false
+
         if providerId == PromptProcessingService.appleIntelligenceId {
             if processingService.isAppleIntelligenceAvailable {
                 Label(String(localized: "Available"), systemImage: "checkmark.circle.fill")
@@ -210,9 +214,25 @@ struct ProviderStatusView: View {
             }
         } else {
             if processingService.isProviderReady(providerId) {
-                Label(String(localized: "API key configured"), systemImage: "checkmark.circle.fill")
+                Label(usesLocalSetup ? String(localized: "Ready") : String(localized: "API key configured"), systemImage: "checkmark.circle.fill")
                     .font(.caption)
                     .foregroundStyle(.green)
+            } else if usesLocalSetup,
+                      let unavailableReason = setupStatus?.unavailableReason {
+                if let onNavigateToIntegrations {
+                    Button {
+                        onNavigateToIntegrations()
+                    } label: {
+                        Label(unavailableReason, systemImage: "exclamationmark.triangle.fill")
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                } else {
+                    Label(unavailableReason, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             } else if let onNavigateToIntegrations {
                 Button {
                     onNavigateToIntegrations()
@@ -228,7 +248,7 @@ struct ProviderStatusView: View {
                     .foregroundStyle(.orange)
             }
 
-            if let plugin = PluginManager.shared.llmProvider(for: providerId) {
+            if let plugin {
                 if let modelId = (plugin as? LLMModelSelectable)?.preferredModelId as? String {
                     // Plugin manages its own model selection - just show info
                     let displayName = plugin.supportedModels.first(where: { $0.id == modelId })?.displayName ?? modelId

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -88,6 +88,13 @@ public protocol LLMProviderPlugin: TypeWhisperPlugin {
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String
 }
 
+/// Optional protocol for LLM plugins that can describe why they are currently unavailable.
+/// This lets the host distinguish local model setup from missing remote credentials.
+public protocol LLMProviderSetupStatusProviding {
+    var requiresExternalCredentials: Bool { get }
+    var unavailableReason: String? { get }
+}
+
 /// Optional protocol for LLM plugins that expose their selected model.
 /// Kept separate from LLMProviderPlugin to preserve binary compatibility with existing plugins.
 @objc public protocol LLMModelSelectable {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7,13 +7,17 @@ import TypeWhisperPluginSDK
 
 final class APIRouterAndHandlersTests: XCTestCase {
     @objc(APIRouterMockLLMProviderPlugin)
-    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
+    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.llm" }
         static var pluginName: String { "Mock LLM" }
 
         private let requestLock = NSLock()
         var models: [PluginModelInfo] = []
         var responseText = "processed"
+        var available = true
+        var configuredProviderName = "Gemini"
+        var requiresExternalCredentials = true
+        var unavailableReason: String?
         nonisolated(unsafe) private var _lastRequestedModel: String?
 
         var lastRequestedModel: String? {
@@ -25,8 +29,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         func activate(host: HostServices) {}
         func deactivate() {}
 
-        var providerName: String { "Gemini" }
-        var isAvailable: Bool { true }
+        var providerName: String { configuredProviderName }
+        var isAvailable: Bool { available }
         var supportedModels: [PluginModelInfo] { models }
 
         func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
@@ -1773,6 +1777,69 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(plugin.lastRequestedModel, "gemini-2.5-pro")
         XCTAssertEqual(service.selectedCloudModel, "gemini-2.5-pro")
         XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "gemini-2.5-pro")
+    }
+
+    @MainActor
+    func testPromptProcessingReturnsSetupRequiredForLocalProviderWithoutLoadedModel() async throws {
+        let providerKey = "llmProviderType"
+        let modelKey = "llmCloudModel"
+        let originalProvider = UserDefaults.standard.object(forKey: providerKey)
+        let originalModel = UserDefaults.standard.object(forKey: modelKey)
+        defer {
+            if let originalProvider {
+                UserDefaults.standard.set(originalProvider, forKey: providerKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: providerKey)
+            }
+            if let originalModel {
+                UserDefaults.standard.set(originalModel, forKey: modelKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: modelKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        UserDefaults.standard.set("Gemma 4 (MLX)", forKey: providerKey)
+        UserDefaults.standard.removeObject(forKey: modelKey)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.available = false
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+        plugin.unavailableReason = "Load a Gemma 4 model in Integrations before using it for prompts."
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.local-llm",
+            name: "Mock Local LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+
+        do {
+            _ = try await service.process(prompt: "Fix grammar", text: "hello world")
+            XCTFail("Expected local provider setup error")
+        } catch {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Load a Gemma 4 model in Integrations before using it for prompts."
+            )
+        }
     }
 
     @MainActor

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -40,6 +40,7 @@ final class PluginManifestValidationTests: XCTestCase {
             "Plugins/WhisperKitPlugin/manifest.json",
             "Plugins/ParakeetPlugin/manifest.json",
             "Plugins/GranitePlugin/manifest.json",
+            "Plugins/Gemma4Plugin/manifest.json",
             "Plugins/Qwen3Plugin/manifest.json",
             "Plugins/VoxtralPlugin/manifest.json",
         ]
@@ -50,6 +51,364 @@ final class PluginManifestValidationTests: XCTestCase {
             let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
             XCTAssertEqual(manifest.supportedArchitectures, ["arm64"], relativePath)
         }
+    }
+}
+
+@MainActor
+final class Gemma4PluginModelPolicyTests: XCTestCase {
+    private actor RequestRecorder {
+        private var request: URLRequest?
+
+        func set(_ request: URLRequest) {
+            self.request = request
+        }
+
+        func get() -> URLRequest? {
+            request
+        }
+    }
+
+    private final class MockEventBus: EventBusProtocol {
+        @discardableResult
+        func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID { UUID() }
+        func unsubscribe(id: UUID) {}
+    }
+
+    private final class MockHostServices: HostServices, @unchecked Sendable {
+        private var defaults: [String: Any]
+        private var secrets: [String: String]
+
+        let pluginDataDirectory: URL
+        let eventBus: EventBusProtocol = MockEventBus()
+        var activeAppBundleId: String?
+        var activeAppName: String?
+        var availableRuleNames: [String] = []
+        private(set) var capabilitiesChangedCount = 0
+        private(set) var streamingDisplayActiveValues: [Bool] = []
+
+        init(
+            pluginDataDirectory: URL,
+            defaults: [String: Any] = [:],
+            secrets: [String: String] = [:]
+        ) {
+            self.pluginDataDirectory = pluginDataDirectory
+            self.defaults = defaults
+            self.secrets = secrets
+        }
+
+        func storeSecret(key: String, value: String) throws { secrets[key] = value }
+        func loadSecret(key: String) -> String? { secrets[key] }
+        func userDefault(forKey key: String) -> Any? { defaults[key] }
+        func setUserDefault(_ value: Any?, forKey key: String) { defaults[key] = value }
+        func notifyCapabilitiesChanged() { capabilitiesChangedCount += 1 }
+        func setStreamingDisplayActive(_ active: Bool) { streamingDisplayActiveValues.append(active) }
+    }
+
+    func testGemma4SupportedModelsRemainTheRecommendedDenseVariants() {
+        XCTAssertEqual(
+            Gemma4Plugin.supportedModelDefinitions.map(\.id),
+            ["gemma-4-e2b-it-4bit", "gemma-4-e4b-it-4bit"]
+        )
+    }
+
+    func testGemma4ExperimentalModelsExposeWarnings() {
+        let experimentalModels = Gemma4Plugin.availableModels.filter { !$0.isSupported }
+
+        XCTAssertEqual(
+            experimentalModels.map(\.id),
+            ["gemma-4-e4b-it-8bit", "gemma-4-26b-a4b-it-4bit"]
+        )
+        XCTAssertTrue(experimentalModels.allSatisfy { ($0.experimentalWarning ?? "").isEmpty == false })
+    }
+
+    func testGemma4ActivationPreservesExperimentalSelectedModel() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: ["selectedLLMModel": "gemma-4-26b-a4b-it-4bit"]
+        )
+        let plugin = Gemma4Plugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedLLMModelId, "gemma-4-26b-a4b-it-4bit")
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "gemma-4-26b-a4b-it-4bit")
+    }
+
+    func testGemma4ActivationKeepsExperimentalLoadedModelForManualRestore() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: [
+                "selectedLLMModel": "gemma-4-e2b-it-4bit",
+                "loadedModel": "gemma-4-26b-a4b-it-4bit"
+            ]
+        )
+        let plugin = Gemma4Plugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "gemma-4-26b-a4b-it-4bit")
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+    }
+
+    func testGemma4CancelModelLoadResetsProgressAndState() throws {
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+
+        plugin.beginModelLoad(for: model, isAlreadyDownloaded: false)
+        plugin.cancelModelLoad()
+
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+        XCTAssertEqual(plugin.selectedLLMModelId, model.id)
+    }
+
+    func testGemma4UnsupportedModelTypeErrorsUseFriendlyMessage() throws {
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-26b-a4b-it-4bit"))
+        let error = NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Model type gemma4 not supported"])
+
+        let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)
+
+        XCTAssertEqual(
+            message,
+            "Gemma 4 26B-A4B (4-bit, MoE) is experimental in this TypeWhisper release and may still fail to load. Recommended models: Gemma 4 E2B (4-bit), Gemma 4 E4B (4-bit)."
+        )
+    }
+
+    func testGemma4TimeoutErrorsSuggestRetryAndOptionalHuggingFaceToken() throws {
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let error = URLError(.timedOut)
+
+        let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)
+
+        XCTAssertEqual(
+            message,
+            "Download timed out while fetching Gemma 4 from Hugging Face. Please retry. Adding an optional HuggingFace token in this plugin can also increase download rate limits."
+        )
+    }
+
+    func testGemma4ValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = Gemma4Plugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_test_123") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","type":"user"}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let maybeRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(maybeRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_test_123")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testGemma4RejectsInvalidHuggingFaceTokenResponses() async {
+        let plugin = Gemma4Plugin()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_invalid") { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        XCTAssertFalse(isValid)
+    }
+
+    func testQwen3ValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = Qwen3Plugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_qwen3_test") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","auth":{"type":"access_token"}}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let maybeRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(maybeRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_qwen3_test")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testQwen3RejectsInvalidHuggingFaceTokenResponses() async {
+        let plugin = Qwen3Plugin()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_invalid") { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        XCTAssertFalse(isValid)
+    }
+
+    func testVoxtralValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = VoxtralPlugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_voxtral_test") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","type":"user"}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let maybeRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(maybeRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_voxtral_test")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testVoxtralRejectsInvalidHuggingFaceTokenResponses() async {
+        let plugin = VoxtralPlugin()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_invalid") { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        XCTAssertFalse(isValid)
+    }
+
+    func testGraniteValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = GranitePlugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_granite_test") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","type":"user"}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let maybeRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(maybeRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_granite_test")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testGraniteRejectsInvalidHuggingFaceTokenResponses() async {
+        let plugin = GranitePlugin()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_invalid") { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        XCTAssertFalse(isValid)
+    }
+
+    func testWhisperKitValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = WhisperKitPlugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_whisperkit_test") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","type":"user"}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let maybeRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(maybeRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_whisperkit_test")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testWhisperKitRejectsInvalidHuggingFaceTokenResponses() async {
+        let plugin = WhisperKitPlugin()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_invalid") { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+
+        XCTAssertFalse(isValid)
+    }
+
+    func testWhisperKitActivationDoesNotAutoRestorePersistedLoadedModel() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: [
+                "selectedModel": "openai_whisper-tiny",
+                "loadedModel": "openai_whisper-tiny",
+            ]
+        )
+        let plugin = WhisperKitPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
+        XCTAssertFalse(plugin.isConfigured)
     }
 }
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -32,6 +32,7 @@
 - Transcript preview toggle for Notch and Overlay
 - Plugin enable/disable
 - MLX plugin settings: save and remove HuggingFace token, then verify download error copy for Qwen3, Granite, and Voxtral
+- Gemma 4 plugin: verify E2B/E4B 4-bit download and load, and verify E4B 8-bit plus 26B-A4B remain visible but disabled with explanatory copy
 - Community term pack download and apply
 - Built-in term packs render localized metadata in English and German
 - App audio recording with separate tracks

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -33,7 +33,7 @@ This matrix describes the officially supported direct-download path for the curr
 | --- | --- | --- |
 | Local engines | Yes | Recommended default path |
 | Cloud engines | Yes | Require valid API keys |
-| Bundled MLX engines | Yes | Qwen3, Granite, and Voxtral support an optional HuggingFace token for higher download rate limits |
+| Bundled MLX engines | Yes | Qwen3, Granite, Voxtral, and Gemma 4 are bundled. Qwen3, Granite, and Voxtral support an optional HuggingFace token for higher download rate limits. Gemma 4 prompt processing is currently limited to the E2B/E4B 4-bit variants |
 | Bundled plugins | Yes | Part of the tested product path |
 | External third-party plugins | Best effort | Not a stable-release blocker for the current stable release |
 


### PR DESCRIPTION
## Summary
- upgrade the shared MLX and WhisperKit dependency stack used by the local model plugins
- add Gemma 4 loading support with experimental larger variants, better errors, and clearer local-model messaging
- add optional Hugging Face token save/validate/remove flows across Gemma 4, Qwen 3, Voxtral, Granite, and WhisperKit
- improve local model UX with download progress, cancellation, and WhisperKit restore/loading fixes
- update tests and docs for the expanded local model support matrix

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginManifestValidationTests`
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme WhisperKitPlugin -destination 'platform=macOS' -derivedDataPath /tmp/typewhisper-whisperkit-loading-fix`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run WhisperKit /Users/marco/.t3/worktrees/typewhisper-mac/t3code-73c90b67`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-73c90b67`

Closes #345