### PR TITLE
Fix active screen indicator placement across display switches

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AA00000000000000000353 /* PostUpdatePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */; };
 		AA00000000000000000354 /* SettingsNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000354 /* SettingsNavigationCoordinator.swift */; };
 		AA00000000000000000355 /* PostUpdateLicensePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000355 /* PostUpdateLicensePromptView.swift */; };
+		AA00000000000000000357 /* FloatingPanelSpacePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000357 /* FloatingPanelSpacePolicy.swift */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
 		C23000000000000000000003 /* Gemma4Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000295 /* Gemma4Plugin.swift */; };
@@ -58,6 +59,7 @@
 		76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */; };
 		7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */; };
 		7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */; };
+		7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */; };
 		86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BD305007A3A158038C75C /* ProfileServiceTests.swift */; };
 		928A1F1B7A0D4C62A2B90761 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000034 /* TypeWhisperPluginSDK */; };
 		A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */; };
@@ -572,6 +574,7 @@
 			BB00000000000000000198 /* OverlayIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorPanel.swift; sourceTree = "<group>"; };
 			BB00000000000000000309 /* MinimalIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalIndicatorView.swift; sourceTree = "<group>"; };
 			BB00000000000000000310 /* MinimalIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalIndicatorPanel.swift; sourceTree = "<group>"; };
+			BB00000000000000000357 /* FloatingPanelSpacePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelSpacePolicy.swift; sourceTree = "<group>"; };
 			BB00000000000000000199 /* DeepgramPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeepgramPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000200 /* DeepgramPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepgramPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000201 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -637,6 +640,7 @@
 		E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRouterAndHandlersTests.swift; sourceTree = "<group>"; };
 		E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TypeWhisperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationViewModelIndicatorSettingsTests.swift; sourceTree = "<group>"; };
+		6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FloatingPanelSpacePolicyTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardComposerTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardInferenceServiceTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionsViewModelWizardTests.swift; sourceTree = "<group>"; };
@@ -1208,6 +1212,7 @@
 					BB00000000000000000195 /* OverlayIndicatorView.swift */,
 					BB00000000000000000310 /* MinimalIndicatorPanel.swift */,
 					BB00000000000000000309 /* MinimalIndicatorView.swift */,
+					BB00000000000000000357 /* FloatingPanelSpacePolicy.swift */,
 					BB00000000000000000197 /* SharedIndicatorComponents.swift */,
 					BB00000000000000000014 /* MenuBarView.swift */,
 					BB00000000000000000016 /* FileTranscriptionView.swift */,
@@ -1731,6 +1736,7 @@
 				CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */,
 				FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
+				6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
 				E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
 				AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
 				D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */,
@@ -2910,6 +2916,7 @@
 				24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */,
 				7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */,
+				7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */,
 				E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,
 				3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,
 				BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,
@@ -2982,6 +2989,7 @@
 				AA00000000000000000183 /* PromptPaletteHandler.swift in Sources */,
 				A91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift in Sources */,
 				AA00000000000000000207 /* IndicatorCoordinator.swift in Sources */,
+				AA00000000000000000357 /* FloatingPanelSpacePolicy.swift in Sources */,
 				AA00000000000000000184 /* DictationSettingsHandler.swift in Sources */,
 				AA00000000000000000040 /* HTTPResponse.swift in Sources */,
 				AA00000000000000000041 /* HTTPRequestParser.swift in Sources */,

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -1,16 +1,30 @@
 import Foundation
 import AppKit
 import Combine
