### PR TITLE
Add watch folder subtitle exports

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -8428,6 +8428,22 @@
         }
       }
     },
+    "watchFolder.export.subtitleSegmentsRequired" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das gewaehlte Untertitel-Format benoetigt Zeitstempel, aber die Engine hat keine Segmente geliefert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selected subtitle format requires timestamps, but the engine returned no segments."
+          }
+        }
+      }
+    },
     "watchFolder.plainText" : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/Services/WatchFolderService.swift
+++ b/TypeWhisper/Services/WatchFolderService.swift
@@ -2,6 +2,108 @@ import Foundation
 import os
 import Combine
 
+enum WatchFolderOutputFormat: String, CaseIterable {
+    case markdown = "md"
+    case plainText = "txt"
+    case srt = "srt"
+    case vtt = "vtt"
+
+    init(storedValue: String?) {
+        self = WatchFolderOutputFormat(rawValue: storedValue ?? "") ?? .markdown
+    }
+
+    var fileExtension: String {
+        rawValue
+    }
+
+    var isSubtitleFormat: Bool {
+        switch self {
+        case .srt, .vtt:
+            true
+        case .markdown, .plainText:
+            false
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .markdown:
+            String(localized: "Markdown (.md)")
+        case .plainText:
+            String(localized: "watchFolder.plainText")
+        case .srt:
+            String(localized: "SRT")
+        case .vtt:
+            String(localized: "VTT")
+        }
+    }
+}
+
+struct WatchFolderExportArtifact {
+    let fileExtension: String
+    let content: String
+}
+
+enum WatchFolderExportBuilder {
+    enum Error: LocalizedError {
+        case missingSubtitleSegments
+
+        var errorDescription: String? {
+            switch self {
+            case .missingSubtitleSegments:
+                String(localized: "watchFolder.export.subtitleSegmentsRequired")
+            }
+        }
+    }
+
+    static func build(
+        format: WatchFolderOutputFormat,
+        result: TranscriptionResult,
+        fileName: String,
+        engineName: String,
+        date: Date
+    ) throws -> WatchFolderExportArtifact {
+        switch format {
+        case .markdown:
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .medium
+            dateFormatter.timeStyle = .medium
+            let dateString = dateFormatter.string(from: date)
+
+            let content = """
+            # Transcription: \(fileName)
+            - Date: \(dateString)
+            - Engine: \(engineName)
+
+            \(result.text)
+            """
+
+            return WatchFolderExportArtifact(fileExtension: format.fileExtension, content: content)
+
+        case .plainText:
+            return WatchFolderExportArtifact(fileExtension: format.fileExtension, content: result.text)
+
+        case .srt:
+            guard !result.segments.isEmpty else {
+                throw Error.missingSubtitleSegments
+            }
+            return WatchFolderExportArtifact(
+                fileExtension: format.fileExtension,
+                content: SubtitleExporter.exportSRT(segments: result.segments)
+            )
+
+        case .vtt:
+            guard !result.segments.isEmpty else {
+                throw Error.missingSubtitleSegments
+            }
+            return WatchFolderExportArtifact(
+                fileExtension: format.fileExtension,
+                content: SubtitleExporter.exportVTT(segments: result.segments)
+            )
+        }
+    }
+}
+
 @MainActor
 final class WatchFolderService: ObservableObject {
     @Published var isWatching: Bool = false
@@ -128,7 +230,9 @@ final class WatchFolderService: ObservableObject {
 
         guard !audioFiles.isEmpty else { return }
 
-        let outputFormat = UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderOutputFormat) ?? "md"
+        let outputFormat = WatchFolderOutputFormat(
+            storedValue: UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderOutputFormat)
+        )
         let deleteSource = UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderDeleteSource)
         let overrides = WatchFolderViewModel.shared.transcriptionOverrides
 
