### PR TITLE
Add 1.3.0-rc3 release notes

### DIFF
--- a/docs/release-notes/1.3.0-rc3.md
+++ b/docs/release-notes/1.3.0-rc3.md
@@ -1,0 +1,19 @@
+TypeWhisper `1.3.0-rc3` refreshes the `1.3` release-candidate line with the redesigned prompt workflow, per-prompt temperature controls, a recent-transcription recovery palette, and the new post-update licensing prompt, plus a round of dictation, dictionary, and plugin-loading fixes since `rc2`.
+
+## New Features
+
+- Redesigned Prompt Actions settings with a native macOS sidebar and a wizard-style create/edit flow.
+- Added per-prompt temperature controls for supported LLM providers, including recommended defaults for the built-in presets.
+- Added a recent transcription recovery palette so you can quickly reopen and reinsert recent results.
+- Added a post-update licensing prompt that routes upgraded installs into the refreshed licensing flow.
+
+## Bug Fixes
+
+- Refined quiet-dictation and short-speech handling for more reliable low-signal recordings.
+- Made dictionary prompts engine-aware so providers can clip global dictionary terms to their documented limits without destabilizing the session.
+- Isolated disabled plugins so they stay registered without being eagerly loaded, which reduces startup and settings regressions from incompatible bundles.
+- Removed the duplicate settings sidebar button on macOS 14.
+
+## Other Changes
+
+- Documented the new `DictionaryTermsBudgetProviding` plugin SDK hook for engines with explicit dictionary-term limits.


### PR DESCRIPTION
## Summary
- Added release notes for TypeWhisper `1.3.0-rc3`.
- Covers the redesigned prompt workflow, per-prompt temperature controls, recent transcription recovery, and the post-update licensing prompt.
- Summarizes dictation, dictionary, and plugin-loading fixes since `rc2`.
- Documents the new `DictionaryTermsBudgetProviding` plugin SDK hook.

## Testing
- Not run (documentation-only change).
- Verified the new file is present at `docs/release-notes/1.3.0-rc3.md`.
- Verified the release notes include `New Features`, `Bug Fixes`, and `Other Changes` sections.