### PR TITLE
Add recent transcription shortcuts

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -392,6 +392,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         ServiceContainer.shared.hotkeyService.onRecentTranscriptionsToggle = {
             DictationViewModel.shared.triggerRecentTranscriptionsPalette()
         }
+        ServiceContainer.shared.hotkeyService.onCopyLastTranscription = {
+            DictationViewModel.shared.copyLastTranscriptionToClipboard()
+        }
 
         // Auto-open Settings with setup wizard when microphone permission is not yet granted
         if AVAudioApplication.shared.recordPermission != .granted {

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -23,6 +23,7 @@ enum UserDefaultsKeys {
     static let toggleHotkey = "toggleHotkey"
     static let promptPaletteHotkey = "promptPaletteHotkey"
     static let recentTranscriptionsHotkey = "recentTranscriptionsHotkey"
+    static let copyLastTranscriptionHotkey = "copyLastTranscriptionHotkey"
 
     // MARK: - Model / Engine
     static let selectedEngine = "selectedEngine"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1810,6 +1810,26 @@
         }
       }
     },
+    "Copy Last Transcription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte Transkription kopieren"
+          }
+        }
+      }
+    },
+    "Copy last transcription shortcut" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tastenkürzel für das Kopieren der letzten Transkription"
+          }
+        }
+      }
+    },
     "Copy original" : {
       "localizations" : {
         "de" : {
@@ -1826,6 +1846,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verarbeitet kopieren"
+          }
+        }
+      }
+    },
+    "Copy your latest transcription to the clipboard." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopiere deine letzte Transkription in die Zwischenablage."
           }
         }
       }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -67,6 +67,7 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
     case toggle
     case promptPalette
     case recentTranscriptions
+    case copyLastTranscription
 
     var defaultsKey: String {
         switch self {
@@ -75,13 +76,18 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
         case .toggle: return UserDefaultsKeys.toggleHotkey
         case .promptPalette: return UserDefaultsKeys.promptPaletteHotkey
         case .recentTranscriptions: return UserDefaultsKeys.recentTranscriptionsHotkey
+        case .copyLastTranscription: return UserDefaultsKeys.copyLastTranscriptionHotkey
         }
     }
 }
 
