### PR TITLE
Fix recorder live preview lag in Recorder

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		A1F000000000000000000102 /* PostUpdatePromptCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */; };
 		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
+		D4A100000000000000000001 /* RecorderTranscriptionBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */; };
+		D4A100000000000000000003 /* RecorderTranscriptionBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */; };
 		F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000141 /* GeminiPlugin.swift */; };
 		A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000001 /* SystemTTSPlugin.swift */; };
 		A10000000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000002 /* manifest.json */; };
@@ -631,6 +633,7 @@
 		BB00000000000000000253 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000254 /* FireworksPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FireworksPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000235 /* AppFormatterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFormatterService.swift; sourceTree = "<group>"; };
+		D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBuffer.swift; sourceTree = "<group>"; };
 		BB00000000000000000238 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		BB00000000000000000239 /* AudioRecorderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000240 /* AudioRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderView.swift; sourceTree = "<group>"; };
@@ -657,6 +660,7 @@
 		2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardInferenceServiceTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionsViewModelWizardTests.swift; sourceTree = "<group>"; };
 		91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginRegistryServiceTests.swift; sourceTree = "<group>"; };
+		D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBufferTests.swift; sourceTree = "<group>"; };
 		91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingHandlerTests.swift; sourceTree = "<group>"; };
 		E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayout.swift; sourceTree = "<group>"; };
 		E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayoutTests.swift; sourceTree = "<group>"; };
@@ -1191,6 +1195,7 @@
 				BB00000000000000000247 /* SpeechFeedbackService.swift */,
 				BB00000000000000000272 /* TermPackRegistryService.swift */,
 				BB00000000000000000286 /* LicenseService.swift */,
+				D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1774,6 +1779,7 @@
 				B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */,
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
+				D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */,
 				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
 				05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */,
@@ -2968,6 +2974,7 @@
 				A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,
 				A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */,
+				D4A100000000000000000003 /* RecorderTranscriptionBufferTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */,
 				204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */,
 				76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */,
@@ -3093,6 +3100,7 @@
 				AA00000000000000000197 /* WidgetDataService.swift in Sources */,
 				AA00000000000000000240 /* MemoryService.swift in Sources */,
 				AA00000000000000000247 /* AppFormatterService.swift in Sources */,
