### PR TITLE
[codex] Add adjustable live transcript preview size

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -12,6 +12,7 @@ enum UserDefaultsKeys {
     static let soundError = "soundError"
     static let indicatorStyle = "indicatorStyle"
     static let indicatorTranscriptPreviewEnabled = "indicatorTranscriptPreviewEnabled"
+    static let indicatorTranscriptPreviewFontSizeOffset = "indicatorTranscriptPreviewFontSizeOffset"
     static let preserveClipboard = "preserveClipboard"
     static let mediaPauseEnabled = "mediaPauseEnabled"
     static let transcribeShortQuietClipsAggressively = "transcribeShortQuietClipsAggressively"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -6701,6 +6701,16 @@
         }
       }
     },
+    "Live transcript size" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schriftgröße des Live-Transkripts"
+          }
+        }
+      }
+    },
     "Show menu bar icon" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TypeWhisper/ViewModels/DictationEnums.swift
+++ b/TypeWhisper/ViewModels/DictationEnums.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 enum IndicatorStyle: String, CaseIterable {
@@ -29,4 +30,40 @@ enum NotchIndicatorDisplay: String, CaseIterable {
 enum OverlayPosition: String, CaseIterable {
     case top
     case bottom
+}
+
+extension IndicatorStyle {
+    var supportsTranscriptPreview: Bool {
+        self != .minimal
+    }
+
+    var transcriptPreviewBaseFontSize: CGFloat {
+        switch self {
+        case .notch:
+            12
+        case .overlay:
+            13
+        case .minimal:
+            12
+        }
+    }
+
+    var transcriptPreviewBaseExpandedHeight: CGFloat {
+        switch self {
+        case .notch:
+            80
+        case .overlay:
+            100
+        case .minimal:
+            0
+        }
+    }
+
+    func scaledTranscriptPreviewMetric(_ baseMetric: CGFloat, fontSize: CGFloat) -> CGFloat {
+        guard supportsTranscriptPreview, transcriptPreviewBaseFontSize > 0 else {
+            return 0
+        }
+
+        return (baseMetric * fontSize / transcriptPreviewBaseFontSize).rounded(.up)
+    }
 }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -75,6 +75,17 @@ final class DictationViewModel: ObservableObject {
     @Published var indicatorTranscriptPreviewEnabled: Bool {
         didSet { Self.persistIndicatorTranscriptPreviewEnabled(indicatorTranscriptPreviewEnabled) }
     }
+    @Published var indicatorTranscriptPreviewFontSizeOffset: Int {
+        didSet {
+            let clampedOffset = Self.clampedIndicatorTranscriptPreviewFontSizeOffset(indicatorTranscriptPreviewFontSizeOffset)
+            if clampedOffset != indicatorTranscriptPreviewFontSizeOffset {
+                indicatorTranscriptPreviewFontSizeOffset = clampedOffset
+                return
+            }
+
+            Self.persistIndicatorTranscriptPreviewFontSizeOffset(clampedOffset)
+        }
+    }
     @Published var preserveClipboard: Bool {
         didSet { UserDefaults.standard.set(preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard) }
     }
@@ -276,6 +287,7 @@ final class DictationViewModel: ObservableObject {
         self.audioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2
         self.soundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true
         self.indicatorTranscriptPreviewEnabled = Self.loadIndicatorTranscriptPreviewEnabled()
+        self.indicatorTranscriptPreviewFontSizeOffset = Self.loadIndicatorTranscriptPreviewFontSizeOffset()
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
         self.transcribeShortQuietClipsAggressively = Self.loadTranscribeShortQuietClipsAggressively()
@@ -355,6 +367,22 @@ final class DictationViewModel: ObservableObject {
         defaults.set(enabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
     }
 
+    nonisolated static func loadIndicatorTranscriptPreviewFontSizeOffset(defaults: UserDefaults = .standard) -> Int {
+        guard let storedValue = defaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset) else {
+            return 0
+        }
+
+        guard let number = storedValue as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() else {
+            return 0
+        }
+
+        return Self.clampedIndicatorTranscriptPreviewFontSizeOffset(number.intValue)
+    }
+
+    nonisolated static func persistIndicatorTranscriptPreviewFontSizeOffset(_ offset: Int, defaults: UserDefaults = .standard) {
+        defaults.set(Self.clampedIndicatorTranscriptPreviewFontSizeOffset(offset), forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
+    }
+
     nonisolated static func loadIndicatorStyle(defaults: UserDefaults = .standard) -> IndicatorStyle {
         defaults.string(forKey: UserDefaultsKeys.indicatorStyle)
             .flatMap { IndicatorStyle(rawValue: $0) } ?? .notch
@@ -370,6 +398,27 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistTranscribeShortQuietClipsAggressively(_ enabled: Bool, defaults: UserDefaults = .standard) {
         defaults.set(enabled, forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively)
+    }
+
+    nonisolated static func indicatorTranscriptPreviewFontSize(for style: IndicatorStyle, offset: Int) -> CGFloat {
+        style.transcriptPreviewBaseFontSize + CGFloat(Self.clampedIndicatorTranscriptPreviewFontSizeOffset(offset))
+    }
+
+    nonisolated static func indicatorTranscriptPreviewExpandedHeight(for style: IndicatorStyle, offset: Int) -> CGFloat {
+        let fontSize = Self.indicatorTranscriptPreviewFontSize(for: style, offset: offset)
+        return style.scaledTranscriptPreviewMetric(style.transcriptPreviewBaseExpandedHeight, fontSize: fontSize)
+    }
+
+    func indicatorTranscriptPreviewFontSize(for style: IndicatorStyle) -> CGFloat {
+        Self.indicatorTranscriptPreviewFontSize(for: style, offset: indicatorTranscriptPreviewFontSizeOffset)
+    }
+
+    func indicatorTranscriptPreviewExpandedHeight(for style: IndicatorStyle) -> CGFloat {
+        Self.indicatorTranscriptPreviewExpandedHeight(for: style, offset: indicatorTranscriptPreviewFontSizeOffset)
+    }
+
+    nonisolated private static func clampedIndicatorTranscriptPreviewFontSizeOffset(_ offset: Int) -> Int {
+        min(max(offset, 0), 8)
     }
 
     var needsMicPermission: Bool {

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -23,7 +23,7 @@ struct GeneralSettingsView: View {
     @ObservedObject private var dictation = DictationViewModel.shared
 
     private var supportsTranscriptPreview: Bool {
-        dictation.indicatorStyle != .minimal
+        dictation.indicatorStyle.supportsTranscriptPreview
     }
 
     private var supportsPositionSelection: Bool {
@@ -67,6 +67,17 @@ struct GeneralSettingsView: View {
         case .dockWhileWindowOpen:
             "TypeWhisper hides both icons until a window opens. To reopen Settings later, launch TypeWhisper from Spotlight or the Applications folder."
         }
+    }
+
+    private var indicatorTranscriptPreviewSliderValue: Binding<Double> {
+        Binding(
+            get: { Double(dictation.indicatorTranscriptPreviewFontSizeOffset) },
+            set: { dictation.indicatorTranscriptPreviewFontSizeOffset = Int($0.rounded()) }
+        )
+    }
+
+    private var indicatorTranscriptPreviewSizeLabel: String {
+        "\(Int(dictation.indicatorTranscriptPreviewFontSize(for: dictation.indicatorStyle))) pt"
     }
 
     var body: some View {
@@ -151,6 +162,19 @@ struct GeneralSettingsView: View {
 
                 if supportsTranscriptPreview {
                     Toggle(String(localized: "Show live transcript preview"), isOn: $dictation.indicatorTranscriptPreviewEnabled)
+
+                    LabeledContent(String(localized: "Live transcript size")) {
+                        HStack(spacing: 12) {
+                            Slider(value: indicatorTranscriptPreviewSliderValue, in: 0...8, step: 1)
+                                .frame(width: 180)
+
+                            Text(verbatim: indicatorTranscriptPreviewSizeLabel)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 54, alignment: .trailing)
+                        }
+                    }
+                    .disabled(!dictation.indicatorTranscriptPreviewEnabled)
 
                     if !dictation.indicatorTranscriptPreviewEnabled {
                         Text(String(localized: "When disabled, TypeWhisper skips live transcript requests for the indicator and only runs the final transcription after you stop recording."))

--- a/TypeWhisper/Views/IndicatorPreviewView.swift
+++ b/TypeWhisper/Views/IndicatorPreviewView.swift
@@ -3,10 +3,16 @@ import SwiftUI
 struct IndicatorPreviewView: View {
     @ObservedObject private var dictation = DictationViewModel.shared
     private let previewNotchWidth: CGFloat = 185
+    private let notchPreviewBaseHeight: CGFloat = 110
+    private let notchPreviewBaseBodyHeight: CGFloat = 38
+    private let notchPreviewBaseFontSize: CGFloat = 11
+    private let overlayPreviewCollapsedHeight: CGFloat = 82
+    private let overlayPreviewBaseHeight: CGFloat = 110
+    private let overlayPreviewBaseFontSize: CGFloat = 12
 
     private let streamingText = String(localized: "Hello, this is a live preview of the streaming text...")
     private var showTranscriptPreview: Bool {
-        dictation.indicatorTranscriptPreviewEnabled && dictation.indicatorStyle != .minimal
+        dictation.indicatorTranscriptPreviewEnabled && dictation.indicatorStyle.supportsTranscriptPreview
     }
     private var notchClosedWidth: CGFloat {
         NotchIndicatorLayout.closedWidth(hasNotch: true, notchWidth: previewNotchWidth)
@@ -33,16 +39,24 @@ struct IndicatorPreviewView: View {
     private var previewHeight: CGFloat {
         switch dictation.indicatorStyle {
         case .notch:
-            return 110
+            return showTranscriptPreview ? notchPreviewBaseHeight + (notchPreviewBodyHeight - notchPreviewBaseBodyHeight) : notchPreviewBaseHeight
         case .overlay:
-            return showTranscriptPreview ? 110 : 82
+            return showTranscriptPreview ? scaledPreviewMetric(overlayPreviewBaseHeight, for: .overlay) : overlayPreviewCollapsedHeight
         case .minimal:
             return 72
         }
     }
 
     private var notchPreviewBodyHeight: CGFloat {
-        showTranscriptPreview ? 38 : 0
+        showTranscriptPreview ? scaledPreviewMetric(notchPreviewBaseBodyHeight, for: .notch) : 0
+    }
+
+    private var notchPreviewFontSize: CGFloat {
+        scaledPreviewMetric(notchPreviewBaseFontSize, for: .notch)
+    }
+
+    private var overlayPreviewFontSize: CGFloat {
+        scaledPreviewMetric(overlayPreviewBaseFontSize, for: .overlay)
     }
 
     var body: some View {
@@ -67,6 +81,7 @@ struct IndicatorPreviewView: View {
         .animation(.easeInOut(duration: 0.2), value: dictation.notchIndicatorLeftContent)
         .animation(.easeInOut(duration: 0.2), value: dictation.notchIndicatorRightContent)
         .animation(.easeInOut(duration: 0.2), value: dictation.indicatorTranscriptPreviewEnabled)
+        .animation(.easeInOut(duration: 0.2), value: dictation.indicatorTranscriptPreviewFontSizeOffset)
         .accessibilityHidden(true)
     }
 
@@ -107,7 +122,7 @@ struct IndicatorPreviewView: View {
 
     private var notchPreviewBody: some View {
         Text(streamingText)
-            .font(.system(size: 11))
+            .font(.system(size: notchPreviewFontSize))
             .foregroundStyle(.white.opacity(0.7))
             .lineLimit(2)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -134,7 +149,7 @@ struct IndicatorPreviewView: View {
 
             if showTranscriptPreview {
                 Text(streamingText)
-                    .font(.system(size: 12))
+                    .font(.system(size: overlayPreviewFontSize))
                     .foregroundStyle(.white.opacity(0.7))
                     .lineLimit(2)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -214,6 +229,11 @@ struct IndicatorPreviewView: View {
         case .none:
             Color.clear.frame(width: 0)
         }
+    }
+
+    private func scaledPreviewMetric(_ baseMetric: CGFloat, for style: IndicatorStyle) -> CGFloat {
+        let fontSize = dictation.indicatorTranscriptPreviewFontSize(for: style)
+        return style.scaledTranscriptPreviewMetric(baseMetric, fontSize: fontSize)
     }
 }
 

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -72,7 +72,11 @@ struct NotchIndicatorView: View {
     }
 
     private var transcriptBodyHeight: CGFloat {
-        hasTranscriptSection && textExpanded ? sizing.textExpandedHeight : 0
+        hasTranscriptSection && textExpanded ? viewModel.indicatorTranscriptPreviewExpandedHeight(for: .notch) : 0
+    }
+
+    private var transcriptFontSize: CGFloat {
+        viewModel.indicatorTranscriptPreviewFontSize(for: .notch)
     }
 
     private var expandedBodyHeight: CGFloat {
@@ -210,7 +214,8 @@ struct NotchIndicatorView: View {
         } else if hasTranscriptSection {
             IndicatorExpandableText(
                 text: viewModel.partialText,
-                sizing: sizing,
+                fontSize: transcriptFontSize,
+                expandedHeight: viewModel.indicatorTranscriptPreviewExpandedHeight(for: .notch),
                 expanded: true,
                 contentPadding: 34
             )

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -42,6 +42,14 @@ struct OverlayIndicatorView: View {
         viewModel.overlayPosition == .top
     }
 
+    private var transcriptFontSize: CGFloat {
+        viewModel.indicatorTranscriptPreviewFontSize(for: .overlay)
+    }
+
+    private var transcriptExpandedHeight: CGFloat {
+        viewModel.indicatorTranscriptPreviewExpandedHeight(for: .overlay)
+    }
+
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             if isTop {
@@ -116,7 +124,8 @@ struct OverlayIndicatorView: View {
             if viewModel.state == .recording, showTranscriptPreview {
                 IndicatorExpandableText(
                     text: viewModel.partialText,
-                    sizing: sizing,
+                    fontSize: transcriptFontSize,
+                    expandedHeight: transcriptExpandedHeight,
                     expanded: textExpanded,
                     contentPadding: contentPadding
                 )
@@ -155,7 +164,8 @@ struct OverlayIndicatorView: View {
             if viewModel.state == .recording, showTranscriptPreview {
                 IndicatorExpandableText(
                     text: viewModel.partialText,
-                    sizing: sizing,
+                    fontSize: transcriptFontSize,
+                    expandedHeight: transcriptExpandedHeight,
                     expanded: textExpanded,
                     contentPadding: contentPadding
                 )

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -25,8 +25,8 @@ struct IndicatorSizing {
         profileFontSize: 9,
         profilePaddingH: 5,
         profilePaddingV: 2,
-        textFontSize: 12,
-        textExpandedHeight: 80
+        textFontSize: IndicatorStyle.notch.transcriptPreviewBaseFontSize,
+        textExpandedHeight: IndicatorStyle.notch.transcriptPreviewBaseExpandedHeight
     )
 
     static let overlay = IndicatorSizing(
@@ -39,8 +39,8 @@ struct IndicatorSizing {
         profileFontSize: 11,
         profilePaddingH: 6,
         profilePaddingV: 3,
-        textFontSize: 13,
-        textExpandedHeight: 100
+        textFontSize: IndicatorStyle.overlay.transcriptPreviewBaseFontSize,
+        textExpandedHeight: IndicatorStyle.overlay.transcriptPreviewBaseExpandedHeight
     )
 
     static let minimal = IndicatorSizing(
@@ -198,7 +198,8 @@ struct IndicatorRecordingContent: View {
 
 struct IndicatorExpandableText: View {
     let text: String
-    let sizing: IndicatorSizing
+    let fontSize: CGFloat
+    let expandedHeight: CGFloat
     let expanded: Bool
     let contentPadding: CGFloat
 
@@ -206,14 +207,14 @@ struct IndicatorExpandableText: View {
         ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: true) {
                 Text(text)
-                    .font(.system(size: sizing.textFontSize))
+                    .font(.system(size: fontSize))
                     .foregroundStyle(.white.opacity(0.85))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, contentPadding)
                     .padding(.vertical, 14)
                     .id("bottom")
             }
-            .frame(height: expanded ? sizing.textExpandedHeight : 0)
+            .frame(height: expanded ? expandedHeight : 0)
             .clipped()
             .onChange(of: text) {
                 withAnimation(nil) {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -39,6 +39,34 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
         XCTAssertTrue(DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults))
     }
 
+    func testIndicatorTranscriptPreviewFontSizeOffsetDefaultsToZero() {
+        XCTAssertEqual(DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults), 0)
+    }
+
+    func testIndicatorTranscriptPreviewFontSizeOffsetPersistsClampedValue() {
+        DictationViewModel.persistIndicatorTranscriptPreviewFontSizeOffset(99, defaults: defaults)
+
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset) as? Int, 8)
+        XCTAssertEqual(DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults), 8)
+    }
+
+    func testMissingIndicatorTranscriptPreviewFontSizeOffsetFallsBackToZero() {
+        defaults.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
+
+        XCTAssertEqual(DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults), 0)
+    }
+
+    func testInvalidIndicatorTranscriptPreviewFontSizeOffsetFallsBackToZero() {
+        defaults.set("large", forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
+
+        XCTAssertEqual(DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults), 0)
+    }
+
+    func testIndicatorTranscriptPreviewFontSizeDefaultsMatchCurrentStyles() {
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .notch, offset: 0), 12)
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .overlay, offset: 0), 13)
+    }
+
     func testIndicatorStyleDefaultsToNotch() {
         defaults.removeObject(forKey: UserDefaultsKeys.indicatorStyle)
 

--- a/TypeWhisperTests/IndicatorTranscriptPreviewSizingTests.swift
+++ b/TypeWhisperTests/IndicatorTranscriptPreviewSizingTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import TypeWhisper
+
+final class IndicatorTranscriptPreviewSizingTests: XCTestCase {
+    func testNotchExpandedHeightScalesWithFontSize() {
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewExpandedHeight(for: .notch, offset: 0), 80)
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewExpandedHeight(for: .notch, offset: 8), 134)
+    }
+
+    func testOverlayExpandedHeightScalesWithFontSize() {
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewExpandedHeight(for: .overlay, offset: 0), 100)
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewExpandedHeight(for: .overlay, offset: 8), 162)
+    }
+
+    func testMaximumOffsetKeepsStyleRelativeFontSizes() {
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .notch, offset: 8), 20)
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .overlay, offset: 8), 21)
+    }
+
+    func testSameOffsetProducesStyleSpecificFontSizes() {
+        let offset = 4
+
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .notch, offset: offset), 16)
+        XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .overlay, offset: offset), 17)
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable transcript preview font size offset for indicator styles that support live preview
- scale the live indicator and settings preview heights with the selected transcript size to avoid clipping
- expose the new setting in `Settings > General > Indicator` and cover the behavior with new sizing tests

## Issue context
Issue #364 asks for a configurable font size for the live transcript preview while preserving the current style-relative defaults for Notch and Overlay.

## Root cause
The transcript preview font size and expanded height were hard-coded for both the live indicator and the settings preview, so users could not adjust readability without risking clipped content.

## Impact
Users can now increase or decrease the live transcript preview size for Notch and Overlay from settings, and both the preview UI and the live indicator scale consistently.

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/NotchIndicatorLayoutTests -only-testing:TypeWhisperTests/IndicatorTranscriptPreviewSizingTests`

Closes #364