@@ -176,7 +280,7 @@ final class WatchFolderService: ObservableObject {
         url: URL,
         fingerprint: String,
         outputFolder: URL,
-        format: String,
+        format: WatchFolderOutputFormat,
         overrides: WatchFolderViewModel.TranscriptionOverrides,
         deleteSource: Bool
     ) async {
@@ -194,16 +298,7 @@ final class WatchFolderService: ObservableObject {
             )
 
             let outputName = url.deletingPathExtension().lastPathComponent
-            let outputExt = format == "md" ? "md" : "txt"
-            let outputURL = outputFolder
-                .appendingPathComponent(outputName)
-                .appendingPathExtension(outputExt)
-
-            let content: String
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateStyle = .medium
-            dateFormatter.timeStyle = .medium
-            let dateString = dateFormatter.string(from: Date())
+            let exportDate = Date()
             let engineName: String
             if let overrideId = overrides.engineId,
                let engine = PluginManager.shared.transcriptionEngine(for: overrideId) {
@@ -212,19 +307,18 @@ final class WatchFolderService: ObservableObject {
                 engineName = modelManagerService.activeEngineName ?? "Unknown"
             }
 
-            if format == "md" {
-                content = """
-                # Transcription: \(fileName)
-                - Date: \(dateString)
-                - Engine: \(engineName)
+            let artifact = try WatchFolderExportBuilder.build(
+                format: format,
+                result: result,
+                fileName: fileName,
+                engineName: engineName,
+                date: exportDate
+            )
+            let outputURL = outputFolder
+                .appendingPathComponent(outputName)
+                .appendingPathExtension(artifact.fileExtension)
 
-                \(result.text)
-                """
-            } else {
-                content = result.text
-            }
-
-            try content.write(to: outputURL, atomically: true, encoding: .utf8)
+            try artifact.content.write(to: outputURL, atomically: true, encoding: .utf8)
 
             if deleteSource {
                 try? FileManager.default.removeItem(at: url)

--- a/TypeWhisper/ViewModels/WatchFolderViewModel.swift
+++ b/TypeWhisper/ViewModels/WatchFolderViewModel.swift
@@ -15,8 +15,8 @@ final class WatchFolderViewModel: ObservableObject {
 
     @Published var watchFolderPath: String?
     @Published var outputFolderPath: String?
-    @Published var outputFormat: String = "md" {
-        didSet { UserDefaults.standard.set(outputFormat, forKey: UserDefaultsKeys.watchFolderOutputFormat) }
+    @Published var outputFormat: WatchFolderOutputFormat = .markdown {
+        didSet { UserDefaults.standard.set(outputFormat.rawValue, forKey: UserDefaultsKeys.watchFolderOutputFormat) }
     }
     @Published var deleteSourceFiles: Bool = false {
         didSet { UserDefaults.standard.set(deleteSourceFiles, forKey: UserDefaultsKeys.watchFolderDeleteSource) }
@@ -154,7 +154,9 @@ final class WatchFolderViewModel: ObservableObject {
     // MARK: - Private
 
     private func loadSettings() {
-        outputFormat = UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderOutputFormat) ?? "md"
+        outputFormat = WatchFolderOutputFormat(
+            storedValue: UserDefaults.standard.string(forKey: UserDefaultsKeys.watchFolderOutputFormat)
+        )
         deleteSourceFiles = UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderDeleteSource)
         autoStartOnLaunch = UserDefaults.standard.bool(forKey: UserDefaultsKeys.watchFolderAutoStart)
         languageSelection = LanguageSelection(

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -120,8 +120,10 @@ struct FileTranscriptionView: View {
 
                 Section(String(localized: "watchFolder.settings")) {
                     Picker(String(localized: "watchFolder.outputFormat"), selection: $watchFolder.outputFormat) {
-                        Text("Markdown (.md)").tag("md")
-                        Text(String(localized: "watchFolder.plainText")).tag("txt")
+                        Text(WatchFolderOutputFormat.markdown.displayName).tag(WatchFolderOutputFormat.markdown)
+                        Text(WatchFolderOutputFormat.plainText.displayName).tag(WatchFolderOutputFormat.plainText)
+                        Text(WatchFolderOutputFormat.srt.displayName).tag(WatchFolderOutputFormat.srt)
+                        Text(WatchFolderOutputFormat.vtt.displayName).tag(WatchFolderOutputFormat.vtt)
                     }
 
                     Toggle(String(localized: "watchFolder.deleteSource"), isOn: $watchFolder.deleteSourceFiles)

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -223,3 +223,148 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertFalse(match.wonBySortOrder)
     }
 }
+
+final class WatchFolderExportTests: XCTestCase {
+    func testWatchFolderOutputFormatSupportsStoredValuesAndFallback() {
+        XCTAssertEqual(WatchFolderOutputFormat.markdown.rawValue, "md")
+        XCTAssertEqual(WatchFolderOutputFormat.plainText.rawValue, "txt")
+        XCTAssertEqual(WatchFolderOutputFormat.srt.rawValue, "srt")
+        XCTAssertEqual(WatchFolderOutputFormat.vtt.rawValue, "vtt")
+
+        XCTAssertEqual(WatchFolderOutputFormat(storedValue: "md"), .markdown)
+        XCTAssertEqual(WatchFolderOutputFormat(storedValue: "txt"), .plainText)
+        XCTAssertEqual(WatchFolderOutputFormat(storedValue: "srt"), .srt)
+        XCTAssertEqual(WatchFolderOutputFormat(storedValue: "vtt"), .vtt)
+        XCTAssertEqual(WatchFolderOutputFormat(storedValue: "unexpected"), .markdown)
+        XCTAssertEqual(WatchFolderOutputFormat(storedValue: nil), .markdown)
+    }
+
+    func testWatchFolderExportBuilderProducesMarkdownAndPlainText() throws {
+        let result = makeTranscriptionResult()
+
+        let markdown = try WatchFolderExportBuilder.build(
+            format: .markdown,
+            result: result,
+            fileName: "meeting.m4a",
+            engineName: "WhisperKit",
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        XCTAssertEqual(markdown.fileExtension, "md")
+        XCTAssertTrue(markdown.content.contains("# Transcription: meeting.m4a"))
+        XCTAssertTrue(markdown.content.contains("- Date:"))
+        XCTAssertTrue(markdown.content.contains("- Engine: WhisperKit"))
+        XCTAssertTrue(markdown.content.contains("Hello world"))
+
+        let plainText = try WatchFolderExportBuilder.build(
+            format: .plainText,
+            result: result,
+            fileName: "meeting.m4a",
+            engineName: "WhisperKit",
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        XCTAssertEqual(plainText.fileExtension, "txt")
+        XCTAssertEqual(plainText.content, "Hello world")
+    }
+
+    func testWatchFolderExportBuilderProducesSubtitleFormats() throws {
+        let result = makeTranscriptionResult()
+
+        let srt = try WatchFolderExportBuilder.build(
+            format: .srt,
+            result: result,
+            fileName: "meeting.m4a",
+            engineName: "WhisperKit",
+            date: .distantPast
+        )
+        XCTAssertEqual(srt.fileExtension, "srt")
+        XCTAssertEqual(
+            srt.content,
+            """
+            1
+            00:00:00,250 --> 00:00:01,500
+            Hello
+
+            2
+            00:00:01,500 --> 00:00:02,750
+            world
+            """
+        )
+
+        let vtt = try WatchFolderExportBuilder.build(
+            format: .vtt,
+            result: result,
+            fileName: "meeting.m4a",
+            engineName: "WhisperKit",
+            date: .distantPast
+        )
+        XCTAssertEqual(vtt.fileExtension, "vtt")
+        XCTAssertEqual(
+            vtt.content,
+            """
+            WEBVTT
+
+            1
+            00:00:00.250 --> 00:00:01.500
+            Hello
+
+            2
+            00:00:01.500 --> 00:00:02.750
+            world
+
+            """
+        )
+    }
+
+    func testWatchFolderExportBuilderRejectsSubtitleFormatsWithoutSegments() {
+        let result = TranscriptionResult(
+            text: "Hello world",
+            detectedLanguage: "en",
+            duration: 2.75,
+            processingTime: 0.3,
+            engineUsed: "whisperkit",
+            segments: []
+        )
+
+        XCTAssertThrowsError(
+            try WatchFolderExportBuilder.build(
+                format: .srt,
+                result: result,
+                fileName: "meeting.m4a",
+                engineName: "WhisperKit",
+                date: .distantPast
+            )
+        ) { error in
+            guard case WatchFolderExportBuilder.Error.missingSubtitleSegments = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(
+            try WatchFolderExportBuilder.build(
+                format: .vtt,
+                result: result,
+                fileName: "meeting.m4a",
+                engineName: "WhisperKit",
+                date: .distantPast
+            )
+        ) { error in
+            guard case WatchFolderExportBuilder.Error.missingSubtitleSegments = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    private func makeTranscriptionResult() -> TranscriptionResult {
+        TranscriptionResult(
+            text: "Hello world",
+            detectedLanguage: "en",
+            duration: 2.75,
+            processingTime: 0.3,
+            engineUsed: "whisperkit",
+            segments: [
+                TranscriptionSegment(text: "Hello", start: 0.25, end: 1.5),
+                TranscriptionSegment(text: "world", start: 1.5, end: 2.75)
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add typed watch-folder output format handling for Markdown, plain text, SRT, and VTT
- reuse the existing subtitle exporter for automatic watch-folder subtitle files
- surface a localized watch-folder error when the selected subtitle format requires timestamps but the engine returns no segments
- cover the new format mapping and export behavior with focused unit tests

## Issue context

Issue #380 reports that the automatic file transcription flow only allowed `.md` and `.txt` exports even though subtitle exports already existed in the manual file transcription flow.

The root cause was that the watch-folder path still hard-coded free-form string handling for only two output formats and never routed subtitle exports through the existing subtitle exporter.

Users can now choose `.srt` and `.vtt` in the watch-folder settings, and files are exported automatically when the engine returns timestamped segments.

Closes #380

## Testing

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WatchFolderExportTests`
