### PR TITLE
feat: add post-update licensing prompt

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */; };
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
+		A1F000000000000000000102 /* PostUpdatePromptCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */; };
 		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
 		F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000141 /* GeminiPlugin.swift */; };
@@ -18,6 +19,9 @@
 		A10000000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000044 /* TypeWhisperPluginSDK */; };
 		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
+		AA00000000000000000353 /* PostUpdatePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */; };
+		AA00000000000000000354 /* SettingsNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000354 /* SettingsNavigationCoordinator.swift */; };
+		AA00000000000000000355 /* PostUpdateLicensePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000355 /* PostUpdateLicensePromptView.swift */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
 		C23000000000000000000003 /* Gemma4Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000295 /* Gemma4Plugin.swift */; };
@@ -389,6 +393,7 @@
 		7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoundServiceTests.swift; sourceTree = "<group>"; };
 		AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationShortSpeechTests.swift; sourceTree = "<group>"; };
 		8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPRequestParserTests.swift; sourceTree = "<group>"; };
+		A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostUpdatePromptCoordinatorTests.swift; sourceTree = "<group>"; };
 		B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackServiceTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000001 /* TypeWhisperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeWhisperApp.swift; sourceTree = "<group>"; };
 		BB00000000000000000002 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
@@ -409,6 +414,9 @@
 		BB00000000000000000350 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		BB00000000000000000351 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		BB00000000000000000352 /* TypeWhisper-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TypeWhisper-Bridging-Header.h"; sourceTree = "<group>"; };
+		BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUpdatePromptCoordinator.swift; sourceTree = "<group>"; };
+		BB00000000000000000354 /* SettingsNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationCoordinator.swift; sourceTree = "<group>"; };
+		BB00000000000000000355 /* PostUpdateLicensePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUpdateLicensePromptView.swift; sourceTree = "<group>"; };
 		BB00000000000000000040 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		BB00000000000000000041 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		BB00000000000000000042 /* APIRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRouter.swift; sourceTree = "<group>"; };
@@ -1076,6 +1084,8 @@
 				BB00000000000000000070 /* UpdateChecker.swift */,
 				BB00000000000000000119 /* UserDefaultsKeys.swift */,
 				BB00000000000000000147 /* AppConstants.swift */,
+				BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */,
+				BB00000000000000000354 /* SettingsNavigationCoordinator.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1204,6 +1214,7 @@
 				BB00000000000000000250 /* AboutSettingsView.swift */,
 				BB00000000000000000287 /* LicenseSettingsView.swift */,
 				BB00000000000000000288 /* WelcomeSheet.swift */,
+				BB00000000000000000355 /* PostUpdateLicensePromptView.swift */,
 				BB00000000000000000289 /* SupporterBadgeView.swift */,
 			);
 			path = Views;
@@ -1702,6 +1713,7 @@
 				A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */,
 				8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */,
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
+				A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */,
@@ -2876,6 +2888,7 @@
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
+				A1F000000000000000000102 /* PostUpdatePromptCoordinatorTests.swift in Sources */,
 				F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */,
 				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
 				C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */,
@@ -3024,6 +3037,9 @@
 				AA00000000000000000300 /* LicenseService.swift in Sources */,
 				AA00000000000000000301 /* LicenseSettingsView.swift in Sources */,
 				AA00000000000000000302 /* WelcomeSheet.swift in Sources */,