+import ApplicationServices
 
 /// Coordinates the display of different indicator styles (Notch vs Overlay).
 @MainActor
 final class IndicatorCoordinator {
-    private let notchPanel = NotchIndicatorPanel()
-    private let overlayPanel = OverlayIndicatorPanel()
-    private let minimalPanel = MinimalIndicatorPanel()
+    private let screenResolver = IndicatorScreenResolver()
+    private let notchPanel: NotchIndicatorPanel
+    private let overlayPanel: OverlayIndicatorPanel
+    private let minimalPanel: MinimalIndicatorPanel
     private var cancellables = Set<AnyCancellable>()
+    private var globalMouseMonitor: Any?
+    private var deferredRefreshTask: Task<Void, Never>?
+    private var isObserving = false
+
+    init() {
+        notchPanel = NotchIndicatorPanel(screenResolver: screenResolver)
+        overlayPanel = OverlayIndicatorPanel(screenResolver: screenResolver)
+        minimalPanel = MinimalIndicatorPanel(screenResolver: screenResolver)
+    }
 
     func startObserving() {
+        guard !isObserving else { return }
+        isObserving = true
+
         let vm = DictationViewModel.shared
 
         // When style changes, dismiss the inactive panel and show the active one
@@ -25,6 +39,7 @@ final class IndicatorCoordinator {
         notchPanel.startObserving()
         overlayPanel.startObserving()
         minimalPanel.startObserving()
+        startObservingActiveScreenContextChanges()
     }
 
     private func switchStyle(_ style: IndicatorStyle, vm: DictationViewModel) {
@@ -43,4 +58,260 @@ final class IndicatorCoordinator {
             minimalPanel.updateVisibility(state: vm.state, vm: vm)
         }
     }
+
+    private func startObservingActiveScreenContextChanges() {
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+
+        workspaceCenter.publisher(for: NSWorkspace.didActivateApplicationNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleActiveScreenRefreshes()
+            }
+            .store(in: &cancellables)
+
+        workspaceCenter.publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleActiveScreenRefreshes()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.scheduleActiveScreenRefreshes()
+            }
+            .store(in: &cancellables)
+
+        if globalMouseMonitor == nil {
+            globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+                matching: [.leftMouseDown, .rightMouseDown]
+            ) { [weak self] _ in
+                DispatchQueue.main.async {
+                    self?.scheduleActiveScreenRefreshes()
+                }
+            }
+        }
+    }
+
+    private func refreshActiveScreenPanels() {
+        notchPanel.refreshPlacementForActiveContextChange()
+        overlayPanel.refreshPlacementForActiveContextChange()
+        minimalPanel.refreshPlacementForActiveContextChange()
+    }
+
+    private func scheduleActiveScreenRefreshes() {
+        refreshActiveScreenPanels()
+
+        deferredRefreshTask?.cancel()
+        deferredRefreshTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            self?.refreshActiveScreenPanels()
+
+            try? await Task.sleep(for: .milliseconds(120))
+            guard !Task.isCancelled else { return }
+            self?.refreshActiveScreenPanels()
+        }
+    }
+}
+
+@MainActor
+final class IndicatorScreenResolver {
+    typealias FocusedElementPositionProvider = () -> CGPoint?
+    typealias FocusedWindowFrameProvider = () -> CGRect?
+    typealias FrontmostApplicationProvider = () -> NSRunningApplication?
+    typealias MouseLocationProvider = () -> CGPoint
+    typealias ScreensProvider = () -> [NSScreen]
+    typealias MainScreenProvider = () -> NSScreen?
+    typealias WindowFrameProvider = (pid_t) -> CGRect?
+
+    private let focusedElementPositionProvider: FocusedElementPositionProvider
+    private let focusedWindowFrameProvider: FocusedWindowFrameProvider
+    private let frontmostApplicationProvider: FrontmostApplicationProvider
+    private let mouseLocationProvider: MouseLocationProvider
+    private let screensProvider: ScreensProvider
+    private let mainScreenProvider: MainScreenProvider
+    private let windowFrameProvider: WindowFrameProvider
+
+    init(
+        focusedElementPositionProvider: @escaping FocusedElementPositionProvider = {
+            ServiceContainer.shared.textInsertionService.focusedElementPosition()
+        },
+        focusedWindowFrameProvider: @escaping FocusedWindowFrameProvider = IndicatorScreenResolver.focusedWindowFrame,
+        frontmostApplicationProvider: @escaping FrontmostApplicationProvider = {
+            ActivationSourceTracker.shared.lastExternalApplication ?? NSWorkspace.shared.frontmostApplication
+        },
+        mouseLocationProvider: @escaping MouseLocationProvider = { NSEvent.mouseLocation },
+        screensProvider: @escaping ScreensProvider = { NSScreen.screens },
+        mainScreenProvider: @escaping MainScreenProvider = { NSScreen.main },
+        windowFrameProvider: @escaping WindowFrameProvider = IndicatorScreenResolver.frontmostWindowFrame(for:)
+    ) {
+        self.focusedElementPositionProvider = focusedElementPositionProvider
+        self.focusedWindowFrameProvider = focusedWindowFrameProvider
+        self.frontmostApplicationProvider = frontmostApplicationProvider
+        self.mouseLocationProvider = mouseLocationProvider
+        self.screensProvider = screensProvider
+        self.mainScreenProvider = mainScreenProvider
+        self.windowFrameProvider = windowFrameProvider
+    }
+
+    func resolveScreen(for displayMode: NotchIndicatorDisplay) -> NSScreen {
+        let screens = screensProvider()
+        precondition(!screens.isEmpty, "Expected at least one screen")
+
+        switch displayMode {
+        case .activeScreen:
+            if let screen = screen(containing: focusedElementPositionProvider()) {
+                return screen
+            }
+
+            if let focusedWindowFrame = focusedWindowFrameProvider(),
+               let screen = screen(intersecting: focusedWindowFrame) {
+                return screen
+            }
+
+            if let application = frontmostApplicationProvider(),
+               let windowFrame = windowFrameProvider(application.processIdentifier),
+               let screen = screen(intersecting: windowFrame) {
+                return screen
+            }
+
+            if let screen = screen(containing: mouseLocationProvider()) {
+                return screen
+            }
+
+            return mainScreenProvider() ?? screens[0]
+        case .primaryScreen:
+            return mainScreenProvider() ?? screens[0]
+        case .builtInScreen:
+            return screens.first { $0.safeAreaInsets.top > 0 } ?? mainScreenProvider() ?? screens[0]
+        }
+    }
+
+    private func screen(containing point: CGPoint?) -> NSScreen? {
+        guard let point else { return nil }
+        return screensProvider().first { $0.frame.contains(point) }
+    }
+
+    private func screen(intersecting frame: CGRect) -> NSScreen? {
+        let screens = screensProvider()
+        let bestScreen = screens
+            .map { screen in
+                let intersection = frame.intersection(screen.frame)
+                let area = intersection.isNull ? 0 : intersection.width * intersection.height
+                return (screen, area)
+            }
+            .max(by: { $0.1 < $1.1 })
+
+        if let bestScreen, bestScreen.1 > 0 {
+            return bestScreen.0
+        }
+
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        return screen(containing: center)
+    }
+
+    nonisolated private static func frontmostWindowFrame(for processIdentifier: pid_t) -> CGRect? {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return nil
+        }
+
+        var fallbackFrame: CGRect?
+
+        for windowInfo in windowList {
+            guard let rawBounds = windowInfo[kCGWindowBounds as String] else {
+                continue
+            }
+
+            let boundsDictionary = rawBounds as! CFDictionary
+
+            guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+                  ownerPID == processIdentifier,
+                  let bounds = CGRect(
+                    dictionaryRepresentation: boundsDictionary
+                  ),
+                  !bounds.isEmpty else {
+                continue
+            }
+
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
+            guard alpha > 0 else { continue }
+
+            let layer = windowInfo[kCGWindowLayer as String] as? Int ?? 0
+            if layer == 0 {
+                return bounds
+            }
+
+            if fallbackFrame == nil {
+                fallbackFrame = bounds
+            }
+        }
+
+        return fallbackFrame
+    }
+
+    nonisolated private static func focusedWindowFrame() -> CGRect? {
+        let systemWide = AXUIElementCreateSystemWide()
+
+        var focusedApplication: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedApplicationAttribute as CFString,
+            &focusedApplication
+        ) == .success,
+              let focusedApplication else {
+            return nil
+        }
+        let applicationElement = focusedApplication as! AXUIElement
+
+        var focusedWindow: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindow
+        ) == .success,
+              let focusedWindow else {
+            return nil
+        }
+        let windowElement = focusedWindow as! AXUIElement
+
+        var positionValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            windowElement,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+              let positionValue else {
+            return nil
+        }
+        let axPosition = positionValue as! AXValue
+
+        var sizeValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            windowElement,
+            kAXSizeAttribute as CFString,
+            &sizeValue
+        ) == .success,
+              let sizeValue else {
+            return nil
+        }
+        let axSize = sizeValue as! AXValue
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        guard AXValueGetValue(axPosition, .cgPoint, &position),
+              AXValueGetValue(axSize, .cgSize, &size),
+              size.width > 0,
+              size.height > 0 else {
+            return nil
+        }
+
+        return CGRect(origin: position, size: size)
+    }
+
 }

