### PR TITLE
Stabilize Push-to-Talk discard handling and short speech classification

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -14,6 +14,7 @@ enum UserDefaultsKeys {
     static let indicatorTranscriptPreviewEnabled = "indicatorTranscriptPreviewEnabled"
     static let preserveClipboard = "preserveClipboard"
     static let mediaPauseEnabled = "mediaPauseEnabled"
+    static let transcribeShortQuietClipsAggressively = "transcribeShortQuietClipsAggressively"
 
     // MARK: - Hotkey (JSON-encoded UnifiedHotkey per slot)
     static let hybridHotkey = "hybridHotkey"

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -118,11 +118,14 @@ final class HotkeyService: ObservableObject {
     var onPromptPaletteToggle: (() -> Void)?
     var onProfileDictationStart: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
+    var onPushToTalkInterruption: (() -> Void)?
+    var discardPushToTalkRecordingOnExtraKeyPress = false
 
     private var keyDownTime: Date?
     private var isActive = false
     private var activeSlotType: HotkeySlotType?
     private(set) var activeProfileId: UUID?
+    private var pushToTalkInterruptionSignaled = false
 
     private static let toggleThreshold: TimeInterval = 1.0
     private static let doubleTapThreshold: TimeInterval = 0.4
@@ -257,6 +260,7 @@ final class HotkeyService: ObservableObject {
         activeProfileId = nil
         currentMode = nil
         keyDownTime = nil
+        pushToTalkInterruptionSignaled = false
     }
 
     // MARK: - Profile Hotkeys
@@ -453,6 +457,7 @@ final class HotkeyService: ObservableObject {
             return false
         }
 
+        signalPushToTalkInterruptionIfNeeded(for: event)
         updateCapsLockOriginTracker(for: event)
         var shouldSuppress = false
 
@@ -609,6 +614,33 @@ final class HotkeyService: ObservableObject {
             source: source
         ) {
             handleProfileKeyUp(profileId: profileId)
+        }
+    }
+
+    private func signalPushToTalkInterruptionIfNeeded(for event: NSEvent) {
+        guard discardPushToTalkRecordingOnExtraKeyPress,
+              !pushToTalkInterruptionSignaled,
+              isActive,
+              activeSlotType == .pushToTalk,
+              activeProfileId == nil,
+              event.type == .keyDown,
+              let hotkey = slots[.pushToTalk]?.hotkey,
+              isExtraKeyDuringActivePushToTalk(event, hotkey: hotkey) else {
+            return
+        }
+
+        pushToTalkInterruptionSignaled = true
+        onPushToTalkInterruption?()
+    }
+
+    private func isExtraKeyDuringActivePushToTalk(_ event: NSEvent, hotkey: UnifiedHotkey) -> Bool {
+        switch hotkey.kind {
+        case .modifierCombo, .modifierOnly, .fn:
+            return true
+        case .keyWithModifiers, .bareKey:
+            return event.keyCode != hotkey.keyCode
+        case .mouseButton:
+            return false
         }
     }
 
@@ -868,14 +900,12 @@ final class HotkeyService: ObservableObject {
             let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
             let current = event.modifierFlags.intersection(relevantMask)
             let allDown = current.contains(requiredFlags)
+            let anyRequiredStillDown = !current.intersection(requiredFlags).isEmpty
             if allDown, !modifierWasDown { return .down }
-            if !allDown, modifierWasDown {
-                // If the sentinel keyCode (0xFFFF) is used, we have no physical key to track.
-                // Otherwise, we'd need to track which modifiers are still down.
-                // For now, modifier-only combos don't have a 'base key'.
-                return .up
-            }
             if allDown, modifierWasDown { return .repeatDown }
+            if modifierWasDown {
+                return anyRequiredStillDown ? .repeatDown : .up
+            }
 
         case .keyWithModifiers:
             let requiredFlags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
@@ -929,12 +959,14 @@ final class HotkeyService: ObservableObject {
             activeProfileId = nil
             currentMode = nil
             keyDownTime = nil
+            pushToTalkInterruptionSignaled = false
             onDictationStop?()
         } else {
             activeSlotType = slotType
             activeProfileId = nil
             keyDownTime = Date()
             isActive = true
+            pushToTalkInterruptionSignaled = false
             currentMode = slotType == .toggle ? .toggle : .pushToTalk
             onDictationStart?()
         }
@@ -953,6 +985,7 @@ final class HotkeyService: ObservableObject {
                 activeSlotType = nil
                 currentMode = nil
                 keyDownTime = nil
+                pushToTalkInterruptionSignaled = false
                 onDictationStop?()
             }
         case .pushToTalk:
@@ -960,6 +993,7 @@ final class HotkeyService: ObservableObject {
             activeSlotType = nil
             currentMode = nil
             keyDownTime = nil
+            pushToTalkInterruptionSignaled = false
             onDictationStop?()
         case .toggle:
             break
@@ -978,12 +1012,14 @@ final class HotkeyService: ObservableObject {
             activeProfileId = nil
             currentMode = nil
             keyDownTime = nil
+            pushToTalkInterruptionSignaled = false
             onDictationStop?()
         } else {
             activeProfileId = profileId
             activeSlotType = nil
             keyDownTime = Date()
             isActive = true
+            pushToTalkInterruptionSignaled = false
             currentMode = .pushToTalk // hybrid behavior
             onProfileDictationStart?(profileId)
         }
@@ -1002,6 +1038,7 @@ final class HotkeyService: ObservableObject {
             activeProfileId = nil
             currentMode = nil
             keyDownTime = nil
+            pushToTalkInterruptionSignaled = false
             onDictationStop?()
         }
     }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -81,6 +81,9 @@ final class DictationViewModel: ObservableObject {
     @Published var mediaPauseEnabled: Bool {
         didSet { UserDefaults.standard.set(mediaPauseEnabled, forKey: UserDefaultsKeys.mediaPauseEnabled) }
     }
+    @Published var transcribeShortQuietClipsAggressively: Bool {
+        didSet { Self.persistTranscribeShortQuietClipsAggressively(transcribeShortQuietClipsAggressively) }
+    }
     @Published var spokenFeedbackEnabled: Bool {
         didSet { speechFeedbackService.spokenFeedbackEnabled = spokenFeedbackEnabled }
     }
@@ -178,6 +181,7 @@ final class DictationViewModel: ObservableObject {
     private var lastStreamingParams: StreamingParamsSnapshot?
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
+    private var pendingPushToTalkDiscardMessage: String?
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
@@ -267,6 +271,7 @@ final class DictationViewModel: ObservableObject {
         self.indicatorTranscriptPreviewEnabled = Self.loadIndicatorTranscriptPreviewEnabled()
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
+        self.transcribeShortQuietClipsAggressively = Self.loadTranscribeShortQuietClipsAggressively()
         self.spokenFeedbackEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
         self.indicatorStyle = Self.loadIndicatorStyle()
         self.notchIndicatorVisibility = UserDefaults.standard.string(forKey: UserDefaultsKeys.notchIndicatorVisibility)
@@ -319,6 +324,7 @@ final class DictationViewModel: ObservableObject {
         settingsHandler.onHotkeyLabelsChanged = { [weak self] in
             self?.hotkeyLabelsVersion += 1
         }
+        hotkeyService.discardPushToTalkRecordingOnExtraKeyPress = true
     }
 
     var canDictate: Bool {
@@ -343,6 +349,14 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistIndicatorStyle(_ style: IndicatorStyle, defaults: UserDefaults = .standard) {
         defaults.set(style.rawValue, forKey: UserDefaultsKeys.indicatorStyle)
+    }
+
+    nonisolated static func loadTranscribeShortQuietClipsAggressively(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively) as? Bool ?? false
+    }
+
+    nonisolated static func persistTranscribeShortQuietClipsAggressively(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively)
     }
 
     var needsMicPermission: Bool {
@@ -480,6 +494,10 @@ final class DictationViewModel: ObservableObject {
             self?.handleCancelHotkey()
         }
 
+        hotkeyService.onPushToTalkInterruption = { [weak self] in
+            self?.handlePushToTalkInterruption()
+        }
+
         // Sync profile hotkeys whenever profiles change
         // dropFirst: avoid early monitor setup during ServiceContainer.init() before app is ready
         profileService.$profiles
@@ -600,6 +618,7 @@ final class DictationViewModel: ObservableObject {
         insertingResetTask?.cancel()
         insertingResetTask = nil
         clearRecordingCancelWarning()
+        pendingPushToTalkDiscardMessage = nil
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
         urlResolutionTask?.cancel()
@@ -820,6 +839,23 @@ final class DictationViewModel: ObservableObject {
         let sessionID = activeDictationSessionID
 
         restoreRecordingSideEffects()
+        if let discardMessage = pendingPushToTalkDiscardMessage {
+            pendingPushToTalkDiscardMessage = nil
+            streamingHandler.stop()
+            lastStreamingParams = nil
+            stopRecordingTimer()
+            _ = await audioRecordingService.stopRecording(policy: .immediate)
+            if let sessionID {
+                failDictationSession(id: sessionID, error: discardMessage)
+            }
+            showNotchFeedback(
+                message: discardMessage,
+                icon: "xmark.circle",
+                duration: 1.8
+            )
+            return
+        }
+
         let liveSessionResult = await streamingHandler.finish()
         lastStreamingParams = nil
         stopRecordingTimer()
@@ -842,7 +878,8 @@ final class DictationViewModel: ObservableObject {
         let decision = classifyShortSpeech(
             rawDuration: rawDuration,
             peakLevel: peakLevel,
-            hasPreviewText: hasPreviewText
+            hasPreviewText: hasPreviewText,
+            transcribeShortQuietClipsAggressively: transcribeShortQuietClipsAggressively
         )
         let graceApplied = audioRecordingService.lastStopGraceCaptureApplied
 
@@ -1103,6 +1140,7 @@ final class DictationViewModel: ObservableObject {
         lastStreamingParams = nil
         isStopInFlight = false
         activeDictationSessionID = nil
+        pendingPushToTalkDiscardMessage = nil
         clearRecordingCancelWarning()
         state = .idle
         partialText = ""
@@ -1116,6 +1154,11 @@ final class DictationViewModel: ObservableObject {
         actionFeedbackIcon = nil
         actionFeedbackIsError = false
         actionDisplayDuration = 3.5
+    }
+
+    private func handlePushToTalkInterruption() {
+        guard state == .recording, !isStopInFlight else { return }
+        pendingPushToTalkDiscardMessage = String(localized: "Recording discarded because additional keys were pressed")
     }
 
     private func applyRuleMatch(
@@ -1420,17 +1463,28 @@ enum ShortSpeechDecision: Equatable {
     }
 }
 
-func classifyShortSpeech(rawDuration: TimeInterval, peakLevel: Float, hasPreviewText: Bool) -> ShortSpeechDecision {
+func classifyShortSpeech(
+    rawDuration: TimeInterval,
+    peakLevel: Float,
+    hasPreviewText: Bool,
+    transcribeShortQuietClipsAggressively: Bool = false
+) -> ShortSpeechDecision {
     guard rawDuration >= 0.04 else { return .discardTooShort }
     if hasPreviewText { return .transcribe }
 
     if rawDuration < 1.0 {
         // Bias toward transcribing short clips. False negatives here are worse than
         // letting the recognizer return empty text for actual silence.
-        return peakLevel < 0.005 ? .discardNoSpeech : .transcribe
+        if peakLevel < 0.005 {
+            return transcribeShortQuietClipsAggressively ? .transcribe : .discardNoSpeech
+        }
+        return .transcribe
     }
 
-    return peakLevel < 0.01 ? .discardNoSpeech : .transcribe
+    if peakLevel < 0.01 {
+        return transcribeShortQuietClipsAggressively ? .transcribe : .discardNoSpeech
+    }
+    return .transcribe
 }
 
 func paddedSamplesForFinalTranscription(_ samples: [Float], rawDuration: TimeInterval) -> [Float] {

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -129,6 +129,15 @@ struct AdvancedSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
+                Toggle(
+                    String(localized: "Transcribe short / quiet clips more aggressively"),
+                    isOn: $dictation.transcribeShortQuietClipsAggressively
+                )
+
+                Text(String(localized: "Still discards accidental ultra-short taps, but keeps more very short or quiet recordings instead of classifying them as no speech."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 if speechFeedbackService.hasAvailableProviders {
                     Toggle(String(localized: "Spoken feedback"), isOn: $dictation.spokenFeedbackEnabled)
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -985,6 +985,53 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testPushToTalkInterruptionDiscardStopsImmediatelyAndMarksSessionFailedByDefault() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        XCTAssertTrue(context.hotkeyService.discardPushToTalkRecordingOnExtraKeyPress)
+
+        var stopPolicies: [String] = []
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { policy in
+            stopPolicies.append(policy.logDescription)
+            return []
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+
+        context.hotkeyService.onPushToTalkInterruption?()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<20 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .failed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertEqual(stopPolicies, [AudioRecordingService.StopPolicy.immediate.logDescription])
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            "Recording discarded because additional keys were pressed"
+        )
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
+        XCTAssertEqual(
+            context.dictationViewModel.apiDictationSession(id: sessionID)?.error,
+            "Recording discarded because additional keys were pressed"
+        )
+    }
+
+    @MainActor
     func testApiStartRecording_appliesBundleProfileBeforeDeferredMetadataCapture() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?
@@ -1615,6 +1662,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     private final class DictationContext: @unchecked Sendable {
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
+        let hotkeyService: HotkeyService
         let audioDeviceService: AudioDeviceService
         let audioDuckingService: AudioDuckingService
         let textInsertionService: TextInsertionService
@@ -1625,6 +1673,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         init(
             dictationViewModel: DictationViewModel,
             audioRecordingService: AudioRecordingService,
+            hotkeyService: HotkeyService,
             audioDeviceService: AudioDeviceService,
             audioDuckingService: AudioDuckingService,
             textInsertionService: TextInsertionService,
@@ -1634,6 +1683,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         ) {
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
+            self.hotkeyService = hotkeyService
             self.audioDeviceService = audioDeviceService
             self.audioDuckingService = audioDuckingService
             self.textInsertionService = textInsertionService
@@ -1736,6 +1786,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         return DictationContext(
             dictationViewModel: dictationViewModel,
             audioRecordingService: audioRecordingService,
+            hotkeyService: hotkeyService,
             audioDeviceService: audioDeviceService,
             audioDuckingService: audioDuckingService,
             textInsertionService: textInsertionService,
@@ -2723,6 +2774,129 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
         XCTAssertEqual(startCount, 1)
         XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testModifierComboPushToTalkDoesNotStopOnTransientFlagsChangedLoss() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionComboHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let comboDown = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+        let transientLoss = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command])
+        let comboRestored = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+        let fullRelease = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [])
+
+        XCTAssertTrue(service.processEventForTesting(comboDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(transientLoss, source: .monitor))
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(comboRestored, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(fullRelease, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testRightSideModifierComboPushToTalkStaysActiveUntilFinalRelease() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionComboHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let rightCommandDown = try makeFlagsChangedEvent(keyCode: 0x36, modifierFlags: [.command])
+        let rightOptionDown = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+        let transientRightCommandLoss = try makeFlagsChangedEvent(keyCode: 0x36, modifierFlags: [.option])
+        let comboRestored = try makeFlagsChangedEvent(keyCode: 0x36, modifierFlags: [.command, .option])
+        let finalRelease = try makeFlagsChangedEvent(keyCode: 0x36, modifierFlags: [])
+
+        XCTAssertFalse(service.processEventForTesting(rightCommandDown, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(rightOptionDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(transientRightCommandLoss, source: .monitor))
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(comboRestored, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(finalRelease, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testPushToTalkExtraKeyInterruptionSignalsDiscardWithoutImmediateStop() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionComboHotkey(), for: .pushToTalk)
+        service.discardPushToTalkRecordingOnExtraKeyPress = true
+
+        var startCount = 0
+        var stopCount = 0
+        var interruptionCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+        service.onPushToTalkInterruption = { interruptionCount += 1 }
+
+        let comboDown = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+        let extraKeyDown = try makeKeyboardEvent(keyCode: 0x25, keyDown: true, flags: [.maskCommand, .maskAlternate])
+        let extraKeyUp = try makeKeyboardEvent(keyCode: 0x25, keyDown: false, flags: [.maskCommand, .maskAlternate])
+        let fullRelease = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [])
+
+        XCTAssertTrue(service.processEventForTesting(comboDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertFalse(service.processEventForTesting(extraKeyDown, source: .monitor))
+        XCTAssertEqual(interruptionCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertFalse(service.processEventForTesting(extraKeyUp, source: .monitor))
+        XCTAssertEqual(interruptionCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(fullRelease, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testPushToTalkExtraKeyInterruptionDoesNothingWhenPolicyDisabled() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandOptionComboHotkey(), for: .pushToTalk)
+        service.discardPushToTalkRecordingOnExtraKeyPress = false
+
+        var interruptionCount = 0
+        service.onPushToTalkInterruption = { interruptionCount += 1 }
+
+        let comboDown = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
+        let extraKeyDown = try makeKeyboardEvent(keyCode: 0x25, keyDown: true, flags: [.maskCommand, .maskAlternate])
+
+        XCTAssertTrue(service.processEventForTesting(comboDown, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(extraKeyDown, source: .monitor))
+        XCTAssertEqual(interruptionCount, 0)
     }
 
     @MainActor

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -41,6 +41,18 @@ final class DictationShortSpeechTests: XCTestCase {
         XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0049, hasPreviewText: false), .discardNoSpeech)
     }
 
+    func testOneHundredTwentyMsQuietClip_transcribesWhenAggressivePolicyEnabled() {
+        XCTAssertEqual(
+            classifyShortSpeech(
+                rawDuration: 0.12,
+                peakLevel: 0.0049,
+                hasPreviewText: false,
+                transcribeShortQuietClipsAggressively: true
+            ),
+            .transcribe
+        )
+    }
+
     func testOneHundredTwentyMsQuietClip_withPreviewText_transcribes() {
         XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0049, hasPreviewText: true), .transcribe)
     }
@@ -56,6 +68,18 @@ final class DictationShortSpeechTests: XCTestCase {
 
     func testFourHundredMsQuietClip_withPreviewText_transcribes() {
         XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0049, hasPreviewText: true), .transcribe)
+    }
+
+    func testThirtyMsQuietClip_staysTooShortEvenWhenAggressivePolicyEnabled() {
+        XCTAssertEqual(
+            classifyShortSpeech(
+                rawDuration: 0.03,
+                peakLevel: 0.2,
+                hasPreviewText: false,
+                transcribeShortQuietClipsAggressively: true
+            ),
+            .discardTooShort
+        )
     }
 
     func testEightHundredEightyFiveMsClip_withLowSpeechPeakStillTranscribes() {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -57,6 +57,20 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
 
         XCTAssertEqual(DictationViewModel.loadIndicatorStyle(defaults: defaults), .notch)
     }
+
+    func testAggressiveShortSpeechTranscriptionDefaultsToDisabled() {
+        XCTAssertFalse(DictationViewModel.loadTranscribeShortQuietClipsAggressively(defaults: defaults))
+    }
+
+    func testAggressiveShortSpeechTranscriptionPersistsWhenEnabled() {
+        DictationViewModel.persistTranscribeShortQuietClipsAggressively(true, defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively) as? Bool,
+            true
+        )
+        XCTAssertTrue(DictationViewModel.loadTranscribeShortQuietClipsAggressively(defaults: defaults))
+    }
 }
 
 final class DockIconVisibilityTests: XCTestCase {


### PR DESCRIPTION
## Summary
- fix premature Push-to-Talk stops for modifier-combo hotkeys by treating transient modifier loss as part of the active hold until the real final release
- discard Push-to-Talk recordings when additional keys are pressed during an active hold, but only on actual hotkey release so the interaction stays predictable
- keep the extra-key discard behavior as the default product behavior instead of exposing it as another visible setting
- add an advanced opt-in to transcribe more short / quiet clips instead of classifying them as no speech
- add regression coverage for modifier-combo handling, Push-to-Talk discard flow, and short-speech classification

## Issue Context
- `#331` reported recordings being discarded immediately because modifier-combo Push-to-Talk could stop on transient `flagsChanged` churn before the real release.
- `#330` asked for discarding a Push-to-Talk recording when other keys are pressed during the active hold.
- `#318` asked for an option to keep more short / quiet recordings instead of discarding them too aggressively.

## Product Behavior
- extra-key interruption discard is now the default Push-to-Talk behavior
- short / quiet aggressive transcription remains an advanced opt-in

Closes #331
Closes #330
Closes #318

## Test Plan
```bash
xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests -only-testing:TypeWhisperTests/DictationShortSpeechTests -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests
```

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$(pwd)"
```