### PR TITLE
feat: add recent transcription recovery palette

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -39,6 +39,11 @@
 		E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */; };
 		3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
 		6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
+		A91F00000000000000000001 /* SelectionPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000001 /* SelectionPalettePanel.swift */; };
+		A91F00000000000000000002 /* RecentTranscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000002 /* RecentTranscriptionStore.swift */; };
+		A91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */; };
+		A91F00000000000000000004 /* RecentTranscriptionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000004 /* RecentTranscriptionStoreTests.swift */; };
+		A91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift */; };
 		6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */; };
 		BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */; };
 		76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */; };
@@ -386,6 +391,11 @@
 		05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDiffServiceTests.swift; sourceTree = "<group>"; };
 		3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
 		3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
+		B91F00000000000000000001 /* SelectionPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPalettePanel.swift; sourceTree = "<group>"; };
+		B91F00000000000000000002 /* RecentTranscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionStore.swift; sourceTree = "<group>"; };
+		B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionPaletteHandler.swift; sourceTree = "<group>"; };
+		B91F00000000000000000004 /* RecentTranscriptionStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionStoreTests.swift; sourceTree = "<group>"; };
+		B91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionPaletteHandlerTests.swift; sourceTree = "<group>"; };
 		7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoundServiceTests.swift; sourceTree = "<group>"; };
 		AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationShortSpeechTests.swift; sourceTree = "<group>"; };
 		8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPRequestParserTests.swift; sourceTree = "<group>"; };
@@ -1113,6 +1123,7 @@
 				BB00000000000000000050 /* SubtitleExporter.swift */,
 				BB00000000000000000148 /* HistoryExporter.swift */,
 				BB00000000000000000061 /* HistoryService.swift */,
+				B91F00000000000000000002 /* RecentTranscriptionStore.swift */,
 				BB00000000000000000062 /* TextDiffService.swift */,
 				BB00000000000000000066 /* ProfileService.swift */,
 				BB00000000000000000073 /* TranslationService.swift */,
@@ -1161,6 +1172,7 @@
 				BB00000000000000000171 /* DictationEnums.swift */,
 				BB00000000000000000172 /* StreamingHandler.swift */,
 				BB00000000000000000173 /* PromptPaletteHandler.swift */,
+				B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */,
 				BB00000000000000000174 /* DictationSettingsHandler.swift */,
 				BB00000000000000000239 /* AudioRecorderViewModel.swift */,
 				BB00000000000000000242 /* WatchFolderViewModel.swift */,
@@ -1191,6 +1203,7 @@
 				BB00000000000000000094 /* AudioWaveformView.swift */,
 				BB00000000000000000117 /* PromptActionsSettingsView.swift */,
 				BB00000000000000000118 /* PromptPalettePanel.swift */,
+				B91F00000000000000000001 /* SelectionPalettePanel.swift */,
 				BB00000000000000000120 /* NotchIndicatorPanel.swift */,
 				E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */,
 				BB00000000000000000121 /* NotchIndicatorView.swift */,
@@ -1702,6 +1715,8 @@
 				A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */,
 				8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */,
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
+				B91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift */,
+				B91F00000000000000000004 /* RecentTranscriptionStoreTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */,
@@ -2876,6 +2891,8 @@
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
+				A91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift in Sources */,
+				A91F00000000000000000004 /* RecentTranscriptionStoreTests.swift in Sources */,
 				F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */,
 				C23000000000000000000001 /* OpenAIPlugin.swift in Sources */,
 				C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */,
@@ -2931,6 +2948,7 @@
 				AA00000000000000000181 /* DictationEnums.swift in Sources */,
 				AA00000000000000000182 /* StreamingHandler.swift in Sources */,
 				AA00000000000000000183 /* PromptPaletteHandler.swift in Sources */,
+				A91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift in Sources */,
 				AA00000000000000000207 /* IndicatorCoordinator.swift in Sources */,
 				AA00000000000000000184 /* DictationSettingsHandler.swift in Sources */,
 				AA00000000000000000040 /* HTTPResponse.swift in Sources */,
@@ -2942,6 +2960,7 @@
 				AA00000000000000000046 /* AdvancedSettingsView.swift in Sources */,
 				AA00000000000000000050 /* SubtitleExporter.swift in Sources */,
 				AA00000000000000000153 /* HistoryExporter.swift in Sources */,
+				A91F00000000000000000002 /* RecentTranscriptionStore.swift in Sources */,
 				AA00000000000000000283 /* DictionaryExporter.swift in Sources */,
 				AA00000000000000000284 /* TermPackRegistryService.swift in Sources */,
 				AA00000000000000000051 /* GeneralSettingsView.swift in Sources */,
@@ -2991,6 +3010,7 @@
 				AA00000000000000000116 /* PromptActionsViewModel.swift in Sources */,
 				AA00000000000000000117 /* PromptActionsSettingsView.swift in Sources */,
 				AA00000000000000000118 /* PromptPalettePanel.swift in Sources */,
