### PR TITLE
Add engine-aware dictionary budgets and refine quiet dictation handling

### DIFF
--- a/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -37,7 +37,7 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(AssemblyAIPlugin)
-final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.assemblyai"
     static let pluginName = "AssemblyAI"
 
@@ -89,6 +89,7 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryTermsBudget(for: _selectedModelId) }
 
     var supportedLanguages: [String] {
         if _selectedModelId == "universal-2" {
@@ -263,8 +264,18 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         return transcriptId
     }
 
+    private static func dictionaryTermsBudget(for modelId: String?) -> DictionaryTermsBudget {
+        if modelId == "universal-3-pro" {
+            return DictionaryTermsBudget(maxTerms: 1_000, maxWordsPerTerm: 6)
+        }
+        return DictionaryTermsBudget(maxTerms: 100, maxCharsPerTerm: 50)
+    }
+
     private static func applyDictionaryTerms(prompt: String?, modelId: String, to body: inout [String: Any]) {
-        let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
+        let terms = PluginDictionaryTerms.clippedTerms(
+            from: PluginDictionaryTerms.terms(fromPrompt: prompt),
+            budget: dictionaryTermsBudget(for: modelId)
+        )
         guard !terms.isEmpty else { return }
 
         if modelId == "universal-3-pro" {
@@ -416,7 +427,10 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
     }
 
     private func streamingKeytermsPromptJSON(from prompt: String?, modelId: String) -> String? {
-        let rawTerms = PluginDictionaryTerms.terms(fromPrompt: prompt)
+        let rawTerms = PluginDictionaryTerms.clippedTerms(
+            from: PluginDictionaryTerms.terms(fromPrompt: prompt),
+            budget: Self.dictionaryTermsBudget(for: modelId)
+        )
         guard !rawTerms.isEmpty else { return nil }
 
         let maxTerms = 100

--- a/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -300,9 +300,11 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(DeepgramPlugin)
-final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.deepgram"
     static let pluginName = "Deepgram"
+    private static let logger = Logger(subsystem: "com.typewhisper.deepgram", category: "Plugin")
+    private static let maxDictionaryTerms = 100
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -356,6 +358,7 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTerms: Self.maxDictionaryTerms) }
 
     var supportedLanguages: [String] {
         [
@@ -618,12 +621,19 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         return PluginTranscriptionResult(text: finalText, detectedLanguage: language)
     }
 
-    private static func dictionaryQueryItems(prompt: String?, modelId: String) -> [URLQueryItem] {
+    internal static func dictionaryQueryItems(prompt: String?, modelId: String) -> [URLQueryItem] {
         let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
         guard !terms.isEmpty else { return [] }
 
+        let limitedTerms = Array(terms.prefix(Self.maxDictionaryTerms))
+        if limitedTerms.count < terms.count {
+            logger.warning(
+                "Deepgram limited dictionary terms to \(Self.maxDictionaryTerms) entries for model \(modelId, privacy: .public)"
+            )
+        }
+
         let parameterName = modelId.lowercased().hasPrefix("nova-3") ? "keyterm" : "keywords"
-        return terms.map { URLQueryItem(name: parameterName, value: $0) }
+        return limitedTerms.map { URLQueryItem(name: parameterName, value: $0) }
     }
 
     // MARK: - JSON Parsing Helpers

--- a/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -73,9 +73,11 @@ private struct GladiaLiveSession: Sendable {
 }
 
 @objc(GladiaPlugin)
-final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gladia"
     static let pluginName = "Gladia"
+    private static let dictionaryLogger = Logger(subsystem: "com.typewhisper.gladia", category: "Plugin")
+    private static let dictionaryBudget = DictionaryTermsBudget(maxTerms: 1_000, maxCharsPerTerm: 50)
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -122,6 +124,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryBudget }
     var supportedLanguages: [String] { gladiaSupportedLanguages }
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
@@ -763,9 +766,15 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
 
     private static func customVocabularyConfig(prompt: String?) -> [String: Any]? {
         let vocabulary = PluginDictionaryTerms.terms(fromPrompt: prompt)
-        guard !vocabulary.isEmpty else { return nil }
+        let clippedVocabulary = PluginDictionaryTerms.clippedTerms(from: vocabulary, budget: dictionaryBudget)
+        if clippedVocabulary.count < vocabulary.count {
+            dictionaryLogger.warning(
+                "Gladia dropped \(vocabulary.count - clippedVocabulary.count) dictionary term(s) outside the documented vocabulary budget"
+            )
+        }
+        guard !clippedVocabulary.isEmpty else { return nil }
         return [
-            "vocabulary": vocabulary,
+            "vocabulary": clippedVocabulary,
             "default_intensity": 0.7,
         ]
     }

--- a/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/Plugins/GranitePlugin/GranitePlugin.swift
@@ -9,7 +9,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(GranitePlugin)
-final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.granite"
     static let pluginName = "Granite Speech"
 
@@ -82,6 +82,7 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     var supportsTranslation: Bool { true }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTotalChars: 4_000) }
 
     func transcribe(
         audio: AudioData,

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 
@@ -107,6 +107,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
     var supportsTranslation: Bool { false }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTotalChars: 10_000) }
 
     func transcribe(
         audio: AudioData,

--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -17,6 +17,13 @@ TypeWhisper supports external plugins as macOS `.bundle` files. Place compiled b
 | `TranscriptionEnginePlugin` | Custom transcription engines | Yes (transcription result) |
 | `ActionPlugin` | Route LLM output to custom actions (e.g. create Linear issues) | Yes (action result) |
 
+For transcription plugins, dictionary-term support remains optional. Engines that
+have documented input limits can additionally conform to `DictionaryTermsBudgetProviding`
+and return a `DictionaryTermsBudget` so the host clips the global dictionary before
+request assembly. Legacy `v1` plugins that do not implement the budget protocol keep
+working unchanged and automatically fall back to the host's default 600-character
+dictionary prompt budget.
+
 ## Event Bus
 
 Plugins can subscribe to events without modifying the transcription pipeline:

--- a/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -67,7 +67,7 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(SonioxPlugin)
-final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.soniox"
     static let pluginName = "Soniox"
 
@@ -119,6 +119,7 @@ final class SonioxPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
     var supportsTranslation: Bool { true }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTotalChars: 10_000) }
 
     var supportedLanguages: [String] { sonioxSupportedLanguages }
 

--- a/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -9,9 +9,11 @@ import os
 
 @available(macOS 26, *)
 @objc(SpeechAnalyzerPlugin)
-final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.speechanalyzer"
     static let pluginName = "Apple Speech"
+    private static let logger = Logger(subsystem: "com.typewhisper.speechanalyzer", category: "Plugin")
+    private static let maxContextualTerms = 100
 
     fileprivate var host: HostServices?
     fileprivate var currentLocale: Locale?
