### PR TITLE
fix: restore prompt palette shortcut when default provider is unavailable

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -17,6 +17,7 @@ final class TextInsertionService {
     var focusedTextFieldOverride: (() -> Bool)?
     var focusedTextElementOverride: (() -> AXUIElement?)?
     var focusedTextStateOverride: ((AXUIElement) -> FocusedTextSnapshot?)?
+    var textSelectionOverride: (() -> TextSelection?)?
     var insertTextAtOverride: ((AXUIElement, String) -> Bool)?
     var pasteSimulatorOverride: (() -> Void)?
     var returnSimulatorOverride: (() -> Void)?
@@ -264,6 +265,9 @@ enum InsertionResult {
 
     /// Returns the selected text and the AXUIElement, so the selection can be replaced later.
     func getTextSelection() -> TextSelection? {
+        if let textSelectionOverride {
+            return textSelectionOverride()
+        }
         guard isAccessibilityGranted else { return nil }
 
         let systemWide = AXUIElementCreateSystemWide()

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -8,8 +8,6 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhis
 
 @MainActor
 final class PromptPaletteHandler {
-    private let promptPaletteController = PromptPaletteController()
-
     private enum InsertionOutcome {
         case failed
         case insertedViaAccessibility
@@ -26,6 +24,7 @@ final class PromptPaletteHandler {
     }
     private var paletteContext: PaletteContext?
 
+    private let promptPaletteController: any PromptPaletteControlling
     private let textInsertionService: TextInsertionService
     private let promptActionService: PromptActionService
     private let promptProcessingService: PromptProcessingService
@@ -46,8 +45,10 @@ final class PromptPaletteHandler {
         promptActionService: PromptActionService,
         promptProcessingService: PromptProcessingService,
         soundService: SoundService,
-        accessibilityAnnouncementService: AccessibilityAnnouncementService
+        accessibilityAnnouncementService: AccessibilityAnnouncementService,
+        promptPaletteController: any PromptPaletteControlling = PromptPaletteController()
     ) {
+        self.promptPaletteController = promptPaletteController
         self.textInsertionService = textInsertionService
         self.promptActionService = promptActionService
         self.promptProcessingService = promptProcessingService
@@ -67,14 +68,12 @@ final class PromptPaletteHandler {
         }
         guard currentState == .idle else { return }
 
-        guard promptProcessingService.isCurrentProviderReady else {
-            soundService.play(.error, enabled: soundFeedbackEnabled)
-            onShowError?(String(localized: "noLLMProvider"))
-            return
-        }
-
         let actions = promptActionService.getEnabledActions()
         guard !actions.isEmpty else { return }
+
+        // Palette presentation should not depend on the currently selected provider.
+        // Individual actions may override the provider, and readiness is validated
+        // when the chosen action actually runs.
 
         // Capture active app BEFORE the palette steals focus
         let activeApp = textInsertionService.captureActiveApp()

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -1,7 +1,14 @@
 import SwiftUI
 
 @MainActor
-final class PromptPaletteController {
+protocol PromptPaletteControlling: AnyObject {
+    var isVisible: Bool { get }
+    func show(actions: [PromptAction], sourceText: String, onSelect: @escaping (PromptAction) -> Void)
+    func hide()
+}
+
+@MainActor
+final class PromptPaletteController: PromptPaletteControlling {
     private let paletteController: any SelectionPaletteControlling
 
     init(paletteController: any SelectionPaletteControlling = SelectionPaletteController()) {

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -145,6 +145,54 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
 }
 
 @MainActor
+final class PromptPaletteHandlerTests: XCTestCase {
+    func testTriggerSelectionStillOpensPaletteWhenCurrentProviderIsNotReady() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", nil, nil) }
+        textInsertionService.textSelectionOverride = {
+            TextInsertionService.TextSelection(
+                text: "Selected text",
+                element: AXUIElementCreateSystemWide()
+            )
+        }
+
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        promptActionService.addAction(
+            name: "Translate",
+            prompt: "Translate the selected text.",
+            providerType: "Groq"
+        )
+
+        let promptProcessingService = PromptProcessingService()
+        promptProcessingService.selectedProviderId = "missing-provider"
+
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            promptActionService: promptActionService,
+            promptProcessingService: promptProcessingService,
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller
+        )
+
+        var shownError: String?
+        handler.onShowError = { shownError = $0 }
+
+        handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
+
+        XCTAssertTrue(controller.isVisible)
+        XCTAssertEqual(controller.lastActions?.map(\.name), ["Translate"])
+        XCTAssertEqual(controller.lastSourceText, "Selected text")
+        XCTAssertNil(shownError)
+    }
+}
+
+@MainActor
 final class SelectionPaletteInteractionModelTests: XCTestCase {
     func testArrowKeysMoveSelectionAndReturnSelectsCurrentItem() throws {
         let items = [
@@ -225,6 +273,25 @@ final class SelectionPaletteInteractionModelTests: XCTestCase {
                 keyCode: keyCode
             )
         )
+    }
+}
+
+@MainActor
+private final class PromptPaletteControllerSpy: PromptPaletteControlling {
+    private(set) var isVisible = false
+    private(set) var lastActions: [PromptAction]?
+    private(set) var lastSourceText: String?
+    private var onSelect: ((PromptAction) -> Void)?
+
+    func show(actions: [PromptAction], sourceText: String, onSelect: @escaping (PromptAction) -> Void) {
+        isVisible = true
+        lastActions = actions
+        lastSourceText = sourceText
+        self.onSelect = onSelect
+    }
+
+    func hide() {
+        isVisible = false
     }
 }
 


### PR DESCRIPTION
## Summary
- restore the prompt palette shortcut even when the currently selected default LLM provider is unavailable
- move the readiness check back to action execution time so the palette can still open and provider-overridden actions remain reachable
- add a regression test for the RC2 -> RC3 palette shortcut breakage and the small test hooks needed to exercise it

## Issue context
Issue #370 reports that the palette shortcut stopped working in RC3 even though it still worked in RC2.

The regression came from gating palette presentation on `isCurrentProviderReady`, which blocked the shortcut before the palette could open. That is too strict because prompt actions can override the provider, so provider readiness should be validated when the selected action runs, not when the palette is shown.

Closes #370

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PromptPaletteHandlerTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- `open '/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app'`