+				A91F00000000000000000001 /* SelectionPalettePanel.swift in Sources */,
 				AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */,
 					AA00000000000000000123 /* EventBus.swift in Sources */,
 					AA00000000000000000124 /* PluginManager.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -12,6 +12,7 @@ final class ServiceContainer: ObservableObject {
     let hotkeyService: HotkeyService
     let textInsertionService: TextInsertionService
     let historyService: HistoryService
+    let recentTranscriptionStore: RecentTranscriptionStore
     let textDiffService: TextDiffService
     let profileService: ProfileService
     let translationService: AnyObject? // TranslationService (macOS 15+)
@@ -62,6 +63,7 @@ final class ServiceContainer: ObservableObject {
         hotkeyService = HotkeyService()
         textInsertionService = TextInsertionService()
         historyService = HistoryService()
+        recentTranscriptionStore = RecentTranscriptionStore()
         textDiffService = TextDiffService()
         profileService = ProfileService()
         #if canImport(Translation)
@@ -109,6 +111,7 @@ final class ServiceContainer: ObservableObject {
             modelManager: modelManagerService,
             settingsViewModel: settingsViewModel,
             historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
             translationService: translationService,
             audioDuckingService: audioDuckingService,

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -287,6 +287,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         ServiceContainer.shared.hotkeyService.onPromptPaletteToggle = {
             DictationViewModel.shared.triggerStandalonePromptSelection()
         }
+        ServiceContainer.shared.hotkeyService.onRecentTranscriptionsToggle = {
+            DictationViewModel.shared.triggerRecentTranscriptionsPalette()
+        }
 
         // Auto-open Settings with setup wizard when microphone permission is not yet granted
         if AVAudioApplication.shared.recordPermission != .granted {

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -21,6 +21,7 @@ enum UserDefaultsKeys {
     static let pttHotkey = "pttHotkey"
     static let toggleHotkey = "toggleHotkey"
     static let promptPaletteHotkey = "promptPaletteHotkey"
+    static let recentTranscriptionsHotkey = "recentTranscriptionsHotkey"
 
     // MARK: - Model / Engine
     static let selectedEngine = "selectedEngine"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -4322,6 +4322,16 @@
         }
       }
     },
+    "No recent transcriptions" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine letzten Transkriptionen"
+          }
+        }
+      }
+    },
     "No memory storage plugins active. Enable one in Integrations." : {
       "localizations" : {
         "de" : {
@@ -4721,6 +4731,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Öffnet das Polar.sh-Kundenportal, wo du dein Abo verwalten, Zahlungsmethoden ändern oder kündigen kannst."
+          }
+        }
+      }
+    },
+    "Open your latest transcriptions and insert one into the focused app." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffne deine letzten Transkriptionen und füge eine in die fokussierte App ein."
           }
         }
       }
@@ -5577,6 +5597,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Letzte Transkriptionen"
+          }
+        }
+      }
+    },
+    "Recent transcription shortcut" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tastenkürzel für letzte Transkriptionen"
           }
         }
       }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -66,6 +66,7 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
     case pushToTalk
     case toggle
     case promptPalette
+    case recentTranscriptions
 
     var defaultsKey: String {
         switch self {
@@ -73,6 +74,7 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
         case .pushToTalk: return UserDefaultsKeys.pttHotkey
         case .toggle: return UserDefaultsKeys.toggleHotkey
         case .promptPalette: return UserDefaultsKeys.promptPaletteHotkey
+        case .recentTranscriptions: return UserDefaultsKeys.recentTranscriptionsHotkey
         }
     }
 }
@@ -116,6 +118,7 @@ final class HotkeyService: ObservableObject {
     var onDictationStart: (() -> Void)?
     var onDictationStop: (() -> Void)?
     var onPromptPaletteToggle: (() -> Void)?
+    var onRecentTranscriptionsToggle: (() -> Void)?
     var onProfileDictationStart: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
     var onPushToTalkInterruption: (() -> Void)?
@@ -162,6 +165,7 @@ final class HotkeyService: ObservableObject {
         .pushToTalk: SlotState(),
         .toggle: SlotState(),
         .promptPalette: SlotState(),
+        .recentTranscriptions: SlotState(),
     ]
 
     // MARK: - Per-Profile Hotkey State
@@ -951,6 +955,10 @@ final class HotkeyService: ObservableObject {
             onPromptPaletteToggle?()
             return
         }
+        if slotType == .recentTranscriptions {
+            onRecentTranscriptionsToggle?()
+            return
+        }
 
         if isActive {
             // Any hotkey stops active recording
@@ -998,6 +1006,8 @@ final class HotkeyService: ObservableObject {
         case .toggle:
             break
         case .promptPalette:
+            break // handled on keyDown only
+        case .recentTranscriptions:
             break // handled on keyDown only
         }
     }

--- a/TypeWhisper/Services/RecentTranscriptionStore.swift
+++ b/TypeWhisper/Services/RecentTranscriptionStore.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Combine
+
+@MainActor
+final class RecentTranscriptionStore: ObservableObject {
+    enum Source: String, Equatable {
+        case session
+        case history
+    }
+
+    struct Entry: Identifiable, Equatable {
+        let id: UUID
+        let finalText: String
+        let timestamp: Date
+        let appName: String?
+        let appBundleIdentifier: String?
+        let source: Source
+    }
+
+    @Published private(set) var sessionEntries: [Entry] = []
+
+    private let maxSessionEntries: Int
+
+    init(maxSessionEntries: Int = 20) {
+        self.maxSessionEntries = maxSessionEntries
+    }
+
+    func recordTranscription(
+        id: UUID,
+        finalText: String,
+        timestamp: Date = Date(),
+        appName: String?,
+        appBundleIdentifier: String?
+    ) {
+        let trimmedText = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return }
+
+        sessionEntries.removeAll { $0.id == id }
+        sessionEntries.insert(
+            Entry(
+                id: id,
+                finalText: trimmedText,
+                timestamp: timestamp,
+                appName: appName,
+                appBundleIdentifier: appBundleIdentifier,
+                source: .session
+            ),
+            at: 0
+        )
+
+        if sessionEntries.count > maxSessionEntries {
+            sessionEntries.removeLast(sessionEntries.count - maxSessionEntries)
+        }
+    }
+
+    func mergedEntries(historyRecords: [TranscriptionRecord], limit: Int = 12) -> [Entry] {
+        let historyEntries = historyRecords.map {
+            Entry(
+                id: $0.id,
+                finalText: $0.finalText,
+                timestamp: $0.timestamp,
+                appName: $0.appName,
+                appBundleIdentifier: $0.appBundleIdentifier,
+                source: .history
+            )
+        }
+
+        let merged = (sessionEntries + historyEntries).sorted {
+            if $0.timestamp == $1.timestamp {
+                return $0.source == .session && $1.source == .history
+            }
+            return $0.timestamp > $1.timestamp
+        }
+
+        var seen = Set<UUID>()
+        var deduped: [Entry] = []
+        for entry in merged where seen.insert(entry.id).inserted {
+            deduped.append(entry)
+            if deduped.count == limit {
+                break
+            }
+        }
+        return deduped
+    }
+}

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -94,6 +94,7 @@ final class DictationViewModel: ObservableObject {
     var pttHotkeyLabel: String { Self.loadHotkeyLabel(for: .pushToTalk) }
     var toggleHotkeyLabel: String { Self.loadHotkeyLabel(for: .toggle) }
     var promptPaletteHotkeyLabel: String { Self.loadHotkeyLabel(for: .promptPalette) }
+    var recentTranscriptionsHotkeyLabel: String { Self.loadHotkeyLabel(for: .recentTranscriptions) }
     @Published var activeRuleName: String?
     @Published var activeRuleReasonLabel: String?
     @Published var activeRuleExplanation: String?
@@ -134,6 +135,7 @@ final class DictationViewModel: ObservableObject {
     private let modelManager: ModelManagerService
     private let settingsViewModel: SettingsViewModel
     private let historyService: HistoryService
+    private let recentTranscriptionStore: RecentTranscriptionStore
     private let profileService: ProfileService
     private let translationService: AnyObject? // TranslationService (macOS 15+)
     private let audioDuckingService: AudioDuckingService
@@ -159,6 +161,7 @@ final class DictationViewModel: ObservableObject {
     private var recordingStartTime: Date?
     private let streamingHandler: StreamingHandler
     private let promptPaletteHandler: PromptPaletteHandler
+    private let recentTranscriptionPaletteHandler: RecentTranscriptionPaletteHandler
     private let settingsHandler: DictationSettingsHandler
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
@@ -198,6 +201,7 @@ final class DictationViewModel: ObservableObject {
         modelManager: ModelManagerService,
         settingsViewModel: SettingsViewModel,
         historyService: HistoryService,
+        recentTranscriptionStore: RecentTranscriptionStore,
         profileService: ProfileService,
         translationService: AnyObject?,
         audioDuckingService: AudioDuckingService,
@@ -219,6 +223,7 @@ final class DictationViewModel: ObservableObject {
         self.modelManager = modelManager
         self.settingsViewModel = settingsViewModel
         self.historyService = historyService
+        self.recentTranscriptionStore = recentTranscriptionStore
         self.profileService = profileService
         self.translationService = translationService
         self.audioDuckingService = audioDuckingService
@@ -258,6 +263,11 @@ final class DictationViewModel: ObservableObject {
             promptProcessingService: promptProcessingService,
             soundService: soundService,
             accessibilityAnnouncementService: accessibilityAnnouncementService
+        )
+        self.recentTranscriptionPaletteHandler = RecentTranscriptionPaletteHandler(
+            textInsertionService: textInsertionService,
+            historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore
         )
         self.settingsHandler = DictationSettingsHandler(
             hotkeyService: hotkeyService,
@@ -315,6 +325,12 @@ final class DictationViewModel: ObservableObject {
             (self?.actionFeedbackMessage, self?.actionFeedbackIcon, self?.actionDisplayDuration ?? 3.5)
         }
         promptPaletteHandler.getPreserveClipboard = { [weak self] in
+            self?.preserveClipboard ?? false
+        }
+        recentTranscriptionPaletteHandler.onShowNotchFeedback = { [weak self] message, icon, duration, isError, category in
+            self?.showNotchFeedback(message: message, icon: icon, duration: duration, isError: isError, errorCategory: category ?? "general")
+        }
+        recentTranscriptionPaletteHandler.getPreserveClipboard = { [weak self] in
             self?.preserveClipboard ?? false
         }
 
@@ -605,6 +621,7 @@ final class DictationViewModel: ObservableObject {
 
         // Dismiss prompt palette if active
         promptPaletteHandler.hide()
+        recentTranscriptionPaletteHandler.hide()
 
         // Cancel auto-unload timer to prevent unloading during recording
         modelManager.cancelAutoUnloadTimer()
@@ -1005,6 +1022,15 @@ final class DictationViewModel: ObservableObject {
                     llmStepName: llmStepName
                 )
                 text = ppResult.text
+                let transcriptionID = sessionID ?? UUID()
+                let completionTimestamp = Date()
+                recentTranscriptionStore.recordTranscription(
+                    id: transcriptionID,
+                    finalText: text,
+                    timestamp: completionTimestamp,
+                    appName: activeApp.name,
+                    appBundleIdentifier: activeApp.bundleId
+                )
 
                 partialText = ""
 
@@ -1035,7 +1061,7 @@ final class DictationViewModel: ObservableObject {
 
                 if UserDefaults.standard.object(forKey: UserDefaultsKeys.historyEnabled) as? Bool ?? true {
                     historyService.addRecord(
-                        id: sessionID ?? UUID(),
+                        id: transcriptionID,
                         rawText: result.text,
                         finalText: text,
                         appName: activeApp.name,
@@ -1069,7 +1095,7 @@ final class DictationViewModel: ObservableObject {
                 let completedTranscription = DictationSessionTranscription(
                     text: text,
                     rawText: result.text,
-                    timestamp: Date(),
+                    timestamp: completionTimestamp,
                     appName: activeApp.name,
                     appBundleIdentifier: activeApp.bundleId,
                     appURL: activeApp.url,
@@ -1399,7 +1425,13 @@ final class DictationViewModel: ObservableObject {
     }
 
     func triggerStandalonePromptSelection() {
+        recentTranscriptionPaletteHandler.hide()
         promptPaletteHandler.triggerSelection(currentState: state, soundFeedbackEnabled: soundFeedbackEnabled)
+    }
+
+    func triggerRecentTranscriptionsPalette() {
+        promptPaletteHandler.hide()
+        recentTranscriptionPaletteHandler.triggerSelection(currentState: state)
     }
 
     private func showNotchFeedback(message: String, icon: String, duration: TimeInterval = 2.5, isError: Bool = false, errorCategory: String = "general") {

--- a/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@MainActor
+final class RecentTranscriptionPaletteHandler {
+    private let paletteController: any SelectionPaletteControlling
+    private let textInsertionService: TextInsertionService
+    private let historyService: HistoryService
+    private let recentTranscriptionStore: RecentTranscriptionStore
+    private let relativeDateFormatter = RelativeDateTimeFormatter()
+
+    var onShowNotchFeedback: ((String, String, TimeInterval, Bool, String?) -> Void)?
+    var getPreserveClipboard: (() -> Bool)?
+
+    init(
+        textInsertionService: TextInsertionService,
+        historyService: HistoryService,
+        recentTranscriptionStore: RecentTranscriptionStore,
+        paletteController: any SelectionPaletteControlling = SelectionPaletteController()
+    ) {
+        self.textInsertionService = textInsertionService
+        self.historyService = historyService
+        self.recentTranscriptionStore = recentTranscriptionStore
+        self.paletteController = paletteController
+        relativeDateFormatter.unitsStyle = .short
+    }
+
+    func hide() {
+        paletteController.hide()
+    }
+
+    func triggerSelection(currentState: DictationViewModel.State) {
+        if paletteController.isVisible {
+            paletteController.hide()
+            return
+        }
+
+        guard currentState == .idle else { return }
+
+        let entries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.records)
+        guard !entries.isEmpty else {
+            onShowNotchFeedback?(
+                String(localized: "No recent transcriptions"),
+                "clock.arrow.circlepath",
+                2.5,
+                false,
+                nil
+            )
+            return
+        }
+
+        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        let items = entries.map { entry in
+            SelectionPaletteItem(
+                id: entry.id,
+                title: entry.finalText,
+                subtitle: subtitle(for: entry),
+                iconSystemName: nil,
+                searchTokens: [entry.appName, entry.appBundleIdentifier].compactMap { $0 }
+            )
+        }
+
+        paletteController.show(
+            configuration: SelectionPaletteConfiguration(
+                panelWidth: 520,
+                panelHeight: 360,
+                titleLineLimit: 2,
+                emptyStateTitle: String(localized: "No recent transcriptions")
+            ),
+            items: items
+        ) { [weak self] item in
+            guard let self, let entry = entriesByID[item.id] else { return }
+            Task { @MainActor in
+                await self.insert(entry)
+            }
+        }
+    }
+
+    private func insert(_ entry: RecentTranscriptionStore.Entry) async {
+        do {
+            _ = try await textInsertionService.insertText(
+                entry.finalText,
+                preserveClipboard: getPreserveClipboard?() ?? false,
+                autoEnter: false
+            )
+            onShowNotchFeedback?(String(localized: "Text inserted"), "checkmark.circle.fill", 2.5, false, nil)
+        } catch {
+            onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "recentTranscriptions")
+        }
+    }
+
+    private func subtitle(for entry: RecentTranscriptionStore.Entry) -> String {
+        let relativeTimestamp = relativeDateFormatter.localizedString(for: entry.timestamp, relativeTo: Date())
+        let appName = entry.appName?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let appName, !appName.isEmpty {
+            return "\(appName) • \(relativeTimestamp)"
+        }
+        return relativeTimestamp
+    }
+}

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -63,6 +63,24 @@ struct HotkeySettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Section(String(localized: "Recent Transcriptions")) {
+                HotkeyRecorderView(
+                    label: dictation.recentTranscriptionsHotkeyLabel,
+                    title: String(localized: "Recent transcription shortcut"),
+                    onRecord: { hotkey in
+                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .recentTranscriptions) {
+                            dictation.clearHotkey(for: conflict)
+                        }
+                        dictation.setHotkey(hotkey, for: .recentTranscriptions)
+                    },
+                    onClear: { dictation.clearHotkey(for: .recentTranscriptions) }
+                )
+
+                Text(String(localized: "Open your latest transcriptions and insert one into the focused app."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
         .padding()

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -1,275 +1,46 @@
 import SwiftUI
-import AppKit
-
-// MARK: - SwiftUI View
-
-struct PromptPaletteContentView: View {
-    let actions: [PromptAction]
-    let sourceText: String
-    let onSelect: (PromptAction) -> Void
-    let onDismiss: () -> Void
-
-    @State private var searchText = ""
-    @State private var selectedIndex = 0
-
-    private var filteredActions: [PromptAction] {
-        if searchText.isEmpty {
-            return actions
-        }
-        return actions.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            // Source text preview
-            Text(sourceText)
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .lineLimit(3)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 14)
-                .padding(.top, 10)
-                .padding(.bottom, 8)
-
-            Divider()
-
-            // Search field
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 14))
-                    .foregroundColor(.secondary)
-                    .accessibilityHidden(true)
-
-                TextField(String(localized: "Search prompts..."), text: $searchText)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 15))
-                    .accessibilityLabel(String(localized: "Search prompts"))
-                    .onSubmit {
-                        if let action = filteredActions[safe: selectedIndex] {
-                            onSelect(action)
-                        }
-                    }
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-
-            Divider()
-
-            // Actions list
-            if filteredActions.isEmpty {
-                VStack(spacing: 8) {
-                    Text(String(localized: "No matching prompts"))
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 20)
-            } else {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 2) {
-                            ForEach(Array(filteredActions.enumerated()), id: \.element.id) { index, action in
-                                PromptPaletteRow(
-                                    action: action,
-                                    isSelected: index == selectedIndex
-                                )
-                                .id(index)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    onSelect(action)
-                                }
-                            }
-                        }
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 6)
-                    }
-                    .onChange(of: selectedIndex) { _, newValue in
-                        proxy.scrollTo(newValue, anchor: .center)
-                    }
-                }
-            }
-        }
-        .frame(width: 380, height: 400)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
-        .onKeyPress(.upArrow) {
-            if selectedIndex > 0 {
-                selectedIndex -= 1
-            }
-            return .handled
-        }
-        .onKeyPress(.downArrow) {
-            if selectedIndex < filteredActions.count - 1 {
-                selectedIndex += 1
-            }
-            return .handled
-        }
-        .onKeyPress(.escape) {
-            onDismiss()
-            return .handled
-        }
-        .onChange(of: searchText) { _, _ in
-            selectedIndex = 0
-        }
-    }
-}
-
-private struct PromptPaletteRow: View {
-    let action: PromptAction
-    let isSelected: Bool
-
-    var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: action.icon)
-                .font(.system(size: 14))
-                .foregroundColor(isSelected ? .white : .accentColor)
-                .frame(width: 24, height: 24)
-                .accessibilityHidden(true)
-
-            Text(action.name)
-                .font(.system(size: 13))
-                .foregroundColor(isSelected ? .white : .primary)
-
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(isSelected ? Color.accentColor : Color.clear)
-        )
-        .accessibilityLabel(action.name)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-}
-
-// MARK: - NSPanel
-
-class PromptPalettePanel: NSPanel {
-    init() {
-        super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 380, height: 300),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-
-        self.level = .floating
-        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        self.isOpaque = false
-        self.backgroundColor = .clear
-        self.hasShadow = false
-        self.isMovableByWindowBackground = false
-    }
-
-    override var canBecomeKey: Bool { true }
-
-    func positionOnActiveScreen() {
-        let screen = activeScreen() ?? NSScreen.main ?? NSScreen.screens.first
-        guard let screen = screen else { return }
-
-        let screenFrame = screen.visibleFrame
-        let x = screenFrame.midX - frame.width / 2
-        let y = screenFrame.midY + 60
-
-        setFrameOrigin(NSPoint(x: x, y: y))
-    }
-
-    private func activeScreen() -> NSScreen? {
-        let mouseLocation = NSEvent.mouseLocation
-        for screen in NSScreen.screens {
-            if screen.frame.contains(mouseLocation) {
-                return screen
-            }
-        }
-        return nil
-    }
-}
-
-// MARK: - Controller
 
 @MainActor
-class PromptPaletteController {
-    private var panel: PromptPalettePanel?
-    private var hostingView: NSHostingView<PromptPaletteContentView>?
-    private var onActionSelected: ((PromptAction) -> Void)?
-    private var localClickMonitor: Any?
-    private var globalClickMonitor: Any?
+final class PromptPaletteController {
+    private let paletteController: any SelectionPaletteControlling
+
+    init(paletteController: any SelectionPaletteControlling = SelectionPaletteController()) {
+        self.paletteController = paletteController
+    }
+
+    var isVisible: Bool { paletteController.isVisible }
 
     func show(actions: [PromptAction], sourceText: String, onSelect: @escaping (PromptAction) -> Void) {
-        hide()
-
-        let enabledActions = actions.filter { $0.isEnabled }
+        let enabledActions = actions.filter(\.isEnabled)
         guard !enabledActions.isEmpty else { return }
 
-        self.onActionSelected = onSelect
-
-        let contentView = PromptPaletteContentView(
-            actions: enabledActions,
-            sourceText: sourceText,
-            onSelect: { [weak self] action in
-                self?.hide()
-                onSelect(action)
-            },
-            onDismiss: { [weak self] in
-                self?.hide()
-            }
-        )
-
-        let hosting = NSHostingView(rootView: contentView)
-        hosting.translatesAutoresizingMaskIntoConstraints = true
-        hostingView = hosting
-
-        let panelSize = NSSize(width: 380, height: 400)
-
-        let palettePanel = PromptPalettePanel()
-        palettePanel.contentView = hosting
-        hosting.frame = NSRect(origin: .zero, size: panelSize)
-        palettePanel.setContentSize(panelSize)
-        palettePanel.positionOnActiveScreen()
-
-        panel = palettePanel
-        palettePanel.makeKeyAndOrderFront(nil)
-
-        localClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
-            if let panel = self?.panel, !panel.frame.contains(NSEvent.mouseLocation) {
-                self?.hide()
-            }
-            return event
+        let items = enabledActions.map {
+            SelectionPaletteItem(
+                id: $0.id,
+                title: $0.name,
+                iconSystemName: $0.icon,
+                searchTokens: [$0.name]
+            )
         }
-        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] _ in
-            self?.hide()
+        let actionsByID = Dictionary(uniqueKeysWithValues: enabledActions.map { ($0.id, $0) })
+
+        paletteController.show(
+            configuration: SelectionPaletteConfiguration(
+                panelWidth: 380,
+                panelHeight: 400,
+                previewText: sourceText,
+                previewLineLimit: 3,
+                searchPrompt: String(localized: "Search prompts..."),
+                emptyStateTitle: String(localized: "No matching prompts")
+            ),
+            items: items
+        ) { item in
+            guard let action = actionsByID[item.id] else { return }
+            onSelect(action)
         }
     }
 
     func hide() {
-        if let monitor = localClickMonitor {
-            NSEvent.removeMonitor(monitor)
-            localClickMonitor = nil
-        }
-        if let monitor = globalClickMonitor {
-            NSEvent.removeMonitor(monitor)
-            globalClickMonitor = nil
-        }
-        panel?.orderOut(nil)
-        panel = nil
-        hostingView = nil
-        onActionSelected = nil
-    }
-
-    var isVisible: Bool {
-        panel?.isVisible ?? false
-    }
-}
-
-// MARK: - Array Extension
-
-private extension Array {
-    subscript(safe index: Int) -> Element? {
-        indices.contains(index) ? self[index] : nil
+        paletteController.hide()
     }
 }

--- a/TypeWhisper/Views/SelectionPalettePanel.swift
+++ b/TypeWhisper/Views/SelectionPalettePanel.swift
@@ -1,0 +1,453 @@
+import AppKit
+import SwiftUI
+
+struct SelectionPaletteItem: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    let subtitle: String?
+    let iconSystemName: String?
+    let searchTokens: [String]
+
+    init(
+        id: UUID,
+        title: String,
+        subtitle: String? = nil,
+        iconSystemName: String? = nil,
+        searchTokens: [String] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.iconSystemName = iconSystemName
+        self.searchTokens = searchTokens
+    }
+}
+
+struct SelectionPaletteConfiguration: Equatable {
+    let panelWidth: CGFloat
+    let panelHeight: CGFloat
+    let previewText: String?
+    let previewLineLimit: Int
+    let titleLineLimit: Int
+    let searchPrompt: String?
+    let emptyStateTitle: String
+
+    init(
+        panelWidth: CGFloat = 380,
+        panelHeight: CGFloat = 400,
+        previewText: String? = nil,
+        previewLineLimit: Int = 3,
+        titleLineLimit: Int = 1,
+        searchPrompt: String? = nil,
+        emptyStateTitle: String
+    ) {
+        self.panelWidth = panelWidth
+        self.panelHeight = panelHeight
+        self.previewText = previewText
+        self.previewLineLimit = previewLineLimit
+        self.titleLineLimit = titleLineLimit
+        self.searchPrompt = searchPrompt
+        self.emptyStateTitle = emptyStateTitle
+    }
+
+    var showsSearchField: Bool { searchPrompt != nil }
+}
+
+@MainActor
+protocol SelectionPaletteControlling: AnyObject {
+    var isVisible: Bool { get }
+    func show(
+        configuration: SelectionPaletteConfiguration,
+        items: [SelectionPaletteItem],
+        onSelect: @escaping (SelectionPaletteItem) -> Void
+    )
+    func hide()
+}
+
+@MainActor
+final class SelectionPaletteInteractionModel: ObservableObject {
+    let configuration: SelectionPaletteConfiguration
+
+    @Published var searchText = "" {
+        didSet {
+            if searchText != oldValue {
+                selectedIndex = 0
+            }
+        }
+    }
+    @Published private(set) var selectedIndex = 0
+
+    private let items: [SelectionPaletteItem]
+    private let onSelect: (SelectionPaletteItem) -> Void
+    private let onDismiss: () -> Void
+
+    init(
+        configuration: SelectionPaletteConfiguration,
+        items: [SelectionPaletteItem],
+        onSelect: @escaping (SelectionPaletteItem) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.configuration = configuration
+        self.items = items
+        self.onSelect = onSelect
+        self.onDismiss = onDismiss
+    }
+
+    var filteredItems: [SelectionPaletteItem] {
+        guard configuration.showsSearchField, !searchText.isEmpty else {
+            return items
+        }
+
+        return items.filter { item in
+            item.title.localizedCaseInsensitiveContains(searchText)
+                || (item.subtitle?.localizedCaseInsensitiveContains(searchText) ?? false)
+                || item.searchTokens.contains(where: { $0.localizedCaseInsensitiveContains(searchText) })
+        }
+    }
+
+    func handleKeyDown(_ event: NSEvent) -> Bool {
+        switch event.keyCode {
+        case 125: // Down arrow
+            moveSelection(by: 1)
+            return true
+        case 126: // Up arrow
+            moveSelection(by: -1)
+            return true
+        case 36, 76: // Return, keypad enter
+            acceptSelection()
+            return true
+        case 53: // Escape
+            onDismiss()
+            return true
+        case 51, 117: // Delete, forward delete
+            guard configuration.showsSearchField else { return false }
+            deleteBackward()
+            return true
+        default:
+            guard configuration.showsSearchField, let typedText = event.selectionPaletteTypedText else {
+                return false
+            }
+            searchText.append(typedText)
+            return true
+        }
+    }
+
+    func selectItem(_ item: SelectionPaletteItem) {
+        onSelect(item)
+    }
+
+    private func moveSelection(by offset: Int) {
+        guard !filteredItems.isEmpty else { return }
+        selectedIndex = min(max(selectedIndex + offset, 0), filteredItems.count - 1)
+    }
+
+    private func acceptSelection() {
+        guard let item = filteredItems[safe: selectedIndex] else { return }
+        onSelect(item)
+    }
+
+    private func deleteBackward() {
+        guard !searchText.isEmpty else { return }
+        searchText.removeLast()
+    }
+}
+
+private struct SelectionPaletteContentView: View {
+    @ObservedObject var model: SelectionPaletteInteractionModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let previewText = model.configuration.previewText {
+                Text(previewText)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(model.configuration.previewLineLimit)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.top, 10)
+                    .padding(.bottom, 8)
+
+                Divider()
+            }
+
+            if let searchPrompt = model.configuration.searchPrompt {
+                SelectionPaletteSearchField(
+                    prompt: searchPrompt,
+                    text: model.searchText
+                )
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+
+                Divider()
+            }
+
+            if model.filteredItems.isEmpty {
+                VStack(spacing: 8) {
+                    Text(model.configuration.emptyStateTitle)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.vertical, 20)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 2) {
+                            ForEach(Array(model.filteredItems.enumerated()), id: \.element.id) { index, item in
+                                SelectionPaletteRow(
+                                    item: item,
+                                    isSelected: index == model.selectedIndex,
+                                    titleLineLimit: model.configuration.titleLineLimit
+                                )
+                                .id(index)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    model.selectItem(item)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 6)
+                    }
+                    .onChange(of: model.selectedIndex) { _, newValue in
+                        proxy.scrollTo(newValue, anchor: .center)
+                    }
+                }
+            }
+        }
+        .frame(width: model.configuration.panelWidth, height: model.configuration.panelHeight)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
+    }
+}
+
+private struct SelectionPaletteSearchField: View {
+    let prompt: String
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+                .accessibilityHidden(true)
+
+            HStack(spacing: 1) {
+                if text.isEmpty {
+                    Text(prompt)
+                        .foregroundColor(.secondary)
+                } else {
+                    Text(text)
+                        .foregroundColor(.primary)
+                }
+
+                Rectangle()
+                    .fill(Color.accentColor.opacity(0.85))
+                    .frame(width: 1, height: 14)
+            }
+            .font(.system(size: 15))
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(prompt)
+        .accessibilityValue(text)
+    }
+}
+
+private struct SelectionPaletteRow: View {
+    let item: SelectionPaletteItem
+    let isSelected: Bool
+    let titleLineLimit: Int
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            if let iconSystemName = item.iconSystemName {
+                Image(systemName: iconSystemName)
+                    .font(.system(size: 14))
+                    .foregroundColor(isSelected ? .white : .accentColor)
+                    .frame(width: 24, height: 24)
+                    .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: item.subtitle == nil ? 0 : 2) {
+                Text(item.title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(isSelected ? .white : .primary)
+                    .lineLimit(titleLineLimit)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(isSelected ? .white.opacity(0.9) : .secondary)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isSelected ? Color.accentColor : Color.clear)
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(item.subtitle.map { "\(item.title), \($0)" } ?? item.title)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+private final class SelectionPalettePanel: NSPanel {
+    var keyDownHandler: ((NSEvent) -> Bool)?
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 380, height: 300),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        level = .floating
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        isMovableByWindowBackground = false
+    }
+
+    override var canBecomeKey: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        if keyDownHandler?(event) == true {
+            return
+        }
+        super.keyDown(with: event)
+    }
+
+    func positionOnActiveScreen() {
+        let screen = activeScreen() ?? NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let screenFrame = screen.visibleFrame
+        let x = screenFrame.midX - frame.width / 2
+        let y = screenFrame.midY + 60
+
+        setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func activeScreen() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+    }
+}
+
+@MainActor
+final class SelectionPaletteController: SelectionPaletteControlling {
+    private var panel: SelectionPalettePanel?
+    private var hostingView: NSHostingView<SelectionPaletteContentView>?
+    private var interactionModel: SelectionPaletteInteractionModel?
+    private var localClickMonitor: Any?
+    private var globalClickMonitor: Any?
+
+    var isVisible: Bool { panel != nil }
+
+    func show(
+        configuration: SelectionPaletteConfiguration,
+        items: [SelectionPaletteItem],
+        onSelect: @escaping (SelectionPaletteItem) -> Void
+    ) {
+        hide()
+        guard !items.isEmpty else { return }
+
+        let interactionModel = SelectionPaletteInteractionModel(
+            configuration: configuration,
+            items: items,
+            onSelect: { [weak self] item in
+                self?.hide()
+                onSelect(item)
+            },
+            onDismiss: { [weak self] in
+                self?.hide()
+            }
+        )
+        self.interactionModel = interactionModel
+
+        let contentView = SelectionPaletteContentView(
+            model: interactionModel
+        )
+
+        let hosting = NSHostingView(rootView: contentView)
+        hosting.translatesAutoresizingMaskIntoConstraints = true
+        hostingView = hosting
+
+        let panelSize = NSSize(width: configuration.panelWidth, height: configuration.panelHeight)
+        let palettePanel = SelectionPalettePanel()
+        palettePanel.contentView = hosting
+        hosting.frame = NSRect(origin: .zero, size: panelSize)
+        palettePanel.setContentSize(panelSize)
+        palettePanel.positionOnActiveScreen()
+        palettePanel.keyDownHandler = { [weak interactionModel] event in
+            interactionModel?.handleKeyDown(event) ?? false
+        }
+
+        panel = palettePanel
+        palettePanel.makeKeyAndOrderFront(nil)
+
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
+            if let panel = self?.panel, !panel.frame.contains(NSEvent.mouseLocation) {
+                self?.hide()
+            }
+            return event
+        }
+        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] _ in
+            self?.hide()
+        }
+    }
+
+    func hide() {
+        if let monitor = localClickMonitor {
+            NSEvent.removeMonitor(monitor)
+            localClickMonitor = nil
+        }
+        if let monitor = globalClickMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalClickMonitor = nil
+        }
+        panel?.orderOut(nil)
+        panel = nil
+        hostingView = nil
+        interactionModel = nil
+    }
+}
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}
+
+private extension NSEvent {
+    var selectionPaletteTypedText: String? {
+        let disallowedModifiers: NSEvent.ModifierFlags = [.command, .control, .option, .function]
+        let modifiers = modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard modifiers.intersection(disallowedModifiers).isEmpty else {
+            return nil
+        }
+
+        guard let characters, !characters.isEmpty else {
+            return nil
+        }
+
+        let containsControlCharacter = characters.unicodeScalars.contains(where: { scalar in
+            CharacterSet.controlCharacters.contains(scalar)
+        })
+        return containsControlCharacter ? nil : characters
+    }
+}

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -1090,6 +1090,7 @@ struct SetupWizardView: View {
         case .pushToTalk: return dictation.pttHotkeyLabel
         case .toggle: return dictation.toggleHotkeyLabel
         case .promptPalette: return dictation.promptPaletteHotkeyLabel
+        case .recentTranscriptions: return dictation.recentTranscriptionsHotkeyLabel
         }
     }
 
@@ -1099,6 +1100,7 @@ struct SetupWizardView: View {
         case .pushToTalk: return String(localized: "Push-to-Talk")
         case .toggle: return String(localized: "Toggle")
         case .promptPalette: return String(localized: "Prompt Palette")
+        case .recentTranscriptions: return String(localized: "Recent Transcriptions")
         }
     }
 }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -675,11 +675,20 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
     func testDictationEndpointsReturnSessionIDAndCompletedTranscription() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let historyEnabledKey = UserDefaultsKeys.historyEnabled
+        let originalHistoryEnabled = UserDefaults.standard.object(forKey: historyEnabledKey)
         var context: APIContext?
         defer {
             context = nil
+            if let originalHistoryEnabled {
+                UserDefaults.standard.set(originalHistoryEnabled, forKey: historyEnabledKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: historyEnabledKey)
+            }
             TestSupport.remove(appSupportDirectory)
         }
+
+        UserDefaults.standard.set(true, forKey: historyEnabledKey)
 
         context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
@@ -1272,6 +1281,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let hotkeyService = HotkeyService()
         let textInsertionService = TextInsertionService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let recentTranscriptionStore = RecentTranscriptionStore()
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
@@ -1293,6 +1303,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             modelManager: modelManager,
             settingsViewModel: settingsViewModel,
             historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
             translationService: nil,
             audioDuckingService: audioDuckingService,
@@ -1609,6 +1620,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let hotkeyService = HotkeyService()
         let textInsertionService = TextInsertionService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let recentTranscriptionStore = RecentTranscriptionStore()
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
@@ -1630,6 +1642,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             modelManager: modelManager,
             settingsViewModel: settingsViewModel,
             historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
             translationService: nil,
             audioDuckingService: audioDuckingService,
@@ -1778,6 +1791,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let hotkeyService = HotkeyService()
         let textInsertionService = TextInsertionService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let recentTranscriptionStore = RecentTranscriptionStore()
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = audioDuckingService ?? AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
@@ -1800,6 +1814,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             modelManager: modelManager,
             settingsViewModel: settingsViewModel,
             historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
             translationService: nil,
             audioDuckingService: audioDuckingService,
@@ -3200,6 +3215,53 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
         XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testRecentTranscriptionsHotkeyInvokesDedicatedCallbackOnKeyDown() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .recentTranscriptions)
+
+        var callbackCount = 0
+        var startCount = 0
+        service.onRecentTranscriptionsToggle = { callbackCount += 1 }
+        service.onDictationStart = { startCount += 1 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testRecentTranscriptionsHotkeyDoesNotStopActiveDictation() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
+        service.setHotkeyForTesting(commandOptionAHotkey(), for: .recentTranscriptions)
+
+        var startCount = 0
+        var stopCount = 0
+        var callbackCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+        service.onRecentTranscriptionsToggle = { callbackCount += 1 }
+
+        let toggleDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        let recentDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+
+        XCTAssertTrue(service.processEventForTesting(toggleDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        XCTAssertTrue(service.processEventForTesting(recentDown, source: .monitor))
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .toggle)
     }
 
     @MainActor

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -1,0 +1,257 @@
+import AppKit
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
+    func testTriggerSelectionOpensOnlyWhenIdle() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let textInsertionService = TextInsertionService()
+        let store = RecentTranscriptionStore()
+        let controller = SelectionPaletteControllerSpy()
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: textInsertionService,
+            historyService: historyService,
+            recentTranscriptionStore: store,
+            paletteController: controller
+        )
+
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Recent session entry",
+            timestamp: Date(),
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes"
+        )
+
+        handler.triggerSelection(currentState: .processing)
+        XCTAssertFalse(controller.isVisible)
+
+        handler.triggerSelection(currentState: .idle)
+        XCTAssertTrue(controller.isVisible)
+        XCTAssertEqual(controller.lastItems?.count, 1)
+    }
+
+    func testTriggerSelectionShowsFeedbackWhenNoEntriesExist() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: TextInsertionService(),
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
+            paletteController: SelectionPaletteControllerSpy()
+        )
+
+        var feedbackMessage: String?
+        handler.onShowNotchFeedback = { message, _, _, _, _ in
+            feedbackMessage = message
+        }
+
+        handler.triggerSelection(currentState: .idle)
+
+        XCTAssertEqual(
+            feedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "No recent transcriptions")
+        )
+    }
+
+    func testTriggerSelectionSortsNewestEntriesFirst() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let store = RecentTranscriptionStore()
+        let controller = SelectionPaletteControllerSpy()
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: TextInsertionService(),
+            historyService: historyService,
+            recentTranscriptionStore: store,
+            paletteController: controller
+        )
+
+        historyService.addRecord(
+            id: UUID(),
+            rawText: "History newest",
+            finalText: "History newest",
+            appName: "Safari",
+            appBundleIdentifier: "com.apple.Safari",
+            durationSeconds: 1,
+            language: "en",
+            engineUsed: "mock"
+        )
+        let historyRecord = try XCTUnwrap(historyService.records.first)
+        historyRecord.timestamp = Date().addingTimeInterval(-10)
+        historyService.updateRecord(historyRecord, finalText: historyRecord.finalText)
+
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Session older",
+            timestamp: Date().addingTimeInterval(-120),
+            appName: "Mail",
+            appBundleIdentifier: "com.apple.mail"
+        )
+
+        handler.triggerSelection(currentState: .idle)
+
+        XCTAssertEqual(controller.lastItems?.map(\.title), ["History newest", "Session older"])
+    }
+
+    func testSelectingItemInsertsWithoutAutoEnter() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pasteboard = NSPasteboard.withUniqueName()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.pasteboardProvider = { pasteboard }
+        textInsertionService.focusedTextFieldOverride = { true }
+
+        var pasteCount = 0
+        var returnCount = 0
+        textInsertionService.pasteSimulatorOverride = { pasteCount += 1 }
+        textInsertionService.returnSimulatorOverride = { returnCount += 1 }
+
+        let store = RecentTranscriptionStore()
+        let controller = SelectionPaletteControllerSpy()
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: textInsertionService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: store,
+            paletteController: controller
+        )
+
+        let id = UUID()
+        store.recordTranscription(
+            id: id,
+            finalText: "Insert me",
+            timestamp: Date(),
+            appName: "Messages",
+            appBundleIdentifier: "com.apple.MobileSMS"
+        )
+
+        handler.triggerSelection(currentState: .idle)
+        controller.select(id: id)
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(returnCount, 0)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Insert me")
+    }
+}
+
+@MainActor
+final class SelectionPaletteInteractionModelTests: XCTestCase {
+    func testArrowKeysMoveSelectionAndReturnSelectsCurrentItem() throws {
+        let items = [
+            SelectionPaletteItem(id: UUID(), title: "First"),
+            SelectionPaletteItem(id: UUID(), title: "Second"),
+            SelectionPaletteItem(id: UUID(), title: "Third"),
+        ]
+        var selectedID: UUID?
+        let model = SelectionPaletteInteractionModel(
+            configuration: SelectionPaletteConfiguration(emptyStateTitle: "Empty"),
+            items: items,
+            onSelect: { selectedID = $0.id },
+            onDismiss: {}
+        )
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 125, characters: "")))
+        XCTAssertEqual(model.selectedIndex, 1)
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 36, characters: "\r")))
+        XCTAssertEqual(selectedID, items[1].id)
+    }
+
+    func testTypingAndDeleteUpdateSearchTextAndFilteredItems() throws {
+        let items = [
+            SelectionPaletteItem(id: UUID(), title: "Translate"),
+            SelectionPaletteItem(id: UUID(), title: "Summarize"),
+        ]
+        let model = SelectionPaletteInteractionModel(
+            configuration: SelectionPaletteConfiguration(
+                searchPrompt: "Search",
+                emptyStateTitle: "Empty"
+            ),
+            items: items,
+            onSelect: { _ in },
+            onDismiss: {}
+        )
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 1, characters: "s")))
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 17, characters: "u")))
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 46, characters: "m")))
+        XCTAssertEqual(model.searchText, "sum")
+        XCTAssertEqual(model.filteredItems.map(\.title), ["Summarize"])
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 51, characters: "")))
+        XCTAssertEqual(model.searchText, "su")
+        XCTAssertEqual(model.filteredItems.map(\.title), ["Summarize"])
+    }
+
+    func testEscapeDismissesPalette() throws {
+        var dismissCount = 0
+        let model = SelectionPaletteInteractionModel(
+            configuration: SelectionPaletteConfiguration(emptyStateTitle: "Empty"),
+            items: [SelectionPaletteItem(id: UUID(), title: "Only")],
+            onSelect: { _ in },
+            onDismiss: { dismissCount += 1 }
+        )
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 53, characters: "")))
+        XCTAssertEqual(dismissCount, 1)
+    }
+
+    private func keyEvent(
+        keyCode: UInt16,
+        characters: String,
+        modifierFlags: NSEvent.ModifierFlags = []
+    ) throws -> NSEvent {
+        try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: modifierFlags,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: characters,
+                charactersIgnoringModifiers: characters,
+                isARepeat: false,
+                keyCode: keyCode
+            )
+        )
+    }
+}
+
+@MainActor
+private final class SelectionPaletteControllerSpy: SelectionPaletteControlling {
+    private(set) var isVisible = false
+    private(set) var lastConfiguration: SelectionPaletteConfiguration?
+    private(set) var lastItems: [SelectionPaletteItem]?
+    private var onSelect: ((SelectionPaletteItem) -> Void)?
+
+    func show(
+        configuration: SelectionPaletteConfiguration,
+        items: [SelectionPaletteItem],
+        onSelect: @escaping (SelectionPaletteItem) -> Void
+    ) {
+        isVisible = true
+        lastConfiguration = configuration
+        lastItems = items
+        self.onSelect = onSelect
+    }
+
+    func hide() {
+        isVisible = false
+    }
+
+    func select(id: UUID) {
+        guard let item = lastItems?.first(where: { $0.id == id }) else { return }
+        onSelect?(item)
+    }
+}

--- a/TypeWhisperTests/RecentTranscriptionStoreTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionStoreTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import TypeWhisper
+
+final class RecentTranscriptionStoreTests: XCTestCase {
+    @MainActor
+    func testMergedEntriesDedupesSessionAndHistoryAndSortsNewestFirst() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let store = RecentTranscriptionStore()
+        let now = Date()
+
+        let duplicatedID = UUID()
+        historyService.addRecord(
+            id: duplicatedID,
+            rawText: "history newer",
+            finalText: "History newer",
+            appName: "Safari",
+            appBundleIdentifier: "com.apple.Safari",
+            durationSeconds: 1,
+            language: "en",
+            engineUsed: "mock"
+        )
+        historyService.addRecord(
+            id: UUID(),
+            rawText: "history oldest",
+            finalText: "History oldest",
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes",
+            durationSeconds: 1,
+            language: "en",
+            engineUsed: "mock"
+        )
+
+        let newerHistory = try XCTUnwrap(historyService.records.first(where: { $0.id == duplicatedID }))
+        newerHistory.timestamp = now.addingTimeInterval(-60)
+        historyService.updateRecord(newerHistory, finalText: newerHistory.finalText)
+
+        let olderHistory = try XCTUnwrap(historyService.records.first(where: { $0.id != duplicatedID }))
+        olderHistory.timestamp = now.addingTimeInterval(-180)
+        historyService.updateRecord(olderHistory, finalText: olderHistory.finalText)
+
+        store.recordTranscription(
+            id: duplicatedID,
+            finalText: "Session duplicate",
+            timestamp: now.addingTimeInterval(-120),
+            appName: "Safari",
+            appBundleIdentifier: "com.apple.Safari"
+        )
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Session newest",
+            timestamp: now.addingTimeInterval(-30),
+            appName: "Mail",
+            appBundleIdentifier: "com.apple.mail"
+        )
+
+        let merged = store.mergedEntries(historyRecords: historyService.records)
+
+        XCTAssertEqual(merged.map(\.finalText), ["Session newest", "History newer", "History oldest"])
+        XCTAssertEqual(merged.count, 3)
+    }
+
+    @MainActor
+    func testMergedEntriesFallsBackToSessionEntriesWhenHistoryIsEmpty() {
+        let store = RecentTranscriptionStore()
+        let id = UUID()
+
+        store.recordTranscription(
+            id: id,
+            finalText: "Fallback session entry",
+            timestamp: Date(),
+            appName: "Slack",
+            appBundleIdentifier: "com.tinyspeck.slackmacgap"
+        )
+
+        let merged = store.mergedEntries(historyRecords: [])
+
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged.first?.id, id)
+        XCTAssertEqual(merged.first?.source, .session)
+    }
+
+    @MainActor
+    func testSessionBufferIsLimitedToTwentyEntries() {
+        let store = RecentTranscriptionStore()
+
+        for index in 0..<25 {
+            store.recordTranscription(
+                id: UUID(),
+                finalText: "Entry \(index)",
+                timestamp: Date().addingTimeInterval(Double(index)),
+                appName: nil,
+                appBundleIdentifier: nil
+            )
+        }
+
+        XCTAssertEqual(store.sessionEntries.count, 20)
+        XCTAssertEqual(store.sessionEntries.first?.finalText, "Entry 24")
+        XCTAssertEqual(store.sessionEntries.last?.finalText, "Entry 5")
+    }
+}


### PR DESCRIPTION
## Summary
- add a generic selection palette and reuse it for the existing prompt palette plus a new recent-transcriptions recovery palette
- persist the latest completed transcriptions in a session store, merge them with history, and reinsert them through the existing text insertion path without auto-enter
- wire a new global hotkey, settings UI, localized strings, and regression tests for the palette, store, and API/hotkey flows

## Issue context
Issue #359 asks for a fast recovery path when macOS Accessibility insertion flakes and a completed dictation never lands in the target app. This PR adds a configurable recent-transcriptions palette so users can recover the last transcription without sacrificing clipboard preservation or opening the history UI.

Closes #359

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/RecentTranscriptionStoreTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests -only-testing:TypeWhisperTests/SelectionPaletteInteractionModelTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`