+				D4A100000000000000000001 /* RecorderTranscriptionBuffer.swift in Sources */,
 				AA00000000000000000250 /* AudioRecorderService.swift in Sources */,
 				AA00000000000000000251 /* AudioRecorderViewModel.swift in Sources */,
 				AA00000000000000000252 /* AudioRecorderView.swift in Sources */,

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -9,64 +9,6 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhis
 /// Records audio from microphone and/or system audio to file.
 /// Uses AVAudioEngine for mic and ScreenCaptureKit for system audio.
 final class AudioRecorderService: ObservableObject, @unchecked Sendable {
-
-    private struct TranscriptionBufferState {
-        var micSamples: [Float] = []
-        var systemSamples: [Float] = []
-
-        mutating func reset() {
-            micSamples.removeAll(keepingCapacity: false)
-            systemSamples.removeAll(keepingCapacity: false)
-        }
-
-        func mixedBuffer(
-            micEnabled: Bool,
-            systemAudioEnabled: Bool,
-            micDuckingMode: MicDuckingMode
-        ) -> [Float] {
-            switch (micEnabled, systemAudioEnabled) {
-            case (true, false):
-                return micSamples
-            case (false, true):
-                return systemSamples
-            case (true, true):
-                return Self.mix(
-                    micSamples: micSamples,
-                    systemSamples: systemSamples,
-                    micDuckingMode: micDuckingMode
-                )
-            case (false, false):
-                return []
-            }
-        }
-
-        static func mix(
-            micSamples: [Float],
-            systemSamples: [Float],
-            micDuckingMode: MicDuckingMode
-        ) -> [Float] {
-            let sampleCount = max(micSamples.count, systemSamples.count)
-            guard sampleCount > 0 else { return [] }
-
-            let duckingProfile = AudioRecorderService.buildMicDuckingProfile(
-                frameCount: sampleCount,
-                sampleRate: AudioRecorderService.transcriptionSampleRate,
-                mode: micDuckingMode
-            ) { index in
-                index < systemSamples.count ? systemSamples[index] : 0
-            }
-
-            var mixed = [Float](repeating: 0, count: sampleCount)
-            for index in 0..<sampleCount {
-                let micSample = index < micSamples.count ? micSamples[index] : 0
-                let systemSample = index < systemSamples.count ? systemSamples[index] : 0
-                let micGain = duckingProfile?.gains[index] ?? 1
-                mixed[index] = max(-1, min(1, (systemSample + (micSample * micGain)) * 0.5))
-            }
-            return mixed
-        }
-    }
-
     private struct MicDuckingProfile {
         let gains: [Float]
         let minimumGain: Float
@@ -166,7 +108,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     var micDuckingMode: MicDuckingMode = .aggressive
 
     // 16kHz mono buffer for streaming transcription
-    private let transcriptionBufferLock = OSAllocatedUnfairLock<TranscriptionBufferState>(initialState: TranscriptionBufferState())
+    private let transcriptionBufferLock = OSAllocatedUnfairLock<RecorderTranscriptionBuffer>(initialState: RecorderTranscriptionBuffer())
     private static let transcriptionSampleRate: Double = 16000
 
     static let recordingsDirectoryName = "TypeWhisper Recordings"
@@ -183,11 +125,18 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let micEnabled = self.micEnabled
         let systemAudioEnabled = self.systemAudioEnabled
         let micDuckingMode = self.micDuckingMode
-        return transcriptionBufferLock.withLock { state in
-            state.mixedBuffer(
+        return transcriptionBufferLock.withLock { buffer in
+            buffer.currentBuffer(
                 micEnabled: micEnabled,
                 systemAudioEnabled: systemAudioEnabled,
-                micDuckingMode: micDuckingMode
+                mixer: { range, micSamples, systemSamples in
+                    Self.mixTranscriptionBuffer(
+                        in: range,
+                        micSamples: micSamples,
+                        systemSamples: systemSamples,
+                        micDuckingMode: micDuckingMode
+                    )
+                }
             )
         }
     }
@@ -197,15 +146,21 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let micEnabled = self.micEnabled
         let systemAudioEnabled = self.systemAudioEnabled
         let micDuckingMode = self.micDuckingMode
-        return transcriptionBufferLock.withLock { state in
-            let buffer = state.mixedBuffer(
+        let maxSampleCount = Int(maxDuration * Self.transcriptionSampleRate)
+        return transcriptionBufferLock.withLock { buffer in
+            buffer.recentBuffer(
+                maxSampleCount: maxSampleCount,
                 micEnabled: micEnabled,
                 systemAudioEnabled: systemAudioEnabled,
-                micDuckingMode: micDuckingMode
+                mixer: { range, micSamples, systemSamples in
+                    Self.mixTranscriptionBuffer(
+                        in: range,
+                        micSamples: micSamples,
+                        systemSamples: systemSamples,
+                        micDuckingMode: micDuckingMode
+                    )
+                }
             )
-            let maxSamples = Int(maxDuration * Self.transcriptionSampleRate)
-            if buffer.count <= maxSamples { return buffer }
-            return Array(buffer.suffix(maxSamples))
         }
     }
 
@@ -214,29 +169,27 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let micEnabled = self.micEnabled
         let systemAudioEnabled = self.systemAudioEnabled
         let micDuckingMode = self.micDuckingMode
-        return transcriptionBufferLock.withLock { state in
-            let buffer = state.mixedBuffer(
+        return transcriptionBufferLock.withLock { buffer in
+            buffer.delta(
+                since: sampleOffset,
                 micEnabled: micEnabled,
                 systemAudioEnabled: systemAudioEnabled,
-                micDuckingMode: micDuckingMode
+                mixer: { range, micSamples, systemSamples in
+                    Self.mixTranscriptionBuffer(
+                        in: range,
+                        micSamples: micSamples,
+                        systemSamples: systemSamples,
+                        micDuckingMode: micDuckingMode
+                    )
+                }
             )
-            let clampedOffset = max(0, min(sampleOffset, buffer.count))
-            return (Array(buffer.dropFirst(clampedOffset)), buffer.count)
         }
     }
 
     /// Total duration of transcription buffer in seconds.
     var totalBufferDuration: TimeInterval {
-        let micEnabled = self.micEnabled
-        let systemAudioEnabled = self.systemAudioEnabled
-        let micDuckingMode = self.micDuckingMode
-        return transcriptionBufferLock.withLock { state in
-            let buffer = state.mixedBuffer(
-                micEnabled: micEnabled,
-                systemAudioEnabled: systemAudioEnabled,
-                micDuckingMode: micDuckingMode
-            )
-            return Double(buffer.count) / Self.transcriptionSampleRate
+        return transcriptionBufferLock.withLock { buffer in
+            Double(buffer.mixedSampleCount) / Self.transcriptionSampleRate
         }
     }
 
@@ -907,13 +860,40 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     }
 
     private func appendMicTranscriptionSamples(_ samples: [Float]) {
-        guard !samples.isEmpty else { return }
-        transcriptionBufferLock.withLock { $0.micSamples.append(contentsOf: samples) }
+        transcriptionBufferLock.withLock { $0.appendMic(samples) }
     }
 
     private func appendSystemTranscriptionSamples(_ samples: [Float]) {
-        guard !samples.isEmpty else { return }
-        transcriptionBufferLock.withLock { $0.systemSamples.append(contentsOf: samples) }
+        transcriptionBufferLock.withLock { $0.appendSystem(samples) }
+    }
+
+    private static func mixTranscriptionBuffer(
+        in range: Range<Int>,
+        micSamples: [Float],
+        systemSamples: [Float],
+        micDuckingMode: MicDuckingMode
+    ) -> [Float] {
+        guard !range.isEmpty else { return [] }
+
+        let duckingProfile = buildMicDuckingProfile(
+            frameCount: range.count,
+            sampleRate: transcriptionSampleRate,
+            mode: micDuckingMode
+        ) { relativeIndex in
+            let absoluteIndex = range.lowerBound + relativeIndex
+            return absoluteIndex < systemSamples.count ? systemSamples[absoluteIndex] : 0
+        }
+
+        var mixed = [Float](repeating: 0, count: range.count)
+        for relativeIndex in 0..<range.count {
+            let absoluteIndex = range.lowerBound + relativeIndex
+            let micSample = absoluteIndex < micSamples.count ? micSamples[absoluteIndex] : 0
+            let systemSample = absoluteIndex < systemSamples.count ? systemSamples[absoluteIndex] : 0
+            let micGain = duckingProfile?.gains[relativeIndex] ?? 1
+            mixed[relativeIndex] = max(-1, min(1, (systemSample + (micSample * micGain)) * 0.5))
+        }
+
+        return mixed
     }
 
     private func rollbackFailedStart() async {

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -183,7 +183,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     /// Thread-safe snapshot of the current recording buffer for streaming transcription.
     func getCurrentBuffer() -> [Float] {
         bufferLock.lock()
-        let copy = sampleBuffer
+        let copy = Array(sampleBuffer)
         bufferLock.unlock()
         return copy
     }

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -203,6 +203,18 @@ final class ModelManagerService: ObservableObject {
         plugin.selectModel(previousId)
     }
 
+    nonisolated private static func makeAudioData(from audioSamples: [Float]) async -> AudioData {
+        let wavData = await Task.detached(priority: .userInitiated) {
+            WavEncoder.encode(audioSamples)
+        }.value
+
+        return AudioData(
+            samples: audioSamples,
+            wavData: wavData,
+            duration: Double(audioSamples.count) / 16000.0
+        )
+    }
+
     func createLiveTranscriptionSession(
         language: String?,
         task: TranscriptionTask,
@@ -333,14 +345,7 @@ final class ModelManagerService: ObservableObject {
         defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         let startTime = CFAbsoluteTimeGetCurrent()
-        let wavData = WavEncoder.encode(audioSamples)
-        let audioDuration = Double(audioSamples.count) / 16000.0
-
-        let audio = AudioData(
-            samples: audioSamples,
-            wavData: wavData,
-            duration: audioDuration
-        )
+        let audio = await Self.makeAudioData(from: audioSamples)
 
         let result = try await transcribeWithResolvedLanguageSelection(
             plugin: plugin,
@@ -357,7 +362,7 @@ final class ModelManagerService: ObservableObject {
         return TranscriptionResult(
             text: result.text,
             detectedLanguage: result.detectedLanguage,
-            duration: audioDuration,
+            duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
             segments: result.segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }
@@ -410,14 +415,7 @@ final class ModelManagerService: ObservableObject {
         defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         let startTime = CFAbsoluteTimeGetCurrent()
-        let wavData = WavEncoder.encode(audioSamples)
-        let audioDuration = Double(audioSamples.count) / 16000.0
-
-        let audio = AudioData(
-            samples: audioSamples,
-            wavData: wavData,
-            duration: audioDuration
-        )
+        let audio = await Self.makeAudioData(from: audioSamples)
 
         let result = try await transcribeWithResolvedLanguageSelection(
             plugin: plugin,
@@ -435,7 +433,7 @@ final class ModelManagerService: ObservableObject {
         return TranscriptionResult(
             text: result.text,
             detectedLanguage: result.detectedLanguage,
-            duration: audioDuration,
+            duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
             segments: result.segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }

--- a/TypeWhisper/Services/RecorderTranscriptionBuffer.swift
+++ b/TypeWhisper/Services/RecorderTranscriptionBuffer.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+struct RecorderTranscriptionBuffer {
+    typealias Mixer = (_ range: Range<Int>, _ micSamples: [Float], _ systemSamples: [Float]) -> [Float]
+
+    var micSamples: [Float] = []
+    var systemSamples: [Float] = []
+
+    var mixedSampleCount: Int {
+        max(micSamples.count, systemSamples.count)
+    }
+
+    mutating func reset() {
+        micSamples.removeAll(keepingCapacity: false)
+        systemSamples.removeAll(keepingCapacity: false)
+    }
+
+    mutating func appendMic(_ samples: [Float]) {
+        guard !samples.isEmpty else { return }
+        micSamples.append(contentsOf: samples)
+    }
+
+    mutating func appendSystem(_ samples: [Float]) {
+        guard !samples.isEmpty else { return }
+        systemSamples.append(contentsOf: samples)
+    }
+
+    func currentBuffer(
+        micEnabled: Bool,
+        systemAudioEnabled: Bool,
+        mixer: Mixer
+    ) -> [Float] {
+        snapshot(
+            in: 0..<mixedSampleCount,
+            micEnabled: micEnabled,
+            systemAudioEnabled: systemAudioEnabled,
+            mixer: mixer
+        )
+    }
+
+    func recentBuffer(
+        maxSampleCount: Int,
+        micEnabled: Bool,
+        systemAudioEnabled: Bool,
+        mixer: Mixer
+    ) -> [Float] {
+        let nextOffset = mixedSampleCount
+        let startOffset = max(0, nextOffset - max(0, maxSampleCount))
+        return snapshot(
+            in: startOffset..<nextOffset,
+            micEnabled: micEnabled,
+            systemAudioEnabled: systemAudioEnabled,
+            mixer: mixer
+        )
+    }
+
+    func delta(
+        since sampleOffset: Int,
+        micEnabled: Bool,
+        systemAudioEnabled: Bool,
+        mixer: Mixer
+    ) -> (samples: [Float], nextOffset: Int) {
+        let nextOffset = mixedSampleCount
+        let clampedOffset = max(0, min(sampleOffset, nextOffset))
+        let samples = snapshot(
+            in: clampedOffset..<nextOffset,
+            micEnabled: micEnabled,
+            systemAudioEnabled: systemAudioEnabled,
+            mixer: mixer
+        )
+        return (samples, nextOffset)
+    }
+
+    private func snapshot(
+        in range: Range<Int>,
+        micEnabled: Bool,
+        systemAudioEnabled: Bool,
+        mixer: Mixer
+    ) -> [Float] {
+        let clampedMixedRange = clampedRange(range, upperBound: mixedSampleCount)
+        guard !clampedMixedRange.isEmpty else { return [] }
+
+        switch (micEnabled, systemAudioEnabled) {
+        case (true, false):
+            return sliceCopy(of: micSamples, in: clampedMixedRange)
+        case (false, true):
+            return sliceCopy(of: systemSamples, in: clampedMixedRange)
+        case (true, true):
+            return mixer(clampedMixedRange, micSamples, systemSamples)
+        case (false, false):
+            return []
+        }
+    }
+
+    private func sliceCopy(of samples: [Float], in range: Range<Int>) -> [Float] {
+        let clamped = clampedRange(range, upperBound: samples.count)
+        guard !clamped.isEmpty else { return [] }
+        return Array(samples[clamped])
+    }
+
+    private func clampedRange(_ range: Range<Int>, upperBound: Int) -> Range<Int> {
+        let lowerBound = max(0, min(range.lowerBound, upperBound))
+        let upperBound = max(lowerBound, min(range.upperBound, upperBound))
+        return lowerBound..<upperBound
+    }
+}

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -99,6 +99,9 @@ final class AudioRecorderViewModel: ObservableObject {
             bufferProvider: { [weak recorderService] in
                 recorderService?.getCurrentBuffer() ?? []
             },
+            recentBufferProvider: { [weak recorderService] maxDuration in
+                recorderService?.getRecentBuffer(maxDuration: maxDuration) ?? []
+            },
             bufferDeltaProvider: { [weak recorderService] offset in
                 recorderService?.getBufferDelta(since: offset) ?? ([], offset)
             },

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -264,6 +264,9 @@ final class DictationViewModel: ObservableObject {
             bufferProvider: { [weak audioRecordingService] in
                 audioRecordingService?.getCurrentBuffer() ?? []
             },
+            recentBufferProvider: { [weak audioRecordingService] maxDuration in
+                audioRecordingService?.getRecentBuffer(maxDuration: maxDuration) ?? []
+            },
             bufferDeltaProvider: { [weak audioRecordingService] offset in
                 audioRecordingService?.getBufferDelta(since: offset) ?? ([], offset)
             },

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -3,16 +3,24 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "StreamingHandler")
 
-@MainActor
-final class StreamingHandler {
+final class StreamingHandler: @unchecked Sendable {
+    private struct SharedState {
+        var confirmedStreamingText = ""
+        var liveSessionHandle: ModelManagerService.LiveTranscriptionSessionHandle?
+        var sampleCursor = 0
+    }
+
+    private static let liveSessionPollInterval: Duration = .milliseconds(350)
+    private static let fallbackPollInterval: Duration = .seconds(3)
+    private static let fallbackPreviewWindowDuration: TimeInterval = 10
+
     private var streamingTask: Task<Void, Never>?
-    private var confirmedStreamingText = ""
     private let progressText = OSAllocatedUnfairLock(initialState: "")
-    private var liveSessionHandle: ModelManagerService.LiveTranscriptionSessionHandle?
-    private var sampleCursor = 0
+    private let sharedState = OSAllocatedUnfairLock(initialState: SharedState())
 
     private let modelManager: ModelManagerService
     private let bufferProvider: () -> [Float]
+    private let recentBufferProvider: (TimeInterval) -> [Float]
     private let bufferDeltaProvider: (Int) -> (samples: [Float], nextOffset: Int)
     private let bufferedDurationProvider: () -> Double
 
@@ -22,15 +30,18 @@ final class StreamingHandler {
     init(
         modelManager: ModelManagerService,
         bufferProvider: @escaping () -> [Float],
+        recentBufferProvider: @escaping (TimeInterval) -> [Float],
         bufferDeltaProvider: @escaping (Int) -> (samples: [Float], nextOffset: Int),
         bufferedDurationProvider: @escaping () -> Double
     ) {
         self.modelManager = modelManager
         self.bufferProvider = bufferProvider
+        self.recentBufferProvider = recentBufferProvider
         self.bufferDeltaProvider = bufferDeltaProvider
         self.bufferedDurationProvider = bufferedDurationProvider
     }
 
+    @MainActor
     func start(
         streamPrompt: String,
         engineOverrideId: String?,
@@ -39,7 +50,7 @@ final class StreamingHandler {
         task: TranscriptionTask,
         cloudModelOverride: String?,
         allowLiveTranscription: Bool,
-        stateCheck: @escaping () -> Bool
+        stateCheck: @escaping @MainActor @Sendable () -> Bool
     ) {
         stop()
 
@@ -47,18 +58,13 @@ final class StreamingHandler {
 
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
-              let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else { return }
+              PluginManager.shared.transcriptionEngine(for: providerId) != nil else { return }
 
-        confirmedStreamingText = ""
-        progressText.withLock { $0 = "" }
-        sampleCursor = 0
+        resetStreamingState()
         onStreamingStateChange?(true)
-
-        let pollInterval: Duration = plugin.supportsStreaming ? .milliseconds(350) : .seconds(3)
 
         streamingTask = Task { [weak self] in
             guard let self else { return }
-            let progressText = self.progressText
 
             if let handle = try? await self.modelManager.createLiveTranscriptionSession(
                 languageSelection: languageSelection,
@@ -68,92 +74,43 @@ final class StreamingHandler {
                 prompt: streamPrompt,
                 onProgress: { [weak self] text in
                     guard let self else { return false }
-                    let confirmed = progressText.withLock { $0 }
+                    let confirmed = self.progressText.withLock { $0 }
                     let stable = Self.stabilizeText(confirmed: confirmed, new: text)
+                    self.progressText.withLock { $0 = stable }
+                    self.sharedState.withLock { $0.confirmedStreamingText = stable }
                     Task { @MainActor [weak self] in
-                        progressText.withLock { $0 = stable }
-                        self?.confirmedStreamingText = stable
                         self?.onPartialTextUpdate?(stable)
                     }
                     return true
                 }
             ) {
-                self.liveSessionHandle = handle
-
-                while !Task.isCancelled, stateCheck() {
-                    let delta = self.bufferDeltaProvider(self.sampleCursor)
-                    self.sampleCursor = delta.nextOffset
-
-                    if !delta.samples.isEmpty {
-                        do {
-                            try await handle.session.appendAudio(samples: delta.samples)
-                        } catch {
-                            logger.warning("Live transcription append failed: \(error.localizedDescription)")
-                            break
-                        }
-                    }
-
-                    try? await Task.sleep(for: pollInterval)
-                }
+                self.sharedState.withLock { $0.liveSessionHandle = handle }
+                await self.runLiveSessionLoop(stateCheck: stateCheck)
                 return
             }
 
-            try? await Task.sleep(for: pollInterval)
-
-            while !Task.isCancelled, stateCheck() {
-                let buffer = self.bufferProvider()
-                let bufferDuration = Double(buffer.count) / 16000.0
-
-                if bufferDuration > 0.5 {
-                    do {
-                        let confirmed = self.confirmedStreamingText
-                        let result = try await self.modelManager.transcribe(
-                            audioSamples: buffer,
-                            languageSelection: languageSelection,
-                            task: task,
-                            engineOverrideId: engineOverrideId,
-                            cloudModelOverride: cloudModelOverride,
-                            prompt: streamPrompt,
-                            onProgress: { [weak self] text in
-                                guard let self, !Task.isCancelled else { return false }
-                                let stable = Self.stabilizeText(confirmed: confirmed, new: text)
-                                Task { @MainActor [weak self] in
-                                    self?.onPartialTextUpdate?(stable)
-                                }
-                                return true
-                            }
-                        )
-                        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !text.isEmpty {
-                            let stable = Self.stabilizeText(confirmed: confirmed, new: text)
-                            self.onPartialTextUpdate?(stable)
-                            self.confirmedStreamingText = stable
-                        }
-                    } catch {
-                        logger.warning("Streaming preview error: \(error.localizedDescription)")
-                    }
-                }
-
-                try? await Task.sleep(for: pollInterval)
-            }
+            await self.runFallbackLoop(
+                streamPrompt: streamPrompt,
+                engineOverrideId: engineOverrideId,
+                languageSelection: languageSelection,
+                task: task,
+                cloudModelOverride: cloudModelOverride,
+                stateCheck: stateCheck
+            )
         }
     }
 
+    @MainActor
     func finish() async -> TranscriptionResult? {
         streamingTask?.cancel()
         streamingTask = nil
 
-        guard let handle = liveSessionHandle else {
-            liveSessionHandle = nil
-            onStreamingStateChange?(false)
-            confirmedStreamingText = ""
-            progressText.withLock { $0 = "" }
-            sampleCursor = 0
+        guard let handle = sharedState.withLock({ $0.liveSessionHandle }) else {
+            clearStreamingState(notifyStreamingStopped: true)
             return nil
         }
 
-        let delta = bufferDeltaProvider(sampleCursor)
-        sampleCursor = delta.nextOffset
+        let delta = nextBufferDelta()
 
         do {
             if !delta.samples.isEmpty {
@@ -163,40 +120,137 @@ final class StreamingHandler {
                 handle,
                 bufferedDuration: bufferedDurationProvider()
             )
-            liveSessionHandle = nil
-            onStreamingStateChange?(false)
-            confirmedStreamingText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            let finalText = confirmedStreamingText
+            clearStreamingState(notifyStreamingStopped: true)
+
+            let finalText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             progressText.withLock { $0 = finalText }
-            sampleCursor = 0
+            sharedState.withLock { $0.confirmedStreamingText = finalText }
             return result
         } catch {
             logger.warning("Finalizing live transcription failed: \(error.localizedDescription)")
             await handle.session.cancel()
-            liveSessionHandle = nil
-            onStreamingStateChange?(false)
-            confirmedStreamingText = ""
-            progressText.withLock { $0 = "" }
-            sampleCursor = 0
+            clearStreamingState(notifyStreamingStopped: true)
             return nil
         }
     }
 
+    @MainActor
     func stop() {
         streamingTask?.cancel()
         streamingTask = nil
 
-        if let handle = liveSessionHandle {
+        let handle = sharedState.withLock { state in
+            let handle = state.liveSessionHandle
+            state.liveSessionHandle = nil
+            return handle
+        }
+        if let handle {
             Task {
                 await handle.session.cancel()
             }
         }
 
-        liveSessionHandle = nil
-        onStreamingStateChange?(false)
-        confirmedStreamingText = ""
+        clearStreamingState(notifyStreamingStopped: true)
+    }
+
+    private func runLiveSessionLoop(stateCheck: @escaping @MainActor @Sendable () -> Bool) async {
+        while !Task.isCancelled {
+            guard await stateCheck() else { break }
+            let delta = nextBufferDelta()
+
+            if !delta.samples.isEmpty,
+               let handle = sharedState.withLock({ $0.liveSessionHandle }) {
+                do {
+                    try await handle.session.appendAudio(samples: delta.samples)
+                } catch {
+                    logger.warning("Live transcription append failed: \(error.localizedDescription)")
+                    break
+                }
+            }
+
+            try? await Task.sleep(for: Self.liveSessionPollInterval)
+        }
+    }
+
+    private func runFallbackLoop(
+        streamPrompt: String,
+        engineOverrideId: String?,
+        languageSelection: LanguageSelection,
+        task: TranscriptionTask,
+        cloudModelOverride: String?,
+        stateCheck: @escaping @MainActor @Sendable () -> Bool
+    ) async {
+        try? await Task.sleep(for: Self.fallbackPollInterval)
+
+        while !Task.isCancelled {
+            guard await stateCheck() else { break }
+            let buffer = recentBufferProvider(Self.fallbackPreviewWindowDuration)
+            let bufferDuration = Double(buffer.count) / 16000.0
+
+            if bufferDuration > 0.5 {
+                do {
+                    let result = try await modelManager.transcribe(
+                        audioSamples: buffer,
+                        languageSelection: languageSelection,
+                        task: task,
+                        engineOverrideId: engineOverrideId,
+                        cloudModelOverride: cloudModelOverride,
+                        prompt: streamPrompt,
+                        onProgress: { [weak self] text in
+                            guard let self, !Task.isCancelled else { return false }
+                            let confirmed = self.progressText.withLock { $0 }
+                            let stable = Self.stabilizeText(confirmed: confirmed, new: text)
+                            Task { @MainActor [weak self] in
+                                self?.onPartialTextUpdate?(stable)
+                            }
+                            return true
+                        }
+                    )
+                    let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !text.isEmpty {
+                        let confirmed = confirmedStreamingText()
+                        let stable = Self.stabilizeText(confirmed: confirmed, new: text)
+                        progressText.withLock { $0 = stable }
+                        sharedState.withLock { $0.confirmedStreamingText = stable }
+                        await MainActor.run { [weak self] in
+                            self?.onPartialTextUpdate?(stable)
+                        }
+                    }
+                } catch {
+                    logger.warning("Streaming preview error: \(error.localizedDescription)")
+                }
+            }
+
+            try? await Task.sleep(for: Self.fallbackPollInterval)
+        }
+    }
+
+    private func nextBufferDelta() -> (samples: [Float], nextOffset: Int) {
+        let sampleCursor = sharedState.withLock { $0.sampleCursor }
+        let delta = bufferDeltaProvider(sampleCursor)
+        sharedState.withLock { $0.sampleCursor = delta.nextOffset }
+        return delta
+    }
+
+    private func resetStreamingState() {
+        sharedState.withLock { state in
+            state.confirmedStreamingText = ""
+            state.liveSessionHandle = nil
+            state.sampleCursor = 0
+        }
         progressText.withLock { $0 = "" }
-        sampleCursor = 0
+    }
+
+    @MainActor
+    private func clearStreamingState(notifyStreamingStopped: Bool) {
+        resetStreamingState()
+        if notifyStreamingStopped {
+            onStreamingStateChange?(false)
+        }
+    }
+
+    private func confirmedStreamingText() -> String {
+        sharedState.withLock { $0.confirmedStreamingText }
     }
 
     /// Keeps confirmed text stable and only appends new content.

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -178,12 +178,11 @@ struct AudioRecorderView: View {
                             .disabled(isEditingLocked)
                         }
 
-                        if !modelManager.supportsLiveTranscriptionSession(engineOverrideId: providerId),
-                           modelManager.usesMeteredStreamingFallback(engineOverrideId: providerId) {
+                        if !modelManager.supportsLiveTranscriptionSession(engineOverrideId: providerId) {
                             Label(
                                 localizedAppText(
-                                    "This engine updates the live preview every few seconds and may use additional API calls while recording.",
-                                    de: "Diese Engine aktualisiert die Live-Vorschau nur alle paar Sekunden und kann waehrend der Aufnahme zusaetzliche API-Aufrufe ausloesen."
+                                    "This engine uses a lightweight live preview that updates every few seconds. Final transcription still runs on the full recording after you stop.",
+                                    de: "Diese Engine nutzt eine leichte Live-Vorschau, die nur alle paar Sekunden aktualisiert wird. Die finale Transkription laeuft nach dem Stoppen weiterhin auf der gesamten Aufnahme."
                                 ),
                                 systemImage: "info.circle"
                             )

--- a/TypeWhisperTests/RecorderTranscriptionBufferTests.swift
+++ b/TypeWhisperTests/RecorderTranscriptionBufferTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import TypeWhisper
+
+final class RecorderTranscriptionBufferTests: XCTestCase {
+    func testRecentBufferReturnsTailForMicOnlySource() {
+        var buffer = RecorderTranscriptionBuffer()
+        buffer.appendMic((0..<8).map(Float.init))
+
+        let recent = buffer.recentBuffer(
+            maxSampleCount: 3,
+            micEnabled: true,
+            systemAudioEnabled: false,
+            mixer: { _, _, _ in
+                XCTFail("mixer should not be used for mic-only buffers")
+                return []
+            }
+        )
+
+        XCTAssertEqual(recent, [5, 6, 7])
+    }
+
+    func testDeltaUsesMixedSampleCountAsNextOffset() {
+        var buffer = RecorderTranscriptionBuffer()
+        buffer.appendMic([1, 2])
+        buffer.appendSystem([10, 20, 30, 40])
+
+        let delta = buffer.delta(
+            since: 3,
+            micEnabled: true,
+            systemAudioEnabled: true,
+            mixer: { range, micSamples, systemSamples in
+                range.map { index in
+                    let micSample = index < micSamples.count ? micSamples[index] : 0
+                    let systemSample = index < systemSamples.count ? systemSamples[index] : 0
+                    return micSample + systemSample
+                }
+            }
+        )
+
+        XCTAssertEqual(delta.nextOffset, 4)
+        XCTAssertEqual(delta.samples, [40])
+    }
+
+    func testMixedRecentBufferUsesTailRangeOnly() {
+        var buffer = RecorderTranscriptionBuffer()
+        buffer.appendMic([1, 2, 3, 4])
+        buffer.appendSystem([10, 20, 30, 40])
+
+        var capturedRange: Range<Int>?
+        let recent = buffer.recentBuffer(
+            maxSampleCount: 2,
+            micEnabled: true,
+            systemAudioEnabled: true,
+            mixer: { range, micSamples, systemSamples in
+                capturedRange = range
+                return range.map { index in
+                    micSamples[index] + systemSamples[index]
+                }
+            }
+        )
+
+        XCTAssertEqual(capturedRange, 2..<4)
+        XCTAssertEqual(recent, [33, 44])
+    }
+
+    func testMixedDeltaReturnsOnlyRequestedSlice() {
+        var buffer = RecorderTranscriptionBuffer()
+        buffer.appendMic([1, 2, 3, 4])
+        buffer.appendSystem([10, 20])
+
+        let delta = buffer.delta(
+            since: 1,
+            micEnabled: true,
+            systemAudioEnabled: true,
+            mixer: { range, micSamples, systemSamples in
+                range.map { index in
+                    let micSample = index < micSamples.count ? micSamples[index] : 0
+                    let systemSample = index < systemSamples.count ? systemSamples[index] : 0
+                    return micSample + systemSample
+                }
+            }
+        )
+
+        XCTAssertEqual(delta.nextOffset, 4)
+        XCTAssertEqual(delta.samples, [22, 3, 4])
+    }
+}

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import os
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
@@ -27,6 +28,48 @@ final class StreamingHandlerTests: XCTestCase {
             transcribeCallCount += 1
             lastPrompt = prompt
             return PluginTranscriptionResult(text: "final", detectedLanguage: language)
+        }
+    }
+
+    private final class MockStreamingFallbackPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.streaming-fallback" }
+        static var pluginName: String { "Mock Streaming Fallback" }
+
+        var providerId: String { "mock-streaming-fallback" }
+        var providerDisplayName: String { "Mock Streaming Fallback" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { true }
+        var supportedLanguages: [String] { ["en"] }
+        private(set) var transcribeCallCount = 0
+        private(set) var recordedSampleCounts: [Int] = []
+        private(set) var lastPrompt: String?
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            transcribeCallCount += 1
+            recordedSampleCounts.append(audio.samples.count)
+            lastPrompt = prompt
+            return PluginTranscriptionResult(text: "fallback-\(audio.samples.count)", detectedLanguage: language)
+        }
+
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> PluginTranscriptionResult {
+            transcribeCallCount += 1
+            recordedSampleCounts.append(audio.samples.count)
+            lastPrompt = prompt
+            _ = onProgress("preview-\(audio.samples.count)")
+            return PluginTranscriptionResult(text: "fallback-\(audio.samples.count)", detectedLanguage: language)
         }
     }
 
@@ -227,6 +270,7 @@ final class StreamingHandlerTests: XCTestCase {
         let handler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { Array(repeating: 0.5, count: 16_000) },
+            recentBufferProvider: { _ in Array(repeating: 0.5, count: 16_000) },
             bufferDeltaProvider: { _ in ([], 0) },
             bufferedDurationProvider: { 1.0 }
         )
@@ -277,6 +321,7 @@ final class StreamingHandlerTests: XCTestCase {
         let handler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { Array(repeating: 0.5, count: 16_000) },
+            recentBufferProvider: { _ in Array(repeating: 0.5, count: 16_000) },
             bufferDeltaProvider: { _ in ([], 0) },
             bufferedDurationProvider: { 1.0 }
         )
@@ -294,6 +339,173 @@ final class StreamingHandlerTests: XCTestCase {
 
         try await Task.sleep(for: .milliseconds(700))
         XCTAssertEqual(plugin.transcribeCallCount, 0)
+    }
+
+    func testStreamingFallbackDoesNotPreviewBeforeThreeSeconds() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockStreamingFallbackPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.streaming-fallback",
+                    name: "Mock Streaming Fallback",
+                    version: "1.0.0",
+                    principalClass: "MockStreamingFallbackPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: {
+                XCTFail("full buffer provider should not be used for fallback previews")
+                return Array(repeating: 0.5, count: 160_000)
+            },
+            recentBufferProvider: { _ in Array(repeating: 0.5, count: 16_000) },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 10.0 }
+        )
+
+        handler.start(
+            streamPrompt: "Fallback Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("en"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(2500))
+        handler.stop()
+
+        XCTAssertEqual(plugin.transcribeCallCount, 0)
+    }
+
+    func testStreamingFallbackCallsPreviewAfterThreeSecondsEvenWithoutLiveSession() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockStreamingFallbackPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.streaming-fallback",
+                    name: "Mock Streaming Fallback",
+                    version: "1.0.0",
+                    principalClass: "MockStreamingFallbackPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: {
+                XCTFail("full buffer provider should not be used for fallback previews")
+                return Array(repeating: 0.5, count: 160_000)
+            },
+            recentBufferProvider: { _ in Array(repeating: 0.5, count: 16_000) },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 10.0 }
+        )
+
+        handler.start(
+            streamPrompt: "Fallback Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("en"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(3400))
+        handler.stop()
+
+        XCTAssertEqual(plugin.transcribeCallCount, 1)
+        XCTAssertEqual(plugin.lastPrompt, "Fallback Terms")
+    }
+
+    func testStreamingFallbackUsesRecentWindowProviderInsteadOfFullBuffer() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockStreamingFallbackPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.streaming-fallback",
+                    name: "Mock Streaming Fallback",
+                    version: "1.0.0",
+                    principalClass: "MockStreamingFallbackPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let requestedWindowLock = OSAllocatedUnfairLock(initialState: Optional<TimeInterval>.none)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: {
+                XCTFail("full buffer provider should not be used for fallback previews")
+                return Array(repeating: 0.5, count: 160_000)
+            },
+            recentBufferProvider: { window in
+                requestedWindowLock.withLock { requestedWindow in
+                    requestedWindow = window
+                }
+                return Array(repeating: 0.5, count: 16_000)
+            },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 10.0 }
+        )
+
+        handler.start(
+            streamPrompt: "Fallback Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("en"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(3400))
+        handler.stop()
+
+        let finalRequestedWindow = requestedWindowLock.withLock { $0 }
+
+        XCTAssertEqual(finalRequestedWindow, 10)
+        XCTAssertEqual(plugin.recordedSampleCounts, [16_000])
     }
 
     func testLiveSessionConsumesOnlyIncrementalAudioDeltas() async throws {
@@ -333,6 +545,7 @@ final class StreamingHandlerTests: XCTestCase {
         let handler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { [] },
+            recentBufferProvider: { _ in [] },
             bufferDeltaProvider: { _ in
                 indexLock.lock()
                 defer { indexLock.unlock() }
@@ -465,6 +678,7 @@ final class StreamingHandlerTests: XCTestCase {
         let handler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { [] },
+            recentBufferProvider: { _ in [] },
             bufferDeltaProvider: { _ in (Array(repeating: 0.1, count: 4000), 4000) },
             bufferedDurationProvider: { 0.25 }
         )


### PR DESCRIPTION
## Summary
Fixes recorder live-preview stalls that could block keyboard input while Recorder is running.

Closes #381

## Issue Context
Issue #381 reports periodic ~1 second keyboard input drops every 10-15 seconds while Recorder is active. The dominant cause here was the recorder live-preview fallback path for engines without a true live transcription session. That path kept re-reading and re-encoding the growing full recorder buffer on a tight cadence, which scaled with recording length and matched the reported CPU spikes.

## What Changed
- split recorder streaming into true live-session and throttled fallback preview modes
- use a 10-second recent-buffer window with 3-second polling for non-live engines
- move recorder transcription snapshots into a dedicated helper that computes full, tail, and delta slices without remixing the whole buffer
- return explicit buffer copies for final stop-time transcription to avoid large copy-on-write churn
- run WAV encoding off the main actor and reuse the same helper in both transcription overloads
- update recorder UI copy to explain the lightweight fallback preview behavior
- add regression coverage for fallback polling/windowing and recorder buffer slice behavior

## Impact
- Recorder live preview for fallback engines remains available, but no longer scales with total recording length.
- Engines with a real live session keep the fast incremental path.
- Final stop-time transcription still uses the full recording.

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
- Manual: start Recorder with live transcription enabled, type continuously in TextEdit or Terminal for 30-60 seconds with a fallback engine, then repeat with a true live-session engine

