### PR TITLE
[codex] Add missing 1.3.0 rc2 and rc3 release notes

### DIFF
--- a/docs/release-notes/1.3.0-rc2.md
+++ b/docs/release-notes/1.3.0-rc2.md
@@ -1,0 +1,18 @@
+TypeWhisper `1.3.0-rc2` advances the `1.3` release-candidate line with upgraded local model runtimes, a redesigned licensing settings flow, and a round of dictation, audio, and plugin reliability fixes since `rc1`.
+
+## New Features
+
+- Upgraded the local model runtime and download flows for on-device plugins, including clearer progress, cancellation, restore behavior, and optional Hugging Face token validation where required.
+- Refreshed the licensing settings experience with a redesigned flow for activation and license management.
+
+## Bug Fixes
+
+- Stabilized push-to-talk discard handling and short-speech detection so brief or low-signal recordings behave more predictably.
+- Delayed media resume after dictation and tightened recording-abort cleanup so paused audio apps recover more cleanly when a session ends.
+- Hardened audio-engine recovery by ignoring benign startup configuration changes, bounding repeated recovery attempts, and surfacing terminal routing failures instead of looping silently.
+- Fixed Gemini model discovery and prompt fallback handling.
+- Aligned language-picker search with the current app locale for more reliable multilingual selection.
+
+## Other Changes
+
+- Expanded automated coverage around dictation cleanup, audio recovery, plugin compatibility validation, and local-model download flows.

--- a/docs/release-notes/1.3.0-rc3.md
+++ b/docs/release-notes/1.3.0-rc3.md
@@ -1,0 +1,19 @@
+TypeWhisper `1.3.0-rc3` refreshes the `1.3` release-candidate line with the redesigned prompt workflow, per-prompt temperature controls, a recent-transcription recovery palette, and the new post-update licensing prompt, plus a round of dictation, dictionary, and plugin-loading fixes since `rc2`.
+
+## New Features
+
+- Redesigned Prompt Actions settings with a native macOS sidebar and a wizard-style create/edit flow.
+- Added per-prompt temperature controls for supported LLM providers, including recommended defaults for the built-in presets.
+- Added a recent transcription recovery palette so you can quickly reopen and reinsert recent results.
+- Added a post-update licensing prompt that routes upgraded installs into the refreshed licensing flow.
+
+## Bug Fixes
+
+- Refined quiet-dictation and short-speech handling for more reliable low-signal recordings.
+- Made dictionary prompts engine-aware so providers can clip global dictionary terms to their documented limits without destabilizing the session.
+- Isolated disabled plugins so they stay registered without being eagerly loaded, which reduces startup and settings regressions from incompatible bundles.
+- Removed the duplicate settings sidebar button on macOS 14.
+
+## Other Changes
+
+- Documented the new `DictionaryTermsBudgetProviding` plugin SDK hook for engines with explicit dictionary-term limits.


### PR DESCRIPTION
## Summary

- add the missing `docs/release-notes/1.3.0-rc2.md` file
- restore `docs/release-notes/1.3.0-rc3.md` from the already tagged `v1.3.0-rc3` content
- keep the release-notes set aligned with the shipped RC tags

## Why

The repository contains tags for `v1.3.0-rc2` and `v1.3.0-rc3`, but the matching release-notes files were not both present on the current branch. That leaves the release documentation incomplete and inconsistent with the published tags.

## User Impact

Release managers and contributors can now find the RC2 and RC3 notes directly in the repository, and release automation has the expected markdown files available.

## Root Cause

`docs/release-notes/1.3.0-rc2.md` was missing entirely, and `docs/release-notes/1.3.0-rc3.md` existed in the `v1.3.0-rc3` tag but was not present on the current branch.

## Test Plan

- `git diff --check --cached`
- `test -f docs/release-notes/1.3.0-rc2.md && test -f docs/release-notes/1.3.0-rc3.md`
- `sh -c 'git show v1.3.0-rc3:docs/release-notes/1.3.0-rc3.md > /tmp/typewhisper-rc3-release-notes.md && diff -u /tmp/typewhisper-rc3-release-notes.md docs/release-notes/1.3.0-rc3.md'`