--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -1,0 +1,19 @@
+import AppKit
+import CoreGraphics
+
+enum FloatingPanelSpacePolicy {
+    // Passive indicator panels should stay above normal desktop spaces,
+    // but they must not bleed into another app's fullscreen space.
+    static let indicatorWindowLevel = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+
+    static let indicatorCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .stationary,
+        .ignoresCycle
+    ]
+
+    static let selectionPaletteCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary
+    ]
+}

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -7,10 +7,12 @@ class MinimalIndicatorPanel: NSPanel {
     private static let panelWidth: CGFloat = 420
     private static let panelHeight: CGFloat = 160
 
+    private let screenResolver: IndicatorScreenResolver
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
 
-    init() {
+    init(screenResolver: IndicatorScreenResolver) {
+        self.screenResolver = screenResolver
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -23,9 +25,9 @@ class MinimalIndicatorPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
-        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        level = FloatingPanelSpacePolicy.indicatorWindowLevel
         appearance = NSAppearance(named: .darkAqua)
-        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        collectionBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
         hidesOnDeactivate = false
         ignoresMouseEvents = true
 
@@ -117,16 +119,14 @@ class MinimalIndicatorPanel: NSPanel {
     }
 
     private func resolveScreen() -> NSScreen {
-        let display = DictationViewModel.shared.notchIndicatorDisplay
-        switch display {
-        case .activeScreen:
-            let mouseLocation = NSEvent.mouseLocation
-            return NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main ?? NSScreen.screens[0]
-        case .primaryScreen:
-            return NSScreen.main ?? NSScreen.screens[0]
-        case .builtInScreen:
-            return NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main ?? NSScreen.screens[0]
-        }
+        screenResolver.resolveScreen(for: DictationViewModel.shared.notchIndicatorDisplay)
+    }
+
+    func refreshPlacementForActiveContextChange() {
+        guard DictationViewModel.shared.notchIndicatorDisplay == .activeScreen else { return }
+        cachedScreen = nil
+        guard isVisible else { return }
+        show()
     }
 
     func dismiss() {

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -39,13 +39,15 @@ class NotchIndicatorPanel: NSPanel {
     private static let panelHeight: CGFloat = 500
     private static let presentationAnimationDuration: Duration = .milliseconds(220)
 
+    private let screenResolver: IndicatorScreenResolver
     private let notchGeometry = NotchGeometry()
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
     private var showTask: Task<Void, Never>?
     private var dismissTask: Task<Void, Never>?
 
-    init() {
+    init(screenResolver: IndicatorScreenResolver) {
+        self.screenResolver = screenResolver
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -58,9 +60,9 @@ class NotchIndicatorPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
-        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        level = FloatingPanelSpacePolicy.indicatorWindowLevel
         appearance = NSAppearance(named: .darkAqua)
-        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        collectionBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
         hidesOnDeactivate = false
         ignoresMouseEvents = true
 
@@ -172,16 +174,14 @@ class NotchIndicatorPanel: NSPanel {
     }
 
     private func resolveScreen() -> NSScreen {
-        let display = DictationViewModel.shared.notchIndicatorDisplay
-        switch display {
-        case .activeScreen:
-            let mouseLocation = NSEvent.mouseLocation
-            return NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main ?? NSScreen.screens[0]
-        case .primaryScreen:
-            return NSScreen.main ?? NSScreen.screens[0]
-        case .builtInScreen:
-            return NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main ?? NSScreen.screens[0]
-        }
+        screenResolver.resolveScreen(for: DictationViewModel.shared.notchIndicatorDisplay)
+    }
+
+    func refreshPlacementForActiveContextChange() {
+        guard DictationViewModel.shared.notchIndicatorDisplay == .activeScreen else { return }
+        cachedScreen = nil
+        guard isVisible else { return }
+        show()
     }
 
     func dismiss() {

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -7,10 +7,12 @@ class OverlayIndicatorPanel: NSPanel {
     private static let panelWidth: CGFloat = 500
     private static let panelHeight: CGFloat = 300
 
+    private let screenResolver: IndicatorScreenResolver
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
 
-    init() {
+    init(screenResolver: IndicatorScreenResolver) {
+        self.screenResolver = screenResolver
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -23,9 +25,9 @@ class OverlayIndicatorPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
-        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        level = FloatingPanelSpacePolicy.indicatorWindowLevel
         appearance = NSAppearance(named: .darkAqua)
-        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        collectionBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
         hidesOnDeactivate = false
         ignoresMouseEvents = true
 
@@ -118,16 +120,14 @@ class OverlayIndicatorPanel: NSPanel {
     }
 
     private func resolveScreen() -> NSScreen {
-        let display = DictationViewModel.shared.notchIndicatorDisplay
-        switch display {
-        case .activeScreen:
-            let mouseLocation = NSEvent.mouseLocation
-            return NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main ?? NSScreen.screens[0]
-        case .primaryScreen:
-            return NSScreen.main ?? NSScreen.screens[0]
-        case .builtInScreen:
-            return NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main ?? NSScreen.screens[0]
-        }
+        screenResolver.resolveScreen(for: DictationViewModel.shared.notchIndicatorDisplay)
+    }
+
+    func refreshPlacementForActiveContextChange() {
+        guard DictationViewModel.shared.notchIndicatorDisplay == .activeScreen else { return }
+        cachedScreen = nil
+        guard isVisible else { return }
+        show()
     }
 
     func dismiss() {

--- a/TypeWhisper/Views/SelectionPalettePanel.swift
+++ b/TypeWhisper/Views/SelectionPalettePanel.swift
@@ -315,7 +315,7 @@ private final class SelectionPalettePanel: NSPanel {
         )
 
         level = .floating
-        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        collectionBehavior = FloatingPanelSpacePolicy.selectionPaletteCollectionBehavior
         isOpaque = false
         backgroundColor = .clear
         hasShadow = false

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -73,6 +73,113 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
     }
 }
 
+final class IndicatorScreenResolverTests: XCTestCase {
+    @MainActor
+    func testActiveScreenPrefersFocusedElementBeforeWindowLookup() throws {
+        let screen = try XCTUnwrap(NSScreen.screens.first)
+        var windowLookupCalled = false
+        var mouseLookupCalled = false
+
+        let resolver = IndicatorScreenResolver(
+            focusedElementPositionProvider: { CGPoint(x: screen.frame.midX, y: screen.frame.midY) },
+            frontmostApplicationProvider: { NSRunningApplication.current },
+            mouseLocationProvider: {
+                mouseLookupCalled = true
+                return .zero
+            },
+            screensProvider: { [screen] },
+            mainScreenProvider: { screen },
+            windowFrameProvider: { _ in
+                windowLookupCalled = true
+                return screen.frame
+            }
+        )
+
+        let resolvedScreen = resolver.resolveScreen(for: .activeScreen)
+
+        XCTAssertTrue(resolvedScreen === screen)
+        XCTAssertFalse(windowLookupCalled)
+        XCTAssertFalse(mouseLookupCalled)
+    }
+
+    @MainActor
+    func testActiveScreenUsesWindowFrameBeforeMouseFallback() throws {
+        let screen = try XCTUnwrap(NSScreen.screens.first)
+        var mouseLookupCalled = false
+
+        let resolver = IndicatorScreenResolver(
+            focusedElementPositionProvider: { nil },
+            focusedWindowFrameProvider: { nil },
+            frontmostApplicationProvider: { NSRunningApplication.current },
+            mouseLocationProvider: {
+                mouseLookupCalled = true
+                return .zero
+            },
+            screensProvider: { [screen] },
+            mainScreenProvider: { screen },
+            windowFrameProvider: { _ in screen.frame }
+        )
+
+        let resolvedScreen = resolver.resolveScreen(for: .activeScreen)
+
+        XCTAssertTrue(resolvedScreen === screen)
+        XCTAssertFalse(mouseLookupCalled)
+    }
+
+    @MainActor
+    func testActiveScreenUsesFocusedWindowBeforeFrontmostApplicationFallback() throws {
+        let screen = try XCTUnwrap(NSScreen.screens.first)
+        var frontmostWindowLookupCalled = false
+        var mouseLookupCalled = false
+
+        let resolver = IndicatorScreenResolver(
+            focusedElementPositionProvider: { nil },
+            focusedWindowFrameProvider: { screen.frame },
+            frontmostApplicationProvider: { NSRunningApplication.current },
+            mouseLocationProvider: {
+                mouseLookupCalled = true
+                return .zero
+            },
+            screensProvider: { [screen] },
+            mainScreenProvider: { screen },
+            windowFrameProvider: { _ in
+                frontmostWindowLookupCalled = true
+                return .zero
+            }
+        )
+
+        let resolvedScreen = resolver.resolveScreen(for: .activeScreen)
+
+        XCTAssertTrue(resolvedScreen === screen)
+        XCTAssertFalse(frontmostWindowLookupCalled)
+        XCTAssertFalse(mouseLookupCalled)
+    }
+
+    @MainActor
+    func testActiveScreenFallsBackToMouseLocation() throws {
+        let screen = try XCTUnwrap(NSScreen.screens.first)
+        var mouseLookupCalled = false
+
+        let resolver = IndicatorScreenResolver(
+            focusedElementPositionProvider: { nil },
+            focusedWindowFrameProvider: { nil },
+            frontmostApplicationProvider: { NSRunningApplication.current },
+            mouseLocationProvider: {
+                mouseLookupCalled = true
+                return CGPoint(x: screen.frame.midX, y: screen.frame.midY)
+            },
+            screensProvider: { [screen] },
+            mainScreenProvider: { screen },
+            windowFrameProvider: { _ in nil }
+        )
+
+        let resolvedScreen = resolver.resolveScreen(for: .activeScreen)
+
+        XCTAssertTrue(resolvedScreen === screen)
+        XCTAssertTrue(mouseLookupCalled)
+    }
+}
+
 final class DockIconVisibilityTests: XCTestCase {
     func testDockIconStaysHiddenWhenMenuBarIconIsVisibleAndNoWindowIsOpen() {
         XCTAssertFalse(

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -1,0 +1,32 @@
+import AppKit
+import XCTest
+@testable import TypeWhisper
+
+final class FloatingPanelSpacePolicyTests: XCTestCase {
+    func testIndicatorPolicyKeepsNormalDesktopSpaceBehavior() {
+        let behavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
+
+        XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(behavior.contains(.stationary))
+        XCTAssertTrue(behavior.contains(.ignoresCycle))
+    }
+
+    func testIndicatorPolicyDoesNotJoinForeignFullscreenSpaces() {
+        XCTAssertFalse(
+            FloatingPanelSpacePolicy.indicatorCollectionBehavior.contains(.fullScreenAuxiliary)
+        )
+    }
+
+    func testSelectionPaletteStillSupportsFullscreenUsage() {
+        XCTAssertTrue(
+            FloatingPanelSpacePolicy.selectionPaletteCollectionBehavior.contains(.fullScreenAuxiliary)
+        )
+    }
+
+    func testIndicatorPolicyKeepsShieldingWindowLevel() {
+        XCTAssertEqual(
+            FloatingPanelSpacePolicy.indicatorWindowLevel,
+            NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        )
+    }
+}


### PR DESCRIPTION
## Summary
This fixes #373 by making `Active Screen` indicator placement resolve against the active app/window context instead of staying pinned to a stale cached display after app, space, or fullscreen transitions.

The implementation keeps the indicator stable while visible, but re-resolves on relevant context changes. Passive indicator panels also use a shared fullscreen/space policy so they do not bleed into foreign fullscreen spaces, while the selection palette keeps its fullscreen behavior.

Closes #373

## Test Plan
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' build`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/IndicatorScreenResolverTests -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests -only-testing:TypeWhisperTests/NotchIndicatorLayoutTests`
