### PR TITLE
feat: redesign prompt settings and adopt native sidebar

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */; };
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
+		1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */; };
+		1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */; };
+		1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
@@ -121,6 +124,7 @@
 		AA00000000000000000113 /* FoundationModelsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000113 /* FoundationModelsProvider.swift */; };
 		AA00000000000000000115 /* PromptProcessingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000115 /* PromptProcessingService.swift */; };
 		AA00000000000000000116 /* PromptActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000116 /* PromptActionsViewModel.swift */; };
+		AA00000000000000000315 /* PromptWizardSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000314 /* PromptWizardSupport.swift */; };
 		AA00000000000000000117 /* PromptActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000117 /* PromptActionsSettingsView.swift */; };
 		AA00000000000000000118 /* PromptPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000118 /* PromptPalettePanel.swift */; };
 		AA00000000000000000119 /* UserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000119 /* UserDefaultsKeys.swift */; };
@@ -466,6 +470,7 @@
 		BB00000000000000000113 /* FoundationModelsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelsProvider.swift; sourceTree = "<group>"; };
 		BB00000000000000000115 /* PromptProcessingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptProcessingService.swift; sourceTree = "<group>"; };
 		BB00000000000000000116 /* PromptActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptActionsViewModel.swift; sourceTree = "<group>"; };
+		BB00000000000000000314 /* PromptWizardSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptWizardSupport.swift; sourceTree = "<group>"; };
 		BB00000000000000000117 /* PromptActionsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptActionsSettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000118 /* PromptPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPalettePanel.swift; sourceTree = "<group>"; };
 		BB00000000000000000119 /* UserDefaultsKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKeys.swift; sourceTree = "<group>"; };
@@ -612,6 +617,9 @@
 		E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRouterAndHandlersTests.swift; sourceTree = "<group>"; };
 		E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TypeWhisperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationViewModelIndicatorSettingsTests.swift; sourceTree = "<group>"; };
+		2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardComposerTests.swift; sourceTree = "<group>"; };
+		2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardInferenceServiceTests.swift; sourceTree = "<group>"; };
+		2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionsViewModelWizardTests.swift; sourceTree = "<group>"; };
 		91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginRegistryServiceTests.swift; sourceTree = "<group>"; };
 		91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingHandlerTests.swift; sourceTree = "<group>"; };
 		E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayout.swift; sourceTree = "<group>"; };
@@ -1158,6 +1166,7 @@
 				BB00000000000000000084 /* SnippetsViewModel.swift */,
 				BB00000000000000000090 /* HomeViewModel.swift */,
 				BB00000000000000000116 /* PromptActionsViewModel.swift */,
+				BB00000000000000000314 /* PromptWizardSupport.swift */,
 				BB00000000000000000171 /* DictationEnums.swift */,
 				BB00000000000000000172 /* StreamingHandler.swift */,
 				BB00000000000000000173 /* PromptPaletteHandler.swift */,
@@ -1705,6 +1714,9 @@
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */,
+				2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */,
+				2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */,
+				2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */,
 				F41BD305007A3A158038C75C /* ProfileServiceTests.swift */,
 				B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */,
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
@@ -2888,6 +2900,9 @@
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */,
+				1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */,
+				1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */,
+				1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
 				A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,
@@ -2989,6 +3004,7 @@
 				AA00000000000000000113 /* FoundationModelsProvider.swift in Sources */,
 				AA00000000000000000115 /* PromptProcessingService.swift in Sources */,
 				AA00000000000000000116 /* PromptActionsViewModel.swift in Sources */,
+				AA00000000000000000315 /* PromptWizardSupport.swift in Sources */,
 				AA00000000000000000117 /* PromptActionsSettingsView.swift in Sources */,
 				AA00000000000000000118 /* PromptPalettePanel.swift in Sources */,
 				AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */,