+				AA00000000000000000353 /* PostUpdatePromptCoordinator.swift in Sources */,
+				AA00000000000000000354 /* SettingsNavigationCoordinator.swift in Sources */,
+				AA00000000000000000355 /* PostUpdateLicensePromptView.swift in Sources */,
 				AA00000000000000000303 /* SupporterBadgeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -83,6 +83,10 @@ enum AppConstants {
 
     static let appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
     static let buildVersion: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+    static let currentReleaseFingerprint: String = {
+        let channel = bundledReleaseChannel()
+        return "\(appVersion)+\(buildVersion)@\(channel.rawValue)"
+    }()
     static func bundledReleaseChannel(infoDictionary: [String: Any]? = Bundle.main.infoDictionary) -> ReleaseChannel {
         guard let rawValue = infoDictionary?["TypeWhisperReleaseChannel"] as? String,
               let channel = ReleaseChannel(rawValue: rawValue) else {

--- a/TypeWhisper/App/PostUpdatePromptCoordinator.swift
+++ b/TypeWhisper/App/PostUpdatePromptCoordinator.swift
@@ -1,0 +1,124 @@
+import Foundation
+import os
+
+enum StartupSheetRoute: String, Identifiable {
+    case welcome
+    case postUpdateLicensing
+
+    var id: String { rawValue }
+}
+
+@MainActor
+final class PostUpdatePromptCoordinator {
+    nonisolated(unsafe) static var shared: PostUpdatePromptCoordinator!
+
+    private let defaults: UserDefaults
+    private let licenseService: LicenseService
+    private let currentReleaseFingerprint: String
+    private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "PostUpdatePromptCoordinator")
+
+    private var currentSessionDismissed = false
+
+    init(
+        defaults: UserDefaults = .standard,
+        licenseService: LicenseService = LicenseService.shared,
+        currentReleaseFingerprint: String = AppConstants.currentReleaseFingerprint
+    ) {
+        self.defaults = defaults
+        self.licenseService = licenseService
+        self.currentReleaseFingerprint = currentReleaseFingerprint
+
+        bootstrapCurrentReleaseIfNeeded()
+    }
+
+    var shouldPresentPrompt: Bool {
+        guard !currentSessionDismissed else { return false }
+        guard !licenseService.needsWelcomeSheet else { return false }
+        guard !hasActiveEntitlement else { return false }
+
+        if licenseService.requiresCommercialLicense {
+            return true
+        }
+
+        return acknowledgedReleaseFingerprint != currentReleaseFingerprint
+    }
+
+    var shouldAutoOpenSettingsOnLaunch: Bool {
+        shouldPresentPrompt
+    }
+
+    var activeSheetRoute: StartupSheetRoute? {
+        shouldPresentPrompt ? .postUpdateLicensing : nil
+    }
+
+    func handlePersonalOSSSelection() {
+        licenseService.setUsageIntent(.personalOSS)
+        acknowledgeCurrentRelease()
+        dismissForCurrentSession()
+    }
+
+    func handleWorkUsageSelection() {
+        licenseService.setUsageIntent(.workSolo)
+        dismissForCurrentSession()
+    }
+
+    func handleExistingKeySelection() {
+        dismissForCurrentSession()
+    }
+
+    func handleSupporterSelection() {
+        dismissForCurrentSession()
+    }
+
+    func handleNotNowSelection() {
+        handleSheetDismissedWithoutExplicitAction()
+    }
+
+    func handleSheetDismissedWithoutExplicitAction() {
+        if licenseService.requiresCommercialLicense {
+            dismissForCurrentSession()
+            return
+        }
+
+        acknowledgeCurrentRelease()
+        dismissForCurrentSession()
+    }
+
+    private var hasActiveEntitlement: Bool {
+        licenseService.licenseStatus == .active || licenseService.supporterStatus == .active
+    }
+
+    private var lastSeenReleaseFingerprint: String? {
+        defaults.string(forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+    }
+
+    private var acknowledgedReleaseFingerprint: String? {
+        defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease)
+    }
+
+    private func dismissForCurrentSession() {
+        currentSessionDismissed = true
+    }
+
+    private func acknowledgeCurrentRelease() {
+        defaults.set(currentReleaseFingerprint, forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease)
+        logger.debug("Acknowledged post-update prompt for \(self.currentReleaseFingerprint, privacy: .public)")
+    }
+
+    private func bootstrapCurrentReleaseIfNeeded() {
+        let previousRelease = lastSeenReleaseFingerprint
+        defaults.set(currentReleaseFingerprint, forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        guard previousRelease == nil else {
+            return
+        }
+
+        if licenseService.needsWelcomeSheet {
+            acknowledgeCurrentRelease()
+            dismissForCurrentSession()
+            logger.debug("Seeded current release for fresh install session")
+        } else {
+            logger.debug("No previous release marker found; treating as existing installation")
+        }
+    }
+}

--- a/TypeWhisper/App/SettingsNavigationCoordinator.swift
+++ b/TypeWhisper/App/SettingsNavigationCoordinator.swift
@@ -1,0 +1,29 @@
+import Combine
+import Foundation
+
+enum LicenseSettingsNavigationTarget: Equatable, Sendable {
+    case top
+    case supporter
+    case activationKey
+}
+
+struct SettingsNavigationRequest: Identifiable, Equatable {
+    let id = UUID()
+    let tab: SettingsTab
+    let licenseTarget: LicenseSettingsNavigationTarget?
+}
+
+@MainActor
+final class SettingsNavigationCoordinator: ObservableObject {
+    nonisolated(unsafe) static var shared: SettingsNavigationCoordinator!
+
+    @Published private(set) var request: SettingsNavigationRequest?
+
+    func navigate(to tab: SettingsTab, licenseTarget: LicenseSettingsNavigationTarget? = nil) {
+        request = SettingsNavigationRequest(tab: tab, licenseTarget: licenseTarget)
+    }
+
+    func navigateToLicense(target: LicenseSettingsNavigationTarget) {
+        navigate(to: .license, licenseTarget: target)
+    }
+}

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -42,7 +42,17 @@ enum DockIconVisibility {
 struct TypeWhisperApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @AppStorage(UserDefaultsKeys.showMenuBarIcon) private var showMenuBarIcon = true
-    @State private var showWelcomeSheet = false
+    @State private var startupSheet: StartupSheetRoute?
+    @State private var lastPresentedStartupSheet: StartupSheetRoute?
+    @State private var ignoreNextStartupSheetDismiss = false
+
+    private var postUpdatePromptCoordinator: PostUpdatePromptCoordinator {
+        PostUpdatePromptCoordinator.shared
+    }
+
+    private var settingsNavigation: SettingsNavigationCoordinator {
+        SettingsNavigationCoordinator.shared
+    }
 
     var body: some Scene {
         MenuBarExtra(AppConstants.isDevelopment ? "TypeWhisper Dev" : "TypeWhisper", systemImage: "waveform", isInserted: $showMenuBarIcon) {
@@ -88,13 +98,22 @@ struct TypeWhisperApp: App {
             EmptyView()
         } else {
             SettingsView()
-                .sheet(isPresented: $showWelcomeSheet) {
-                    WelcomeSheet()
+                .sheet(item: $startupSheet, onDismiss: handleStartupSheetDismissed) { route in
+                    switch route {
+                    case .welcome:
+                        WelcomeSheet()
+                    case .postUpdateLicensing:
+                        PostUpdateLicensePromptView(
+                            onPersonalOSS: handlePersonalOSSSelection,
+                            onWorkUsage: handleWorkUsageSelection,
+                            onExistingKey: handleExistingKeySelection,
+                            onBecomeSupporter: handleSupporterSelection,
+                            onNotNow: handlePromptDismissalAction
+                        )
+                    }
                 }
                 .task {
-                    if LicenseService.shared.needsWelcomeSheet {
-                        showWelcomeSheet = true
-                    }
+                    refreshStartupSheet()
                 }
         }
     }
@@ -122,9 +141,86 @@ struct TypeWhisperApp: App {
 
         // Trigger ServiceContainer initialization
         _ = ServiceContainer.shared
+        SettingsNavigationCoordinator.shared = SettingsNavigationCoordinator()
+        PostUpdatePromptCoordinator.shared = PostUpdatePromptCoordinator()
 
         Task { @MainActor in
             await ServiceContainer.shared.initialize()
+        }
+    }
+
+    private func refreshStartupSheet() {
+        if HomeViewModel.shared.showSetupWizard {
+            startupSheet = nil
+            return
+        }
+
+        let nextRoute: StartupSheetRoute?
+        if LicenseService.shared.needsWelcomeSheet {
+            nextRoute = .welcome
+        } else {
+            nextRoute = postUpdatePromptCoordinator.activeSheetRoute
+        }
+
+        startupSheet = nextRoute
+        if let nextRoute {
+            lastPresentedStartupSheet = nextRoute
+        }
+    }
+
+    private func handleStartupSheetDismissed() {
+        let dismissedRoute = lastPresentedStartupSheet
+        defer {
+            lastPresentedStartupSheet = nil
+        }
+
+        if dismissedRoute == .postUpdateLicensing {
+            if ignoreNextStartupSheetDismiss {
+                ignoreNextStartupSheetDismiss = false
+            } else {
+                postUpdatePromptCoordinator.handleSheetDismissedWithoutExplicitAction()
+            }
+        }
+
+        refreshStartupSheet()
+    }
+
+    private func dismissStartupPrompt(after action: () -> Void) {
+        ignoreNextStartupSheetDismiss = true
+        action()
+        startupSheet = nil
+    }
+
+    private func handlePersonalOSSSelection() {
+        dismissStartupPrompt {
+            postUpdatePromptCoordinator.handlePersonalOSSSelection()
+        }
+    }
+
+    private func handleWorkUsageSelection() {
+        dismissStartupPrompt {
+            postUpdatePromptCoordinator.handleWorkUsageSelection()
+            settingsNavigation.navigateToLicense(target: .top)
+        }
+    }
+
+    private func handleExistingKeySelection() {
+        dismissStartupPrompt {
+            postUpdatePromptCoordinator.handleExistingKeySelection()
+            settingsNavigation.navigateToLicense(target: .activationKey)
+        }
+    }
+
+    private func handleSupporterSelection() {
+        dismissStartupPrompt {
+            postUpdatePromptCoordinator.handleSupporterSelection()
+            settingsNavigation.navigateToLicense(target: .supporter)
+        }
+    }
+
+    private func handlePromptDismissalAction() {
+        dismissStartupPrompt {
+            postUpdatePromptCoordinator.handleNotNowSelection()
         }
     }
 }
@@ -294,6 +390,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             HomeViewModel.shared.showSetupWizard = true
             NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.openSettingsWindow()
+            }
+        } else if PostUpdatePromptCoordinator.shared.shouldAutoOpenSettingsOnLaunch {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 self.openSettingsWindow()
             }
         }

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -113,6 +113,8 @@ enum UserDefaultsKeys {
     static let licenseIsLifetime = "licenseIsLifetime"
     static let welcomeSheetShown = "welcomeSheetShown"
     static let workUsagePromptDismissed = "workUsagePromptDismissed"
+    static let lastSeenReleaseFingerprint = "lastSeenReleaseFingerprint"
+    static let lastAcknowledgedPostUpdatePromptRelease = "lastAcknowledgedPostUpdatePromptRelease"
 
     // MARK: - Supporter
     static let supporterTier = "supporterTier"

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -2,12 +2,24 @@ import AppKit
 import SwiftUI
 
 struct LicenseSettingsView: View {
+    private enum ScrollAnchor: Hashable {
+        case top
+        case supporter
+        case activationKey
+    }
+
+    private enum FocusField: Hashable {
+        case licenseKey
+    }
+
     @ObservedObject private var license = LicenseService.shared
     @ObservedObject private var supporterDiscord =
         SupporterDiscordService.shared ?? SupporterDiscordService(licenseService: LicenseService.shared)
+    @ObservedObject private var settingsNavigation = SettingsNavigationCoordinator.shared
 
     @State private var licenseKeyInput = ""
     @State private var activationNotice: String?
+    @FocusState private var focusedField: FocusField?
 
     private let planColumns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
     private let planDescriptionMinHeight: CGFloat = 52
@@ -17,26 +29,38 @@ struct LicenseSettingsView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                planSelectionSection
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Color.clear
+                        .frame(height: 0)
+                        .id(ScrollAnchor.top)
 
-                if shouldShowCommercialSection {
-                    commercialSection
+                    planSelectionSection
+
+                    if shouldShowCommercialSection {
+                        commercialSection
+                    }
+
+                    supporterSection
+                        .id(ScrollAnchor.supporter)
+
+                    sharedActivationSection
+                        .id(ScrollAnchor.activationKey)
                 }
-
-                supporterSection
-
-                sharedActivationSection
+                .padding(20)
             }
-            .padding(20)
-        }
-        .frame(minWidth: 560, minHeight: 360)
-        .task(id: "\(license.supporterStatus.rawValue)-\(license.supporterTier?.rawValue ?? "none")") {
-            if license.isSupporter {
-                await supporterDiscord.refreshStatusIfNeeded()
-            } else {
-                supporterDiscord.handleSupporterEntitlementRemoved()
+            .frame(minWidth: 560, minHeight: 360)
+            .task(id: "\(license.supporterStatus.rawValue)-\(license.supporterTier?.rawValue ?? "none")") {
+                if license.isSupporter {
+                    await supporterDiscord.refreshStatusIfNeeded()
+                } else {
+                    supporterDiscord.handleSupporterEntitlementRemoved()
+                }
+            }
+            .onReceive(settingsNavigation.$request.compactMap { $0 }) { request in
+                guard request.tab == .license else { return }
+                handleNavigation(request.licenseTarget ?? .top, proxy: proxy)
             }
         }
     }
@@ -386,6 +410,7 @@ struct LicenseSettingsView: View {
         HStack {
             TextField(localizedAppText("TYPEWHISPER-xxxx-xxxx", de: "TYPEWHISPER-xxxx-xxxx"), text: input)
                 .textFieldStyle(.roundedBorder)
+                .focused($focusedField, equals: .licenseKey)
 
             Button(localizedAppText("Activate", de: "Aktivieren")) {
                 Task { await action() }
@@ -803,6 +828,27 @@ struct LicenseSettingsView: View {
 
     private func openClaimURL(_ url: URL?) async {
         openURL(url)
+    }
+
+    private func handleNavigation(_ target: LicenseSettingsNavigationTarget, proxy: ScrollViewProxy) {
+        focusedField = nil
+
+        withAnimation(.easeInOut(duration: 0.15)) {
+            switch target {
+            case .top:
+                proxy.scrollTo(ScrollAnchor.top, anchor: .top)
+            case .supporter:
+                proxy.scrollTo(ScrollAnchor.supporter, anchor: .top)
+            case .activationKey:
+                proxy.scrollTo(ScrollAnchor.activationKey, anchor: .top)
+            }
+        }
+
+        guard target == .activationKey else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            focusedField = .licenseKey
+        }
     }
 
     @ViewBuilder

--- a/TypeWhisper/Views/PostUpdateLicensePromptView.swift
+++ b/TypeWhisper/Views/PostUpdateLicensePromptView.swift
@@ -1,0 +1,131 @@
+import AppKit
+import SwiftUI
+
+struct PostUpdateLicensePromptView: View {
+    let onPersonalOSS: () -> Void
+    let onWorkUsage: () -> Void
+    let onExistingKey: () -> Void
+    let onBecomeSupporter: () -> Void
+    let onNotNow: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(alignment: .top) {
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .frame(width: 64, height: 64)
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+                Spacer()
+
+                Button(action: onNotNow) {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.secondary)
+                        .padding(8)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(localizedAppText("Close", de: "Schließen"))
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(localizedAppText("Using TypeWhisper professionally?", de: "Nutzt du TypeWhisper beruflich?"))
+                    .font(.title2.weight(.semibold))
+
+                Text(localizedAppText(
+                    "Private and GPL-compatible open-source use stays free. If you use TypeWhisper for work, please get a license.",
+                    de: "Private Nutzung und GPL-kompatible Open-Source-Arbeit bleiben kostenlos. Wenn du TypeWhisper beruflich nutzt, hole dir bitte eine Lizenz."
+                ))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 12) {
+                actionCard(
+                    title: localizedAppText("Private / OSS", de: "Privat / OSS"),
+                    description: localizedAppText(
+                        "Keep using it for personal work and compliant open source.",
+                        de: "Nutze es weiter privat oder für kompatible Open-Source-Arbeit."
+                    ),
+                    systemImage: "person",
+                    emphasized: false,
+                    action: onPersonalOSS
+                )
+
+                actionCard(
+                    title: localizedAppText("I use it for work", de: "Ich nutze es beruflich"),
+                    description: localizedAppText(
+                        "Open the licensing options and keep this reminder active until a license is in place.",
+                        de: "Öffne die Lizenzoptionen und behalte diese Erinnerung aktiv, bis eine Lizenz hinterlegt ist."
+                    ),
+                    systemImage: "briefcase.fill",
+                    emphasized: true,
+                    action: onWorkUsage
+                )
+
+                actionCard(
+                    title: localizedAppText("I already have a key", de: "Ich habe schon einen Schlüssel"),
+                    description: localizedAppText(
+                        "Jump straight to the activation field in License settings.",
+                        de: "Springe direkt zum Aktivierungsfeld in den Lizenz-Einstellungen."
+                    ),
+                    systemImage: "key.fill",
+                    emphasized: false,
+                    action: onExistingKey
+                )
+            }
+
+            HStack {
+                Button(localizedAppText("Become a supporter", de: "Supporter werden"), action: onBecomeSupporter)
+                    .buttonStyle(.link)
+
+                Spacer()
+
+                Button(localizedAppText("Not now", de: "Später"), action: onNotNow)
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(28)
+        .frame(width: 540)
+    }
+
+    private func actionCard(
+        title: String,
+        description: String,
+        systemImage: String,
+        emphasized: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: systemImage)
+                    .font(.title3)
+                    .foregroundStyle(emphasized ? .white : Color.accentColor)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(emphasized ? .white : .primary)
+
+                    Text(description)
+                        .font(.subheadline)
+                        .foregroundStyle(emphasized ? .white.opacity(0.86) : .secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(emphasized ? Color.accentColor : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(emphasized ? Color.accentColor : Color.primary.opacity(0.08), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @ObservedObject private var registryService = PluginRegistryService.shared
     @ObservedObject private var homeViewModel = HomeViewModel.shared
     @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
+    @ObservedObject private var settingsNavigation = SettingsNavigationCoordinator.shared
 
     private var destinations: [SettingsDestination] {
         [
@@ -84,6 +85,9 @@ struct SettingsView: View {
                 selectedTab = .integrations
                 promptActionsViewModel.navigateToIntegrations = false
             }
+        }
+        .onReceive(settingsNavigation.$request.compactMap { $0 }) { request in
+            selectedTab = request.tab
         }
     }
 

--- a/TypeWhisperTests/PostUpdatePromptCoordinatorTests.swift
+++ b/TypeWhisperTests/PostUpdatePromptCoordinatorTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+final class PostUpdatePromptCoordinatorTests: XCTestCase {
+    func testMissingVersionMarkerAndPendingWelcomeSeedsCurrentReleaseWithoutPrompting() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let license = LicenseService(defaults: defaults)
+        let coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: "1.3.0+123@stable"
+        )
+
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.lastSeenReleaseFingerprint), "1.3.0+123@stable")
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease), "1.3.0+123@stable")
+    }
+
+    func testMissingVersionMarkerAndCompletedWelcomePromptsImmediately() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+
+        let license = LicenseService(defaults: defaults)
+        let coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: "1.3.0+123@stable"
+        )
+
+        XCTAssertTrue(coordinator.shouldPresentPrompt)
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.lastSeenReleaseFingerprint), "1.3.0+123@stable")
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease))
+    }
+
+    func testActiveCommercialLicenseSuppressesPrompt() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set("1.2.9+99@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        let license = LicenseService(defaults: defaults)
+        license.licenseStatus = .active
+        license.licenseTier = .individual
+
+        let coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: "1.3.0+123@stable"
+        )
+
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+    }
+
+    func testActiveSupporterSuppressesPrompt() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set("1.2.9+99@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        let license = LicenseService(defaults: defaults)
+        license.supporterStatus = .active
+        license.supporterTier = .gold
+
+        let coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: "1.3.0+123@stable"
+        )
+
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+    }
+
+    func testPersonalUseRequiresAcknowledgementForCurrentRelease() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set("1.2.9+99@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        let license = LicenseService(defaults: defaults)
+        let currentRelease = "1.3.0+123@stable"
+
+        var coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: currentRelease
+        )
+        XCTAssertTrue(coordinator.shouldPresentPrompt)
+
+        coordinator.handlePersonalOSSSelection()
+
+        XCTAssertEqual(license.usageIntent, .personalOSS)
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease), currentRelease)
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+
+        coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: currentRelease
+        )
+
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+    }
+
+    func testBusinessIntentPromptsEveryLaunchUntilLicensed() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set(UsageIntent.team.rawValue, forKey: UserDefaultsKeys.usageIntent)
+        defaults.set(LicenseUserType.business.rawValue, forKey: UserDefaultsKeys.userType)
+        defaults.set("1.3.0+123@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+        defaults.set("1.3.0+123@stable", forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease)
+
+        let license = LicenseService(defaults: defaults)
+        let coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: "1.3.0+123@stable"
+        )
+
+        XCTAssertTrue(coordinator.shouldPresentPrompt)
+    }
+
+    func testWorkSelectionSetsWorkSoloWithoutAcknowledgingCurrentRelease() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set("1.2.9+99@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        let license = LicenseService(defaults: defaults)
+        let currentRelease = "1.3.0+123@stable"
+        var coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: currentRelease
+        )
+
+        coordinator.handleWorkUsageSelection()
+
+        XCTAssertEqual(license.usageIntent, .workSolo)
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease))
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+
+        coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: currentRelease
+        )
+
+        XCTAssertTrue(coordinator.shouldPresentPrompt)
+    }
+
+    func testExistingKeyAndSupporterActionsDismissOnlyForCurrentSession() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set(UsageIntent.workSolo.rawValue, forKey: UserDefaultsKeys.usageIntent)
+        defaults.set(LicenseUserType.business.rawValue, forKey: UserDefaultsKeys.userType)
+        defaults.set("1.3.0+123@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        let license = LicenseService(defaults: defaults)
+        let currentRelease = "1.3.0+123@stable"
+
+        var coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: currentRelease
+        )
+        XCTAssertTrue(coordinator.shouldPresentPrompt)
+
+        coordinator.handleExistingKeySelection()
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease))
+
+        coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: currentRelease
+        )
+        XCTAssertTrue(coordinator.shouldPresentPrompt)
+
+        coordinator.handleSupporterSelection()
+        XCTAssertFalse(coordinator.shouldPresentPrompt)
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease))
+    }
+
+    func testSettingsNavigationCoordinatorPublishesLicenseTargets() throws {
+        let coordinator = SettingsNavigationCoordinator()
+
+        coordinator.navigateToLicense(target: .activationKey)
+        let activationRequest = try XCTUnwrap(coordinator.request)
+        XCTAssertEqual(activationRequest.tab, .license)
+        XCTAssertEqual(activationRequest.licenseTarget, .activationKey)
+
+        coordinator.navigateToLicense(target: .supporter)
+        let supporterRequest = try XCTUnwrap(coordinator.request)
+        XCTAssertEqual(supporterRequest.tab, .license)
+        XCTAssertEqual(supporterRequest.licenseTarget, .supporter)
+        XCTAssertNotEqual(activationRequest.id, supporterRequest.id)
+
+        coordinator.navigate(to: .license, licenseTarget: .top)
+        let topRequest = try XCTUnwrap(coordinator.request)
+        XCTAssertEqual(topRequest.tab, .license)
+        XCTAssertEqual(topRequest.licenseTarget, .top)
+    }
+
+    private func makeIsolatedDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "TypeWhisperTests.PostUpdatePrompt.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw XCTSkip("Failed to create isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a post-update licensing prompt for users without an active commercial license or supporter entitlement.

The new flow opens in Settings, distinguishes between personal and business usage, keeps reminding business users on every launch until they activate a license or supporter status, and deep-links directly into the relevant License settings sections.

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-7b07f5d9`
- Manually verified the post-update licensing prompt appears on relaunch for an unlizenized business-usage state and routes into `Settings > License`.