@@ -83,6 +85,7 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTerms: Self.maxContextualTerms) }
 
     var supportedLanguages: [String] {
         let codes = Set(cachedModels.compactMap { model -> String? in
@@ -190,11 +193,15 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
         )
     }
 
-    fileprivate static func analysisContext(from prompt: String?) -> AnalysisContext {
+    static func analysisContext(from prompt: String?) -> AnalysisContext {
         let context = AnalysisContext()
         let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
-        if !terms.isEmpty {
-            context.contextualStrings[.general] = terms
+        let limitedTerms = Array(terms.prefix(Self.maxContextualTerms))
+        if limitedTerms.count < terms.count {
+            logger.warning("Apple Speech limited dictionary terms to \(Self.maxContextualTerms) entries")
+        }
+        if !limitedTerms.isEmpty {
+            context.contextualStrings[.general] = limitedTerms
         }
         return context
     }

--- a/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -37,9 +37,10 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(SpeechmaticsPlugin)
-final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.speechmatics"
     static let pluginName = "Speechmatics"
+    private static let dictionaryBudget = DictionaryTermsBudget(maxTerms: 1_000, maxWordsPerTerm: 6)
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -91,6 +92,7 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryBudget }
 
     var supportedLanguages: [String] {
         [
@@ -486,7 +488,14 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
     }
 
     private static func additionalVocabulary(prompt: String?) -> [String] {
-        PluginDictionaryTerms.terms(fromPrompt: prompt)
+        let vocabulary = PluginDictionaryTerms.terms(fromPrompt: prompt)
+        let clippedVocabulary = PluginDictionaryTerms.clippedTerms(from: vocabulary, budget: dictionaryBudget)
+        if clippedVocabulary.count < vocabulary.count {
+            Logger(subsystem: "com.typewhisper.speechmatics", category: "Plugin").warning(
+                "Speechmatics dropped \(vocabulary.count - clippedVocabulary.count) dictionary term(s) outside the documented vocabulary budget"
+            )
+        }
+        return clippedVocabulary
     }
 
     // MARK: - Audio Conversion

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -6,9 +6,10 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(WhisperKitPlugin)
-final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.whisperkit"
     static let pluginName = "WhisperKit"
+    private static let maxConditioningPromptChars = 500
 
     fileprivate var host: HostServices?
     fileprivate var whisperKit: WhisperKit?
@@ -77,6 +78,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
     var supportsTranslation: Bool { true }
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTotalChars: Self.maxConditioningPromptChars) }
 
     var supportedLanguages: [String] {
         [
@@ -173,7 +175,11 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
             audioArray: audio.samples,
             decodeOptions: options,
             callback: { progress in
-                let shouldContinue = onProgress(progress.text)
+                let sanitizedText = Self.sanitizedStreamingText(
+                    progress.text,
+                    conditioningPrompt: effectivePrompt
+                )
+                let shouldContinue = onProgress(sanitizedText)
                 return shouldContinue ? nil : false
             }
         )
@@ -197,8 +203,8 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
         return encoded.isEmpty ? nil : encoded
     }
 
-    private static func conditioningPrompt(from prompt: String?) -> String? {
-        guard let prompt else { return nil }
+    static func conditioningPrompt(from prompt: String?) -> String? {
+        guard let prompt = clampedPrompt(prompt, maxLength: maxConditioningPromptChars) else { return nil }
 
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPrompt.isEmpty else { return nil }
@@ -207,10 +213,39 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
         // Convert the legacy transport format into a softer natural-language context line.
         let terms = PluginDictionaryTerms.terms(fromPrompt: trimmedPrompt)
         if !terms.isEmpty && Self.looksLikePlainTermList(trimmedPrompt, terms: terms) {
-            return "The audio may contain these names or technical terms: \(terms.joined(separator: ", "))."
+            let prefix = "The audio may contain these names or technical terms: "
+            let suffix = "."
+            let availableTermChars = max(0, maxConditioningPromptChars - prefix.count - suffix.count)
+            guard let termPrompt = PluginDictionaryTerms.prompt(from: terms, maxLength: availableTermChars) else {
+                return nil
+            }
+            return prefix + termPrompt + suffix
         }
 
         return trimmedPrompt
+    }
+
+    static func sanitizedStreamingText(_ text: String, conditioningPrompt: String?) -> String {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return "" }
+
+        guard let conditioningPrompt = conditioningPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !conditioningPrompt.isEmpty,
+              let promptRange = trimmedText.range(
+                  of: conditioningPrompt,
+                  options: [.anchored, .caseInsensitive, .diacriticInsensitive]
+              ) else {
+            return trimmedText
+        }
+
+        return String(trimmedText[promptRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func clampedPrompt(_ prompt: String?, maxLength: Int) -> String? {
+        guard let prompt else { return nil }
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(maxLength))
     }
 
     private static func looksLikePlainTermList(_ prompt: String, terms: [String]) -> Bool {
@@ -582,6 +617,45 @@ enum WhisperModelState: Equatable {
     }
 }
 
+struct WhisperKitSettingsPollState: Equatable {
+    var modelState: WhisperModelState
+    var downloadProgress: Double
+    var activeModelId: String?
+    var isPolling: Bool
+
+    var isBusy: Bool {
+        switch modelState {
+        case .downloading, .loading:
+            return true
+        case .notLoaded, .ready, .error:
+            return false
+        }
+    }
+
+    func applyingPolledPluginState(
+        _ pluginState: WhisperModelState,
+        downloadProgress: Double,
+        selectedModelId: String?
+    ) -> WhisperKitSettingsPollState {
+        var updated = self
+        updated.modelState = pluginState
+        updated.downloadProgress = downloadProgress
+
+        switch pluginState {
+        case .ready:
+            updated.activeModelId = selectedModelId ?? updated.activeModelId
+            updated.isPolling = false
+        case .downloading, .loading:
+            updated.isPolling = true
+        case .notLoaded, .error:
+            updated.activeModelId = selectedModelId ?? updated.activeModelId
+            updated.isPolling = false
+        }
+
+        return updated
+    }
+}
+
 // MARK: - Settings View
 
 private struct WhisperKitSettingsView: View {
@@ -719,27 +793,30 @@ private struct WhisperKitSettingsView: View {
                 hfTokenInput = token
             }
             // If the plugin is mid-load (e.g., restoring on app launch), start polling
-            if case .downloading = plugin.modelState { isPolling = true }
-            else if case .loading = plugin.modelState { isPolling = true }
+            isPolling = WhisperKitSettingsPollState(
+                modelState: plugin.modelState,
+                downloadProgress: plugin.downloadProgress,
+                activeModelId: plugin._selectedModelId,
+                isPolling: false
+            ).isBusy
         }
         .onReceive(pollTimer) { _ in
             guard isPolling else { return }
-            downloadProgress = plugin.downloadProgress
-            let pluginState = plugin.modelState
-            if pluginState != .notLoaded {
-                modelState = pluginState
+            let updatedState = WhisperKitSettingsPollState(
+                modelState: modelState,
+                downloadProgress: downloadProgress,
+                activeModelId: activeModelId,
+                isPolling: isPolling
+            ).applyingPolledPluginState(
+                plugin.modelState,
+                downloadProgress: plugin.downloadProgress,
+                selectedModelId: plugin._selectedModelId
+            )
 
-                switch pluginState {
-                case .ready:
-                    activeModelId = plugin._selectedModelId ?? activeModelId
-                case .downloading, .loading:
-                    break
-                case .notLoaded, .error:
-                    activeModelId = plugin._selectedModelId ?? activeModelId
-                }
-            }
-            if case .ready = pluginState { isPolling = false }
-            else if case .error = pluginState { isPolling = false }
+            modelState = updatedState.modelState
+            downloadProgress = updatedState.downloadProgress
+            activeModelId = updatedState.activeModelId
+            isPolling = updatedState.isPolling
         }
         .onChange(of: hfTokenInput) { _, newValue in
             let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -808,6 +885,12 @@ private struct WhisperKitSettingsView: View {
             }
         } else {
             let isDownloaded = plugin.isModelDownloaded(modelDef)
+            let viewState = WhisperKitSettingsPollState(
+                modelState: modelState,
+                downloadProgress: downloadProgress,
+                activeModelId: activeModelId,
+                isPolling: isPolling
+            )
             Button(
                 isDownloaded
                     ? String(localized: "Load", bundle: bundle)
@@ -827,7 +910,7 @@ private struct WhisperKitSettingsView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
-            .disabled(modelState == .downloading || modelState == .loading(phase: "loading"))
+            .disabled(viewState.isBusy)
         }
     }
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		C2300000000000000000000C /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000013 /* MLXAudioCore */; };
 		C2300000000000000000000D /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000015 /* WhisperKit */; };
 		C2300000000000000000000E /* WhisperKitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000154 /* WhisperKitPlugin.swift */; };
+		C2300000000000000000000F /* SpeechAnalyzerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000160 /* SpeechAnalyzerPlugin.swift */; };
+		C23000000000000000000010 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
 		91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */; };
 		91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */; };
