### PR TITLE
replace prompts and rules with workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 ### AI Processing
 
-- **Custom prompts** - Process transcriptions (or any text) with LLM prompts. 8 presets included (Translate, Formal, Summarize, Fix Grammar, Email, List, Shorter, Explain). Standalone Prompt Palette via global hotkey - a floating panel for AI text processing independent of dictation
+- **Custom prompts** - Build reusable LLM prompts for translation, rewriting, extraction, and formatting. Automatic prompt processing during dictation runs through Rules; without a Rule, prompts stay available from the standalone Prompt Palette via global hotkey
 - **LLM providers** - Apple Intelligence (macOS 26+), Groq, OpenAI / ChatGPT, Gemini, and OpenAI Compatible with per-prompt provider and model override
 - **Local prompt processing** - Gemma 4 via MLX runs on-device on Apple Silicon, with the current verified release path limited to the E2B/E4B 4-bit models
 - **Translation** - Translate transcriptions on-device using Apple Translate
@@ -372,7 +372,7 @@ Rules let you configure transcription settings per application or website. For e
 - **github.com** - English language (matches in any browser)
 - **docs.google.com** - German language, translate to English
 
-Create rules in Settings > Regeln. Assign apps and/or URL patterns, set language/task/engine overrides, assign a custom prompt for automatic post-processing, optionally configure a manual rule shortcut, enable auto-submit (automatically sends text in chat apps), and adjust priority. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. URL patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`. The domain autocomplete suggests domains from your transcription history.
+Create rules in Settings > Regeln. Assign apps and/or URL patterns, set language/task/engine overrides, assign a custom prompt for automatic post-processing, optionally configure a manual rule shortcut, enable auto-submit (automatically sends text in chat apps), and adjust priority. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. URL patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`. The domain autocomplete suggests domains from your transcription history. If you want a prompt to run for normal dictation, assign it to a Rule; otherwise it remains a manual Prompt Palette action.
 
 When you start dictating, TypeWhisper matches the active app and browser URL against your rules with the following priority:
 1. **App + URL match** - highest specificity (e.g. Chrome + github.com)

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -21,10 +21,16 @@
 		A10000000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000002 /* manifest.json */; };
 		A10000000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000044 /* TypeWhisperPluginSDK */; };
 		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
+		A10000000000000000000006 /* WorkflowServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000005 /* WorkflowServiceTests.swift */; };
+		A10000000000000000000007 /* LegacyWorkflowServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000006 /* LegacyWorkflowServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
 		AA00000000000000000353 /* PostUpdatePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */; };
 		AA00000000000000000354 /* SettingsNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000354 /* SettingsNavigationCoordinator.swift */; };
 		AA00000000000000000355 /* PostUpdateLicensePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000355 /* PostUpdateLicensePromptView.swift */; };
+		AA00000000000000000356 /* Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000356 /* Workflow.swift */; };
+		AA00000000000000000357 /* WorkflowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000357 /* WorkflowService.swift */; };
+		AA00000000000000000358 /* LegacyWorkflowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000358 /* LegacyWorkflowService.swift */; };
+		AA00000000000000000359 /* WorkflowsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000359 /* WorkflowsSettingsView.swift */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
 		C23000000000000000000003 /* Gemma4Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000295 /* Gemma4Plugin.swift */; };
@@ -411,6 +417,8 @@
 		8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPRequestParserTests.swift; sourceTree = "<group>"; };
 		A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostUpdatePromptCoordinatorTests.swift; sourceTree = "<group>"; };
 		B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackServiceTests.swift; sourceTree = "<group>"; };
+		B10000000000000000000005 /* WorkflowServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowServiceTests.swift; sourceTree = "<group>"; };
+		B10000000000000000000006 /* LegacyWorkflowServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegacyWorkflowServiceTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000001 /* TypeWhisperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeWhisperApp.swift; sourceTree = "<group>"; };
 		BB00000000000000000002 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
 		BB00000000000000000005 /* TranscriptionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionResult.swift; sourceTree = "<group>"; };
@@ -433,6 +441,10 @@
 		BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUpdatePromptCoordinator.swift; sourceTree = "<group>"; };
 		BB00000000000000000354 /* SettingsNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationCoordinator.swift; sourceTree = "<group>"; };
 		BB00000000000000000355 /* PostUpdateLicensePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUpdateLicensePromptView.swift; sourceTree = "<group>"; };
+		BB00000000000000000356 /* Workflow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow.swift; sourceTree = "<group>"; };
+		BB00000000000000000357 /* WorkflowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowService.swift; sourceTree = "<group>"; };
+		BB00000000000000000358 /* LegacyWorkflowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWorkflowService.swift; sourceTree = "<group>"; };
+		BB00000000000000000359 /* WorkflowsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsSettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000040 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		BB00000000000000000041 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		BB00000000000000000042 /* APIRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRouter.swift; sourceTree = "<group>"; };
@@ -1116,6 +1128,7 @@
 				BB00000000000000000005 /* TranscriptionResult.swift */,
 				BB00000000000000000060 /* TranscriptionRecord.swift */,
 				BB00000000000000000065 /* Profile.swift */,
+				BB00000000000000000356 /* Workflow.swift */,
 				BB00000000000000000077 /* DictionaryEntry.swift */,
 				BB00000000000000000078 /* TermPack.swift */,
 				BB00000000000000000080 /* Snippet.swift */,
@@ -1146,6 +1159,8 @@
 				B91F00000000000000000002 /* RecentTranscriptionStore.swift */,
 				BB00000000000000000062 /* TextDiffService.swift */,
 				BB00000000000000000066 /* ProfileService.swift */,
+				BB00000000000000000357 /* WorkflowService.swift */,
+				BB00000000000000000358 /* LegacyWorkflowService.swift */,
 				BB00000000000000000073 /* TranslationService.swift */,
 				BB00000000000000000074 /* AudioDuckingService.swift */,
 				BB00000000000000000273 /* MediaPlaybackService.swift */,
@@ -1204,14 +1219,15 @@
 			CC00000000000000000008 /* Views */ = {
 				isa = PBXGroup;
 				children = (
-					BB00000000000000000198 /* OverlayIndicatorPanel.swift */,
-					BB00000000000000000195 /* OverlayIndicatorView.swift */,
-					BB00000000000000000310 /* MinimalIndicatorPanel.swift */,
-					BB00000000000000000309 /* MinimalIndicatorView.swift */,
-					BB00000000000000000197 /* SharedIndicatorComponents.swift */,
-					BB00000000000000000014 /* MenuBarView.swift */,
-					BB00000000000000000016 /* FileTranscriptionView.swift */,
+				BB00000000000000000198 /* OverlayIndicatorPanel.swift */,
+				BB00000000000000000195 /* OverlayIndicatorView.swift */,
+				BB00000000000000000310 /* MinimalIndicatorPanel.swift */,
+				BB00000000000000000309 /* MinimalIndicatorView.swift */,
+				BB00000000000000000197 /* SharedIndicatorComponents.swift */,
+				BB00000000000000000014 /* MenuBarView.swift */,
+				BB00000000000000000016 /* FileTranscriptionView.swift */,
 				BB00000000000000000017 /* SettingsView.swift */,
+				BB00000000000000000359 /* WorkflowsSettingsView.swift */,
 				BB00000000000000000046 /* AdvancedSettingsView.swift */,
 				BB00000000000000000051 /* GeneralSettingsView.swift */,
 				BB00000000000000000064 /* HistoryView.swift */,
@@ -1747,6 +1763,8 @@
 				2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */,
 				2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */,
 				F41BD305007A3A158038C75C /* ProfileServiceTests.swift */,
+				B10000000000000000000005 /* WorkflowServiceTests.swift */,
+				B10000000000000000000006 /* LegacyWorkflowServiceTests.swift */,
 				B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */,
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
@@ -2938,6 +2956,8 @@
 				1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */,
 				1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
+				A10000000000000000000006 /* WorkflowServiceTests.swift in Sources */,
+				A10000000000000000000007 /* LegacyWorkflowServiceTests.swift in Sources */,
 				A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,
 				A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */,
@@ -3002,7 +3022,10 @@
 				AA00000000000000000063 /* HistoryViewModel.swift in Sources */,
 				AA00000000000000000064 /* HistoryView.swift in Sources */,
 				AA00000000000000000065 /* Profile.swift in Sources */,
+				AA00000000000000000356 /* Workflow.swift in Sources */,
 				AA00000000000000000066 /* ProfileService.swift in Sources */,
+				AA00000000000000000357 /* WorkflowService.swift in Sources */,
+				AA00000000000000000358 /* LegacyWorkflowService.swift in Sources */,
 				AA00000000000000000067 /* ProfilesViewModel.swift in Sources */,
 				AA00000000000000000068 /* ProfilesSettingsView.swift in Sources */,
 				AA00000000000000000070 /* UpdateChecker.swift in Sources */,
@@ -3042,6 +3065,7 @@
 				AA00000000000000000116 /* PromptActionsViewModel.swift in Sources */,
 				AA00000000000000000315 /* PromptWizardSupport.swift in Sources */,
 				AA00000000000000000117 /* PromptActionsSettingsView.swift in Sources */,
+				AA00000000000000000359 /* WorkflowsSettingsView.swift in Sources */,
 				AA00000000000000000118 /* PromptPalettePanel.swift in Sources */,
 				A91F00000000000000000001 /* SelectionPalettePanel.swift in Sources */,
 				AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -15,6 +15,8 @@ final class ServiceContainer: ObservableObject {
     let recentTranscriptionStore: RecentTranscriptionStore
     let textDiffService: TextDiffService
     let profileService: ProfileService
+    let workflowService: WorkflowService
+    let legacyWorkflowService: LegacyWorkflowService
     let translationService: AnyObject? // TranslationService (macOS 15+)
     let audioDuckingService: AudioDuckingService
     let mediaPlaybackService: MediaPlaybackService
@@ -66,6 +68,12 @@ final class ServiceContainer: ObservableObject {
         recentTranscriptionStore = RecentTranscriptionStore()
         textDiffService = TextDiffService()
         profileService = ProfileService()
+        workflowService = WorkflowService()
+        promptActionService = PromptActionService()
+        legacyWorkflowService = LegacyWorkflowService(
+            profileService: profileService,
+            promptActionService: promptActionService
+        )
         #if canImport(Translation)
         if #available(macOS 15, *) {
             translationService = TranslationService()
@@ -81,7 +89,6 @@ final class ServiceContainer: ObservableObject {
         snippetService = SnippetService()
         soundService = SoundService()
         audioDeviceService = AudioDeviceService()
-        promptActionService = PromptActionService()
         promptProcessingService = PromptProcessingService()
         pluginManager = PluginManager()
         pluginRegistryService = PluginRegistryService()
@@ -113,6 +120,7 @@ final class ServiceContainer: ObservableObject {
             historyService: historyService,
             recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
+            workflowService: workflowService,
             translationService: translationService,
             audioDuckingService: audioDuckingService,
             dictionaryService: dictionaryService,
@@ -158,7 +166,8 @@ final class ServiceContainer: ObservableObject {
         homeViewModel = HomeViewModel(historyService: historyService)
         promptActionsViewModel = PromptActionsViewModel(
             promptActionService: promptActionService,
-            promptProcessingService: promptProcessingService
+            promptProcessingService: promptProcessingService,
+            profileService: profileService
         )
         audioRecorderViewModel = AudioRecorderViewModel(recorderService: audioRecorderService, modelManager: modelManagerService, dictionaryService: dictionaryService)
         watchFolderViewModel = WatchFolderViewModel(
@@ -200,7 +209,7 @@ final class ServiceContainer: ObservableObject {
         guard !AppConstants.isRunningTests else { return }
 
         hotkeyService.setup()
-        dictationViewModel.registerInitialProfileHotkeys()
+        dictationViewModel.registerInitialTriggerHotkeys()
         let retentionDays = UserDefaults.standard.integer(forKey: UserDefaultsKeys.historyRetentionDays)
         if retentionDays > 0 { historyService.purgeOldRecords(retentionDays: retentionDays) }
 
@@ -209,7 +218,19 @@ final class ServiceContainer: ObservableObject {
         }
 
         pluginManager.setRuleNamesProvider { [weak self] in
-            self?.profileService.profiles.map(\.name) ?? []
+            guard let self else { return [] }
+            var names: [String] = []
+            for workflow in self.workflowService.workflows {
+                if !names.contains(workflow.name) {
+                    names.append(workflow.name)
+                }
+            }
+            for profile in self.profileService.profiles {
+                if !names.contains(profile.name) {
+                    names.append(profile.name)
+                }
+            }
+            return names
         }
         pluginManager.scanAndLoadPlugins()
 

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -142,6 +142,7 @@ struct TypeWhisperApp: App {
         // Trigger ServiceContainer initialization
         _ = ServiceContainer.shared
         SettingsNavigationCoordinator.shared = SettingsNavigationCoordinator()
+        WorkflowsNavigationCoordinator.shared = WorkflowsNavigationCoordinator()
         PostUpdatePromptCoordinator.shared = PostUpdatePromptCoordinator()
 
         Task { @MainActor in
@@ -349,12 +350,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         )
     }
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        UserDefaults.standard.register(defaults: [
+    static func registerDefaultUserDefaults(_ defaults: UserDefaults = .standard) {
+        defaults.register(defaults: [
             UserDefaultsKeys.showMenuBarIcon: true,
             UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden: DockIconBehavior.keepVisible.rawValue,
-            UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue
+            UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue,
+            UserDefaultsKeys.appFormattingEnabled: false
         ])
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        Self.registerDefaultUserDefaults()
 
         guard !AppConstants.isRunningTests else {
             return
@@ -379,9 +385,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
         #endif
 
-        // Prompt palette hotkey - opens standalone prompt palette panel
+        // Workflow palette hotkey - opens the standalone workflow palette panel
         ServiceContainer.shared.hotkeyService.onPromptPaletteToggle = {
-            DictationViewModel.shared.triggerStandalonePromptSelection()
+            DictationViewModel.shared.triggerWorkflowPalette()
         }
         ServiceContainer.shared.hotkeyService.onRecentTranscriptionsToggle = {
             DictationViewModel.shared.triggerRecentTranscriptionsPalette()

--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -1,0 +1,495 @@
+import Foundation
+import SwiftData
+import TypeWhisperPluginSDK
+
+enum WorkflowTemplate: String, CaseIterable, Codable, Sendable {
+    case cleanedText
+    case translation
+    case emailReply
+    case meetingNotes
+    case checklist
+    case json
+    case summary
+    case custom
+
+    static var catalog: [WorkflowTemplateDefinition] {
+        allCases.map(\.definition)
+    }
+
+    var definition: WorkflowTemplateDefinition {
+        switch self {
+        case .cleanedText:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Cleaned Text", de: "Bereinigter Text"),
+                description: localizedAppText(
+                    "Clean up dictated text for readability and punctuation.",
+                    de: "Bereinigt diktierten Text fuer bessere Lesbarkeit und Zeichensetzung."
+                ),
+                systemImage: "text.badge.checkmark"
+            )
+        case .translation:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Translation", de: "Uebersetzung"),
+                description: localizedAppText(
+                    "Translate dictated text into the target language.",
+                    de: "Uebersetzt diktierten Text in die Zielsprache."
+                ),
+                systemImage: "globe"
+            )
+        case .emailReply:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Email Reply", de: "E-Mail-Antwort"),
+                description: localizedAppText(
+                    "Turn dictated notes into a reply email.",
+                    de: "Formt diktierte Notizen in eine Antwort-E-Mail um."
+                ),
+                systemImage: "envelope"
+            )
+        case .meetingNotes:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Meeting Notes", de: "Meeting Notes"),
+                description: localizedAppText(
+                    "Structure dictated notes into a meeting summary.",
+                    de: "Strukturiert diktierte Notizen zu einer Meeting-Zusammenfassung."
+                ),
+                systemImage: "doc.text.magnifyingglass"
+            )
+        case .checklist:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Checklist", de: "Checkliste"),
+                description: localizedAppText(
+                    "Extract action items into a checklist.",
+                    de: "Extrahiert Aufgaben in eine Checkliste."
+                ),
+                systemImage: "checklist"
+            )
+        case .json:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: "JSON",
+                description: localizedAppText(
+                    "Extract structured data as JSON.",
+                    de: "Extrahiert strukturierte Daten als JSON."
+                ),
+                systemImage: "curlybraces"
+            )
+        case .summary:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Summary", de: "Zusammenfassung"),
+                description: localizedAppText(
+                    "Condense dictated text into a concise summary.",
+                    de: "Verdichtet diktierten Text zu einer kompakten Zusammenfassung."
+                ),
+                systemImage: "text.alignleft"
+            )
+        case .custom:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Custom Workflow", de: "Eigener Workflow"),
+                description: localizedAppText(
+                    "Start with a flexible workflow draft.",
+                    de: "Startet mit einem flexiblen Workflow-Entwurf."
+                ),
+                systemImage: "slider.horizontal.3"
+            )
+        }
+    }
+}
+
+struct WorkflowTemplateDefinition: Identifiable, Equatable, Sendable {
+    let template: WorkflowTemplate
+    let name: String
+    let description: String
+    let systemImage: String
+
+    var id: WorkflowTemplate { template }
+}
+
+enum WorkflowTriggerKind: String, CaseIterable, Codable, Sendable {
+    case app
+    case website
+    case hotkey
+}
+
+struct WorkflowTrigger: Codable, Equatable, Sendable {
+    let kind: WorkflowTriggerKind
+    var appBundleIdentifiers: [String]
+    var websitePatterns: [String]
+    var hotkeys: [UnifiedHotkey]
+
+    init(
+        kind: WorkflowTriggerKind,
+        appBundleIdentifiers: [String] = [],
+        websitePatterns: [String] = [],
+        hotkeys: [UnifiedHotkey] = []
+    ) {
+        self.kind = kind
+        self.appBundleIdentifiers = appBundleIdentifiers
+        self.websitePatterns = websitePatterns
+        self.hotkeys = hotkeys
+    }
+
+    static func app(_ bundleIdentifier: String) -> WorkflowTrigger {
+        apps([bundleIdentifier])
+    }
+
+    static func apps(_ bundleIdentifiers: [String]) -> WorkflowTrigger {
+        WorkflowTrigger(kind: .app, appBundleIdentifiers: bundleIdentifiers)
+    }
+
+    static func website(_ pattern: String) -> WorkflowTrigger {
+        websites([pattern])
+    }
+
+    static func websites(_ patterns: [String]) -> WorkflowTrigger {
+        WorkflowTrigger(kind: .website, websitePatterns: patterns)
+    }
+
+    static func hotkey(_ hotkey: UnifiedHotkey) -> WorkflowTrigger {
+        hotkeys([hotkey])
+    }
+
+    static func hotkeys(_ hotkeys: [UnifiedHotkey]) -> WorkflowTrigger {
+        WorkflowTrigger(kind: .hotkey, hotkeys: hotkeys)
+    }
+
+    var appBundleIdentifier: String? {
+        appBundleIdentifiers.first
+    }
+
+    var websitePattern: String? {
+        websitePatterns.first
+    }
+
+    var hotkey: UnifiedHotkey? {
+        hotkeys.first
+    }
+
+    var hasValues: Bool {
+        switch kind {
+        case .app:
+            !appBundleIdentifiers.isEmpty
+        case .website:
+            !websitePatterns.isEmpty
+        case .hotkey:
+            !hotkeys.isEmpty
+        }
+    }
+}
+
+struct WorkflowBehavior: Codable, Equatable, Sendable {
+    var settings: [String: String]
+    var fineTuning: String
+    var providerId: String?
+    var cloudModel: String?
+    var temperatureModeRaw: String?
+    var temperatureValue: Double?
+
+    init(
+        settings: [String: String] = [:],
+        fineTuning: String = "",
+        providerId: String? = nil,
+        cloudModel: String? = nil,
+        temperatureModeRaw: String? = nil,
+        temperatureValue: Double? = nil
+    ) {
+        self.settings = settings
+        self.fineTuning = fineTuning
+        self.providerId = providerId
+        self.cloudModel = cloudModel
+        self.temperatureModeRaw = temperatureModeRaw
+        self.temperatureValue = temperatureValue
+    }
+
+    var temperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: temperatureModeRaw ?? "") ?? .inheritProviderSetting
+    }
+
+    var temperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: temperatureMode, value: temperatureValue)
+    }
+}
+
+struct WorkflowOutput: Codable, Equatable, Sendable {
+    var format: String?
+    var autoEnter: Bool
+    var targetActionPluginId: String?
+
+    init(
+        format: String? = nil,
+        autoEnter: Bool = false,
+        targetActionPluginId: String? = nil
+    ) {
+        self.format = format
+        self.autoEnter = autoEnter
+        self.targetActionPluginId = targetActionPluginId
+    }
+}
+
+@Model
+final class Workflow {
+    var id: UUID
+    var name: String
+    var isEnabled: Bool
+    var sortOrder: Int
+    var templateRaw: String
+    var triggerKindRaw: String
+    var triggerData: Data?
+    var triggerAppBundleIdentifier: String?
+    var triggerWebsitePattern: String?
+    var triggerHotkeyData: Data?
+    var behaviorData: Data?
+    var outputData: Data?
+    var createdAt: Date
+    var updatedAt: Date
+
+    var template: WorkflowTemplate {
+        get { WorkflowTemplate(rawValue: templateRaw) ?? .custom }
+        set { templateRaw = newValue.rawValue }
+    }
+
+    var trigger: WorkflowTrigger? {
+        get {
+            if let triggerData,
+               let decodedTrigger = try? JSONDecoder().decode(WorkflowTrigger.self, from: triggerData),
+               decodedTrigger.hasValues {
+                return decodedTrigger
+            }
+
+            guard let kind = WorkflowTriggerKind(rawValue: triggerKindRaw) else { return nil }
+
+            switch kind {
+            case .app:
+                guard let bundleIdentifier = triggerAppBundleIdentifier, !bundleIdentifier.isEmpty else { return nil }
+                return .app(bundleIdentifier)
+            case .website:
+                guard let pattern = triggerWebsitePattern, !pattern.isEmpty else { return nil }
+                return .website(pattern)
+            case .hotkey:
+                guard let triggerHotkeyData,
+                      let hotkey = try? JSONDecoder().decode(UnifiedHotkey.self, from: triggerHotkeyData) else {
+                    return nil
+                }
+                return .hotkey(hotkey)
+            }
+        }
+        set {
+            guard let newValue else {
+                triggerKindRaw = WorkflowTriggerKind.app.rawValue
+                triggerData = nil
+                triggerAppBundleIdentifier = nil
+                triggerWebsitePattern = nil
+                triggerHotkeyData = nil
+                return
+            }
+
+            triggerKindRaw = newValue.kind.rawValue
+            triggerData = Self.encode(newValue)
+
+            switch newValue.kind {
+            case .app:
+                triggerAppBundleIdentifier = newValue.appBundleIdentifiers.first
+                triggerWebsitePattern = nil
+                triggerHotkeyData = nil
+            case .website:
+                triggerAppBundleIdentifier = nil
+                triggerWebsitePattern = newValue.websitePatterns.first
+                triggerHotkeyData = nil
+            case .hotkey:
+                triggerAppBundleIdentifier = nil
+                triggerWebsitePattern = nil
+                triggerHotkeyData = newValue.hotkeys.first.flatMap { try? JSONEncoder().encode($0) }
+            }
+        }
+    }
+
+    var behavior: WorkflowBehavior {
+        get { Self.decode(behaviorData, defaultValue: WorkflowBehavior()) }
+        set { behaviorData = Self.encode(newValue) }
+    }
+
+    var output: WorkflowOutput {
+        get { Self.decode(outputData, defaultValue: WorkflowOutput()) }
+        set { outputData = Self.encode(newValue) }
+    }
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        isEnabled: Bool = true,
+        sortOrder: Int = 0,
+        template: WorkflowTemplate,
+        trigger: WorkflowTrigger,
+        behavior: WorkflowBehavior = WorkflowBehavior(),
+        output: WorkflowOutput = WorkflowOutput(),
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.isEnabled = isEnabled
+        self.sortOrder = sortOrder
+        self.templateRaw = template.rawValue
+        self.triggerKindRaw = trigger.kind.rawValue
+        self.triggerData = nil
+        self.triggerAppBundleIdentifier = nil
+        self.triggerWebsitePattern = nil
+        self.triggerHotkeyData = nil
+        self.behaviorData = Self.encode(behavior)
+        self.outputData = Self.encode(output)
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.trigger = trigger
+    }
+
+    private static func encode<Value: Encodable>(_ value: Value) -> Data? {
+        try? JSONEncoder().encode(value)
+    }
+
+    private static func decode<Value: Decodable>(_ data: Data?, defaultValue: Value) -> Value {
+        guard let data, let decoded = try? JSONDecoder().decode(Value.self, from: data) else {
+            return defaultValue
+        }
+        return decoded
+    }
+}
+
+extension WorkflowTriggerKind {
+    var paletteLabel: String {
+        switch self {
+        case .app:
+            localizedAppText("App", de: "App")
+        case .website:
+            localizedAppText("Website", de: "Website")
+        case .hotkey:
+            localizedAppText("Hotkey", de: "Hotkey")
+        }
+    }
+}
+
+extension Workflow {
+    var definition: WorkflowTemplateDefinition {
+        template.definition
+    }
+
+    var isManuallyRunnable: Bool {
+        systemPrompt() != nil || output.targetActionPluginId != nil
+    }
+
+    func systemPrompt(
+        fallbackTranslationTarget: String? = nil,
+        detectedLanguage: String? = nil,
+        configuredLanguage: String? = nil
+    ) -> String? {
+        let outputInstruction = workflowOutputInstruction(for: output)
+        let settingsInstruction = workflowSettingsInstruction(for: behavior.settings)
+        let fineTuningInstruction = workflowFineTuningInstruction(for: behavior.fineTuning)
+        let languageHint = workflowLanguageHint(
+            detectedLanguage: detectedLanguage,
+            configuredLanguage: configuredLanguage
+        )
+
+        switch template {
+        case .cleanedText:
+            return """
+            Clean up the dictated text for readability. Fix punctuation, grammar, and formatting while preserving the original meaning and language. Return only the cleaned text.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .translation:
+            let targetLanguage = behavior.settings["targetLanguage"]
+                ?? behavior.settings["target"]
+                ?? fallbackTranslationTarget
+                ?? "English"
+            return """
+            Translate the dictated text into \(targetLanguage). Preserve meaning, names, and domain-specific terminology unless the instruction explicitly says otherwise. Return only the translated text.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .emailReply:
+            return """
+            Turn the dictated text into a complete reply email. Use an appropriate greeting and closing, keep the same language as the source unless instructed otherwise, and return only the email body.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .meetingNotes:
+            return """
+            Restructure the dictated text into clear meeting notes with concise sections, decisions, and action items where applicable. Return only the final notes.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .checklist:
+            return """
+            Extract the actionable items from the dictated text and return them as a checklist. Keep the source language unless instructed otherwise.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .json:
+            return """
+            Extract structured information from the dictated text and return valid JSON only. Do not wrap the JSON in markdown fences.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .summary:
+            return """
+            Summarize the dictated text into a concise, accurate summary. Preserve important facts and keep the source language unless instructed otherwise. Return only the summary.
+            \(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
+            """
+        case .custom:
+            let customInstruction = behavior.settings["instruction"]
+                ?? behavior.settings["goal"]
+                ?? behavior.settings["prompt"]
+                ?? behavior.fineTuning
+            let trimmedInstruction = customInstruction.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedInstruction.isEmpty else {
+                return nil
+            }
+            return """
+            Apply the following workflow instruction to the dictated text and return only the final result:
+            \(trimmedInstruction)
+            \(languageHint)\(settingsInstruction)\(outputInstruction)
+            """
+        }
+    }
+
+    private func workflowSettingsInstruction(for settings: [String: String]) -> String {
+        let relevantSettings = settings
+            .filter { key, value in
+                !["instruction", "goal", "prompt", "targetLanguage", "target"].contains(key)
+                && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
+
+        guard !relevantSettings.isEmpty else { return "" }
+        let lines = relevantSettings.map { "- \($0.key): \($0.value)" }.joined(separator: "\n")
+        return "\nAdditional workflow settings:\n\(lines)"
+    }
+
+    private func workflowFineTuningInstruction(for fineTuning: String) -> String {
+        let trimmed = fineTuning.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        return "\nFine-tuning:\n\(trimmed)"
+    }
+
+    private func workflowOutputInstruction(for output: WorkflowOutput) -> String {
+        var lines: [String] = []
+        if let format = output.format?.trimmingCharacters(in: .whitespacesAndNewlines), !format.isEmpty {
+            lines.append("Return the result as \(format).")
+        }
+        if output.targetActionPluginId != nil {
+            lines.append("Return only the transformed text result without commentary.")
+        }
+        guard !lines.isEmpty else { return "" }
+        return "\nOutput requirements:\n" + lines.joined(separator: "\n")
+    }
+
+    private func workflowLanguageHint(detectedLanguage: String?, configuredLanguage: String?) -> String {
+        if let detectedLanguage, !detectedLanguage.isEmpty {
+            return "\nDetected source language: \(detectedLanguage)."
+        }
+        if let configuredLanguage, !configuredLanguage.isEmpty {
+            return "\nConfigured source language: \(configuredLanguage)."
+        }
+        return ""
+    }
+}

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -5459,6 +5459,46 @@
         }
       }
     },
