### PR TITLE
Fix duplicate macOS 14 settings sidebar button

### DIFF
--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -259,23 +259,26 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
     let destinations: [SettingsDestination]
     let detail: (SettingsTab) -> DetailContent
 
-    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var isSidebarVisible = true
 
     var body: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
-            List(destinations, selection: $selectedTab) { destination in
-                SettingsSidebarRow(destination: destination)
-                    .tag(destination.tab)
+        HStack(spacing: 0) {
+            if isSidebarVisible {
+                List(destinations, selection: $selectedTab) { destination in
+                    SettingsSidebarRow(destination: destination)
+                        .tag(destination.tab)
+                }
+                .listStyle(.sidebar)
+                .frame(width: 240)
+
+                Divider()
             }
-            .listStyle(.sidebar)
-            .navigationSplitViewColumnWidth(240)
-        } detail: {
+
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         // macOS 14 glitches when the default NavigationSplitView sidebar reveal animates.
         // Use a custom zero-duration toggle instead.
-        .toolbar(removing: .sidebarToggle)
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 Button(action: toggleSidebar) {
@@ -292,7 +295,7 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
             context.duration = 0
             context.allowsImplicitAnimation = false
             withAnimation(nil) {
-                columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
+                isSidebarVisible.toggle()
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the macOS 14 settings fallback `NavigationSplitView` with an app-managed two-column layout
- keep the custom sidebar toggle and remove reliance on the system sidebar toolbar item
- preserve the selected settings tab while avoiding duplicate toolbar buttons on Sonoma

## Issue Context
Issue #354 reports that TypeWhisper 1.3.0 rc2 shows two sidebar toggle buttons in Settings on macOS 14. The default split-view sidebar toggle still appears alongside the custom zero-animation toggle, so users see two buttons for the same action. This change removes the system-managed sidebar toggle path from the macOS 14 fallback so only the working custom button remains.

Closes #354

## Testing
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
