### PR TITLE
feat: add prompt temperature overrides and isolate disabled plugins

### DIFF
--- a/Plugins/CerebrasPlugin/CerebrasPlugin.swift
+++ b/Plugins/CerebrasPlugin/CerebrasPlugin.swift
@@ -12,6 +12,8 @@ final class CerebrasPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedModels: [CerebrasFetchedModel] = []
 
     private let chatHelper = PluginOpenAIChatHelper(
@@ -31,6 +33,10 @@ final class CerebrasPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
         }
         _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
             ?? supportedModels.first?.id
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
     }
 
     func deactivate() {
@@ -69,6 +75,20 @@ final class CerebrasPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
@@ -77,7 +97,8 @@ final class CerebrasPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         )
     }
 
@@ -87,6 +108,24 @@ final class CerebrasPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -207,6 +246,8 @@ private struct CerebrasSettingsView: View {
     @State private var validationResult: Bool?
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedModels: [CerebrasFetchedModel] = []
     private let bundle = Bundle(for: CerebrasPlugin.self)
 
@@ -311,6 +352,38 @@ private struct CerebrasSettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -323,6 +396,8 @@ private struct CerebrasSettingsView: View {
                 apiKeyInput = key
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
             fetchedModels = plugin._fetchedModels
         }
     }