@@ -2925,6 +2927,8 @@
 				C23000000000000000000009 /* VoxtralPlugin.swift in Sources */,
 				C2300000000000000000000A /* GranitePlugin.swift in Sources */,
 				C2300000000000000000000E /* WhisperKitPlugin.swift in Sources */,
+				C2300000000000000000000F /* SpeechAnalyzerPlugin.swift in Sources */,
+				C23000000000000000000010 /* DeepgramPlugin.swift in Sources */,
 				C23000000000000000000003 /* Gemma4Plugin.swift in Sources */,
 				C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -291,10 +291,23 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     func stopRecording(policy: StopPolicy) async -> [Float] {
         if let stopRecordingOverride {
             let samples = await stopRecordingOverride(policy)
+            let rms: Float
+            if samples.isEmpty {
+                rms = 0
+            } else {
+                rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(samples.count))
+            }
+            let normalizedLevel = min(1.0, rms * 5)
+
+            bufferLock.withLock {
+                _peakRawAudioLevel = rms
+            }
+
             setLastStopGraceCaptureApplied(false)
             DispatchQueue.main.async { [weak self] in
                 self?.isRecording = false
-                self?.audioLevel = 0
+                self?.audioLevel = normalizedLevel
+                self?.rawAudioLevel = rms
             }
             return samples
         }

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -292,8 +292,17 @@ final class DictionaryService: ObservableObject {
         }
     }
 
