### PR TITLE
fix(audio): delay media resume after dictation

### DIFF
--- a/TypeWhisper/Services/MediaPlaybackService.swift
+++ b/TypeWhisper/Services/MediaPlaybackService.swift
@@ -28,21 +28,40 @@ class MediaPlaybackService {
     private var didPause = false
 
     #if !APPSTORE
+    typealias ResumeScheduler = @MainActor (_ delay: TimeInterval, _ action: @escaping @MainActor () -> Void) -> Void
+
     private let controllerFactory: () -> MediaPlaybackControlling
+    private let resumeDelay: TimeInterval
+    private let resumeScheduler: ResumeScheduler
     private lazy var mediaController: MediaPlaybackControlling = controllerFactory()
     private var nowPlayingBundleID: String?
     private var trackInfoRequestGeneration = 0
+    private var resumeGeneration = 0
 
     init(
         startListening _: Bool = true,
         controllerFactory: @escaping () -> MediaPlaybackControlling = { MediaController() }
     ) {
         self.controllerFactory = controllerFactory
+        self.resumeDelay = 0.6
+        self.resumeScheduler = Self.defaultResumeScheduler
+    }
+
+    init(
+        startListening _: Bool = true,
+        resumeDelay: TimeInterval,
+        resumeScheduler: @escaping ResumeScheduler,
+        controllerFactory: @escaping () -> MediaPlaybackControlling = { MediaController() }
+    ) {
+        self.controllerFactory = controllerFactory
+        self.resumeDelay = resumeDelay
+        self.resumeScheduler = resumeScheduler
     }
 
     /// Uses a one-shot status probe to avoid keeping MediaRemote listener processes
     /// alive while TypeWhisper is idle in the menu bar.
     func pauseIfPlaying() {
+        cancelPendingResume()
         guard !didPause else { return }
         trackInfoRequestGeneration += 1
         let generation = trackInfoRequestGeneration
@@ -66,9 +85,32 @@ class MediaPlaybackService {
     func resumeIfWePaused() {
         trackInfoRequestGeneration += 1
         guard didPause else { return }
-        mediaController.play()
-        didPause = false
-        logger.info("Media playback resumed")
+        cancelPendingResume()
+        let generation = resumeGeneration
+
+        resumeScheduler(resumeDelay) { [weak self] in
+            guard let self else { return }
+            guard generation == self.resumeGeneration else { return }
+            guard self.didPause else { return }
+
+            self.mediaController.play()
+            self.didPause = false
+            logger.info("Media playback resumed")
+        }
+
+        logger.info("Scheduled media playback resume in \(self.resumeDelay, privacy: .public)s")
+    }
+
+    private func cancelPendingResume() {
+        resumeGeneration += 1
+    }
+
+    private static let defaultResumeScheduler: ResumeScheduler = { delay, action in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            Task { @MainActor in
+                action()
+            }
+        }
     }
     #else
     init(startListening: Bool = true) {}

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -340,6 +340,25 @@ final class APIRouterAndHandlersTests: XCTestCase {
             pauseCalls += 1
         }
     }
+
+    @MainActor
+    private final class TestMediaPlaybackResumeScheduler {
+        private(set) var scheduledDelays: [TimeInterval] = []
+        private var actions: [@MainActor () -> Void] = []
+
+        func schedule(after delay: TimeInterval, action: @escaping @MainActor () -> Void) {
+            scheduledDelays.append(delay)
+            actions.append(action)
+        }
+
+        func runPendingActions() {
+            let pendingActions = actions
+            actions.removeAll()
+            for action in pendingActions {
+                action()
+            }
+        }
+    }
     #endif
 
     func testRouterHandlesOptionsAndNotFound() async {
@@ -1015,13 +1034,23 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     func testMediaPlaybackServicePausesAndResumesFromOneShotTrackInfo() {
         let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
         controller.returnedSnapshot = (true, "com.apple.Music")
-        let service = MediaPlaybackService(startListening: false) { controller }
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
 
         service.pauseIfPlaying()
         service.resumeIfWePaused()
 
         XCTAssertEqual(controller.pauseCalls, 1)
+        XCTAssertEqual(controller.playCalls, 0)
+        XCTAssertEqual(scheduler.scheduledDelays, [0.6])
+
+        scheduler.runPendingActions()
+
         XCTAssertEqual(controller.playCalls, 1)
     }
 
@@ -1041,11 +1070,16 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     func testMediaPlaybackServiceIgnoresStalePauseProbeAfterResume() {
         let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
         var deferredCallback: ((_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void)?
         controller.onGetPlaybackSnapshot = { callback in
             deferredCallback = callback
         }
-        let service = MediaPlaybackService(startListening: false) { controller }
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
 
         service.pauseIfPlaying()
         service.resumeIfWePaused()
@@ -1053,6 +1087,58 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(controller.pauseCalls, 0)
         XCTAssertEqual(controller.playCalls, 0)
+
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceCancelsPendingResumeWhenRecordingRestartsBeforeDelayElapses() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = (true, "com.apple.Music")
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        service.pauseIfPlaying()
+
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+        XCTAssertEqual(controller.playCalls, 0)
+
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.playCalls, 1)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceCoalescesDuplicateResumeRequestsIntoSinglePlay() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = (true, "com.apple.Music")
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        service.resumeIfWePaused()
+
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+        XCTAssertEqual(controller.playCalls, 1)
     }
     #endif
 


### PR DESCRIPTION
Closes #347

## Summary
- delay media playback resume by 600ms after TypeWhisper stops dictation
- cancel pending resume requests if recording restarts before the delay elapses
- add service-level tests for delayed resume scheduling, cancellation, duplicate resume coalescing, and stale pause probe handling

## Testing
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testMediaPlaybackServicePausesAndResumesFromOneShotTrackInfo -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testMediaPlaybackServiceIgnoresStalePauseProbeAfterResume -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testMediaPlaybackServiceCancelsPendingResumeWhenRecordingRestartsBeforeDelayElapses -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testMediaPlaybackServiceCoalescesDuplicateResumeRequestsIntoSinglePlay`
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testMediaPlaybackServiceSkipsPauseWhenPlaybackIsAlreadyStopped -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_pausesMediaAfterAudioStart`