--- a/Plugins/ClaudePlugin/ClaudePlugin.swift
+++ b/Plugins/ClaudePlugin/ClaudePlugin.swift
@@ -12,6 +12,8 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
 
     required override init() {
         super.init()
@@ -22,6 +24,10 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
         _apiKey = host.loadSecret(key: "api-key")
         _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
             ?? supportedModels.first?.id
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
     }
 
     func deactivate() {
@@ -46,11 +52,32 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
         let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
-        return try await callMessagesAPI(apiKey: apiKey, model: modelId, systemPrompt: systemPrompt, userText: userText)
+        let resolvedTemperature = providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
+        return try await callMessagesAPI(
+            apiKey: apiKey,
+            model: modelId,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            temperature: resolvedTemperature
+        )
     }
 
     func selectLLMModel(_ modelId: String) {
@@ -59,6 +86,24 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -112,20 +157,28 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
 
     // MARK: - Anthropic Messages API
 
-    private func callMessagesAPI(apiKey: String, model: String, systemPrompt: String, userText: String) async throws -> String {
+    private func callMessagesAPI(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        temperature: Double?
+    ) async throws -> String {
         guard let url = URL(string: "https://api.anthropic.com/v1/messages") else {
             throw PluginChatError.apiError("Invalid URL")
         }
 
-        let requestBody: [String: Any] = [
+        var requestBody: [String: Any] = [
             "model": model,
             "max_tokens": 4096,
-            "temperature": 0.3,
             "system": systemPrompt,
             "messages": [
                 ["role": "user", "content": userText]
             ]
         ]
+        if let temperature {
+            requestBody["temperature"] = temperature
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -178,6 +231,8 @@ private struct ClaudeSettingsView: View {
     @State private var validationResult: Bool?
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     private let bundle = Bundle(for: ClaudePlugin.self)
 
     var body: some View {
@@ -259,6 +314,38 @@ private struct ClaudeSettingsView: View {
                         plugin.selectLLMModel(selectedModel)
                     }
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -271,6 +358,8 @@ private struct ClaudeSettingsView: View {
                 apiKeyInput = key
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
         }
     }
 

--- a/Plugins/FireworksPlugin/FireworksPlugin.swift
+++ b/Plugins/FireworksPlugin/FireworksPlugin.swift
@@ -13,6 +13,8 @@ final class FireworksPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
     fileprivate var _apiKey: String?
     fileprivate var _selectedModelId: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedLLMModels: [FireworksFetchedModel] = []
 
     private let chatHelper = PluginOpenAIChatHelper(
@@ -34,6 +36,10 @@ final class FireworksPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
             ?? transcriptionModels.first?.id
         _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
             ?? supportedModels.first?.id
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
     }
 
     func deactivate() {
@@ -173,6 +179,20 @@ final class FireworksPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
@@ -181,7 +201,8 @@ final class FireworksPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         )
     }
 
@@ -191,6 +212,24 @@ final class FireworksPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -337,6 +376,8 @@ private struct FireworksSettingsView: View {
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
     @State private var selectedLLMModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var customModelId: String = ""
     @State private var fetchedLLMModels: [FireworksFetchedModel] = []
     private let bundle = Bundle(for: FireworksPlugin.self)
@@ -471,6 +512,38 @@ private struct FireworksSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -484,6 +557,8 @@ private struct FireworksSettingsView: View {
             }
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
             selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
         }
     }

--- a/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -27,6 +27,8 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedLLMModels: [GeminiFetchedModel] = []
 
     private let chatHelper = PluginOpenAIChatHelper(
@@ -47,6 +49,10 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
         }
         host.setUserDefault(nil, forKey: Self.legacyCachedLLMModelsKey)
         _selectedLLMModelId = host.userDefault(forKey: Self.selectedLLMModelKey) as? String
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
         normalizeSelectedModel()
         refreshCompatibleModelsIfNeeded()
     }
@@ -78,6 +84,20 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
@@ -86,7 +106,8 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         )
     }
 
@@ -96,6 +117,24 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -265,6 +304,8 @@ private struct GeminiSettingsView: View {
     @State private var validationResult: Bool?
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedLLMModels: [GeminiFetchedModel] = []
     private let bundle = Bundle(for: GeminiPlugin.self)
 
@@ -365,6 +406,38 @@ private struct GeminiSettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -377,6 +450,8 @@ private struct GeminiSettingsView: View {
                 apiKeyInput = key
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
             if plugin.isAvailable, fetchedLLMModels.isEmpty {
                 refreshLLMModels()

--- a/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -90,11 +90,12 @@ private struct Gemma4TokenizerLoader: TokenizerLoader {
 // MARK: - Plugin Entry Point
 
 @objc(Gemma4Plugin)
-final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, @unchecked Sendable {
+final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gemma4"
     static let pluginName = "Gemma 4"
     static let defaultGenerationTemperature = 0.1
     static let experimentalModelWarning = "Experimental. You can try it at your own risk."
+    static let promptMaxTokens = 2048
 
     enum DownloadError: LocalizedError {
         case invalidRepositoryID(String)
@@ -112,6 +113,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
     fileprivate var modelContainer: ModelContainer?
     fileprivate var loadedModelId: String?
     fileprivate var _generationTemperature: Double = 0.1
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.custom.rawValue
     fileprivate var _hfToken: String?
 
     private func modelsDirectory() -> URL {
@@ -146,6 +148,8 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
 
         _generationTemperature = host.userDefault(forKey: "generationTemperature") as? Double
             ?? Self.defaultGenerationTemperature
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.custom.rawValue
         _hfToken = host.loadSecret(key: "hf-token")
 
         Task { await restoreLoadedModel(allowDownloads: false) }
@@ -175,6 +179,20 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let modelContainer else {
             throw PluginChatError.notConfigured
         }
@@ -197,10 +215,12 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
         ]
         let userInput = UserInput(chat: chat)
         let input = try await modelContainer.prepare(input: userInput)
+        let resolvedTemperature = providerTemperatureDirective
+            .resolvedTemperature(applying: temperatureDirective) ?? Self.defaultGenerationTemperature
 
-        let parameters = GenerateParameters(
-            maxTokens: 2048,
-            temperature: Float(_generationTemperature)
+        let parameters = Self.promptGenerationParameters(
+            temperature: resolvedTemperature,
+            modelId: model ?? loadedModelId
         )
 
         let stream = try await modelContainer.generate(input: input, parameters: parameters)
@@ -231,6 +251,17 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
     var currentDownloadProgress: Double { downloadProgress }
 
     var generationTemperature: Double { _generationTemperature }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .custom
+    }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        switch llmTemperatureMode {
+        case .providerDefault:
+            return .custom(Self.defaultGenerationTemperature)
+        case .custom, .inheritProviderSetting:
+            return .custom(_generationTemperature)
+        }
+    }
 
     var requiresExternalCredentials: Bool { false }
 
@@ -253,6 +284,18 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
         let clamped = min(max(temperature, 0.0), 1.0)
         _generationTemperature = clamped
         host?.setUserDefault(clamped, forKey: "generationTemperature")
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        let storedMode: PluginLLMTemperatureMode
+        switch mode {
+        case .providerDefault:
+            storedMode = .providerDefault
+        case .custom, .inheritProviderSetting:
+            storedMode = .custom
+        }
+        _llmTemperatureModeRaw = storedMode.rawValue
+        host?.setUserDefault(storedMode.rawValue, forKey: "llmTemperatureMode")
     }
 
     func saveHuggingFaceToken(_ token: String) {
@@ -514,6 +557,27 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusPro
         }
 
         return error.localizedDescription
+    }
+
+    static func promptPrefillStepSize(for modelId: String?) -> Int {
+        switch modelId {
+        case "gemma-4-e2b-it-4bit":
+            return 256
+        case "gemma-4-e4b-it-4bit", "gemma-4-e4b-it-8bit":
+            return 128
+        case "gemma-4-26b-a4b-it-4bit":
+            return 64
+        default:
+            return 128
+        }
+    }
+
+    static func promptGenerationParameters(temperature: Double, modelId: String?) -> GenerateParameters {
+        GenerateParameters(
+            maxTokens: promptMaxTokens,
+            temperature: Float(temperature),
+            prefillStepSize: promptPrefillStepSize(for: modelId)
+        )
     }
 
     private static func unsupportedModelMessage(for modelDef: Gemma4ModelDef) -> String {

--- a/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -6,6 +6,7 @@ struct Gemma4SettingsView: View {
     private let bundle = Bundle(for: Gemma4Plugin.self)
     @State private var modelState: Gemma4ModelState = .notLoaded
     @State private var selectedModelId: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .custom
     @State private var generationTemperature: Double = Gemma4Plugin.defaultGenerationTemperature
     @State private var downloadProgress: Double = 0
     @State private var hfTokenInput = ""
@@ -44,27 +45,41 @@ struct Gemma4SettingsView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
 
-                HStack {
-                    Text("Temperature", bundle: bundle)
-                    Spacer()
-                    Text(generationTemperature, format: .number.precision(.fractionLength(2)))
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
+                Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                    Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                    Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
                 }
-                .font(.caption)
+                .onChange(of: llmTemperatureMode) { _, newValue in
+                    plugin.setLLMTemperatureMode(newValue)
+                }
 
-                Slider(value: $generationTemperature, in: 0...1, step: 0.05)
-                    .onChange(of: generationTemperature) { _, newValue in
-                        plugin.setGenerationTemperature(newValue)
+                if llmTemperatureMode == .custom {
+                    HStack {
+                        Text("Temperature", bundle: bundle)
+                        Spacer()
+                        Text(generationTemperature, format: .number.precision(.fractionLength(2)))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
                     }
+                    .font(.caption)
 
-                HStack {
-                    Text("Precise", bundle: bundle)
-                    Spacer()
-                    Text("Creative", bundle: bundle)
+                    Slider(value: $generationTemperature, in: 0...1, step: 0.05)
+                        .onChange(of: generationTemperature) { _, newValue in
+                            plugin.setGenerationTemperature(newValue)
+                        }
+
+                    HStack {
+                        Text("Precise", bundle: bundle)
+                        Spacer()
+                        Text("Creative", bundle: bundle)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                } else {
+                    Text("Uses Gemma 4's built-in default temperature.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-                .font(.caption)
-                .foregroundStyle(.secondary)
             }
 
             Divider()
@@ -153,6 +168,7 @@ struct Gemma4SettingsView: View {
         .onAppear {
             modelState = plugin.modelState
             selectedModelId = plugin.selectedLLMModelId ?? Gemma4Plugin.availableModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
             generationTemperature = plugin.generationTemperature
             downloadProgress = plugin.currentDownloadProgress
             if let token = plugin.huggingFaceToken, !token.isEmpty {

--- a/Plugins/GroqPlugin/GroqPlugin.swift
+++ b/Plugins/GroqPlugin/GroqPlugin.swift
@@ -13,6 +13,8 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
     fileprivate var _apiKey: String?
     fileprivate var _selectedModelId: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedLLMModels: [GroqFetchedModel] = []
 
     private let transcriptionHelper = PluginOpenAITranscriptionHelper(
@@ -39,6 +41,10 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
             ?? transcriptionModels.first?.id
         _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
             ?? supportedModels.first?.id
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
     }
 
     func deactivate() {
@@ -128,6 +134,20 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
@@ -136,7 +156,8 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         )
     }
 
@@ -146,6 +167,24 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -256,6 +295,8 @@ private struct GroqSettingsView: View {
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
     @State private var selectedLLMModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedLLMModels: [GroqFetchedModel] = []
     private let bundle = Bundle(for: GroqPlugin.self)
 
@@ -374,6 +415,38 @@ private struct GroqSettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -387,6 +460,8 @@ private struct GroqSettingsView: View {
             }
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
             selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
         }
     }

--- a/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -14,6 +14,8 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
     fileprivate var _baseURL: String?
     fileprivate var _selectedModelId: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedModels: [FetchedModel] = []
 
     required override init() {
@@ -26,6 +28,10 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
         _baseURL = host.userDefault(forKey: "baseURL") as? String
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
         _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
 
         if let data = host.userDefault(forKey: "fetchedModels") as? Data {
             _fetchedModels = (try? JSONDecoder().decode([FetchedModel].self, from: data)) ?? []
@@ -125,6 +131,20 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let helper = makeChatHelper() else {
             throw PluginChatError.notConfigured
         }
@@ -136,7 +156,8 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
             apiKey: _apiKey ?? "",
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         )
     }
 
@@ -146,6 +167,24 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -277,6 +316,8 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var selectedLLMModel = ""
     @State private var manualTranscriptionModel = ""
     @State private var manualLLMModel = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedModels: [FetchedModel] = []
     private let bundle = Bundle(for: OpenAICompatiblePlugin.self)
 
@@ -479,6 +520,38 @@ private struct OpenAICompatibleSettingsView: View {
                         }
                     }
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -494,6 +567,8 @@ private struct OpenAICompatibleSettingsView: View {
             fetchedModels = plugin._fetchedModels
             selectedTranscriptionModel = plugin.selectedModelId ?? ""
             selectedLLMModel = plugin.selectedLLMModelId ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
             manualTranscriptionModel = plugin.selectedModelId ?? ""
             manualLLMModel = plugin.selectedLLMModelId ?? ""
         }

--- a/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -462,6 +462,8 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     fileprivate var _fetchedLLMModels: [OpenAIFetchedModel] = []
     fileprivate var _authMode: OpenAIAuthMode = .apiKey
     fileprivate var _reasoningEffort: OpenAIReasoningEffort = .medium
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _oauthAccessToken: String?
     fileprivate var _oauthRefreshToken: String?
     fileprivate var _oauthIDToken: String?
@@ -485,6 +487,8 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         reasoningEffort: "reasoningEffort",
         selectedModel: "selectedModel",
         selectedLLMModel: "selectedLLMModel",
+        llmTemperatureMode: "llmTemperatureMode",
+        llmTemperatureValue: "llmTemperatureValue",
         fetchedLLMModels: "fetchedLLMModels",
         oauthAccountID: "oauthAccountID",
         oauthPlanType: "oauthPlanType",
@@ -541,6 +545,10 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             ?? transcriptionModels.first?.id
         _selectedLLMModelId = host.userDefault(forKey: Self.storageKeys.selectedLLMModel) as? String
             ?? supportedModels.first?.id
+        _llmTemperatureModeRaw = host.userDefault(forKey: Self.storageKeys.llmTemperatureMode) as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: Self.storageKeys.llmTemperatureValue) as? Double
+            ?? 0.3
         _oauthAccountID = host.userDefault(forKey: Self.storageKeys.oauthAccountID) as? String
         _oauthPlanType = host.userDefault(forKey: Self.storageKeys.oauthPlanType) as? String
         _oauthExpiresAt = host.userDefault(forKey: Self.storageKeys.oauthExpiresAt) as? Date
@@ -641,6 +649,20 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
         let reasoningEffort = Self.supportsReasoningEffort(for: modelId) ? _reasoningEffort.rawValue : nil
 
@@ -656,7 +678,11 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
                 userText: userText,
                 maxOutputTokenParameter: Self.outputTokenParameter(for: modelId),
                 reasoningEffort: reasoningEffort,
-                temperature: Self.chatCompletionTemperature(for: modelId, reasoningEffort: reasoningEffort)
+                temperature: resolvedTemperature(
+                    for: modelId,
+                    reasoningEffort: reasoningEffort,
+                    temperatureDirective: temperatureDirective
+                )
             )
         case .chatGPT:
             return try await processWithChatGPT(systemPrompt: systemPrompt, userText: userText, model: modelId)
@@ -670,10 +696,25 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
     fileprivate var reasoningEffort: OpenAIReasoningEffort { _reasoningEffort }
+    fileprivate var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    fileprivate var llmTemperatureValue: Double { _llmTemperatureValue }
 
     fileprivate func setReasoningEffort(_ effort: OpenAIReasoningEffort) {
         _reasoningEffort = effort
         host?.setUserDefault(effort.rawValue, forKey: Self.storageKeys.reasoningEffort)
+    }
+
+    fileprivate func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: Self.storageKeys.llmTemperatureMode)
+    }
+
+    fileprivate func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: Self.storageKeys.llmTemperatureValue)
     }
 
     // MARK: - Settings View
@@ -695,6 +736,31 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
     fileprivate var chatGPTPlanType: String? { _oauthPlanType }
     fileprivate func supportsReasoningEffort(for modelID: String) -> Bool {
         Self.supportsReasoningEffort(for: modelID)
+    }
+
+    fileprivate func supportsCustomTemperature(for modelID: String) -> Bool {
+        let reasoningEffort = Self.supportsReasoningEffort(for: modelID) ? _reasoningEffort.rawValue : nil
+        return Self.supportsCustomTemperature(for: modelID, reasoningEffort: reasoningEffort)
+    }
+
+    fileprivate func resolvedTemperature(
+        for modelID: String,
+        reasoningEffort: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) -> Double? {
+        switch temperatureDirective {
+        case .providerDefault:
+            return Self.chatCompletionTemperature(for: modelID, reasoningEffort: reasoningEffort)
+        case .custom(let value):
+            return Self.supportsCustomTemperature(for: modelID, reasoningEffort: reasoningEffort) ? value : nil
+        case .inheritProviderSetting:
+            switch llmTemperatureMode {
+            case .providerDefault, .inheritProviderSetting:
+                return Self.chatCompletionTemperature(for: modelID, reasoningEffort: reasoningEffort)
+            case .custom:
+                return Self.supportsCustomTemperature(for: modelID, reasoningEffort: reasoningEffort) ? _llmTemperatureValue : nil
+            }
+        }
     }
 
     fileprivate func setAuthMode(_ mode: OpenAIAuthMode) {
@@ -1098,6 +1164,10 @@ final class OpenAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             || lowered.contains("codex")
     }
 
+    nonisolated static func supportsCustomTemperature(for modelID: String, reasoningEffort: String?) -> Bool {
+        chatCompletionTemperature(for: modelID, reasoningEffort: reasoningEffort) != nil
+    }
+
     nonisolated static func chatCompletionTemperature(for modelID: String, reasoningEffort: String?) -> Double? {
         let lowered = modelID.lowercased()
         if lowered.hasPrefix("gpt-5"), reasoningEffort?.isEmpty == false {
@@ -1142,6 +1212,8 @@ private struct OpenAISettingsView: View {
     @State private var selectedModel: String = ""
     @State private var selectedLLMModel: String = ""
     @State private var selectedReasoningEffort: OpenAIReasoningEffort = .medium
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedLLMModels: [OpenAIFetchedModel] = []
     @State private var oauthBusy = false
     @State private var oauthStatusMessage: String?
@@ -1212,6 +1284,8 @@ private struct OpenAISettingsView: View {
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
             selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             selectedReasoningEffort = plugin.reasoningEffort
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
         }
     }
@@ -1411,6 +1485,47 @@ private struct OpenAISettingsView: View {
                 Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            if authMode == .apiKey {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+
+                    if llmTemperatureMode == .custom,
+                       !plugin.supportsCustomTemperature(for: selectedLLMModel) {
+                        Text("Custom temperature is ignored for the selected GPT-5 reasoning configuration.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
         }
     }

--- a/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -12,6 +12,8 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedModels: [OpenRouterFetchedModel] = []
 
     private let chatHelper = PluginOpenAIChatHelper(
@@ -31,6 +33,10 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
         }
         _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
             ?? supportedModels.first?.id
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
     }
 
     func deactivate() {
@@ -63,6 +69,20 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
@@ -71,7 +91,8 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
-            userText: userText
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         )
     }
 
@@ -82,6 +103,24 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
     @objc var preferredModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
 
     // MARK: - Settings View
 
@@ -265,6 +304,8 @@ private struct OpenRouterSettingsView: View {
     @State private var validationResult: Bool?
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedModels: [OpenRouterFetchedModel] = []
     @State private var searchText = ""
     @State private var remainingCredits: Double?
@@ -394,6 +435,38 @@ private struct OpenRouterSettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -407,6 +480,8 @@ private struct OpenRouterSettingsView: View {
             }
             fetchedModels = plugin._fetchedModels
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
 
             if plugin.isAvailable {
                 Task {

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */; };
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
+		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
 		F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000141 /* GeminiPlugin.swift */; };
 		A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000001 /* SystemTTSPlugin.swift */; };
@@ -602,6 +603,7 @@
 		BB00000000000000000247 /* SpeechFeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackService.swift; sourceTree = "<group>"; };
 		BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginManifestValidationTests.swift; sourceTree = "<group>"; };
 		BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnippetServiceTests.swift; sourceTree = "<group>"; };
+		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppFormatterServiceTests.swift; sourceTree = "<group>"; };
 		D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryServiceTests.swift; sourceTree = "<group>"; };
 		D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
@@ -1702,6 +1704,7 @@
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
+				B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */,
 				F41BD305007A3A158038C75C /* ProfileServiceTests.swift */,
 				B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */,
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
@@ -2884,6 +2887,7 @@
 				C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
+				A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
 				A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,

--- a/TypeWhisper/Models/PromptAction.swift
+++ b/TypeWhisper/Models/PromptAction.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftData
+import TypeWhisperPluginSDK
 
 @Model
 final class PromptAction {
@@ -14,6 +15,8 @@ final class PromptAction {
     var hotkeyModifiers: Int?
     var providerType: String?
     var cloudModel: String?
+    var temperatureModeRaw: String
+    var temperatureValue: Double?
     var targetActionPluginId: String?
     var createdAt: Date
     var updatedAt: Date
@@ -30,6 +33,8 @@ final class PromptAction {
         hotkeyModifiers: Int? = nil,
         providerType: String? = nil,
         cloudModel: String? = nil,
+        temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
+        temperatureValue: Double? = nil,
         targetActionPluginId: String? = nil,
         createdAt: Date = Date(),
         updatedAt: Date? = nil
@@ -45,9 +50,20 @@ final class PromptAction {
         self.hotkeyModifiers = hotkeyModifiers
         self.providerType = providerType
         self.cloudModel = cloudModel
+        self.temperatureModeRaw = temperatureModeRaw
+        self.temperatureValue = temperatureValue
         self.targetActionPluginId = targetActionPluginId
         self.createdAt = createdAt
         self.updatedAt = updatedAt ?? createdAt
+    }
+
+    var temperatureMode: PluginLLMTemperatureMode {
+        get { PluginLLMTemperatureMode(rawValue: temperatureModeRaw) ?? .inheritProviderSetting }
+        set { temperatureModeRaw = newValue.rawValue }
+    }
+
+    var temperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: temperatureMode, value: temperatureValue)
     }
 
     static var presets: [PromptAction] {
@@ -57,63 +73,81 @@ final class PromptAction {
                 prompt: "Translate the following text to English. If it's already in English, translate it to German. Only return the translation, nothing else.",
                 icon: "globe",
                 isPreset: true,
-                sortOrder: 0
+                sortOrder: 0,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.0
             ),
             PromptAction(
                 name: String(localized: "preset.writeEmail"),
                 prompt: "Turn the following text into a well-structured, professional email. Respond in the same language as the input text. Only return the email text.",
                 icon: "envelope",
                 isPreset: true,
-                sortOrder: 1
+                sortOrder: 1,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.3
             ),
             PromptAction(
                 name: String(localized: "preset.formatAsList"),
                 prompt: "Format the following text as a clean bullet-point list. Respond in the same language as the input text. Only return the formatted list.",
                 icon: "list.bullet",
                 isPreset: true,
-                sortOrder: 2
+                sortOrder: 2,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.1
             ),
             PromptAction(
                 name: String(localized: "preset.actionItems"),
                 prompt: "Extract all action items, tasks, and to-dos from the following text. Format them as a checklist. Respond in the same language as the input text. Only return the checklist.",
                 icon: "checklist",
                 isPreset: true,
-                sortOrder: 3
+                sortOrder: 3,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.1
             ),
             PromptAction(
                 name: String(localized: "preset.reply"),
                 prompt: "Write a concise, friendly reply to the following message. Respond in the same language as the input text. Only return the reply.",
                 icon: "arrowshape.turn.up.left",
                 isPreset: true,
-                sortOrder: 4
+                sortOrder: 4,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.4
             ),
             PromptAction(
                 name: String(localized: "preset.createTable"),
                 prompt: "Convert the following text into a well-formatted Markdown table. Extract key information and organize it into appropriate columns. Respond in the same language as the input text. Only return the table, nothing else.",
                 icon: "tablecells",
                 isPreset: true,
-                sortOrder: 5
+                sortOrder: 5,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.1
             ),
             PromptAction(
                 name: String(localized: "preset.draftEmail"),
                 prompt: "Draft a complete, professional email from the following notes. Include an appropriate subject line, greeting, body paragraphs, and closing. Respond in the same language as the input text. Only return the email.",
                 icon: "envelope.badge",
                 isPreset: true,
-                sortOrder: 6
+                sortOrder: 6,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.4
             ),
             PromptAction(
                 name: String(localized: "preset.jsonData"),
                 prompt: "Extract structured data from the following text and format it as valid, well-indented JSON. Use descriptive keys and appropriate data types. Only return the JSON, nothing else.",
                 icon: "curlybraces",
                 isPreset: true,
-                sortOrder: 7
+                sortOrder: 7,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.0
             ),
             PromptAction(
                 name: String(localized: "preset.meetingNotes"),
                 prompt: "Structure the following text as professional meeting notes. Include sections for: Attendees (if mentioned), Key Discussion Points, Decisions Made, and Action Items with owners. Use Markdown formatting. Respond in the same language as the input text.",
                 icon: "doc.text.magnifyingglass",
                 isPreset: true,
-                sortOrder: 8
+                sortOrder: 8,
+                temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+                temperatureValue: 0.2
             ),
         ]
     }

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -120,6 +120,18 @@ private enum PluginLoadError: LocalizedError {
 
 // MARK: - Loaded Plugin
 
+private final class UnloadedPluginPlaceholder: NSObject, TypeWhisperPlugin, @unchecked Sendable {
+    static var pluginId: String { "com.typewhisper.unloaded-placeholder" }
+    static var pluginName: String { "Unloaded Plugin Placeholder" }
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+}
+
 struct LoadedPlugin: Identifiable {
     let manifest: PluginManifest
     let instance: TypeWhisperPlugin
@@ -132,6 +144,14 @@ struct LoadedPlugin: Identifiable {
     var isBundled: Bool {
         guard let builtInURL = Bundle.main.builtInPlugInsURL else { return false }
         return sourceURL.path.hasPrefix(builtInURL.path)
+    }
+
+    var isRuntimeLoaded: Bool {
+        !(instance is UnloadedPluginPlaceholder)
+    }
+
+    var supportsSettingsWindow: Bool {
+        isRuntimeLoaded && instance.settingsView != nil
     }
 }
 
@@ -313,7 +333,10 @@ final class PluginManager: ObservableObject {
             return
         }
 
-        let bundles = contents.filter { $0.pathExtension == "bundle" }
+        let bundles = sortedPluginBundleURLs(
+            contents.filter { $0.pathExtension == "bundle" },
+            isBundledSource: false
+        )
         logger.info("Found \(bundles.count) plugin bundle(s)")
 
         for bundleURL in bundles {
@@ -327,7 +350,10 @@ final class PluginManager: ObservableObject {
         // Built-in plugins from app bundle
         if let builtInURL = Bundle.main.builtInPlugInsURL,
            let builtIn = try? fm.contentsOfDirectory(at: builtInURL, includingPropertiesForKeys: nil) {
-            let builtInBundles = builtIn.filter { $0.pathExtension == "bundle" }
+            let builtInBundles = sortedPluginBundleURLs(
+                builtIn.filter { $0.pathExtension == "bundle" },
+                isBundledSource: true
+            )
             logger.info("Found \(builtInBundles.count) built-in plugin bundle(s)")
             for bundleURL in builtInBundles {
                 do {
@@ -337,6 +363,36 @@ final class PluginManager: ObservableObject {
                 }
             }
         }
+    }
+
+    func sortedPluginBundleURLs(_ urls: [URL], isBundledSource: Bool) -> [URL] {
+        urls.sorted { lhs, rhs in
+            let left = pluginBundleSortMetadata(for: lhs, isBundledSource: isBundledSource)
+            let right = pluginBundleSortMetadata(for: rhs, isBundledSource: isBundledSource)
+
+            if left.isEnabled != right.isEnabled {
+                return left.isEnabled && !right.isEnabled
+            }
+
+            if left.sortName != right.sortName {
+                return left.sortName < right.sortName
+            }
+
+            return lhs.path < rhs.path
+        }
+    }
+
+    private func pluginBundleSortMetadata(for url: URL, isBundledSource: Bool) -> (isEnabled: Bool, sortName: String) {
+        let manifestURL = url.appendingPathComponent("Contents/Resources/manifest.json")
+
+        guard let data = try? Data(contentsOf: manifestURL),
+              let manifest = try? JSONDecoder().decode(PluginManifest.self, from: data) else {
+            return (isBundledSource, url.lastPathComponent.lowercased())
+        }
+
+        let enabledKey = "plugin.\(manifest.id).enabled"
+        let isEnabled = (UserDefaults.standard.object(forKey: enabledKey) as? Bool) ?? isBundledSource
+        return (isEnabled, url.lastPathComponent.lowercased())
     }
 
     func loadPlugin(at url: URL) throws {
@@ -409,6 +465,8 @@ final class PluginManager: ObservableObject {
             }
         }
 
+        let isEnabled = resolvedEnabledState(for: manifest, isBundledSource: isBundledSource)
+
         if let existingIndex = loadedPlugins.firstIndex(where: { $0.manifest.id == manifest.id }) {
             let existing = loadedPlugins[existingIndex]
             guard shouldReplace(existing: existing, with: manifest, from: url) else {
@@ -422,6 +480,13 @@ final class PluginManager: ObservableObject {
             existing.bundle.unload()
             loadedPlugins.remove(at: existingIndex)
             logger.info("Replacing plugin \(manifest.id) from \(existing.sourceURL.lastPathComponent) with \(url.lastPathComponent)")
+        }
+
+        if !isEnabled {
+            let unloaded = try makeUnloadedPluginRecord(manifest: manifest, sourceURL: url)
+            loadedPlugins.append(unloaded)
+            logger.info("Registered disabled plugin without loading bundle: \(manifest.name) v\(manifest.version)")
+            return
         }
 
         guard let bundle = Bundle(url: url) else {
@@ -447,18 +512,6 @@ final class PluginManager: ObservableObject {
 
         let instance = pluginClass.init()
 
-        let enabledKey = "plugin.\(manifest.id).enabled"
-        let isEnabled: Bool
-        if let stored = UserDefaults.standard.object(forKey: enabledKey) as? Bool {
-            isEnabled = stored
-        } else {
-            // Auto-enable bundled plugins on first encounter
-            isEnabled = isBundledSource
-            if isBundledSource {
-                UserDefaults.standard.set(true, forKey: enabledKey)
-            }
-        }
-
         let loaded = LoadedPlugin(
             manifest: manifest, instance: instance, bundle: bundle, sourceURL: url, isEnabled: isEnabled
         )
@@ -469,6 +522,34 @@ final class PluginManager: ObservableObject {
         }
 
         logger.info("Loaded plugin: \(manifest.name) v\(manifest.version)")
+    }
+
+    private func resolvedEnabledState(for manifest: PluginManifest, isBundledSource: Bool) -> Bool {
+        let enabledKey = "plugin.\(manifest.id).enabled"
+        if let stored = UserDefaults.standard.object(forKey: enabledKey) as? Bool {
+            return stored
+        }
+
+        if isBundledSource {
+            UserDefaults.standard.set(true, forKey: enabledKey)
+            return true
+        }
+
+        return false
+    }
+
+    private func makeUnloadedPluginRecord(manifest: PluginManifest, sourceURL: URL) throws -> LoadedPlugin {
+        guard let bundle = Bundle(url: sourceURL) else {
+            throw PluginLoadError.failedToCreateBundle(bundleName: sourceURL.lastPathComponent)
+        }
+
+        return LoadedPlugin(
+            manifest: manifest,
+            instance: UnloadedPluginPlaceholder(),
+            bundle: bundle,
+            sourceURL: sourceURL,
+            isEnabled: false
+        )
     }
 
     func setRuleNamesProvider(_ provider: @escaping () -> [String]) {
@@ -489,11 +570,23 @@ final class PluginManager: ObservableObject {
     func setPluginEnabled(_ pluginId: String, enabled: Bool) {
         guard let index = loadedPlugins.firstIndex(where: { $0.manifest.id == pluginId }) else { return }
 
-        loadedPlugins[index].isEnabled = enabled
         UserDefaults.standard.set(enabled, forKey: "plugin.\(pluginId).enabled")
 
         if enabled {
-            activatePlugin(loadedPlugins[index])
+            if loadedPlugins[index].isRuntimeLoaded {
+                loadedPlugins[index].isEnabled = true
+                activatePlugin(loadedPlugins[index])
+                return
+            }
+
+            let unloaded = loadedPlugins.remove(at: index)
+            do {
+                try loadPlugin(at: unloaded.sourceURL)
+            } catch {
+                logger.error("Failed to enable plugin \(pluginId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                UserDefaults.standard.set(false, forKey: "plugin.\(pluginId).enabled")
+                loadedPlugins.insert(unloaded, at: index)
+            }
         } else {
             // If the deactivated plugin was selected as default engine, fall back to first available
             if let engine = loadedPlugins[index].instance as? TranscriptionEnginePlugin {
@@ -505,8 +598,23 @@ final class PluginManager: ObservableObject {
                     }
                 }
             }
-            loadedPlugins[index].instance.deactivate()
-            logger.info("Deactivated plugin: \(pluginId)")
+
+            let plugin = loadedPlugins[index]
+            if plugin.isRuntimeLoaded {
+                plugin.instance.deactivate()
+                plugin.bundle.unload()
+            }
+
+            do {
+                loadedPlugins[index] = try makeUnloadedPluginRecord(
+                    manifest: plugin.manifest,
+                    sourceURL: plugin.sourceURL
+                )
+                logger.info("Deactivated plugin: \(pluginId)")
+            } catch {
+                logger.error("Failed to convert disabled plugin \(pluginId, privacy: .public) into unloaded placeholder: \(error.localizedDescription, privacy: .public)")
+                loadedPlugins[index].isEnabled = false
+            }
         }
     }
 
@@ -524,10 +632,12 @@ final class PluginManager: ObservableObject {
     func unloadPlugin(_ pluginId: String) {
         guard let index = loadedPlugins.firstIndex(where: { $0.manifest.id == pluginId }) else { return }
         let plugin = loadedPlugins[index]
-        if plugin.isEnabled {
+        if plugin.isEnabled && plugin.isRuntimeLoaded {
             plugin.instance.deactivate()
         }
-        plugin.bundle.unload()
+        if plugin.isRuntimeLoaded {
+            plugin.bundle.unload()
+        }
         loadedPlugins.remove(at: index)
         logger.info("Unloaded plugin: \(pluginId)")
     }

--- a/TypeWhisper/Services/PromptActionService.swift
+++ b/TypeWhisper/Services/PromptActionService.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftData
 import Combine
 import os.log
+import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "PromptActionService")
 
@@ -80,7 +81,12 @@ class PromptActionService: ObservableObject {
                     prompt: preset.prompt,
                     icon: preset.icon,
                     isPreset: true,
-                    sortOrder: nextSortOrder + offset
+                    sortOrder: nextSortOrder + offset,
+                    providerType: preset.providerType,
+                    cloudModel: preset.cloudModel,
+                    temperatureModeRaw: preset.temperatureModeRaw,
+                    temperatureValue: preset.temperatureValue,
+                    targetActionPluginId: preset.targetActionPluginId
                 )
                 context.insert(newAction)
             }
@@ -103,7 +109,12 @@ class PromptActionService: ObservableObject {
             prompt: preset.prompt,
             icon: preset.icon,
             isPreset: true,
-            sortOrder: maxOrder + 1
+            sortOrder: maxOrder + 1,
+            providerType: preset.providerType,
+            cloudModel: preset.cloudModel,
+            temperatureModeRaw: preset.temperatureModeRaw,
+            temperatureValue: preset.temperatureValue,
+            targetActionPluginId: preset.targetActionPluginId
         )
 
         context.insert(newAction)
@@ -116,7 +127,16 @@ class PromptActionService: ObservableObject {
         }
     }
 
-    func addAction(name: String, prompt: String, icon: String = "sparkles", providerType: String? = nil, cloudModel: String? = nil, targetActionPluginId: String? = nil) {
+    func addAction(
+        name: String,
+        prompt: String,
+        icon: String = "sparkles",
+        providerType: String? = nil,
+        cloudModel: String? = nil,
+        temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
+        temperatureValue: Double? = nil,
+        targetActionPluginId: String? = nil
+    ) {
         guard let context = modelContext else { return }
 
         let maxOrder = promptActions.map(\.sortOrder).max() ?? -1
@@ -127,6 +147,8 @@ class PromptActionService: ObservableObject {
             sortOrder: maxOrder + 1,
             providerType: providerType,
             cloudModel: cloudModel,
+            temperatureModeRaw: temperatureModeRaw,
+            temperatureValue: temperatureValue,
             targetActionPluginId: targetActionPluginId
         )
 
@@ -140,7 +162,17 @@ class PromptActionService: ObservableObject {
         }
     }
 
-    func updateAction(_ action: PromptAction, name: String, prompt: String, icon: String, providerType: String? = nil, cloudModel: String? = nil, targetActionPluginId: String? = nil) {
+    func updateAction(
+        _ action: PromptAction,
+        name: String,
+        prompt: String,
+        icon: String,
+        providerType: String? = nil,
+        cloudModel: String? = nil,
+        temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
+        temperatureValue: Double? = nil,
+        targetActionPluginId: String? = nil
+    ) {
         guard let context = modelContext else { return }
 
         action.name = name
@@ -148,6 +180,8 @@ class PromptActionService: ObservableObject {
         action.icon = icon
         action.providerType = providerType
         action.cloudModel = cloudModel
+        action.temperatureModeRaw = temperatureModeRaw
+        action.temperatureValue = temperatureValue
         action.targetActionPluginId = targetActionPluginId
         action.updatedAt = Date()
 

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Combine
 import TypeWhisperPluginSDK
@@ -124,6 +125,31 @@ class PromptProcessingService: ObservableObject {
     }
 
     func process(prompt: String, text: String, providerOverride: String? = nil, cloudModelOverride: String? = nil, skipMemoryInjection: Bool = false) async throws -> String {
+        try await process(
+            prompt: prompt,
+            text: text,
+            providerOverride: providerOverride,
+            cloudModelOverride: cloudModelOverride,
+            temperatureDirective: .inheritProviderSetting,
+            skipMemoryInjection: skipMemoryInjection
+        )
+    }
+
+    static func requiresForegroundActivation(for plugin: any LLMProviderPlugin) -> Bool {
+        guard let setupStatus = plugin as? any LLMProviderSetupStatusProviding else {
+            return false
+        }
+        return !setupStatus.requiresExternalCredentials
+    }
+
+    func process(
+        prompt: String,
+        text: String,
+        providerOverride: String? = nil,
+        cloudModelOverride: String? = nil,
+        temperatureDirective: PluginLLMTemperatureDirective = .inheritProviderSetting,
+        skipMemoryInjection: Bool = false
+    ) async throws -> String {
         // Inject memory context into prompt if available
         var effectivePrompt = prompt
         if !skipMemoryInjection, let memoryService {
@@ -167,13 +193,79 @@ class PromptProcessingService: ObservableObject {
             persistGlobalSelection: false
         )
         logger.info("Processing prompt with plugin \(effectiveId)")
-        let result = try await plugin.process(
-            systemPrompt: effectivePrompt,
+        let result = try await withForegroundActivationIfNeeded(for: plugin, providerId: effectiveId) {
+            try await processWithPlugin(
+                plugin,
+                prompt: effectivePrompt,
+                text: text,
+                model: model,
+                temperatureDirective: temperatureDirective
+            )
+        }
+        logger.info("Prompt processing complete, result length: \(result.count)")
+        return result
+    }
+
+    private func processWithPlugin(
+        _ plugin: any LLMProviderPlugin,
+        prompt: String,
+        text: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
+        if let temperatureAwarePlugin = plugin as? any LLMTemperatureControllableProvider {
+            return try await temperatureAwarePlugin.process(
+                systemPrompt: prompt,
+                userText: text,
+                model: model,
+                temperatureDirective: temperatureDirective
+            )
+        }
+
+        return try await plugin.process(
+            systemPrompt: prompt,
             userText: text,
             model: model
         )
-        logger.info("Prompt processing complete, result length: \(result.count)")
-        return result
+    }
+
+    private func withForegroundActivationIfNeeded<T>(
+        for plugin: any LLMProviderPlugin,
+        providerId: String,
+        operation: () async throws -> T
+    ) async throws -> T {
+        guard Self.requiresForegroundActivation(for: plugin) else {
+            return try await operation()
+        }
+
+        activateAppForLocalPromptProcessing(providerId: providerId)
+        let activity = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .latencyCritical],
+            reason: "Local prompt processing with \(providerId)"
+        )
+        defer {
+            ProcessInfo.processInfo.endActivity(activity)
+        }
+
+        return try await operation()
+    }
+
+    private func activateAppForLocalPromptProcessing(providerId: String) {
+        guard !AppConstants.isRunningTests, !NSApp.isActive else { return }
+
+        logger.info("Activating app for local prompt processing with plugin \(providerId)")
+        let currentApplication = NSRunningApplication.current
+        let sourceApplication = ActivationSourceTracker.shared.lastExternalApplication
+            ?? NSWorkspace.shared.frontmostApplication
+
+        if let sourceApplication,
+           sourceApplication.processIdentifier != currentApplication.processIdentifier,
+           currentApplication.activate(from: sourceApplication) {
+            return
+        }
+
+        _ = currentApplication.activate()
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func normalizeSelectedCloudModelIfNeeded(for providerId: String) {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1303,7 +1303,8 @@ final class DictationViewModel: ObservableObject {
                 try await pps.process(
                     prompt: prompt, text: text,
                     providerOverride: providerOverride,
-                    cloudModelOverride: modelOverride
+                    cloudModelOverride: modelOverride,
+                    temperatureDirective: promptAction?.temperatureDirective ?? .inheritProviderSetting
                 )
             }
         }

--- a/TypeWhisper/ViewModels/PromptActionsViewModel.swift
+++ b/TypeWhisper/ViewModels/PromptActionsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import TypeWhisperPluginSDK
 
 @MainActor
 class PromptActionsViewModel: ObservableObject {
@@ -23,6 +24,8 @@ class PromptActionsViewModel: ObservableObject {
     @Published var editIcon = "sparkles"
     @Published var editProviderId: String?
     @Published var editCloudModel = ""
+    @Published var editTemperatureMode: PluginLLMTemperatureMode = .inheritProviderSetting
+    @Published var editTemperatureValue: Double = 0.3
     @Published var editTargetActionPluginId: String?
 
     private let promptActionService: PromptActionService
@@ -61,6 +64,8 @@ class PromptActionsViewModel: ObservableObject {
         editIcon = "sparkles"
         editProviderId = nil
         editCloudModel = ""
+        editTemperatureMode = .inheritProviderSetting
+        editTemperatureValue = defaultTemperatureValue(for: promptProcessingService.selectedProviderId)
         editTargetActionPluginId = nil
     }
 
@@ -73,6 +78,8 @@ class PromptActionsViewModel: ObservableObject {
         editIcon = action.icon
         editProviderId = action.providerType
         editCloudModel = action.cloudModel ?? ""
+        editTemperatureMode = action.temperatureMode
+        editTemperatureValue = action.temperatureValue ?? defaultTemperatureValue(for: action.providerType ?? promptProcessingService.selectedProviderId)
         editTargetActionPluginId = action.targetActionPluginId
     }
 
@@ -85,6 +92,8 @@ class PromptActionsViewModel: ObservableObject {
         editIcon = "sparkles"
         editProviderId = nil
         editCloudModel = ""
+        editTemperatureMode = .inheritProviderSetting
+        editTemperatureValue = defaultTemperatureValue(for: promptProcessingService.selectedProviderId)
         editTargetActionPluginId = nil
     }
 
@@ -101,6 +110,8 @@ class PromptActionsViewModel: ObservableObject {
                 icon: editIcon,
                 providerType: editProviderId,
                 cloudModel: editCloudModel.isEmpty ? nil : editCloudModel,
+                temperatureModeRaw: editTemperatureMode.rawValue,
+                temperatureValue: editTemperatureMode == .custom ? editTemperatureValue : nil,
                 targetActionPluginId: editTargetActionPluginId
             )
         } else if let action = selectedAction {
@@ -111,6 +122,8 @@ class PromptActionsViewModel: ObservableObject {
                 icon: editIcon,
                 providerType: editProviderId,
                 cloudModel: editCloudModel.isEmpty ? nil : editCloudModel,
+                temperatureModeRaw: editTemperatureMode.rawValue,
+                temperatureValue: editTemperatureMode == .custom ? editTemperatureValue : nil,
                 targetActionPluginId: editTargetActionPluginId
             )
         }
@@ -144,5 +157,23 @@ class PromptActionsViewModel: ObservableObject {
 
     func clearError() {
         error = nil
+    }
+
+    func clampTemperatureValueForEffectiveProvider() {
+        let range = supportedTemperatureRange(
+            for: editProviderId ?? promptProcessingService.selectedProviderId
+        )
+        editTemperatureValue = min(max(editTemperatureValue, range.lowerBound), range.upperBound)
+    }
+
+    func supportedTemperatureRange(for providerId: String?) -> ClosedRange<Double> {
+        guard providerId == "Gemma 4 (MLX)" else {
+            return 0.0...2.0
+        }
+        return 0.0...1.0
+    }
+
+    func defaultTemperatureValue(for providerId: String?) -> Double {
+        providerId == "Gemma 4 (MLX)" ? 0.1 : 0.3
     }
 }

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -168,7 +168,8 @@ final class PromptPaletteHandler {
                     prompt: action.prompt,
                     text: ctx.text,
                     providerOverride: action.providerType,
-                    cloudModelOverride: action.cloudModel
+                    cloudModelOverride: action.cloudModel,
+                    temperatureDirective: action.temperatureDirective
                 )
                 guard !Task.isCancelled else { return }
 

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -156,6 +156,9 @@ struct PluginSettingsView: View {
         if let regPlugin = registryService.registry.first(where: { $0.id == plugin.id }) {
             return PluginCategory(rawValue: regPlugin.category) ?? .utility
         }
+        if let manifestCategory = plugin.manifest.category {
+            return PluginCategory(rawValue: manifestCategory) ?? .utility
+        }
         if plugin.instance is TranscriptionEnginePlugin { return .transcription }
         if plugin.instance is TTSProviderPlugin { return .tts }
         if plugin.instance is LLMProviderPlugin { return .llm }
@@ -617,7 +620,7 @@ private struct InstalledPluginRow: View {
                 .accessibilityLabel(String(localized: "Uninstall \(plugin.manifest.name)"))
             }
 
-            if plugin.instance.settingsView != nil {
+            if plugin.supportsSettingsWindow {
                 Button {
                     PluginSettingsWindowManager.shared.present(plugin)
                 } label: {
@@ -645,6 +648,10 @@ private struct InstalledPluginRow: View {
     }
 
     private func refreshPluginActivity() {
+        guard plugin.isRuntimeLoaded else {
+            pluginActivity = nil
+            return
+        }
         pluginActivity = (plugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
     }
 }

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -546,8 +546,10 @@ private struct PromptActionEditorSheet: View {
                                     if let newId {
                                         let models = viewModel.promptProcessingService.modelsForProvider(newId)
                                         viewModel.editCloudModel = models.first?.id ?? ""
+                                        viewModel.clampTemperatureValueForEffectiveProvider()
                                     } else {
                                         viewModel.editCloudModel = ""
+                                        viewModel.clampTemperatureValueForEffectiveProvider()
                                     }
                                 }
 
@@ -568,6 +570,71 @@ private struct PromptActionEditorSheet: View {
                             }
                             .padding(.vertical, 4)
                         }
+                    }
+
+                    GroupBox(String(localized: "Temperature")) {
+                        let effectiveProviderId = viewModel.editProviderId ?? viewModel.promptProcessingService.selectedProviderId
+                        let isAppleIntelligence = effectiveProviderId == PromptProcessingService.appleIntelligenceId
+                        let supportedRange = viewModel.supportedTemperatureRange(for: effectiveProviderId)
+                        VStack(alignment: .leading, spacing: 8) {
+                            Picker(String(localized: "Who decides?"), selection: $viewModel.editTemperatureMode) {
+                                Text(String(localized: "Use my provider setting")).tag(PluginLLMTemperatureMode.inheritProviderSetting)
+                                Text(String(localized: "Use provider default")).tag(PluginLLMTemperatureMode.providerDefault)
+                                Text(String(localized: "Set for this prompt")).tag(PluginLLMTemperatureMode.custom)
+                            }
+                            .disabled(isAppleIntelligence)
+
+                            if viewModel.editTemperatureMode == .custom {
+                                HStack {
+                                    Text(String(localized: "Temperature"))
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Text(viewModel.editTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                        .foregroundStyle(.secondary)
+                                        .monospacedDigit()
+                                }
+
+                                Slider(
+                                    value: $viewModel.editTemperatureValue,
+                                    in: supportedRange,
+                                    step: effectiveProviderId == "Gemma 4 (MLX)" ? 0.05 : 0.1
+                                )
+                                .disabled(isAppleIntelligence)
+
+                                HStack {
+                                    Text("\(supportedRange.lowerBound, format: .number.precision(.fractionLength(1)))")
+                                    Spacer()
+                                    Text("\(supportedRange.upperBound, format: .number.precision(.fractionLength(1)))")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            }
+
+                            let helperText: LocalizedStringResource = {
+                                if isAppleIntelligence {
+                                    return "Temperature is not available for Apple Intelligence."
+                                }
+
+                                switch viewModel.editTemperatureMode {
+                                case .inheritProviderSetting:
+                                    return "Uses the temperature saved in this provider's settings."
+                                case .providerDefault:
+                                    return "Ignores your saved provider setting and lets the provider use its own default behavior."
+                                case .custom:
+                                    if effectiveProviderId == "Gemma 4 (MLX)" {
+                                        return "Uses this value only for this prompt. Gemma 4 supports values from 0.0 to 1.0."
+                                    } else {
+                                        return "Uses this value only for this prompt and overrides the provider setting."
+                                    }
+                                }
+                            }()
+
+                            Text(helperText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
                     }
 
                     let actionPlugins = PluginManager.shared.actionPlugins

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -1111,7 +1111,13 @@ private struct RecommendationSettingsButton: View {
     var body: some View {
         Button {
             if let loaded = PluginManager.shared.loadedPlugins.first(where: { $0.manifest.id == manifestId }) {
-                PluginSettingsWindowManager.shared.present(loaded)
+                if !loaded.isEnabled {
+                    PluginManager.shared.setPluginEnabled(manifestId, enabled: true)
+                }
+                if let activePlugin = PluginManager.shared.loadedPlugins.first(where: { $0.manifest.id == manifestId }),
+                   activePlugin.supportsSettingsWindow {
+                    PluginSettingsWindowManager.shared.present(activePlugin)
+                }
             }
         } label: {
             HStack(spacing: 4) {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/LLMTemperatureSupport.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/LLMTemperatureSupport.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+public enum PluginLLMTemperatureMode: String, Codable, CaseIterable, Sendable {
+    case inheritProviderSetting
+    case providerDefault
+    case custom
+}
+
+public enum PluginLLMTemperatureDirective: Sendable, Equatable {
+    case inheritProviderSetting
+    case providerDefault
+    case custom(Double)
+
+    public init(mode: PluginLLMTemperatureMode, value: Double?) {
+        switch mode {
+        case .inheritProviderSetting:
+            self = .inheritProviderSetting
+        case .providerDefault:
+            self = .providerDefault
+        case .custom:
+            self = .custom(value ?? 0.3)
+        }
+    }
+
+    public var mode: PluginLLMTemperatureMode {
+        switch self {
+        case .inheritProviderSetting:
+            return .inheritProviderSetting
+        case .providerDefault:
+            return .providerDefault
+        case .custom:
+            return .custom
+        }
+    }
+
+    public var customValue: Double? {
+        switch self {
+        case .custom(let value):
+            return value
+        case .inheritProviderSetting, .providerDefault:
+            return nil
+        }
+    }
+
+    public var resolvedTemperatureValue: Double? {
+        switch self {
+        case .custom(let value):
+            return value
+        case .inheritProviderSetting, .providerDefault:
+            return nil
+        }
+    }
+
+    public func resolvedTemperature(applying ruleDirective: PluginLLMTemperatureDirective) -> Double? {
+        switch ruleDirective {
+        case .inheritProviderSetting:
+            return resolvedTemperatureValue
+        case .providerDefault:
+            return nil
+        case .custom(let value):
+            return value
+        }
+    }
+
+    public func clamped(to range: ClosedRange<Double>) -> PluginLLMTemperatureDirective {
+        switch self {
+        case .custom(let value):
+            return .custom(min(max(value, range.lowerBound), range.upperBound))
+        case .inheritProviderSetting, .providerDefault:
+            return self
+        }
+    }
+}
+
+public protocol LLMTemperatureControllableProvider: LLMProviderPlugin {
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String
+}

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/LLMTemperatureSupportTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/LLMTemperatureSupportTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class LLMTemperatureSupportTests: XCTestCase {
+    func testResolvedTemperatureUsesProviderSettingWhenInheriting() {
+        let providerDirective = PluginLLMTemperatureDirective.custom(0.7)
+        let resolved = providerDirective.resolvedTemperature(
+            applying: .inheritProviderSetting
+        )
+
+        XCTAssertEqual(resolved, 0.7)
+    }
+
+    func testResolvedTemperatureOmitsValueForProviderDefault() {
+        let providerDirective = PluginLLMTemperatureDirective.custom(0.7)
+        let resolved = providerDirective.resolvedTemperature(
+            applying: .providerDefault
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    func testResolvedTemperatureUsesCustomOverride() {
+        let providerDirective = PluginLLMTemperatureDirective.custom(0.2)
+        let resolved = providerDirective.resolvedTemperature(
+            applying: .custom(1.1)
+        )
+
+        XCTAssertEqual(resolved, 1.1)
+    }
+}

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7,7 +7,7 @@ import TypeWhisperPluginSDK
 
 final class APIRouterAndHandlersTests: XCTestCase {
     @objc(APIRouterMockLLMProviderPlugin)
-    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, @unchecked Sendable {
+    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, LLMTemperatureControllableProvider, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.llm" }
         static var pluginName: String { "Mock LLM" }
 
@@ -19,9 +19,14 @@ final class APIRouterAndHandlersTests: XCTestCase {
         var requiresExternalCredentials = true
         var unavailableReason: String?
         nonisolated(unsafe) private var _lastRequestedModel: String?
+        nonisolated(unsafe) private var _lastTemperatureDirective: PluginLLMTemperatureDirective?
 
         var lastRequestedModel: String? {
             requestLock.withLock { _lastRequestedModel }
+        }
+
+        var lastTemperatureDirective: PluginLLMTemperatureDirective? {
+            requestLock.withLock { _lastTemperatureDirective }
         }
 
         required override init() {}
@@ -38,6 +43,38 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 _lastRequestedModel = model
             }
             return responseText
+        }
+
+        func process(
+            systemPrompt: String,
+            userText: String,
+            model: String?,
+            temperatureDirective: PluginLLMTemperatureDirective
+        ) async throws -> String {
+            requestLock.withLock {
+                _lastRequestedModel = model
+                _lastTemperatureDirective = temperatureDirective
+            }
+            return responseText
+        }
+    }
+
+    @objc(APIRouterMockLegacyLLMProviderPlugin)
+    private final class MockLegacyLLMProviderPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.legacy-llm" }
+        static var pluginName: String { "Mock Legacy LLM" }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerName: String { "Legacy LLM" }
+        var isAvailable: Bool { true }
+        var supportedModels: [PluginModelInfo] { [] }
+
+        func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+            "processed"
         }
     }
 
@@ -1948,6 +1985,64 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testPromptProcessingPassesTemperatureDirectiveToTemperatureAwareProvider() async throws {
+        let providerKey = "llmProviderType"
+        let modelKey = "llmCloudModel"
+        let originalProvider = UserDefaults.standard.object(forKey: providerKey)
+        let originalModel = UserDefaults.standard.object(forKey: modelKey)
+        defer {
+            if let originalProvider {
+                UserDefaults.standard.set(originalProvider, forKey: providerKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: providerKey)
+            }
+            if let originalModel {
+                UserDefaults.standard.set(originalModel, forKey: modelKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: modelKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        UserDefaults.standard.set("Gemini", forKey: providerKey)
+        UserDefaults.standard.set("gemini-2.5-pro", forKey: modelKey)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.models = [PluginModelInfo(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro")]
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.llm",
+            name: "Mock LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+        _ = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            temperatureDirective: .custom(0.8)
+        )
+
+        XCTAssertEqual(plugin.lastRequestedModel, "gemini-2.5-pro")
+        XCTAssertEqual(plugin.lastTemperatureDirective, .custom(0.8))
+    }
+
+    @MainActor
     func testPromptProcessingReturnsSetupRequiredForLocalProviderWithoutLoadedModel() async throws {
         let providerKey = "llmProviderType"
         let modelKey = "llmCloudModel"
@@ -2008,6 +2103,21 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 "Load a Gemma 4 model in Integrations before using it for prompts."
             )
         }
+    }
+
+    @MainActor
+    func testPromptProcessingRequiresForegroundActivationOnlyForLocalProviders() {
+        let remotePlugin = MockLLMProviderPlugin()
+        remotePlugin.requiresExternalCredentials = true
+
+        let localPlugin = MockLLMProviderPlugin()
+        localPlugin.requiresExternalCredentials = false
+
+        let legacyPlugin = MockLegacyLLMProviderPlugin()
+
+        XCTAssertFalse(PromptProcessingService.requiresForegroundActivation(for: remotePlugin))
+        XCTAssertTrue(PromptProcessingService.requiresForegroundActivation(for: localPlugin))
+        XCTAssertFalse(PromptProcessingService.requiresForegroundActivation(for: legacyPlugin))
     }
 
     @MainActor

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -232,6 +232,20 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertFalse(isValid)
     }
 
+    func testGemma4UsesTemperatureControllableProviderPath() {
+        let plugin: any LLMProviderPlugin = Gemma4Plugin()
+
+        XCTAssertTrue(plugin is any LLMTemperatureControllableProvider)
+    }
+
+    func testGemma4PromptPrefillStepSizeIsReducedForLargerModels() {
+        XCTAssertEqual(Gemma4Plugin.promptPrefillStepSize(for: "gemma-4-e2b-it-4bit"), 256)
+        XCTAssertEqual(Gemma4Plugin.promptPrefillStepSize(for: "gemma-4-e4b-it-4bit"), 128)
+        XCTAssertEqual(Gemma4Plugin.promptPrefillStepSize(for: "gemma-4-e4b-it-8bit"), 128)
+        XCTAssertEqual(Gemma4Plugin.promptPrefillStepSize(for: "gemma-4-26b-a4b-it-4bit"), 64)
+        XCTAssertEqual(Gemma4Plugin.promptPrefillStepSize(for: nil), 128)
+    }
+
     func testQwen3ValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
         let plugin = Qwen3Plugin()
         let requestRecorder = RequestRecorder()
@@ -409,6 +423,130 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
 
         XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
         XCTAssertFalse(plugin.isConfigured)
+    }
+}
+
+@MainActor
+final class PluginManagerLoadOrderTests: XCTestCase {
+    func testSortedPluginBundleURLsPrioritizeEnabledBundlesBeforeDisabledOnes() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let pluginsDirectory = manager.pluginsDirectory
+        try FileManager.default.createDirectory(at: pluginsDirectory, withIntermediateDirectories: true)
+
+        let disabledVoxtral = try makePluginBundle(
+            at: pluginsDirectory,
+            bundleName: "VoxtralPlugin.bundle",
+            pluginId: "com.typewhisper.voxtral",
+            pluginName: "Voxtral"
+        )
+        let enabledGemma = try makePluginBundle(
+            at: pluginsDirectory,
+            bundleName: "Gemma4Plugin.bundle",
+            pluginId: "com.typewhisper.gemma4",
+            pluginName: "Gemma 4"
+        )
+        let enabledParakeet = try makePluginBundle(
+            at: pluginsDirectory,
+            bundleName: "ParakeetPlugin.bundle",
+            pluginId: "com.typewhisper.parakeet",
+            pluginName: "Parakeet"
+        )
+
+        let voxtralKey = "plugin.com.typewhisper.voxtral.enabled"
+        let gemmaKey = "plugin.com.typewhisper.gemma4.enabled"
+        let parakeetKey = "plugin.com.typewhisper.parakeet.enabled"
+
+        let defaults = UserDefaults.standard
+        let originalVoxtral = defaults.object(forKey: voxtralKey)
+        let originalGemma = defaults.object(forKey: gemmaKey)
+        let originalParakeet = defaults.object(forKey: parakeetKey)
+        defer {
+            restore(defaults, key: voxtralKey, value: originalVoxtral)
+            restore(defaults, key: gemmaKey, value: originalGemma)
+            restore(defaults, key: parakeetKey, value: originalParakeet)
+        }
+
+        defaults.set(false, forKey: voxtralKey)
+        defaults.set(true, forKey: gemmaKey)
+        defaults.set(true, forKey: parakeetKey)
+
+        let sorted = manager.sortedPluginBundleURLs(
+            [disabledVoxtral, enabledParakeet, enabledGemma],
+            isBundledSource: false
+        )
+
+        XCTAssertEqual(
+            sorted.map(\.lastPathComponent),
+            ["Gemma4Plugin.bundle", "ParakeetPlugin.bundle", "VoxtralPlugin.bundle"]
+        )
+    }
+
+    func testScanAndLoadPluginsRegistersDisabledBundleWithoutLoadingRuntime() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let pluginsDirectory = manager.pluginsDirectory
+        try FileManager.default.createDirectory(at: pluginsDirectory, withIntermediateDirectories: true)
+
+        _ = try makePluginBundle(
+            at: pluginsDirectory,
+            bundleName: "DisabledLLMPlugin.bundle",
+            pluginId: "com.typewhisper.disabled-llm",
+            pluginName: "Disabled LLM",
+            principalClass: "MissingPluginClass",
+            category: "llm"
+        )
+
+        let enabledKey = "plugin.com.typewhisper.disabled-llm.enabled"
+        let defaults = UserDefaults.standard
+        let originalValue = defaults.object(forKey: enabledKey)
+        defer { restore(defaults, key: enabledKey, value: originalValue) }
+        defaults.set(false, forKey: enabledKey)
+
+        manager.scanAndLoadPlugins()
+
+        let plugin = try XCTUnwrap(manager.loadedPlugins.first { $0.manifest.id == "com.typewhisper.disabled-llm" })
+        XCTAssertFalse(plugin.isEnabled)
+        XCTAssertFalse(plugin.bundle.isLoaded)
+        XCTAssertEqual(plugin.manifest.category, "llm")
+    }
+
+    private func makePluginBundle(
+        at directory: URL,
+        bundleName: String,
+        pluginId: String,
+        pluginName: String,
+        sdkCompatibilityVersion: String? = PluginSDKCompatibility.currentVersion,
+        principalClass: String = "NSObject",
+        category: String? = nil
+    ) throws -> URL {
+        let bundleURL = directory.appendingPathComponent(bundleName, isDirectory: true)
+        let resourcesURL = bundleURL.appendingPathComponent("Contents/Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let manifest = PluginManifest(
+            id: pluginId,
+            name: pluginName,
+            version: "1.0.0",
+            sdkCompatibilityVersion: sdkCompatibilityVersion,
+            principalClass: principalClass,
+            category: category
+        )
+        let data = try JSONEncoder().encode(manifest)
+        try data.write(to: resourcesURL.appendingPathComponent("manifest.json"))
+        return bundleURL
+    }
+
+    private func restore(_ defaults: UserDefaults, key: String, value: Any?) {
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
     }
 }
 

--- a/TypeWhisperTests/PromptActionTemperaturePersistenceTests.swift
+++ b/TypeWhisperTests/PromptActionTemperaturePersistenceTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+final class PromptActionTemperaturePersistenceTests: XCTestCase {
+    func testAddActionDefaultsToInheritProviderSetting() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = PromptActionService(appSupportDirectory: appSupportDirectory)
+        service.addAction(
+            name: "Rewrite",
+            prompt: "Rewrite this text."
+        )
+
+        let action = try XCTUnwrap(service.promptActions.first)
+        XCTAssertEqual(action.temperatureModeRaw, "inheritProviderSetting")
+        XCTAssertNil(action.temperatureValue)
+    }
+
+    func testCustomTemperaturePersistsAcrossReload() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = PromptActionService(appSupportDirectory: appSupportDirectory)
+        service.addAction(
+            name: "Creative",
+            prompt: "Rewrite creatively.",
+            temperatureModeRaw: "custom",
+            temperatureValue: 0.9
+        )
+
+        let reloaded = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let action = try XCTUnwrap(reloaded.promptActions.first)
+        XCTAssertEqual(action.temperatureModeRaw, "custom")
+        XCTAssertEqual(action.temperatureValue, 0.9)
+    }
+
+    func testImportedPresetKeepsRecommendedTemperature() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let preset = try XCTUnwrap(PromptAction.presets.first { $0.name == String(localized: "preset.translate") })
+
+        service.addPreset(preset)
+
+        let action = try XCTUnwrap(service.promptActions.first)
+        XCTAssertEqual(action.temperatureModeRaw, "custom")
+        XCTAssertEqual(action.temperatureValue, 0.0)
+    }
+}


### PR DESCRIPTION
## Summary
- add prompt-level temperature controls for prompt actions/custom rules with provider fallback semantics
- extend supported prompt-processing providers, including remote providers and Gemma 4, while keeping legacy plugin compatibility
- stop loading disabled plugin runtimes during scan so disabled local MLX bundles do not interfere with active providers

## Issue Context
Issue #352 asked for per-rule temperature overrides for Groq custom rules so users can choose deterministic behavior for cleanup-style rules and more variation for creative rewrite flows. This change implements that behavior at the prompt-action level and keeps provider-level temperature settings as the fallback.

## What Changed
- added shared SDK temperature types and an optional temperature-aware provider protocol
- persisted temperature mode and value on `PromptAction`
- added prompt editor UI for `Use my provider setting`, `Use provider default`, and `Set for this prompt`
- propagated temperature directives through prompt processing to Groq, OpenAI-compatible providers, Claude, OpenAI, and Gemma 4
- added preset-specific recommended temperatures for built-in prompt templates
- changed plugin scanning/loading so disabled bundles are registered as placeholders without loading their runtime code

Closes #352

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh Gemma4Plugin /Users/marco/.t3/worktrees/typewhisper-mac/t3code-51553d69`