-/// Manages global hotkeys for dictation with three independent slots:
-/// hybrid (short=toggle, long=push-to-talk), push-to-talk, and toggle.
+/// Manages global hotkeys for dictation and standalone app actions.
 final class HotkeyService: ObservableObject {
+    struct MenuShortcutDescriptor: Equatable, Sendable {
+        let keyEquivalent: Character
+        let modifiers: NSEvent.ModifierFlags
+    }
+
     enum HotkeyEventSource: Sendable {
         case eventTap
         case monitor
@@ -120,6 +126,7 @@ final class HotkeyService: ObservableObject {
     var onDictationStop: (() -> Void)?
     var onPromptPaletteToggle: (() -> Void)?
     var onRecentTranscriptionsToggle: (() -> Void)?
+    var onCopyLastTranscription: (() -> Void)?
     var onProfileDictationStart: ((UUID) -> Void)?
     var onWorkflowDictationStart: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
@@ -169,6 +176,7 @@ final class HotkeyService: ObservableObject {
         .toggle: SlotState(),
         .promptPalette: SlotState(),
         .recentTranscriptions: SlotState(),
+        .copyLastTranscription: SlotState(),
     ]
 
     // MARK: - Per-Profile Hotkey State
@@ -1088,6 +1096,10 @@ final class HotkeyService: ObservableObject {
             onRecentTranscriptionsToggle?()
             return
         }
+        if slotType == .copyLastTranscription {
+            onCopyLastTranscription?()
+            return
+        }
 
         if isActive {
             // Any hotkey stops active recording
@@ -1139,6 +1151,8 @@ final class HotkeyService: ObservableObject {
         case .promptPalette:
             break // handled on keyDown only
         case .recentTranscriptions:
+            break // handled on keyDown only
+        case .copyLastTranscription:
             break // handled on keyDown only
         }
     }
@@ -1231,6 +1245,24 @@ final class HotkeyService: ObservableObject {
 
     // MARK: - Display Name
 
+    nonisolated static func menuShortcutDescriptor(for hotkey: UnifiedHotkey) -> MenuShortcutDescriptor? {
+        guard !hotkey.isDoubleTap,
+              hotkey.mouseButton == nil,
+              !hotkey.isFn,
+              hotkey.kind == .keyWithModifiers || hotkey.kind == .bareKey,
+              let keyEquivalent = menuKeyEquivalent(for: hotkey.keyCode) else {
+            return nil
+        }
+
+        let relevantModifiers = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
+            .intersection([.command, .option, .control, .shift, .function])
+
+        return MenuShortcutDescriptor(
+            keyEquivalent: keyEquivalent,
+            modifiers: relevantModifiers
+        )
+    }
+
     nonisolated static func displayName(for hotkey: UnifiedHotkey) -> String {
         if let button = hotkey.mouseButton {
             let baseName = mouseButtonName(for: button)
@@ -1296,6 +1328,50 @@ final class HotkeyService: ObservableObject {
         if let name = qwertyFallback[keyCode] { return name }
 
         return "Key \(keyCode)"
+    }
+
+    private nonisolated static func menuKeyEquivalent(for keyCode: UInt16) -> Character? {
+        let specialKeys: [UInt16: UInt32] = [
+            0x24: 0x000D,
+            0x30: 0x0009,
+            0x31: 0x0020,
+            0x33: 0x0008,
+            0x35: 0x001B,
+            0x60: UInt32(NSF5FunctionKey),
+            0x61: UInt32(NSF6FunctionKey),
+            0x62: UInt32(NSF7FunctionKey),
+            0x63: UInt32(NSF3FunctionKey),
+            0x64: UInt32(NSF8FunctionKey),
+            0x65: UInt32(NSF9FunctionKey),
+            0x67: UInt32(NSF11FunctionKey),
+            0x69: UInt32(NSF13FunctionKey),
+            0x6B: UInt32(NSF14FunctionKey),
+            0x6D: UInt32(NSF10FunctionKey),
+            0x6F: UInt32(NSF12FunctionKey),
+            0x71: UInt32(NSF15FunctionKey),
+            0x76: UInt32(NSF4FunctionKey),
+            0x78: UInt32(NSF2FunctionKey),
+            0x7A: UInt32(NSF1FunctionKey),
+            0x7B: UInt32(NSLeftArrowFunctionKey),
+            0x7C: UInt32(NSRightArrowFunctionKey),
+            0x7D: UInt32(NSDownArrowFunctionKey),
+            0x7E: UInt32(NSUpArrowFunctionKey),
+        ]
+        if let scalarValue = specialKeys[keyCode], let scalar = UnicodeScalar(scalarValue) {
+            return Character(scalar)
+        }
+
+        guard let character = characterForKeyCode(keyCode),
+              character.count == 1,
+              let scalar = character.unicodeScalars.first else {
+            return nil
+        }
+
+        if CharacterSet.letters.contains(scalar) {
+            return Character(character.lowercased())
+        }
+
+        return Character(String(scalar))
     }
 
     /// Resolves the character for a keyCode using the current keyboard input source.

--- a/TypeWhisper/Services/RecentTranscriptionStore.swift
+++ b/TypeWhisper/Services/RecentTranscriptionStore.swift
@@ -82,4 +82,8 @@ final class RecentTranscriptionStore: ObservableObject {
         }
         return deduped
     }
+
+    func latestEntry(historyRecords: [TranscriptionRecord]) -> Entry? {
+        mergedEntries(historyRecords: historyRecords, limit: 1).first
+    }
 }

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -55,12 +55,21 @@ final class DictationSettingsHandler {
         hotkeyService.isHotkeyAssigned(hotkey, excluding: excluding)
     }
 
-    static func loadHotkeyLabel(for slotType: HotkeySlotType) -> String {
-        if let data = UserDefaults.standard.data(forKey: slotType.defaultsKey),
-           let hotkey = try? JSONDecoder().decode(UnifiedHotkey.self, from: data) {
-            return HotkeyService.displayName(for: hotkey)
+    static func loadHotkey(for slotType: HotkeySlotType) -> UnifiedHotkey? {
+        guard let data = UserDefaults.standard.data(forKey: slotType.defaultsKey) else {
+            return nil
         }
-        return ""
+        return try? JSONDecoder().decode(UnifiedHotkey.self, from: data)
+    }
+
+    static func loadHotkeyLabel(for slotType: HotkeySlotType) -> String {
+        guard let hotkey = loadHotkey(for: slotType) else { return "" }
+        return HotkeyService.displayName(for: hotkey)
+    }
+
+    static func loadMenuShortcutDescriptor(for slotType: HotkeySlotType) -> HotkeyService.MenuShortcutDescriptor? {
+        guard let hotkey = loadHotkey(for: slotType) else { return nil }
+        return HotkeyService.menuShortcutDescriptor(for: hotkey)
     }
 
     func registerInitialTriggerHotkeys() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -106,6 +106,7 @@ final class DictationViewModel: ObservableObject {
     var toggleHotkeyLabel: String { Self.loadHotkeyLabel(for: .toggle) }
     var promptPaletteHotkeyLabel: String { Self.loadHotkeyLabel(for: .promptPalette) }
     var recentTranscriptionsHotkeyLabel: String { Self.loadHotkeyLabel(for: .recentTranscriptions) }
+    var copyLastTranscriptionHotkeyLabel: String { Self.loadHotkeyLabel(for: .copyLastTranscription) }
     @Published var activeRuleName: String?
     @Published var activeRuleReasonLabel: String?
     @Published var activeRuleExplanation: String?
@@ -184,6 +185,7 @@ final class DictationViewModel: ObservableObject {
     @Published private(set) var recordingCancelWarningActive: Bool = false
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
+    var pasteboardProvider: () -> NSPasteboard = { .general }
     /// Snapshot of the streaming params used in the most recent `streamingHandler.start(...)`.
     /// Used to detect when an on-the-fly rule refinement (e.g. browser URL resolution)
     /// changes the effective engine/language selection/task/cloud-model so the live
@@ -1620,6 +1622,20 @@ final class DictationViewModel: ObservableObject {
     }
 
     // MARK: - Workflow Palette
+
+    var canCopyLastTranscription: Bool {
+        recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
+    }
+
+    func copyLastTranscriptionToClipboard() {
+        guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) else { return }
+        let text = entry.finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        let pasteboard = pasteboardProvider()
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
 
     func readBackLastTranscription() {
         guard let text = lastTranscribedText else { return }

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -71,6 +71,7 @@ struct HotkeySettingsView: View {
                 HotkeyRecorderView(
                     label: dictation.recentTranscriptionsHotkeyLabel,
                     title: String(localized: "Recent transcription shortcut"),
+                    subtitle: String(localized: "Open your latest transcriptions and insert one into the focused app."),
                     onRecord: { hotkey in
                         if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .recentTranscriptions) {
                             dictation.clearHotkey(for: conflict)
@@ -80,9 +81,18 @@ struct HotkeySettingsView: View {
                     onClear: { dictation.clearHotkey(for: .recentTranscriptions) }
                 )
 
-                Text(String(localized: "Open your latest transcriptions and insert one into the focused app."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HotkeyRecorderView(
+                    label: dictation.copyLastTranscriptionHotkeyLabel,
+                    title: String(localized: "Copy last transcription shortcut"),
+                    subtitle: String(localized: "Copy your latest transcription to the clipboard."),
+                    onRecord: { hotkey in
+                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .copyLastTranscription) {
+                            dictation.clearHotkey(for: conflict)
+                        }
+                        dictation.setHotkey(hotkey, for: .copyLastTranscription)
+                    },
+                    onClear: { dictation.clearHotkey(for: .copyLastTranscription) }
+                )
             }
         }
         .formStyle(.grouped)

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -8,15 +8,26 @@ private final class MenuBarState: ObservableObject {
     @Published var statusText: String
     @Published var statusImage: String
     @Published var isModelReady: Bool
+    @Published var hasRecentTranscriptions: Bool
+    @Published var canCopyLastTranscription: Bool
+    @Published var recentTranscriptionsMenuShortcut: HotkeyService.MenuShortcutDescriptor?
+    @Published var copyLastTranscriptionMenuShortcut: HotkeyService.MenuShortcutDescriptor?
 
     private var cancellables = Set<AnyCancellable>()
 
     init() {
         let dictation = DictationViewModel.shared
         let modelManager = ServiceContainer.shared.modelManagerService
+        let historyService = ServiceContainer.shared.historyService
+        let recentTranscriptionStore = ServiceContainer.shared.recentTranscriptionStore
 
         // Set initial values immediately
         self.isModelReady = modelManager.isModelReady
+        let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
+        self.hasRecentTranscriptions = hasRecentTranscriptions
+        self.canCopyLastTranscription = hasRecentTranscriptions
+        self.recentTranscriptionsMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recentTranscriptions)
+        self.copyLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .copyLastTranscription)
         if let name = modelManager.activeModelName, modelManager.isModelReady {
             self.statusText = String(localized: "\(name) ready")
             self.statusImage = "checkmark.circle.fill"
@@ -47,6 +58,27 @@ private final class MenuBarState: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        recentTranscriptionStore.$sessionEntries
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshCopyAvailability()
+            }
+            .store(in: &cancellables)
+
+        historyService.$records
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshCopyAvailability()
+            }
+            .store(in: &cancellables)
+
+        dictation.$hotkeyLabelsVersion
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshMenuShortcuts()
+            }
+            .store(in: &cancellables)
     }
 
     private func update(state: DictationViewModel.State) {
@@ -68,6 +100,19 @@ private final class MenuBarState: ObservableObject {
             }
         }
         isModelReady = modelManager.isModelReady
+    }
+
+    private func refreshCopyAvailability() {
+        let historyService = ServiceContainer.shared.historyService
+        let recentTranscriptionStore = ServiceContainer.shared.recentTranscriptionStore
+        let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
+        self.hasRecentTranscriptions = hasRecentTranscriptions
+        canCopyLastTranscription = hasRecentTranscriptions
+    }
+
+    private func refreshMenuShortcuts() {
+        recentTranscriptionsMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recentTranscriptions)
+        copyLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .copyLastTranscription)
     }
 }
 
@@ -113,6 +158,22 @@ struct MenuBarView: View {
             .disabled(!status.isModelReady)
 
             Button {
+                DictationViewModel.shared.triggerRecentTranscriptionsPalette()
+            } label: {
+                Label(String(localized: "Recent Transcriptions"), systemImage: "clock.arrow.circlepath")
+            }
+            .keyboardShortcut(keyboardShortcut(from: status.recentTranscriptionsMenuShortcut))
+            .disabled(!status.hasRecentTranscriptions)
+
+            Button {
+                DictationViewModel.shared.copyLastTranscriptionToClipboard()
+            } label: {
+                Label(String(localized: "Copy Last Transcription"), systemImage: "doc.on.doc")
+            }
+            .keyboardShortcut(keyboardShortcut(from: status.copyLastTranscriptionMenuShortcut))
+            .disabled(!status.canCopyLastTranscription)
+
+            Button {
                 DictationViewModel.shared.readBackLastTranscription()
             } label: {
                 Label(String(localized: "Read Back Last Transcription"), systemImage: "speaker.wave.2")
@@ -140,5 +201,25 @@ struct MenuBarView: View {
 
     private func openManagedWindow(_ id: String) {
         ManagedAppWindowOpener.shared.open(id: id)
+    }
+
+    private func keyboardShortcut(
+        from descriptor: HotkeyService.MenuShortcutDescriptor?
+    ) -> KeyboardShortcut? {
+        guard let descriptor else { return nil }
+        return KeyboardShortcut(
+            KeyEquivalent(descriptor.keyEquivalent),
+            modifiers: eventModifiers(from: descriptor.modifiers)
+        )
+    }
+
+    private func eventModifiers(from flags: NSEvent.ModifierFlags) -> EventModifiers {
+        var modifiers: EventModifiers = []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.option) { modifiers.insert(.option) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        if flags.contains(.function) { modifiers.insert(EventModifiers(rawValue: 1 << 23)) }
+        return modifiers
     }
 }

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -1091,6 +1091,7 @@ struct SetupWizardView: View {
         case .toggle: return dictation.toggleHotkeyLabel
         case .promptPalette: return dictation.promptPaletteHotkeyLabel
         case .recentTranscriptions: return dictation.recentTranscriptionsHotkeyLabel
+        case .copyLastTranscription: return dictation.copyLastTranscriptionHotkeyLabel
         }
     }
 
@@ -1101,6 +1102,7 @@ struct SetupWizardView: View {
         case .toggle: return String(localized: "Toggle")
         case .promptPalette: return localizedAppText("Workflow Palette", de: "Workflow-Palette")
         case .recentTranscriptions: return String(localized: "Recent Transcriptions")
+        case .copyLastTranscription: return String(localized: "Copy Last Transcription")
         }
     }
 }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1865,6 +1865,84 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testCopyLastTranscriptionToClipboardUsesNewestSessionEntry() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        let pasteboard = NSPasteboard.withUniqueName()
+        context.dictationViewModel.pasteboardProvider = { pasteboard }
+
+        context.recentTranscriptionStore.recordTranscription(
+            id: UUID(),
+            finalText: "Newest session text",
+            timestamp: Date(),
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes"
+        )
+
+        context.dictationViewModel.copyLastTranscriptionToClipboard()
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "Newest session text")
+    }
+
+    @MainActor
+    func testCopyLastTranscriptionToClipboardFallsBackToHistory() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        let pasteboard = NSPasteboard.withUniqueName()
+        context.dictationViewModel.pasteboardProvider = { pasteboard }
+
+        context.historyService.addRecord(
+            id: UUID(),
+            rawText: "raw history text",
+            finalText: "History fallback text",
+            appName: "Safari",
+            appBundleIdentifier: "com.apple.Safari",
+            durationSeconds: 1,
+            language: "en",
+            engineUsed: "mock"
+        )
+
+        context.dictationViewModel.copyLastTranscriptionToClipboard()
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "History fallback text")
+    }
+
+    @MainActor
+    func testCopyLastTranscriptionToClipboardIsNoOpWithoutEntries() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+        context.dictationViewModel.pasteboardProvider = { pasteboard }
+
+        context.dictationViewModel.copyLastTranscriptionToClipboard()
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
     private final class DictationContext: @unchecked Sendable {
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
@@ -1872,6 +1950,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let audioDeviceService: AudioDeviceService
         let audioDuckingService: AudioDuckingService
         let textInsertionService: TextInsertionService
+        let historyService: HistoryService
+        let recentTranscriptionStore: RecentTranscriptionStore
         let profileService: ProfileService
         let ttsProvider: MockTTSProviderPlugin
         private let retainedObjects: [AnyObject]
@@ -1883,6 +1963,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             audioDeviceService: AudioDeviceService,
             audioDuckingService: AudioDuckingService,
             textInsertionService: TextInsertionService,
+            historyService: HistoryService,
+            recentTranscriptionStore: RecentTranscriptionStore,
             profileService: ProfileService,
             ttsProvider: MockTTSProviderPlugin,
             retainedObjects: [AnyObject]
@@ -1893,6 +1975,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.audioDeviceService = audioDeviceService
             self.audioDuckingService = audioDuckingService
             self.textInsertionService = textInsertionService
+            self.historyService = historyService
+            self.recentTranscriptionStore = recentTranscriptionStore
             self.profileService = profileService
             self.ttsProvider = ttsProvider
             self.retainedObjects = retainedObjects
@@ -2000,6 +2084,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             audioDeviceService: audioDeviceService,
             audioDuckingService: audioDuckingService,
             textInsertionService: textInsertionService,
+            historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
             ttsProvider: ttsProvider,
             retainedObjects: [
@@ -2010,6 +2096,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 hotkeyService,
                 textInsertionService,
                 historyService,
+                recentTranscriptionStore,
                 profileService,
                 audioDuckingService,
                 dictionaryService,
@@ -3423,6 +3510,82 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testCopyLastTranscriptionHotkeyInvokesDedicatedCallbackOnKeyDown() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(commandShiftCHotkey(), for: .copyLastTranscription)
+
+        var callbackCount = 0
+        var startCount = 0
+        service.onCopyLastTranscription = { callbackCount += 1 }
+        service.onDictationStart = { startCount += 1 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x08, keyDown: true, flags: [.maskCommand, .maskShift])
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testCopyLastTranscriptionHotkeyDoesNotStopActiveDictation() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
+        service.setHotkeyForTesting(commandShiftCHotkey(), for: .copyLastTranscription)
+
+        var startCount = 0
+        var stopCount = 0
+        var callbackCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+        service.onCopyLastTranscription = { callbackCount += 1 }
+
+        let toggleDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        let copyDown = try makeKeyboardEvent(keyCode: 0x08, keyDown: true, flags: [.maskCommand, .maskShift])
+
+        XCTAssertTrue(service.processEventForTesting(toggleDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        XCTAssertTrue(service.processEventForTesting(copyDown, source: .monitor))
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .toggle)
+    }
+
+    @MainActor
+    func testMenuShortcutDescriptorSupportsPrintableKeyboardShortcut() {
+        let descriptor = HotkeyService.menuShortcutDescriptor(for: commandShiftCHotkey())
+
+        XCTAssertEqual(descriptor?.keyEquivalent, "c")
+        XCTAssertEqual(descriptor?.modifiers, [.command, .shift])
+    }
+
+    @MainActor
+    func testMenuShortcutDescriptorSupportsFunctionKeyShortcut() {
+        let hotkey = UnifiedHotkey(
+            keyCode: 0x64,
+            modifierFlags: NSEvent.ModifierFlags.function.rawValue,
+            isFn: false
+        )
+
+        let descriptor = HotkeyService.menuShortcutDescriptor(for: hotkey)
+
+        XCTAssertEqual(descriptor?.keyEquivalent, Character(UnicodeScalar(NSF8FunctionKey)!))
+        XCTAssertEqual(descriptor?.modifiers, [.function])
+    }
+
+    @MainActor
+    func testMenuShortcutDescriptorSkipsUnsupportedModifierOnlyShortcut() {
+        let descriptor = HotkeyService.menuShortcutDescriptor(for: fnHotkey())
+
+        XCTAssertNil(descriptor)
+    }
+
+    @MainActor
     func testWorkflowHotkeyInvokesDedicatedWorkflowCallback() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -3509,6 +3672,15 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         UnifiedHotkey(
             keyCode: 0x00,
             modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func commandShiftCHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x08,
+            modifierFlags: NSEvent.ModifierFlags([.command, .shift]).rawValue,
             isFn: false
         )
     }

--- a/TypeWhisperTests/RecentTranscriptionStoreTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionStoreTests.swift
@@ -83,6 +83,43 @@ final class RecentTranscriptionStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testLatestEntryMatchesFirstMergedEntry() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let store = RecentTranscriptionStore()
+        let now = Date()
+
+        historyService.addRecord(
+            id: UUID(),
+            rawText: "Older history",
+            finalText: "Older history",
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes",
+            durationSeconds: 1,
+            language: "en",
+            engineUsed: "mock"
+        )
+        let historyRecord = try XCTUnwrap(historyService.records.first)
+        historyRecord.timestamp = now.addingTimeInterval(-120)
+        historyService.updateRecord(historyRecord, finalText: historyRecord.finalText)
+
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Newest session",
+            timestamp: now.addingTimeInterval(-15),
+            appName: "Mail",
+            appBundleIdentifier: "com.apple.mail"
+        )
+
+        let mergedFirst = try XCTUnwrap(store.mergedEntries(historyRecords: historyService.records).first)
+        let latest = try XCTUnwrap(store.latestEntry(historyRecords: historyService.records))
+
+        XCTAssertEqual(latest, mergedFirst)
+    }
+
+    @MainActor
     func testSessionBufferIsLimitedToTwentyEntries() {
         let store = RecentTranscriptionStore()
 


### PR DESCRIPTION
## Summary
- add a `Copy Last Transcription` menu action that resolves from the merged recent transcription source instead of session-only state
- add configurable hotkeys for `Recent Transcriptions` and `Copy Last Transcription`, and surface them in the hotkey settings
- render supported hotkeys with native menu shortcut alignment in the menu bar menu

## Issue Context
Issue #382 asks for a menu bar action to copy the latest transcription the same way the Recent Transcriptions palette resolves its top entry, including persisted history after restart.

## Root Cause
The menu bar only exposed read-back for the last session transcription. There was no shared helper for the latest merged transcription across session and history, and the shortcut sync work needed a native menu-shortcut path instead of inline text rendering.

## Impact
Users can now copy the latest final transcription from the menu bar or a dedicated hotkey, recent-transcription actions stay consistent across settings and the menu, and supported shortcuts show up in the native trailing shortcut column.

Closes #382

## Test Plan
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests`