+    "Prompt already selected" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prompt bereits ausgewählt"
+          }
+        }
+      }
+    },
+    "Prompt saved. Create a rule to run it automatically during dictation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prompt gespeichert. Erstelle eine Regel, damit er bei Diktaten automatisch läuft."
+          }
+        }
+      }
+    },
+    "Build reusable AI actions for Rules or the Prompt Palette." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baue wiederverwendbare KI-Aktionen für Regeln oder die Prompt-Palette."
+          }
+        }
+      }
+    },
+    "Create Rule" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regel erstellen"
+          }
+        }
+      }
+    },
     "Prompts" : {
       "localizations" : {
         "de" : {
@@ -5475,6 +5515,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prompts & KI"
+          }
+        }
+      }
+    },
+    "Prompts become automatic during dictation only when a rule assigns them. Otherwise they stay available from the Prompt Palette." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prompts werden bei Diktaten nur dann automatisch, wenn eine Regel sie zuweist. Andernfalls bleiben sie über die Prompt-Palette verfügbar."
+          }
+        }
+      }
+    },
+    "Prompts run automatically during dictation only when a rule assigns them. Without a rule, they remain available via the Prompt Palette." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prompts laufen bei Diktaten nur dann automatisch, wenn eine Regel sie zuweist. Ohne Regel bleiben sie über die Prompt-Palette verfügbar."
+          }
+        }
+      }
+    },
+    "Saving without an app or website creates a global fallback rule with this prompt." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern ohne App oder Website erstellt eine globale Fallback-Regel mit diesem Prompt."
+          }
+        }
+      }
+    },
+    "Without a rule, prompts remain available via the Prompt Palette." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ohne Regel bleiben Prompts über die Prompt-Palette verfügbar."
           }
         }
       }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -96,6 +96,7 @@ final class HotkeyService: ObservableObject {
         enum Target: Hashable {
             case slot(HotkeySlotType)
             case profile(UUID)
+            case workflow(UUID)
         }
 
         let target: Target
@@ -120,6 +121,7 @@ final class HotkeyService: ObservableObject {
     var onPromptPaletteToggle: (() -> Void)?
     var onRecentTranscriptionsToggle: (() -> Void)?
     var onProfileDictationStart: ((UUID) -> Void)?
+    var onWorkflowDictationStart: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
     var onPushToTalkInterruption: (() -> Void)?
     var discardPushToTalkRecordingOnExtraKeyPress = false
@@ -128,6 +130,7 @@ final class HotkeyService: ObservableObject {
     private var isActive = false
     private var activeSlotType: HotkeySlotType?
     private(set) var activeProfileId: UUID?
+    private(set) var activeWorkflowId: UUID?
     private var pushToTalkInterruptionSignaled = false
 
     private static let toggleThreshold: TimeInterval = 1.0
@@ -194,6 +197,30 @@ final class HotkeyService: ObservableObject {
     }
 
     private var profileSlots: [UUID: ProfileHotkeyState] = [:]
+
+    private struct WorkflowHotkeyState {
+        let workflowId: UUID
+        var hotkey: UnifiedHotkey
+        var fnWasDown = false
+        var fnComboKeyPressed = false
+        var modifierWasDown = false
+        var keyWasDown = false
+        var mouseButtonWasDown = false
+        var lastTapUpTime: Date?
+        var tapCount: Int = 0
+
+        mutating func resetTransientState() {
+            fnWasDown = false
+            fnComboKeyPressed = false
+            modifierWasDown = false
+            keyWasDown = false
+            mouseButtonWasDown = false
+            lastTapUpTime = nil
+            tapCount = 0
+        }
+    }
+
+    private var workflowSlots: [UUID: [WorkflowHotkeyState]] = [:]
 
     private var globalMonitor: Any?
     private var localMonitor: Any?
@@ -262,6 +289,7 @@ final class HotkeyService: ObservableObject {
         isActive = false
         activeSlotType = nil
         activeProfileId = nil
+        activeWorkflowId = nil
         currentMode = nil
         keyDownTime = nil
         pushToTalkInterruptionSignaled = false
@@ -278,6 +306,17 @@ final class HotkeyService: ObservableObject {
         setupMonitor()
     }
 
+    func registerWorkflowHotkeys(_ entries: [(id: UUID, hotkey: UnifiedHotkey)]) {
+        workflowSlots.removeAll()
+        for entry in entries {
+            workflowSlots[entry.id, default: []].append(
+                WorkflowHotkeyState(workflowId: entry.id, hotkey: entry.hotkey)
+            )
+        }
+        tearDownMonitor()
+        setupMonitor()
+    }
+
     func isHotkeyAssignedToProfile(_ hotkey: UnifiedHotkey, excludingProfileId: UUID?) -> UUID? {
         for (id, state) in profileSlots where id != excludingProfileId {
             if state.hotkey == hotkey { return id }
@@ -287,6 +326,22 @@ final class HotkeyService: ObservableObject {
                 && state.hotkey.mouseButton == hotkey.mouseButton
                 && state.hotkey.isDoubleTap != hotkey.isDoubleTap {
                 return id
+            }
+        }
+        return nil
+    }
+
+    func isHotkeyAssignedToWorkflow(_ hotkey: UnifiedHotkey, excludingWorkflowId: UUID?) -> UUID? {
+        for (id, states) in workflowSlots where id != excludingWorkflowId {
+            for state in states {
+                if state.hotkey == hotkey { return id }
+                if state.hotkey.keyCode == hotkey.keyCode
+                    && state.hotkey.modifierFlags == hotkey.modifierFlags
+                    && state.hotkey.isFn == hotkey.isFn
+                    && state.hotkey.mouseButton == hotkey.mouseButton
+                    && state.hotkey.isDoubleTap != hotkey.isDoubleTap {
+                    return id
+                }
             }
         }
         return nil
@@ -528,6 +583,52 @@ final class HotkeyService: ObservableObject {
             )
         }
 
+        // Workflow slots
+        for workflowId in Array(workflowSlots.keys) {
+            guard var states = workflowSlots[workflowId] else { continue }
+            for index in states.indices {
+                var wState = states[index]
+                if shouldSuppressForCapsLockOrigin(event, hotkey: wState.hotkey, keyWasDown: wState.keyWasDown) {
+                    wState.resetTransientState()
+                    states[index] = wState
+                    continue
+                }
+                var state = SlotState(
+                    hotkey: wState.hotkey,
+                    fnWasDown: wState.fnWasDown,
+                    fnComboKeyPressed: wState.fnComboKeyPressed,
+                    modifierWasDown: wState.modifierWasDown,
+                    keyWasDown: wState.keyWasDown,
+                    mouseButtonWasDown: wState.mouseButtonWasDown,
+                    lastTapUpTime: wState.lastTapUpTime,
+                    tapCount: wState.tapCount
+                )
+                let (keyDown, keyUp, isMatch) = processKeyEvent(
+                    event,
+                    hotkey: wState.hotkey,
+                    state: &state,
+                    fnTriggerMode: .pressThenRelease
+                )
+                wState.fnWasDown = state.fnWasDown
+                wState.fnComboKeyPressed = state.fnComboKeyPressed
+                wState.modifierWasDown = state.modifierWasDown
+                wState.keyWasDown = state.keyWasDown
+                wState.mouseButtonWasDown = state.mouseButtonWasDown
+                wState.lastTapUpTime = state.lastTapUpTime
+                wState.tapCount = state.tapCount
+                states[index] = wState
+                if isMatch { shouldSuppress = true }
+                dispatchWorkflowMatch(
+                    workflowId: workflowId,
+                    hotkey: wState.hotkey,
+                    keyDown: keyDown,
+                    keyUp: keyUp,
+                    source: source
+                )
+            }
+            workflowSlots[workflowId] = states
+        }
+
         return shouldSuppress
     }
 
@@ -621,12 +722,40 @@ final class HotkeyService: ObservableObject {
         }
     }
 
+    private func dispatchWorkflowMatch(
+        workflowId: UUID,
+        hotkey: UnifiedHotkey,
+        keyDown: Bool,
+        keyUp: Bool,
+        source: HotkeyEventSource
+    ) {
+        if keyDown, shouldDispatch(
+            target: .workflow(workflowId),
+            phase: .down,
+            hotkey: hotkey,
+            source: source
+        ) {
+            if source != .eventTap {
+                logFallbackMatchIfNeeded(hotkey: hotkey, source: source)
+            }
+            handleWorkflowKeyDown(workflowId: workflowId)
+        } else if keyUp, shouldDispatch(
+            target: .workflow(workflowId),
+            phase: .up,
+            hotkey: hotkey,
+            source: source
+        ) {
+            handleWorkflowKeyUp(workflowId: workflowId)
+        }
+    }
+
     private func signalPushToTalkInterruptionIfNeeded(for event: NSEvent) {
         guard discardPushToTalkRecordingOnExtraKeyPress,
               !pushToTalkInterruptionSignaled,
               isActive,
               activeSlotType == .pushToTalk,
               activeProfileId == nil,
+              activeWorkflowId == nil,
               event.type == .keyDown,
               let hotkey = slots[.pushToTalk]?.hotkey,
               isExtraKeyDuringActivePushToTalk(event, hotkey: hotkey) else {
@@ -965,6 +1094,7 @@ final class HotkeyService: ObservableObject {
             isActive = false
             activeSlotType = nil
             activeProfileId = nil
+            activeWorkflowId = nil
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
@@ -972,6 +1102,7 @@ final class HotkeyService: ObservableObject {
         } else {
             activeSlotType = slotType
             activeProfileId = nil
+            activeWorkflowId = nil
             keyDownTime = Date()
             isActive = true
             pushToTalkInterruptionSignaled = false
@@ -981,7 +1112,7 @@ final class HotkeyService: ObservableObject {
     }
 
     private func handleKeyUp(slotType: HotkeySlotType) {
-        guard isActive, slotType == activeSlotType, activeProfileId == nil else { return }
+        guard isActive, slotType == activeSlotType, activeProfileId == nil, activeWorkflowId == nil else { return }
 
         switch slotType {
         case .hybrid:
@@ -1020,12 +1151,14 @@ final class HotkeyService: ObservableObject {
             isActive = false
             activeSlotType = nil
             activeProfileId = nil
+            activeWorkflowId = nil
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
             onDictationStop?()
         } else {
             activeProfileId = profileId
+            activeWorkflowId = nil
             activeSlotType = nil
             keyDownTime = Date()
             isActive = true
@@ -1046,6 +1179,49 @@ final class HotkeyService: ObservableObject {
             isActive = false
             activeSlotType = nil
             activeProfileId = nil
+            activeWorkflowId = nil
+            currentMode = nil
+            keyDownTime = nil
+            pushToTalkInterruptionSignaled = false
+            onDictationStop?()
+        }
+    }
+
+    // MARK: - Key Down / Up (Workflow Slots)
+
+    private func handleWorkflowKeyDown(workflowId: UUID) {
+        if isActive {
+            isActive = false
+            activeSlotType = nil
+            activeProfileId = nil
+            activeWorkflowId = nil
+            currentMode = nil
+            keyDownTime = nil
+            pushToTalkInterruptionSignaled = false
+            onDictationStop?()
+        } else {
+            activeProfileId = nil
+            activeWorkflowId = workflowId
+            activeSlotType = nil
+            keyDownTime = Date()
+            isActive = true
+            pushToTalkInterruptionSignaled = false
+            currentMode = .pushToTalk
+            onWorkflowDictationStart?(workflowId)
+        }
+    }
+
+    private func handleWorkflowKeyUp(workflowId: UUID) {
+        guard isActive, activeWorkflowId == workflowId else { return }
+
+        guard let downTime = keyDownTime else { return }
+        if Date().timeIntervalSince(downTime) < Self.toggleThreshold {
+            currentMode = .toggle
+        } else {
+            isActive = false
+            activeSlotType = nil
+            activeProfileId = nil
+            activeWorkflowId = nil
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false

--- a/TypeWhisper/Services/LegacyWorkflowService.swift
+++ b/TypeWhisper/Services/LegacyWorkflowService.swift
@@ -1,0 +1,279 @@
+import AppKit
+import Combine
+import Foundation
+
+enum LegacyWorkflowSourceKind: String, CaseIterable, Sendable {
+    case rule
+    case prompt
+
+    var title: String {
+        switch self {
+        case .rule:
+            localizedAppText("Legacy Rule", de: "Legacy-Regel")
+        case .prompt:
+            localizedAppText("Legacy Prompt", de: "Legacy-Prompt")
+        }
+    }
+}
+
+struct LegacyWorkflowItem: Identifiable, Equatable, Sendable {
+    let id: String
+    let sourceKind: LegacyWorkflowSourceKind
+    let sourceObjectId: UUID
+    let name: String
+    let summary: String
+    let detail: String
+    let isEnabled: Bool
+    let isImported: Bool
+}
+
+@MainActor
+final class LegacyWorkflowService: ObservableObject {
+    static let importedDefaultsKey = "legacyWorkflowImportedIds"
+
+    @Published private(set) var items: [LegacyWorkflowItem] = []
+
+    private let profileService: ProfileService
+    private let promptActionService: PromptActionService
+    private let defaults: UserDefaults
+    private var cancellables = Set<AnyCancellable>()
+    private var importedIds: Set<String>
+
+    init(
+        profileService: ProfileService,
+        promptActionService: PromptActionService,
+        defaults: UserDefaults = .standard
+    ) {
+        self.profileService = profileService
+        self.promptActionService = promptActionService
+        self.defaults = defaults
+        self.importedIds = Set(defaults.stringArray(forKey: Self.importedDefaultsKey) ?? [])
+
+        rebuildItems()
+        setupBindings()
+    }
+
+    var ruleItems: [LegacyWorkflowItem] {
+        items.filter { $0.sourceKind == .rule }
+    }
+
+    var promptItems: [LegacyWorkflowItem] {
+        items.filter { $0.sourceKind == .prompt }
+    }
+
+    func deleteItem(_ item: LegacyWorkflowItem) {
+        switch item.sourceKind {
+        case .rule:
+            guard let profile = profileService.profiles.first(where: { $0.id == item.sourceObjectId }) else { return }
+            profileService.deleteProfile(profile)
+        case .prompt:
+            let promptId = item.sourceObjectId.uuidString
+            let linkedProfiles = profileService.profiles.filter { $0.promptActionId == promptId }
+            for profile in linkedProfiles {
+                profile.promptActionId = nil
+                profileService.updateProfile(profile)
+            }
+
+            guard let promptAction = promptActionService.promptActions.first(where: { $0.id == item.sourceObjectId }) else { return }
+            promptActionService.deleteAction(promptAction)
+        }
+
+        rebuildItems()
+    }
+
+    func markImported(_ item: LegacyWorkflowItem) {
+        importedIds.insert(item.id)
+        defaults.set(Array(importedIds).sorted(), forKey: Self.importedDefaultsKey)
+        rebuildItems()
+    }
+
+    private func setupBindings() {
+        profileService.$profiles
+            .sink { [weak self] _ in
+                self?.rebuildItems()
+            }
+            .store(in: &cancellables)
+
+        promptActionService.$promptActions
+            .sink { [weak self] _ in
+                self?.rebuildItems()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func rebuildItems() {
+        let promptActionsById = Dictionary(
+            uniqueKeysWithValues: promptActionService.promptActions.map { ($0.id.uuidString, $0) }
+        )
+
+        let legacyRules = profileService.profiles.map { profile in
+            buildLegacyRuleItem(profile: profile, promptActionsById: promptActionsById)
+        }
+
+        let legacyPrompts = promptActionService.promptActions.map { prompt in
+            buildLegacyPromptItem(promptAction: prompt)
+        }
+
+        items = (legacyRules + legacyPrompts).sorted { lhs, rhs in
+            if lhs.sourceKind != rhs.sourceKind {
+                return lhs.sourceKind.rawValue < rhs.sourceKind.rawValue
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    private func buildLegacyRuleItem(
+        profile: Profile,
+        promptActionsById: [String: PromptAction]
+    ) -> LegacyWorkflowItem {
+        let promptAction = profile.promptActionId.flatMap { promptActionsById[$0] }
+        let contextSummary = legacyContextSummary(for: profile)
+        let behaviorSummary = legacyBehaviorSummary(for: profile, promptAction: promptAction)
+
+        return LegacyWorkflowItem(
+            id: "rule-\(profile.id.uuidString)",
+            sourceKind: .rule,
+            sourceObjectId: profile.id,
+            name: profile.name,
+            summary: contextSummary,
+            detail: behaviorSummary,
+            isEnabled: profile.isEnabled,
+            isImported: importedIds.contains("rule-\(profile.id.uuidString)")
+        )
+    }
+
+    private func buildLegacyPromptItem(promptAction: PromptAction) -> LegacyWorkflowItem {
+        let linkedRuleCount = profileService.profiles.filter { $0.promptActionId == promptAction.id.uuidString }.count
+        let detail: String
+        if linkedRuleCount == 0 {
+            detail = localizedAppText(
+                "Not linked to any legacy rules.",
+                de: "Mit keiner Legacy-Regel verknuepft."
+            )
+        } else if linkedRuleCount == 1 {
+            detail = localizedAppText(
+                "Used by 1 legacy rule.",
+                de: "Wird von 1 Legacy-Regel verwendet."
+            )
+        } else {
+            detail = localizedAppText(
+                "Used by \(linkedRuleCount) legacy rules.",
+                de: "Wird von \(linkedRuleCount) Legacy-Regeln verwendet."
+            )
+        }
+
+        return LegacyWorkflowItem(
+            id: "prompt-\(promptAction.id.uuidString)",
+            sourceKind: .prompt,
+            sourceObjectId: promptAction.id,
+            name: promptAction.name,
+            summary: localizedAppText(
+                "Legacy prompt action",
+                de: "Legacy-Prompt-Aktion"
+            ),
+            detail: detail,
+            isEnabled: promptAction.isEnabled,
+            isImported: importedIds.contains("prompt-\(promptAction.id.uuidString)")
+        )
+    }
+
+    private func legacyContextSummary(for profile: Profile) -> String {
+        if let hotkey = profile.hotkey {
+            return localizedAppText(
+                "Manual trigger via \(HotkeyService.displayName(for: hotkey))",
+                de: "Manueller Trigger per \(HotkeyService.displayName(for: hotkey))"
+            )
+        }
+
+        let appNames = profile.bundleIdentifiers.prefix(2).map(legacyAppName(for:))
+        let domains = profile.urlPatterns.prefix(2)
+
+        if let appName = appNames.first, let domain = domains.first {
+            return localizedAppText(
+                "App \(appName) and website \(domain)",
+                de: "App \(appName) und Website \(domain)"
+            )
+        }
+        if let domain = domains.first {
+            return localizedAppText(
+                "Website \(domain)",
+                de: "Website \(domain)"
+            )
+        }
+        if let appName = appNames.first {
+            return localizedAppText(
+                "App \(appName)",
+                de: "App \(appName)"
+            )
+        }
+
+        return localizedAppText(
+            "No explicit trigger",
+            de: "Kein expliziter Trigger"
+        )
+    }
+
+    private func legacyBehaviorSummary(for profile: Profile, promptAction: PromptAction?) -> String {
+        var parts: [String] = []
+
+        if let promptAction {
+            parts.append(
+                localizedAppText(
+                    "Prompt: \(promptAction.name)",
+                    de: "Prompt: \(promptAction.name)"
+                )
+            )
+        } else if profile.inlineCommandsEnabled {
+            parts.append(localizedAppText("Inline commands", de: "Inline-Commands"))
+        }
+
+        if profile.translationEnabled == true,
+           let targetLanguage = profile.translationTargetLanguage,
+           !targetLanguage.isEmpty {
+            parts.append(
+                localizedAppText(
+                    "Translation to \(localizedAppLanguageName(for: targetLanguage))",
+                    de: "Uebersetzung nach \(localizedAppLanguageName(for: targetLanguage))"
+                )
+            )
+        } else if let outputFormat = profile.outputFormat, !outputFormat.isEmpty {
+            parts.append(
+                localizedAppText(
+                    "Output: \(outputFormat)",
+                    de: "Ausgabe: \(outputFormat)"
+                )
+            )
+        }
+
+        if let engineOverride = profile.engineOverride, !engineOverride.isEmpty {
+            parts.append(
+                localizedAppText(
+                    "Engine: \(engineOverride)",
+                    de: "Engine: \(engineOverride)"
+                )
+            )
+        }
+
+        if parts.isEmpty {
+            return localizedAppText(
+                "Legacy rule behavior",
+                de: "Legacy-Regelverhalten"
+            )
+        }
+
+        return parts.joined(separator: " • ")
+    }
+
+    private func legacyAppName(for bundleIdentifier: String) -> String {
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
+           let bundle = Bundle(url: appURL),
+           let name = bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+                ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String,
+           !name.isEmpty {
+            return name
+        }
+
+        let fallback = bundleIdentifier.split(separator: ".").last.map(String.init) ?? bundleIdentifier
+        return fallback.replacingOccurrences(of: "-", with: " ").capitalized
+    }
+}

--- a/TypeWhisper/Services/PromptActionService.swift
+++ b/TypeWhisper/Services/PromptActionService.swift
@@ -127,6 +127,7 @@ class PromptActionService: ObservableObject {
         }
     }
 
+    @discardableResult
     func addAction(
         name: String,
         prompt: String,
@@ -137,8 +138,8 @@ class PromptActionService: ObservableObject {
         temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
         temperatureValue: Double? = nil,
         targetActionPluginId: String? = nil
-    ) {
-        guard let context = modelContext else { return }
+    ) -> PromptAction? {
+        guard let context = modelContext else { return nil }
 
         let maxOrder = promptActions.map(\.sortOrder).max() ?? -1
         let action = PromptAction(
@@ -162,8 +163,11 @@ class PromptActionService: ObservableObject {
         } catch {
             logger.error("Failed to save prompt action: \(error.localizedDescription)")
         }
+
+        return action
     }
 
+    @discardableResult
     func updateAction(
         _ action: PromptAction,
         name: String,
@@ -175,8 +179,8 @@ class PromptActionService: ObservableObject {
         temperatureModeRaw: String = PluginLLMTemperatureMode.inheritProviderSetting.rawValue,
         temperatureValue: Double? = nil,
         targetActionPluginId: String? = nil
-    ) {
-        guard let context = modelContext else { return }
+    ) -> PromptAction? {
+        guard let context = modelContext else { return nil }
 
         action.name = name
         action.prompt = prompt
@@ -195,6 +199,8 @@ class PromptActionService: ObservableObject {
         } catch {
             logger.error("Failed to update prompt action: \(error.localizedDescription)")
         }
+
+        return action
     }
 
     func deleteAction(_ action: PromptAction) {

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -238,7 +238,9 @@ class PromptProcessingService: ObservableObject {
             return try await operation()
         }
 
-        activateAppForLocalPromptProcessing(providerId: providerId)
+        // Keep local prompt processing on a high-priority activity budget, but do not
+        // activate the app window. Stealing focus here breaks insertion because the
+        // original target text field is no longer frontmost once the LLM step finishes.
         let activity = ProcessInfo.processInfo.beginActivity(
             options: [.userInitiated, .latencyCritical],
             reason: "Local prompt processing with \(providerId)"
@@ -248,24 +250,6 @@ class PromptProcessingService: ObservableObject {
         }
 
         return try await operation()
-    }
-
-    private func activateAppForLocalPromptProcessing(providerId: String) {
-        guard !AppConstants.isRunningTests, !NSApp.isActive else { return }
-
-        logger.info("Activating app for local prompt processing with plugin \(providerId)")
-        let currentApplication = NSRunningApplication.current
-        let sourceApplication = ActivationSourceTracker.shared.lastExternalApplication
-            ?? NSWorkspace.shared.frontmostApplication
-
-        if let sourceApplication,
-           sourceApplication.processIdentifier != currentApplication.processIdentifier,
-           currentApplication.activate(from: sourceApplication) {
-            return
-        }
-
-        _ = currentApplication.activate()
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func normalizeSelectedCloudModelIfNeeded(for providerId: String) {

--- a/TypeWhisper/Services/WorkflowService.swift
+++ b/TypeWhisper/Services/WorkflowService.swift
@@ -1,0 +1,234 @@
+import Foundation
+import SwiftData
+import Combine
+import os.log
+
+private let workflowLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper",
+    category: "WorkflowService"
+)
+
+enum WorkflowMatchKind: String, Sendable {
+    case website
+    case app
+    case manualOverride
+
+    var label: String {
+        switch self {
+        case .website:
+            localizedAppText("Website", de: "Website")
+        case .app:
+            localizedAppText("App", de: "App")
+        case .manualOverride:
+            localizedAppText("Manually triggered", de: "Manuell ausgeloest")
+        }
+    }
+}
+
+struct WorkflowMatchResult {
+    let workflow: Workflow
+    let kind: WorkflowMatchKind
+    let matchedDomain: String?
+    let competingWorkflowCount: Int
+    let wonBySortOrder: Bool
+}
+
+@MainActor
+final class WorkflowService: ObservableObject {
+    @Published private(set) var workflows: [Workflow] = []
+
+    private let modelContainer: ModelContainer
+    private let modelContext: ModelContext
+
+    init(appSupportDirectory: URL = AppConstants.appSupportDirectory) {
+        let schema = Schema([Workflow.self])
+        let storeDir = appSupportDirectory
+        try? FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
+
+        let storeURL = storeDir.appendingPathComponent("workflows.store")
+        let config = ModelConfiguration(url: storeURL)
+
+        do {
+            modelContainer = try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            for suffix in ["", "-wal", "-shm"] {
+                let url = storeDir.appendingPathComponent("workflows.store\(suffix)")
+                try? FileManager.default.removeItem(at: url)
+            }
+
+            do {
+                modelContainer = try ModelContainer(for: schema, configurations: [config])
+            } catch {
+                fatalError("Failed to create workflows ModelContainer after reset: \(error)")
+            }
+        }
+
+        modelContext = ModelContext(modelContainer)
+        modelContext.autosaveEnabled = true
+
+        fetchWorkflows()
+    }
+
+    @discardableResult
+    func addWorkflow(
+        name: String,
+        template: WorkflowTemplate,
+        trigger: WorkflowTrigger,
+        behavior: WorkflowBehavior = WorkflowBehavior(),
+        output: WorkflowOutput = WorkflowOutput(),
+        isEnabled: Bool = true,
+        sortOrder: Int? = nil
+    ) -> Workflow? {
+        let workflow = Workflow(
+            name: name,
+            isEnabled: isEnabled,
+            sortOrder: sortOrder ?? nextSortOrder(),
+            template: template,
+            trigger: trigger,
+            behavior: behavior,
+            output: output
+        )
+
+        modelContext.insert(workflow)
+        save()
+        fetchWorkflows()
+        return workflow
+    }
+
+    func nextSortOrder() -> Int {
+        (workflows.map(\.sortOrder).max() ?? -1) + 1
+    }
+
+    func updateWorkflow(_ workflow: Workflow) {
+        workflow.updatedAt = Date()
+        save()
+        fetchWorkflows()
+    }
+
+    func deleteWorkflow(_ workflow: Workflow) {
+        modelContext.delete(workflow)
+        save()
+        fetchWorkflows()
+    }
+
+    func toggleWorkflow(_ workflow: Workflow) {
+        workflow.isEnabled.toggle()
+        workflow.updatedAt = Date()
+        save()
+        fetchWorkflows()
+    }
+
+    func reorderWorkflows(_ orderedWorkflows: [Workflow]) {
+        for (index, workflow) in orderedWorkflows.enumerated() {
+            workflow.sortOrder = index
+            workflow.updatedAt = Date()
+        }
+
+        save()
+        fetchWorkflows()
+    }
+
+    func workflow(id: UUID) -> Workflow? {
+        workflows.first(where: { $0.id == id })
+    }
+
+    func forcedWorkflowMatch(for workflow: Workflow) -> WorkflowMatchResult {
+        WorkflowMatchResult(
+            workflow: workflow,
+            kind: .manualOverride,
+            matchedDomain: nil,
+            competingWorkflowCount: 0,
+            wonBySortOrder: false
+        )
+    }
+
+    func matchWorkflow(bundleIdentifier: String?, url: String? = nil) -> WorkflowMatchResult? {
+        let bundleId = bundleIdentifier ?? ""
+        let domain = extractDomain(from: url)
+        let enabled = workflows.filter(\.isEnabled)
+
+        if let domain {
+            let matches = enabled.filter { workflow in
+                guard let trigger = workflow.trigger, trigger.kind == .website else { return false }
+                return trigger.websitePatterns.contains { pattern in
+                    !pattern.isEmpty && domainMatches(domain, pattern: pattern)
+                }
+            }
+            if let result = bestMatch(from: matches, kind: .website, matchedDomain: domain) {
+                return result
+            }
+        }
+
+        if !bundleId.isEmpty {
+            let matches = enabled.filter { workflow in
+                guard let trigger = workflow.trigger, trigger.kind == .app else { return false }
+                return trigger.appBundleIdentifiers.contains(bundleId)
+            }
+            if let result = bestMatch(from: matches, kind: .app, matchedDomain: nil) {
+                return result
+            }
+        }
+
+        return nil
+    }
+
+    private func fetchWorkflows() {
+        let descriptor = FetchDescriptor<Workflow>(
+            sortBy: [SortDescriptor(\.sortOrder, order: .forward), SortDescriptor(\.name)]
+        )
+
+        do {
+            workflows = try modelContext.fetch(descriptor)
+        } catch {
+            workflows = []
+        }
+    }
+
+    private func save() {
+        do {
+            try modelContext.save()
+        } catch {
+            workflowLogger.error("Save failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func extractDomain(from urlString: String?) -> String? {
+        guard let urlString,
+              !urlString.isEmpty,
+              let url = URL(string: urlString),
+              let host = url.host() else {
+            return nil
+        }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+
+    private func domainMatches(_ domain: String, pattern: String) -> Bool {
+        let normalizedDomain = domain.lowercased()
+        let normalizedPattern = pattern.lowercased()
+        return normalizedDomain == normalizedPattern || normalizedDomain.hasSuffix("." + normalizedPattern)
+    }
+
+    private func bestMatch(
+        from matches: [Workflow],
+        kind: WorkflowMatchKind,
+        matchedDomain: String?
+    ) -> WorkflowMatchResult? {
+        let sorted = matches.sorted {
+            if $0.sortOrder != $1.sortOrder {
+                return $0.sortOrder < $1.sortOrder
+            }
+            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+
+        guard let best = sorted.first else { return nil }
+        let secondSortOrder = sorted.dropFirst().first?.sortOrder
+
+        return WorkflowMatchResult(
+            workflow: best,
+            kind: kind,
+            matchedDomain: matchedDomain,
+            competingWorkflowCount: max(sorted.count - 1, 0),
+            wonBySortOrder: secondSortOrder.map { best.sortOrder < $0 } ?? false
+        )
+    }
+}

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -6,6 +6,7 @@ final class DictationSettingsHandler {
     private let audioRecordingService: AudioRecordingService
     private let textInsertionService: TextInsertionService
     private let profileService: ProfileService
+    private let workflowService: WorkflowService
     private var permissionPollTask: Task<Void, Never>?
 
     var onObjectWillChange: (() -> Void)?
@@ -15,12 +16,14 @@ final class DictationSettingsHandler {
         hotkeyService: HotkeyService,
         audioRecordingService: AudioRecordingService,
         textInsertionService: TextInsertionService,
-        profileService: ProfileService
+        profileService: ProfileService,
+        workflowService: WorkflowService
     ) {
         self.hotkeyService = hotkeyService
         self.audioRecordingService = audioRecordingService
         self.textInsertionService = textInsertionService
         self.profileService = profileService
+        self.workflowService = workflowService
     }
 
     func requestMicPermission() {
@@ -60,8 +63,14 @@ final class DictationSettingsHandler {
         return ""
     }
 
-    func registerInitialProfileHotkeys() {
+    func registerInitialTriggerHotkeys() {
         syncProfileHotkeys(profileService.profiles)
+        syncWorkflowHotkeys(workflowService.workflows)
+    }
+
+    @available(*, deprecated, renamed: "registerInitialTriggerHotkeys")
+    func registerInitialProfileHotkeys() {
+        registerInitialTriggerHotkeys()
     }
 
     func syncProfileHotkeys(_ profiles: [Profile]) {
@@ -72,6 +81,20 @@ final class DictationSettingsHandler {
                 return (id: profile.id, hotkey: hotkey)
             }
         hotkeyService.registerProfileHotkeys(entries)
+    }
+
+    func syncWorkflowHotkeys(_ workflows: [Workflow]) {
+        let entries = workflows
+            .filter(\.isEnabled)
+            .flatMap { workflow -> [(id: UUID, hotkey: UnifiedHotkey)] in
+                guard let trigger = workflow.trigger, trigger.kind == .hotkey else {
+                    return []
+                }
+                return trigger.hotkeys.map { hotkey in
+                    (id: workflow.id, hotkey: hotkey)
+                }
+            }
+        hotkeyService.registerWorkflowHotkeys(entries)
     }
 
     func pollPermissionStatus() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -137,6 +137,7 @@ final class DictationViewModel: ObservableObject {
     private let historyService: HistoryService
     private let recentTranscriptionStore: RecentTranscriptionStore
     private let profileService: ProfileService
+    private let workflowService: WorkflowService
     private let translationService: AnyObject? // TranslationService (macOS 15+)
     private let audioDuckingService: AudioDuckingService
     private let dictionaryService: DictionaryService
@@ -150,9 +151,12 @@ final class DictationViewModel: ObservableObject {
     private let errorLogService: ErrorLogService
     private let mediaPlaybackService: MediaPlaybackService
     private let postProcessingPipeline: PostProcessingPipeline
+    private var matchedWorkflow: Workflow?
+    private var activeWorkflowMatch: WorkflowMatchResult?
     private var matchedProfile: Profile?
     private var activeRuleMatch: RuleMatchResult?
     private var forcedProfileId: UUID?
+    private var forcedWorkflowId: UUID?
     private var capturedActiveApp: (name: String?, bundleId: String?, url: String?)?
     private var capturedSelectedText: String?
 
@@ -203,6 +207,7 @@ final class DictationViewModel: ObservableObject {
         historyService: HistoryService,
         recentTranscriptionStore: RecentTranscriptionStore,
         profileService: ProfileService,
+        workflowService: WorkflowService,
         translationService: AnyObject?,
         audioDuckingService: AudioDuckingService,
         dictionaryService: DictionaryService,
@@ -225,6 +230,7 @@ final class DictationViewModel: ObservableObject {
         self.historyService = historyService
         self.recentTranscriptionStore = recentTranscriptionStore
         self.profileService = profileService
+        self.workflowService = workflowService
         self.translationService = translationService
         self.audioDuckingService = audioDuckingService
         self.dictionaryService = dictionaryService
@@ -256,7 +262,7 @@ final class DictationViewModel: ObservableObject {
         )
         self.promptPaletteHandler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
-            promptActionService: promptActionService,
+            workflowService: workflowService,
             promptProcessingService: promptProcessingService,
             soundService: soundService,
             accessibilityAnnouncementService: accessibilityAnnouncementService
@@ -270,7 +276,8 @@ final class DictationViewModel: ObservableObject {
             hotkeyService: hotkeyService,
             audioRecordingService: audioRecordingService,
             textInsertionService: textInsertionService,
-            profileService: profileService
+            profileService: profileService,
+            workflowService: workflowService
         )
         self.audioDuckingEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.audioDuckingEnabled)
         self.audioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2
@@ -503,6 +510,10 @@ final class DictationViewModel: ObservableObject {
             self?.startRecording(forcedProfileId: profileId)
         }
 
+        hotkeyService.onWorkflowDictationStart = { [weak self] workflowId in
+            self?.startRecording(forcedWorkflowId: workflowId)
+        }
+
         hotkeyService.onCancelPressed = { [weak self] in
             self?.handleCancelHotkey()
         }
@@ -518,6 +529,14 @@ final class DictationViewModel: ObservableObject {
             .sink { [weak self] profiles in
                 guard let self else { return }
                 self.settingsHandler.syncProfileHotkeys(profiles)
+            }
+            .store(in: &cancellables)
+
+        workflowService.$workflows
+            .dropFirst()
+            .sink { [weak self] workflows in
+                guard let self else { return }
+                self.settingsHandler.syncWorkflowHotkeys(workflows)
             }
             .store(in: &cancellables)
 
@@ -613,7 +632,11 @@ final class DictationViewModel: ObservableObject {
         }
     }
 
-    private func startRecording(forcedProfileId: UUID? = nil, sessionID: UUID = UUID()) {
+    private func startRecording(
+        forcedProfileId: UUID? = nil,
+        forcedWorkflowId: UUID? = nil,
+        sessionID: UUID = UUID()
+    ) {
         let startTimestamp = CFAbsoluteTimeGetCurrent()
 
         // Dismiss prompt palette if active
@@ -639,6 +662,7 @@ final class DictationViewModel: ObservableObject {
         urlResolutionTask = nil
 
         self.forcedProfileId = forcedProfileId
+        self.forcedWorkflowId = forcedWorkflowId
         beginDictationSession(id: sessionID)
 
         guard canDictate else {
@@ -661,9 +685,14 @@ final class DictationViewModel: ObservableObject {
         capturedSelectedText = nil
         activeAppIcon = nil
 
-        if let forcedProfileId,
+        if let forcedWorkflowId,
+           let forcedWorkflow = workflowService.workflows.first(where: { $0.id == forcedWorkflowId && $0.isEnabled }) {
+            applyWorkflowMatch(workflowService.forcedWorkflowMatch(for: forcedWorkflow), activeApp: activeApp)
+        } else if let forcedProfileId,
            let forcedProfile = profileService.profiles.first(where: { $0.id == forcedProfileId && $0.isEnabled }) {
             applyRuleMatch(profileService.forcedRuleMatch(for: forcedProfile), activeApp: activeApp)
+        } else if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: activeApp.bundleId, url: nil) {
+            applyWorkflowMatch(workflowMatch, activeApp: activeApp)
         } else {
             applyRuleMatch(profileService.matchRule(bundleIdentifier: activeApp.bundleId, url: nil), activeApp: activeApp)
         }
@@ -695,7 +724,11 @@ final class DictationViewModel: ObservableObject {
                 appName: capturedActiveApp?.name,
                 bundleIdentifier: capturedActiveApp?.bundleId
             )))
-            scheduleDeferredRecordingMetadataCapture(activeApp: activeApp, forcedProfileId: forcedProfileId)
+            scheduleDeferredRecordingMetadataCapture(
+                activeApp: activeApp,
+                forcedProfileId: forcedProfileId,
+                forcedWorkflowId: forcedWorkflowId
+            )
 
             let totalStartMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
             logger.info(
@@ -724,7 +757,8 @@ final class DictationViewModel: ObservableObject {
 
     private func scheduleDeferredRecordingMetadataCapture(
         activeApp: (name: String?, bundleId: String?, url: String?),
-        forcedProfileId: UUID?
+        forcedProfileId: UUID?,
+        forcedWorkflowId: UUID?
     ) {
         let metadataStartTimestamp = CFAbsoluteTimeGetCurrent()
 
@@ -752,7 +786,7 @@ final class DictationViewModel: ObservableObject {
         // Resolve browser URL asynchronously after recording has already started.
         // If a more specific URL rule matches, update the active rule on the fly.
         // Skip URL resolution when a forced rule is set (manual rule shortcut overrides app matching).
-        guard forcedProfileId == nil, let bundleId = activeApp.bundleId else { return }
+        guard forcedProfileId == nil, forcedWorkflowId == nil, let bundleId = activeApp.bundleId else { return }
         urlResolutionTask = Task { [weak self] in
             guard let self else { return }
             logger.info("URL resolution: starting for bundleId=\(bundleId)")
@@ -773,12 +807,24 @@ final class DictationViewModel: ObservableObject {
                 logger.info("URL resolution: no URL resolved")
                 return
             }
-            guard let refinedRule = profileService.matchRule(bundleIdentifier: bundleId, url: resolvedURL) else {
-                logger.info("URL resolution: no rule matched for URL \(resolvedURL)")
+
+            if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: bundleId, url: resolvedURL) {
+                logger.info("URL resolution: matched workflow '\(workflowMatch.workflow.name)'")
+                applyWorkflowMatch(workflowMatch, activeApp: capturedActiveApp)
+                refreshLiveStreamingIfParamsChanged()
                 return
             }
 
-            logger.info("URL resolution: matched rule '\(refinedRule.profile.name)'")
+            guard matchedWorkflow == nil else {
+                logger.info("URL resolution: keeping existing workflow match")
+                return
+            }
+            guard let refinedRule = profileService.matchRule(bundleIdentifier: bundleId, url: resolvedURL) else {
+                logger.info("URL resolution: no legacy rule matched for URL \(resolvedURL)")
+                return
+            }
+
+            logger.info("URL resolution: matched legacy rule '\(refinedRule.profile.name)'")
             applyRuleMatch(refinedRule, activeApp: capturedActiveApp)
             refreshLiveStreamingIfParamsChanged()
         }
@@ -833,11 +879,30 @@ final class DictationViewModel: ObservableObject {
         matchedProfile?.cloudModelOverride
     }
 
+    private var effectiveRuleName: String? {
+        matchedWorkflow?.name ?? matchedProfile?.name
+    }
+
     private var effectivePromptAction: PromptAction? {
         if let actionId = matchedProfile?.promptActionId {
             return promptActionService.action(byId: actionId)
         }
         return nil
+    }
+
+    private var effectiveOutputFormat: String? {
+        matchedWorkflow?.output.format ?? matchedProfile?.outputFormat
+    }
+
+    private var effectiveActionPluginId: String? {
+        matchedWorkflow?.output.targetActionPluginId ?? effectivePromptAction?.targetActionPluginId
+    }
+
+    private var effectiveAutoEnterEnabled: Bool {
+        if let matchedWorkflow {
+            return matchedWorkflow.output.autoEnter
+        }
+        return matchedProfile?.autoEnterEnabled == true
     }
 
     private func stopDictation() {
@@ -1002,7 +1067,11 @@ final class DictationViewModel: ObservableObject {
 
                 // Post-processing pipeline (priority-based)
                 let llmStepName: String? = if llmHandler != nil {
-                    (self.effectivePromptAction != nil || self.matchedProfile?.inlineCommandsEnabled == true) ? "Prompt" : "Translation"
+                    if self.matchedWorkflow != nil {
+                        "Workflow"
+                    } else {
+                        (self.effectivePromptAction != nil || self.matchedProfile?.inlineCommandsEnabled == true) ? "Prompt" : "Translation"
+                    }
                 } else {
                     nil
                 }
@@ -1013,12 +1082,12 @@ final class DictationViewModel: ObservableObject {
                     bundleIdentifier: activeApp.bundleId,
                     url: activeApp.url,
                     language: language,
-                    ruleName: self.matchedProfile?.name,
+                    ruleName: self.effectiveRuleName,
                     selectedText: self.capturedSelectedText
                 )
                 let ppResult = try await postProcessingPipeline.process(
                     text: text, context: ppContext, llmHandler: llmHandler,
-                    outputFormat: self.matchedProfile?.outputFormat,
+                    outputFormat: self.effectiveOutputFormat,
                     llmStepName: llmStepName
                 )
                 text = ppResult.text
@@ -1035,7 +1104,7 @@ final class DictationViewModel: ObservableObject {
                 partialText = ""
 
                 // Route to action plugin or insert text
-                if let actionPluginId = self.effectivePromptAction?.targetActionPluginId,
+                if let actionPluginId = self.effectiveActionPluginId,
                    let actionPlugin = PluginManager.shared.actionPlugin(for: actionPluginId) {
                     try await executeActionPlugin(
                         actionPlugin, pluginId: actionPluginId, text: text,
@@ -1045,7 +1114,7 @@ final class DictationViewModel: ObservableObject {
                     _ = try await textInsertionService.insertText(
                         text,
                         preserveClipboard: preserveClipboard,
-                        autoEnter: self.matchedProfile?.autoEnterEnabled == true
+                        autoEnter: self.effectiveAutoEnterEnabled
                     )
                     EventBus.shared.emit(.textInserted(TextInsertedPayload(
                         text: text,
@@ -1086,7 +1155,7 @@ final class DictationViewModel: ObservableObject {
                     appName: activeApp.name,
                     bundleIdentifier: activeApp.bundleId,
                     url: activeApp.url,
-                    ruleName: self.matchedProfile?.name
+                    ruleName: self.effectiveRuleName
                 )))
 
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
@@ -1151,9 +1220,12 @@ final class DictationViewModel: ObservableObject {
         DictationSettingsHandler.loadHotkeyLabel(for: slotType)
     }
 
-    /// Register profile hotkeys after app is fully initialized.
+    /// Register profile/workflow hotkeys after app is fully initialized.
     /// Called from ServiceContainer.initialize() to avoid early monitor setup.
-    func registerInitialProfileHotkeys() { settingsHandler.registerInitialProfileHotkeys() }
+    func registerInitialTriggerHotkeys() { settingsHandler.registerInitialTriggerHotkeys() }
+
+    @available(*, deprecated, renamed: "registerInitialTriggerHotkeys")
+    func registerInitialProfileHotkeys() { registerInitialTriggerHotkeys() }
 
     private func resetDictationState() {
         errorResetTask?.cancel()
@@ -1187,10 +1259,27 @@ final class DictationViewModel: ObservableObject {
         pendingPushToTalkDiscardMessage = String(localized: "Recording discarded because additional keys were pressed")
     }
 
+    private func applyWorkflowMatch(
+        _ match: WorkflowMatchResult?,
+        activeApp: (name: String?, bundleId: String?, url: String?)?
+    ) {
+        activeWorkflowMatch = match
+        matchedWorkflow = match?.workflow
+        matchedProfile = nil
+        activeRuleMatch = nil
+        forcedProfileId = nil
+        activeRuleName = match?.workflow.name
+        activeRuleReasonLabel = match?.kind.label
+        activeRuleExplanation = match.map { workflowExplanation(for: $0, activeApp: activeApp) }
+    }
+
     private func applyRuleMatch(
         _ match: RuleMatchResult?,
         activeApp: (name: String?, bundleId: String?, url: String?)?
     ) {
+        activeWorkflowMatch = nil
+        matchedWorkflow = nil
+        forcedWorkflowId = nil
         activeRuleMatch = match
         matchedProfile = match?.profile
         activeRuleName = match?.profile.name
@@ -1245,12 +1334,54 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func clearActiveRuleState() {
+        matchedWorkflow = nil
+        activeWorkflowMatch = nil
         matchedProfile = nil
         activeRuleMatch = nil
         forcedProfileId = nil
+        forcedWorkflowId = nil
         activeRuleName = nil
         activeRuleReasonLabel = nil
         activeRuleExplanation = nil
+    }
+
+    private func workflowExplanation(
+        for match: WorkflowMatchResult,
+        activeApp: (name: String?, bundleId: String?, url: String?)?
+    ) -> String {
+        let appDescriptor = activeApp?.name ?? activeApp?.bundleId ?? "the active app"
+
+        let base: String
+        switch match.kind {
+        case .website:
+            if let domain = match.matchedDomain {
+                base = localizedAppText(
+                    "This workflow applies because \(domain) was detected.",
+                    de: "Dieser Workflow greift, weil \(domain) erkannt wurde."
+                )
+            } else {
+                base = localizedAppText(
+                    "This workflow applies because the current website was detected.",
+                    de: "Dieser Workflow greift, weil die aktuelle Website erkannt wurde."
+                )
+            }
+        case .app:
+            base = localizedAppText(
+                "This workflow applies because \(appDescriptor) was detected.",
+                de: "Dieser Workflow greift, weil \(appDescriptor) erkannt wurde."
+            )
+        case .manualOverride:
+            base = localizedAppText(
+                "This workflow was manually triggered via its keyboard shortcut.",
+                de: "Dieser Workflow wurde manuell ueber seine Tastenkombination ausgeloest."
+            )
+        }
+
+        guard match.wonBySortOrder else { return base }
+        return base + localizedAppText(
+            " Among multiple matching workflows, the one higher in the list wins here.",
+            de: " Unter mehreren passenden Workflows gewinnt hier der weiter oben stehende Eintrag."
+        )
     }
 
     private func ruleExplanation(
@@ -1312,12 +1443,31 @@ final class DictationViewModel: ObservableObject {
     // MARK: - Shared Helpers
 
     /// Builds an LLM handler for the post-processing pipeline.
-    /// Priority: inline commands > prompt action > translation > nil.
+    /// Priority: workflow > legacy inline/prompt action > translation > nil.
     private func buildLLMHandler(
         translationTarget: String?,
         detectedLanguage: String?,
         configuredLanguage: String?
     ) -> ((String) async throws -> String)? {
+        if let matchedWorkflow,
+           let systemPrompt = matchedWorkflow.systemPrompt(
+                fallbackTranslationTarget: translationTarget,
+                detectedLanguage: detectedLanguage,
+                configuredLanguage: configuredLanguage
+           ) {
+            let pps = promptProcessingService
+            let behavior = matchedWorkflow.behavior
+            return { text in
+                try await pps.process(
+                    prompt: systemPrompt,
+                    text: text,
+                    providerOverride: behavior.providerId,
+                    cloudModelOverride: behavior.cloudModel,
+                    temperatureDirective: behavior.temperatureDirective
+                )
+            }
+        }
+
         // Inline commands compose with profile prompt; otherwise use prompt action directly
         let inlineEnabled = matchedProfile?.inlineCommandsEnabled == true
         if inlineEnabled || effectivePromptAction != nil {
@@ -1420,14 +1570,14 @@ final class DictationViewModel: ObservableObject {
         )))
     }
 
-    // MARK: - Standalone Prompt Palette
+    // MARK: - Workflow Palette
 
     func readBackLastTranscription() {
         guard let text = lastTranscribedText else { return }
         speechFeedbackService.readBack(text: text, language: lastTranscriptionLanguage)
     }
 
-    func triggerStandalonePromptSelection() {
+    func triggerWorkflowPalette() {
         recentTranscriptionPaletteHandler.hide()
         promptPaletteHandler.triggerSelection(currentState: state, soundFeedbackEnabled: soundFeedbackEnabled)
     }

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -244,6 +244,7 @@ final class ProfilesViewModel: ObservableObject {
     }
 
     @Published var profiles: [Profile] = []
+    @Published private(set) var focusedPromptActionId: String?
 
     // Editor state
     @Published var showingEditor = false
@@ -283,6 +284,7 @@ final class ProfilesViewModel: ObservableObject {
     @Published var editorDetectedDomain: String?
     @Published var editorDetectedIsSupportedBrowser = false
     @Published var showingWebsiteScope = false
+    @Published private(set) var editorPromptActionWasPrefilled = false
     var availableDomains: [String] = []
 
     private let profileService: ProfileService
@@ -306,6 +308,25 @@ final class ProfilesViewModel: ObservableObject {
         return installedApps.filter {
             $0.name.lowercased().contains(query) || $0.id.lowercased().contains(query)
         }
+    }
+
+    var isFilteringRulesByPrompt: Bool {
+        focusedPromptActionId != nil
+    }
+
+    var focusedPromptAction: PromptAction? {
+        guard let focusedPromptActionId else { return nil }
+        return availablePromptActions.first { $0.id.uuidString == focusedPromptActionId }
+    }
+
+    var editorPromptAction: PromptAction? {
+        guard let editorPromptActionId else { return nil }
+        return availablePromptActions.first { $0.id.uuidString == editorPromptActionId }
+    }
+
+    var visibleProfiles: [Profile] {
+        guard let focusedPromptActionId else { return profiles }
+        return profiles.filter { $0.promptActionId == focusedPromptActionId }
     }
 
     var suggestedRuleName: String {
@@ -339,6 +360,12 @@ final class ProfilesViewModel: ObservableObject {
         case .behavior, .review:
             return true
         }
+    }
+    var shouldShowPrefilledPromptFallbackNotice: Bool {
+        editorPromptActionWasPrefilled &&
+        editorPromptActionId != nil &&
+        editorBundleIdentifiers.isEmpty &&
+        editorUrlPatterns.isEmpty
     }
 
     // MARK: - CRUD
@@ -431,8 +458,9 @@ final class ProfilesViewModel: ObservableObject {
 
     // MARK: - Editor
 
-    func prepareNewProfile() {
+    func prepareNewProfile(prefilledPromptActionId: String? = nil) {
         editingProfile = nil
+        focusedPromptActionId = prefilledPromptActionId
         editorStep = .scope
         editorIsEnabled = true
         showingAdvancedSettings = false
@@ -446,7 +474,7 @@ final class ProfilesViewModel: ObservableObject {
         editorSelectedTask = nil
         editorEngineOverride = nil
         editorCloudModelOverride = nil
-        editorPromptActionId = nil
+        editorPromptActionId = prefilledPromptActionId
         editorMemoryEnabled = false
         editorOutputFormat = nil
         editorInlineCommandsEnabled = false
@@ -454,6 +482,7 @@ final class ProfilesViewModel: ObservableObject {
         editorHotkey = nil
         editorHotkeyLabel = ""
         editorPriority = 0
+        editorPromptActionWasPrefilled = prefilledPromptActionId != nil
         urlPatternInput = ""
         domainSuggestions = []
         editorDetectedAppName = nil
@@ -506,6 +535,7 @@ final class ProfilesViewModel: ObservableObject {
         editorDetectedDomain = nil
         editorDetectedIsSupportedBrowser = false
         showingWebsiteScope = !profile.urlPatterns.isEmpty
+        editorPromptActionWasPrefilled = false
         loadAvailableDomains()
         refreshEditorContext()
         showingEditor = true
@@ -517,6 +547,31 @@ final class ProfilesViewModel: ObservableObject {
         } else {
             editorBundleIdentifiers.append(bundleId)
         }
+    }
+
+    func focusRules(usingPromptActionId promptActionId: String) {
+        focusedPromptActionId = promptActionId
+        showingEditor = false
+    }
+
+    func clearPromptRuleFocus() {
+        focusedPromptActionId = nil
+    }
+
+    func promptAction(for profile: Profile) -> PromptAction? {
+        guard let promptActionId = profile.promptActionId else { return nil }
+        return availablePromptActions.first { $0.id.uuidString == promptActionId }
+    }
+
+    func editPrompt(for profile: Profile) {
+        guard let promptAction = promptAction(for: profile) else { return }
+        editPrompt(promptActionId: promptAction.id.uuidString)
+    }
+
+    func editPrompt(promptActionId: String) {
+        guard let promptAction = availablePromptActions.first(where: { $0.id.uuidString == promptActionId }) else { return }
+        PromptActionsViewModel.shared.startEditing(promptAction)
+        SettingsNavigationCoordinator.shared.navigate(to: .prompts)
     }
 
     // MARK: - App Scanner
@@ -962,5 +1017,11 @@ final class ProfilesViewModel: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+    }
+}
+
+private extension ProfilesViewModel {
+    var availablePromptActions: [PromptAction] {
+        PromptActionsViewModel._shared?.promptActions ?? []
     }
 }

--- a/TypeWhisper/ViewModels/PromptActionsViewModel.swift
+++ b/TypeWhisper/ViewModels/PromptActionsViewModel.swift
@@ -2,6 +2,12 @@ import Foundation
 import Combine
 import TypeWhisperPluginSDK
 
+struct PromptRuleAssignmentStatus: Equatable {
+    let ruleCount: Int
+
+    var isAssigned: Bool { ruleCount > 0 }
+}
+
 @MainActor
 class PromptActionsViewModel: ObservableObject {
     nonisolated(unsafe) static var _shared: PromptActionsViewModel?
@@ -15,6 +21,7 @@ class PromptActionsViewModel: ObservableObject {
     @Published var promptActions: [PromptAction] = []
     @Published var error: String?
     @Published var navigateToIntegrations = false
+    @Published var pendingRuleAssignmentPromptId: String?
 
     // Editor state
     @Published var isEditing = false
@@ -34,6 +41,7 @@ class PromptActionsViewModel: ObservableObject {
     @Published var manualPromptOverride = false
 
     private let promptActionService: PromptActionService
+    private let profileService: ProfileService?
     var promptProcessingService: PromptProcessingService
     private var cancellables = Set<AnyCancellable>()
     private var selectedAction: PromptAction?
@@ -52,9 +60,22 @@ class PromptActionsViewModel: ObservableObject {
         }
         return suggestedPromptName
     }
+    var pendingRuleAssignmentPrompt: PromptAction? {
+        guard let pendingRuleAssignmentPromptId else { return nil }
+        return promptActionService.action(byId: pendingRuleAssignmentPromptId)
+    }
+    var shouldShowRuleAssignmentCallout: Bool {
+        guard let action = pendingRuleAssignmentPrompt else { return false }
+        return !assignmentStatus(for: action).isAssigned
+    }
 
-    init(promptActionService: PromptActionService, promptProcessingService: PromptProcessingService) {
+    init(
+        promptActionService: PromptActionService,
+        promptProcessingService: PromptProcessingService,
+        profileService: ProfileService? = nil
+    ) {
         self.promptActionService = promptActionService
+        self.profileService = profileService
         self.promptProcessingService = promptProcessingService
         self.promptActions = promptActionService.promptActions
         setupBindings()
@@ -66,6 +87,15 @@ class PromptActionsViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] actions in
                 self?.promptActions = actions
+            }
+            .store(in: &cancellables)
+
+        profileService?.$profiles
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshPendingRuleAssignmentCalloutState()
+                self?.objectWillChange.send()
             }
             .store(in: &cancellables)
     }
@@ -136,8 +166,9 @@ class PromptActionsViewModel: ObservableObject {
             regeneratePromptFromWizardSelections()
         }
 
+        let savedAction: PromptAction?
         if isCreatingNew {
-            promptActionService.addAction(
+            savedAction = promptActionService.addAction(
                 name: resolvedName,
                 prompt: editPrompt,
                 icon: editIcon,
@@ -149,7 +180,7 @@ class PromptActionsViewModel: ObservableObject {
                 targetActionPluginId: editTargetActionPluginId
             )
         } else if let action = selectedAction {
-            promptActionService.updateAction(
+            savedAction = promptActionService.updateAction(
                 action,
                 name: resolvedName,
                 prompt: editPrompt,
@@ -161,12 +192,18 @@ class PromptActionsViewModel: ObservableObject {
                 temperatureValue: editTemperatureMode == .custom ? editTemperatureValue : nil,
                 targetActionPluginId: editTargetActionPluginId
             )
+        } else {
+            savedAction = nil
         }
 
+        updatePendingRuleAssignment(for: savedAction)
         cancelEditing()
     }
 
     func deleteAction(_ action: PromptAction) {
+        if pendingRuleAssignmentPromptId == action.id.uuidString {
+            pendingRuleAssignmentPromptId = nil
+        }
         promptActionService.deleteAction(action)
     }
 
@@ -192,6 +229,56 @@ class PromptActionsViewModel: ObservableObject {
 
     func clearError() {
         error = nil
+    }
+
+    func assignmentStatus(for action: PromptAction) -> PromptRuleAssignmentStatus {
+        PromptRuleAssignmentStatus(ruleCount: ruleCount(forPromptActionId: action.id.uuidString))
+    }
+
+    func assignmentSummary(for action: PromptAction) -> String {
+        let status = assignmentStatus(for: action)
+        if status.isAssigned {
+            let ruleCount = status.ruleCount
+            return localizedAppText(
+                "Used in \(ruleCount) rule\(ruleCount == 1 ? "" : "s")",
+                de: "In \(ruleCount) Regel\(ruleCount == 1 ? "" : "n") verwendet"
+            )
+        }
+
+        return localizedAppText(
+            "Not used in any rules",
+            de: "Nicht in Regeln verwendet"
+        )
+    }
+
+    func rulesUsing(_ action: PromptAction) -> [Profile] {
+        profilesForAssignmentStatus.filter { $0.promptActionId == action.id.uuidString }
+    }
+
+    func showRules(for action: PromptAction) {
+        pendingRuleAssignmentPromptId = nil
+        ProfilesViewModel.shared.focusRules(usingPromptActionId: action.id.uuidString)
+        SettingsNavigationCoordinator.shared.navigate(to: .profiles)
+    }
+
+    func openRule(_ profile: Profile) {
+        if let promptActionId = profile.promptActionId {
+            ProfilesViewModel.shared.focusRules(usingPromptActionId: promptActionId)
+        } else {
+            ProfilesViewModel.shared.clearPromptRuleFocus()
+        }
+        ProfilesViewModel.shared.prepareEditProfile(profile)
+        SettingsNavigationCoordinator.shared.navigate(to: .profiles)
+    }
+
+    func createRule(for action: PromptAction) {
+        pendingRuleAssignmentPromptId = nil
+        ProfilesViewModel.shared.prepareNewProfile(prefilledPromptActionId: action.id.uuidString)
+        SettingsNavigationCoordinator.shared.navigate(to: .profiles)
+    }
+
+    func dismissRuleAssignmentCallout() {
+        pendingRuleAssignmentPromptId = nil
     }
 
     func setWizardGoal(_ goal: PromptWizardGoal) {
@@ -369,6 +456,37 @@ class PromptActionsViewModel: ObservableObject {
 
     func defaultTemperatureValue(for providerId: String?) -> Double {
         providerId == "Gemma 4 (MLX)" ? 0.1 : 0.3
+    }
+
+    private var profilesForAssignmentStatus: [Profile] {
+        profileService?.profiles ?? ProfilesViewModel._shared?.profiles ?? []
+    }
+
+    private func ruleCount(forPromptActionId promptActionId: String) -> Int {
+        profilesForAssignmentStatus.filter { $0.promptActionId == promptActionId }.count
+    }
+
+    private func updatePendingRuleAssignment(for action: PromptAction?) {
+        guard let action else {
+            pendingRuleAssignmentPromptId = nil
+            return
+        }
+
+        pendingRuleAssignmentPromptId = assignmentStatus(for: action).isAssigned
+            ? nil
+            : action.id.uuidString
+    }
+
+    private func refreshPendingRuleAssignmentCalloutState() {
+        guard let pendingRuleAssignmentPromptId else { return }
+        guard let action = promptActionService.action(byId: pendingRuleAssignmentPromptId) else {
+            self.pendingRuleAssignmentPromptId = nil
+            return
+        }
+
+        if assignmentStatus(for: action).isAssigned {
+            self.pendingRuleAssignmentPromptId = nil
+        }
     }
 
     private func syncEditorFieldsFromWizardDraft(resetName: Bool) {

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -26,7 +26,7 @@ final class PromptPaletteHandler {
 
     private let promptPaletteController: any PromptPaletteControlling
     private let textInsertionService: TextInsertionService
-    private let promptActionService: PromptActionService
+    private let workflowService: WorkflowService
     private let promptProcessingService: PromptProcessingService
     private let soundService: SoundService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
@@ -42,7 +42,7 @@ final class PromptPaletteHandler {
 
     init(
         textInsertionService: TextInsertionService,
-        promptActionService: PromptActionService,
+        workflowService: WorkflowService,
         promptProcessingService: PromptProcessingService,
         soundService: SoundService,
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
@@ -50,7 +50,7 @@ final class PromptPaletteHandler {
     ) {
         self.promptPaletteController = promptPaletteController
         self.textInsertionService = textInsertionService
-        self.promptActionService = promptActionService
+        self.workflowService = workflowService
         self.promptProcessingService = promptProcessingService
         self.soundService = soundService
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
@@ -68,12 +68,8 @@ final class PromptPaletteHandler {
         }
         guard currentState == .idle else { return }
 
-        let actions = promptActionService.getEnabledActions()
-        guard !actions.isEmpty else { return }
-
-        // Palette presentation should not depend on the currently selected provider.
-        // Individual actions may override the provider, and readiness is validated
-        // when the chosen action actually runs.
+        let workflows = workflowService.workflows.filter { $0.isEnabled && $0.isManuallyRunnable }
+        guard !workflows.isEmpty else { return }
 
         // Capture active app BEFORE the palette steals focus
         let activeApp = textInsertionService.captureActiveApp()
@@ -93,7 +89,7 @@ final class PromptPaletteHandler {
             showPalette(
                 text: sel.text, selection: sel, focusedElement: nil,
                 selectionViaCopy: false, activeApp: activeApp,
-                browserInfoTask: browserInfoTask, actions: actions,
+                browserInfoTask: browserInfoTask, workflows: workflows,
                 soundFeedbackEnabled: soundFeedbackEnabled
             )
         } else {
@@ -105,7 +101,7 @@ final class PromptPaletteHandler {
                     showPalette(
                         text: copied, selection: nil, focusedElement: nil,
                         selectionViaCopy: true, activeApp: activeApp,
-                        browserInfoTask: browserInfoTask, actions: actions,
+                        browserInfoTask: browserInfoTask, workflows: workflows,
                         soundFeedbackEnabled: soundFeedbackEnabled
                     )
                 } else if let clipboard = NSPasteboard.general.string(forType: .string), !clipboard.isEmpty {
@@ -114,7 +110,7 @@ final class PromptPaletteHandler {
                     showPalette(
                         text: clipboard, selection: nil, focusedElement: focusedElement,
                         selectionViaCopy: false, activeApp: activeApp,
-                        browserInfoTask: browserInfoTask, actions: actions,
+                        browserInfoTask: browserInfoTask, workflows: workflows,
                         soundFeedbackEnabled: soundFeedbackEnabled
                     )
                 } else {
@@ -122,7 +118,7 @@ final class PromptPaletteHandler {
                     let message = "Please select or copy some text first."
                     soundService.play(.error, enabled: soundFeedbackEnabled)
                     self.accessibilityAnnouncementService.announceError(message)
-                    self.onShowNotchFeedback?(message, "xmark.circle.fill", 2.5, true, "prompt")
+                    self.onShowNotchFeedback?(message, "xmark.circle.fill", 2.5, true, "workflow")
                     self.onShowError?(message)
                 }
             }
@@ -136,7 +132,7 @@ final class PromptPaletteHandler {
         selectionViaCopy: Bool,
         activeApp: (name: String?, bundleId: String?, url: String?),
         browserInfoTask: Task<(url: String?, title: String?), Never>?,
-        actions: [PromptAction],
+        workflows: [Workflow],
         soundFeedbackEnabled: Bool
     ) {
         paletteContext = PaletteContext(
@@ -148,32 +144,37 @@ final class PromptPaletteHandler {
             selectionViaCopy: selectionViaCopy
         )
 
-        promptPaletteController.show(actions: actions, sourceText: text) { [weak self] action in
-            self?.processStandalonePrompt(action: action, soundFeedbackEnabled: soundFeedbackEnabled)
+        promptPaletteController.show(workflows: workflows, sourceText: text) { [weak self] workflow in
+            self?.processStandaloneWorkflow(workflow: workflow, soundFeedbackEnabled: soundFeedbackEnabled)
         }
     }
 
-    private func processStandalonePrompt(action: PromptAction, soundFeedbackEnabled: Bool) {
+    private func processStandaloneWorkflow(workflow: Workflow, soundFeedbackEnabled: Bool) {
         guard let ctx = paletteContext else { return }
         paletteContext = nil
 
-        onShowNotchFeedback?(action.name + "...", "ellipsis.circle", 30, false, nil)
-        accessibilityAnnouncementService.announcePromptProcessing(action.name)
+        onShowNotchFeedback?(workflow.name + "...", "ellipsis.circle", 30, false, nil)
+        accessibilityAnnouncementService.announcePromptProcessing(workflow.name)
 
         Task { [weak self] in
             guard let self else { return }
             do {
-                let result = try await promptProcessingService.process(
-                    prompt: action.prompt,
-                    text: ctx.text,
-                    providerOverride: action.providerType,
-                    cloudModelOverride: action.cloudModel,
-                    temperatureDirective: action.temperatureDirective
-                )
+                let result: String
+                if let systemPrompt = workflow.systemPrompt() {
+                    result = try await promptProcessingService.process(
+                        prompt: systemPrompt,
+                        text: ctx.text,
+                        providerOverride: workflow.behavior.providerId,
+                        cloudModelOverride: workflow.behavior.cloudModel,
+                        temperatureDirective: workflow.behavior.temperatureDirective
+                    )
+                } else {
+                    result = ctx.text
+                }
                 guard !Task.isCancelled else { return }
 
                 // Route to action plugin if configured
-                if let actionPluginId = action.targetActionPluginId,
+                if let actionPluginId = workflow.output.targetActionPluginId,
                    let actionPlugin = PluginManager.shared.actionPlugin(for: actionPluginId) {
                     let browserInfo = await ctx.browserInfoTask?.value
                     let resolvedUrl = browserInfo?.url ?? ctx.activeApp.url
@@ -231,6 +232,11 @@ final class PromptPaletteHandler {
                     textInsertionService.restoreClipboard(savedClipboard)
                 }
 
+                if workflow.output.autoEnter, insertionOutcome != .failed {
+                    try? await Task.sleep(for: .milliseconds(50))
+                    textInsertionService.simulateReturn()
+                }
+
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                 self.accessibilityAnnouncementService.announcePromptComplete()
                 let feedbackMessage: String
@@ -250,7 +256,7 @@ final class PromptPaletteHandler {
                 guard !Task.isCancelled else { return }
                 soundService.play(.error, enabled: soundFeedbackEnabled)
                 self.accessibilityAnnouncementService.announceError(error.localizedDescription)
-                onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "prompt")
+                onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "workflow")
             }
         }
     }

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -233,7 +233,7 @@ struct GeneralSettingsView: View {
         Text(String(localized: "Recording Indicator")).tag(NotchIndicatorContent.indicator)
         Text(String(localized: "Timer")).tag(NotchIndicatorContent.timer)
         Text(String(localized: "Waveform")).tag(NotchIndicatorContent.waveform)
-        Text("Rule").tag(NotchIndicatorContent.profile)
+        Text(localizedAppText("Workflow", de: "Workflow")).tag(NotchIndicatorContent.profile)
         Text(String(localized: "None")).tag(NotchIndicatorContent.none)
     }
 

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -46,10 +46,10 @@ struct HotkeySettingsView: View {
                 )
             }
 
-            Section(String(localized: "Prompt Palette")) {
+            Section(localizedAppText("Workflow Palette", de: "Workflow-Palette")) {
                 HotkeyRecorderView(
                     label: dictation.promptPaletteHotkeyLabel,
-                    title: String(localized: "Palette shortcut"),
+                    title: localizedAppText("Palette shortcut", de: "Palette-Shortcut"),
                     onRecord: { hotkey in
                         if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .promptPalette) {
                             dictation.clearHotkey(for: conflict)
@@ -59,7 +59,10 @@ struct HotkeySettingsView: View {
                     onClear: { dictation.clearHotkey(for: .promptPalette) }
                 )
 
-                Text(String(localized: "Select text in any app, press the shortcut, and choose a prompt to process the text."))
+                Text(localizedAppText(
+                    "Select text in any app, press the shortcut, and choose a workflow to process the text.",
+                    de: "Markiere Text in einer App, drücke den Shortcut und wähle einen Workflow für die Verarbeitung."
+                ))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/TypeWhisper/Views/IndicatorPreviewView.swift
+++ b/TypeWhisper/Views/IndicatorPreviewView.swift
@@ -203,7 +203,7 @@ struct IndicatorPreviewView: View {
             }
             .frame(height: 14)
         case .profile:
-            Text("Rule")
+            Text(localizedAppText("Workflow", de: "Workflow"))
                 .font(.system(size: size * 0.85, weight: .medium))
                 .foregroundStyle(.white)
                 .lineLimit(1)

--- a/TypeWhisper/Views/ProfilesSettingsView.swift
+++ b/TypeWhisper/Views/ProfilesSettingsView.swift
@@ -20,8 +20,14 @@ struct ProfilesSettingsView: View {
                         )
                     }
 
+                    if viewModel.isFilteringRulesByPrompt {
+                        PromptRuleFilterBanner(viewModel: viewModel)
+                    }
+
                     if viewModel.profiles.isEmpty {
                         emptyState
+                    } else if viewModel.visibleProfiles.isEmpty {
+                        filteredEmptyState
                     } else {
                         rulesList
                     }
@@ -89,8 +95,28 @@ struct ProfilesSettingsView: View {
         }
     }
 
+    private var filteredEmptyState: some View {
+        ContentUnavailableView {
+            Label(localizedAppText("No Matching Rules", de: "Keine passenden Regeln"), systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text(localizedAppText(
+                "No rules currently use the selected prompt.",
+                de: "Aktuell nutzt keine Regel den ausgewählten Prompt."
+            ))
+        } actions: {
+            Button(localizedAppText("Show All Rules", de: "Alle Regeln anzeigen")) {
+                viewModel.clearPromptRuleFocus()
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity, minHeight: 220)
+        .background {
+            groupedListSurface(cornerRadius: 16)
+        }
+    }
+
     private var rulesList: some View {
-        let indexedProfiles = Array(viewModel.profiles.enumerated())
+        let indexedProfiles = Array(viewModel.visibleProfiles.enumerated())
 
         return LazyVStack(spacing: 0) {
             ForEach(indexedProfiles, id: \.element.id) { index, profile in
@@ -148,6 +174,49 @@ private struct ActiveRuleBanner: View {
     }
 }
 
+private struct PromptRuleFilterBanner: View {
+    @ObservedObject var viewModel: ProfilesViewModel
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(localizedAppText("Showing rules linked to this prompt.", de: "Es werden Regeln zu diesem Prompt gezeigt."))
+                    .font(.subheadline.weight(.semibold))
+
+                if let promptAction = viewModel.focusedPromptAction {
+                    RulePromptChip(action: promptAction)
+                }
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                if let promptAction = viewModel.focusedPromptAction {
+                    Button(localizedAppText("Open Prompt", de: "Prompt öffnen")) {
+                        viewModel.editPrompt(promptActionId: promptAction.id.uuidString)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+
+                Button(localizedAppText("Show All", de: "Alle anzeigen")) {
+                    viewModel.clearPromptRuleFocus()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+        .padding(16)
+        .background {
+            groupedListSurface(cornerRadius: 16)
+        }
+    }
+}
+
 private struct RuleRow: View {
     let profile: Profile
     @ObservedObject var viewModel: ProfilesViewModel
@@ -183,6 +252,16 @@ private struct RuleRow: View {
                     }
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                    if let promptAction = viewModel.promptAction(for: profile) {
+                        Button {
+                            viewModel.editPrompt(for: profile)
+                        } label: {
+                            RulePromptChip(action: promptAction)
+                        }
+                        .buttonStyle(.plain)
+                        .help(localizedAppText("Open prompt", de: "Prompt öffnen"))
+                    }
                 }
 
                 Spacer()
@@ -279,6 +358,22 @@ private struct RuleRow: View {
                 isPressingReorderHandle = isPressing
             }
             .help(localizedAppText("Change order via drag and drop", de: "Reihenfolge per Drag & Drop ändern"))
+    }
+}
+
+private struct RulePromptChip: View {
+    let action: PromptAction
+
+    var body: some View {
+        Label(
+            localizedAppText("Prompt: \(action.name)", de: "Prompt: \(action.name)"),
+            systemImage: action.icon
+        )
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.accent)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.accentColor.opacity(0.14), in: Capsule())
     }
 }
 
@@ -533,6 +628,35 @@ private struct RuleScopeStep: View {
                 ))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+            }
+
+            if viewModel.shouldShowPrefilledPromptFallbackNotice {
+                HStack(alignment: .top, spacing: 12) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.orange.opacity(0.16))
+                            .frame(width: 36, height: 36)
+
+                        Image(systemName: "sparkles")
+                            .foregroundStyle(.orange)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(String(localized: "Prompt already selected"))
+                            .font(.subheadline.weight(.semibold))
+                        Text(String(localized: "Saving without an app or website creates a global fallback rule with this prompt."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+                }
+                .padding(16)
+                .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(Color.orange.opacity(0.18), lineWidth: 1)
+                }
             }
 
             card(
@@ -864,11 +988,21 @@ private struct RuleBehaviorStep: View {
                         title: localizedAppText("Prompt", de: "Prompt"),
                         description: localizedAppText("Optional post-processing step for this rule.", de: "Optionaler Nachbearbeitungsschritt für diese Regel.")
                     ) {
-                        Picker(localizedAppText("Prompt", de: "Prompt"), selection: $viewModel.editorPromptActionId) {
-                            Text(localizedAppText("None", de: "Keiner")).tag(nil as String?)
-                            Divider()
-                            ForEach(PromptActionsViewModel.shared.promptActions.filter(\.isEnabled)) { action in
-                                Label(action.name, systemImage: action.icon).tag(action.id.uuidString as String?)
+                        HStack(spacing: 10) {
+                            Picker(localizedAppText("Prompt", de: "Prompt"), selection: $viewModel.editorPromptActionId) {
+                                Text(localizedAppText("None", de: "Keiner")).tag(nil as String?)
+                                Divider()
+                                ForEach(PromptActionsViewModel.shared.promptActions.filter(\.isEnabled)) { action in
+                                    Label(action.name, systemImage: action.icon).tag(action.id.uuidString as String?)
+                                }
+                            }
+
+                            if let editorPromptAction = viewModel.editorPromptAction {
+                                Button(localizedAppText("Edit Prompt", de: "Prompt bearbeiten")) {
+                                    viewModel.editPrompt(promptActionId: editorPromptAction.id.uuidString)
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
                             }
                         }
                     }

--- a/TypeWhisper/Views/PromptActionsSettingsView.swift
+++ b/TypeWhisper/Views/PromptActionsSettingsView.swift
@@ -53,10 +53,10 @@ struct PromptActionsSettingsView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(localizedAppText("Prompts", de: "Prompts"))
                     .font(.headline)
-                Text(localizedAppText(
-                    "Create reusable AI actions like translation, replies, extraction, or formatting.",
-                    de: "Erstelle wiederverwendbare KI-Aktionen wie Übersetzen, Antworten, Extrahieren oder Formatieren."
-                ))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(localized: "Build reusable AI actions for Rules or the Prompt Palette."))
+                    Text(String(localized: "Prompts run automatically during dictation only when a rule assigns them. Without a rule, they remain available via the Prompt Palette."))
+                }
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
             }
@@ -204,18 +204,25 @@ struct PromptActionsSettingsView: View {
         let indexedActions = Array(viewModel.promptActions.enumerated())
 
         return ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(indexedActions, id: \.element.id) { index, action in
-                    PromptActionRow(action: action, viewModel: viewModel, processingService: processingService)
+            VStack(alignment: .leading, spacing: 12) {
+                if viewModel.shouldShowRuleAssignmentCallout,
+                   let action = viewModel.pendingRuleAssignmentPrompt {
+                    PromptRuleAssignmentCallout(action: action, viewModel: viewModel)
+                }
 
-                    if index < indexedActions.count - 1 {
-                        Divider()
-                            .padding(.leading, 64)
+                LazyVStack(spacing: 0) {
+                    ForEach(indexedActions, id: \.element.id) { index, action in
+                        PromptActionRow(action: action, viewModel: viewModel, processingService: processingService)
+
+                        if index < indexedActions.count - 1 {
+                            Divider()
+                                .padding(.leading, 64)
+                        }
                     }
                 }
-            }
-            .background {
-                promptWizardGroupedListSurface(cornerRadius: 14)
+                .background {
+                    promptWizardGroupedListSurface(cornerRadius: 14)
+                }
             }
         }
     }
@@ -233,6 +240,7 @@ struct PromptActionsSettingsView: View {
                     "Examples: translate English/German, draft a reply, extract JSON, or turn notes into meeting notes.",
                     de: "Beispiele: Englisch/Deutsch übersetzen, eine Antwort formulieren, JSON extrahieren oder Notizen in Meeting Notes umwandeln."
                 ))
+                Text(String(localized: "Prompts become automatic during dictation only when a rule assigns them. Otherwise they stay available from the Prompt Palette."))
             }
         }
         actions: {
@@ -416,6 +424,9 @@ private struct PromptActionRow: View {
     @State private var isHovering = false
 
     var body: some View {
+        let assignmentStatus = viewModel.assignmentStatus(for: action)
+        let matchingRules = viewModel.rulesUsing(action)
+
         HStack(alignment: .top, spacing: 12) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -447,6 +458,38 @@ private struct PromptActionRow: View {
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+                HStack(spacing: 10) {
+                    if assignmentStatus.isAssigned {
+                        Button {
+                            viewModel.showRules(for: action)
+                        } label: {
+                            PromptRuleAssignmentChip(
+                                title: viewModel.assignmentSummary(for: action),
+                                isAssigned: true
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .help(localizedAppText("Show matching rules", de: "Passende Regeln anzeigen"))
+                    } else {
+                        PromptRuleAssignmentChip(
+                            title: viewModel.assignmentSummary(for: action),
+                            isAssigned: false
+                        )
+                    }
+
+                    if !assignmentStatus.isAssigned {
+                        Button(String(localized: "Create Rule")) {
+                            viewModel.createRule(for: action)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+
+                if !matchingRules.isEmpty {
+                    PromptRuleUsageLinks(profiles: matchingRules, viewModel: viewModel)
+                }
             }
 
             Spacer()
@@ -528,6 +571,94 @@ private struct PromptActionRow: View {
         }
 
         return Color.clear
+    }
+}
+
+private struct PromptRuleAssignmentCallout: View {
+    let action: PromptAction
+    @ObservedObject var viewModel: PromptActionsViewModel
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.orange.opacity(0.16))
+                    .frame(width: 36, height: 36)
+
+                Image(systemName: "point.3.connected.trianglepath.dotted")
+                    .foregroundStyle(.orange)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Prompt saved. Create a rule to run it automatically during dictation."))
+                    .font(.subheadline.weight(.semibold))
+                Text(String(localized: "Without a rule, prompts remain available via the Prompt Palette."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Button(String(localized: "Create Rule")) {
+                    viewModel.createRule(for: action)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+
+                Button {
+                    viewModel.dismissRuleAssignmentCallout()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.orange.opacity(0.08))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color.orange.opacity(0.18), lineWidth: 1)
+        }
+    }
+}
+
+private struct PromptRuleAssignmentChip: View {
+    let title: String
+    let isAssigned: Bool
+
+    var body: some View {
+        let tint: Color = isAssigned ? .green : .orange
+
+        Label(title, systemImage: isAssigned ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(tint.opacity(0.14), in: Capsule())
+    }
+}
+
+private struct PromptRuleUsageLinks: View {
+    let profiles: [Profile]
+    @ObservedObject var viewModel: PromptActionsViewModel
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(profiles) { profile in
+                    Button(profile.name) {
+                        viewModel.openRule(profile)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+        }
     }
 }
 

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -1,9 +1,10 @@
+import AppKit
 import SwiftUI
 
 @MainActor
 protocol PromptPaletteControlling: AnyObject {
     var isVisible: Bool { get }
-    func show(actions: [PromptAction], sourceText: String, onSelect: @escaping (PromptAction) -> Void)
+    func show(workflows: [Workflow], sourceText: String, onSelect: @escaping (Workflow) -> Void)
     func hide()
 }
 
@@ -17,37 +18,82 @@ final class PromptPaletteController: PromptPaletteControlling {
 
     var isVisible: Bool { paletteController.isVisible }
 
-    func show(actions: [PromptAction], sourceText: String, onSelect: @escaping (PromptAction) -> Void) {
-        let enabledActions = actions.filter(\.isEnabled)
-        guard !enabledActions.isEmpty else { return }
+    func show(workflows: [Workflow], sourceText: String, onSelect: @escaping (Workflow) -> Void) {
+        let enabledWorkflows = workflows.filter(\.isEnabled)
+        guard !enabledWorkflows.isEmpty else { return }
 
-        let items = enabledActions.map {
+        let items = enabledWorkflows.map {
             SelectionPaletteItem(
                 id: $0.id,
                 title: $0.name,
-                iconSystemName: $0.icon,
-                searchTokens: [$0.name]
+                subtitle: workflowPaletteSubtitle(for: $0),
+                iconSystemName: $0.definition.systemImage,
+                searchTokens: workflowPaletteSearchTokens(for: $0)
             )
         }
-        let actionsByID = Dictionary(uniqueKeysWithValues: enabledActions.map { ($0.id, $0) })
+        let workflowsByID = Dictionary(uniqueKeysWithValues: enabledWorkflows.map { ($0.id, $0) })
 
         paletteController.show(
             configuration: SelectionPaletteConfiguration(
                 panelWidth: 380,
-                panelHeight: 400,
-                previewText: sourceText,
+                panelHeight: 344,
+                previewText: nil,
                 previewLineLimit: 3,
-                searchPrompt: String(localized: "Search prompts..."),
-                emptyStateTitle: String(localized: "No matching prompts")
+                searchPrompt: localizedAppText("Search workflows...", de: "Workflows suchen..."),
+                emptyStateTitle: localizedAppText("No matching workflows", de: "Keine passenden Workflows")
             ),
             items: items
         ) { item in
-            guard let action = actionsByID[item.id] else { return }
-            onSelect(action)
+            guard let workflow = workflowsByID[item.id] else { return }
+            onSelect(workflow)
         }
     }
 
     func hide() {
         paletteController.hide()
+    }
+
+    private func workflowPaletteSubtitle(for workflow: Workflow) -> String? {
+        guard let trigger = workflow.trigger else {
+            return workflow.definition.name
+        }
+
+        let triggerSummary: String
+        switch trigger.kind {
+        case .app:
+            let appNames = trigger.appBundleIdentifiers.map(resolveAppDisplayName(for:))
+            triggerSummary = "\(trigger.kind.paletteLabel): \(appNames.joined(separator: ", "))"
+        case .website:
+            triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.websitePatterns.joined(separator: ", "))"
+        case .hotkey:
+            triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", "))"
+        }
+
+        if workflow.name.localizedCaseInsensitiveCompare(workflow.definition.name) == .orderedSame {
+            return triggerSummary
+        }
+        return "\(workflow.definition.name) · \(triggerSummary)"
+    }
+
+    private func workflowPaletteSearchTokens(for workflow: Workflow) -> [String] {
+        var tokens = [workflow.name, workflow.definition.name]
+        if let trigger = workflow.trigger {
+            tokens.append(trigger.kind.paletteLabel)
+            tokens.append(contentsOf: trigger.appBundleIdentifiers.map(resolveAppDisplayName(for:)))
+            tokens.append(contentsOf: trigger.appBundleIdentifiers)
+            tokens.append(contentsOf: trigger.websitePatterns)
+            tokens.append(contentsOf: trigger.hotkeys.map(HotkeyService.displayName(for:)))
+        }
+        return tokens
+    }
+
+    private func resolveAppDisplayName(for bundleIdentifier: String) -> String {
+        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
+              let bundle = Bundle(url: appURL) else {
+            return bundleIdentifier
+        }
+        return bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? bundle.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
+            ?? bundleIdentifier
     }
 }

--- a/TypeWhisper/Views/SelectionPalettePanel.swift
+++ b/TypeWhisper/Views/SelectionPalettePanel.swift
@@ -159,12 +159,12 @@ private struct SelectionPaletteContentView: View {
         VStack(spacing: 0) {
             if let previewText = model.configuration.previewText {
                 Text(previewText)
-                    .font(.system(size: 12))
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(model.configuration.previewLineLimit)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 14)
-                    .padding(.top, 10)
+                    .padding(.top, 12)
                     .padding(.bottom, 8)
 
                 Divider()
@@ -175,10 +175,9 @@ private struct SelectionPaletteContentView: View {
                     prompt: searchPrompt,
                     text: model.searchText
                 )
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-
-                Divider()
+                .padding(.horizontal, 12)
+                .padding(.top, model.configuration.previewText == nil ? 12 : 10)
+                .padding(.bottom, 10)
             }
 
             if model.filteredItems.isEmpty {
@@ -207,7 +206,7 @@ private struct SelectionPaletteContentView: View {
                             }
                         }
                         .padding(.vertical, 4)
-                        .padding(.horizontal, 6)
+                        .padding(.horizontal, 8)
                     }
                     .onChange(of: model.selectedIndex) { _, newValue in
                         proxy.scrollTo(newValue, anchor: .center)
@@ -216,12 +215,12 @@ private struct SelectionPaletteContentView: View {
             }
         }
         .frame(width: model.configuration.panelWidth, height: model.configuration.panelHeight)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
         )
-        .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
+        .shadow(color: .black.opacity(0.28), radius: 24, y: 12)
     }
 }
 
@@ -232,26 +231,31 @@ private struct SelectionPaletteSearchField: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 14))
+                .font(.system(size: 14, weight: .medium))
                 .foregroundColor(.secondary)
                 .accessibilityHidden(true)
 
             HStack(spacing: 1) {
-                if text.isEmpty {
-                    Text(prompt)
-                        .foregroundColor(.secondary)
-                } else {
-                    Text(text)
-                        .foregroundColor(.primary)
-                }
+                Text(text.isEmpty ? prompt : text)
+                    .foregroundColor(text.isEmpty ? .secondary : .primary)
 
                 Rectangle()
                     .fill(Color.accentColor.opacity(0.85))
-                    .frame(width: 1, height: 14)
+                    .frame(width: 1, height: 13)
             }
-            .font(.system(size: 15))
+            .font(.system(size: 14, weight: .medium))
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.white.opacity(0.045))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(Color.white.opacity(0.06), lineWidth: 1)
+        )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(prompt)
         .accessibilityValue(text)
@@ -266,24 +270,29 @@ private struct SelectionPaletteRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
             if let iconSystemName = item.iconSystemName {
-                Image(systemName: iconSystemName)
-                    .font(.system(size: 14))
-                    .foregroundColor(isSelected ? .white : .accentColor)
-                    .frame(width: 24, height: 24)
-                    .accessibilityHidden(true)
+                ZStack {
+                    Circle()
+                        .fill(isSelected ? Color.white.opacity(0.14) : Color.accentColor.opacity(0.12))
+                        .frame(width: 28, height: 28)
+
+                    Image(systemName: iconSystemName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(isSelected ? .white : .accentColor)
+                        .accessibilityHidden(true)
+                }
             }
 
             VStack(alignment: .leading, spacing: item.subtitle == nil ? 0 : 2) {
                 Text(item.title)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.system(size: 13.5, weight: .semibold))
                     .foregroundColor(isSelected ? .white : .primary)
                     .lineLimit(titleLineLimit)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if let subtitle = item.subtitle {
                     Text(subtitle)
-                        .font(.system(size: 11))
-                        .foregroundColor(isSelected ? .white.opacity(0.9) : .secondary)
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundColor(isSelected ? .white.opacity(0.82) : .secondary)
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -291,11 +300,15 @@ private struct SelectionPaletteRow: View {
 
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
         .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(isSelected ? Color.accentColor : Color.clear)
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isSelected ? Color.accentColor.opacity(0.22) : Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(isSelected ? Color.accentColor.opacity(0.55) : Color.clear, lineWidth: 1)
         )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(item.subtitle.map { "\(item.title), \($0)" } ?? item.title)

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -3,7 +3,7 @@ import AppKit
 
 enum SettingsTab: Hashable {
     case home, general, recording, hotkeys, recorder
-    case fileTranscription, history, dictionary, snippets, profiles, prompts, integrations, advanced, license, about
+    case fileTranscription, history, dictionary, snippets, workflows, legacyWorkflows, profiles, prompts, integrations, advanced, license, about
 }
 
 private struct SettingsDestination: Identifiable, Hashable {
@@ -27,9 +27,10 @@ struct SettingsView: View {
     @ObservedObject private var homeViewModel = HomeViewModel.shared
     @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
     @ObservedObject private var settingsNavigation = SettingsNavigationCoordinator.shared
+    @ObservedObject private var legacyWorkflowService = ServiceContainer.shared.legacyWorkflowService
 
     private var destinations: [SettingsDestination] {
-        [
+        var items = [
             SettingsDestination(tab: .home, title: String(localized: "Home"), systemImage: "house", badge: nil),
             SettingsDestination(tab: .general, title: String(localized: "General"), systemImage: "gear", badge: nil),
             SettingsDestination(tab: .recording, title: String(localized: "Recording"), systemImage: "mic.fill", badge: nil),
@@ -44,18 +45,40 @@ struct SettingsView: View {
             SettingsDestination(tab: .history, title: String(localized: "History"), systemImage: "clock.arrow.circlepath", badge: nil),
             SettingsDestination(tab: .dictionary, title: String(localized: "Dictionary"), systemImage: "book.closed", badge: nil),
             SettingsDestination(tab: .snippets, title: String(localized: "Snippets"), systemImage: "text.badge.plus", badge: nil),
-            SettingsDestination(tab: .profiles, title: localizedAppText("Rules", de: "Regeln"), systemImage: "point.3.connected.trianglepath.dotted", badge: nil),
-            SettingsDestination(tab: .prompts, title: String(localized: "Prompts"), systemImage: "sparkles", badge: nil),
             SettingsDestination(
-                tab: .integrations,
-                title: String(localized: "Integrations"),
-                systemImage: "puzzlepiece.extension",
-                badge: registryService.availableUpdatesCount > 0 ? registryService.availableUpdatesCount : nil
-            ),
-            SettingsDestination(tab: .advanced, title: String(localized: "Advanced"), systemImage: "gearshape.2", badge: nil),
-            SettingsDestination(tab: .license, title: String(localized: "License"), systemImage: "key", badge: nil),
-            SettingsDestination(tab: .about, title: String(localized: "About"), systemImage: "info.circle", badge: nil)
+                tab: .workflows,
+                title: localizedAppText("Workflows", de: "Workflows"),
+                systemImage: "point.3.connected.trianglepath.dotted",
+                badge: nil
+            )
         ]
+
+        if !legacyWorkflowService.items.isEmpty {
+            items.append(
+                SettingsDestination(
+                    tab: .legacyWorkflows,
+                    title: localizedAppText("Legacy", de: "Legacy"),
+                    systemImage: "archivebox",
+                    badge: legacyWorkflowService.items.count
+                )
+            )
+        }
+
+        items.append(
+            contentsOf: [
+                SettingsDestination(
+                    tab: .integrations,
+                    title: String(localized: "Integrations"),
+                    systemImage: "puzzlepiece.extension",
+                    badge: registryService.availableUpdatesCount > 0 ? registryService.availableUpdatesCount : nil
+                ),
+                SettingsDestination(tab: .advanced, title: String(localized: "Advanced"), systemImage: "gearshape.2", badge: nil),
+                SettingsDestination(tab: .license, title: String(localized: "License"), systemImage: "key", badge: nil),
+                SettingsDestination(tab: .about, title: String(localized: "About"), systemImage: "info.circle", badge: nil)
+            ]
+        )
+
+        return items
     }
 
     private var destinationSections: [SettingsDestinationSection] {
@@ -96,7 +119,35 @@ struct SettingsView: View {
             }
         }
         .onReceive(settingsNavigation.$request.compactMap { $0 }) { request in
-            selectedTab = request.tab
+            switch request.tab {
+            case .profiles:
+                if legacyWorkflowService.items.isEmpty {
+                    selectedTab = .workflows
+                    WorkflowsNavigationCoordinator.shared.showMine()
+                } else {
+                    selectedTab = .legacyWorkflows
+                    WorkflowsNavigationCoordinator.shared.showLegacy(focus: .rule)
+                }
+            case .prompts:
+                if legacyWorkflowService.items.isEmpty {
+                    selectedTab = .workflows
+                    WorkflowsNavigationCoordinator.shared.showMine()
+                } else {
+                    selectedTab = .legacyWorkflows
+                    WorkflowsNavigationCoordinator.shared.showLegacy(focus: .prompt)
+                }
+            case .workflows:
+                selectedTab = .workflows
+                WorkflowsNavigationCoordinator.shared.showMine()
+            default:
+                selectedTab = request.tab
+            }
+        }
+        .onChange(of: legacyWorkflowService.items.count) { _, count in
+            if count == 0 && selectedTab == .legacyWorkflows {
+                selectedTab = .workflows
+                WorkflowsNavigationCoordinator.shared.showMine()
+            }
         }
     }
 
@@ -127,10 +178,14 @@ struct SettingsView: View {
             DictionarySettingsView()
         case .snippets:
             SnippetsSettingsView()
+        case .workflows:
+            WorkflowsSettingsView()
+        case .legacyWorkflows:
+            LegacyWorkflowsSettingsView()
         case .profiles:
-            ProfilesSettingsView()
+            WorkflowsSettingsView()
         case .prompts:
-            PromptActionsSettingsView()
+            LegacyWorkflowsSettingsView()
         case .integrations:
             PluginSettingsView()
         case .advanced:
@@ -224,7 +279,20 @@ private func settingsBadge(_ destinations: [SettingsDestination], _ tab: Setting
 }
 
 private func settingsDestinationSections(_ destinations: [SettingsDestination]) -> [SettingsDestinationSection] {
-    [
+    var workspaceDestinations = [
+        settingsDestination(destinations, .history),
+        settingsDestination(destinations, .dictionary),
+        settingsDestination(destinations, .snippets),
+        settingsDestination(destinations, .workflows)
+    ]
+
+    if let legacyDestination = destinations.first(where: { $0.tab == .legacyWorkflows }) {
+        workspaceDestinations.append(legacyDestination)
+    }
+
+    workspaceDestinations.append(settingsDestination(destinations, .integrations))
+
+    return [
         SettingsDestinationSection(
             id: "home",
             destinations: [settingsDestination(destinations, .home)]
@@ -241,14 +309,7 @@ private func settingsDestinationSections(_ destinations: [SettingsDestination]) 
         ),
         SettingsDestinationSection(
             id: "workspace",
-            destinations: [
-                settingsDestination(destinations, .history),
-                settingsDestination(destinations, .dictionary),
-                settingsDestination(destinations, .snippets),
-                settingsDestination(destinations, .profiles),
-                settingsDestination(destinations, .prompts),
-                settingsDestination(destinations, .integrations)
-            ]
+            destinations: workspaceDestinations
         ),
         SettingsDestinationSection(
             id: "system",

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -205,7 +205,6 @@ private struct SettingsModernShell: View {
     let detail: (SettingsTab) -> AnyView
 
     @State private var sidebarSearchText = ""
-    @State private var splitViewVisibility: NavigationSplitViewVisibility = .all
 
     private var filteredSections: [SettingsDestinationSection] {
         let query = sidebarSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -224,7 +223,7 @@ private struct SettingsModernShell: View {
     }
 
     var body: some View {
-        NavigationSplitView(columnVisibility: $splitViewVisibility) {
+        NavigationSplitView {
             List(selection: $selectedTab) {
                 ForEach(filteredSections) { section in
                     Section {
@@ -246,19 +245,6 @@ private struct SettingsModernShell: View {
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                Button(action: toggleSidebar) {
-                    Image(systemName: "sidebar.leading")
-                }
-                .help(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
-                .accessibilityLabel(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
-            }
-        }
-    }
-
-    private func toggleSidebar() {
-        splitViewVisibility = splitViewVisibility == .detailOnly ? .all : .detailOnly
     }
 }
 

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -1099,7 +1099,7 @@ struct SetupWizardView: View {
         case .hybrid: return String(localized: "Hybrid")
         case .pushToTalk: return String(localized: "Push-to-Talk")
         case .toggle: return String(localized: "Toggle")
-        case .promptPalette: return String(localized: "Prompt Palette")
+        case .promptPalette: return localizedAppText("Workflow Palette", de: "Workflow-Palette")
         case .recentTranscriptions: return String(localized: "Recent Transcriptions")
         }
     }

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -183,7 +183,7 @@ struct IndicatorRecordingContent: View {
                     .padding(.horizontal, sizing.profilePaddingH)
                     .padding(.vertical, sizing.profilePaddingV)
                     .background(.white.opacity(0.2), in: Capsule())
-                    .accessibilityLabel("Active rule")
+                    .accessibilityLabel(localizedAppText("Active workflow", de: "Aktiver Workflow"))
                     .accessibilityValue(name)
             } else {
                 Color.clear.frame(width: 0, height: 0)

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1,0 +1,2139 @@
+import AppKit
+import SwiftUI
+
+enum WorkflowRoute: Equatable {
+    case create
+    case edit(UUID)
+}
+
+@MainActor
+final class WorkflowsNavigationCoordinator: ObservableObject {
+    nonisolated(unsafe) static var shared: WorkflowsNavigationCoordinator!
+
+    @Published private(set) var route: WorkflowRoute?
+    @Published private(set) var legacyFocus: LegacyWorkflowSourceKind?
+
+    func showMine() {
+        route = nil
+        legacyFocus = nil
+    }
+
+    func showLegacy(focus: LegacyWorkflowSourceKind? = nil) {
+        route = nil
+        legacyFocus = focus
+    }
+
+    func setLegacyFocus(_ focus: LegacyWorkflowSourceKind?) {
+        legacyFocus = focus
+    }
+
+    func createWorkflow() {
+        route = .create
+        legacyFocus = nil
+    }
+
+    func editWorkflow(id: UUID) {
+        route = .edit(id)
+        legacyFocus = nil
+    }
+
+    func goBackToList() {
+        route = nil
+    }
+}
+
+struct WorkflowsSettingsView: View {
+    @ObservedObject private var workflowService = ServiceContainer.shared.workflowService
+    @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
+
+    var body: some View {
+        detailView
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .frame(minWidth: 760, minHeight: 480)
+    }
+
+    @ViewBuilder
+    private var detailView: some View {
+        switch navigation.route {
+        case .none:
+            MyWorkflowsPage()
+        case .create:
+            WorkflowEditorPage(workflow: nil)
+        case .edit(let id):
+            if let workflow = workflowService.workflow(id: id) {
+                WorkflowEditorPage(workflow: workflow)
+            } else {
+                MissingWorkflowPage()
+            }
+        }
+    }
+}
+
+struct LegacyWorkflowsSettingsView: View {
+    var body: some View {
+        LegacyWorkflowsPage()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .frame(minWidth: 760, minHeight: 480)
+    }
+}
+
+private struct MyWorkflowsPage: View {
+    @ObservedObject private var workflowService = ServiceContainer.shared.workflowService
+    @ObservedObject private var promptProcessingService = ServiceContainer.shared.promptProcessingService
+    @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
+
+    @State private var searchText = ""
+    @State private var pendingDeleteWorkflowId: UUID?
+
+    private var filteredWorkflows: [Workflow] {
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else { return workflowService.workflows }
+
+        return workflowService.workflows.filter { workflow in
+            workflow.name.localizedCaseInsensitiveContains(trimmedQuery)
+                || workflow.template.definition.name.localizedCaseInsensitiveContains(trimmedQuery)
+                || workflowTriggerSummary(for: workflow).localizedCaseInsensitiveContains(trimmedQuery)
+                || workflowTriggerDetail(for: workflow).localizedCaseInsensitiveContains(trimmedQuery)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    providerDefaultsCard
+
+                    if workflowService.workflows.isEmpty {
+                        emptyState
+                    } else {
+                        searchField
+
+                        if filteredWorkflows.isEmpty {
+                            filteredEmptyState
+                        } else {
+                            workflowsList
+                        }
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .confirmationDialog(
+            localizedAppText("Delete workflow?", de: "Workflow löschen?"),
+            isPresented: Binding(
+                get: { pendingDeleteWorkflowId != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        pendingDeleteWorkflowId = nil
+                    }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(localizedAppText("Delete", de: "Löschen"), role: .destructive) {
+                guard let pendingDeleteWorkflowId,
+                      let workflow = workflowService.workflow(id: pendingDeleteWorkflowId) else {
+                    self.pendingDeleteWorkflowId = nil
+                    return
+                }
+                workflowService.deleteWorkflow(workflow)
+                self.pendingDeleteWorkflowId = nil
+            }
+            Button(localizedAppText("Cancel", de: "Abbrechen"), role: .cancel) {
+                pendingDeleteWorkflowId = nil
+            }
+        } message: {
+            if let pendingDeleteWorkflowId,
+               let workflow = workflowService.workflow(id: pendingDeleteWorkflowId) {
+                Text(
+                    localizedAppText(
+                        "This removes “\(workflow.name)” from the active workflow list.",
+                        de: "Dadurch wird „\(workflow.name)“ aus der aktiven Workflow-Liste entfernt."
+                    )
+                )
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(localizedAppText("Workflows", de: "Workflows"))
+                    .font(.headline)
+                Text(
+                    localizedAppText(
+                        "Create and manage the workflows TypeWhisper should actively run.",
+                        de: "Erstelle und verwalte die Workflows, die TypeWhisper aktiv ausführen soll."
+                    )
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                navigation.createWorkflow()
+            } label: {
+                Label(localizedAppText("New Workflow", de: "Neuer Workflow"), systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(16)
+        .background(.bar)
+    }
+
+    private var providerDefaultsCard: some View {
+        WorkflowSectionCard(
+            title: localizedAppText("Default LLM", de: "Standard-LLM"),
+            description: localizedAppText(
+                "New workflows use this provider unless a workflow overrides it in Advanced.",
+                de: "Neue Workflows verwenden diesen Provider, sofern ein Workflow ihn nicht unter Erweitert überschreibt."
+            )
+        ) {
+            let providers = promptProcessingService.availableProviders
+
+            VStack(alignment: .leading, spacing: 10) {
+                if providers.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(
+                            localizedAppText(
+                                "No LLM providers are installed yet.",
+                                de: "Es sind noch keine LLM-Provider installiert."
+                            )
+                        )
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                        Button(localizedAppText("Open Integrations", de: "Integrationen öffnen")) {
+                            SettingsNavigationCoordinator.shared.navigate(to: .integrations)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                } else {
+                    let models = promptProcessingService.modelsForProvider(promptProcessingService.selectedProviderId)
+
+                    ViewThatFits(in: .horizontal) {
+                        HStack(alignment: .top, spacing: 12) {
+                            compactDefaultLLMField(title: localizedAppText("Provider", de: "Provider")) {
+                                Picker(
+                                    localizedAppText("Provider", de: "Provider"),
+                                    selection: $promptProcessingService.selectedProviderId
+                                ) {
+                                    ForEach(providers, id: \.id) { provider in
+                                        Text(provider.displayName).tag(provider.id)
+                                    }
+                                }
+                            }
+
+                            if !models.isEmpty {
+                                compactDefaultLLMField(title: localizedAppText("Model", de: "Modell")) {
+                                    Picker(
+                                        localizedAppText("Model", de: "Modell"),
+                                        selection: $promptProcessingService.selectedCloudModel
+                                    ) {
+                                        ForEach(models, id: \.id) { model in
+                                            Text(model.displayName).tag(model.id)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            compactDefaultLLMField(title: localizedAppText("Provider", de: "Provider")) {
+                                Picker(
+                                    localizedAppText("Provider", de: "Provider"),
+                                    selection: $promptProcessingService.selectedProviderId
+                                ) {
+                                    ForEach(providers, id: \.id) { provider in
+                                        Text(provider.displayName).tag(provider.id)
+                                    }
+                                }
+                            }
+
+                            if !models.isEmpty {
+                                compactDefaultLLMField(title: localizedAppText("Model", de: "Modell")) {
+                                    Picker(
+                                        localizedAppText("Model", de: "Modell"),
+                                        selection: $promptProcessingService.selectedCloudModel
+                                    ) {
+                                        ForEach(models, id: \.id) { model in
+                                            Text(model.displayName).tag(model.id)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text(
+                            promptProcessingService.isProviderReady(promptProcessingService.selectedProviderId)
+                                ? localizedAppText(
+                                    "Ready for new workflows.",
+                                    de: "Bereit für neue Workflows."
+                                )
+                                : localizedAppText(
+                                    "Provider setup not finished yet.",
+                                    de: "Provider-Setup ist noch nicht abgeschlossen."
+                                )
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                        Spacer(minLength: 0)
+
+                        Button(localizedAppText("Manage in Integrations", de: "In Integrationen verwalten")) {
+                            SettingsNavigationCoordinator.shared.navigate(to: .integrations)
+                        }
+                        .buttonStyle(.link)
+                        .font(.caption)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func compactDefaultLLMField<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            content()
+                .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField(localizedAppText("Search workflows", de: "Workflows durchsuchen"), text: $searchText)
+                .textFieldStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(localizedAppText("No Workflows Yet", de: "Noch keine Workflows"), systemImage: "point.3.connected.trianglepath.dotted")
+        } description: {
+            Text(
+                localizedAppText(
+                    "Workflows replace the old split between rules and prompts. Start with a concrete outcome and attach exactly one trigger.",
+                    de: "Workflows ersetzen die alte Trennung zwischen Regeln und Prompts. Starte mit einem konkreten Ergebnis und hänge genau einen Trigger daran."
+                )
+            )
+            .frame(maxWidth: 440)
+        } actions: {
+            Button(localizedAppText("Create First Workflow", de: "Ersten Workflow erstellen")) {
+                navigation.createWorkflow()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, minHeight: 320)
+        .background {
+            workflowsGroupedSurface(cornerRadius: 16)
+        }
+    }
+
+    private var filteredEmptyState: some View {
+        ContentUnavailableView {
+            Label(localizedAppText("No Matching Workflows", de: "Keine passenden Workflows"), systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text(localizedAppText("Adjust the search to see more workflows.", de: "Passe die Suche an, um mehr Workflows zu sehen."))
+        } actions: {
+            Button(localizedAppText("Clear Search", de: "Suche löschen")) {
+                searchText = ""
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity, minHeight: 220)
+        .background {
+            workflowsGroupedSurface(cornerRadius: 16)
+        }
+    }
+
+    private var workflowsList: some View {
+        let orderedIds = workflowService.workflows.map(\.id)
+
+        return LazyVStack(spacing: 0) {
+            ForEach(Array(filteredWorkflows.enumerated()), id: \.element.id) { index, workflow in
+                WorkflowRow(
+                    workflow: workflow,
+                    canMoveUp: orderedIds.firstIndex(of: workflow.id).map { $0 > 0 } ?? false,
+                    canMoveDown: orderedIds.firstIndex(of: workflow.id).map { $0 < orderedIds.count - 1 } ?? false,
+                    onToggle: { workflowService.toggleWorkflow(workflow) },
+                    onEdit: { navigation.editWorkflow(id: workflow.id) },
+                    onDelete: { pendingDeleteWorkflowId = workflow.id },
+                    onMoveUp: { move(workflow: workflow, by: -1) },
+                    onMoveDown: { move(workflow: workflow, by: 1) }
+                )
+
+                if index < filteredWorkflows.count - 1 {
+                    Divider()
+                        .padding(.leading, 62)
+                }
+            }
+        }
+        .background {
+            workflowsGroupedSurface(cornerRadius: 16)
+        }
+    }
+
+    private func move(workflow: Workflow, by offset: Int) {
+        guard let currentIndex = workflowService.workflows.firstIndex(where: { $0.id == workflow.id }) else {
+            return
+        }
+
+        let targetIndex = currentIndex + offset
+        guard workflowService.workflows.indices.contains(targetIndex) else { return }
+
+        var reordered = workflowService.workflows
+        reordered.swapAt(currentIndex, targetIndex)
+        workflowService.reorderWorkflows(reordered)
+    }
+}
+
+private struct WorkflowRow: View {
+    let workflow: Workflow
+    let canMoveUp: Bool
+    let canMoveDown: Bool
+    let onToggle: () -> Void
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+    let onMoveUp: () -> Void
+    let onMoveDown: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: workflow.template.definition.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 28, height: 28)
+                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .center, spacing: 6) {
+                    Text(workflow.name)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+
+                    WorkflowBadge(
+                        title: workflow.template.definition.name,
+                        compact: true,
+                        tint: .accentColor.opacity(0.14),
+                        foreground: .accentColor
+                    )
+
+                    WorkflowBadge(
+                        title: workflow.isEnabled
+                            ? localizedAppText("Enabled", de: "Aktiv")
+                            : localizedAppText("Disabled", de: "Deaktiviert"),
+                        compact: true,
+                        tint: workflow.isEnabled ? .green.opacity(0.14) : .secondary.opacity(0.14),
+                        foreground: workflow.isEnabled ? .green : .secondary
+                    )
+                }
+
+                Text(workflowReviewText(for: workflow))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 6) {
+                    WorkflowBadge(title: workflowTriggerSummary(for: workflow), compact: true)
+                    if !workflowTriggerDetail(for: workflow).isEmpty {
+                        WorkflowBadge(
+                            title: workflowTriggerDetail(for: workflow),
+                            compact: true,
+                            tint: .secondary.opacity(0.12),
+                            foreground: .secondary
+                        )
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            HStack(spacing: 6) {
+                Toggle("", isOn: Binding(
+                    get: { workflow.isEnabled },
+                    set: { _ in onToggle() }
+                ))
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .controlSize(.small)
+
+                Button(action: onMoveUp) {
+                    Image(systemName: "arrow.up")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!canMoveUp)
+
+                Button(action: onMoveDown) {
+                    Image(systemName: "arrow.down")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!canMoveDown)
+
+                Button(action: onEdit) {
+                    Image(systemName: "pencil")
+                }
+                .buttonStyle(.borderless)
+
+                Button(role: .destructive, action: onDelete) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+            }
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onEdit()
+        }
+    }
+}
+
+private struct LegacyWorkflowsPage: View {
+    @ObservedObject private var legacyWorkflowService = ServiceContainer.shared.legacyWorkflowService
+    @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
+
+    @State private var searchText = ""
+    @State private var pendingDeleteItem: LegacyWorkflowItem?
+
+    private var filteredItems: [LegacyWorkflowItem] {
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let scoped = legacyWorkflowService.items.filter { item in
+            guard let focus = navigation.legacyFocus else { return true }
+            return item.sourceKind == focus
+        }
+
+        guard !trimmedQuery.isEmpty else { return scoped }
+
+        return scoped.filter { item in
+            item.name.localizedCaseInsensitiveContains(trimmedQuery)
+                || item.summary.localizedCaseInsensitiveContains(trimmedQuery)
+                || item.detail.localizedCaseInsensitiveContains(trimmedQuery)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    filterBar
+
+                    if filteredItems.isEmpty {
+                        ContentUnavailableView {
+                            Label(localizedAppText("No Legacy Entries", de: "Keine Legacy-Einträge"), systemImage: "archivebox")
+                        } description: {
+                            Text(localizedAppText("There are currently no rules or prompts in the old system.", de: "Aktuell gibt es keine Regeln oder Prompts im alten System."))
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 220)
+                        .background {
+                            workflowsGroupedSurface(cornerRadius: 16)
+                        }
+                    } else {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(filteredItems.enumerated()), id: \.element.id) { index, item in
+                                LegacyWorkflowRow(item: item) {
+                                    pendingDeleteItem = item
+                                }
+
+                                if index < filteredItems.count - 1 {
+                                    Divider()
+                                        .padding(.leading, 62)
+                                }
+                            }
+                        }
+                        .background {
+                            workflowsGroupedSurface(cornerRadius: 16)
+                        }
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .confirmationDialog(
+            localizedAppText("Delete legacy entry?", de: "Legacy-Eintrag löschen?"),
+            isPresented: Binding(
+                get: { pendingDeleteItem != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        pendingDeleteItem = nil
+                    }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(localizedAppText("Delete", de: "Löschen"), role: .destructive) {
+                guard let pendingDeleteItem else { return }
+                legacyWorkflowService.deleteItem(pendingDeleteItem)
+                self.pendingDeleteItem = nil
+            }
+
+            Button(localizedAppText("Cancel", de: "Abbrechen"), role: .cancel) {
+                pendingDeleteItem = nil
+            }
+        } message: {
+            if let pendingDeleteItem {
+                Text(deleteMessage(for: pendingDeleteItem))
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(localizedAppText("Legacy", de: "Legacy"))
+                .font(.headline)
+            Text(
+                localizedAppText(
+                    "View and clean up the old rules and prompts while the workflow migration is underway.",
+                    de: "Sichte und bereinige die alten Regeln und Prompts, während die Workflow-Migration läuft."
+                )
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(.bar)
+    }
+
+    private var filterBar: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Picker(
+                localizedAppText("Legacy Filter", de: "Legacy-Filter"),
+                selection: Binding(
+                    get: { navigation.legacyFocus },
+                    set: { navigation.setLegacyFocus($0) }
+                )
+            ) {
+                Text(localizedAppText("All", de: "Alle")).tag(nil as LegacyWorkflowSourceKind?)
+                Text(localizedAppText("Rules", de: "Regeln")).tag(LegacyWorkflowSourceKind.rule as LegacyWorkflowSourceKind?)
+                Text(localizedAppText("Prompts", de: "Prompts")).tag(LegacyWorkflowSourceKind.prompt as LegacyWorkflowSourceKind?)
+            }
+            .pickerStyle(.segmented)
+
+            HStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(localizedAppText("Search legacy entries", de: "Legacy-Einträge durchsuchen"), text: $searchText)
+                    .textFieldStyle(.plain)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            }
+        }
+    }
+
+    private func deleteMessage(for item: LegacyWorkflowItem) -> String {
+        switch item.sourceKind {
+        case .rule:
+            return localizedAppText(
+                "This removes the legacy rule “\(item.name)” from the old store.",
+                de: "Dadurch wird die Legacy-Regel „\(item.name)“ aus dem alten Store entfernt."
+            )
+        case .prompt:
+            return localizedAppText(
+                "This removes the legacy prompt “\(item.name)” and clears its links from old rules.",
+                de: "Dadurch wird der Legacy-Prompt „\(item.name)“ entfernt und aus alten Regeln ausgetragen."
+            )
+        }
+    }
+}
+
+private struct LegacyWorkflowRow: View {
+    let item: LegacyWorkflowItem
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: item.sourceKind == .rule ? "archivebox" : "sparkles.rectangle.stack")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 30, height: 30)
+                .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Text(item.name)
+                        .font(.headline)
+
+                    WorkflowBadge(title: item.sourceKind.title, tint: .secondary.opacity(0.14), foreground: .secondary)
+
+                    if item.isImported {
+                        WorkflowBadge(title: localizedAppText("Imported", de: "Importiert"), tint: .green.opacity(0.14), foreground: .green)
+                    }
+                }
+
+                Text(item.summary)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+
+                Text(item.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                WorkflowBadge(
+                    title: item.isEnabled
+                        ? localizedAppText("Enabled in legacy store", de: "Im Legacy-Store aktiv")
+                        : localizedAppText("Disabled in legacy store", de: "Im Legacy-Store deaktiviert"),
+                    tint: item.isEnabled ? .orange.opacity(0.14) : .secondary.opacity(0.14),
+                    foreground: item.isEnabled ? .orange : .secondary
+                )
+            }
+
+            Spacer(minLength: 12)
+
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help(localizedAppText("Delete legacy entry", de: "Legacy-Eintrag löschen"))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+}
+
+private struct WorkflowEditorPage: View {
+    let workflow: Workflow?
+
+    @ObservedObject private var workflowService = ServiceContainer.shared.workflowService
+    @ObservedObject private var hotkeyService = ServiceContainer.shared.hotkeyService
+    @ObservedObject private var profileService = ServiceContainer.shared.profileService
+    @ObservedObject private var profilesViewModel = ServiceContainer.shared.profilesViewModel
+    @ObservedObject private var historyService = ServiceContainer.shared.historyService
+    @ObservedObject private var promptProcessingService = ServiceContainer.shared.promptProcessingService
+    @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
+
+    @State private var draft: WorkflowDraft
+    @State private var validationMessage: String?
+    @State private var isAdvancedExpanded = false
+    @State private var showingAppPicker = false
+    @State private var websiteInput = ""
+
+    init(workflow: Workflow?) {
+        self.workflow = workflow
+        _draft = State(initialValue: workflow.map(WorkflowDraft.init) ?? WorkflowDraft(template: .cleanedText))
+    }
+
+    private var isEditing: Bool { workflow != nil }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if let validationMessage {
+                        ValidationBanner(message: validationMessage)
+                    }
+
+                    templateSection
+                    behaviorSection
+                    triggerSection
+                    reviewSection
+                }
+                .padding(16)
+            }
+        }
+        .sheet(isPresented: $showingAppPicker) {
+            WorkflowAppPickerSheet(
+                installedApps: profilesViewModel.installedApps,
+                selectedBundleIdentifiers: $draft.appBundleIdentifiers
+            )
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center) {
+                Button {
+                    navigation.goBackToList()
+                } label: {
+                    Label(localizedAppText("Back", de: "Zurück"), systemImage: "chevron.left")
+                }
+                .buttonStyle(.borderless)
+
+                Spacer()
+
+                Button(localizedAppText("Save Workflow", de: "Workflow speichern")) {
+                    save()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(isEditing
+                    ? localizedAppText("Edit Workflow", de: "Workflow bearbeiten")
+                    : localizedAppText("New Workflow", de: "Neuer Workflow")
+                )
+                .font(.headline)
+
+                Text(
+                    isEditing
+                        ? localizedAppText("Adjust the current workflow without changing its template.", de: "Passe den aktuellen Workflow an, ohne seine Vorlage zu ändern.")
+                        : localizedAppText("Pick a concrete outcome first, then add behavior and one trigger category.", de: "Wähle zuerst ein konkretes Ergebnis und ergänze dann Verhalten und eine Trigger-Kategorie.")
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(16)
+        .background(.bar)
+    }
+
+    private var templateSection: some View {
+        WorkflowSectionCard(
+            title: localizedAppText("Template", de: "Vorlage"),
+            description: isEditing
+                ? localizedAppText("The template stays fixed after creation.", de: "Die Vorlage bleibt nach dem Erstellen fix.")
+                : localizedAppText("Choose the concrete outcome this workflow should produce.", de: "Wähle das konkrete Ergebnis, das dieser Workflow erzeugen soll.")
+        ) {
+            if isEditing {
+                selectedTemplateCard(definition: draft.template.definition)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 190), spacing: 10)], spacing: 10) {
+                    ForEach(WorkflowTemplate.catalog) { definition in
+                        WorkflowTemplateCard(
+                            definition: definition,
+                            isSelected: definition.template == draft.template
+                        ) {
+                            draft.selectTemplate(definition.template)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var behaviorSection: some View {
+        WorkflowSectionCard(
+            title: localizedAppText("Behavior", de: "Verhalten"),
+            description: localizedAppText("Define the outcome, optional fine-tuning, and the output settings.", de: "Definiere das Ergebnis, optionale Feinabstimmung und die Ausgabeeinstellungen.")
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(localizedAppText("Name", de: "Name"))
+                        .font(.subheadline.weight(.semibold))
+                    TextField(localizedAppText("Workflow name", de: "Workflow-Name"), text: $draft.name)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                if draft.template == .translation {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(localizedAppText("Target Language", de: "Zielsprache"))
+                            .font(.subheadline.weight(.semibold))
+                        TextField(localizedAppText("e.g. English", de: "z. B. Englisch"), text: $draft.translationTargetLanguage)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                }
+
+                if draft.template == .custom {
+                    WorkflowTextEditorField(
+                        title: localizedAppText("Instruction", de: "Anweisung"),
+                        placeholder: localizedAppText(
+                            "Describe what this custom workflow should do.",
+                            de: "Beschreibe, was dieser eigene Workflow tun soll."
+                        ),
+                        text: $draft.customInstruction
+                    )
+                }
+
+                WorkflowTextEditorField(
+                    title: localizedAppText("Fine-Tuning", de: "Feinabstimmung"),
+                    placeholder: localizedAppText(
+                        "Optional: add tone, length, or wording hints.",
+                        de: "Optional: ergänze Hinweise zu Ton, Länge oder Formulierung."
+                    ),
+                    text: $draft.fineTuning
+                )
+
+                VStack(alignment: .leading, spacing: 0) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.16)) {
+                            isAdvancedExpanded.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 10) {
+                            Text(localizedAppText("Advanced", de: "Erweitert"))
+                                .font(.subheadline.weight(.semibold))
+
+                            Spacer()
+
+                            Image(systemName: "chevron.right")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .rotationEffect(.degrees(isAdvancedExpanded ? 90 : 0))
+                        }
+                        .padding(.vertical, 10)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+
+                    if isAdvancedExpanded {
+                        VStack(alignment: .leading, spacing: 14) {
+                            workflowProviderOverrideSection
+
+                            Divider()
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(localizedAppText("Output Format", de: "Ausgabeformat"))
+                                    .font(.subheadline.weight(.semibold))
+                                TextField(localizedAppText("e.g. Markdown, JSON, plain text", de: "z. B. Markdown, JSON, Plain Text"), text: $draft.outputFormat)
+                                    .textFieldStyle(.roundedBorder)
+                            }
+
+                            Toggle(localizedAppText("Press Enter after inserting", de: "Nach dem Einfügen Enter drücken"), isOn: $draft.autoEnter)
+                        }
+                        .padding(.top, 4)
+                    }
+                }
+            }
+        }
+    }
+
+    private var workflowProviderOverrideSection: some View {
+        let providers = promptProcessingService.availableProviders
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text(localizedAppText("LLM Override", de: "LLM-Override"))
+                .font(.subheadline.weight(.semibold))
+
+            if providers.isEmpty {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(
+                        localizedAppText(
+                            "Install an LLM provider in Integrations before using workflow overrides.",
+                            de: "Installiere zuerst einen LLM-Provider in Integrationen, bevor du Workflow-Overrides nutzt."
+                        )
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                    Button(localizedAppText("Open Integrations", de: "Integrationen öffnen")) {
+                        SettingsNavigationCoordinator.shared.navigate(to: .integrations)
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                }
+            } else {
+                Picker(
+                    localizedAppText("Provider", de: "Provider"),
+                    selection: workflowProviderOverrideBinding
+                ) {
+                    Text(
+                        localizedAppText(
+                            "Use Workflow Default (\(promptProcessingService.displayName(for: promptProcessingService.selectedProviderId)))",
+                            de: "Workflow-Standard verwenden (\(promptProcessingService.displayName(for: promptProcessingService.selectedProviderId)))"
+                        )
+                    )
+                    .tag(nil as String?)
+
+                    ForEach(providers, id: \.id) { provider in
+                        Text(provider.displayName).tag(provider.id as String?)
+                    }
+                }
+
+                Text(
+                    draft.providerId == nil
+                        ? localizedAppText(
+                            "This workflow currently inherits the default provider from the workflow settings.",
+                            de: "Dieser Workflow übernimmt aktuell den Standard-Provider aus den Workflow-Einstellungen."
+                        )
+                        : localizedAppText(
+                            "This workflow uses its own provider selection instead of the workflow default.",
+                            de: "Dieser Workflow verwendet seine eigene Provider-Auswahl statt des Workflow-Standards."
+                        )
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                if let providerId = draft.providerId {
+                    let models = promptProcessingService.modelsForProvider(providerId)
+                    if !models.isEmpty {
+                        Picker(
+                            localizedAppText("Model", de: "Modell"),
+                            selection: workflowModelOverrideBinding
+                        ) {
+                            Text(localizedAppText("Provider Default", de: "Provider-Standard"))
+                                .tag(nil as String?)
+                            ForEach(models, id: \.id) { model in
+                                Text(model.displayName).tag(model.id as String?)
+                            }
+                        }
+
+                        Text(
+                            localizedAppText(
+                                "Leave the model on Provider Default to follow the selected provider's preferred model.",
+                                de: "Lass das Modell auf Provider-Standard, um dem bevorzugten Modell des ausgewählten Providers zu folgen."
+                            )
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    if !promptProcessingService.isProviderReady(providerId) {
+                        Text(
+                            localizedAppText(
+                                "This provider is not ready yet. Finish its setup in Integrations before this workflow can use it.",
+                                de: "Dieser Provider ist noch nicht einsatzbereit. Schließe sein Setup in Integrationen ab, bevor der Workflow ihn nutzen kann."
+                            )
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    }
+                }
+            }
+        }
+    }
+
+    private var triggerSection: some View {
+        WorkflowSectionCard(
+            title: localizedAppText("Trigger", de: "Trigger"),
+            description: localizedAppText(
+                "Choose one trigger category. Inside it, you can add multiple apps, websites, or shortcuts.",
+                de: "Wähle eine Trigger-Kategorie. Darin kannst du mehrere Apps, Websites oder Shortcuts ergänzen."
+            )
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                Picker(localizedAppText("Trigger", de: "Trigger"), selection: $draft.triggerKind) {
+                    Text(localizedAppText("App", de: "App")).tag(WorkflowTriggerKind.app)
+                    Text(localizedAppText("Website", de: "Website")).tag(WorkflowTriggerKind.website)
+                    Text(localizedAppText("Hotkey", de: "Hotkey")).tag(WorkflowTriggerKind.hotkey)
+                }
+                .pickerStyle(.segmented)
+
+                switch draft.triggerKind {
+                case .app:
+                    appTriggerEditor
+                case .website:
+                    websiteTriggerEditor
+                case .hotkey:
+                    hotkeyTriggerEditor
+                }
+            }
+        }
+    }
+
+    private var reviewSection: some View {
+        WorkflowSectionCard(
+            title: localizedAppText("Review", de: "Review"),
+            description: localizedAppText("This is how the workflow currently reads before saving.", de: "So liest sich der Workflow aktuell vor dem Speichern.")
+        ) {
+            Text(draft.reviewText)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.08))
+                }
+        }
+    }
+
+    private var appTriggerEditor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if draft.appBundleIdentifiers.isEmpty {
+                Text(localizedAppText("No apps selected yet.", de: "Noch keine Apps ausgewählt."))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(draft.appBundleIdentifiers, id: \.self) { bundleId in
+                        WorkflowSelectionRow(
+                            title: installedAppName(for: bundleId),
+                            subtitle: bundleId,
+                            icon: installedAppIcon(for: bundleId)
+                        ) {
+                            draft.appBundleIdentifiers.removeAll { $0 == bundleId }
+                        }
+                    }
+                }
+            }
+
+            Button(localizedAppText("Select Apps…", de: "Apps auswählen…")) {
+                showingAppPicker = true
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var websiteTriggerEditor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if draft.websitePatterns.isEmpty {
+                Text(localizedAppText("No websites added yet.", de: "Noch keine Websites hinzugefügt."))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(draft.websitePatterns, id: \.self) { pattern in
+                        WorkflowSelectionRow(
+                            title: pattern,
+                            subtitle: localizedAppText("Website trigger", de: "Website-Trigger"),
+                            iconSystemName: "globe"
+                        ) {
+                            draft.websitePatterns.removeAll { $0 == pattern }
+                        }
+                    }
+                }
+            }
+
+            HStack(alignment: .top, spacing: 10) {
+                TextField("docs.github.com", text: $websiteInput)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit {
+                        addWebsiteInput()
+                    }
+
+                Button(localizedAppText("Add", de: "Hinzufügen")) {
+                    addWebsiteInput()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            if !websiteSuggestions.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(localizedAppText("Suggested websites", de: "Vorgeschlagene Websites"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    ForEach(websiteSuggestions, id: \.self) { domain in
+                        Button(domain) {
+                            draft.addWebsitePattern(domain)
+                            websiteInput = ""
+                            validationMessage = nil
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.primary)
+                    }
+                }
+            }
+
+            Text(localizedAppText("You can paste a full URL; only the domain is kept.", de: "Du kannst eine komplette URL einfügen; gespeichert wird nur die Domain."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var hotkeyTriggerEditor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if draft.hotkeys.isEmpty {
+                Text(localizedAppText("No shortcuts recorded yet.", de: "Noch keine Shortcuts aufgenommen."))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(draft.hotkeys, id: \.self) { hotkey in
+                        WorkflowSelectionRow(
+                            title: HotkeyService.displayName(for: hotkey),
+                            subtitle: localizedAppText("Workflow shortcut", de: "Workflow-Shortcut"),
+                            iconSystemName: "keyboard"
+                        ) {
+                            draft.hotkeys.removeAll { $0 == hotkey }
+                        }
+                    }
+                }
+            }
+
+            HotkeyRecorderView(
+                label: "",
+                title: localizedAppText("Add Shortcut", de: "Shortcut hinzufügen"),
+                subtitle: localizedAppText("You can attach more than one shortcut to the same workflow.", de: "Du kannst mehrere Shortcuts mit demselben Workflow verbinden."),
+                onRecord: { hotkey in
+                    addRecordedHotkey(hotkey)
+                },
+                onClear: {}
+            )
+        }
+    }
+
+    private var websiteSuggestions: [String] {
+        let query = workflowNormalizedDomain(websiteInput)
+        let source = historyService.uniqueDomains(limit: 8)
+
+        if query.isEmpty {
+            return source.filter { !draft.websitePatterns.contains($0) }
+        }
+
+        return source.filter { domain in
+            !draft.websitePatterns.contains(domain) && domain.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    private func save() {
+        if let validationError = draft.validationError(
+            hotkeyService: hotkeyService,
+            workflowService: workflowService,
+            profileService: profileService,
+            existingWorkflowId: workflow?.id
+        ) {
+            validationMessage = validationError
+            return
+        }
+
+        guard let trigger = draft.resolvedTrigger() else {
+            validationMessage = localizedAppText(
+                "The selected trigger is incomplete.",
+                de: "Der ausgewählte Trigger ist unvollständig."
+            )
+            return
+        }
+
+        let behavior = draft.resolvedBehavior()
+        let output = draft.resolvedOutput()
+
+        if let workflow {
+            workflow.name = draft.resolvedName
+            workflow.isEnabled = draft.isEnabled
+            workflow.trigger = trigger
+            workflow.behavior = behavior
+            workflow.output = output
+            workflow.updatedAt = Date()
+            workflowService.updateWorkflow(workflow)
+        } else {
+            _ = workflowService.addWorkflow(
+                name: draft.resolvedName,
+                template: draft.template,
+                trigger: trigger,
+                behavior: behavior,
+                output: output,
+                isEnabled: draft.isEnabled
+            )
+        }
+
+        validationMessage = nil
+        navigation.goBackToList()
+    }
+
+    private func installedAppName(for bundleId: String) -> String {
+        profilesViewModel.installedApps.first(where: { $0.id == bundleId })?.name
+            ?? workflowAppDisplayName(for: bundleId)
+    }
+
+    private func installedAppIcon(for bundleId: String) -> NSImage? {
+        profilesViewModel.installedApps.first(where: { $0.id == bundleId })?.icon
+    }
+
+    private func addWebsiteInput() {
+        let normalized = workflowNormalizedDomainFromInput(websiteInput)
+        guard !normalized.isEmpty else { return }
+        draft.addWebsitePattern(normalized)
+        websiteInput = ""
+        validationMessage = nil
+    }
+
+    private func addRecordedHotkey(_ hotkey: UnifiedHotkey) {
+        if draft.containsEquivalentHotkey(hotkey) {
+            validationMessage = localizedAppText(
+                "This shortcut is already part of the workflow.",
+                de: "Dieser Shortcut ist bereits Teil des Workflows."
+            )
+            return
+        }
+
+        if let workflowId = hotkeyService.isHotkeyAssignedToWorkflow(hotkey, excludingWorkflowId: workflow?.id),
+           let conflictWorkflow = workflowService.workflow(id: workflowId) {
+            validationMessage = localizedAppText(
+                "This hotkey is already used by workflow “\(conflictWorkflow.name)”.",
+                de: "Dieser Hotkey wird bereits vom Workflow „\(conflictWorkflow.name)“ verwendet."
+            )
+            return
+        }
+
+        if let profileId = hotkeyService.isHotkeyAssignedToProfile(hotkey, excludingProfileId: nil),
+           let conflictProfile = profileService.profiles.first(where: { $0.id == profileId }) {
+            validationMessage = localizedAppText(
+                "This hotkey is already used by legacy rule “\(conflictProfile.name)”.",
+                de: "Dieser Hotkey wird bereits von der Legacy-Regel „\(conflictProfile.name)“ verwendet."
+            )
+            return
+        }
+
+        if let slot = hotkeyService.isHotkeyAssignedToGlobalSlot(hotkey) {
+            validationMessage = localizedAppText(
+                "This hotkey is already used by the global slot “\(slot.rawValue)”.",
+                de: "Dieser Hotkey wird bereits vom globalen Slot „\(slot.rawValue)“ verwendet."
+            )
+            return
+        }
+
+        draft.hotkeys.append(hotkey)
+        validationMessage = nil
+    }
+
+    private func selectedTemplateCard(definition: WorkflowTemplateDefinition) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: definition.systemImage)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(definition.name)
+                    .font(.headline)
+                Text(definition.description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                WorkflowBadge(title: localizedAppText("Template fixed after creation", de: "Vorlage nach Erstellung fix"))
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.accentColor.opacity(0.08))
+        }
+    }
+
+    private var workflowProviderOverrideBinding: Binding<String?> {
+        Binding(
+            get: { draft.providerId },
+            set: { providerId in
+                draft.providerId = providerId
+                if providerId == nil {
+                    draft.cloudModel = nil
+                    return
+                }
+
+                if let cloudModel = draft.cloudModel,
+                   let providerId,
+                   !promptProcessingService.modelsForProvider(providerId).contains(where: { $0.id == cloudModel }) {
+                    draft.cloudModel = nil
+                }
+            }
+        )
+    }
+
+    private var workflowModelOverrideBinding: Binding<String?> {
+        Binding(
+            get: { draft.cloudModel },
+            set: { modelId in
+                draft.cloudModel = modelId
+            }
+        )
+    }
+}
+
+private struct WorkflowTemplateCard: View {
+    let definition: WorkflowTemplateDefinition
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(isSelected ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
+                            .frame(width: 32, height: 32)
+
+                        Image(systemName: definition.systemImage)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                    }
+                    Spacer()
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Color.accentColor)
+                    }
+                }
+
+                Text(definition.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                Text(definition.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, minHeight: 108, alignment: .topLeading)
+            .background {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.10) : Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .stroke(isSelected ? Color.accentColor.opacity(0.45) : Color.secondary.opacity(0.15), lineWidth: 1)
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct WorkflowSelectionRow: View {
+    let title: String
+    let subtitle: String?
+    var icon: NSImage? = nil
+    var iconSystemName: String? = nil
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if let icon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+            } else if let iconSystemName {
+                Image(systemName: iconSystemName)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+
+                if let subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer()
+
+            Button {
+                onRemove()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(workflowsGroupedSurface(cornerRadius: 12))
+    }
+}
+
+private struct WorkflowTextEditorField: View {
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+    var minHeight: CGFloat = 86
+
+    private let editorFont: Font = .body
+    private let editorHorizontalPadding: CGFloat = 10
+    private let editorTopPadding: CGFloat = 10
+    private let editorBottomPadding: CGFloat = 8
+    private let placeholderLeadingInset: CGFloat = 15
+    private let placeholderTopInset: CGFloat = 13
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $text)
+                    .font(editorFont)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: minHeight)
+                    .padding(.leading, editorHorizontalPadding)
+                    .padding(.trailing, editorHorizontalPadding)
+                    .padding(.top, editorTopPadding)
+                    .padding(.bottom, editorBottomPadding)
+                    .background(Color.clear)
+
+                if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text(placeholder)
+                        .font(editorFont)
+                        .foregroundStyle(.tertiary)
+                        .padding(.leading, placeholderLeadingInset)
+                        .padding(.top, placeholderTopInset)
+                        .padding(.trailing, 12)
+                        .allowsHitTesting(false)
+                }
+            }
+            .background {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(Color.secondary.opacity(0.14), lineWidth: 1)
+                    )
+            }
+        }
+    }
+}
+
+private struct WorkflowAppPickerSheet: View {
+    let installedApps: [InstalledApp]
+    @Binding var selectedBundleIdentifiers: [String]
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
+
+    private var filteredApps: [InstalledApp] {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return installedApps }
+        return installedApps.filter { app in
+            app.name.localizedCaseInsensitiveContains(trimmed)
+                || app.id.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(localizedAppText("Select Apps", de: "Apps auswählen"))
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField(localizedAppText("Search Apps…", de: "Apps durchsuchen…"), text: $searchText)
+                    .textFieldStyle(.plain)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(8)
+
+            Divider()
+
+            List(filteredApps) { app in
+                HStack {
+                    if let icon = app.icon {
+                        Image(nsImage: icon)
+                    }
+                    Text(app.name)
+                    Spacer()
+                    if selectedBundleIdentifiers.contains(app.id) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.blue)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    toggleSelection(app.id)
+                }
+            }
+            .listStyle(.inset)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(localizedAppText("Done", de: "Fertig")) {
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(width: 400, height: 500)
+    }
+
+    private func toggleSelection(_ bundleId: String) {
+        if selectedBundleIdentifiers.contains(bundleId) {
+            selectedBundleIdentifiers.removeAll { $0 == bundleId }
+        } else {
+            selectedBundleIdentifiers.append(bundleId)
+        }
+    }
+}
+
+private struct WorkflowSectionCard<Content: View>: View {
+    let title: String
+    let description: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            content
+        }
+        .padding(16)
+        .background {
+            workflowsElevatedPanel(cornerRadius: 18)
+        }
+    }
+}
+
+private struct WorkflowBadge: View {
+    let title: String
+    var compact: Bool = false
+    var tint: Color = .secondary.opacity(0.12)
+    var foreground: Color = .secondary
+
+    var body: some View {
+        Text(title)
+            .font((compact ? Font.caption2 : Font.caption).weight(.semibold))
+            .padding(.horizontal, compact ? 8 : 10)
+            .padding(.vertical, compact ? 4 : 6)
+            .background(tint, in: Capsule())
+            .foregroundStyle(foreground)
+    }
+}
+
+private struct ValidationBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.subheadline)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.orange.opacity(0.12))
+        }
+    }
+}
+
+private struct MissingWorkflowPage: View {
+    @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(localizedAppText("Workflow Not Found", de: "Workflow nicht gefunden"), systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(localizedAppText("The selected workflow no longer exists.", de: "Der ausgewählte Workflow existiert nicht mehr."))
+        } actions: {
+            Button(localizedAppText("Back to List", de: "Zurück zur Liste")) {
+                navigation.goBackToList()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct WorkflowDraft {
+    var name: String
+    var isEnabled: Bool
+    var template: WorkflowTemplate
+    var triggerKind: WorkflowTriggerKind
+    var appBundleIdentifiers: [String]
+    var websitePatterns: [String]
+    var hotkeys: [UnifiedHotkey]
+    var fineTuning: String
+    var translationTargetLanguage: String
+    var customInstruction: String
+    var outputFormat: String
+    var autoEnter: Bool
+
+    private var preservedBehaviorSettings: [String: String]
+    var providerId: String?
+    var cloudModel: String?
+    private let temperatureModeRaw: String?
+    private let temperatureValue: Double?
+    private let targetActionPluginId: String?
+
+    init(template: WorkflowTemplate) {
+        self.name = template.definition.name
+        self.isEnabled = true
+        self.template = template
+        self.triggerKind = .hotkey
+        self.appBundleIdentifiers = []
+        self.websitePatterns = []
+        self.hotkeys = []
+        self.fineTuning = ""
+        self.translationTargetLanguage = template == .translation ? "English" : ""
+        self.customInstruction = ""
+        self.outputFormat = ""
+        self.autoEnter = false
+        self.preservedBehaviorSettings = [:]
+        self.providerId = nil
+        self.cloudModel = nil
+        self.temperatureModeRaw = nil
+        self.temperatureValue = nil
+        self.targetActionPluginId = nil
+    }
+
+    init(_ workflow: Workflow) {
+        let behavior = workflow.behavior
+        let output = workflow.output
+
+        self.name = workflow.name
+        self.isEnabled = workflow.isEnabled
+        self.template = workflow.template
+        self.fineTuning = behavior.fineTuning
+        self.translationTargetLanguage = behavior.settings["targetLanguage"] ?? behavior.settings["target"] ?? ""
+        self.customInstruction = behavior.settings["instruction"] ?? behavior.settings["goal"] ?? behavior.settings["prompt"] ?? ""
+        self.outputFormat = output.format ?? ""
+        self.autoEnter = output.autoEnter
+        self.preservedBehaviorSettings = behavior.settings
+        self.providerId = behavior.providerId
+        self.cloudModel = behavior.cloudModel
+        self.temperatureModeRaw = behavior.temperatureModeRaw
+        self.temperatureValue = behavior.temperatureValue
+        self.targetActionPluginId = output.targetActionPluginId
+
+        if let trigger = workflow.trigger {
+            switch trigger.kind {
+            case .app:
+                self.triggerKind = .app
+                self.appBundleIdentifiers = trigger.appBundleIdentifiers
+                self.websitePatterns = []
+                self.hotkeys = []
+            case .website:
+                self.triggerKind = .website
+                self.appBundleIdentifiers = []
+                self.websitePatterns = trigger.websitePatterns
+                self.hotkeys = []
+            case .hotkey:
+                self.triggerKind = .hotkey
+                self.appBundleIdentifiers = []
+                self.websitePatterns = []
+                self.hotkeys = trigger.hotkeys
+            }
+        } else {
+            self.triggerKind = .app
+            self.appBundleIdentifiers = []
+            self.websitePatterns = []
+            self.hotkeys = []
+        }
+    }
+
+    var resolvedName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? template.definition.name : trimmed
+    }
+
+    var reviewText: String {
+        localizedAppText(
+            "\(resolvedName) runs as \(template.definition.name) via \(triggerReviewText).",
+            de: "\(resolvedName) läuft als \(template.definition.name) über \(triggerReviewText)."
+        )
+    }
+
+    mutating func selectTemplate(_ newTemplate: WorkflowTemplate) {
+        let currentTrimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let previousDefaultName = template.definition.name
+
+        template = newTemplate
+
+        if currentTrimmedName.isEmpty || currentTrimmedName == previousDefaultName {
+            name = newTemplate.definition.name
+        }
+
+        if newTemplate != .translation {
+            translationTargetLanguage = ""
+        } else if translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            translationTargetLanguage = "English"
+        }
+
+        if newTemplate != .custom {
+            customInstruction = ""
+        }
+    }
+
+    @MainActor
+    func validationError(
+        hotkeyService: HotkeyService,
+        workflowService: WorkflowService,
+        profileService: ProfileService,
+        existingWorkflowId: UUID?
+    ) -> String? {
+        switch triggerKind {
+        case .app:
+            if appBundleIdentifiers.isEmpty {
+                return localizedAppText(
+                    "Please select at least one app.",
+                    de: "Bitte wähle mindestens eine App aus."
+                )
+            }
+        case .website:
+            if websitePatterns.isEmpty {
+                return localizedAppText(
+                    "Please add at least one website or domain.",
+                    de: "Bitte füge mindestens eine Website oder Domain hinzu."
+                )
+            }
+        case .hotkey:
+            guard !hotkeys.isEmpty else {
+                return localizedAppText(
+                    "Please record at least one workflow shortcut.",
+                    de: "Bitte nimm mindestens einen Workflow-Shortcut auf."
+                )
+            }
+
+            for hotkey in hotkeys {
+                if hotkeys.contains(where: { candidate in
+                    candidate != hotkey && workflowHotkeysConflict(candidate, hotkey)
+                }) {
+                    return localizedAppText(
+                        "The workflow contains duplicate shortcuts.",
+                        de: "Der Workflow enthält doppelte Shortcuts."
+                    )
+                }
+
+                if let conflictWorkflowId = hotkeyService.isHotkeyAssignedToWorkflow(hotkey, excludingWorkflowId: existingWorkflowId),
+                   let conflictWorkflow = workflowService.workflow(id: conflictWorkflowId) {
+                    return localizedAppText(
+                        "This hotkey is already used by workflow “\(conflictWorkflow.name)”.",
+                        de: "Dieser Hotkey wird bereits vom Workflow „\(conflictWorkflow.name)“ verwendet."
+                    )
+                }
+
+                if let conflictProfileId = hotkeyService.isHotkeyAssignedToProfile(hotkey, excludingProfileId: nil),
+                   let conflictProfile = profileService.profiles.first(where: { $0.id == conflictProfileId }) {
+                    return localizedAppText(
+                        "This hotkey is already used by legacy rule “\(conflictProfile.name)”.",
+                        de: "Dieser Hotkey wird bereits von der Legacy-Regel „\(conflictProfile.name)“ verwendet."
+                    )
+                }
+
+                if let conflictSlot = hotkeyService.isHotkeyAssignedToGlobalSlot(hotkey) {
+                    return localizedAppText(
+                        "This hotkey is already used by the global slot “\(conflictSlot.rawValue)”.",
+                        de: "Dieser Hotkey wird bereits vom globalen Slot „\(conflictSlot.rawValue)“ verwendet."
+                    )
+                }
+            }
+        }
+
+        if template == .translation && translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return localizedAppText(
+                "Translation workflows need a target language.",
+                de: "Übersetzungs-Workflows brauchen eine Zielsprache."
+            )
+        }
+
+        if template == .custom {
+            let hasCustomInstruction = !customInstruction.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            let hasFineTuning = !fineTuning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if !hasCustomInstruction && !hasFineTuning {
+                return localizedAppText(
+                    "Custom workflows need an instruction or fine-tuning text.",
+                    de: "Eigene Workflows brauchen eine Anweisung oder Feinabstimmung."
+                )
+            }
+        }
+
+        return nil
+    }
+
+    func resolvedTrigger() -> WorkflowTrigger? {
+        switch triggerKind {
+        case .app:
+            guard !appBundleIdentifiers.isEmpty else { return nil }
+            return .apps(appBundleIdentifiers)
+        case .website:
+            guard !websitePatterns.isEmpty else { return nil }
+            return .websites(websitePatterns)
+        case .hotkey:
+            guard !hotkeys.isEmpty else { return nil }
+            return .hotkeys(hotkeys)
+        }
+    }
+
+    func resolvedBehavior() -> WorkflowBehavior {
+        var settings = preservedBehaviorSettings
+        settings.removeValue(forKey: "targetLanguage")
+        settings.removeValue(forKey: "target")
+        settings.removeValue(forKey: "instruction")
+        settings.removeValue(forKey: "goal")
+        settings.removeValue(forKey: "prompt")
+
+        let trimmedTargetLanguage = translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+        if template == .translation && !trimmedTargetLanguage.isEmpty {
+            settings["targetLanguage"] = trimmedTargetLanguage
+        }
+
+        let trimmedInstruction = customInstruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        if template == .custom && !trimmedInstruction.isEmpty {
+            settings["instruction"] = trimmedInstruction
+        }
+
+        let trimmedProviderId = providerId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedCloudModel = cloudModel?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return WorkflowBehavior(
+            settings: settings,
+            fineTuning: fineTuning.trimmingCharacters(in: .whitespacesAndNewlines),
+            providerId: trimmedProviderId?.isEmpty == false ? trimmedProviderId : nil,
+            cloudModel: trimmedCloudModel?.isEmpty == false ? trimmedCloudModel : nil,
+            temperatureModeRaw: temperatureModeRaw,
+            temperatureValue: temperatureValue
+        )
+    }
+
+    func resolvedOutput() -> WorkflowOutput {
+        let trimmedFormat = outputFormat.trimmingCharacters(in: .whitespacesAndNewlines)
+        return WorkflowOutput(
+            format: trimmedFormat.isEmpty ? nil : trimmedFormat,
+            autoEnter: autoEnter,
+            targetActionPluginId: targetActionPluginId
+        )
+    }
+
+    private var triggerReviewText: String {
+        switch triggerKind {
+        case .app:
+            if appBundleIdentifiers.isEmpty {
+                return localizedAppText("an app trigger", de: "einen App-Trigger")
+            }
+            return localizedAppText(
+                "the apps \(workflowCompactList(appBundleIdentifiers.map(workflowAppDisplayName(for:)), conjunction: localizedAppText("and", de: "und")))",
+                de: "die Apps \(workflowCompactList(appBundleIdentifiers.map(workflowAppDisplayName(for:)), conjunction: "und"))"
+            )
+        case .website:
+            if websitePatterns.isEmpty {
+                return localizedAppText("a website trigger", de: "einen Website-Trigger")
+            }
+            return localizedAppText(
+                "the websites \(workflowCompactList(websitePatterns, conjunction: localizedAppText("and", de: "und")))",
+                de: "die Websites \(workflowCompactList(websitePatterns, conjunction: "und"))"
+            )
+        case .hotkey:
+            if !hotkeys.isEmpty {
+                return localizedAppText(
+                    "the shortcuts \(workflowCompactList(hotkeys.map(HotkeyService.displayName(for:)), conjunction: localizedAppText("and", de: "und")))",
+                    de: "die Shortcuts \(workflowCompactList(hotkeys.map(HotkeyService.displayName(for:)), conjunction: "und"))"
+                )
+            }
+            return localizedAppText("a hotkey", de: "einen Hotkey")
+        }
+    }
+
+    mutating func addWebsitePattern(_ value: String) {
+        let normalized = workflowNormalizedDomainFromInput(value)
+        guard !normalized.isEmpty, !websitePatterns.contains(normalized) else { return }
+        websitePatterns.append(normalized)
+    }
+
+    func containsEquivalentHotkey(_ hotkey: UnifiedHotkey) -> Bool {
+        hotkeys.contains { candidate in
+            workflowHotkeysConflict(candidate, hotkey)
+        }
+    }
+}
+
+private func workflowSummaryText(for workflow: Workflow) -> String {
+    let templateName = workflow.template.definition.name
+    switch workflow.template {
+    case .translation:
+        let targetLanguage = workflow.behavior.settings["targetLanguage"]
+            ?? workflow.behavior.settings["target"]
+        if let targetLanguage, !targetLanguage.isEmpty {
+            return localizedAppText(
+                "\(templateName) to \(targetLanguage)",
+                de: "\(templateName) nach \(targetLanguage)"
+            )
+        }
+        return templateName
+    case .custom:
+        let instruction = workflow.behavior.settings["instruction"]
+            ?? workflow.behavior.settings["goal"]
+            ?? workflow.behavior.settings["prompt"]
+        if let instruction, !instruction.isEmpty {
+            return instruction
+        }
+        return templateName
+    default:
+        return templateName
+    }
+}
+
+private func workflowTriggerSummary(for workflow: Workflow) -> String {
+    guard let trigger = workflow.trigger else {
+        return localizedAppText("No Trigger", de: "Kein Trigger")
+    }
+
+    switch trigger.kind {
+    case .app:
+        return trigger.appBundleIdentifiers.count == 1
+            ? localizedAppText("App", de: "App")
+            : localizedAppText("Apps", de: "Apps")
+    case .website:
+        return trigger.websitePatterns.count == 1
+            ? localizedAppText("Website", de: "Website")
+            : localizedAppText("Websites", de: "Websites")
+    case .hotkey:
+        return trigger.hotkeys.count == 1
+            ? localizedAppText("Hotkey", de: "Hotkey")
+            : localizedAppText("Hotkeys", de: "Hotkeys")
+    }
+}
+
+private func workflowTriggerDetail(for workflow: Workflow) -> String {
+    guard let trigger = workflow.trigger else { return "" }
+
+    switch trigger.kind {
+    case .app:
+        return workflowCompactList(trigger.appBundleIdentifiers.map(workflowAppDisplayName(for:)))
+    case .website:
+        return workflowCompactList(trigger.websitePatterns)
+    case .hotkey:
+        return workflowCompactList(trigger.hotkeys.map(HotkeyService.displayName(for:)))
+    }
+}
+
+private func workflowReviewText(for workflow: Workflow) -> String {
+    let summary = workflowSummaryText(for: workflow)
+    let triggerSummary = workflowTriggerSummary(for: workflow)
+    let triggerDetail = workflowTriggerDetail(for: workflow)
+
+    if triggerDetail.isEmpty {
+        return localizedAppText(
+            "\(summary) via \(triggerSummary)",
+            de: "\(summary) über \(triggerSummary)"
+        )
+    }
+
+    return localizedAppText(
+        "\(summary) via \(triggerSummary): \(triggerDetail)",
+        de: "\(summary) über \(triggerSummary): \(triggerDetail)"
+    )
+}
+
+private func workflowAppDisplayName(for bundleIdentifier: String) -> String {
+    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
+       let bundle = Bundle(url: appURL),
+       let name = bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String,
+       !name.isEmpty {
+        return name
+    }
+
+    let fallback = bundleIdentifier.split(separator: ".").last.map(String.init) ?? bundleIdentifier
+    return fallback.replacingOccurrences(of: "-", with: " ").capitalized
+}
+
+private func workflowCompactList(_ values: [String], conjunction: String = localizedAppText("and", de: "und")) -> String {
+    let filtered = values.filter { !$0.isEmpty }
+    switch filtered.count {
+    case 0:
+        return ""
+    case 1:
+        return filtered[0]
+    case 2:
+        return "\(filtered[0]) \(conjunction) \(filtered[1])"
+    default:
+        return "\(filtered[0]), \(filtered[1]) +\(filtered.count - 2)"
+    }
+}
+
+private func workflowHotkeysConflict(_ lhs: UnifiedHotkey, _ rhs: UnifiedHotkey) -> Bool {
+    lhs == rhs || (
+        lhs.keyCode == rhs.keyCode
+            && lhs.modifierFlags == rhs.modifierFlags
+            && lhs.isFn == rhs.isFn
+            && lhs.mouseButton == rhs.mouseButton
+            && lhs.isDoubleTap != rhs.isDoubleTap
+    )
+}
+
+private func workflowNormalizedDomainFromInput(_ value: String) -> String {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return "" }
+
+    if let url = URL(string: trimmed), let host = url.host() {
+        return workflowNormalizedDomain(host)
+    }
+
+    let withoutScheme = trimmed.replacingOccurrences(
+        of: #"^[a-zA-Z][a-zA-Z0-9+\-.]*://"#,
+        with: "",
+        options: .regularExpression
+    )
+    let hostCandidate = withoutScheme.split(separator: "/").first.map(String.init) ?? withoutScheme
+    return workflowNormalizedDomain(hostCandidate)
+}
+
+private func workflowNormalizedDomain(_ value: String) -> String {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !trimmed.isEmpty else { return "" }
+    if trimmed.hasPrefix("www.") {
+        return String(trimmed.dropFirst(4))
+    }
+    return trimmed
+}
+
+private func workflowsElevatedPanel(cornerRadius: CGFloat) -> some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color(nsColor: .windowBackgroundColor))
+        .shadow(color: Color.black.opacity(0.06), radius: 18, x: 0, y: 10)
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(Color.white.opacity(0.18), lineWidth: 1)
+        )
+}
+
+private func workflowsGroupedSurface(cornerRadius: CGFloat) -> some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .fill(Color(nsColor: .controlBackgroundColor))
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .stroke(Color.black.opacity(0.05), lineWidth: 1)
+        )
+}

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1426,6 +1426,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
         let recentTranscriptionStore = RecentTranscriptionStore()
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
@@ -1448,6 +1449,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             historyService: historyService,
             recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
+            workflowService: workflowService,
             translationService: nil,
             audioDuckingService: audioDuckingService,
             dictionaryService: dictionaryService,
@@ -1765,6 +1767,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
         let recentTranscriptionStore = RecentTranscriptionStore()
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
@@ -1787,6 +1790,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             historyService: historyService,
             recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
+            workflowService: workflowService,
             translationService: nil,
             audioDuckingService: audioDuckingService,
             dictionaryService: dictionaryService,
@@ -1945,6 +1949,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
         let recentTranscriptionStore = RecentTranscriptionStore()
         let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = audioDuckingService ?? AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
@@ -1968,6 +1973,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             historyService: historyService,
             recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
+            workflowService: workflowService,
             translationService: nil,
             audioDuckingService: audioDuckingService,
             dictionaryService: dictionaryService,
@@ -3417,10 +3423,74 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testWorkflowHotkeyInvokesDedicatedWorkflowCallback() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let workflowId = UUID()
+        service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey())])
+
+        var startedWorkflowId: UUID?
+        service.onWorkflowDictationStart = { startedWorkflowId = $0 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        let keyUp = try makeKeyboardEvent(keyCode: 0x31, keyDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startedWorkflowId, workflowId)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(service.currentMode, .toggle)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+    }
+
+    @MainActor
+    func testWorkflowCanRegisterMultipleHotkeysForSameWorkflow() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let workflowId = UUID()
+        service.registerWorkflowHotkeys([
+            (id: workflowId, hotkey: spaceHotkey()),
+            (id: workflowId, hotkey: alternateSpaceHotkey())
+        ])
+
+        var startedWorkflowIds: [UUID] = []
+        service.onWorkflowDictationStart = { startedWorkflowIds.append($0) }
+
+        let firstDown = try makeKeyboardEvent(
+            keyCode: 0x31,
+            keyDown: true,
+            flags: [.maskCommand, .maskAlternate, .maskShift, .maskControl]
+        )
+        let secondDown = try makeKeyboardEvent(
+            keyCode: 0x31,
+            keyDown: true,
+            flags: [.maskCommand, .maskAlternate]
+        )
+
+        XCTAssertTrue(service.processEventForTesting(firstDown, source: .monitor))
+        service.cancelDictation()
+        XCTAssertTrue(service.processEventForTesting(secondDown, source: .monitor))
+        XCTAssertEqual(startedWorkflowIds, [workflowId, workflowId])
+    }
+
+    @MainActor
     private func spaceHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
             keyCode: 0x31,
             modifierFlags: NSEvent.ModifierFlags([.control, .option, .shift, .command]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func alternateSpaceHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x31,
+            modifierFlags: NSEvent.ModifierFlags([.option, .command]).rawValue,
             isFn: false
         )
     }

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -67,4 +67,17 @@ final class AppFormatterServiceTests: XCTestCase {
 
         XCTAssertEqual(output, "<p>hello &lt;team&gt;</p>\n<ul>\n<li>launch</li>\n</ul>")
     }
+
+    @MainActor
+    func testRegisterDefaultUserDefaultsIncludesAppFormattingFlag() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer {
+            defaults.removePersistentDomain(forName: #function)
+        }
+
+        AppDelegate.registerDefaultUserDefaults(defaults)
+
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.appFormattingEnabled) as? Bool, false)
+    }
 }

--- a/TypeWhisperTests/LegacyWorkflowServiceTests.swift
+++ b/TypeWhisperTests/LegacyWorkflowServiceTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+final class LegacyWorkflowServiceTests: XCTestCase {
+    func testProjectsLegacyRulesAndPromptsIntoReadOnlyItems() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LegacyWorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let promptAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Follow-up",
+            prompt: "Turn the input into a concise follow-up message."
+        ))
+
+        profileService.addProfile(
+            name: "Mail Follow-up",
+            bundleIdentifiers: ["com.apple.mail"],
+            translationEnabled: true,
+            translationTargetLanguage: "de",
+            promptActionId: promptAction.id.uuidString
+        )
+
+        let suiteName = "LegacyWorkflowServiceTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LegacyWorkflowService(
+            profileService: profileService,
+            promptActionService: promptActionService,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(service.ruleItems.count, 1)
+        XCTAssertEqual(service.promptItems.count, 1)
+
+        let ruleItem = try XCTUnwrap(service.ruleItems.first)
+        XCTAssertEqual(ruleItem.name, "Mail Follow-up")
+        XCTAssertEqual(ruleItem.sourceKind, .rule)
+        XCTAssertTrue(ruleItem.isEnabled)
+        XCTAssertTrue(ruleItem.detail.contains("Follow-up"))
+
+        let promptItem = try XCTUnwrap(service.promptItems.first)
+        XCTAssertEqual(promptItem.name, "Follow-up")
+        XCTAssertEqual(promptItem.sourceKind, .prompt)
+        XCTAssertTrue(promptItem.isEnabled)
+        XCTAssertTrue(promptItem.detail.contains("1"))
+    }
+
+    func testMarkImportedPersistsAcrossReload() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LegacyWorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let promptAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Checklist",
+            prompt: "Return a checklist."
+        ))
+
+        let suiteName = "LegacyWorkflowServiceTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var service = LegacyWorkflowService(
+            profileService: profileService,
+            promptActionService: promptActionService,
+            defaults: defaults
+        )
+
+        let item = try XCTUnwrap(service.promptItems.first(where: { $0.sourceObjectId == promptAction.id }))
+        service.markImported(item)
+
+        service = LegacyWorkflowService(
+            profileService: profileService,
+            promptActionService: promptActionService,
+            defaults: defaults
+        )
+
+        let reloadedItem = try XCTUnwrap(service.promptItems.first(where: { $0.sourceObjectId == promptAction.id }))
+        XCTAssertTrue(reloadedItem.isImported)
+    }
+
+    func testDeleteLegacyRuleRemovesRuleItem() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LegacyWorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+
+        profileService.addProfile(
+            name: "Notes Rule",
+            bundleIdentifiers: ["com.apple.Notes"]
+        )
+
+        let suiteName = "LegacyWorkflowServiceTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LegacyWorkflowService(
+            profileService: profileService,
+            promptActionService: promptActionService,
+            defaults: defaults
+        )
+
+        let ruleItem = try XCTUnwrap(service.ruleItems.first)
+        service.deleteItem(ruleItem)
+
+        XCTAssertTrue(service.ruleItems.isEmpty)
+        XCTAssertTrue(profileService.profiles.isEmpty)
+    }
+
+    func testDeleteLegacyPromptRemovesPromptAndUnlinksProfiles() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LegacyWorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let promptAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Translate",
+            prompt: "Translate the input."
+        ))
+
+        profileService.addProfile(
+            name: "Mail Translate",
+            bundleIdentifiers: ["com.apple.mail"],
+            promptActionId: promptAction.id.uuidString
+        )
+
+        let suiteName = "LegacyWorkflowServiceTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LegacyWorkflowService(
+            profileService: profileService,
+            promptActionService: promptActionService,
+            defaults: defaults
+        )
+
+        let promptItem = try XCTUnwrap(service.promptItems.first(where: { $0.sourceObjectId == promptAction.id }))
+        service.deleteItem(promptItem)
+
+        XCTAssertTrue(service.promptItems.isEmpty)
+        XCTAssertNil(profileService.profiles.first?.promptActionId)
+        XCTAssertFalse(service.ruleItems.first?.detail.contains("Prompt:") ?? true)
+    }
+}

--- a/TypeWhisperTests/ProfileServiceTests.swift
+++ b/TypeWhisperTests/ProfileServiceTests.swift
@@ -110,4 +110,94 @@ final class ProfileServiceTests: XCTestCase {
         XCTAssertEqual(specificMatch?.profile.name, "Safari Only")
         XCTAssertEqual(specificMatch?.kind, .appOnly)
     }
+
+    @MainActor
+    func testPrepareNewProfilePrefillsPromptActionAndKeepsEmptyScope() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let settingsViewModel = SettingsViewModel(modelManager: ModelManagerService())
+        let viewModel = ProfilesViewModel(
+            profileService: profileService,
+            historyService: historyService,
+            settingsViewModel: settingsViewModel
+        )
+
+        viewModel.prepareNewProfile(prefilledPromptActionId: "prompt-123")
+
+        XCTAssertTrue(viewModel.showingEditor)
+        XCTAssertEqual(viewModel.editorStep, .scope)
+        XCTAssertEqual(viewModel.editorPromptActionId, "prompt-123")
+        XCTAssertTrue(viewModel.editorPromptActionWasPrefilled)
+        XCTAssertTrue(viewModel.editorBundleIdentifiers.isEmpty)
+        XCTAssertTrue(viewModel.editorUrlPatterns.isEmpty)
+        XCTAssertTrue(viewModel.shouldShowPrefilledPromptFallbackNotice)
+    }
+
+    @MainActor
+    func testPrepareNewProfileWithoutPrefillKeepsPromptUnset() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let settingsViewModel = SettingsViewModel(modelManager: ModelManagerService())
+        let viewModel = ProfilesViewModel(
+            profileService: profileService,
+            historyService: historyService,
+            settingsViewModel: settingsViewModel
+        )
+
+        viewModel.prepareNewProfile()
+
+        XCTAssertNil(viewModel.editorPromptActionId)
+        XCTAssertFalse(viewModel.editorPromptActionWasPrefilled)
+        XCTAssertFalse(viewModel.shouldShowPrefilledPromptFallbackNotice)
+    }
+
+    @MainActor
+    func testFocusRulesByPromptFiltersVisibleProfiles() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let settingsViewModel = SettingsViewModel(modelManager: ModelManagerService())
+        let viewModel = ProfilesViewModel(
+            profileService: profileService,
+            historyService: historyService,
+            settingsViewModel: settingsViewModel
+        )
+
+        profileService.addProfile(name: "Prompt A 1", promptActionId: "prompt-a")
+        profileService.addProfile(name: "Prompt B", promptActionId: "prompt-b")
+        profileService.addProfile(name: "Prompt A 2", promptActionId: "prompt-a")
+        viewModel.profiles = profileService.profiles
+
+        XCTAssertEqual(viewModel.visibleProfiles.count, 3)
+
+        viewModel.focusRules(usingPromptActionId: "prompt-a")
+
+        XCTAssertTrue(viewModel.isFilteringRulesByPrompt)
+        XCTAssertEqual(
+            Set(viewModel.visibleProfiles.map(\.name)),
+            Set(["Prompt A 1", "Prompt A 2"])
+        )
+
+        viewModel.clearPromptRuleFocus()
+
+        XCTAssertFalse(viewModel.isFilteringRulesByPrompt)
+        XCTAssertEqual(viewModel.visibleProfiles.count, 3)
+    }
 }

--- a/TypeWhisperTests/PromptActionsViewModelWizardTests.swift
+++ b/TypeWhisperTests/PromptActionsViewModelWizardTests.swift
@@ -139,6 +139,97 @@ final class PromptActionsViewModelWizardTests: XCTestCase {
         XCTAssertEqual(action.name, localizedAppText("Extract JSON", de: "JSON extrahieren"))
     }
 
+    func testAssignmentStatusTracksRuleUsageCounts() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let viewModel = PromptActionsViewModel(
+            promptActionService: promptActionService,
+            promptProcessingService: PromptProcessingService(),
+            profileService: profileService
+        )
+
+        let unusedAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Unused",
+            prompt: "Do nothing."
+        ))
+        let assignedAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Assigned",
+            prompt: "Translate this."
+        ))
+
+        XCTAssertEqual(viewModel.assignmentStatus(for: unusedAction), PromptRuleAssignmentStatus(ruleCount: 0))
+        XCTAssertEqual(viewModel.assignmentSummary(for: unusedAction), localizedAppText("Not used in any rules", de: "Nicht in Regeln verwendet"))
+
+        profileService.addProfile(name: "Global 1", promptActionId: assignedAction.id.uuidString)
+
+        XCTAssertEqual(viewModel.assignmentStatus(for: assignedAction), PromptRuleAssignmentStatus(ruleCount: 1))
+        XCTAssertEqual(viewModel.assignmentSummary(for: assignedAction), localizedAppText("Used in 1 rule", de: "In 1 Regel verwendet"))
+
+        profileService.addProfile(name: "Global 2", promptActionId: assignedAction.id.uuidString)
+
+        XCTAssertEqual(viewModel.assignmentStatus(for: assignedAction), PromptRuleAssignmentStatus(ruleCount: 2))
+        XCTAssertEqual(viewModel.assignmentSummary(for: assignedAction), localizedAppText("Used in 2 rules", de: "In 2 Regeln verwendet"))
+    }
+
+    func testSaveEditingFlagsUnassignedPromptForRuleAssignmentCallout() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let viewModel = PromptActionsViewModel(
+            promptActionService: service,
+            promptProcessingService: PromptProcessingService(),
+            profileService: profileService
+        )
+
+        viewModel.startCreating()
+        viewModel.setWizardGoal(.extract)
+        viewModel.updateWizardDraft { draft in
+            draft.extractFormat = .json
+        }
+
+        viewModel.saveEditing()
+
+        let action = try XCTUnwrap(service.promptActions.first)
+        XCTAssertEqual(viewModel.pendingRuleAssignmentPromptId, action.id.uuidString)
+        XCTAssertTrue(viewModel.shouldShowRuleAssignmentCallout)
+    }
+
+    func testRulesUsingReturnsMatchingProfiles() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let viewModel = PromptActionsViewModel(
+            promptActionService: promptActionService,
+            promptProcessingService: PromptProcessingService(),
+            profileService: profileService
+        )
+
+        let linkedAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Linked",
+            prompt: "Refine this text."
+        ))
+        let otherAction = try XCTUnwrap(promptActionService.addAction(
+            name: "Other",
+            prompt: "Translate this."
+        ))
+
+        profileService.addProfile(name: "Rule A", promptActionId: linkedAction.id.uuidString)
+        profileService.addProfile(name: "Rule B", promptActionId: linkedAction.id.uuidString)
+        profileService.addProfile(name: "Rule C", promptActionId: otherAction.id.uuidString)
+
+        XCTAssertEqual(
+            Set(viewModel.rulesUsing(linkedAction).map(\.name)),
+            Set(["Rule A", "Rule B"])
+        )
+    }
+
     private func makeViewModel() throws -> PromptActionsViewModel {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PromptActionsViewModelWizardTests")
         addTeardownBlock {

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -149,6 +149,9 @@ final class PromptPaletteHandlerTests: XCTestCase {
     func testTriggerSelectionStillOpensPaletteWhenCurrentProviderIsNotReady() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
+        let previousPluginManager = PluginManager.shared
+        PluginManager.shared = PluginManager()
+        defer { PluginManager.shared = previousPluginManager }
 
         let textInsertionService = TextInsertionService()
         textInsertionService.accessibilityGrantedOverride = true
@@ -160,11 +163,12 @@ final class PromptPaletteHandlerTests: XCTestCase {
             )
         }
 
-        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
-        promptActionService.addAction(
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = workflowService.addWorkflow(
             name: "Translate",
-            prompt: "Translate the selected text.",
-            providerType: "Groq"
+            template: .translation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(settings: ["targetLanguage": "German"])
         )
 
         let promptProcessingService = PromptProcessingService()
@@ -173,7 +177,7 @@ final class PromptPaletteHandlerTests: XCTestCase {
         let controller = PromptPaletteControllerSpy()
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
-            promptActionService: promptActionService,
+            workflowService: workflowService,
             promptProcessingService: promptProcessingService,
             soundService: SoundService(),
             accessibilityAnnouncementService: AccessibilityAnnouncementService(),
@@ -186,7 +190,7 @@ final class PromptPaletteHandlerTests: XCTestCase {
         handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
 
         XCTAssertTrue(controller.isVisible)
-        XCTAssertEqual(controller.lastActions?.map(\.name), ["Translate"])
+        XCTAssertEqual(controller.lastWorkflows?.map(\.name), ["Translate"])
         XCTAssertEqual(controller.lastSourceText, "Selected text")
         XCTAssertNil(shownError)
     }
@@ -279,13 +283,13 @@ final class SelectionPaletteInteractionModelTests: XCTestCase {
 @MainActor
 private final class PromptPaletteControllerSpy: PromptPaletteControlling {
     private(set) var isVisible = false
-    private(set) var lastActions: [PromptAction]?
+    private(set) var lastWorkflows: [Workflow]?
     private(set) var lastSourceText: String?
-    private var onSelect: ((PromptAction) -> Void)?
+    private var onSelect: ((Workflow) -> Void)?
 
-    func show(actions: [PromptAction], sourceText: String, onSelect: @escaping (PromptAction) -> Void) {
+    func show(workflows: [Workflow], sourceText: String, onSelect: @escaping (Workflow) -> Void) {
         isVisible = true
-        lastActions = actions
+        lastWorkflows = workflows
         lastSourceText = sourceText
         self.onSelect = onSelect
     }

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -1,0 +1,225 @@
+import AppKit
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+final class WorkflowServiceTests: XCTestCase {
+    func testWorkflowServicePersistsEncodedTriggerBehaviorAndOutput() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let primaryHotkey = UnifiedHotkey(keyCode: 15, modifierFlags: 0, isFn: false)
+        let secondaryHotkey = UnifiedHotkey(keyCode: 17, modifierFlags: NSEvent.ModifierFlags.command.rawValue, isFn: false)
+
+        service.addWorkflow(
+            name: "Meeting Notes",
+            template: .meetingNotes,
+            trigger: .hotkeys([primaryHotkey, secondaryHotkey]),
+            behavior: WorkflowBehavior(
+                settings: ["tone": "professional", "sections": "decisions,actions"],
+                fineTuning: "Keep it concise.",
+                providerId: "Groq",
+                cloudModel: "llama-3.3",
+                temperatureModeRaw: "custom",
+                temperatureValue: 0.2
+            ),
+            output: WorkflowOutput(
+                format: "markdown",
+                autoEnter: true,
+                targetActionPluginId: "plugin.action"
+            )
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(workflow.name, "Meeting Notes")
+        XCTAssertEqual(workflow.template, .meetingNotes)
+        XCTAssertEqual(workflow.trigger, .hotkeys([primaryHotkey, secondaryHotkey]))
+        XCTAssertEqual(
+            workflow.behavior,
+            WorkflowBehavior(
+                settings: ["tone": "professional", "sections": "decisions,actions"],
+                fineTuning: "Keep it concise.",
+                providerId: "Groq",
+                cloudModel: "llama-3.3",
+                temperatureModeRaw: "custom",
+                temperatureValue: 0.2
+            )
+        )
+        XCTAssertEqual(
+            workflow.output,
+            WorkflowOutput(
+                format: "markdown",
+                autoEnter: true,
+                targetActionPluginId: "plugin.action"
+            )
+        )
+    }
+
+    func testReorderWorkflowsUsesProvidedOrder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let first = try XCTUnwrap(service.addWorkflow(
+            name: "First",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail")
+        ))
+        let second = try XCTUnwrap(service.addWorkflow(
+            name: "Second",
+            template: .translation,
+            trigger: .website("docs.github.com")
+        ))
+        let third = try XCTUnwrap(service.addWorkflow(
+            name: "Third",
+            template: .summary,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 3, modifierFlags: 0, isFn: false))
+        ))
+
+        service.reorderWorkflows([third, first, second])
+
+        XCTAssertEqual(service.workflows.map(\.name), ["Third", "First", "Second"])
+        XCTAssertEqual(service.workflows.map(\.sortOrder), [0, 1, 2])
+        XCTAssertEqual(service.nextSortOrder(), 3)
+    }
+
+    func testToggleAndDeleteWorkflowUpdatePublishedState() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(service.addWorkflow(
+            name: "Checklist",
+            template: .checklist,
+            trigger: .website("linear.app")
+        ))
+
+        XCTAssertTrue(workflow.isEnabled)
+
+        service.toggleWorkflow(workflow)
+
+        XCTAssertFalse(service.workflows[0].isEnabled)
+
+        service.deleteWorkflow(workflow)
+
+        XCTAssertTrue(service.workflows.isEmpty)
+    }
+
+    func testTemplateCatalogMatchesApprovedInitialOrder() {
+        XCTAssertEqual(
+            WorkflowTemplate.catalog.map(\.template),
+            [.cleanedText, .translation, .emailReply, .meetingNotes, .checklist, .json, .summary, .custom]
+        )
+    }
+
+    func testMatchWorkflowSupportsMultipleAppsAndWebsitesPerWorkflow() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Browsers Summary",
+            template: .summary,
+            trigger: .apps(["com.apple.Safari", "com.google.Chrome"])
+        )
+        _ = service.addWorkflow(
+            name: "Docs Translation",
+            template: .translation,
+            trigger: .websites(["docs.github.com", "developer.apple.com"]),
+            sortOrder: 0
+        )
+
+        let websiteMatch = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "com.google.Chrome",
+            url: "https://developer.apple.com/documentation/swiftui"
+        ))
+        XCTAssertEqual(websiteMatch.workflow.name, "Docs Translation")
+        XCTAssertEqual(websiteMatch.kind, .website)
+
+        let appMatch = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "com.google.Chrome",
+            url: "https://example.com"
+        ))
+        XCTAssertEqual(appMatch.workflow.name, "Browsers Summary")
+        XCTAssertEqual(appMatch.kind, .app)
+    }
+
+    func testMatchWorkflowPrefersWebsiteBeforeAppAndUsesSortOrder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Mail Cleanup",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail"),
+            sortOrder: 2
+        )
+        _ = service.addWorkflow(
+            name: "Docs Summary",
+            template: .summary,
+            trigger: .website("docs.github.com"),
+            sortOrder: 1
+        )
+        _ = service.addWorkflow(
+            name: "Fallback Summary",
+            template: .summary,
+            trigger: .website("github.com"),
+            sortOrder: 3
+        )
+
+        let match = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "com.apple.mail",
+            url: "https://docs.github.com/en/actions"
+        ))
+
+        XCTAssertEqual(match.workflow.name, "Docs Summary")
+        XCTAssertEqual(match.kind, .website)
+        XCTAssertEqual(match.matchedDomain, "docs.github.com")
+        XCTAssertEqual(match.competingWorkflowCount, 1)
+        XCTAssertTrue(match.wonBySortOrder)
+    }
+
+    func testMatchWorkflowIgnoresDisabledAndHotkeyOnlyEntries() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Disabled App Workflow",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail"),
+            isEnabled: false
+        )
+        _ = service.addWorkflow(
+            name: "Manual Checklist",
+            template: .checklist,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 3, modifierFlags: 0, isFn: false))
+        )
+
+        XCTAssertNil(service.matchWorkflow(bundleIdentifier: "com.apple.mail", url: "https://mail.google.com"))
+    }
+
+    func testForcedWorkflowMatchUsesManualOverrideKind() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(service.addWorkflow(
+            name: "Manual Meeting Notes",
+            template: .meetingNotes,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 14, modifierFlags: 0, isFn: false))
+        ))
+
+        let match = service.forcedWorkflowMatch(for: workflow)
+
+        XCTAssertEqual(match.workflow.id, workflow.id)
+        XCTAssertEqual(match.kind, .manualOverride)
+        XCTAssertNil(match.matchedDomain)
+        XCTAssertEqual(match.competingWorkflowCount, 0)
+        XCTAssertFalse(match.wonBySortOrder)
+    }
+}

--- a/docs/specs/2026-04-22-workflows-design.md
+++ b/docs/specs/2026-04-22-workflows-design.md
@@ -1,0 +1,415 @@
+# Workflows Redesign
+
+## Summary
+
+TypeWhisper replaces the current user-facing `Prompts` + `Rules` model with a single new primary object: `Workflow`.
+
+A workflow always has:
+- exactly one template
+- exactly one trigger
+- behavior details based on the selected template
+- optional fine-tuning
+- an output configuration
+
+`Legacy` data remains visible and importable, but is no longer executable.
+
+## Why This Change
+
+The current model forces users to split one intention into two objects:
+- create a prompt
+- assign that prompt to a rule
+
+That produces avoidable navigation hops, unclear ownership, and frequent misuse of fallback rules for manual actions.
+
+The redesign aligns the product with the user’s actual mental model:
+- “I want meeting notes”
+- “triggered by this hotkey”
+- “with this output style”
+
+## Goals
+
+- Make `Workflow` the only active automation concept in the product.
+- Remove `Prompt` and `Rule` as user-facing concepts.
+- Make manual actions first-class via `Hotkey` workflows.
+- Keep creation and editing in one consistent builder experience.
+- Preserve old user data safely without auto-migrating it.
+- Allow per-entry import from legacy data into the new model.
+
+## Non-Goals
+
+- No automatic migration of old prompts/rules into workflows in v1.
+- No free-form canvas or node-based editor.
+- No multi-trigger workflows.
+- No multi-app or mixed app+website workflows.
+- No global fallback workflow in v1.
+- No prompt palette in v1.
+
+## Information Architecture
+
+### Navigation
+
+The `Rules` area is renamed to `Workflows`.
+
+Primary navigation inside the area:
+- `Meine Workflows`
+- `Legacy`
+
+Primary action in `Meine Workflows`:
+- `Neuer Workflow`
+
+`Neuer Workflow` is a button, not a permanent navigation destination.
+
+### Page Model
+
+`Meine Workflows`
+- list of active new workflows
+- search, ordering, enable/disable
+- primary button `Neuer Workflow`
+
+`Neuer Workflow`
+- dedicated page
+- opened via push-style navigation with a back button
+- starts with workflow creation builder
+
+`Workflow bearbeiten`
+- dedicated page
+- uses the same builder shell as creation
+- opens directly into the existing workflow state
+
+`Legacy`
+- dedicated page
+- shows old prompts/rules in read-only form
+- every entry can be imported into a new workflow
+
+## User-Facing Naming
+
+New primary term:
+- `Workflow`
+
+New labels:
+- `Meine Workflows`
+- `Neuer Workflow`
+- `Workflow bearbeiten`
+- `Legacy`
+
+Terms removed from the UI:
+- `Prompt`
+- `Rule`
+
+This rename also applies internally. New domain objects, stores, view models, and screens should use `Workflow` naming instead of `Rule` or `Prompt`.
+
+## Workflow Model
+
+### Core Model
+
+A workflow has:
+- `id`
+- `name`
+- `isEnabled`
+- `template`
+- `trigger`
+- `behavior`
+- `output`
+- `sortOrder`
+- timestamps / metadata as needed
+
+### Template
+
+Each workflow has exactly one template.
+
+Initial template set:
+- `Bereinigter Text`
+- `Übersetzung`
+- `E-Mail-Antwort`
+- `Meeting Notes`
+- `Checkliste`
+- `JSON`
+- `Zusammenfassung`
+- `Eigener Workflow`
+
+Template selection is immutable after creation.
+
+If a user wants a different template later, they create a new workflow or duplicate an existing one as a new workflow.
+
+### Trigger
+
+Each workflow has exactly one trigger.
+
+Allowed trigger types in v1:
+- `App`
+- `Website`
+- `Hotkey`
+
+Not supported in v1:
+- global workflows
+- mixed triggers
+- app + website combinations
+- multiple apps
+
+### Behavior
+
+`Behavior` contains:
+- template-specific fields
+- optional `Feinabstimmung`
+- advanced output configuration
+
+`Feinabstimmung` is the replacement for free-form prompt-level customization.
+
+It is explicitly secondary to the structured template fields.
+
+### Output
+
+Output remains available for every workflow, but lives inside an `Erweitert` section of the behavior step rather than as a top-level primary choice.
+
+## Builder
+
+### Shared Builder Shell
+
+Creation and editing use the same builder shell and visual language.
+
+Creation flow:
+1. `Vorlage`
+2. `Verhalten`
+3. `Trigger`
+4. `Review`
+
+Edit flow:
+- same builder shell
+- no template selection step
+- template shown as fixed header information
+
+### Step 1: Vorlage
+
+This step is a large gallery of concrete outcomes, not abstract prompt types.
+
+Each card should describe the end result clearly.
+
+`Eigener Workflow` is the last card and enters the same builder, not a separate prompt editor.
+
+### Step 2: Verhalten
+
+This step includes:
+- template-specific details
+- optional `Feinabstimmung`
+- `Erweitert` section with output controls
+
+This is the main behavior-first step and should carry most of the workflow’s configuration weight.
+
+### Step 3: Trigger
+
+User chooses exactly one trigger:
+- `App`
+- `Website`
+- `Hotkey`
+
+Each trigger type gets a focused configuration UI for a single target only.
+
+### Step 4: Review
+
+This step presents a readable summary of the workflow before saving.
+
+The review should read like a concise sentence or short paragraph, for example:
+- “Wenn Hotkey X gedrückt wird, erzeugt TypeWhisper Meeting Notes.”
+- “Wenn Website Y aktiv ist, übersetzt TypeWhisper den Text nach Englisch.”
+
+## Workflow List
+
+`Meine Workflows` should be optimized for quick scanning and management.
+
+Recommended row style:
+- short readable sentence
+- plus a few compact badges for template, trigger, and status
+
+This keeps the list human-readable without becoming too verbose.
+
+## Legacy Strategy
+
+### Legacy Principles
+
+Legacy data remains:
+- visible
+- read-only
+- importable
+
+Legacy data does not remain:
+- executable
+- editable
+
+There is no mixed runtime between new workflows and legacy items in v1.
+
+### Legacy Storage
+
+Legacy data lives in a completely separate model and store from the new workflow system.
+
+This separation is required to keep the new domain model clean and prevent compatibility logic from polluting the workflow core.
+
+Suggested internal split:
+- `Workflow` store
+- `LegacyWorkflow` store or equivalent legacy archive store
+
+### Legacy Presentation
+
+`Legacy` is a separate page in navigation.
+
+Each legacy entry:
+- is readable
+- is clearly marked as deprecated / legacy
+- can be imported
+- may show an `Importiert` status after successful import
+
+Imported status does not need to link to the new workflow.
+
+Legacy entries remain visible after import.
+
+## Import Flow
+
+### Import Principles
+
+Import is:
+- per entry
+- explicit
+- user-confirmed
+- copy-based, not move-based
+
+Import is not:
+- automatic
+- bulk-based
+- silent
+
+### Import UX
+
+Per legacy entry action:
+- `Als Workflow importieren`
+
+Import result:
+- opens the new workflow builder as a prefilled draft
+- user reviews and saves it explicitly
+
+After save:
+- no deactivation prompt is needed
+- legacy entry remains visible in `Legacy`
+- legacy entry may be marked as `Importiert`
+
+### Import Mapping
+
+Import behavior depends on source quality:
+
+Legacy rule with clear trigger and clear behavior:
+- import into matching workflow template and trigger when possible
+
+Legacy prompt without a clear trigger:
+- import as a prefilled `Eigener Workflow`
+- require the user to choose a trigger before save
+
+If a legacy item cannot be mapped cleanly:
+- preserve as much behavior text as possible
+- fall back to `Eigener Workflow`
+- show a short warning/explanation inside the draft
+
+## Internal Architecture
+
+### New Domain
+
+New internal domain should use workflow terminology consistently:
+- `Workflow`
+- `WorkflowTemplate`
+- `WorkflowTrigger`
+- `WorkflowBehavior`
+- `WorkflowOutput`
+- `WorkflowStore`
+- `WorkflowListViewModel`
+- `WorkflowBuilderViewModel`
+
+### Legacy Domain
+
+Legacy should be modeled separately:
+- `LegacyWorkflow`
+- `LegacyStore`
+- `LegacyImportMapper`
+
+No shared write path between workflow and legacy stores.
+
+### Runtime
+
+Only the new workflow system participates in runtime matching and execution.
+
+Legacy is an archive/import surface only.
+
+This removes:
+- old-vs-new precedence rules
+- duplicate execution risk
+- hidden compatibility behavior
+
+## Rollout Plan
+
+### Phase 1
+
+- Introduce new workflow domain model and store
+- Build new `Meine Workflows` list
+- Build new workflow builder
+- Rename user-facing language from rules/prompts to workflows
+- Add `Legacy` page
+- make legacy entries read-only and non-executable
+- add per-entry import
+
+### Phase 2
+
+- polish template gallery and builder copy
+- improve import fidelity
+- add duplication / cloning for workflows if useful
+
+### Phase 3
+
+- evaluate whether legacy can eventually be hidden further or removed
+
+## Testing
+
+### Model Tests
+
+- workflow persistence roundtrip
+- template immutability after creation
+- single-trigger validation
+- no-global-trigger validation
+- import mapping from legacy rule to workflow
+- import mapping from legacy prompt to `Eigener Workflow`
+
+### View Model Tests
+
+- create flow starts in template gallery
+- edit flow skips template selection
+- behavior step exposes `Feinabstimmung`
+- output is only shown under `Erweitert`
+- import creates prefilled workflow draft
+- legacy items are marked read-only
+- legacy items are never returned by runtime matching
+
+### UI / Navigation Tests
+
+- `Meine Workflows` is default landing page
+- `Neuer Workflow` opens dedicated page with back navigation
+- saving returns correctly to workflow list
+- `Legacy` is reachable via navigation
+- imported legacy entry can display `Importiert`
+
+### Manual QA
+
+- create one workflow per trigger type
+- edit a workflow without changing template
+- verify hotkey-only workflow replaces prompt-palette style manual usage
+- verify legacy entries remain visible but do not execute
+- import a legacy entry and confirm the new workflow executes
+
+## Risks
+
+- The rename is broad and touches both UI and internal model names.
+- Import quality may vary across legacy data shapes.
+- Users familiar with the old split model may need clear onboarding copy.
+- Removing legacy execution in v1 is a hard behavioral break and must be communicated clearly.
+
+## Success Criteria
+
+- New users can create an automation without learning prompt-to-rule assignment.
+- Manual actions are configured through hotkey workflows, not fallback tricks.
+- The builder feels like one coherent flow.
+- Legacy items are preserved safely without blocking the new architecture.
+- The codebase reflects the new workflow model cleanly rather than carrying prompt/rule duality forward.

--- a/docs/specs/2026-04-22-workflows-implementation-plan.md
+++ b/docs/specs/2026-04-22-workflows-implementation-plan.md
@@ -1,0 +1,379 @@
+# Workflows Implementation Plan
+
+## Ziel
+
+Dieser Plan übersetzt den freigegebenen Workflow-Spec in eine konkrete, code-nahe Umsetzungsreihenfolge.
+
+Er ist auf den aktuellen Stand des Repos zugeschnitten:
+- `Profile` ist heute das aktive Laufzeitobjekt in [TypeWhisper/Models/Profile.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Models/Profile.swift)
+- `PromptAction` ist heute das aktive LLM-/Preset-Objekt in [TypeWhisper/Models/PromptAction.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Models/PromptAction.swift)
+- `ProfileService` matcht Regeln für Runtime und Hotkeys in [TypeWhisper/Services/ProfileService.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Services/ProfileService.swift)
+- `PromptActionService` liefert Prompt-Presets, Prompt-Lookups und Prompt-Persistenz in [TypeWhisper/Services/PromptActionService.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Services/PromptActionService.swift)
+- `DictationViewModel` hängt aktuell direkt an `ProfileService` und `PromptActionService` in [TypeWhisper/ViewModels/DictationViewModel.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/ViewModels/DictationViewModel.swift)
+- Settings zeigt derzeit getrennte Tabs `Rules` und `Prompts` in [TypeWhisper/Views/SettingsView.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Views/SettingsView.swift)
+
+## Leitplanken
+
+- Neue Features werden nur noch auf dem neuen `Workflow`-Modell gebaut.
+- Bestehende `profiles.store` und `prompt-actions.store` bleiben in `v1` unangetastet und bilden die Legacy-Grenze.
+- `Legacy` ist read-only, sichtbar und importierbar, aber nicht ausführbar.
+- Die neue Runtime führt ausschließlich `Workflows` aus.
+- Der Umbau erfolgt in einer Reihenfolge, die jederzeit ein sauberes Branch-Endergebnis zulässt. Temporäre interne Parallelität ist in der Implementierung erlaubt, aber kein Zwischenzustand darf shipped werden, in dem alte und neue Runtime gleichzeitig aktiv arbeiten.
+
+## Wichtige Architekturentscheidung
+
+### Alte SwiftData-Modelle nicht vorschnell umbenennen
+
+Obwohl das neue Produktmodell intern ebenfalls `Workflow` heißen soll, sollten die bestehenden SwiftData-Typen `Profile` und `PromptAction` in `v1` nicht direkt physisch umbenannt werden.
+
+Grund:
+- diese Typen hängen an bestehenden Persistenzdateien
+- eine harte Umbenennung der `@Model`-Typen erhöht das Risiko für Store-Resets oder unerwartete Schema-Brüche
+- der eigentliche Gewinn liegt darin, dass neue Codepfade nicht mehr von ihnen abhängen
+
+Konsequenz:
+- neues System bekommt durchgehend neue `Workflow`-Typen
+- altes System wird über eine explizite Legacy-Schicht gekapselt
+- physische Umbenennung alter `@Model`-Typen kann später separat erfolgen, wenn Legacy wirklich entfernt wird
+
+## Zielarchitektur
+
+### Neues aktives System
+
+- `Workflow`
+- `WorkflowTemplate`
+- `WorkflowTrigger`
+- `WorkflowBehavior`
+- `WorkflowOutput`
+- `WorkflowService`
+- `WorkflowMatcher`
+- `WorkflowImportMapper`
+- `WorkflowsViewModel`
+- `WorkflowBuilderViewModel`
+
+### Legacy-Grenze
+
+- `ProfileService` bleibt als Persistenzzugang für `profiles.store`
+- `PromptActionService` bleibt als Persistenzzugang für `prompt-actions.store`
+- darüber liegt ein neuer read-only Adapter:
+  - `LegacyWorkflowService`
+  - `LegacyWorkflow`
+  - `LegacyImportDraft`
+
+Der Rest der App soll nach der Migration nicht mehr direkt mit `Profile` oder `PromptAction` arbeiten, außer innerhalb dieser Legacy-Schicht.
+
+## Phasen
+
+## Phase 1: Neues Workflow-Domain-Modell und Store
+
+### Ziel
+
+Ein eigenständiges aktives Workflow-System schaffen, ohne bestehende Legacy-Daten zu verändern.
+
+### Arbeitspakete
+
+- Neues SwiftData-Modell anlegen:
+  - `TypeWhisper/Models/Workflow.swift`
+- Neue modellnahe Hilfstypen anlegen:
+  - `WorkflowTemplate`
+  - `WorkflowTrigger`
+  - `WorkflowBehavior`
+  - `WorkflowOutput`
+- Neuen Store/Service anlegen:
+  - `TypeWhisper/Services/WorkflowService.swift`
+  - Persistenzdatei z. B. `workflows.store`
+- Sortierung, Aktivierung, CRUD und `nextSortOrder()` für Workflows aufbauen
+- Template-Katalog als neues System definieren, nicht aus `PromptAction.presets` ableiten
+  - z. B. `WorkflowTemplateCatalog`
+- `ServiceContainer` um `WorkflowService` erweitern
+
+### Bewusste Abgrenzung
+
+- `ProfileService` und `PromptActionService` bleiben unverändert aktiv im Code, aber nur als Legacy-Abhängigkeit
+- keine UI-Anbindung an alte `ProfilesViewModel`-/`PromptActionsViewModel`-Flows mehr neu bauen
+
+### Exit-Kriterien
+
+- Workflows lassen sich unabhängig vom Legacy-Bestand speichern und laden
+- `ServiceContainer` kann `WorkflowService` sauber initialisieren
+- Basis-Tests für CRUD, Sortierung und Persistenz stehen
+
+## Phase 2: Workflow-Runtime und Matching
+
+### Ziel
+
+Die aktive Laufzeit von `Profile`/`PromptAction` auf `Workflow` umstellen.
+
+### Aktuelle Nahtstellen
+
+- `ProfileService.matchRule(...)`
+- `DictationViewModel.startRecording(...)`
+- `DictationViewModel.scheduleDeferredRecordingMetadataCapture(...)`
+- `DictationViewModel.buildLLMHandler(...)`
+- `DictationSettingsHandler.syncProfileHotkeys(...)`
+- `HotkeyService.registerProfileHotkeys(...)`
+
+### Arbeitspakete
+
+- Neuen Matcher einführen:
+  - `WorkflowMatcher` oder Workflow-Matching direkt in `WorkflowService`
+- Matching-Regeln für `App`, `Website`, `Hotkey` definieren
+- `Global`-Fallback komplett entfernen
+- `DictationViewModel` auf `WorkflowService` umstellen:
+  - `matchedProfile`/`ruleMatch` durch Workflow-Pendants ersetzen
+  - LLM-Postprocessing aus `WorkflowBehavior` ableiten
+  - Output/Auto-Enter aus `WorkflowOutput` ableiten
+- `DictationSettingsHandler` auf Workflow-Hotkeys umstellen
+  - entweder umbenennen oder durch neuen `WorkflowHotkeySync` ersetzen
+- `HotkeyService.registerProfileHotkeys(...)` durch workflow-neutrale API ersetzen
+  - z. B. `registerWorkflowHotkeys(...)` oder `registerTriggerHotkeys(...)`
+- Prompt Palette Runtime entfernen:
+  - `promptPalette`-Slot nicht mehr für aktive Features verwenden
+  - `PromptPaletteHandler` nicht mehr in den neuen Laufzeitpfad hängen
+
+### Nebenwirkungen, die mitgezogen werden müssen
+
+- `MemoryService` prüft heute `payload.ruleName` gegen `Profile`
+  - auf Workflow-ID oder Workflow-Name umstellen
+- `HostServicesImpl.availableRuleNames`
+  - auf Workflow-Namen umstellen
+- EventBus-Payloads mit `ruleName`
+  - konsistent auf Workflow-Semantik bringen
+
+### Exit-Kriterien
+
+- Diktat ohne Legacy-Regeln funktioniert vollständig über Workflows
+- Hotkey-Trigger für Workflows funktionieren
+- Es gibt keinen aktiven Runtime-Pfad mehr, der `ProfileService.matchRule(...)` für neue Ausführung verwendet
+
+## Phase 3: Neue Workflows-Oberfläche in Settings
+
+### Ziel
+
+Die alte Trennung `Rules`/`Prompts` im UI durch einen einzigen `Workflows`-Bereich ersetzen.
+
+### Aktuelle Nahtstellen
+
+- `SettingsView` mit Tabs `.profiles` und `.prompts`
+- `ProfilesSettingsView`
+- `PromptActionsSettingsView`
+
+### Arbeitspakete
+
+- `SettingsTab` umstellen:
+  - neuer Tab `.workflows`
+  - `profiles` und `prompts` aus der aktiven Navigation entfernen
+- Neue Root-Ansicht:
+  - `TypeWhisper/Views/WorkflowsSettingsView.swift`
+- Interne Navigation im Workflows-Bereich:
+  - `Meine Workflows`
+  - `Legacy`
+  - Push-Navigation für `Neuer Workflow` und `Workflow bearbeiten`
+- Neue Listenansicht aufbauen:
+  - lesbare Kurzbeschreibung
+  - Badges für Vorlage, Trigger, Status
+  - Suche, Aktivierung, Reihenfolge
+
+### Wichtige Designregel
+
+`Neuer Workflow` bleibt eine Aktion, kein fester Navigationspunkt.
+
+### Exit-Kriterien
+
+- Settings zeigt nur noch einen aktiven Workflows-Bereich
+- `Prompts` ist aus der Hauptnavigation verschwunden
+- die neue Liste ist vollständig an `WorkflowService` gebunden
+
+## Phase 4: Workflow-Builder
+
+### Ziel
+
+Erstellen und Bearbeiten über denselben Builder-Shell abbilden.
+
+### Arbeitspakete
+
+- `WorkflowBuilderViewModel` aufbauen
+- Builder-Seite anlegen:
+  - `Vorlage`
+  - `Verhalten`
+  - `Trigger`
+  - `Review`
+- Vorlagen-Galerie als erster Abschnitt nur im Create-Flow
+- Bearbeiten ohne Vorlagenwahl
+- Template nach Erstellung sperren
+- `Verhalten` aufteilen in:
+  - vorlagenspezifische Felder
+  - `Feinabstimmung`
+  - `Erweitert` für Output
+- Trigger-UI strikt auf genau einen Trigger beschränken:
+  - App
+  - Website
+  - Hotkey
+- Review-Satz aus dem neuen Workflow-Modell generieren
+
+### Neue Hilfstypen
+
+- `WorkflowDraft`
+- `WorkflowTemplateDefinition`
+- ggf. `WorkflowBehaviorFormState`
+- ggf. `WorkflowImportWarning`
+
+### Exit-Kriterien
+
+- neuer Workflow kann vollständig erstellt und gespeichert werden
+- bestehender Workflow kann bearbeitet werden
+- die gewählte Vorlage bleibt im Edit-Flow unveränderlich
+
+## Phase 5: Legacy-Seite und per-Eintrag-Import
+
+### Ziel
+
+Alte Daten lesbar halten, aber vollständig aus der aktiven Runtime herausnehmen.
+
+### Arbeitspakete
+
+- `LegacyWorkflowService` anlegen
+  - liest `ProfileService` und `PromptActionService`
+  - projiziert beides in read-only `LegacyWorkflow`-Einträge
+- `Legacy`-Ansicht bauen:
+  - read-only
+  - klar als deprecated markiert
+  - sichtbarer Import-Button pro Eintrag
+- `WorkflowImportMapper` bauen:
+  - `Profile` + optional `PromptAction` -> `WorkflowDraft`
+  - `PromptAction` ohne klaren Trigger -> `Eigener Workflow`
+  - unscharfe Fälle mit Import-Hinweis
+- Import-Status persistieren
+  - minimal z. B. über eigene Import-Metadaten im Workflow-Store oder kleinen Legacy-Status-Store
+  - kein Link zurück zum neuen Workflow nötig
+
+### Wichtige technische Entscheidung
+
+Legacy wird in `v1` nicht in einen neuen Persistenzstore kopiert.
+
+Stattdessen:
+- bestehende `profiles.store` und `prompt-actions.store` bleiben die physische Quelle
+- `LegacyWorkflowService` bildet daraus eine read-only Projektion
+
+Das ist robuster und vermeidet unnötige Kopien alter Daten.
+
+### Exit-Kriterien
+
+- Legacy-Einträge sind sichtbar, aber nicht editierbar
+- kein Legacy-Eintrag wird zur Laufzeit ausgeführt
+- pro Eintrag lässt sich ein vorausgefüllter Workflow-Entwurf öffnen
+
+## Phase 6: Nebenflächen und alte Produktbegriffe entfernen
+
+### Ziel
+
+Die restliche App sprachlich und funktional auf das neue Modell ausrichten.
+
+### Arbeitspakete
+
+- `HotkeySettingsView`
+  - Prompt-Palette-Hotkey entfernen
+  - nur noch globale Diktier-Hotkeys plus workflowbezogene Hotkeys im Builder
+- `SetupWizardView`
+  - Schritt `Prompts & AI` neu zuschneiden
+  - keine Verweise mehr auf `Prompts`-Tab oder Prompt-Presets
+- `LLMProvider.swift`
+  - Copy `Settings > Prompts` auf `Settings > Workflows` bzw. neuen Ort anpassen
+- `SettingsView`-Texte und lokalisierte Strings aktualisieren
+- `ProfilesSettingsView`, `PromptActionsSettingsView`, `PromptPaletteHandler`, `PromptPalettePanel`
+  - nach Abschluss der neuen Oberfläche entfernen oder klar auf Legacy reduzieren
+- `PromptWizardSupport` und prompt-spezifische Wizard-Helfer entfernen, sofern keine Legacy-Abhängigkeit bleibt
+
+### API- und Plugin-Kompatibilität
+
+- HTTP-API in [TypeWhisper/Services/HTTPServer/APIHandlers.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Services/HTTPServer/APIHandlers.swift) heute mit `/v1/rules` und `/v1/profiles`
+- für `v1` empfohlen:
+  - bestehende Endpunkte als Kompatibilitätsalias behalten
+  - Antwort intern aus `WorkflowService` speisen
+  - neue Benennung erst ergänzen, nicht brechen
+- Plugin-Host in [TypeWhisper/Services/HostServicesImpl.swift](/Users/marco/.t3/worktrees/typewhisper-mac/t3code-c5f10b51/TypeWhisper/Services/HostServicesImpl.swift)
+  - `availableRuleNames` semantisch auf Workflow-Namen umstellen
+  - API-Name kann in `v1` als Kompatibilitätsname bestehen bleiben, wenn SDK-Stabilität wichtiger ist
+
+### Exit-Kriterien
+
+- keine sichtbare Produktfläche spricht noch von `Prompt` oder `Rule`, außer im expliziten Legacy-Bereich
+- Prompt Palette ist nicht mehr Teil des aktiven Produkts
+
+## Phase 7: Test- und QA-Härtung
+
+### Automatisierte Tests
+
+- `WorkflowServiceTests`
+  - CRUD
+  - Sortierung
+  - Persistenz
+  - Aktivierung/Deaktivierung
+- `WorkflowMatcherTests`
+  - App-Match
+  - Website-Match
+  - Hotkey-Match
+  - kein Global-Fallback
+- `WorkflowBuilderViewModelTests`
+  - Create/Edit
+  - immutable Vorlage
+  - Review-Text
+- `LegacyWorkflowServiceTests`
+  - Projektion aus `Profile` + `PromptAction`
+  - read-only Verhalten
+- `WorkflowImportMapperTests`
+  - klare Rule-Fälle
+  - Prompt-ohne-Trigger-Fälle
+  - Fallback auf `Eigener Workflow`
+- `DictationViewModel`-bezogene Tests
+  - Runtime nutzt Workflows statt Profiles
+  - LLM-Handler aus Workflow-Verhalten
+  - Hotkey-Trigger ruft Workflow auf
+- API-Kompatibilitätstests
+  - `/v1/rules` liefert Workflow-basierten Output
+
+### Manuelle QA
+
+- Workflow mit App-Trigger
+- Workflow mit Website-Trigger
+- Workflow mit Hotkey-Trigger
+- Workflow mit Feinabstimmung
+- Workflow mit erweitertem Output
+- Legacy-Liste sichtbar, read-only, nicht ausführbar
+- Import eines Legacy-Eintrags in neuen Builder
+- Setup-Wizard und Hotkey-Settings ohne alte Prompt-Palette-Begriffe
+
+## Empfohlene Umsetzungsreihenfolge im Branch
+
+1. Phase 1
+2. Phase 2
+3. Phase 3
+4. Phase 4
+5. Phase 5
+6. Phase 6
+7. Phase 7
+
+Diese Reihenfolge ist absichtlich backend- und runtime-first.
+
+Grund:
+- der riskanteste Teil ist nicht die neue Oberfläche, sondern der saubere Schnitt zwischen neuer Workflow-Runtime und altem Legacy-Bestand
+- sobald das neue aktive Modell steht, können UI und Import darauf stabil aufsetzen
+
+## Explizit nicht Teil von v1
+
+- automatische Bulk-Migration
+- Legacy-Runtime parallel zu Workflows
+- freier Canvas
+- Multi-Trigger-Workflows
+- Multi-App-Workflows
+- Wiedereinführung einer globalen Fallback-Regel
+
+## Ergebnis nach Abschluss
+
+Nach Abschluss dieses Plans gilt:
+
+- `Workflow` ist das einzige aktive Modell für neue Automationen
+- `Legacy` ist Archiv und Importquelle, aber keine Runtime
+- die App hat keinen aktiven `Prompts`-Tab mehr
+- manuelle Aktionen laufen als `Hotkey`-Workflows
+- die Benutzerführung ist auf ein einziges Objekt reduziert


### PR DESCRIPTION
## Summary
- replace the separate prompt and rule UX with a workflow-first system
- add a dedicated workflow model, service layer, runtime matching, and workflow editor UI
- move old prompts and rules into a legacy archive with cleanup actions and migration-oriented visibility

## Issue context
Issue #367 reported that post-transcription LLM processing felt broken because prompts could be enabled in one place while the actual automatic execution path depended on a separate rule assignment. This change removes that split from the active product surface and makes workflows the single primary object for LLM-powered dictation behavior.

Closes #367

## What changed
- added the new `Workflow` model and `WorkflowService`, including workflow matching for app, website, and hotkey triggers
- switched the active settings experience to `Workflows`, including the workflow builder, workflow palette, and default LLM configuration
- kept old prompts and rules in a separate `Legacy` surface, including cleanup actions for old entries
- updated runtime integration so workflows are preferred in dictation and hotkey flows while the migration layer stays isolated
- refreshed related UI copy from rules/prompts to workflows, including indicator labels and palette terminology

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/LegacyWorkflowServiceTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -derivedDataPath /Users/marco/Projects/typewhisper-mac-dev/DerivedData -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CONFIGURATION_BUILD_DIR=/Users/marco/Projects/typewhisper-mac-dev/Build build`