-    func getTermsForPrompt() -> String? {
-        PluginDictionaryTerms.prompt(from: enabledTerms())
+    func getTermsForPrompt(providerId: String?) -> String? {
+        let terms = enabledTerms()
+        guard !terms.isEmpty else { return nil }
+
+        guard let providerId,
+              let plugin = PluginManager.shared?.transcriptionEngine(for: providerId),
+              let budget = (plugin as? any DictionaryTermsBudgetProviding)?.dictionaryTermsBudget else {
+            return PluginDictionaryTerms.prompt(from: terms)
+        }
+
+        return PluginDictionaryTerms.prompt(from: terms, budget: budget)
     }
 
     /// Apply all enabled corrections to the given text

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -190,7 +190,15 @@ final class APIHandlers: @unchecked Sendable {
             defer { try? FileManager.default.removeItem(at: tempURL) }
 
             let samples = try await audioFileService.loadAudioSamples(from: tempURL)
-            let dictionaryPrompt = await MainActor.run { dictionaryService.getTermsForPrompt() }
+            let effectiveProviderId: String?
+            if let engineId = resolvedOverride.engineId {
+                effectiveProviderId = engineId
+            } else {
+                effectiveProviderId = await modelManager.selectedProviderId
+            }
+            let dictionaryPrompt = await MainActor.run {
+                dictionaryService.getTermsForPrompt(providerId: effectiveProviderId)
+            }
             let prompt = mergedPrompt(requestPrompt: requestPrompt, dictionaryPrompt: dictionaryPrompt)
             let languageSelection: LanguageSelection
             if !languageHints.isEmpty {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -96,9 +96,6 @@ final class AudioRecorderViewModel: ObservableObject {
         self.dictionaryService = dictionaryService
         self.streamingHandler = StreamingHandler(
             modelManager: modelManager,
-            streamPromptProvider: { [weak dictionaryService] in
-                dictionaryService?.getTermsForPrompt() ?? ""
-            },
             bufferProvider: { [weak recorderService] in
                 recorderService?.getCurrentBuffer() ?? []
             },
@@ -225,7 +222,7 @@ final class AudioRecorderViewModel: ObservableObject {
                     task: selectedTask,
                     providerId: modelManager.selectedProviderId,
                     modelId: modelManager.selectedModelId,
-                    prompt: dictionaryService.getTermsForPrompt(),
+                    prompt: dictionaryService.getTermsForPrompt(providerId: modelManager.selectedProviderId),
                     liveSessionResult: liveSessionResult
                 )
                 state = .finalizing
@@ -353,6 +350,7 @@ final class AudioRecorderViewModel: ObservableObject {
 
         let task = (selectedTask == .translate && !plugin.supportsTranslation) ? .transcribe : selectedTask
         streamingHandler.start(
+            streamPrompt: dictionaryService.getTermsForPrompt(providerId: providerId) ?? "",
             engineOverrideId: providerId,
             selectedProviderId: modelManager.selectedProviderId,
             languageSelection: languageSelection,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -244,9 +244,6 @@ final class DictationViewModel: ObservableObject {
         )
         self.streamingHandler = StreamingHandler(
             modelManager: modelManager,
-            streamPromptProvider: { [weak dictionaryService] in
-                dictionaryService?.getTermsForPrompt() ?? ""
-            },
             bufferProvider: { [weak audioRecordingService] in
                 audioRecordingService?.getCurrentBuffer() ?? []
             },
@@ -959,7 +956,9 @@ final class DictationViewModel: ObservableObject {
                 let engineOverride = effectiveEngineOverrideId
                 let cloudModelOverride = effectiveCloudModelOverride
                 let translationTarget = effectiveTranslationTarget
-                let termsPrompt = dictionaryService.getTermsForPrompt()
+                let termsPrompt = dictionaryService.getTermsForPrompt(
+                    providerId: engineOverride ?? modelManager.selectedProviderId
+                )
 
                 let result = if let liveSessionResult {
                     liveSessionResult
@@ -1211,6 +1210,9 @@ final class DictationViewModel: ObservableObject {
         )
         lastStreamingParams = allowLiveTranscription ? params : nil
         streamingHandler.start(
+            streamPrompt: dictionaryService.getTermsForPrompt(
+                providerId: params.engineOverrideId ?? params.providerId
+            ) ?? "",
             engineOverrideId: params.engineOverrideId,
             selectedProviderId: params.providerId,
             languageSelection: params.languageSelection,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -861,6 +861,7 @@ final class DictationViewModel: ObservableObject {
         stopRecordingTimer()
         let previewText = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasPreviewText = !previewText.isEmpty
+        let hasConfirmedText = hasConfirmedTranscriptionResultText(liveSessionResult)
 
         if !partialText.isEmpty {
             let elapsed = recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
@@ -878,13 +879,13 @@ final class DictationViewModel: ObservableObject {
         let decision = classifyShortSpeech(
             rawDuration: rawDuration,
             peakLevel: peakLevel,
-            hasPreviewText: hasPreviewText,
+            hasConfirmedText: hasConfirmedText,
             transcribeShortQuietClipsAggressively: transcribeShortQuietClipsAggressively
         )
         let graceApplied = audioRecordingService.lastStopGraceCaptureApplied
 
         logger.info(
-            "Stop finalized: rawDuration=\(String(format: "%.3f", rawDuration), privacy: .public)s, bufferedSamples=\(samples.count), peakLevel=\(String(format: "%.4f", peakLevel), privacy: .public), hasPreviewText=\(hasPreviewText, privacy: .public), previewTextLength=\(previewText.count, privacy: .public), stopPolicy=\(stopPolicy.logDescription, privacy: .public), graceApplied=\(graceApplied, privacy: .public), decision=\(decision.logDescription, privacy: .public)"
+            "Stop finalized: rawDuration=\(String(format: "%.3f", rawDuration), privacy: .public)s, bufferedSamples=\(samples.count), peakLevel=\(String(format: "%.4f", peakLevel), privacy: .public), hasPreviewText=\(hasPreviewText, privacy: .public), previewTextLength=\(previewText.count, privacy: .public), hasConfirmedText=\(hasConfirmedText, privacy: .public), stopPolicy=\(stopPolicy.logDescription, privacy: .public), graceApplied=\(graceApplied, privacy: .public), decision=\(decision.logDescription, privacy: .public)"
         )
 
         switch decision {
@@ -1464,25 +1465,30 @@ enum ShortSpeechDecision: Equatable {
     }
 }
 
+func hasConfirmedTranscriptionResultText(_ result: TranscriptionResult?) -> Bool {
+    guard let result else { return false }
+    return !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+}
+
 func classifyShortSpeech(
     rawDuration: TimeInterval,
     peakLevel: Float,
-    hasPreviewText: Bool,
+    hasConfirmedText: Bool,
     transcribeShortQuietClipsAggressively: Bool = false
 ) -> ShortSpeechDecision {
     guard rawDuration >= 0.04 else { return .discardTooShort }
-    if hasPreviewText { return .transcribe }
+    if hasConfirmedText { return .transcribe }
 
     if rawDuration < 1.0 {
         // Bias toward transcribing short clips. False negatives here are worse than
         // letting the recognizer return empty text for actual silence.
-        if peakLevel < 0.005 {
+        if peakLevel < 0.003 {
             return transcribeShortQuietClipsAggressively ? .transcribe : .discardNoSpeech
         }
         return .transcribe
     }
 
-    if peakLevel < 0.01 {
+    if peakLevel < 0.006 {
         return transcribeShortQuietClipsAggressively ? .transcribe : .discardNoSpeech
     }
     return .transcribe

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -12,7 +12,6 @@ final class StreamingHandler {
     private var sampleCursor = 0
 
     private let modelManager: ModelManagerService
-    private let streamPromptProvider: () -> String
     private let bufferProvider: () -> [Float]
     private let bufferDeltaProvider: (Int) -> (samples: [Float], nextOffset: Int)
     private let bufferedDurationProvider: () -> Double
@@ -22,19 +21,18 @@ final class StreamingHandler {
 
     init(
         modelManager: ModelManagerService,
-        streamPromptProvider: @escaping () -> String,
         bufferProvider: @escaping () -> [Float],
         bufferDeltaProvider: @escaping (Int) -> (samples: [Float], nextOffset: Int),
         bufferedDurationProvider: @escaping () -> Double
     ) {
         self.modelManager = modelManager
-        self.streamPromptProvider = streamPromptProvider
         self.bufferProvider = bufferProvider
         self.bufferDeltaProvider = bufferDeltaProvider
         self.bufferedDurationProvider = bufferedDurationProvider
     }
 
     func start(
+        streamPrompt: String,
         engineOverrideId: String?,
         selectedProviderId: String?,
         languageSelection: LanguageSelection,
@@ -56,7 +54,6 @@ final class StreamingHandler {
         sampleCursor = 0
         onStreamingStateChange?(true)
 
-        let streamPrompt = streamPromptProvider()
         let pollInterval: Duration = plugin.supportsStreaming ? .milliseconds(350) : .seconds(3)
 
         streamingTask = Task { [weak self] in

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -141,6 +141,27 @@ extension MyTranscriptionEngine: TranscriptionModelCatalogProviding {
 }
 ```
 
+If your engine accepts custom dictionary terms and has documented limits, you can
+optionally add `DictionaryTermsBudgetProviding` so TypeWhisper clips the global
+dictionary before your engine sees it:
+
+```swift
+extension MyTranscriptionEngine: DictionaryTermsBudgetProviding {
+    var dictionaryTermsBudget: DictionaryTermsBudget {
+        DictionaryTermsBudget(
+            maxTerms: 1000,
+            maxCharsPerTerm: 50,
+            maxWordsPerTerm: 6,
+            maxTotalChars: 10_000
+        )
+    }
+}
+```
+
+This protocol is optional. Legacy plugins that do not adopt it remain compatible on
+`sdkCompatibilityVersion = "v1"` and automatically continue to use TypeWhisper's
+default 600-character fallback when building dictionary prompts.
+
 ### LLMProviderPlugin
 
 Add an LLM for prompt processing (text transformation, summarization, etc.).

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -244,6 +244,25 @@ public enum DictionaryTermsSupport: String, Sendable, CaseIterable {
     case unsupported
 }
 
+public struct DictionaryTermsBudget: Sendable, Equatable {
+    public let maxTerms: Int?
+    public let maxCharsPerTerm: Int?
+    public let maxWordsPerTerm: Int?
+    public let maxTotalChars: Int?
+
+    public init(
+        maxTerms: Int? = nil,
+        maxCharsPerTerm: Int? = nil,
+        maxWordsPerTerm: Int? = nil,
+        maxTotalChars: Int? = nil
+    ) {
+        self.maxTerms = maxTerms
+        self.maxCharsPerTerm = maxCharsPerTerm
+        self.maxWordsPerTerm = maxWordsPerTerm
+        self.maxTotalChars = maxTotalChars
+    }
+}
+
 public protocol DictionaryTermsCapabilityProviding: TypeWhisperPlugin {
     var dictionaryTermsSupport: DictionaryTermsSupport { get }
 }
@@ -274,6 +293,50 @@ public enum PluginDictionaryTerms {
     public static func terms(fromPrompt prompt: String?) -> [String] {
         guard let prompt, !prompt.isEmpty else { return [] }
         return normalizedTerms(from: prompt.split(separator: ",").map(String.init))
+    }
+
+    public static func clippedTerms(from terms: [String], budget: DictionaryTermsBudget?) -> [String] {
+        var clipped = normalizedTerms(from: terms)
+
+        if let maxCharsPerTerm = budget?.maxCharsPerTerm {
+            clipped = clipped.filter { $0.count <= maxCharsPerTerm }
+        }
+
+        if let maxWordsPerTerm = budget?.maxWordsPerTerm {
+            clipped = clipped.filter {
+                $0.split(whereSeparator: \.isWhitespace).count <= maxWordsPerTerm
+            }
+        }
+
+        if let maxTerms = budget?.maxTerms {
+            let safeMaxTerms = max(0, maxTerms)
+            if clipped.count > safeMaxTerms {
+                clipped = Array(clipped.prefix(safeMaxTerms))
+            }
+        }
+
+        if let maxTotalChars = budget?.maxTotalChars {
+            var limited: [String] = []
+            var totalChars = 0
+
+            for term in clipped {
+                let separatorChars = limited.isEmpty ? 0 : 2
+                let nextTotal = totalChars + separatorChars + term.count
+                guard nextTotal <= maxTotalChars else { break }
+                limited.append(term)
+                totalChars = nextTotal
+            }
+
+            clipped = limited
+        }
+
+        return clipped
+    }
+
+    public static func prompt(from terms: [String], budget: DictionaryTermsBudget?) -> String? {
+        let clipped = clippedTerms(from: terms, budget: budget)
+        guard !clipped.isEmpty else { return nil }
+        return clipped.joined(separator: ", ")
     }
 
     public static func prompt(from terms: [String], maxLength: Int = 600) -> String? {
@@ -312,6 +375,10 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var supportedLanguages: [String] { get }
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?,
                     onProgress: @Sendable @escaping (String) -> Bool) async throws -> PluginTranscriptionResult
+}
+
+public protocol DictionaryTermsBudgetProviding: TranscriptionEnginePlugin {
+    var dictionaryTermsBudget: DictionaryTermsBudget { get }
 }
 
 /// Optional model-catalog extension for engines that expose a broader model list than

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -114,6 +114,32 @@ private final class MockDictionaryTermsPlugin: NSObject, TranscriptionEnginePlug
     }
 }
 
+@objc(MockDictionaryBudgetPlugin)
+private final class MockDictionaryBudgetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsBudgetProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.dictionary-budget"
+    static let pluginName = "Mock Dictionary Budget"
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    var providerId: String { "mock-dictionary-budget" }
+    var providerDisplayName: String { "Mock Dictionary Budget" }
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] { [] }
+    var selectedModelId: String? { nil }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+    var dictionaryTermsBudget: DictionaryTermsBudget {
+        DictionaryTermsBudget(maxTerms: 10, maxCharsPerTerm: 20, maxWordsPerTerm: 3, maxTotalChars: 120)
+    }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "ok", detectedLanguage: language)
+    }
+}
+
 @objc(MockCatalogTranscriptionPlugin)
 private final class MockCatalogTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.catalog"
@@ -245,6 +271,17 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertEqual(capabilityPlugin.dictionaryTermsSupport, .requiresPluginSetting)
     }
 
+    func testDictionaryTermsBudgetProtocolIsOptional() {
+        let legacyPlugin = MockTranscriptionPlugin()
+        let budgetPlugin = MockDictionaryBudgetPlugin()
+
+        XCTAssertFalse(legacyPlugin is any DictionaryTermsBudgetProviding)
+        XCTAssertEqual(
+            budgetPlugin.dictionaryTermsBudget,
+            DictionaryTermsBudget(maxTerms: 10, maxCharsPerTerm: 20, maxWordsPerTerm: 3, maxTotalChars: 120)
+        )
+    }
+
     func testTranscriptionModelCatalogProtocolIsOptional() {
         let legacyPlugin = MockTranscriptionPlugin()
         let catalogPlugin = MockCatalogTranscriptionPlugin()
@@ -289,6 +326,52 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertEqual(
             PluginDictionaryTerms.prompt(from: ["TypeWhisper", "MLX"], maxLength: 100),
             "TypeWhisper, MLX"
+        )
+    }
+
+    func testPluginDictionaryTermsClippedTermsApplyPerTermFiltersBeforeMaxTerms() {
+        XCTAssertEqual(
+            PluginDictionaryTerms.clippedTerms(
+                from: ["toolongchars", "beta", "gamma"],
+                budget: DictionaryTermsBudget(maxTerms: 1, maxCharsPerTerm: 5)
+            ),
+            ["beta"]
+        )
+        XCTAssertEqual(
+            PluginDictionaryTerms.clippedTerms(
+                from: ["one two three", "alpha beta", "gamma"],
+                budget: DictionaryTermsBudget(maxTerms: 1, maxWordsPerTerm: 2)
+            ),
+            ["alpha beta"]
+        )
+    }
+
+    func testPluginDictionaryTermsClippedTermsApplyTotalCharacterBudgetToJoinedPrompt() {
+        XCTAssertEqual(
+            PluginDictionaryTerms.clippedTerms(
+                from: ["AA", "BB", "CC"],
+                budget: DictionaryTermsBudget(maxTotalChars: 6)
+            ),
+            ["AA", "BB"]
+        )
+    }
+
+    func testPluginDictionaryTermsClippedTermsTreatNegativeMaxTermsAsZero() {
+        let budget = DictionaryTermsBudget(maxTerms: -1)
+
+        XCTAssertEqual(
+            PluginDictionaryTerms.clippedTerms(from: ["Alpha", "Beta", "Gamma"], budget: budget),
+            []
+        )
+        XCTAssertNil(PluginDictionaryTerms.prompt(from: ["Alpha", "Beta", "Gamma"], budget: budget))
+    }
+
+    func testPluginDictionaryTermsPromptWithBudgetReturnsNilWhenNothingSurvives() {
+        XCTAssertNil(
+            PluginDictionaryTerms.prompt(
+                from: ["toolong"],
+                budget: DictionaryTermsBudget(maxCharsPerTerm: 2)
+            )
         )
     }
 }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -142,6 +142,45 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterBudgetedTranscriptionPlugin)
+    private final class BudgetedTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsBudgetProviding, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.budgeted-transcription" }
+        static var pluginName: String { "Budgeted Mock Transcription" }
+        private static let promptLock = NSLock()
+        nonisolated(unsafe) private static var _lastPrompt: String?
+
+        static var lastPrompt: String? {
+            promptLock.withLock { _lastPrompt }
+        }
+
+        static func reset() {
+            promptLock.withLock {
+                _lastPrompt = nil
+            }
+        }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "budgeted-mock" }
+        var providerDisplayName: String { "Budgeted Mock" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [PluginModelInfo(id: "large", displayName: "Large")] }
+        var selectedModelId: String? { "large" }
+        func selectModel(_ modelId: String) {}
+        var supportsTranslation: Bool { false }
+        var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTotalChars: 2_000) }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            Self.promptLock.withLock {
+                Self._lastPrompt = prompt
+            }
+            return PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
     @objc(APIRouterConfigurableTranscriptionPlugin)
     private final class ConfigurableTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.configurable-transcription" }
@@ -308,6 +347,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
     private final class APIContext: @unchecked Sendable {
         let router: APIRouter
+        let modelManager: ModelManagerService
         let historyService: HistoryService
         let profileService: ProfileService
         let dictionaryService: DictionaryService
@@ -319,6 +359,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         init(
             router: APIRouter,
+            modelManager: ModelManagerService,
             historyService: HistoryService,
             profileService: ProfileService,
             dictionaryService: DictionaryService,
@@ -329,6 +370,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             retainedObjects: [AnyObject]
         ) {
             self.router = router
+            self.modelManager = modelManager
             self.historyService = historyService
             self.profileService = profileService
             self.dictionaryService = dictionaryService
@@ -575,6 +617,107 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(response["text"] as? String, "transcribed")
         XCTAssertEqual(MockTranscriptionPlugin.lastPrompt, "TypeWhisper, WhisperKit")
+    }
+
+    func testTranscribeEndpointUsesOverrideEngineBudgetForDictionaryPrompt() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        BudgetedTranscriptionPlugin.reset()
+        context = await MainActor.run {
+            let context = Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+            PluginManager.shared.loadedPlugins.append(
+                LoadedPlugin(
+                    manifest: PluginManifest(
+                        id: "com.typewhisper.mock.budgeted-transcription",
+                        name: "Budgeted Mock Transcription",
+                        version: "1.0.0",
+                        principalClass: "APIRouterBudgetedTranscriptionPlugin"
+                    ),
+                    instance: BudgetedTranscriptionPlugin(),
+                    bundle: Bundle.main,
+                    sourceURL: appSupportDirectory,
+                    isEnabled: true
+                )
+            )
+            context.dictionaryService.setTerms(Self.makeLongTerms(count: 40, length: 24), replaceExisting: true)
+            return context
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+
+        let response = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-engine": "budgeted-mock",
+                ],
+                body: wavData
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "transcribed")
+        XCTAssertNil(MockTranscriptionPlugin.lastPrompt)
+        XCTAssertGreaterThan(try XCTUnwrap(BudgetedTranscriptionPlugin.lastPrompt).count, 600)
+    }
+
+    func testTranscribeEndpointUsesSelectedEngineBudgetWhenNoOverrideIsProvided() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        BudgetedTranscriptionPlugin.reset()
+        context = await MainActor.run {
+            let context = Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+            let budgetedPlugin = BudgetedTranscriptionPlugin()
+            PluginManager.shared.loadedPlugins.append(
+                LoadedPlugin(
+                    manifest: PluginManifest(
+                        id: "com.typewhisper.mock.budgeted-transcription",
+                        name: "Budgeted Mock Transcription",
+                        version: "1.0.0",
+                        principalClass: "APIRouterBudgetedTranscriptionPlugin"
+                    ),
+                    instance: budgetedPlugin,
+                    bundle: Bundle.main,
+                    sourceURL: appSupportDirectory,
+                    isEnabled: true
+                )
+            )
+            context.modelManager.selectProvider(budgetedPlugin.providerId)
+            context.dictionaryService.setTerms(Self.makeLongTerms(count: 40, length: 24), replaceExisting: true)
+            return context
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+
+        let response = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "audio/wav"],
+                body: wavData
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "transcribed")
+        XCTAssertNil(MockTranscriptionPlugin.lastPrompt)
+        XCTAssertGreaterThan(try XCTUnwrap(BudgetedTranscriptionPlugin.lastPrompt).count, 600)
     }
 
     func testTranscribeEndpointAcceptsRepeatedLanguageHints() async throws {
@@ -1673,6 +1816,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         return APIContext(
             router: router,
+            modelManager: modelManager,
             historyService: historyService,
             profileService: profileService,
             dictionaryService: dictionaryService,
@@ -1707,6 +1851,14 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 handlers
             ]
         )
+    }
+
+    private static func makeLongTerms(count: Int, length: Int) -> [String] {
+        (1...count).map { index in
+            let prefix = "Term\(index)-"
+            let paddingLength = max(0, length - prefix.count)
+            return prefix + String(repeating: "x", count: paddingLength)
+        }
     }
 
     private final class DictationContext: @unchecked Sendable {

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -16,58 +16,62 @@ final class DictationShortSpeechTests: XCTestCase {
     }
 
     func testEmptyBuffer_isDiscardedAsTooShort() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0, peakLevel: 0, hasPreviewText: false), .discardTooShort)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0, peakLevel: 0, hasConfirmedText: false), .discardTooShort)
     }
 
     func testThirtyMsHighPeak_isStillTooShort() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2, hasPreviewText: false), .discardTooShort)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2, hasConfirmedText: false), .discardTooShort)
     }
 
     func testThirtyMsPreviewText_isStillTooShort() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2, hasPreviewText: true), .discardTooShort)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.03, peakLevel: 0.2, hasConfirmedText: true), .discardTooShort)
     }
 
     func testEightyMsSpeechAtPointZeroZeroEight_transcribesAndPadsToZeroPointSevenFive() {
         let samples = makeSamples(duration: 0.08)
 
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.08, peakLevel: 0.008, hasPreviewText: false), .transcribe)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.08, peakLevel: 0.008, hasConfirmedText: false), .transcribe)
 
         let paddedSamples = paddedSamplesForFinalTranscription(samples, rawDuration: 0.08)
         XCTAssertEqual(paddedSamples.count, 12_000)
         XCTAssertEqual(Double(paddedSamples.count) / AudioRecordingService.targetSampleRate, 0.75, accuracy: 0.0001)
     }
 
-    func testOneHundredTwentyMsQuietClip_isNoSpeech() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0049, hasPreviewText: false), .discardNoSpeech)
+    func testOneHundredTwentyMsVeryQuietClip_isNoSpeech() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0029, hasConfirmedText: false), .discardNoSpeech)
+    }
+
+    func testOneHundredTwentyMsBorderlineQuietClip_nowTranscribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0034, hasConfirmedText: false), .transcribe)
     }
 
     func testOneHundredTwentyMsQuietClip_transcribesWhenAggressivePolicyEnabled() {
         XCTAssertEqual(
             classifyShortSpeech(
                 rawDuration: 0.12,
-                peakLevel: 0.0049,
-                hasPreviewText: false,
+                peakLevel: 0.0034,
+                hasConfirmedText: false,
                 transcribeShortQuietClipsAggressively: true
             ),
             .transcribe
         )
     }
 
-    func testOneHundredTwentyMsQuietClip_withPreviewText_transcribes() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0049, hasPreviewText: true), .transcribe)
+    func testOneHundredTwentyMsQuietClip_withConfirmedText_transcribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.12, peakLevel: 0.0029, hasConfirmedText: true), .transcribe)
     }
 
-    func testFourHundredMsSpeech_usesRelaxedShortClipThresholdAndNoMinimumPad() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0049, hasPreviewText: false), .discardNoSpeech)
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.009, hasPreviewText: false), .transcribe)
+    func testFourHundredMsSpeech_usesLoweredShortClipThresholdAndNoMinimumPad() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0029, hasConfirmedText: false), .discardNoSpeech)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0034, hasConfirmedText: false), .transcribe)
 
         let paddedSamples = paddedSamplesForFinalTranscription(makeSamples(duration: 0.4), rawDuration: 0.4)
         XCTAssertEqual(paddedSamples.count, 12_000)
         XCTAssertEqual(Double(paddedSamples.count) / AudioRecordingService.targetSampleRate, 0.75, accuracy: 0.0001)
     }
 
-    func testFourHundredMsQuietClip_withPreviewText_transcribes() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0049, hasPreviewText: true), .transcribe)
+    func testFourHundredMsQuietClip_withConfirmedText_transcribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.4, peakLevel: 0.0029, hasConfirmedText: true), .transcribe)
     }
 
     func testThirtyMsQuietClip_staysTooShortEvenWhenAggressivePolicyEnabled() {
@@ -75,7 +79,7 @@ final class DictationShortSpeechTests: XCTestCase {
             classifyShortSpeech(
                 rawDuration: 0.03,
                 peakLevel: 0.2,
-                hasPreviewText: false,
+                hasConfirmedText: false,
                 transcribeShortQuietClipsAggressively: true
             ),
             .discardTooShort
@@ -83,7 +87,47 @@ final class DictationShortSpeechTests: XCTestCase {
     }
 
     func testEightHundredEightyFiveMsClip_withLowSpeechPeakStillTranscribes() {
-        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.885, peakLevel: 0.0069, hasPreviewText: false), .transcribe)
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 0.885, peakLevel: 0.0069, hasConfirmedText: false), .transcribe)
+    }
+
+    func testOnePointTwoSecondsVeryQuietClip_isNoSpeech() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 1.2, peakLevel: 0.0059, hasConfirmedText: false), .discardNoSpeech)
+    }
+
+    func testOnePointTwoSecondsBorderlineQuietClip_nowTranscribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 1.2, peakLevel: 0.0061, hasConfirmedText: false), .transcribe)
+    }
+
+    func testOnePointTwoSecondsVeryQuietClip_withConfirmedText_transcribes() {
+        XCTAssertEqual(classifyShortSpeech(rawDuration: 1.2, peakLevel: 0.0059, hasConfirmedText: true), .transcribe)
+    }
+
+    func testConfirmedTranscriptionResultText_requiresNonEmptyResult() {
+        XCTAssertFalse(hasConfirmedTranscriptionResultText(nil))
+        XCTAssertFalse(hasConfirmedTranscriptionResultText(TranscriptionResult(
+            text: "",
+            detectedLanguage: nil,
+            duration: 1.2,
+            processingTime: 0.1,
+            engineUsed: "whisper",
+            segments: []
+        )))
+        XCTAssertFalse(hasConfirmedTranscriptionResultText(TranscriptionResult(
+            text: "   ",
+            detectedLanguage: nil,
+            duration: 1.2,
+            processingTime: 0.1,
+            engineUsed: "whisper",
+            segments: []
+        )))
+        XCTAssertTrue(hasConfirmedTranscriptionResultText(TranscriptionResult(
+            text: "hello",
+            detectedLanguage: "en",
+            duration: 1.2,
+            processingTime: 0.1,
+            engineUsed: "whisper",
+            segments: []
+        )))
     }
 
     func testFinalizeShortSpeechPolicy_waitsOnlyWhenBufferedDurationIsBelowFiveHundredths() {

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -2,6 +2,54 @@ import XCTest
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
+private final class BudgetedDictionaryEnginePlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsBudgetProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.tests.budgeted-dictionary-engine"
+    static let pluginName = "Budgeted Dictionary Engine"
+    var providerIdValue = "budgeted"
+    var budgetValue = DictionaryTermsBudget()
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    var providerId: String { providerIdValue }
+    var providerDisplayName: String { "Budgeted Mock" }
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] { [] }
+    var selectedModelId: String? { nil }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+    var dictionaryTermsBudget: DictionaryTermsBudget { budgetValue }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "ok", detectedLanguage: language)
+    }
+}
+
+private final class LegacyDictionaryEnginePlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.tests.legacy-dictionary-engine"
+    static let pluginName = "Legacy Dictionary Engine"
+    var providerIdValue = "legacy"
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    var providerId: String { providerIdValue }
+    var providerDisplayName: String { "Legacy Mock" }
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] { [] }
+    var selectedModelId: String? { nil }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "ok", detectedLanguage: language)
+    }
+}
+
 final class DictionaryServiceTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -12,6 +60,7 @@ final class DictionaryServiceTests: XCTestCase {
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activatedTermPacks)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activatedTermPackStates)
+        PluginManager.shared = nil
         super.tearDown()
     }
 
@@ -28,7 +77,7 @@ final class DictionaryServiceTests: XCTestCase {
 
         XCTAssertEqual(service.termsCount, 1)
         XCTAssertEqual(service.correctionsCount, 1)
-        XCTAssertEqual(service.getTermsForPrompt(), "TypeWhisper")
+        XCTAssertEqual(service.getTermsForPrompt(providerId: nil), "TypeWhisper")
 
         let corrected = service.applyCorrections(to: "teh TypeWhisper")
         XCTAssertEqual(corrected, "the TypeWhisper")
@@ -72,9 +121,80 @@ final class DictionaryServiceTests: XCTestCase {
 
         XCTAssertEqual(service.enabledTerms(), ["Kubernetes", "MLX", "TypeWhisper"])
         XCTAssertEqual(
-            service.getTermsForPrompt(),
+            service.getTermsForPrompt(providerId: nil),
             PluginDictionaryTerms.prompt(from: ["Kubernetes", "MLX", "TypeWhisper"])
         )
+    }
+
+    @MainActor
+    func testGetTermsForPromptUsesLoadedEngineBudget() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.setTerms(["Alpha", "BetaBeta", "Gamma", "alpha"], replaceExisting: true)
+
+        let plugin = BudgetedDictionaryEnginePlugin()
+        plugin.providerIdValue = "budgeted"
+        plugin.budgetValue = DictionaryTermsBudget(maxTerms: 2, maxCharsPerTerm: 5)
+        installPlugins([plugin], appSupportDirectory: appSupportDirectory)
+
+        XCTAssertEqual(service.getTermsForPrompt(providerId: plugin.providerId), "Alpha, Gamma")
+    }
+
+    @MainActor
+    func testGetTermsForPromptFallsBackToLegacyBudgetForUnknownOrUnbudgetedEngines() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.setTerms(makeLongTerms(count: 40, length: 24), replaceExisting: true)
+
+        let plugin = LegacyDictionaryEnginePlugin()
+        plugin.providerIdValue = "legacy"
+        installPlugins([plugin], appSupportDirectory: appSupportDirectory)
+
+        let expectedFallback = PluginDictionaryTerms.prompt(from: service.enabledTerms())
+        XCTAssertEqual(service.getTermsForPrompt(providerId: nil), expectedFallback)
+        XCTAssertEqual(service.getTermsForPrompt(providerId: plugin.providerId), expectedFallback)
+        XCTAssertEqual(service.getTermsForPrompt(providerId: "missing"), expectedFallback)
+        XCTAssertLessThanOrEqual(expectedFallback?.count ?? 0, 600)
+    }
+
+    @MainActor
+    func testGetTermsForPromptAllowsBudgetsAboveLegacy600Characters() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.setTerms(makeLongTerms(count: 40, length: 24), replaceExisting: true)
+
+        let plugin = BudgetedDictionaryEnginePlugin()
+        plugin.providerIdValue = "budgeted"
+        plugin.budgetValue = DictionaryTermsBudget(maxTotalChars: 2_000)
+        installPlugins([plugin], appSupportDirectory: appSupportDirectory)
+
+        let prompt = try XCTUnwrap(service.getTermsForPrompt(providerId: plugin.providerId))
+        XCTAssertGreaterThan(prompt.count, 600)
+    }
+
+    @MainActor
+    func testGetTermsForPromptAppliesWordAndCharacterFilters() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.setTerms(
+            ["Alpha", "one two three", "123456789012345678901", "Beta Beta", "Gamma"],
+            replaceExisting: true
+        )
+
+        let plugin = BudgetedDictionaryEnginePlugin()
+        plugin.providerIdValue = "budgeted"
+        plugin.budgetValue = DictionaryTermsBudget(maxCharsPerTerm: 20, maxWordsPerTerm: 2)
+        installPlugins([plugin], appSupportDirectory: appSupportDirectory)
+
+        XCTAssertEqual(service.getTermsForPrompt(providerId: plugin.providerId), "Alpha, Beta Beta, Gamma")
     }
 
     @MainActor
@@ -150,6 +270,33 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(service.entries.filter { $0.type == .term }.map(\.original), ["Cargo"])
         XCTAssertEqual(viewModel.activatedPackStates[v2.id]?.installedTerms, ["Cargo"])
         XCTAssertEqual(viewModel.activatedPackStates[v2.id]?.installedVersion, "1.1.0")
+    }
+
+    @MainActor
+    private func installPlugins(_ plugins: [any TranscriptionEnginePlugin], appSupportDirectory: URL) {
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = plugins.enumerated().map { index, plugin in
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.tests.\(plugin.providerId).\(index)",
+                    name: plugin.providerDisplayName,
+                    version: "1.0.0",
+                    principalClass: "DictionaryServiceTestsPlugin\(index)"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        }
+    }
+
+    private func makeLongTerms(count: Int, length: Int) -> [String] {
+        (1...count).map { index in
+            let prefix = "Term\(index)-"
+            let paddingLength = max(0, length - prefix.count)
+            return prefix + String(repeating: "x", count: paddingLength)
+        }
     }
 }
 

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -424,6 +424,93 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
         XCTAssertFalse(plugin.isConfigured)
     }
+
+}
+
+final class PluginDictionaryGuardTests: XCTestCase {
+    func testWhisperKitConditioningPromptClampsPlainTermListsTo500Characters() {
+        let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 80, length: 18), maxLength: 10_000)
+        let conditioned = WhisperKitPlugin.conditioningPrompt(from: prompt)
+
+        XCTAssertNotNil(conditioned)
+        XCTAssertTrue(conditioned?.hasPrefix("The audio may contain these names or technical terms: ") == true)
+        XCTAssertLessThanOrEqual(conditioned?.count ?? .max, 500)
+    }
+
+    func testWhisperKitSanitizedStreamingTextRemovesConditioningPromptPrefix() {
+        let prompt = "AssemblyAI, Deepgram, Gemini, Nova 2, Nova 3, OpenAI, Speechmatics, Whisper"
+        let conditioned = WhisperKitPlugin.conditioningPrompt(from: prompt)
+
+        XCTAssertEqual(
+            WhisperKitPlugin.sanitizedStreamingText(
+                "\(conditioned ?? "") hello world",
+                conditioningPrompt: conditioned
+            ),
+            "hello world"
+        )
+    }
+
+    func testDeepgramDictionaryQueryItemsLimitDictionaryTermsTo100AndPreserveOrder() {
+        let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 150, length: 10), maxLength: 10_000)
+        let queryItems = DeepgramPlugin.dictionaryQueryItems(prompt: prompt, modelId: "nova-2")
+
+        XCTAssertEqual(queryItems.count, 100)
+        XCTAssertTrue(queryItems.allSatisfy { $0.name == "keywords" })
+        XCTAssertEqual(queryItems.first?.value, "Term1-xxxx")
+        XCTAssertEqual(queryItems.last?.value, "Term100-xx")
+    }
+
+    @available(macOS 26, *)
+    func testSpeechAnalyzerAnalysisContextLimitsDictionaryTermsTo100() {
+        let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 150, length: 10), maxLength: 10_000)
+        let context = SpeechAnalyzerPlugin.analysisContext(from: prompt)
+        let terms = context.contextualStrings[.general] ?? []
+
+        XCTAssertEqual(terms.count, 100)
+        XCTAssertEqual(terms.first, "Term1-xxxx")
+        XCTAssertEqual(terms.last, "Term100-xx")
+    }
+
+    private func makeLongTerms(count: Int, length: Int) -> [String] {
+        (1...count).map { index in
+            let prefix = "Term\(index)-"
+            let paddingLength = max(0, length - prefix.count)
+            return prefix + String(repeating: "x", count: paddingLength)
+        }
+    }
+}
+
+final class WhisperKitSettingsStateTests: XCTestCase {
+    func testApplyingNotLoadedStateClearsStaleLoadingAndStopsPolling() {
+        let initial = WhisperKitSettingsPollState(
+            modelState: .loading(phase: "loading"),
+            downloadProgress: 0.9,
+            activeModelId: "openai_whisper-large-v3_turbo",
+            isPolling: true
+        )
+
+        let updated = initial.applyingPolledPluginState(
+            .notLoaded,
+            downloadProgress: 0,
+            selectedModelId: "openai_whisper-large-v3_turbo"
+        )
+
+        XCTAssertEqual(updated.modelState, .notLoaded)
+        XCTAssertEqual(updated.downloadProgress, 0)
+        XCTAssertEqual(updated.activeModelId, "openai_whisper-large-v3_turbo")
+        XCTAssertFalse(updated.isPolling)
+    }
+
+    func testBusyStateTreatsPrewarmingAsLoading() {
+        let state = WhisperKitSettingsPollState(
+            modelState: .loading(phase: "prewarming"),
+            downloadProgress: 0.9,
+            activeModelId: "openai_whisper-large-v3_turbo",
+            isPolling: true
+        )
+
+        XCTAssertTrue(state.isBusy)
+    }
 }
 
 @MainActor

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -17,6 +17,7 @@ final class StreamingHandlerTests: XCTestCase {
         var supportsStreaming: Bool { false }
         var supportedLanguages: [String] { ["en"] }
         private(set) var transcribeCallCount = 0
+        private(set) var lastPrompt: String?
 
         func activate(host: HostServices) {}
         func deactivate() {}
@@ -24,6 +25,7 @@ final class StreamingHandlerTests: XCTestCase {
 
         func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
             transcribeCallCount += 1
+            lastPrompt = prompt
             return PluginTranscriptionResult(text: "final", detectedLanguage: language)
         }
     }
@@ -75,6 +77,7 @@ final class StreamingHandlerTests: XCTestCase {
         var supportsStreaming: Bool { true }
         var supportedLanguages: [String] { ["en"] }
         let session = MockLiveSession()
+        private(set) var lastPrompt: String?
 
         func activate(host: HostServices) {}
         func deactivate() {}
@@ -102,6 +105,7 @@ final class StreamingHandlerTests: XCTestCase {
             prompt: String?,
             onProgress: @Sendable @escaping (String) -> Bool
         ) async throws -> any LiveTranscriptionSession {
+            lastPrompt = prompt
             await session.setOnProgress(onProgress)
             return session
         }
@@ -121,6 +125,7 @@ final class StreamingHandlerTests: XCTestCase {
         var supportedLanguages: [String] { ["de", "en"] }
         let session = MockLiveSession()
         private(set) var lastSelection = PluginLanguageSelection()
+        private(set) var lastPrompt: String?
 
         func activate(host: HostServices) {}
         func deactivate() {}
@@ -159,6 +164,7 @@ final class StreamingHandlerTests: XCTestCase {
             onProgress: @Sendable @escaping (String) -> Bool
         ) async throws -> any LiveTranscriptionSession {
             lastSelection = languageSelection
+            lastPrompt = prompt
             await session.setOnProgress(onProgress)
             return session
         }
@@ -220,13 +226,13 @@ final class StreamingHandlerTests: XCTestCase {
 
         let handler = StreamingHandler(
             modelManager: modelManager,
-            streamPromptProvider: { "" },
             bufferProvider: { Array(repeating: 0.5, count: 16_000) },
             bufferDeltaProvider: { _ in ([], 0) },
             bufferedDurationProvider: { 1.0 }
         )
 
         handler.start(
+            streamPrompt: "Batch Terms",
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
             languageSelection: .exact("en"),
@@ -240,6 +246,7 @@ final class StreamingHandlerTests: XCTestCase {
         handler.stop()
 
         XCTAssertEqual(plugin.transcribeCallCount, 1)
+        XCTAssertEqual(plugin.lastPrompt, "Batch Terms")
     }
 
     func testDisabledLiveTranscriptionPreventsAnyIntermediateWork() async throws {
@@ -269,13 +276,13 @@ final class StreamingHandlerTests: XCTestCase {
 
         let handler = StreamingHandler(
             modelManager: modelManager,
-            streamPromptProvider: { "" },
             bufferProvider: { Array(repeating: 0.5, count: 16_000) },
             bufferDeltaProvider: { _ in ([], 0) },
             bufferedDurationProvider: { 1.0 }
         )
 
         handler.start(
+            streamPrompt: "Unused Terms",
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
             languageSelection: .exact("en"),
@@ -325,7 +332,6 @@ final class StreamingHandlerTests: XCTestCase {
 
         let handler = StreamingHandler(
             modelManager: modelManager,
-            streamPromptProvider: { "" },
             bufferProvider: { [] },
             bufferDeltaProvider: { _ in
                 indexLock.lock()
@@ -343,6 +349,7 @@ final class StreamingHandlerTests: XCTestCase {
 
         var activeChecks = 0
         handler.start(
+            streamPrompt: "Live Terms",
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
             languageSelection: .exact("en"),
@@ -361,6 +368,7 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertEqual(result?.text, "finished")
         let recorded = await plugin.session.recordedChunks()
         XCTAssertEqual(recorded, chunks.map(\.count))
+        XCTAssertEqual(plugin.lastPrompt, "Live Terms")
     }
 
     func testModelManagerUsesHintAwarePluginWhenMultipleHintsAreSelected() async throws {
@@ -456,13 +464,13 @@ final class StreamingHandlerTests: XCTestCase {
 
         let handler = StreamingHandler(
             modelManager: modelManager,
-            streamPromptProvider: { "" },
             bufferProvider: { [] },
             bufferDeltaProvider: { _ in (Array(repeating: 0.1, count: 4000), 4000) },
             bufferedDurationProvider: { 0.25 }
         )
 
         handler.start(
+            streamPrompt: "Hint Terms",
             engineOverrideId: plugin.providerId,
             selectedProviderId: plugin.providerId,
             languageSelection: .hints(["de", "en"]),
@@ -477,5 +485,6 @@ final class StreamingHandlerTests: XCTestCase {
 
         XCTAssertEqual(plugin.lastSelection.languageHints, ["de", "en"])
         XCTAssertNil(plugin.lastSelection.requestedLanguage)
+        XCTAssertEqual(plugin.lastPrompt, "Hint Terms")
     }
 }


### PR DESCRIPTION
## Issue context
Issue #304 removes the global 600-character dictionary bottleneck for engines with documented limits, without changing the dictionary UI or data model.

Closes #304

## What changed
- adds `DictionaryTermsBudget` and optional `DictionaryTermsBudgetProviding` to the plugin SDK while keeping SDK compatibility at `v1`
- resolves dictionary prompts by engine ID across HTTP, live streaming, and final transcription paths instead of using a provider-agnostic prompt
- applies documented per-engine budgets for Qwen3, Granite, Soniox, Gladia, AssemblyAI, Speechmatics, Deepgram, SpeechAnalyzer, and WhisperKit
- keeps local guards where the shared budget model is not enough, including WhisperKit, Deepgram, SpeechAnalyzer, AssemblyAI, Speechmatics, and Gladia
- updates SDK/plugin docs and adds regression coverage for SDK contracts, dictionary service resolution, HTTP routing, streaming prompt wiring, and plugin-specific guards
- refines quiet dictation handling so unconfirmed preview text no longer forces final transcription, and updates the audio stop override to backfill peak levels for test recordings

## Test plan
- `swift test --package-path TypeWhisperPluginSDK 2>&1 | tee /tmp/ship_typewhisper_sdk_tests.txt`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testDictationEndpointsReturnSessionIDAndCompletedTranscription -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testDictationEndpointsSpeakCompletedTranscriptionOnly 2>&1 | tee /tmp/ship_typewhisper_api_regression_tests.txt`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/ship_typewhisper_tests.txt`
- `for plugin in AssemblyAI Deepgram Gladia Granite Qwen3 Soniox SpeechAnalyzer Speechmatics WhisperKit; do /Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh "$plugin" "$(pwd)" || exit 1; done 2>&1 | tee /tmp/ship_typewhisper_plugin_builds.txt`