### PR TITLE
Refactor recording abort cleanup and add regression tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+## Pull Requests
+
+When a pull request fixes or implements a GitHub issue, always:
+- include the issue context in the PR body
+- include an auto-close reference such as `Closes #123`
+- include a short test plan with the exact verification command(s)
+

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -427,6 +427,31 @@ final class DictationViewModel: ObservableObject {
         failDictationSession(id: sessionID, error: message)
     }
 
+    private func restoreRecordingSideEffects() {
+        audioDuckingService.restoreAudio()
+        mediaPlaybackService.resumeIfWePaused()
+    }
+
+    private func clearDeferredRecordingContext() {
+        metadataCaptureTask?.cancel()
+        metadataCaptureTask = nil
+        urlResolutionTask?.cancel()
+        urlResolutionTask = nil
+        lastStreamingParams = nil
+    }
+
+    private func abortActiveRecordingImmediately(sessionMessage: String) {
+        clearDeferredRecordingContext()
+        restoreRecordingSideEffects()
+        streamingHandler.stop()
+        stopRecordingTimer()
+        Task {
+            _ = await audioRecordingService.stopRecording(policy: .immediate)
+        }
+        cancelActiveDictationSessionIfNeeded(message: sessionMessage)
+        hotkeyService.cancelDictation()
+    }
+
     private func storeDictationSession(_ session: DictationSessionSnapshot) {
         dictationSessions[session.id] = session
         dictationSessionOrder.removeAll { $0 == session.id }
@@ -487,20 +512,9 @@ final class DictationViewModel: ObservableObject {
                 // longer active (stop-in-flight, already processed, etc.).
                 defer { self.audioRecordingService.clearRecoveryError() }
                 guard self.state == .recording, !self.isStopInFlight else { return }
-                self.metadataCaptureTask?.cancel()
-                self.metadataCaptureTask = nil
-                self.urlResolutionTask?.cancel()
-                self.urlResolutionTask = nil
-                self.lastStreamingParams = nil
-                self.audioDuckingService.restoreAudio()
-                self.mediaPlaybackService.resumeIfWePaused()
-                self.streamingHandler.stop()
-                self.stopRecordingTimer()
-
                 let errorMessage = error.localizedDescription
+                self.abortActiveRecordingImmediately(sessionMessage: errorMessage)
                 self.accessibilityAnnouncementService.announceError(errorMessage)
-                self.cancelActiveDictationSessionIfNeeded(message: errorMessage)
-                self.hotkeyService.cancelDictation()
                 self.showError(errorMessage, category: "recording")
             }
             .store(in: &cancellables)
@@ -517,15 +531,8 @@ final class DictationViewModel: ObservableObject {
             .compactMap { $0 }
             .sink { [weak self] _ in
                 guard let self, self.state == .recording, !self.isStopInFlight else { return }
-                self.audioDuckingService.restoreAudio()
-                self.streamingHandler.stop()
-                self.stopRecordingTimer()
-                Task {
-                    _ = await self.audioRecordingService.stopRecording(policy: .immediate)
-                }
                 let errorMessage = String(localized: "Microphone disconnected")
-                self.cancelActiveDictationSessionIfNeeded(message: errorMessage)
-                self.hotkeyService.cancelDictation()
+                self.abortActiveRecordingImmediately(sessionMessage: errorMessage)
                 self.showNotchFeedback(
                     message: errorMessage,
                     icon: "mic.slash",
@@ -563,14 +570,7 @@ final class DictationViewModel: ObservableObject {
         switch state {
         case .recording:
             guard !isStopInFlight else { return }
-            audioDuckingService.restoreAudio()
-            streamingHandler.stop()
-            stopRecordingTimer()
-            Task {
-                _ = await audioRecordingService.stopRecording(policy: .immediate)
-            }
-            cancelActiveDictationSessionIfNeeded(message: cancelledMessage)
-            hotkeyService.cancelDictation()
+            abortActiveRecordingImmediately(sessionMessage: cancelledMessage)
             showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
         case .processing:
             cancelActiveDictationSessionIfNeeded(message: cancelledMessage)
@@ -669,13 +669,8 @@ final class DictationViewModel: ObservableObject {
                 "Recording started: immediateContextMs=\(String(format: "%.1f", immediateContextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
             )
         } catch {
-            metadataCaptureTask?.cancel()
-            metadataCaptureTask = nil
-            urlResolutionTask?.cancel()
-            urlResolutionTask = nil
-            lastStreamingParams = nil
-            audioDuckingService.restoreAudio()
-            mediaPlaybackService.resumeIfWePaused()
+            clearDeferredRecordingContext()
+            restoreRecordingSideEffects()
             let errorMessage: String
             if let recordingError = error as? AudioRecordingService.AudioRecordingError,
                case .noMicrophoneDetected = recordingError {
@@ -824,8 +819,7 @@ final class DictationViewModel: ObservableObject {
     private func finalizeStopDictation() async {
         let sessionID = activeDictationSessionID
 
-        audioDuckingService.restoreAudio()
-        mediaPlaybackService.resumeIfWePaused()
+        restoreRecordingSideEffects()
         let liveSessionResult = await streamingHandler.finish()
         lastStreamingParams = nil
         stopRecordingTimer()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -302,14 +302,36 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     private final class MockMediaPlaybackService: MediaPlaybackService {
         let onPause: () -> Void
+        let onResume: () -> Void
 
-        init(onPause: @escaping () -> Void) {
+        init(
+            onPause: @escaping () -> Void = {},
+            onResume: @escaping () -> Void = {}
+        ) {
             self.onPause = onPause
+            self.onResume = onResume
             super.init(startListening: false)
         }
 
         override func pauseIfPlaying() {
             onPause()
+        }
+
+        override func resumeIfWePaused() {
+            onResume()
+        }
+    }
+
+    @MainActor
+    private final class MockAudioDuckingService: AudioDuckingService {
+        let onRestore: () -> Void
+
+        init(onRestore: @escaping () -> Void = {}) {
+            self.onRestore = onRestore
+        }
+
+        override func restoreAudio() {
+            onRestore()
         }
     }
 
@@ -1503,6 +1525,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
     private final class DictationContext: @unchecked Sendable {
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
+        let audioDeviceService: AudioDeviceService
+        let audioDuckingService: AudioDuckingService
         let textInsertionService: TextInsertionService
         let profileService: ProfileService
         let ttsProvider: MockTTSProviderPlugin
@@ -1511,6 +1535,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         init(
             dictationViewModel: DictationViewModel,
             audioRecordingService: AudioRecordingService,
+            audioDeviceService: AudioDeviceService,
+            audioDuckingService: AudioDuckingService,
             textInsertionService: TextInsertionService,
             profileService: ProfileService,
             ttsProvider: MockTTSProviderPlugin,
@@ -1518,6 +1544,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         ) {
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
+            self.audioDeviceService = audioDeviceService
+            self.audioDuckingService = audioDuckingService
             self.textInsertionService = textInsertionService
             self.profileService = profileService
             self.ttsProvider = ttsProvider
@@ -1528,6 +1556,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     private static func makeDictationContext(
         appSupportDirectory: URL,
+        audioDuckingService: AudioDuckingService? = nil,
         mediaPlaybackService: MediaPlaybackService? = nil
     ) -> DictationContext {
         EventBus.shared = EventBus()
@@ -1573,7 +1602,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let textInsertionService = TextInsertionService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
-        let audioDuckingService = AudioDuckingService()
+        let audioDuckingService = audioDuckingService ?? AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
         let soundService = SoundService()
@@ -1617,6 +1646,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         return DictationContext(
             dictationViewModel: dictationViewModel,
             audioRecordingService: audioRecordingService,
+            audioDeviceService: audioDeviceService,
+            audioDuckingService: audioDuckingService,
             textInsertionService: textInsertionService,
             profileService: profileService,
             ttsProvider: ttsProvider,
@@ -2306,6 +2337,49 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleCancelHotkey_secondEscapeDuringRecordingRestoresAudioThenResumesMediaBeforeImmediateStop() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var events: [String] = []
+        let stopRecordingCalled = expectation(description: "stop recording called")
+        let audioDuckingService = MockAudioDuckingService {
+            events.append("restore_audio")
+        }
+        let mediaPlaybackService = MockMediaPlaybackService(
+            onResume: {
+                events.append("resume_media")
+            }
+        )
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService,
+            mediaPlaybackService: mediaPlaybackService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.audioRecordingService.stopRecordingOverride = { policy in
+            events.append("stop_recording_\(policy.logDescription)")
+            stopRecordingCalled.fulfill()
+            return []
+        }
+        context.dictationViewModel.state = .recording
+
+        context.dictationViewModel.handleCancelHotkey()
+        context.dictationViewModel.handleCancelHotkey()
+
+        await fulfillment(of: [stopRecordingCalled], timeout: 1.0)
+
+        XCTAssertEqual(
+            events,
+            ["restore_audio", "resume_media", "stop_recording_immediate"]
+        )
+    }
+
+    @MainActor
     func testHandleCancelHotkey_processingStillCancelsImmediately() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?
@@ -2325,6 +2399,52 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(
             context.dictationViewModel.actionFeedbackMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Cancelled")
+        )
+    }
+
+    @MainActor
+    func testDisconnectedDeviceDuringRecordingRestoresAudioThenResumesMediaBeforeImmediateStop() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var events: [String] = []
+        let stopRecordingCalled = expectation(description: "stop recording called")
+        let audioDuckingService = MockAudioDuckingService {
+            events.append("restore_audio")
+        }
+        let mediaPlaybackService = MockMediaPlaybackService(
+            onResume: {
+                events.append("resume_media")
+            }
+        )
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService,
+            mediaPlaybackService: mediaPlaybackService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.audioRecordingService.stopRecordingOverride = { policy in
+            events.append("stop_recording_\(policy.logDescription)")
+            stopRecordingCalled.fulfill()
+            return []
+        }
+        context.dictationViewModel.state = .recording
+
+        context.audioDeviceService.disconnectedDeviceName = "USB Mic"
+
+        await fulfillment(of: [stopRecordingCalled], timeout: 1.0)
+
+        XCTAssertEqual(
+            events,
+            ["restore_audio", "resume_media", "stop_recording_immediate"]
+        )
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Microphone disconnected")
         )
     }
 


### PR DESCRIPTION
## Summary
- centralize recording-abort cleanup in `DictationViewModel` so cancel, recovery, and disconnected-device paths share the same teardown logic
- resume paused media when recording is canceled or the microphone disappears mid-session, and clear deferred recording context consistently
- add regression coverage for cancel-hotkey and disconnected-device flows, plus repo-local agent guidance to always include issue context in future PR bodies

## Root Cause
Two recording-abort paths restored audio ducking but skipped `mediaPlaybackService.resumeIfWePaused()`. Those cleanup paths had also drifted from the other termination flows and were no longer resetting deferred recording context consistently.

Closes #344

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`