--- a/TypeWhisper/Services/PromptActionService.swift
+++ b/TypeWhisper/Services/PromptActionService.swift
@@ -131,6 +131,7 @@ class PromptActionService: ObservableObject {
         name: String,
         prompt: String,
         icon: String = "sparkles",
+        isEnabled: Bool = true,
         providerType: String? = nil,
         cloudModel: String? = nil,
         temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
@@ -144,6 +145,7 @@ class PromptActionService: ObservableObject {
             name: name,
             prompt: prompt,
             icon: icon,
+            isEnabled: isEnabled,
             sortOrder: maxOrder + 1,
             providerType: providerType,
             cloudModel: cloudModel,
@@ -167,6 +169,7 @@ class PromptActionService: ObservableObject {
         name: String,
         prompt: String,
         icon: String,
+        isEnabled: Bool = true,
         providerType: String? = nil,
         cloudModel: String? = nil,
         temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
@@ -178,6 +181,7 @@ class PromptActionService: ObservableObject {
         action.name = name
         action.prompt = prompt
         action.icon = icon
+        action.isEnabled = isEnabled
         action.providerType = providerType
         action.cloudModel = cloudModel
         action.temperatureModeRaw = temperatureModeRaw

--- a/TypeWhisper/ViewModels/PromptActionsViewModel.swift
+++ b/TypeWhisper/ViewModels/PromptActionsViewModel.swift
@@ -19,22 +19,39 @@ class PromptActionsViewModel: ObservableObject {
     // Editor state
     @Published var isEditing = false
     @Published var isCreatingNew = false
+    @Published var isEditingExistingPrompt = false
     @Published var editName = ""
     @Published var editPrompt = ""
     @Published var editIcon = "sparkles"
+    @Published var editIsEnabled = true
     @Published var editProviderId: String?
     @Published var editCloudModel = ""
     @Published var editTemperatureMode: PluginLLMTemperatureMode = .inheritProviderSetting
     @Published var editTemperatureValue: Double = 0.3
     @Published var editTargetActionPluginId: String?
+    @Published var wizardStep: PromptWizardStep = .goal
+    @Published var wizardDraft = PromptWizardDraft(goal: .custom)
+    @Published var manualPromptOverride = false
 
     private let promptActionService: PromptActionService
     var promptProcessingService: PromptProcessingService
     private var cancellables = Set<AnyCancellable>()
     private var selectedAction: PromptAction?
+    private var editNameManuallyEdited = false
 
     var enabledCount: Int { promptActionService.getEnabledActions().count }
     var totalCount: Int { promptActions.count }
+    var suggestedPromptName: String { PromptWizardNameSuggester.suggestedName(for: wizardDraft) }
+    var currentPromptName: String {
+        let trimmed = editName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if editNameManuallyEdited, !trimmed.isEmpty {
+            return trimmed
+        }
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+        return suggestedPromptName
+    }
 
     init(promptActionService: PromptActionService, promptProcessingService: PromptProcessingService) {
         self.promptActionService = promptActionService
@@ -58,38 +75,49 @@ class PromptActionsViewModel: ObservableObject {
     func startCreating() {
         selectedAction = nil
         isCreatingNew = true
+        isEditingExistingPrompt = false
         isEditing = true
-        editName = ""
-        editPrompt = ""
-        editIcon = "sparkles"
-        editProviderId = nil
-        editCloudModel = ""
-        editTemperatureMode = .inheritProviderSetting
-        editTemperatureValue = defaultTemperatureValue(for: promptProcessingService.selectedProviderId)
-        editTargetActionPluginId = nil
+        wizardStep = .goal
+        manualPromptOverride = false
+        editNameManuallyEdited = false
+        wizardDraft = PromptWizardDraft(goal: .custom)
+        wizardDraft.temperatureValue = defaultTemperatureValue(for: promptProcessingService.selectedProviderId)
+        syncEditorFieldsFromWizardDraft(resetName: true)
+        regeneratePromptFromWizardSelections()
     }
 
     func startEditing(_ action: PromptAction) {
         selectedAction = action
         isCreatingNew = false
+        isEditingExistingPrompt = true
         isEditing = true
+        wizardStep = .goal
+        manualPromptOverride = false
+        editNameManuallyEdited = true
+        wizardDraft = PromptWizardInferenceService.infer(from: action)
+        if let temperatureValue = action.temperatureValue {
+            wizardDraft.temperatureValue = temperatureValue
+        } else {
+            wizardDraft.temperatureValue = defaultTemperatureValue(for: action.providerType ?? promptProcessingService.selectedProviderId)
+        }
+        syncEditorFieldsFromWizardDraft(resetName: false)
         editName = action.name
         editPrompt = action.prompt
-        editIcon = action.icon
-        editProviderId = action.providerType
-        editCloudModel = action.cloudModel ?? ""
-        editTemperatureMode = action.temperatureMode
-        editTemperatureValue = action.temperatureValue ?? defaultTemperatureValue(for: action.providerType ?? promptProcessingService.selectedProviderId)
-        editTargetActionPluginId = action.targetActionPluginId
     }
 
     func cancelEditing() {
         isEditing = false
         isCreatingNew = false
+        isEditingExistingPrompt = false
         selectedAction = nil
+        wizardStep = .goal
+        wizardDraft = PromptWizardDraft(goal: .custom)
+        manualPromptOverride = false
+        editNameManuallyEdited = false
         editName = ""
         editPrompt = ""
         editIcon = "sparkles"
+        editIsEnabled = true
         editProviderId = nil
         editCloudModel = ""
         editTemperatureMode = .inheritProviderSetting
@@ -98,16 +126,22 @@ class PromptActionsViewModel: ObservableObject {
     }
 
     func saveEditing() {
-        guard !editName.isEmpty, !editPrompt.isEmpty else {
+        let resolvedName = currentPromptName
+        guard !resolvedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, !editPrompt.isEmpty else {
             error = String(localized: "Name and prompt cannot be empty")
             return
         }
 
+        if !manualPromptOverride {
+            regeneratePromptFromWizardSelections()
+        }
+
         if isCreatingNew {
             promptActionService.addAction(
-                name: editName,
+                name: resolvedName,
                 prompt: editPrompt,
                 icon: editIcon,
+                isEnabled: editIsEnabled,
                 providerType: editProviderId,
                 cloudModel: editCloudModel.isEmpty ? nil : editCloudModel,
                 temperatureModeRaw: editTemperatureMode.rawValue,
@@ -117,9 +151,10 @@ class PromptActionsViewModel: ObservableObject {
         } else if let action = selectedAction {
             promptActionService.updateAction(
                 action,
-                name: editName,
+                name: resolvedName,
                 prompt: editPrompt,
                 icon: editIcon,
+                isEnabled: editIsEnabled,
                 providerType: editProviderId,
                 cloudModel: editCloudModel.isEmpty ? nil : editCloudModel,
                 temperatureModeRaw: editTemperatureMode.rawValue,
@@ -159,6 +194,165 @@ class PromptActionsViewModel: ObservableObject {
         error = nil
     }
 
+    func setWizardGoal(_ goal: PromptWizardGoal) {
+        let previousIcon = wizardDraft.goal.defaultIcon
+        wizardDraft.goal = goal
+        if editIcon == previousIcon || editIcon.isEmpty {
+            wizardDraft.icon = goal.defaultIcon
+        } else {
+            wizardDraft.icon = editIcon
+        }
+
+        switch goal {
+        case .translate:
+            if wizardDraft.translationMode == nil {
+                wizardDraft.translationMode = .alternatingPair(primaryLanguage: "en", secondaryLanguage: "de")
+            }
+        case .extract:
+            wizardDraft.extractFormat = .checklist
+        case .replyEmail:
+            wizardDraft.replyMode = .reply
+        case .structure:
+            wizardDraft.structureFormat = .bulletList
+        case .rewrite, .custom:
+            break
+        }
+
+        syncEditorFieldsFromWizardDraft(resetName: false)
+        if !manualPromptOverride {
+            regeneratePromptFromWizardSelections()
+        }
+    }
+
+    func starterPresets(for goal: PromptWizardGoal) -> [PromptAction] {
+        PromptAction.presets.filter { preset in
+            PromptWizardInferenceService.infer(from: preset).goal == goal
+        }
+    }
+
+    func applyPresetStarter(_ preset: PromptAction) {
+        manualPromptOverride = false
+        editNameManuallyEdited = false
+        wizardDraft = PromptWizardInferenceService.infer(from: preset)
+        if wizardDraft.temperatureValue == nil {
+            wizardDraft.temperatureValue = defaultTemperatureValue(for: wizardDraft.providerId ?? promptProcessingService.selectedProviderId)
+        }
+        syncEditorFieldsFromWizardDraft(resetName: true)
+        editPrompt = preset.prompt
+    }
+
+    func updateWizardDraft(_ mutate: (inout PromptWizardDraft) -> Void) {
+        mutate(&wizardDraft)
+        syncEditorFieldsFromWizardDraft(resetName: false)
+        if !manualPromptOverride {
+            regeneratePromptFromWizardSelections()
+        }
+    }
+
+    func updateWizardName(_ name: String) {
+        editName = name
+        editNameManuallyEdited = true
+    }
+
+    func setWizardIcon(_ icon: String) {
+        wizardDraft.icon = icon
+        editIcon = icon
+    }
+
+    func setWizardEnabled(_ isEnabled: Bool) {
+        wizardDraft.isEnabled = isEnabled
+        editIsEnabled = isEnabled
+    }
+
+    func setWizardProviderOverride(_ providerId: String?) {
+        updateWizardDraft { draft in
+            draft.providerId = providerId
+
+            if let providerId {
+                let models = promptProcessingService.modelsForProvider(providerId)
+                if !draft.cloudModel.isEmpty, models.contains(where: { $0.id == draft.cloudModel }) {
+                    draft.cloudModel = draft.cloudModel
+                } else {
+                    draft.cloudModel = models.first?.id ?? ""
+                }
+            } else {
+                draft.cloudModel = ""
+            }
+
+            let effectiveProviderId = providerId ?? promptProcessingService.selectedProviderId
+            let defaultValue = defaultTemperatureValue(for: effectiveProviderId)
+            let range = supportedTemperatureRange(for: effectiveProviderId)
+            let currentValue = draft.temperatureValue ?? defaultValue
+            draft.temperatureValue = min(max(currentValue, range.lowerBound), range.upperBound)
+        }
+    }
+
+    func setWizardCloudModel(_ cloudModel: String) {
+        updateWizardDraft { draft in
+            draft.cloudModel = cloudModel
+        }
+    }
+
+    func setWizardTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        updateWizardDraft { draft in
+            draft.temperatureMode = mode
+
+            let effectiveProviderId = draft.providerId ?? promptProcessingService.selectedProviderId
+            let defaultValue = defaultTemperatureValue(for: effectiveProviderId)
+            let range = supportedTemperatureRange(for: effectiveProviderId)
+            let currentValue = draft.temperatureValue ?? defaultValue
+            draft.temperatureValue = min(max(currentValue, range.lowerBound), range.upperBound)
+        }
+    }
+
+    func setWizardTemperatureValue(_ value: Double) {
+        updateWizardDraft { draft in
+            let effectiveProviderId = draft.providerId ?? promptProcessingService.selectedProviderId
+            let range = supportedTemperatureRange(for: effectiveProviderId)
+            draft.temperatureValue = min(max(value, range.lowerBound), range.upperBound)
+        }
+    }
+
+    func setWizardTargetActionPluginId(_ pluginId: String?) {
+        wizardDraft.targetActionPluginId = pluginId
+        editTargetActionPluginId = pluginId
+    }
+
+    func updateManualPrompt(_ prompt: String) {
+        manualPromptOverride = true
+        editPrompt = prompt
+    }
+
+    func regeneratePromptFromWizardSelections() {
+        manualPromptOverride = false
+        editPrompt = PromptWizardComposer.compose(from: wizardDraft)
+    }
+
+    func goToNextWizardStep() {
+        guard let next = PromptWizardStep(rawValue: wizardStep.rawValue + 1) else { return }
+        wizardStep = next
+    }
+
+    func goToPreviousWizardStep() {
+        guard let previous = PromptWizardStep(rawValue: wizardStep.rawValue - 1) else { return }
+        wizardStep = previous
+    }
+
+    var canAdvanceFromCurrentWizardStep: Bool {
+        switch wizardStep {
+        case .goal:
+            return true
+        case .response:
+            if wizardDraft.goal == .custom {
+                return !wizardDraft.customGoal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            return true
+        case .review:
+            return !currentPromptName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !editPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
     func clampTemperatureValueForEffectiveProvider() {
         let range = supportedTemperatureRange(
             for: editProviderId ?? promptProcessingService.selectedProviderId
@@ -175,5 +369,18 @@ class PromptActionsViewModel: ObservableObject {
 
     func defaultTemperatureValue(for providerId: String?) -> Double {
         providerId == "Gemma 4 (MLX)" ? 0.1 : 0.3
+    }
+
+    private func syncEditorFieldsFromWizardDraft(resetName: Bool) {
+        if resetName || editName.isEmpty {
+            editName = wizardDraft.name
+        }
+        editIcon = wizardDraft.icon
+        editIsEnabled = wizardDraft.isEnabled
+        editProviderId = wizardDraft.providerId
+        editCloudModel = wizardDraft.cloudModel
+        editTemperatureMode = wizardDraft.temperatureMode
+        editTemperatureValue = wizardDraft.temperatureValue ?? defaultTemperatureValue(for: wizardDraft.providerId ?? promptProcessingService.selectedProviderId)
+        editTargetActionPluginId = wizardDraft.targetActionPluginId
     }
 }

--- a/TypeWhisper/ViewModels/PromptWizardSupport.swift
+++ b/TypeWhisper/ViewModels/PromptWizardSupport.swift
@@ -1,0 +1,697 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+enum PromptWizardStep: Int, CaseIterable {
+    case goal
+    case response
+    case review
+}
+
+enum PromptWizardGoal: String, CaseIterable, Equatable {
+    case translate
+    case rewrite
+    case replyEmail
+    case extract
+    case structure
+    case custom
+}
+
+enum PromptWizardTranslationMode: Equatable {
+    case direct(targetLanguage: String)
+    case alternatingPair(primaryLanguage: String, secondaryLanguage: String)
+}
+
+enum PromptWizardTone: String, CaseIterable, Equatable {
+    case neutral
+    case formal
+    case friendly
+    case concise
+    case clear
+    case professional
+}
+
+enum PromptWizardResponseLength: String, CaseIterable, Equatable {
+    case short
+    case medium
+    case detailed
+}
+
+enum PromptWizardLanguageMode: Equatable {
+    case sameAsInput
+    case target(String)
+}
+
+enum PromptWizardReplyMode: String, CaseIterable, Equatable {
+    case reply
+    case email
+}
+
+enum PromptWizardExtractFormat: String, CaseIterable, Equatable {
+    case checklist
+    case json
+    case table
+    case keyPoints
+}
+
+enum PromptWizardStructureFormat: String, CaseIterable, Equatable {
+    case bulletList
+    case meetingNotes
+    case table
+    case json
+}
+
+enum PromptWizardRewriteFormat: String, CaseIterable, Equatable {
+    case paragraph
+    case list
+}
+
+struct PromptWizardDraft: Equatable {
+    var goal: PromptWizardGoal
+    var name: String
+    var icon: String
+    var isEnabled: Bool
+    var translationMode: PromptWizardTranslationMode?
+    var preserveFormatting: Bool
+    var tone: PromptWizardTone
+    var responseLength: PromptWizardResponseLength
+    var languageMode: PromptWizardLanguageMode
+    var replyMode: PromptWizardReplyMode
+    var extractFormat: PromptWizardExtractFormat
+    var structureFormat: PromptWizardStructureFormat
+    var rewriteFormat: PromptWizardRewriteFormat
+    var includeHeadings: Bool
+    var customGoal: String
+    var customOutputHint: String
+    var providerId: String?
+    var cloudModel: String
+    var temperatureMode: PluginLLMTemperatureMode
+    var temperatureValue: Double?
+    var targetActionPluginId: String?
+
+    init(goal: PromptWizardGoal) {
+        self.goal = goal
+        self.name = ""
+        self.icon = goal.defaultIcon
+        self.isEnabled = true
+        self.translationMode = nil
+        self.preserveFormatting = false
+        self.tone = .neutral
+        self.responseLength = .medium
+        self.languageMode = .sameAsInput
+        self.replyMode = .reply
+        self.extractFormat = .checklist
+        self.structureFormat = .bulletList
+        self.rewriteFormat = .paragraph
+        self.includeHeadings = true
+        self.customGoal = ""
+        self.customOutputHint = ""
+        self.providerId = nil
+        self.cloudModel = ""
+        self.temperatureMode = .inheritProviderSetting
+        self.temperatureValue = nil
+        self.targetActionPluginId = nil
+    }
+}
+
+extension PromptWizardGoal {
+    var defaultIcon: String {
+        switch self {
+        case .translate:
+            return "globe"
+        case .rewrite:
+            return "wand.and.stars"
+        case .replyEmail:
+            return "arrowshape.turn.up.left"
+        case .extract:
+            return "checklist"
+        case .structure:
+            return "list.bullet"
+        case .custom:
+            return "sparkles"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .translate:
+            return localizedAppText("Translate", de: "Übersetzen")
+        case .rewrite:
+            return localizedAppText("Rewrite", de: "Umschreiben")
+        case .replyEmail:
+            return localizedAppText("Reply / Email", de: "Antwort / E-Mail")
+        case .extract:
+            return localizedAppText("Extract", de: "Extrahieren")
+        case .structure:
+            return localizedAppText("Structure / Format", de: "Struktur / Format")
+        case .custom:
+            return localizedAppText("Custom", de: "Benutzerdefiniert")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .translate:
+            return localizedAppText("Translate text into one language or toggle between a pair.", de: "Text in eine Sprache übersetzen oder zwischen einem Sprachpaar wechseln.")
+        case .rewrite:
+            return localizedAppText("Improve wording, tone, and readability without changing the meaning.", de: "Formulierung, Ton und Lesbarkeit verbessern, ohne die Bedeutung zu ändern.")
+        case .replyEmail:
+            return localizedAppText("Draft a reply or a full email from the input.", de: "Aus dem Input eine Antwort oder vollständige E-Mail erstellen.")
+        case .extract:
+            return localizedAppText("Pull out action items, JSON, tables, or key facts.", de: "Action Items, JSON, Tabellen oder Kerndaten herausziehen.")
+        case .structure:
+            return localizedAppText("Reformat text into lists, meeting notes, tables, or JSON.", de: "Text in Listen, Meeting Notes, Tabellen oder JSON umformatieren.")
+        case .custom:
+            return localizedAppText("Describe your own task and let the wizard scaffold the prompt.", de: "Beschreibe deine eigene Aufgabe und lass den Wizard den Prompt vorbereiten.")
+        }
+    }
+
+    var example: String {
+        switch self {
+        case .translate:
+            return localizedAppText("Example: EN <-> DE translation with formatting preserved.", de: "Beispiel: EN <-> DE Übersetzung mit erhaltener Formatierung.")
+        case .rewrite:
+            return localizedAppText("Example: make rough notes sound concise and clear.", de: "Beispiel: rohe Notizen knapp und klar formulieren.")
+        case .replyEmail:
+            return localizedAppText("Example: write a friendly short reply to an incoming message.", de: "Beispiel: eine kurze freundliche Antwort auf eine Nachricht formulieren.")
+        case .extract:
+            return localizedAppText("Example: extract JSON payloads or action items from meeting notes.", de: "Beispiel: JSON-Daten oder Action Items aus Meeting Notes extrahieren.")
+        case .structure:
+            return localizedAppText("Example: turn raw notes into meeting notes or a table.", de: "Beispiel: rohe Notizen in Meeting Notes oder eine Tabelle umwandeln.")
+        case .custom:
+            return localizedAppText("Example: summarize bugs for Slack in a strict bullet format.", de: "Beispiel: Bugs für Slack in einem strikten Bullet-Format zusammenfassen.")
+        }
+    }
+}
+
+extension PromptWizardGoal {
+    var tintName: String {
+        switch self {
+        case .translate: return "blue"
+        case .rewrite: return "purple"
+        case .replyEmail: return "green"
+        case .extract: return "orange"
+        case .structure: return "teal"
+        case .custom: return "accent"
+        }
+    }
+
+    var promptWizardGoalSummary: String {
+        switch self {
+        case .translate:
+            return localizedAppText("Translate text into one target language or switch between a language pair.", de: "Übersetze Text in eine Zielsprache oder wechsle zwischen einem Sprachpaar.")
+        case .rewrite:
+            return localizedAppText("Improve wording and tone while keeping the original meaning intact.", de: "Verbessere Formulierung und Ton, ohne die ursprüngliche Bedeutung zu verändern.")
+        case .replyEmail:
+            return localizedAppText("Draft a reply or complete email from the incoming text.", de: "Erstelle aus dem eingehenden Text eine Antwort oder vollständige E-Mail.")
+        case .extract:
+            return localizedAppText("Pull structured output like JSON, tables, action items, or key facts from the input.", de: "Ziehe strukturierte Ausgaben wie JSON, Tabellen, Action Items oder Kernfakten aus dem Input.")
+        case .structure:
+            return localizedAppText("Reformat loose input into a reliable structure such as lists, meeting notes, tables, or JSON.", de: "Forme losen Input in eine verlässliche Struktur wie Listen, Meeting Notes, Tabellen oder JSON um.")
+        case .custom:
+            return localizedAppText("Describe your own task and let the wizard scaffold the prompt for you.", de: "Beschreibe deine eigene Aufgabe und lass den Wizard den Prompt für dich vorbereiten.")
+        }
+    }
+}
+
+extension PromptWizardStep {
+    var title: String {
+        switch self {
+        case .goal:
+            return localizedAppText("What should it do?", de: "Was soll es tun?")
+        case .response:
+            return localizedAppText("How should it respond?", de: "Wie soll es antworten?")
+        case .review:
+            return localizedAppText("Review & Advanced", de: "Review & Erweitert")
+        }
+    }
+}
+
+extension PromptWizardTranslationMode {
+    var primaryLanguage: String? {
+        switch self {
+        case .direct(let targetLanguage):
+            return targetLanguage
+        case .alternatingPair(let primaryLanguage, _):
+            return primaryLanguage
+        }
+    }
+
+    var secondaryLanguage: String? {
+        switch self {
+        case .direct:
+            return nil
+        case .alternatingPair(_, let secondaryLanguage):
+            return secondaryLanguage
+        }
+    }
+}
+
+extension PromptWizardLanguageMode {
+    var targetLanguageCode: String? {
+        switch self {
+        case .sameAsInput:
+            return nil
+        case .target(let language):
+            return language
+        }
+    }
+}
+
+enum PromptWizardComposer {
+    static func compose(from draft: PromptWizardDraft) -> String {
+        switch draft.goal {
+        case .translate:
+            return composeTranslatePrompt(from: draft)
+        case .rewrite:
+            return composeRewritePrompt(from: draft)
+        case .replyEmail:
+            return composeReplyPrompt(from: draft)
+        case .extract:
+            return composeExtractPrompt(from: draft)
+        case .structure:
+            return composeStructurePrompt(from: draft)
+        case .custom:
+            return composeCustomPrompt(from: draft)
+        }
+    }
+
+    static func reviewSummary(for draft: PromptWizardDraft) -> String {
+        switch draft.goal {
+        case .translate:
+            return translateSummary(for: draft)
+        case .rewrite:
+            return rewriteSummary(for: draft)
+        case .replyEmail:
+            return replySummary(for: draft)
+        case .extract:
+            return extractSummary(for: draft)
+        case .structure:
+            return structureSummary(for: draft)
+        case .custom:
+            return customSummary(for: draft)
+        }
+    }
+
+    private static func composeTranslatePrompt(from draft: PromptWizardDraft) -> String {
+        var parts: [String] = []
+
+        switch draft.translationMode {
+        case .alternatingPair(let primary, let secondary):
+            parts.append("Translate the following text to \(languageName(for: primary)).")
+            parts.append("If it's already in \(languageName(for: primary)), translate it to \(languageName(for: secondary)).")
+        case .direct(let targetLanguage):
+            parts.append("Translate the following text to \(languageName(for: targetLanguage)).")
+        case nil:
+            parts.append("Translate the following text.")
+        }
+
+        if draft.preserveFormatting {
+            parts.append("Preserve the original formatting when possible.")
+        }
+
+        parts.append("Only return the translation, nothing else.")
+        return parts.joined(separator: " ")
+    }
+
+    private static func composeRewritePrompt(from draft: PromptWizardDraft) -> String {
+        var parts = ["Rewrite the following text"]
+
+        if draft.tone != .neutral {
+            parts[0] += " in a \(draft.tone.rawValue) tone"
+        }
+
+        switch draft.languageMode {
+        case .sameAsInput:
+            parts.append("Respond in the same language as the input text.")
+        case .target(let language):
+            parts.append("Respond in \(languageName(for: language)).")
+        }
+
+        switch draft.rewriteFormat {
+        case .paragraph:
+            parts.append("Return a polished paragraph.")
+        case .list:
+            parts.append("Return a clean bullet-point list.")
+        }
+
+        parts.append("Only return the rewritten text.")
+        return parts.joined(separator: " ")
+    }
+
+    private static func composeReplyPrompt(from draft: PromptWizardDraft) -> String {
+        let noun = draft.replyMode == .email ? "email" : "reply"
+        let length = lengthDescriptor(for: draft.responseLength)
+        let tone = draft.tone == .neutral ? "" : "\(draft.tone.rawValue), "
+        var parts = ["Write a \(length)\(tone)\(noun) to the following message."]
+
+        switch draft.languageMode {
+        case .sameAsInput:
+            parts.append("Respond in the same language as the input text.")
+        case .target(let language):
+            parts.append("Respond in \(languageName(for: language)).")
+        }
+
+        if draft.replyMode == .email {
+            parts.append("Only return the email text.")
+        } else {
+            parts.append("Only return the reply.")
+        }
+
+        return parts.joined(separator: " ")
+    }
+
+    private static func composeExtractPrompt(from draft: PromptWizardDraft) -> String {
+        switch draft.extractFormat {
+        case .checklist:
+            return "Extract all action items, tasks, and to-dos from the following text. Format them as a checklist. Only return the checklist."
+        case .json:
+            return "Extract structured data from the following text and format it as valid, well-indented JSON. Use descriptive keys and appropriate data types. Only return the JSON, nothing else."
+        case .table:
+            return "Extract key information from the following text and format it as a well-structured Markdown table. Only return the table, nothing else."
+        case .keyPoints:
+            return "Extract the key points from the following text and return them as a concise bullet-point list. Only return the key points."
+        }
+    }
+
+    private static func composeStructurePrompt(from draft: PromptWizardDraft) -> String {
+        switch draft.structureFormat {
+        case .bulletList:
+            if draft.includeHeadings {
+                return "Format the following text as a clean bullet-point list with short section headings where helpful. Respond in the same language as the input text. Only return the formatted list."
+            }
+            return "Format the following text as a clean bullet-point list. Respond in the same language as the input text. Only return the formatted list."
+        case .meetingNotes:
+            return "Structure the following text as professional meeting notes. Include sections for: Attendees (if mentioned), Key Discussion Points, Decisions Made, and Action Items with owners. Use Markdown formatting. Respond in the same language as the input text."
+        case .table:
+            if draft.includeHeadings {
+                return "Convert the following text into a well-formatted Markdown table. Add a short heading if it improves readability. Extract key information and organize it into appropriate columns. Respond in the same language as the input text. Only return the table, nothing else."
+            }
+            return "Convert the following text into a well-formatted Markdown table. Extract key information and organize it into appropriate columns. Respond in the same language as the input text. Only return the table, nothing else."
+        case .json:
+            if draft.includeHeadings {
+                return "Structure the following text as valid, well-indented JSON. Use descriptive top-level keys and preserve the original meaning. Only return the JSON."
+            }
+            return "Structure the following text as valid, well-indented JSON. Use descriptive keys and preserve the original meaning. Only return the JSON."
+        }
+    }
+
+    private static func composeCustomPrompt(from draft: PromptWizardDraft) -> String {
+        let trimmedGoal = draft.customGoal.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedGoal.isEmpty {
+            return "Help with the following text. Only return the final result."
+        }
+
+        var parts = ["\(trimmedGoal)."]
+        if draft.tone != .neutral {
+            parts.append("Use a \(draft.tone.rawValue) tone.")
+        }
+        switch draft.languageMode {
+        case .sameAsInput:
+            parts.append("Respond in the same language as the input text.")
+        case .target(let language):
+            parts.append("Respond in \(languageName(for: language)).")
+        }
+        let outputHint = draft.customOutputHint.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !outputHint.isEmpty {
+            parts.append(outputHint.hasSuffix(".") ? outputHint : outputHint + ".")
+        }
+        parts.append("Only return the final result.")
+        return parts.joined(separator: " ")
+    }
+
+    private static func translateSummary(for draft: PromptWizardDraft) -> String {
+        switch draft.translationMode {
+        case .alternatingPair(let primary, let secondary):
+            return "Translate between \(languageName(for: primary)) and \(languageName(for: secondary))."
+        case .direct(let targetLanguage):
+            return "Translate into \(languageName(for: targetLanguage))."
+        case nil:
+            return "Translate the input text."
+        }
+    }
+
+    private static func rewriteSummary(for draft: PromptWizardDraft) -> String {
+        let tone = draft.tone == .neutral ? "clear" : draft.tone.rawValue
+        return "Rewrite the text in a \(tone) tone."
+    }
+
+    private static func replySummary(for draft: PromptWizardDraft) -> String {
+        let length = lengthDescriptor(for: draft.responseLength)
+        let tone = draft.tone == .neutral ? "clear" : draft.tone.rawValue
+        let noun = draft.replyMode == .email ? "email" : "reply"
+        let language = languageSummary(for: draft.languageMode)
+        return "Write a \(length), \(tone) \(noun) \(language)."
+    }
+
+    private static func extractSummary(for draft: PromptWizardDraft) -> String {
+        switch draft.extractFormat {
+        case .checklist:
+            return "Extract action items as a checklist."
+        case .json:
+            return "Extract structured data as JSON."
+        case .table:
+            return "Extract key information as a table."
+        case .keyPoints:
+            return "Extract the key points as a list."
+        }
+    }
+
+    private static func structureSummary(for draft: PromptWizardDraft) -> String {
+        switch draft.structureFormat {
+        case .bulletList:
+            return "Format the input as a bullet list."
+        case .meetingNotes:
+            return "Format the input as meeting notes."
+        case .table:
+            return "Format the input as a table."
+        case .json:
+            return "Format the input as JSON."
+        }
+    }
+
+    private static func customSummary(for draft: PromptWizardDraft) -> String {
+        let trimmedGoal = draft.customGoal.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedGoal.isEmpty ? "Custom prompt." : trimmedGoal + "."
+    }
+
+    private static func lengthDescriptor(for length: PromptWizardResponseLength) -> String {
+        switch length {
+        case .short:
+            return "short"
+        case .medium:
+            return "balanced"
+        case .detailed:
+            return "detailed"
+        }
+    }
+
+    private static func languageSummary(for mode: PromptWizardLanguageMode) -> String {
+        switch mode {
+        case .sameAsInput:
+            return "in the same language as the input"
+        case .target(let language):
+            return "in \(languageName(for: language))"
+        }
+    }
+
+    static func languageNameForDisplay(_ code: String) -> String {
+        switch code.lowercased() {
+        case "en", "english":
+            return "English"
+        case "de", "german":
+            return "German"
+        default:
+            return code
+        }
+    }
+
+    private static func languageName(for code: String) -> String {
+        languageNameForDisplay(code)
+    }
+}
+
+enum PromptWizardInferenceService {
+    static func infer(from action: PromptAction) -> PromptWizardDraft {
+        let prompt = action.prompt.lowercased()
+        let goal = inferGoal(from: prompt)
+        var draft = PromptWizardDraft(goal: goal)
+        draft.name = action.name
+        draft.icon = action.icon
+        draft.isEnabled = action.isEnabled
+        draft.providerId = action.providerType
+        draft.cloudModel = action.cloudModel ?? ""
+        draft.temperatureMode = action.temperatureMode
+        draft.temperatureValue = action.temperatureValue
+        draft.targetActionPluginId = action.targetActionPluginId
+
+        if prompt.contains("translate") {
+            if prompt.contains("to english"), prompt.contains("to german") {
+                draft.translationMode = .alternatingPair(primaryLanguage: "en", secondaryLanguage: "de")
+            } else if let targetLanguage = firstMatchedLanguage(in: prompt) {
+                draft.translationMode = .direct(targetLanguage: targetLanguage)
+            }
+            draft.preserveFormatting = prompt.contains("preserve the original formatting")
+        }
+
+        if prompt.contains("same language as the input") {
+            draft.languageMode = .sameAsInput
+        } else if let targetLanguage = firstMatchedLanguage(in: prompt) {
+            draft.languageMode = .target(targetLanguage)
+        }
+
+        if prompt.contains("friendly") {
+            draft.tone = .friendly
+        } else if prompt.contains("professional") {
+            draft.tone = .professional
+        } else if prompt.contains("formal") {
+            draft.tone = .formal
+        } else if prompt.contains("concise") {
+            draft.tone = .concise
+        } else if prompt.contains("clear") {
+            draft.tone = .clear
+        }
+
+        if prompt.contains("concise") || prompt.contains("short") {
+            draft.responseLength = .short
+        } else if prompt.contains("detailed") || prompt.contains("complete") {
+            draft.responseLength = .detailed
+        }
+
+        if prompt.contains("reply") {
+            draft.replyMode = .reply
+        } else if prompt.contains("email") {
+            draft.replyMode = .email
+        }
+
+        if prompt.contains("json") {
+            draft.extractFormat = .json
+            draft.structureFormat = .json
+        } else if prompt.contains("checklist") || prompt.contains("action items") || prompt.contains("to-dos") {
+            draft.extractFormat = .checklist
+        } else if prompt.contains("table") {
+            draft.extractFormat = .table
+            draft.structureFormat = .table
+        } else if prompt.contains("key points") {
+            draft.extractFormat = .keyPoints
+        }
+
+        if prompt.contains("meeting notes") {
+            draft.structureFormat = .meetingNotes
+        } else if prompt.contains("bullet-point list") || prompt.contains("bullet point list") {
+            draft.structureFormat = .bulletList
+            draft.rewriteFormat = .list
+        }
+
+        if goal == .custom {
+            draft.customGoal = action.prompt
+        }
+
+        return draft
+    }
+
+    private static func inferGoal(from prompt: String) -> PromptWizardGoal {
+        if prompt.contains("translate") {
+            return .translate
+        }
+        if prompt.contains("reply") || prompt.contains("email") {
+            return .replyEmail
+        }
+        if prompt.contains("json") || prompt.contains("checklist") || prompt.contains("action items") {
+            return .extract
+        }
+        if prompt.contains("meeting notes") || prompt.contains("markdown table") || prompt.contains("bullet-point list") {
+            return .structure
+        }
+        if prompt.contains("rewrite") || prompt.contains("rephrase") {
+            return .rewrite
+        }
+        return .custom
+    }
+
+    private static func firstMatchedLanguage(in prompt: String) -> String? {
+        if prompt.contains("english") { return "en" }
+        if prompt.contains("german") { return "de" }
+        return nil
+    }
+}
+
+enum PromptWizardNameSuggester {
+    static func suggestedName(for draft: PromptWizardDraft) -> String {
+        switch draft.goal {
+        case .translate:
+            switch draft.translationMode {
+            case .direct(let targetLanguage):
+                return localizedAppText(
+                    "Translate to \(displayName(for: targetLanguage))",
+                    de: "Nach \(displayName(for: targetLanguage)) übersetzen"
+                )
+            case .alternatingPair(let primaryLanguage, let secondaryLanguage):
+                return localizedAppText(
+                    "Translate \(displayName(for: primaryLanguage)) / \(displayName(for: secondaryLanguage))",
+                    de: "\(displayName(for: primaryLanguage)) / \(displayName(for: secondaryLanguage)) übersetzen"
+                )
+            case nil:
+                return localizedAppText("Translate", de: "Übersetzen")
+            }
+        case .rewrite:
+            switch draft.tone {
+            case .formal:
+                return localizedAppText("Formal Rewrite", de: "Formal umschreiben")
+            case .friendly:
+                return localizedAppText("Friendly Rewrite", de: "Freundlich umschreiben")
+            case .concise:
+                return localizedAppText("Concise Rewrite", de: "Knapp umschreiben")
+            case .clear:
+                return localizedAppText("Clear Rewrite", de: "Klar umschreiben")
+            case .professional:
+                return localizedAppText("Professional Rewrite", de: "Professionell umschreiben")
+            case .neutral:
+                return localizedAppText("Rewrite", de: "Umschreiben")
+            }
+        case .replyEmail:
+            switch draft.replyMode {
+            case .reply:
+                return localizedAppText("Reply", de: "Antwort")
+            case .email:
+                return localizedAppText("Email Draft", de: "E-Mail-Entwurf")
+            }
+        case .extract:
+            switch draft.extractFormat {
+            case .checklist:
+                return localizedAppText("Action Items", de: "Action Items")
+            case .json:
+                return localizedAppText("Extract JSON", de: "JSON extrahieren")
+            case .table:
+                return localizedAppText("Extract Table", de: "Tabelle extrahieren")
+            case .keyPoints:
+                return localizedAppText("Key Points", de: "Kernpunkte")
+            }
+        case .structure:
+            switch draft.structureFormat {
+            case .bulletList:
+                return localizedAppText("Format as List", de: "Als Liste formatieren")
+            case .meetingNotes:
+                return localizedAppText("Meeting Notes", de: "Meeting Notes")
+            case .table:
+                return localizedAppText("Create Table", de: "Tabelle erstellen")
+            case .json:
+                return localizedAppText("Structure JSON", de: "JSON strukturieren")
+            }
+        case .custom:
+            let trimmedGoal = draft.customGoal.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedGoal.isEmpty {
+                return localizedAppText("Custom Prompt", de: "Benutzerdefinierter Prompt")
+            }
+            let compact = trimmedGoal.replacingOccurrences(of: "\n", with: " ")
+            if compact.count <= 36 {
+                return compact
+            }
+            let endIndex = compact.index(compact.startIndex, offsetBy: 36)
+            return String(compact[..<endIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func displayName(for languageCode: String) -> String {
+        PromptWizardComposer.languageNameForDisplay(languageCode)
+    }
+}

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -11,7 +11,6 @@ struct PromptActionsSettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Provider selection
             providerSection
                 .padding(.horizontal, 8)
                 .padding(.bottom, 12)
@@ -19,45 +18,22 @@ struct PromptActionsSettingsView: View {
             Divider()
                 .padding(.bottom, 8)
 
-            if viewModel.promptActions.isEmpty {
-                emptyState
-            } else {
-                // Header with add button
-                HStack {
-                    Text(String(format: String(localized: "%d Prompts"), viewModel.promptActions.count))
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+            VStack(alignment: .leading, spacing: 16) {
+                promptsHeader
 
-                    Spacer()
-
-                    presetMenu
-
-                    Button {
-                        viewModel.startCreating()
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .help(String(localized: "Add new prompt"))
-                    .accessibilityLabel(String(localized: "Add new prompt"))
-                }
-                .padding(.horizontal, 4)
-                .padding(.bottom, 8)
-
-                ScrollView {
-                    LazyVStack(spacing: 10) {
-                        ForEach(viewModel.promptActions) { action in
-                            PromptActionCardView(action: action, viewModel: viewModel, processingService: processingService)
-                        }
-                    }
-                    .padding(.horizontal, 2)
+                if viewModel.promptActions.isEmpty {
+                    emptyState
+                } else {
+                    promptsList
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, 8)
         .padding(.horizontal, 8)
         .sheet(isPresented: $viewModel.isEditing) {
-            PromptActionEditorSheet(viewModel: viewModel)
+            PromptWizardSheet(viewModel: viewModel, processingService: processingService)
         }
         .alert(String(localized: "Error"), isPresented: Binding(
             get: { viewModel.error != nil },
@@ -72,42 +48,136 @@ struct PromptActionsSettingsView: View {
         }
     }
 
+    private var promptsHeader: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(localizedAppText("Prompts", de: "Prompts"))
+                    .font(.headline)
+                Text(localizedAppText(
+                    "Create reusable AI actions like translation, replies, extraction, or formatting.",
+                    de: "Erstelle wiederverwendbare KI-Aktionen wie Übersetzen, Antworten, Extrahieren oder Formatieren."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                viewModel.startCreating()
+            } label: {
+                Label(localizedAppText("New Prompt", de: "Neuer Prompt"), systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 4)
+    }
+
     // MARK: - Provider Section
 
     private var providerSection: some View {
-        GroupBox(String(localized: "Default LLM Provider")) {
-            let providers = processingService.availableProviders
-            if providers.isEmpty {
-                VStack(spacing: 8) {
-                    Image(systemName: "puzzlepiece.extension")
-                        .font(.system(size: 24))
-                        .foregroundStyle(.secondary)
-                    Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) to use prompts."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                    Button(String(localized: "Go to Integrations")) {
-                        viewModel.navigateToIntegrations = true
-                    }
-                    .buttonStyle(.link)
-                    .font(.caption)
+        let providers = processingService.availableProviders
+        let statusInfo = promptProviderStatusInfo(
+            providerId: processingService.selectedProviderId,
+            processingService: processingService
+        )
+        let fixedModelName = promptProviderFixedModelName(for: processingService.selectedProviderId)
+        let shouldShowModelPicker = fixedModelName == nil && !processingService.modelsForProvider(processingService.selectedProviderId).isEmpty
+
+        return VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(localizedAppText("Default LLM Provider", de: "Standard-LLM-Provider"))
+                        .font(.headline)
+                    Text(localizedAppText(
+                        "Used by prompts unless a prompt overrides provider or model in Advanced.",
+                        de: "Wird von Prompts genutzt, solange ein Prompt Provider oder Modell nicht unter Erweitert überschreibt."
+                    ))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-            } else {
-                VStack(alignment: .leading, spacing: 8) {
-                    Picker(String(localized: "Provider"), selection: $processingService.selectedProviderId) {
-                        ForEach(providers, id: \.id) { provider in
-                            Text(provider.displayName).tag(provider.id)
+
+                Spacer()
+
+                if !providers.isEmpty, let statusInfo {
+                    PromptProviderStatusChip(statusInfo: statusInfo) {
+                        if statusInfo.isActionable {
+                            viewModel.navigateToIntegrations = true
                         }
                     }
+                }
+            }
 
-                    ProviderStatusView(
-                        providerId: processingService.selectedProviderId,
-                        processingService: processingService,
-                        cloudModel: $processingService.selectedCloudModel,
-                        onNavigateToIntegrations: { viewModel.navigateToIntegrations = true }
-                    )
+            if providers.isEmpty {
+                HStack(alignment: .center, spacing: 12) {
+                    Image(systemName: "puzzlepiece.extension")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.secondary)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) to use prompts."))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        Button(String(localized: "Go to Integrations")) {
+                            viewModel.navigateToIntegrations = true
+                        }
+                        .buttonStyle(.link)
+                        .font(.caption)
+                    }
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .center, spacing: 12) {
+                        Text(localizedAppText("Provider", de: "Provider"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 62, alignment: .leading)
+
+                        Picker(String(localized: "Provider"), selection: $processingService.selectedProviderId) {
+                            ForEach(providers, id: \.id) { provider in
+                                Text(provider.displayName).tag(provider.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 240, alignment: .leading)
+
+                        Spacer()
+                    }
+
+                    if let detail = statusInfo?.detail, !detail.isEmpty {
+                        Text(detail)
+                            .font(.caption)
+                            .foregroundStyle(statusInfo?.tint ?? .secondary)
+                    }
+
+                    if let fixedModelName {
+                        HStack(spacing: 6) {
+                            Text(localizedAppText("Model", de: "Modell"))
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+
+                            Text(fixedModelName)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if shouldShowModelPicker {
+                        HStack(alignment: .center, spacing: 12) {
+                            Text(localizedAppText("Model", de: "Modell"))
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 62, alignment: .leading)
+
+                            ModelPickerView(
+                                models: processingService.modelsForProvider(processingService.selectedProviderId),
+                                selection: $processingService.selectedCloudModel
+                            )
+                            .frame(maxWidth: 320, alignment: .leading)
+
+                            Spacer()
+                        }
+                    }
 
                     if PluginManager.shared.llmProviders.isEmpty {
                         Button {
@@ -122,154 +192,176 @@ struct PromptActionsSettingsView: View {
                         .font(.caption)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, 4)
             }
+        }
+        .padding(16)
+        .background {
+            promptWizardGroupedListSurface(cornerRadius: 16)
         }
     }
 
-    // MARK: - Empty State
+    private var promptsList: some View {
+        let indexedActions = Array(viewModel.promptActions.enumerated())
 
-    private var presetMenu: some View {
-        Menu {
-            let available = viewModel.availablePresets
-            if available.isEmpty {
-                Text(String(localized: "All presets imported"))
-            } else {
-                ForEach(available, id: \.name) { preset in
-                    Button {
-                        viewModel.importPreset(preset)
-                    } label: {
-                        Label(preset.name, systemImage: preset.icon)
+        return ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(indexedActions, id: \.element.id) { index, action in
+                    PromptActionRow(action: action, viewModel: viewModel, processingService: processingService)
+
+                    if index < indexedActions.count - 1 {
+                        Divider()
+                            .padding(.leading, 64)
                     }
                 }
-
-                Divider()
-
-                Button {
-                    viewModel.loadPresets()
-                } label: {
-                    Label(String(localized: "Import All"), systemImage: "square.and.arrow.down.on.square")
-                }
             }
-        } label: {
-            Image(systemName: "tray.and.arrow.down")
+            .background {
+                promptWizardGroupedListSurface(cornerRadius: 14)
+            }
         }
-        .help(String(localized: "Import Preset"))
     }
 
     private var emptyState: some View {
-        VStack {
-            Spacer()
-            VStack(spacing: 12) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 40))
-                    .foregroundColor(.secondary)
-                Text(String(localized: "No prompts yet"))
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-                Text(String(localized: "Create prompts to process your dictated text with AI"))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
-
-                HStack(spacing: 12) {
-                    presetMenu
-                        .buttonStyle(.borderedProminent)
-
-                    Button(String(localized: "Add Prompt")) {
-                        viewModel.startCreating()
-                    }
-                    .buttonStyle(.bordered)
-                }
+        ContentUnavailableView {
+            Label(localizedAppText("No Prompts Yet", de: "Noch keine Prompts"), systemImage: "sparkles")
+        } description: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(localizedAppText(
+                    "Build reusable prompt actions with the same wizard style as Rules.",
+                    de: "Baue wiederverwendbare Prompt-Aktionen im gleichen Wizard-Stil wie bei den Regeln."
+                ))
+                Text(localizedAppText(
+                    "Examples: translate English/German, draft a reply, extract JSON, or turn notes into meeting notes.",
+                    de: "Beispiele: Englisch/Deutsch übersetzen, eine Antwort formulieren, JSON extrahieren oder Notizen in Meeting Notes umwandeln."
+                ))
             }
-            Spacer()
+        }
+        actions: {
+            Button(localizedAppText("Create First Prompt", de: "Ersten Prompt erstellen")) {
+                viewModel.startCreating()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 280)
+        .background {
+            promptWizardGroupedListSurface(cornerRadius: 16)
         }
     }
 }
 
 // MARK: - Provider Status (reused in main settings + editor)
 
-struct ProviderStatusView: View {
-    let providerId: String
-    let processingService: PromptProcessingService
-    var cloudModel: Binding<String>?
-    var onNavigateToIntegrations: (() -> Void)? = nil
+@MainActor
+private struct PromptProviderStatusInfo {
+    let title: String
+    let detail: String?
+    let icon: String
+    let tint: Color
+    let isActionable: Bool
+}
+
+@MainActor
+private struct PromptProviderStatusChip: View {
+    let statusInfo: PromptProviderStatusInfo
+    let action: () -> Void
 
     var body: some View {
-        let plugin = PluginManager.shared.llmProvider(for: providerId)
-        let setupStatus = plugin as? any LLMProviderSetupStatusProviding
-        let usesLocalSetup = setupStatus?.requiresExternalCredentials == false
-
-        if providerId == PromptProcessingService.appleIntelligenceId {
-            if processingService.isAppleIntelligenceAvailable {
-                Label(String(localized: "Available"), systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.green)
+        Group {
+            if statusInfo.isActionable {
+                Button(action: action) {
+                    chipLabel
+                }
+                .buttonStyle(.plain)
             } else {
-                Label(String(localized: "Not available - Apple Intelligence must be enabled in System Settings"), systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-        } else {
-            if processingService.isProviderReady(providerId) {
-                Label(usesLocalSetup ? String(localized: "Ready") : String(localized: "API key configured"), systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.green)
-            } else if usesLocalSetup,
-                      let unavailableReason = setupStatus?.unavailableReason {
-                if let onNavigateToIntegrations {
-                    Button {
-                        onNavigateToIntegrations()
-                    } label: {
-                        Label(unavailableReason, systemImage: "exclamationmark.triangle.fill")
-                    }
-                    .buttonStyle(.link)
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                } else {
-                    Label(unavailableReason, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                }
-            } else if let onNavigateToIntegrations {
-                Button {
-                    onNavigateToIntegrations()
-                } label: {
-                    Label(String(localized: "API key required - configure in Integrations tab"), systemImage: "exclamationmark.triangle.fill")
-                }
-                .buttonStyle(.link)
-                .font(.caption)
-                .foregroundStyle(.orange)
-            } else {
-                Label(String(localized: "API key required - configure in Integrations tab"), systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-
-            if let plugin {
-                if let modelId = (plugin as? LLMModelSelectable)?.preferredModelId as? String {
-                    // Plugin manages its own model selection - just show info
-                    let displayName = plugin.supportedModels.first(where: { $0.id == modelId })?.displayName ?? modelId
-                    HStack(spacing: 4) {
-                        Text(String(localized: "Model:"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(displayName)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                } else if let cloudModel {
-                    // Plugin without LLMModelSelectable - show picker as before
-                    let models = plugin.supportedModels
-                    if !models.isEmpty {
-                        ModelPickerView(models: models, selection: cloudModel)
-                    }
-                }
+                chipLabel
             }
         }
     }
+
+    private var chipLabel: some View {
+        Label(statusInfo.title, systemImage: statusInfo.icon)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(statusInfo.tint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(statusInfo.tint.opacity(0.14), in: Capsule())
+    }
+}
+
+@MainActor
+private func promptProviderStatusInfo(
+    providerId: String,
+    processingService: PromptProcessingService
+) -> PromptProviderStatusInfo? {
+    if providerId == PromptProcessingService.appleIntelligenceId {
+        if processingService.isAppleIntelligenceAvailable {
+            return .init(
+                title: localizedAppText("Ready", de: "Bereit"),
+                detail: nil,
+                icon: "checkmark.circle.fill",
+                tint: .green,
+                isActionable: false
+            )
+        }
+
+        return .init(
+            title: localizedAppText("Unavailable", de: "Nicht verfügbar"),
+            detail: localizedAppText(
+                "Apple Intelligence must be enabled in System Settings.",
+                de: "Apple Intelligence muss in den Systemeinstellungen aktiviert sein."
+            ),
+            icon: "exclamationmark.triangle.fill",
+            tint: .orange,
+            isActionable: false
+        )
+    }
+
+    let plugin = PluginManager.shared.llmProvider(for: providerId)
+    let setupStatus = plugin as? any LLMProviderSetupStatusProviding
+    let usesLocalSetup = setupStatus?.requiresExternalCredentials == false
+
+    if processingService.isProviderReady(providerId) {
+        return .init(
+            title: usesLocalSetup
+                ? localizedAppText("Ready", de: "Bereit")
+                : localizedAppText("Configured", de: "Konfiguriert"),
+            detail: nil,
+            icon: "checkmark.circle.fill",
+            tint: .green,
+            isActionable: false
+        )
+    }
+
+    if usesLocalSetup, let unavailableReason = setupStatus?.unavailableReason {
+        return .init(
+            title: localizedAppText("Needs Setup", de: "Setup nötig"),
+            detail: unavailableReason,
+            icon: "exclamationmark.triangle.fill",
+            tint: .orange,
+            isActionable: true
+        )
+    }
+
+    return .init(
+        title: localizedAppText("API Key Needed", de: "API-Key nötig"),
+        detail: localizedAppText(
+            "Configure the provider in Integrations.",
+            de: "Konfiguriere den Provider unter Integrationen."
+        ),
+        icon: "exclamationmark.triangle.fill",
+        tint: .orange,
+        isActionable: true
+    )
+}
+
+@MainActor
+private func promptProviderFixedModelName(for providerId: String) -> String? {
+    guard providerId != PromptProcessingService.appleIntelligenceId,
+          let plugin = PluginManager.shared.llmProvider(for: providerId),
+          let modelId = (plugin as? LLMModelSelectable)?.preferredModelId as? String else {
+        return nil
+    }
+
+    return plugin.supportedModels.first(where: { $0.id == modelId })?.displayName ?? modelId
 }
 
 // MARK: - Model Picker with Search
@@ -315,105 +407,81 @@ struct ModelPickerView: View {
     }
 }
 
-// MARK: - Prompt Action Card
+// MARK: - Prompt Action List
 
-private struct PromptActionCardView: View {
+private struct PromptActionRow: View {
     let action: PromptAction
     @ObservedObject var viewModel: PromptActionsViewModel
     let processingService: PromptProcessingService
     @State private var isHovering = false
-    @State private var isDropTargeted = false
 
     var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "line.3.horizontal")
-                .font(.system(size: 12))
-                .foregroundColor(.secondary)
-                .frame(width: 16, height: 28)
-                .opacity(isHovering ? 1 : 0)
-                .accessibilityHidden(true)
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.14))
+                    .frame(width: 36, height: 36)
 
-            HStack(spacing: 6) {
                 Image(systemName: action.icon)
-                    .font(.system(size: 16))
-                    .foregroundColor(.accentColor)
-                    .frame(width: 28, height: 28)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
                     .accessibilityHidden(true)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 4) {
-                        Text(action.name)
-                            .font(.callout)
-                            .fontWeight(.medium)
-
-                        if let providerName = action.providerType {
-                            Text(processingService.displayName(for: providerName))
-                                .font(.caption2)
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 1)
-                                .background(Color.accentColor.opacity(0.12))
-                                .foregroundColor(.accentColor)
-                                .cornerRadius(3)
-                        }
-
-                        if let actionId = action.targetActionPluginId,
-                           let plugin = PluginManager.shared.actionPlugin(for: actionId) {
-                            Text(plugin.actionName)
-                                .font(.caption2)
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 1)
-                                .background(Color.orange.opacity(0.12))
-                                .foregroundColor(.orange)
-                                .cornerRadius(3)
-                        }
-                    }
-                    Text(action.prompt)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
             }
-            .contentShape(Rectangle())
-            .onTapGesture {
-                viewModel.startEditing(action)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(action.name)
+                    .font(.headline)
+
+                Text(promptNarrative)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 8) {
+                    Text(providerSummary)
+
+                    if let targetSummary {
+                        Text("•")
+                        Text(targetSummary)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
 
             Spacer()
 
-            Toggle("", isOn: Binding(
-                get: { action.isEnabled },
-                set: { _ in viewModel.toggleAction(action) }
-            ))
-            .toggleStyle(.switch)
-            .labelsHidden()
-            .accessibilityLabel(String(localized: "Enable \(action.name)"))
+            VStack(alignment: .trailing, spacing: 8) {
+                Toggle("", isOn: Binding(
+                    get: { action.isEnabled },
+                    set: { _ in viewModel.toggleAction(action) }
+                ))
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .accessibilityLabel(String(localized: "Enable \(action.name)"))
+
+                Button {
+                    viewModel.startEditing(action)
+                } label: {
+                    Image(systemName: "pencil")
+                }
+                .buttonStyle(.borderless)
+                .opacity(isHovering ? 1 : 0.7)
+                .help(localizedAppText("Edit prompt", de: "Prompt bearbeiten"))
+            }
         }
-        .padding(.leading, 4)
-        .padding(.trailing, 10)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color(NSColor.controlBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(isDropTargeted ? Color.accentColor.opacity(0.5) : isHovering ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.06), lineWidth: isDropTargeted ? 2 : 1)
-        )
-        .overlay(OpenHandCursorView())
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(rowHighlightColor)
+        }
+        .contentShape(Rectangle())
         .onHover { hovering in
             isHovering = hovering
         }
-        .draggable(action.id.uuidString)
-        .dropDestination(for: String.self) { droppedItems, _ in
-            guard let droppedId = droppedItems.first,
-                  let fromIndex = viewModel.promptActions.firstIndex(where: { $0.id.uuidString == droppedId }),
-                  let toIndex = viewModel.promptActions.firstIndex(where: { $0.id == action.id }) else {
-                return false
-            }
-            viewModel.moveAction(fromIndex: fromIndex, toIndex: toIndex)
-            return true
-        } isTargeted: { targeted in
-            isDropTargeted = targeted
+        .onTapGesture(count: 2) {
+            viewModel.startEditing(action)
         }
         .contextMenu {
             Button(String(localized: "Edit")) {
@@ -425,268 +493,1667 @@ private struct PromptActionCardView: View {
             }
         }
     }
-}
 
-// MARK: - Editor Sheet
-
-private struct PromptActionEditorSheet: View {
-    @ObservedObject var viewModel: PromptActionsViewModel
-    @Environment(\.dismiss) private var dismiss
-    @FocusState private var focusedField: Field?
-
-    enum Field {
-        case name, prompt
+    private var promptNarrative: String {
+        let inferredDraft = PromptWizardInferenceService.infer(from: action)
+        return PromptWizardComposer.reviewSummary(for: inferredDraft)
     }
 
-    // Common SF Symbols for prompts
+    private var providerSummary: String {
+        if let providerType = action.providerType {
+            return localizedAppText(
+                "Provider: \(processingService.displayName(for: providerType))",
+                de: "Provider: \(processingService.displayName(for: providerType))"
+            )
+        }
+
+        return localizedAppText("Default provider", de: "Standard-Provider")
+    }
+
+    private var targetSummary: String? {
+        guard let actionId = action.targetActionPluginId,
+              let plugin = PluginManager.shared.actionPlugin(for: actionId) else {
+            return nil
+        }
+
+        return localizedAppText(
+            "Target: \(plugin.actionName)",
+            de: "Ziel: \(plugin.actionName)"
+        )
+    }
+
+    private var rowHighlightColor: Color {
+        if isHovering {
+            return Color.white.opacity(0.025)
+        }
+
+        return Color.clear
+    }
+}
+
+// MARK: - Prompt Wizard
+
+private struct PromptWizardSheet: View {
+    @ObservedObject var viewModel: PromptActionsViewModel
+    @ObservedObject var processingService: PromptProcessingService
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingAdvancedOptions = false
+
     private let iconOptions = [
-        "sparkles", "globe", "textformat.abc", "text.badge.minus",
-        "checkmark.circle", "envelope", "list.bullet", "scissors",
-        "lightbulb", "pencil", "doc.text", "text.quote",
-        "wand.and.stars", "arrow.triangle.2.circlepath", "text.magnifyingglass",
-        "character.textbox", "checklist", "arrowshape.turn.up.left"
+        "sparkles", "globe", "wand.and.stars", "arrowshape.turn.up.left",
+        "envelope", "envelope.badge", "list.bullet", "checklist",
+        "tablecells", "curlybraces", "doc.text.magnifyingglass", "textformat.abc",
+        "text.quote", "pencil", "lightbulb", "character.textbox"
     ]
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                Text(viewModel.isCreatingNew ? String(localized: "New Prompt") : String(localized: "Edit Prompt"))
-                    .font(.headline)
-                Spacer()
-            }
-            .padding()
-            .background(Color(NSColor.windowBackgroundColor))
+            header
 
             Divider()
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    GroupBox(String(localized: "Prompt")) {
-                        VStack(alignment: .leading, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(String(localized: "Name"))
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                TextField(String(localized: "e.g. Make Formal"), text: $viewModel.editName)
-                                    .textFieldStyle(.roundedBorder)
-                                    .focused($focusedField, equals: .name)
-                            }
+                    PromptWizardStepHeader(currentStep: viewModel.wizardStep)
 
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(String(localized: "System Prompt"))
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                TextEditor(text: $viewModel.editPrompt)
-                                    .font(.body)
-                                    .frame(height: 120)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 6)
-                                            .stroke(Color(NSColor.separatorColor), lineWidth: 1)
-                                    )
-                                    .focused($focusedField, equals: .prompt)
-                            }
-                        }
-                        .padding(.vertical, 8)
-                    }
-
-                    GroupBox(String(localized: "Icon")) {
-                        LazyVGrid(columns: Array(repeating: GridItem(.fixed(36), spacing: 8), count: 8), spacing: 8) {
-                            ForEach(iconOptions, id: \.self) { icon in
-                                Button {
-                                    viewModel.editIcon = icon
-                                } label: {
-                                    Image(systemName: icon)
-                                        .font(.system(size: 16))
-                                        .frame(width: 32, height: 32)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 6)
-                                                .fill(viewModel.editIcon == icon ? Color.accentColor.opacity(0.2) : Color.clear)
-                                        )
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 6)
-                                                .strokeBorder(viewModel.editIcon == icon ? Color.accentColor : Color.clear, lineWidth: 1.5)
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel(icon)
-                                .accessibilityValue(viewModel.editIcon == icon ? String(localized: "Selected") : "")
-                            }
-                        }
-                        .padding(.vertical, 8)
-                    }
-
-                    GroupBox(String(localized: "LLM Provider")) {
-                        let providers = viewModel.promptProcessingService.availableProviders
-                        if providers.isEmpty {
-                            VStack(spacing: 8) {
-                                Image(systemName: "puzzlepiece.extension")
-                                    .font(.system(size: 20))
-                                    .foregroundStyle(.secondary)
-                                Text(String(localized: "Install an LLM provider plugin (e.g. Groq, OpenAI) to use prompts."))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .multilineTextAlignment(.center)
-                                Button(String(localized: "Go to Integrations")) {
-                                    viewModel.navigateToIntegrations = true
-                                }
-                                .buttonStyle(.link)
-                                .font(.caption)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 8)
-                        } else {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Picker(String(localized: "Provider"), selection: $viewModel.editProviderId) {
-                                    Text(String(localized: "Default")).tag(nil as String?)
-                                    ForEach(providers, id: \.id) { provider in
-                                        Text(provider.displayName).tag(provider.id as String?)
-                                    }
-                                }
-                                .onChange(of: viewModel.editProviderId) { _, newId in
-                                    if let newId {
-                                        let models = viewModel.promptProcessingService.modelsForProvider(newId)
-                                        viewModel.editCloudModel = models.first?.id ?? ""
-                                        viewModel.clampTemperatureValueForEffectiveProvider()
-                                    } else {
-                                        viewModel.editCloudModel = ""
-                                        viewModel.clampTemperatureValueForEffectiveProvider()
-                                    }
-                                }
-
-                                Text(String(localized: "Override the default provider for this prompt. Leave on \"Default\" to use the global setting."))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-
-                                if let selectedId = viewModel.editProviderId {
-                                    let models = viewModel.promptProcessingService.modelsForProvider(selectedId)
-                                    if !models.isEmpty {
-                                        Picker(String(localized: "Model"), selection: $viewModel.editCloudModel) {
-                                            ForEach(models, id: \.id) { model in
-                                                Text(model.displayName).tag(model.id)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            .padding(.vertical, 4)
-                        }
-                    }
-
-                    GroupBox(String(localized: "Temperature")) {
-                        let effectiveProviderId = viewModel.editProviderId ?? viewModel.promptProcessingService.selectedProviderId
-                        let isAppleIntelligence = effectiveProviderId == PromptProcessingService.appleIntelligenceId
-                        let supportedRange = viewModel.supportedTemperatureRange(for: effectiveProviderId)
-                        VStack(alignment: .leading, spacing: 8) {
-                            Picker(String(localized: "Who decides?"), selection: $viewModel.editTemperatureMode) {
-                                Text(String(localized: "Use my provider setting")).tag(PluginLLMTemperatureMode.inheritProviderSetting)
-                                Text(String(localized: "Use provider default")).tag(PluginLLMTemperatureMode.providerDefault)
-                                Text(String(localized: "Set for this prompt")).tag(PluginLLMTemperatureMode.custom)
-                            }
-                            .disabled(isAppleIntelligence)
-
-                            if viewModel.editTemperatureMode == .custom {
-                                HStack {
-                                    Text(String(localized: "Temperature"))
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    Spacer()
-                                    Text(viewModel.editTemperatureValue, format: .number.precision(.fractionLength(2)))
-                                        .foregroundStyle(.secondary)
-                                        .monospacedDigit()
-                                }
-
-                                Slider(
-                                    value: $viewModel.editTemperatureValue,
-                                    in: supportedRange,
-                                    step: effectiveProviderId == "Gemma 4 (MLX)" ? 0.05 : 0.1
-                                )
-                                .disabled(isAppleIntelligence)
-
-                                HStack {
-                                    Text("\(supportedRange.lowerBound, format: .number.precision(.fractionLength(1)))")
-                                    Spacer()
-                                    Text("\(supportedRange.upperBound, format: .number.precision(.fractionLength(1)))")
-                                }
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            }
-
-                            let helperText: LocalizedStringResource = {
-                                if isAppleIntelligence {
-                                    return "Temperature is not available for Apple Intelligence."
-                                }
-
-                                switch viewModel.editTemperatureMode {
-                                case .inheritProviderSetting:
-                                    return "Uses the temperature saved in this provider's settings."
-                                case .providerDefault:
-                                    return "Ignores your saved provider setting and lets the provider use its own default behavior."
-                                case .custom:
-                                    if effectiveProviderId == "Gemma 4 (MLX)" {
-                                        return "Uses this value only for this prompt. Gemma 4 supports values from 0.0 to 1.0."
-                                    } else {
-                                        return "Uses this value only for this prompt and overrides the provider setting."
-                                    }
-                                }
-                            }()
-
-                            Text(helperText)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.vertical, 4)
-                    }
-
-                    let actionPlugins = PluginManager.shared.actionPlugins
-                    if !actionPlugins.isEmpty {
-                        GroupBox(String(localized: "Action Target")) {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Picker(String(localized: "Target"), selection: $viewModel.editTargetActionPluginId) {
-                                    Text(String(localized: "Insert Text")).tag(nil as String?)
-                                    ForEach(actionPlugins, id: \.actionId) { plugin in
-                                        Label(plugin.actionName, systemImage: plugin.actionIcon)
-                                            .tag(plugin.actionId as String?)
-                                    }
-                                }
-
-                                Text(String(localized: "Instead of inserting the LLM result as text, send it to an action plugin."))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.vertical, 4)
-                        }
+                    switch viewModel.wizardStep {
+                    case .goal:
+                        PromptWizardGoalStep(viewModel: viewModel)
+                    case .response:
+                        PromptWizardResponseStep(viewModel: viewModel, processingService: processingService)
+                    case .review:
+                        PromptWizardReviewStep(
+                            viewModel: viewModel,
+                            showingAdvancedOptions: $showingAdvancedOptions,
+                            iconOptions: iconOptions
+                        )
                     }
                 }
-                .padding()
+                .padding(24)
             }
 
             Divider()
 
-            HStack {
-                Button(String(localized: "Cancel")) {
-                    viewModel.cancelEditing()
-                    dismiss()
+            footer
+        }
+        .frame(width: 700, height: 790)
+        .background(sheetBackground)
+        .onAppear {
+            showingAdvancedOptions = viewModel.manualPromptOverride || viewModel.editTargetActionPluginId != nil
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 10) {
+                promptWizardInfoChip(
+                    viewModel.isCreatingNew
+                        ? localizedAppText("Prompt Wizard", de: "Prompt-Wizard")
+                        : localizedAppText("Adjust Prompt", de: "Prompt anpassen"),
+                    tint: .accentColor
+                )
+
+                Text(
+                    viewModel.isCreatingNew
+                        ? localizedAppText("New Prompt", de: "Neuer Prompt")
+                        : localizedAppText("Edit Prompt", de: "Prompt bearbeiten")
+                )
+                .font(.title2.weight(.semibold))
+
+                Text(localizedAppText(
+                    "From goal to final system prompt in three clear steps.",
+                    de: "Vom Ziel zum finalen System-Prompt in drei klaren Schritten."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 10) {
+                promptWizardInfoChip(
+                    localizedAppText(
+                        "Step \(currentStepNumber) of \(totalSteps)",
+                        de: "Schritt \(currentStepNumber) von \(totalSteps)"
+                    ),
+                    tint: .accentColor
+                )
+            }
+        }
+        .padding(24)
+    }
+
+    private var footer: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(localizedAppText(
+                    "Step \(currentStepNumber) of \(totalSteps)",
+                    de: "Schritt \(currentStepNumber) von \(totalSteps)"
+                ))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+                Text(stepGuidance)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+            }
+
+            Spacer()
+
+            Button(localizedAppText("Cancel", de: "Abbrechen")) {
+                viewModel.cancelEditing()
+                dismiss()
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+
+            if viewModel.wizardStep != .goal {
+                Button(localizedAppText("Back", de: "Zurück")) {
+                    viewModel.goToPreviousWizardStep()
                 }
-                .keyboardShortcut(.cancelAction)
+                .buttonStyle(.bordered)
+            }
 
-                Spacer()
-
-                Button(String(localized: "Save")) {
+            if viewModel.wizardStep == .review {
+                Button(localizedAppText("Save Prompt", de: "Prompt speichern")) {
                     viewModel.saveEditing()
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.roundedRectangle(radius: 10))
+                .controlSize(.large)
+                .tint(.accentColor)
+                .shadow(color: .accentColor.opacity(0.18), radius: 8, x: 0, y: 4)
                 .keyboardShortcut(.defaultAction)
-                .disabled(viewModel.editName.isEmpty || viewModel.editPrompt.isEmpty)
+                .disabled(!viewModel.canAdvanceFromCurrentWizardStep)
+            } else {
+                Button(localizedAppText("Next", de: "Weiter")) {
+                    viewModel.goToNextWizardStep()
+                }
+                .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.roundedRectangle(radius: 10))
+                .controlSize(.large)
+                .tint(.accentColor)
+                .shadow(color: .accentColor.opacity(0.18), radius: 8, x: 0, y: 4)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!viewModel.canAdvanceFromCurrentWizardStep)
             }
-            .padding()
-            .background(Color(NSColor.windowBackgroundColor))
         }
-        .frame(minWidth: 450, idealWidth: 500, minHeight: 520)
-        .fixedSize(horizontal: false, vertical: true)
-        .onAppear {
-            focusedField = .name
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+        .background(.bar)
+    }
+
+    private var currentStepNumber: Int { viewModel.wizardStep.rawValue + 1 }
+    private var totalSteps: Int { PromptWizardStep.allCases.count }
+
+    private var stepGuidance: String {
+        switch viewModel.wizardStep {
+        case .goal:
+            return localizedAppText(
+                "Pick the job first. Presets can be used as starters and refined in the next step.",
+                de: "Wähle zuerst die Aufgabe. Presets dienen als Starter und werden im nächsten Schritt verfeinert."
+            )
+        case .response:
+            return localizedAppText(
+                "Define the response behavior first. Advanced includes provider, model, and temperature.",
+                de: "Lege zuerst das Antwortverhalten fest. Erweitert enthält Provider, Modell und Temperatur."
+            )
+        case .review:
+            return localizedAppText(
+                "Review the name and preview first. Advanced includes the system prompt and target.",
+                de: "Prüfe zuerst Name und Vorschau. Erweitert enthält System-Prompt und Ziel."
+            )
         }
+    }
+
+    private var sheetBackground: some View {
+        ZStack(alignment: .top) {
+            Color(nsColor: .windowBackgroundColor)
+
+            Rectangle()
+                .fill(Color.accentColor.opacity(0.028))
+                .frame(height: 150)
+                .blur(radius: 30)
+                .offset(y: -18)
+        }
+    }
+}
+
+private struct PromptWizardStepHeader: View {
+    let currentStep: PromptWizardStep
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ForEach(Array(PromptWizardStep.allCases.enumerated()), id: \.element.rawValue) { index, step in
+                stepItem(for: step)
+
+                if index < PromptWizardStep.allCases.count - 1 {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func stepItem(for step: PromptWizardStep) -> some View {
+        let isCurrent = step == currentStep
+        let isCompleted = step.rawValue < currentStep.rawValue
+        let isReachable = step.rawValue <= currentStep.rawValue
+
+        return HStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(stepCircleFill(isCurrent: isCurrent, isCompleted: isCompleted))
+                    .frame(width: 30, height: 30)
+
+                if isCompleted {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white)
+                } else {
+                    Text("\(step.rawValue + 1)")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(isCurrent ? .white : .primary)
+                }
+            }
+
+            Text(step.title)
+                .font(.subheadline.weight(isCurrent ? .semibold : .regular))
+                .foregroundStyle(stepTitleStyle(isCurrent: isCurrent, isReachable: isReachable))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(stepBackground(isCurrent: isCurrent, isCompleted: isCompleted), in: Capsule())
+    }
+
+    private func stepCircleFill(isCurrent: Bool, isCompleted: Bool) -> some ShapeStyle {
+        if isCurrent {
+            return AnyShapeStyle(Color.accentColor)
+        }
+
+        if isCompleted {
+            return AnyShapeStyle(Color.accentColor.opacity(0.82))
+        }
+
+        return AnyShapeStyle(Color.primary.opacity(0.10))
+    }
+
+    private func stepBackground(isCurrent: Bool, isCompleted: Bool) -> some ShapeStyle {
+        if isCurrent {
+            return AnyShapeStyle(Color.accentColor.opacity(0.14))
+        }
+
+        if isCompleted {
+            return AnyShapeStyle(Color.accentColor.opacity(0.07))
+        }
+
+        return AnyShapeStyle(Color.clear)
+    }
+
+    private func stepTitleStyle(isCurrent: Bool, isReachable: Bool) -> some ShapeStyle {
+        if isCurrent {
+            return AnyShapeStyle(Color.accentColor)
+        }
+
+        return AnyShapeStyle(isReachable ? .primary : .secondary)
+    }
+}
+
+private struct PromptWizardGoalStep: View {
+    @ObservedObject var viewModel: PromptActionsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localizedAppText("What should this prompt do?", de: "Was soll dieser Prompt tun?"))
+                    .font(.title3.weight(.semibold))
+                Text(localizedAppText(
+                    "Pick the job first. Details and presets appear only for the active goal.",
+                    de: "Wähle zuerst die Aufgabe. Details und Presets erscheinen nur für das aktive Ziel."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(PromptWizardGoal.allCases, id: \.self) { goal in
+                        Button {
+                            viewModel.setWizardGoal(goal)
+                        } label: {
+                            PromptWizardGoalRow(goal: goal, isSelected: viewModel.wizardDraft.goal == goal)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .frame(width: 220, alignment: .topLeading)
+
+                PromptWizardGoalDetailPanel(
+                    goal: viewModel.wizardDraft.goal,
+                    starters: Array(viewModel.starterPresets(for: viewModel.wizardDraft.goal).prefix(3)),
+                    onSelectPreset: viewModel.applyPresetStarter
+                )
+            }
+        }
+    }
+}
+
+private struct PromptWizardGoalRow: View {
+    let goal: PromptWizardGoal
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(goal.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(isSelected ? .white : .primary)
+
+            Spacer(minLength: 0)
+
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white.opacity(0.92))
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(isSelected ? AnyShapeStyle(promptWizardActiveSelectionFill()) : AnyShapeStyle(Color.white.opacity(0.03)))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(isSelected ? Color.accentColor.opacity(0.42) : Color.white.opacity(0.05), lineWidth: isSelected ? 1.2 : 1)
+                }
+                .shadow(color: .black.opacity(isSelected ? 0.18 : 0.08), radius: isSelected ? 14 : 8, x: 0, y: isSelected ? 8 : 4)
+        }
+    }
+}
+
+private struct PromptWizardGoalDetailPanel: View {
+    let goal: PromptWizardGoal
+    let starters: [PromptAction]
+    let onSelectPreset: (PromptAction) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localizedAppText("Selected Goal", de: "Ausgewähltes Ziel"))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                Text(goal.title)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                Text(goal.promptWizardGoalSummary)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if !starters.isEmpty {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(localizedAppText("Starter Presets", de: "Starter-Presets"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+
+                    HStack(spacing: 8) {
+                        ForEach(starters, id: \.name) { preset in
+                            Button {
+                                onSelectPreset(preset)
+                            } label: {
+                                Text(preset.name)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(Color.accentColor)
+                                    .lineLimit(1)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 7)
+                                    .background(Color.accentColor.opacity(0.10), in: Capsule())
+                                    .overlay {
+                                        Capsule()
+                                            .strokeBorder(Color.accentColor.opacity(0.20), lineWidth: 1)
+                                    }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+
+            Text(localizedAppText(
+                "You can shape tone, format, language behavior, and model settings in the next step.",
+                de: "Ton, Format, Sprachverhalten und Modell-Einstellungen formst du im nächsten Schritt."
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(18)
+        .background { promptWizardElevatedPanel(cornerRadius: 20) }
+        .overlay {
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(0.14), lineWidth: 1)
+        }
+    }
+}
+
+private struct PromptWizardResponseStep: View {
+    @ObservedObject var viewModel: PromptActionsViewModel
+    @ObservedObject var processingService: PromptProcessingService
+    @State private var showingAdvancedOptions = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localizedAppText("How should it respond?", de: "Wie soll es antworten?"))
+                    .font(.title3.weight(.semibold))
+                HStack(spacing: 8) {
+                    promptWizardInfoChip(viewModel.wizardDraft.goal.title, tint: .accentColor)
+
+                    Text(localizedAppText(
+                        "Configure behavior first, then fine-tune the model settings for this prompt.",
+                        de: "Konfiguriere zuerst das Verhalten und verfeinere danach die Modell-Einstellungen für diesen Prompt."
+                    ))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                }
+            }
+
+            behaviorSection
+            advancedSection
+        }
+    }
+
+    private var behaviorSection: some View {
+        promptWizardCompactSection(
+            title: behaviorSectionTitle,
+            description: behaviorSectionDescription
+        ) {
+            goalSpecificSectionContent
+        }
+    }
+
+    private var advancedSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    showingAdvancedOptions.toggle()
+                }
+            } label: {
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(localizedAppText("Advanced", de: "Erweitert"))
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+
+                        Text(advancedSummary)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: showingAdvancedOptions ? "chevron.up" : "chevron.down")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if showingAdvancedOptions {
+                VStack(alignment: .leading, spacing: 16) {
+                    Divider()
+                        .padding(.top, 12)
+
+                    promptWizardEditorSubsection(
+                        title: localizedAppText("Provider", de: "Provider"),
+                        description: localizedAppText(
+                            "Override the default provider only when this prompt needs a different model stack.",
+                            de: "Überschreibe den Standard-Provider nur, wenn dieser Prompt einen anderen Modell-Stack braucht."
+                        )
+                    ) {
+                        providerSettingsContent
+                    }
+
+                    Divider()
+
+                    promptWizardEditorSubsection(
+                        title: localizedAppText("Temperature", de: "Temperatur"),
+                        description: localizedAppText(
+                            "Keep this on the provider default unless this prompt needs a different creativity level.",
+                            de: "Lass dies beim Provider-Standard, außer dieser Prompt braucht ein anderes Kreativitätsniveau."
+                        )
+                    ) {
+                        temperatureSettingsContent
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background {
+            promptWizardElevatedPanel(cornerRadius: 18)
+        }
+    }
+
+    @ViewBuilder
+    private var goalSpecificSectionContent: some View {
+        switch viewModel.wizardDraft.goal {
+        case .translate:
+            VStack(alignment: .leading, spacing: 14) {
+                promptWizardEditorSubsection(
+                    title: localizedAppText("Mode", de: "Modus"),
+                    description: localizedAppText(
+                        "Choose whether this prompt always translates into one language or toggles between a fixed pair.",
+                        de: "Lege fest, ob dieser Prompt immer in eine Sprache übersetzt oder zwischen einem festen Paar wechselt."
+                    )
+                ) {
+                    Picker(
+                        localizedAppText("Mode", de: "Modus"),
+                        selection: translationModeChoiceBinding
+                    ) {
+                        Text(localizedAppText("One Target", de: "Eine Zielsprache")).tag(PromptWizardTranslationChoice.direct)
+                        Text(localizedAppText("Two-Way Pair", de: "Zwei-Wege-Paar")).tag(PromptWizardTranslationChoice.alternating)
+                    }
+                    .pickerStyle(.segmented)
+                    .controlSize(.large)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(
+                    title: localizedAppText("Languages", de: "Sprachen"),
+                    description: localizedAppText(
+                        "Set the target language or the two fixed languages for the pair.",
+                        de: "Lege die Zielsprache oder die beiden festen Sprachen für das Paar fest."
+                    )
+                ) {
+                    switch viewModel.wizardDraft.translationMode {
+                    case .alternatingPair:
+                        HStack(spacing: 14) {
+                            promptWizardLanguagePicker(
+                                title: localizedAppText("Primary Language", de: "Primärsprache"),
+                                selection: alternatingPrimaryLanguageBinding
+                            )
+                            promptWizardLanguagePicker(
+                                title: localizedAppText("Secondary Language", de: "Sekundärsprache"),
+                                selection: alternatingSecondaryLanguageBinding
+                            )
+                        }
+                    case .direct, .none:
+                        promptWizardLanguagePicker(
+                            title: localizedAppText("Target Language", de: "Zielsprache"),
+                            selection: directTargetLanguageBinding
+                        )
+                    }
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(
+                    title: localizedAppText("Output Rules", de: "Ausgaberegeln")
+                ) {
+                    Toggle(
+                        localizedAppText("Preserve formatting when possible", de: "Formatierung wenn möglich beibehalten"),
+                        isOn: Binding(
+                            get: { viewModel.wizardDraft.preserveFormatting },
+                            set: { newValue in
+                                viewModel.updateWizardDraft { draft in
+                                    draft.preserveFormatting = newValue
+                                }
+                            }
+                        )
+                    )
+                }
+            }
+        case .rewrite:
+            VStack(alignment: .leading, spacing: 14) {
+                promptWizardEditorSubsection(title: localizedAppText("Tone", de: "Ton")) {
+                    promptWizardTonePicker(tone: toneBinding)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Language", de: "Sprache")) {
+                    promptWizardLanguageModeSection(mode: languageChoiceBinding, targetLanguage: targetLanguageBinding)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Output", de: "Ausgabe")) {
+                    Picker(localizedAppText("Output", de: "Ausgabe"), selection: rewriteFormatBinding) {
+                        Text(localizedAppText("Paragraph", de: "Absatz")).tag(PromptWizardRewriteFormat.paragraph)
+                        Text(localizedAppText("List", de: "Liste")).tag(PromptWizardRewriteFormat.list)
+                    }
+                    .pickerStyle(.segmented)
+                }
+            }
+        case .replyEmail:
+            VStack(alignment: .leading, spacing: 14) {
+                promptWizardEditorSubsection(title: localizedAppText("Mode", de: "Modus")) {
+                    Picker(localizedAppText("Mode", de: "Modus"), selection: replyModeBinding) {
+                        Text(localizedAppText("Reply", de: "Antwort")).tag(PromptWizardReplyMode.reply)
+                        Text(localizedAppText("Email", de: "E-Mail")).tag(PromptWizardReplyMode.email)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Tone", de: "Ton")) {
+                    promptWizardTonePicker(tone: toneBinding)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Length", de: "Länge")) {
+                    Picker(localizedAppText("Length", de: "Länge"), selection: responseLengthBinding) {
+                        Text(localizedAppText("Short", de: "Kurz")).tag(PromptWizardResponseLength.short)
+                        Text(localizedAppText("Balanced", de: "Ausgewogen")).tag(PromptWizardResponseLength.medium)
+                        Text(localizedAppText("Detailed", de: "Detailliert")).tag(PromptWizardResponseLength.detailed)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Language", de: "Sprache")) {
+                    promptWizardLanguageModeSection(mode: languageChoiceBinding, targetLanguage: targetLanguageBinding)
+                }
+            }
+        case .extract:
+            promptWizardEditorSubsection(title: localizedAppText("Output Format", de: "Ausgabeformat")) {
+                Picker(localizedAppText("Format", de: "Format"), selection: extractFormatBinding) {
+                    Text(localizedAppText("Checklist", de: "Checkliste")).tag(PromptWizardExtractFormat.checklist)
+                    Text("JSON").tag(PromptWizardExtractFormat.json)
+                    Text(localizedAppText("Table", de: "Tabelle")).tag(PromptWizardExtractFormat.table)
+                    Text(localizedAppText("Key Points", de: "Kernpunkte")).tag(PromptWizardExtractFormat.keyPoints)
+                }
+                .pickerStyle(.segmented)
+            }
+        case .structure:
+            VStack(alignment: .leading, spacing: 14) {
+                promptWizardEditorSubsection(title: localizedAppText("Output Format", de: "Ausgabeformat")) {
+                    Picker(localizedAppText("Format", de: "Format"), selection: structureFormatBinding) {
+                        Text(localizedAppText("Bullet List", de: "Bullet-Liste")).tag(PromptWizardStructureFormat.bulletList)
+                        Text(localizedAppText("Meeting Notes", de: "Meeting Notes")).tag(PromptWizardStructureFormat.meetingNotes)
+                        Text(localizedAppText("Table", de: "Tabelle")).tag(PromptWizardStructureFormat.table)
+                        Text("JSON").tag(PromptWizardStructureFormat.json)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Output Rules", de: "Ausgaberegeln")) {
+                    Toggle(
+                        localizedAppText("Add helpful headings when useful", de: "Hilfreiche Überschriften ergänzen"),
+                        isOn: Binding(
+                            get: { viewModel.wizardDraft.includeHeadings },
+                            set: { newValue in
+                                viewModel.updateWizardDraft { draft in
+                                    draft.includeHeadings = newValue
+                                }
+                            }
+                        )
+                    )
+                }
+            }
+        case .custom:
+            VStack(alignment: .leading, spacing: 14) {
+                promptWizardEditorSubsection(title: localizedAppText("Goal", de: "Ziel")) {
+                    TextEditor(text: Binding(
+                        get: { viewModel.wizardDraft.customGoal },
+                        set: { newValue in
+                            viewModel.updateWizardDraft { draft in
+                                draft.customGoal = newValue
+                            }
+                        }
+                    ))
+                    .font(.body)
+                    .frame(height: 80)
+                    .padding(8)
+                    .background(Color.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                    }
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Tone", de: "Ton")) {
+                    promptWizardTonePicker(tone: toneBinding)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Language", de: "Sprache")) {
+                    promptWizardLanguageModeSection(mode: languageChoiceBinding, targetLanguage: targetLanguageBinding)
+                }
+
+                Divider()
+
+                promptWizardEditorSubsection(title: localizedAppText("Output Hint", de: "Ausgabehinweis")) {
+                    TextField(
+                        localizedAppText("e.g. Return a short bullet list", de: "z. B. Gib eine kurze Bullet-Liste zurück"),
+                        text: Binding(
+                            get: { viewModel.wizardDraft.customOutputHint },
+                            set: { newValue in
+                                viewModel.updateWizardDraft { draft in
+                                    draft.customOutputHint = newValue
+                                }
+                            }
+                        )
+                    )
+                    .textFieldStyle(.roundedBorder)
+                }
+            }
+        }
+    }
+
+    private var providerSettingsContent: some View {
+        let providers = processingService.availableProviders
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text(localizedAppText("Provider", de: "Provider"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if providers.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "puzzlepiece.extension")
+                        .font(.system(size: 20))
+                        .foregroundStyle(.secondary)
+                    Text(localizedAppText(
+                        "Install an LLM provider plugin such as Groq or OpenAI to use prompt actions.",
+                        de: "Installiere ein LLM-Provider-Plugin wie Groq oder OpenAI, um Prompt-Aktionen zu nutzen."
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                    Button(localizedAppText("Go to Integrations", de: "Zu Integrationen")) {
+                        viewModel.navigateToIntegrations = true
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+            } else {
+                Picker(localizedAppText("Provider", de: "Provider"), selection: providerBinding) {
+                    Text(localizedAppText("Default", de: "Standard")).tag(nil as String?)
+                    ForEach(providers, id: \.id) { provider in
+                        Text(provider.displayName).tag(provider.id as String?)
+                    }
+                }
+
+                Text(localizedAppText(
+                    "When left on Default, this prompt uses the provider selected above in Prompts settings.",
+                    de: "Bei Standard nutzt dieser Prompt den oben in den Prompt-Einstellungen gewählten Provider."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                if let selectedId = viewModel.editProviderId {
+                    let models = processingService.modelsForProvider(selectedId)
+                    if !models.isEmpty {
+                        Picker(localizedAppText("Model", de: "Modell"), selection: cloudModelBinding) {
+                            ForEach(models, id: \.id) { model in
+                                Text(model.displayName).tag(model.id)
+                            }
+                        }
+                    }
+                } else {
+                    Text(localizedAppText(
+                        "Uses the global default provider: \(processingService.displayName(for: processingService.selectedProviderId)).",
+                        de: "Verwendet den globalen Standard-Provider: \(processingService.displayName(for: processingService.selectedProviderId))."
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var temperatureSettingsContent: some View {
+        let effectiveProviderId = viewModel.editProviderId ?? processingService.selectedProviderId
+        let isAppleIntelligence = effectiveProviderId == PromptProcessingService.appleIntelligenceId
+        let supportedRange = viewModel.supportedTemperatureRange(for: effectiveProviderId)
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text(localizedAppText("Temperature", de: "Temperatur"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Picker(localizedAppText("Who decides?", de: "Wer entscheidet?"), selection: temperatureModeBinding) {
+                Text(localizedAppText("Use my provider setting", de: "Meine Provider-Einstellung")).tag(PluginLLMTemperatureMode.inheritProviderSetting)
+                Text(localizedAppText("Use provider default", de: "Provider-Standard")).tag(PluginLLMTemperatureMode.providerDefault)
+                Text(localizedAppText("Set for this prompt", de: "Für diesen Prompt setzen")).tag(PluginLLMTemperatureMode.custom)
+            }
+            .disabled(isAppleIntelligence)
+
+            if viewModel.editTemperatureMode == .custom {
+                HStack {
+                    Text(localizedAppText("Temperature", de: "Temperatur"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(viewModel.editTemperatureValue, format: .number.precision(.fractionLength(2)))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+
+                Slider(
+                    value: temperatureValueBinding,
+                    in: supportedRange,
+                    step: effectiveProviderId == "Gemma 4 (MLX)" ? 0.05 : 0.1
+                )
+                .disabled(isAppleIntelligence)
+
+                HStack {
+                    Text("\(supportedRange.lowerBound, format: .number.precision(.fractionLength(1)))")
+                    Spacer()
+                    Text("\(supportedRange.upperBound, format: .number.precision(.fractionLength(1)))")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Text(temperatureHelperText(isAppleIntelligence: isAppleIntelligence, effectiveProviderId: effectiveProviderId))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var advancedSummary: String {
+        var items: [String] = []
+        let formattedTemperature = viewModel.editTemperatureValue.formatted(.number.precision(.fractionLength(2)))
+
+        if let providerId = viewModel.editProviderId {
+            items.append(processingService.displayName(for: providerId))
+        } else {
+            items.append(localizedAppText("Default provider", de: "Standard-Provider"))
+        }
+
+        if !viewModel.editCloudModel.isEmpty {
+            let effectiveProviderId = viewModel.editProviderId ?? processingService.selectedProviderId
+            let modelName = processingService.modelsForProvider(effectiveProviderId)
+                .first(where: { $0.id == viewModel.editCloudModel })?
+                .displayName ?? viewModel.editCloudModel
+            items.append(modelName)
+        }
+
+        switch viewModel.editTemperatureMode {
+        case .inheritProviderSetting:
+            items.append(localizedAppText("Provider temperature", de: "Provider-Temperatur"))
+        case .providerDefault:
+            items.append(localizedAppText("Provider default temp", de: "Provider-Standardtemp"))
+        case .custom:
+            items.append(localizedAppText(
+                "Temp \(formattedTemperature)",
+                de: "Temp \(formattedTemperature)"
+            ))
+        }
+
+        return items.joined(separator: " • ")
+    }
+
+    private var behaviorSectionTitle: String {
+        switch viewModel.wizardDraft.goal {
+        case .translate:
+            return localizedAppText("Translation Behavior", de: "Übersetzungsverhalten")
+        case .rewrite:
+            return localizedAppText("Rewrite Behavior", de: "Umformulierungsverhalten")
+        case .replyEmail:
+            return localizedAppText("Reply Behavior", de: "Antwortverhalten")
+        case .extract:
+            return localizedAppText("Extraction Output", de: "Extraktionsausgabe")
+        case .structure:
+            return localizedAppText("Formatting Output", de: "Formatierungsausgabe")
+        case .custom:
+            return localizedAppText("Custom Behavior", de: "Benutzerdefiniertes Verhalten")
+        }
+    }
+
+    private var behaviorSectionDescription: String {
+        switch viewModel.wizardDraft.goal {
+        case .translate:
+            return localizedAppText("Choose one target language or a two-way language pair.", de: "Wähle eine Zielsprache oder ein Zwei-Wege-Sprachpaar.")
+        case .rewrite:
+            return localizedAppText("Pick tone, language behavior, and output form.", de: "Wähle Ton, Sprachverhalten und Ausgabeform.")
+        case .replyEmail:
+            return localizedAppText("Decide whether this drafts a reply or a full email.", de: "Lege fest, ob eine Antwort oder eine vollständige E-Mail erstellt wird.")
+        case .extract:
+            return localizedAppText("Define the structure for the extracted information.", de: "Definiere die Struktur für die extrahierten Informationen.")
+        case .structure:
+            return localizedAppText("Choose how the input should be reformatted.", de: "Wähle, wie der Input umformatiert werden soll.")
+        case .custom:
+            return localizedAppText("Describe the job briefly, then add optional tone and output hints.", de: "Beschreibe die Aufgabe kurz und ergänze optionale Ton- und Ausgabehinweise.")
+        }
+    }
+
+    private var translationModeChoiceBinding: Binding<PromptWizardTranslationChoice> {
+        Binding(
+            get: {
+                switch viewModel.wizardDraft.translationMode {
+                case .alternatingPair:
+                    return .alternating
+                case .direct, .none:
+                    return .direct
+                }
+            },
+            set: { choice in
+                viewModel.updateWizardDraft { draft in
+                    switch choice {
+                    case .direct:
+                        let currentTarget: String
+                        switch draft.translationMode {
+                        case .alternatingPair(let primaryLanguage, _):
+                            currentTarget = primaryLanguage
+                        case .direct(let targetLanguage):
+                            currentTarget = targetLanguage
+                        case nil:
+                            currentTarget = "en"
+                        }
+                        draft.translationMode = .direct(targetLanguage: currentTarget)
+                    case .alternating:
+                        let primaryLanguage: String
+                        switch draft.translationMode {
+                        case .direct(let targetLanguage):
+                            primaryLanguage = targetLanguage
+                        case .alternatingPair(let primary, _):
+                            primaryLanguage = primary
+                        case nil:
+                            primaryLanguage = "en"
+                        }
+                        let secondaryLanguage = primaryLanguage == "en" ? "de" : "en"
+                        draft.translationMode = .alternatingPair(primaryLanguage: primaryLanguage, secondaryLanguage: secondaryLanguage)
+                    }
+                }
+            }
+        )
+    }
+
+    private var directTargetLanguageBinding: Binding<String> {
+        Binding(
+            get: {
+                switch viewModel.wizardDraft.translationMode {
+                case .direct(let targetLanguage):
+                    return targetLanguage
+                case .alternatingPair(let primaryLanguage, _):
+                    return primaryLanguage
+                case nil:
+                    return "en"
+                }
+            },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.translationMode = .direct(targetLanguage: newValue)
+                }
+            }
+        )
+    }
+
+    private var alternatingPrimaryLanguageBinding: Binding<String> {
+        Binding(
+            get: {
+                if case .alternatingPair(let primaryLanguage, _) = viewModel.wizardDraft.translationMode {
+                    return primaryLanguage
+                }
+                return "en"
+            },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    let secondary = (draft.translationMode?.secondaryLanguage ?? (newValue == "en" ? "de" : "en"))
+                    draft.translationMode = .alternatingPair(primaryLanguage: newValue, secondaryLanguage: secondary)
+                }
+            }
+        )
+    }
+
+    private var alternatingSecondaryLanguageBinding: Binding<String> {
+        Binding(
+            get: {
+                if case .alternatingPair(_, let secondaryLanguage) = viewModel.wizardDraft.translationMode {
+                    return secondaryLanguage
+                }
+                return "de"
+            },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    let primary = draft.translationMode?.primaryLanguage ?? "en"
+                    draft.translationMode = .alternatingPair(primaryLanguage: primary, secondaryLanguage: newValue)
+                }
+            }
+        )
+    }
+
+    private var toneBinding: Binding<PromptWizardTone> {
+        Binding(
+            get: { viewModel.wizardDraft.tone },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.tone = newValue
+                }
+            }
+        )
+    }
+
+    private var languageChoiceBinding: Binding<PromptWizardLanguageChoice> {
+        Binding(
+            get: {
+                switch viewModel.wizardDraft.languageMode {
+                case .sameAsInput:
+                    return .sameAsInput
+                case .target:
+                    return .targetLanguage
+                }
+            },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    switch newValue {
+                    case .sameAsInput:
+                        draft.languageMode = .sameAsInput
+                    case .targetLanguage:
+                        let target = draft.languageMode.targetLanguageCode ?? "en"
+                        draft.languageMode = .target(target)
+                    }
+                }
+            }
+        )
+    }
+
+    private var targetLanguageBinding: Binding<String> {
+        Binding(
+            get: { viewModel.wizardDraft.languageMode.targetLanguageCode ?? "en" },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.languageMode = .target(newValue)
+                }
+            }
+        )
+    }
+
+    private var rewriteFormatBinding: Binding<PromptWizardRewriteFormat> {
+        Binding(
+            get: { viewModel.wizardDraft.rewriteFormat },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.rewriteFormat = newValue
+                }
+            }
+        )
+    }
+
+    private var replyModeBinding: Binding<PromptWizardReplyMode> {
+        Binding(
+            get: { viewModel.wizardDraft.replyMode },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.replyMode = newValue
+                }
+            }
+        )
+    }
+
+    private var responseLengthBinding: Binding<PromptWizardResponseLength> {
+        Binding(
+            get: { viewModel.wizardDraft.responseLength },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.responseLength = newValue
+                }
+            }
+        )
+    }
+
+    private var extractFormatBinding: Binding<PromptWizardExtractFormat> {
+        Binding(
+            get: { viewModel.wizardDraft.extractFormat },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.extractFormat = newValue
+                }
+            }
+        )
+    }
+
+    private var structureFormatBinding: Binding<PromptWizardStructureFormat> {
+        Binding(
+            get: { viewModel.wizardDraft.structureFormat },
+            set: { newValue in
+                viewModel.updateWizardDraft { draft in
+                    draft.structureFormat = newValue
+                }
+            }
+        )
+    }
+
+    private var providerBinding: Binding<String?> {
+        Binding(
+            get: { viewModel.editProviderId },
+            set: { newValue in
+                viewModel.setWizardProviderOverride(newValue)
+            }
+        )
+    }
+
+    private var cloudModelBinding: Binding<String> {
+        Binding(
+            get: { viewModel.editCloudModel },
+            set: { newValue in
+                viewModel.setWizardCloudModel(newValue)
+            }
+        )
+    }
+
+    private var temperatureModeBinding: Binding<PluginLLMTemperatureMode> {
+        Binding(
+            get: { viewModel.editTemperatureMode },
+            set: { newValue in
+                viewModel.setWizardTemperatureMode(newValue)
+            }
+        )
+    }
+
+    private var temperatureValueBinding: Binding<Double> {
+        Binding(
+            get: { viewModel.editTemperatureValue },
+            set: { newValue in
+                viewModel.setWizardTemperatureValue(newValue)
+            }
+        )
+    }
+
+    private func temperatureHelperText(isAppleIntelligence: Bool, effectiveProviderId: String) -> String {
+        if isAppleIntelligence {
+            return localizedAppText(
+                "Temperature is not available for Apple Intelligence.",
+                de: "Temperatur ist für Apple Intelligence nicht verfügbar."
+            )
+        }
+
+        switch viewModel.editTemperatureMode {
+        case .inheritProviderSetting:
+            return localizedAppText(
+                "Uses the temperature saved in this provider's settings.",
+                de: "Verwendet die in den Provider-Einstellungen gespeicherte Temperatur."
+            )
+        case .providerDefault:
+            return localizedAppText(
+                "Ignores your saved provider setting and lets the provider use its own default behavior.",
+                de: "Ignoriert deine gespeicherte Provider-Einstellung und nutzt das Standardverhalten des Providers."
+            )
+        case .custom:
+            if effectiveProviderId == "Gemma 4 (MLX)" {
+                return localizedAppText(
+                    "Uses this value only for this prompt. Gemma 4 supports values from 0.0 to 1.0.",
+                    de: "Verwendet diesen Wert nur für diesen Prompt. Gemma 4 unterstützt Werte von 0.0 bis 1.0."
+                )
+            }
+            return localizedAppText(
+                "Uses this value only for this prompt and overrides the provider setting.",
+                de: "Verwendet diesen Wert nur für diesen Prompt und überschreibt die Provider-Einstellung."
+            )
+        }
+    }
+}
+
+private struct PromptWizardReviewStep: View {
+    @ObservedObject var viewModel: PromptActionsViewModel
+    @Binding var showingAdvancedOptions: Bool
+    let iconOptions: [String]
+
+    var body: some View {
+        let actionPlugins = PluginManager.shared.actionPlugins
+
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localizedAppText("Review & Advanced", de: "Review & Erweitert"))
+                    .font(.title3.weight(.semibold))
+                Text(localizedAppText(
+                    "Finalize the visible prompt details first. The raw system prompt and action target live in Advanced.",
+                    de: "Finalisiere zuerst die sichtbaren Prompt-Details. Roh-System-Prompt und Action-Ziel liegen unter Erweitert."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+
+            promptWizardCompactSection(
+                title: localizedAppText("Prompt Details", de: "Prompt-Details"),
+                description: localizedAppText("Set the final name, enabled state, icon, and list preview.", de: "Lege finalen Namen, Aktiv-Status, Icon und Listen-Vorschau fest.")
+            ) {
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack(alignment: .center, spacing: 14) {
+                        TextField(
+                            localizedAppText("Prompt Name", de: "Prompt-Name"),
+                            text: Binding(
+                                get: { viewModel.currentPromptName },
+                                set: { viewModel.updateWizardName($0) }
+                            )
+                        )
+                        .textFieldStyle(.roundedBorder)
+
+                        HStack(spacing: 10) {
+                            Text(localizedAppText("Active", de: "Aktiv"))
+                                .font(.subheadline.weight(.medium))
+
+                            Toggle(
+                                localizedAppText("Active", de: "Aktiv"),
+                                isOn: Binding(
+                                    get: { viewModel.editIsEnabled },
+                                    set: { viewModel.setWizardEnabled($0) }
+                                )
+                            )
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color.white.opacity(0.03), in: Capsule())
+                        .overlay {
+                            Capsule()
+                                .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                        }
+                        .fixedSize()
+                    }
+
+                    HStack(alignment: .top, spacing: 12) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .fill(Color.accentColor.opacity(0.14))
+                                .frame(width: 42, height: 42)
+
+                            Image(systemName: viewModel.editIcon)
+                                .foregroundStyle(Color.accentColor)
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(viewModel.currentPromptName)
+                                .font(.title3.weight(.semibold))
+                            Text(PromptWizardComposer.reviewSummary(for: viewModel.wizardDraft))
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer(minLength: 12)
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(localizedAppText("Icon", de: "Icon"))
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+
+                            Picker(
+                                localizedAppText("Icon", de: "Icon"),
+                                selection: Binding(
+                                    get: { viewModel.editIcon },
+                                    set: { viewModel.setWizardIcon($0) }
+                                )
+                            ) {
+                                ForEach(iconOptions, id: \.self) { icon in
+                                    Label(promptWizardIconDisplayName(for: icon), systemImage: icon)
+                                        .tag(icon)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
+                            .frame(width: 180, alignment: .leading)
+                        }
+
+                        Spacer()
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        showingAdvancedOptions.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(localizedAppText("Advanced", de: "Erweitert"))
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+
+                            Text(localizedAppText(
+                                "System prompt editing and optional action target.",
+                                de: "Bearbeitung des System-Prompts und optionales Action-Ziel."
+                            ))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Text(reviewAdvancedSummary)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        Image(systemName: showingAdvancedOptions ? "chevron.up" : "chevron.down")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                if showingAdvancedOptions {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Divider()
+                            .padding(.top, 12)
+
+                        promptWizardEditorSubsection(
+                            title: localizedAppText("System Prompt", de: "System-Prompt"),
+                            description: localizedAppText("This is the final raw prompt that will be saved and executed.", de: "Das ist der finale Roh-Prompt, der gespeichert und ausgeführt wird.")
+                        ) {
+                            VStack(alignment: .leading, spacing: 12) {
+                                if viewModel.manualPromptOverride {
+                                    HStack(spacing: 10) {
+                                        Label(localizedAppText("Manual override active", de: "Manueller Override aktiv"), systemImage: "pencil.and.outline")
+                                            .font(.caption.weight(.semibold))
+                                            .foregroundStyle(.orange)
+
+                                        Spacer()
+
+                                        Button(localizedAppText("Regenerate from selections", de: "Aus Auswahl neu erzeugen")) {
+                                            viewModel.regeneratePromptFromWizardSelections()
+                                        }
+                                        .buttonStyle(.bordered)
+                                        .controlSize(.small)
+                                    }
+                                } else {
+                                    Label(localizedAppText(
+                                        "Changes in the wizard still regenerate this prompt automatically.",
+                                        de: "Änderungen im Wizard erzeugen diesen Prompt weiterhin automatisch neu."
+                                    ), systemImage: "wand.and.stars")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                }
+
+                                TextEditor(text: Binding(
+                                    get: { viewModel.editPrompt },
+                                    set: { viewModel.updateManualPrompt($0) }
+                                ))
+                                .font(.body)
+                                .frame(height: 180)
+                                .padding(8)
+                                .background(Color.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                        .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+                                }
+                            }
+                        }
+
+                        if !actionPlugins.isEmpty {
+                            Divider()
+
+                            promptWizardEditorSubsection(
+                                title: localizedAppText("Action Target", de: "Action-Ziel"),
+                                description: localizedAppText(
+                                    "Optional action target instead of direct text insertion.",
+                                    de: "Optionales Action-Ziel statt direktem Texteinsatz."
+                                )
+                            ) {
+                                VStack(alignment: .leading, spacing: 10) {
+                                    Picker(
+                                        localizedAppText("Target", de: "Ziel"),
+                                        selection: Binding(
+                                            get: { viewModel.editTargetActionPluginId },
+                                            set: { viewModel.setWizardTargetActionPluginId($0) }
+                                        )
+                                    ) {
+                                        Text(localizedAppText("Insert Text", de: "Text einfügen")).tag(nil as String?)
+                                        ForEach(actionPlugins, id: \.actionId) { plugin in
+                                            Label(plugin.actionName, systemImage: plugin.actionIcon)
+                                                .tag(plugin.actionId as String?)
+                                        }
+                                    }
+
+                                    Text(localizedAppText(
+                                        "Leave this on Insert Text unless the result should trigger a plugin action.",
+                                        de: "Lass dies auf Text einfügen, wenn das Ergebnis keine Plugin-Aktion auslösen soll."
+                                    ))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(18)
+            .background {
+                promptWizardElevatedPanel(cornerRadius: 20)
+            }
+        }
+    }
+
+    private var reviewAdvancedSummary: String {
+        var parts: [String] = [
+            viewModel.manualPromptOverride
+                ? localizedAppText("Manual prompt", de: "Manueller Prompt")
+                : localizedAppText("Auto prompt", de: "Auto-Prompt")
+        ]
+
+        if let targetActionPluginId = viewModel.editTargetActionPluginId,
+           let plugin = PluginManager.shared.actionPlugin(for: targetActionPluginId) {
+            parts.append(plugin.actionName)
+        } else {
+            parts.append(localizedAppText("Insert Text", de: "Text einfügen"))
+        }
+
+        return parts.joined(separator: " • ")
+    }
+}
+
+private enum PromptWizardTranslationChoice: Hashable {
+    case direct
+    case alternating
+}
+
+private enum PromptWizardLanguageChoice: Hashable {
+    case sameAsInput
+    case targetLanguage
+}
+
+private struct PromptWizardLanguageOption {
+    let code: String
+    let name: String
+}
+
+private let promptWizardCommonLanguages: [PromptWizardLanguageOption] = [
+    .init(code: "en", name: "English"),
+    .init(code: "de", name: "German"),
+    .init(code: "fr", name: "French"),
+    .init(code: "es", name: "Spanish"),
+    .init(code: "it", name: "Italian"),
+    .init(code: "pt", name: "Portuguese")
+]
+
+private func promptWizardLanguagePicker(title: String, selection: Binding<String>) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+
+        Picker(title, selection: selection) {
+            ForEach(promptWizardCommonLanguages, id: \.code) { language in
+                Text(language.name).tag(language.code)
+            }
+        }
+        .labelsHidden()
+    }
+}
+
+private func promptWizardTonePicker(tone: Binding<PromptWizardTone>) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+        Text(localizedAppText("Tone", de: "Ton"))
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+
+        Picker(localizedAppText("Tone", de: "Ton"), selection: tone) {
+            Text(localizedAppText("Neutral", de: "Neutral")).tag(PromptWizardTone.neutral)
+            Text(localizedAppText("Formal", de: "Formal")).tag(PromptWizardTone.formal)
+            Text(localizedAppText("Friendly", de: "Freundlich")).tag(PromptWizardTone.friendly)
+            Text(localizedAppText("Concise", de: "Knapp")).tag(PromptWizardTone.concise)
+            Text(localizedAppText("Clear", de: "Klar")).tag(PromptWizardTone.clear)
+            Text(localizedAppText("Professional", de: "Professionell")).tag(PromptWizardTone.professional)
+        }
+    }
+}
+
+private func promptWizardLanguageModeSection(
+    mode: Binding<PromptWizardLanguageChoice>,
+    targetLanguage: Binding<String>
+) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+        Picker(localizedAppText("Language", de: "Sprache"), selection: mode) {
+            Text(localizedAppText("Same as Input", de: "Wie Input")).tag(PromptWizardLanguageChoice.sameAsInput)
+            Text(localizedAppText("Target Language", de: "Zielsprache")).tag(PromptWizardLanguageChoice.targetLanguage)
+        }
+        .pickerStyle(.segmented)
+
+        if mode.wrappedValue == .targetLanguage {
+            promptWizardLanguagePicker(
+                title: localizedAppText("Target Language", de: "Zielsprache"),
+                selection: targetLanguage
+            )
+        }
+    }
+}
+
+private func promptWizardCompactSection<Content: View>(
+    title: String,
+    description: String? = nil,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.headline)
+
+            if let description, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        content()
+    }
+    .padding(16)
+    .background {
+        promptWizardElevatedPanel(cornerRadius: 18)
+    }
+}
+
+private func promptWizardEditorSubsection<Content: View>(
+    title: String,
+    description: String? = nil,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.accentColor)
+
+            if let description, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        content()
+    }
+}
+
+private func promptWizardInfoChip(_ text: String, tint: Color) -> some View {
+    Text(text)
+        .font(.caption.weight(.semibold))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .foregroundStyle(.white)
+        .background(tint, in: Capsule())
+        .overlay {
+            Capsule()
+                .strokeBorder(tint.opacity(0.95), lineWidth: 1)
+        }
+}
+
+private func promptWizardActiveSelectionFill() -> some ShapeStyle {
+    Color.accentColor
+}
+
+private func promptWizardElevatedPanel(cornerRadius: CGFloat) -> some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color(nsColor: .controlBackgroundColor).opacity(0.98))
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.05), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.18), radius: 16, x: 0, y: 10)
+        .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
+}
+
+private func promptWizardGroupedListSurface(cornerRadius: CGFloat) -> some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color.white.opacity(0.022))
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.038), lineWidth: 1)
+        }
+}
+
+private func promptWizardIconDisplayName(for icon: String) -> String {
+    switch icon {
+    case "sparkles":
+        return localizedAppText("Sparkles", de: "Funkeln")
+    case "globe":
+        return localizedAppText("Translate", de: "Übersetzen")
+    case "wand.and.stars":
+        return localizedAppText("Magic", de: "Magie")
+    case "arrowshape.turn.up.left":
+        return localizedAppText("Reply", de: "Antwort")
+    case "envelope":
+        return localizedAppText("Email", de: "E-Mail")
+    case "envelope.badge":
+        return localizedAppText("Email Action", de: "E-Mail-Aktion")
+    case "list.bullet":
+        return localizedAppText("List", de: "Liste")
+    case "checklist":
+        return localizedAppText("Checklist", de: "Checkliste")
+    case "tablecells":
+        return localizedAppText("Table", de: "Tabelle")
+    case "curlybraces":
+        return localizedAppText("JSON", de: "JSON")
+    case "doc.text.magnifyingglass":
+        return localizedAppText("Extract", de: "Extrahieren")
+    case "textformat.abc":
+        return localizedAppText("Rewrite", de: "Umschreiben")
+    case "text.quote":
+        return localizedAppText("Quote", de: "Zitat")
+    case "pencil":
+        return localizedAppText("Draft", de: "Entwurf")
+    case "lightbulb":
+        return localizedAppText("Idea", de: "Idee")
+    case "character.textbox":
+        return localizedAppText("Text Box", de: "Textfeld")
+    default:
+        return icon
     }
 }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -15,6 +15,11 @@ private struct SettingsDestination: Identifiable, Hashable {
     var id: SettingsTab { tab }
 }
 
+private struct SettingsDestinationSection: Identifiable {
+    let id: String
+    let destinations: [SettingsDestination]
+}
+
 struct SettingsView: View {
     @State private var selectedTab: SettingsTab = .home
     @ObservedObject private var fileTranscription = FileTranscriptionViewModel.shared
@@ -52,18 +57,22 @@ struct SettingsView: View {
         ]
     }
 
+    private var destinationSections: [SettingsDestinationSection] {
+        settingsDestinationSections(destinations)
+    }
+
     var body: some View {
         Group {
             if #available(macOS 15, *) {
                 SettingsModernShell(
                     selectedTab: $selectedTab,
-                    destinations: destinations,
+                    sections: destinationSections,
                     detail: { tab in AnyView(settingsDetail(for: tab)) }
                 )
             } else {
                 SettingsSidebarShell(
                     selectedTab: $selectedTab,
-                    destinations: destinations,
+                    sections: destinationSections,
                     detail: settingsDetail(for:)
                 )
             }
@@ -133,108 +142,64 @@ struct SettingsView: View {
 @available(macOS 15, *)
 private struct SettingsModernShell: View {
     @Binding var selectedTab: SettingsTab
-    let destinations: [SettingsDestination]
+    let sections: [SettingsDestinationSection]
     let detail: (SettingsTab) -> AnyView
+
+    @State private var sidebarSearchText = ""
+    @State private var splitViewVisibility: NavigationSplitViewVisibility = .all
+
+    private var filteredSections: [SettingsDestinationSection] {
+        let query = sidebarSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return sections }
+
+        return sections
+            .map { section in
+                SettingsDestinationSection(
+                    id: section.id,
+                    destinations: section.destinations.filter { destination in
+                        destination.title.localizedCaseInsensitiveContains(query)
+                    }
+                )
+            }
+            .filter { !$0.destinations.isEmpty }
+    }
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            SettingsModernMainTabs(destinations: destinations, detail: detail)
-        }
-        .tabViewStyle(.sidebarAdaptable)
-    }
-}
-
-@available(macOS 15, *)
-private struct SettingsModernMainTabs: TabContent {
-    let destinations: [SettingsDestination]
-    let detail: (SettingsTab) -> AnyView
-
-    var body: some TabContent<SettingsTab> {
-        Tab(settingsTitle(destinations, .home), systemImage: settingsSystemImage(destinations, .home), value: .home) {
-            detail(.home)
-        }
-
-        Tab(settingsTitle(destinations, .general), systemImage: settingsSystemImage(destinations, .general), value: .general) {
-            detail(.general)
-        }
-
-        Tab(settingsTitle(destinations, .recording), systemImage: settingsSystemImage(destinations, .recording), value: .recording) {
-            detail(.recording)
-        }
-
-        Tab(settingsTitle(destinations, .hotkeys), systemImage: settingsSystemImage(destinations, .hotkeys), value: .hotkeys) {
-            detail(.hotkeys)
-        }
-
-        Tab(settingsTitle(destinations, .fileTranscription), systemImage: settingsSystemImage(destinations, .fileTranscription), value: .fileTranscription) {
-            detail(.fileTranscription)
-        }
-
-        Tab(settingsTitle(destinations, .recorder), systemImage: settingsSystemImage(destinations, .recorder), value: .recorder) {
-            detail(.recorder)
-        }
-
-        Tab(settingsTitle(destinations, .history), systemImage: settingsSystemImage(destinations, .history), value: .history) {
-            detail(.history)
-        }
-        SettingsModernExtraTabs(destinations: destinations, detail: detail)
-    }
-}
-
-@available(macOS 15, *)
-private struct SettingsModernExtraTabs: TabContent {
-    let destinations: [SettingsDestination]
-    let detail: (SettingsTab) -> AnyView
-
-    var body: some TabContent<SettingsTab> {
-        Tab(settingsTitle(destinations, .dictionary), systemImage: settingsSystemImage(destinations, .dictionary), value: .dictionary) {
-            detail(.dictionary)
-        }
-
-        Tab(settingsTitle(destinations, .snippets), systemImage: settingsSystemImage(destinations, .snippets), value: .snippets) {
-            detail(.snippets)
-        }
-
-        Tab(settingsTitle(destinations, .profiles), systemImage: settingsSystemImage(destinations, .profiles), value: .profiles) {
-            detail(.profiles)
-        }
-
-        Tab(settingsTitle(destinations, .prompts), systemImage: settingsSystemImage(destinations, .prompts), value: .prompts) {
-            detail(.prompts)
-        }
-
-        if let integrationsBadge = settingsBadge(destinations, .integrations) {
-            Tab(settingsTitle(destinations, .integrations), systemImage: settingsSystemImage(destinations, .integrations), value: .integrations) {
-                detail(.integrations)
+        NavigationSplitView(columnVisibility: $splitViewVisibility) {
+            List(selection: $selectedTab) {
+                ForEach(filteredSections) { section in
+                    Section {
+                        ForEach(section.destinations) { destination in
+                            SettingsSidebarRow(destination: destination)
+                                .tag(destination.tab)
+                        }
+                    }
+                }
             }
-            .badge(integrationsBadge)
-        } else {
-            Tab(settingsTitle(destinations, .integrations), systemImage: settingsSystemImage(destinations, .integrations), value: .integrations) {
-                detail(.integrations)
+            .listStyle(.sidebar)
+            .searchable(
+                text: $sidebarSearchText,
+                placement: .sidebar,
+                prompt: Text(localizedAppText("Search Settings", de: "Einstellungen durchsuchen"))
+            )
+            .navigationSplitViewColumnWidth(min: 240, ideal: 270, max: 320)
+        } detail: {
+            detail(selectedTab)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: toggleSidebar) {
+                    Image(systemName: "sidebar.leading")
+                }
+                .help(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
+                .accessibilityLabel(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
             }
         }
-
-        SettingsModernBottomTabs(destinations: destinations, detail: detail)
     }
-}
 
-@available(macOS 15, *)
-private struct SettingsModernBottomTabs: TabContent {
-    let destinations: [SettingsDestination]
-    let detail: (SettingsTab) -> AnyView
-
-    var body: some TabContent<SettingsTab> {
-        Tab(settingsTitle(destinations, .advanced), systemImage: settingsSystemImage(destinations, .advanced), value: .advanced) {
-            detail(.advanced)
-        }
-
-        Tab(settingsTitle(destinations, .license), systemImage: settingsSystemImage(destinations, .license), value: .license) {
-            detail(.license)
-        }
-
-        Tab(settingsTitle(destinations, .about), systemImage: settingsSystemImage(destinations, .about), value: .about) {
-            detail(.about)
-        }
+    private func toggleSidebar() {
+        splitViewVisibility = splitViewVisibility == .detailOnly ? .all : .detailOnly
     }
 }
 
@@ -254,9 +219,47 @@ private func settingsBadge(_ destinations: [SettingsDestination], _ tab: Setting
     settingsDestination(destinations, tab).badge
 }
 
+private func settingsDestinationSections(_ destinations: [SettingsDestination]) -> [SettingsDestinationSection] {
+    [
+        SettingsDestinationSection(
+            id: "home",
+            destinations: [settingsDestination(destinations, .home)]
+        ),
+        SettingsDestinationSection(
+            id: "core",
+            destinations: [
+                settingsDestination(destinations, .general),
+                settingsDestination(destinations, .recording),
+                settingsDestination(destinations, .hotkeys),
+                settingsDestination(destinations, .fileTranscription),
+                settingsDestination(destinations, .recorder)
+            ]
+        ),
+        SettingsDestinationSection(
+            id: "workspace",
+            destinations: [
+                settingsDestination(destinations, .history),
+                settingsDestination(destinations, .dictionary),
+                settingsDestination(destinations, .snippets),
+                settingsDestination(destinations, .profiles),
+                settingsDestination(destinations, .prompts),
+                settingsDestination(destinations, .integrations)
+            ]
+        ),
+        SettingsDestinationSection(
+            id: "system",
+            destinations: [
+                settingsDestination(destinations, .advanced),
+                settingsDestination(destinations, .license),
+                settingsDestination(destinations, .about)
+            ]
+        )
+    ]
+}
+
 private struct SettingsSidebarShell<DetailContent: View>: View {
     @Binding var selectedTab: SettingsTab
-    let destinations: [SettingsDestination]
+    let sections: [SettingsDestinationSection]
     let detail: (SettingsTab) -> DetailContent
 
     @State private var isSidebarVisible = true
@@ -264,9 +267,15 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
     var body: some View {
         HStack(spacing: 0) {
             if isSidebarVisible {
-                List(destinations, selection: $selectedTab) { destination in
-                    SettingsSidebarRow(destination: destination)
-                        .tag(destination.tab)
+                List(selection: $selectedTab) {
+                    ForEach(sections) { section in
+                        Section {
+                            ForEach(section.destinations) { destination in
+                                SettingsSidebarRow(destination: destination)
+                                    .tag(destination.tab)
+                            }
+                        }
+                    }
                 }
                 .listStyle(.sidebar)
                 .frame(width: 240)
@@ -311,16 +320,26 @@ private struct SettingsSidebarRow: View {
             Spacer(minLength: 8)
 
             if let badge = destination.badge {
-                Text("\(badge)")
-                    .font(.caption2.weight(.semibold))
-                    .monospacedDigit()
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.tertiary, in: Capsule())
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel("\(destination.title), \(badge) updates")
+                SettingsSidebarBadge(title: destination.title, count: badge)
             }
         }
+        .contentShape(Rectangle())
+    }
+}
+
+private struct SettingsSidebarBadge: View {
+    let title: String
+    let count: Int
+
+    var body: some View {
+        Text("\(count)")
+            .font(.caption2.weight(.semibold))
+            .monospacedDigit()
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.tertiary, in: Capsule())
+            .foregroundStyle(.secondary)
+            .accessibilityLabel("\(title), \(count) updates")
     }
 }
 

--- a/TypeWhisperTests/PromptActionsViewModelWizardTests.swift
+++ b/TypeWhisperTests/PromptActionsViewModelWizardTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+@MainActor
+final class PromptActionsViewModelWizardTests: XCTestCase {
+    func testStartCreatingResetsWizardState() throws {
+        let viewModel = try makeViewModel()
+
+        viewModel.startCreating()
+
+        XCTAssertEqual(viewModel.wizardStep, .goal)
+        XCTAssertEqual(viewModel.wizardDraft.goal, .custom)
+        XCTAssertFalse(viewModel.manualPromptOverride)
+        XCTAssertFalse(viewModel.isEditingExistingPrompt)
+        XCTAssertTrue(viewModel.isCreatingNew)
+        XCTAssertEqual(viewModel.editIcon, "sparkles")
+    }
+
+    func testCurrentPromptNameFallsBackToSuggestedName() throws {
+        let viewModel = try makeViewModel()
+
+        viewModel.startCreating()
+        XCTAssertEqual(viewModel.currentPromptName, localizedAppText("Custom Prompt", de: "Benutzerdefinierter Prompt"))
+
+        viewModel.setWizardGoal(.extract)
+        viewModel.updateWizardDraft { draft in
+            draft.extractFormat = .json
+        }
+        XCTAssertEqual(viewModel.currentPromptName, localizedAppText("Extract JSON", de: "JSON extrahieren"))
+
+        viewModel.updateWizardName("My Extractor")
+        XCTAssertEqual(viewModel.currentPromptName, "My Extractor")
+
+        viewModel.updateWizardName("")
+        XCTAssertEqual(viewModel.currentPromptName, localizedAppText("Extract JSON", de: "JSON extrahieren"))
+    }
+
+    func testManualPromptOverridePreventsAutomaticRegeneration() throws {
+        let viewModel = try makeViewModel()
+        viewModel.startCreating()
+        viewModel.setWizardGoal(.translate)
+        viewModel.updateWizardDraft { draft in
+            draft.translationMode = .alternatingPair(primaryLanguage: "en", secondaryLanguage: "de")
+        }
+
+        let generatedPrompt = viewModel.editPrompt
+        XCTAssertFalse(generatedPrompt.isEmpty)
+
+        viewModel.updateManualPrompt("My custom prompt.")
+        viewModel.setWizardGoal(.extract)
+
+        XCTAssertTrue(viewModel.manualPromptOverride)
+        XCTAssertEqual(viewModel.editPrompt, "My custom prompt.")
+    }
+
+    func testStartEditingInfersWizardStateFromExistingPrompt() throws {
+        let viewModel = try makeViewModel()
+        let action = PromptAction(
+            name: "Reply",
+            prompt: "Write a concise, friendly reply to the following message. Respond in the same language as the input text. Only return the reply.",
+            icon: "arrowshape.turn.up.left",
+            providerType: "Groq",
+            cloudModel: "llama-3.3",
+            temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+            temperatureValue: 0.4
+        )
+
+        viewModel.startEditing(action)
+
+        XCTAssertFalse(viewModel.isCreatingNew)
+        XCTAssertTrue(viewModel.isEditingExistingPrompt)
+        XCTAssertEqual(viewModel.wizardStep, .goal)
+        XCTAssertEqual(viewModel.wizardDraft.goal, .replyEmail)
+        XCTAssertEqual(viewModel.wizardDraft.replyMode, .reply)
+        XCTAssertEqual(viewModel.wizardDraft.tone, .friendly)
+        XCTAssertEqual(viewModel.wizardDraft.languageMode, .sameAsInput)
+        XCTAssertEqual(viewModel.editPrompt, action.prompt)
+        XCTAssertFalse(viewModel.manualPromptOverride)
+    }
+
+    func testSaveEditingPersistsPromptAndAdvancedFields() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let processingService = PromptProcessingService()
+        let viewModel = PromptActionsViewModel(
+            promptActionService: service,
+            promptProcessingService: processingService
+        )
+
+        viewModel.startCreating()
+        viewModel.setWizardGoal(.extract)
+        viewModel.updateWizardDraft { draft in
+            draft.extractFormat = .json
+        }
+        viewModel.editName = "JSON Extractor"
+        viewModel.setWizardEnabled(false)
+        viewModel.editProviderId = "Groq"
+        viewModel.editCloudModel = "llama-3.3"
+        viewModel.editTemperatureMode = .custom
+        viewModel.editTemperatureValue = 0.2
+        viewModel.editTargetActionPluginId = "plugin.action"
+
+        viewModel.saveEditing()
+
+        let action = try XCTUnwrap(service.promptActions.first)
+        XCTAssertEqual(action.name, "JSON Extractor")
+        XCTAssertFalse(action.isEnabled)
+        XCTAssertEqual(action.prompt, "Extract structured data from the following text and format it as valid, well-indented JSON. Use descriptive keys and appropriate data types. Only return the JSON, nothing else.")
+        XCTAssertEqual(action.providerType, "Groq")
+        XCTAssertEqual(action.cloudModel, "llama-3.3")
+        XCTAssertEqual(action.temperatureModeRaw, PluginLLMTemperatureMode.custom.rawValue)
+        XCTAssertEqual(action.temperatureValue, 0.2)
+        XCTAssertEqual(action.targetActionPluginId, "plugin.action")
+    }
+
+    func testSaveEditingUsesSuggestedNameWhenNameWasNotEdited() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let processingService = PromptProcessingService()
+        let viewModel = PromptActionsViewModel(
+            promptActionService: service,
+            promptProcessingService: processingService
+        )
+
+        viewModel.startCreating()
+        viewModel.setWizardGoal(.extract)
+        viewModel.updateWizardDraft { draft in
+            draft.extractFormat = .json
+        }
+
+        viewModel.saveEditing()
+
+        let action = try XCTUnwrap(service.promptActions.first)
+        XCTAssertEqual(action.name, localizedAppText("Extract JSON", de: "JSON extrahieren"))
+    }
+
+    private func makeViewModel() throws -> PromptActionsViewModel {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
+        addTeardownBlock {
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        return PromptActionsViewModel(
+            promptActionService: PromptActionService(appSupportDirectory: appSupportDirectory),
+            promptProcessingService: PromptProcessingService()
+        )
+    }
+}

--- a/TypeWhisperTests/PromptWizardComposerTests.swift
+++ b/TypeWhisperTests/PromptWizardComposerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import TypeWhisper
+
+final class PromptWizardComposerTests: XCTestCase {
+    func testTranslatePromptBuildsExpectedSystemPrompt() {
+        var draft = PromptWizardDraft(goal: .translate)
+        draft.translationMode = .alternatingPair(primaryLanguage: "en", secondaryLanguage: "de")
+        draft.preserveFormatting = true
+
+        let prompt = PromptWizardComposer.compose(from: draft)
+
+        XCTAssertEqual(
+            prompt,
+            "Translate the following text to English. If it's already in English, translate it to German. Preserve the original formatting when possible. Only return the translation, nothing else."
+        )
+    }
+
+    func testExtractPromptBuildsJSONInstruction() {
+        var draft = PromptWizardDraft(goal: .extract)
+        draft.extractFormat = .json
+
+        let prompt = PromptWizardComposer.compose(from: draft)
+
+        XCTAssertEqual(
+            prompt,
+            "Extract structured data from the following text and format it as valid, well-indented JSON. Use descriptive keys and appropriate data types. Only return the JSON, nothing else."
+        )
+    }
+
+    func testReviewNarrativeSummarizesPromptGoal() {
+        var draft = PromptWizardDraft(goal: .replyEmail)
+        draft.replyMode = .reply
+        draft.tone = .friendly
+        draft.responseLength = .short
+        draft.languageMode = .sameAsInput
+
+        XCTAssertEqual(
+            PromptWizardComposer.reviewSummary(for: draft),
+            "Write a short, friendly reply in the same language as the input."
+        )
+    }
+}

--- a/TypeWhisperTests/PromptWizardInferenceServiceTests.swift
+++ b/TypeWhisperTests/PromptWizardInferenceServiceTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import TypeWhisper
+
+final class PromptWizardInferenceServiceTests: XCTestCase {
+    func testInferenceMapsTranslatePresetToAlternatingPair() throws {
+        let preset = try XCTUnwrap(PromptAction.presets.first { $0.icon == "globe" })
+
+        let draft = PromptWizardInferenceService.infer(from: preset)
+
+        XCTAssertEqual(draft.goal, .translate)
+        XCTAssertEqual(draft.translationMode, .alternatingPair(primaryLanguage: "en", secondaryLanguage: "de"))
+        XCTAssertEqual(draft.icon, "globe")
+    }
+
+    func testInferenceMapsJSONPromptToExtractGoal() {
+        let action = PromptAction(
+            name: "JSON",
+            prompt: "Extract structured data from the following text and format it as valid, well-indented JSON. Use descriptive keys and appropriate data types. Only return the JSON, nothing else.",
+            icon: "curlybraces"
+        )
+
+        let draft = PromptWizardInferenceService.infer(from: action)
+
+        XCTAssertEqual(draft.goal, .extract)
+        XCTAssertEqual(draft.extractFormat, .json)
+        XCTAssertEqual(draft.icon, "curlybraces")
+    }
+
+    func testInferenceMapsReplyPromptToneAndLanguageMode() {
+        let action = PromptAction(
+            name: "Reply",
+            prompt: "Write a concise, friendly reply to the following message. Respond in the same language as the input text. Only return the reply.",
+            icon: "arrowshape.turn.up.left"
+        )
+
+        let draft = PromptWizardInferenceService.infer(from: action)
+
+        XCTAssertEqual(draft.goal, .replyEmail)
+        XCTAssertEqual(draft.replyMode, .reply)
+        XCTAssertEqual(draft.tone, .friendly)
+        XCTAssertEqual(draft.responseLength, .short)
+        XCTAssertEqual(draft.languageMode, .sameAsInput)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the old prompt editor with a three-step wizard and rules-style prompt management flow
- restyle the prompts list, default provider card, and review flow to feel more native and easier to scan
- move the settings sidebar closer to macOS System Settings with grouped sections and a native split-view sidebar on macOS 15

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PromptActionsViewModelWizardTests -only-testing:TypeWhisperTests/PromptWizardComposerTests -only-testing:TypeWhisperTests/PromptWizardInferenceServiceTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-51553d69`
