### PR TITLE
Fix Parakeet language filtering with FluidAudio upstream

### DIFF
--- a/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -150,7 +150,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             ?? Self.defaultGenerationTemperature
         _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
             ?? PluginLLMTemperatureMode.custom.rawValue
-        _hfToken = host.loadSecret(key: "hf-token")
+        _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
         Task { await restoreLoadedModel(allowDownloads: false) }
     }
@@ -299,46 +299,19 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     }
 
     func saveHuggingFaceToken(_ token: String) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        _hfToken = trimmed.isEmpty ? nil : trimmed
-        try? host?.storeSecret(key: "hf-token", value: trimmed)
+        _hfToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
     }
 
     func clearHuggingFaceToken() {
         _hfToken = nil
-        try? host?.storeSecret(key: "hf-token", value: "")
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
     }
 
     func validateHuggingFaceToken(
         _ token: String,
         dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
     ) async -> Bool {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await dataFetcher(request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return false
-            }
-
-            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
-        } catch {
-            return false
-        }
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
     }
 
     func isModelDownloaded(_ modelDef: Gemma4ModelDef) -> Bool {

--- a/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/Plugins/GranitePlugin/GranitePlugin.swift
@@ -29,7 +29,7 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.availableModels.first?.id
-        _hfToken = host.loadSecret(key: "hf-token")
+        _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
         Task { await restoreLoadedModel(allowDownloads: false) }
     }
@@ -157,9 +157,7 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
             let cache = HubCache(cacheDirectory: modelsDir)
-            if let token = _hfToken, !token.isEmpty {
-                setenv("HF_TOKEN", token, 1)
-            }
+            PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
             let loaded = try await GraniteSpeechModel.fromPretrained(modelDef.repoId, cache: cache)
 
             model = loaded
@@ -236,46 +234,19 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     }
 
     func setHuggingFaceToken(_ token: String) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        _hfToken = trimmed.isEmpty ? nil : trimmed
-        try? host?.storeSecret(key: "hf-token", value: trimmed)
+        _hfToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
     }
 
     func clearHuggingFaceToken() {
         _hfToken = nil
-        try? host?.storeSecret(key: "hf-token", value: "")
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
     }
 
     func validateHuggingFaceToken(
         _ token: String,
         dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
     ) async -> Bool {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await dataFetcher(request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return false
-            }
-
-            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
-        } catch {
-            return false
-        }
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
     }
 
     // MARK: - Model Definitions

--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -20,6 +20,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     fileprivate var modelState: ParakeetModelState = .notLoaded
     fileprivate var downloadProgress: Double = 0
     fileprivate var selectedVersion: ParakeetVersion = .v3
+    fileprivate var _hfToken: String?
 
     // Vocabulary Boosting
     fileprivate var ctcModels: CtcModels?
@@ -39,6 +40,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     func activate(host: HostServices) {
         self.host = host
+        _hfToken = host.loadSecret(key: "hf-token")
         vocabularyBoostingEnabled = host.userDefault(forKey: "vocabularyBoostingEnabled") as? Bool ?? false
         if let versionString = host.userDefault(forKey: "selectedVersion") as? String,
            let version = ParakeetVersion(rawValue: versionString) {
@@ -52,6 +54,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         asrManager = nil
         loadedModelId = nil
         modelState = .notLoaded
+        _hfToken = nil
         host = nil
     }
 
@@ -253,6 +256,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     fileprivate func downloadCtcModel() async {
         ctcModelState = .downloading
         do {
+            applyHuggingFaceTokenToEnvironment()
             let models = try await CtcModels.downloadAndLoad(variant: .ctc110m)
             let cacheDir = CtcModels.defaultCacheDirectory(for: .ctc110m)
             let tokenizer = try await CtcTokenizer.load(from: cacheDir)
@@ -408,6 +412,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         downloadProgress = 0.1
 
         do {
+            applyHuggingFaceTokenToEnvironment()
             let models = try await AsrModels.downloadAndLoad(version: selectedVersion.asrModelVersion)
             downloadProgress = 0.7
 
@@ -494,6 +499,71 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     var settingsView: AnyView? {
         AnyView(ParakeetSettingsView(plugin: self))
+    }
+
+    var huggingFaceToken: String? { _hfToken }
+
+    func setHuggingFaceToken(_ token: String) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        _hfToken = trimmed.isEmpty ? nil : trimmed
+        try? host?.storeSecret(key: "hf-token", value: trimmed)
+    }
+
+    func clearHuggingFaceToken() {
+        _hfToken = nil
+        try? host?.storeSecret(key: "hf-token", value: "")
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
+    }
+
+    func applyHuggingFaceTokenToEnvironment() {
+        let envKeys = [
+            "HF_TOKEN",
+            "HUGGING_FACE_HUB_TOKEN",
+            "HUGGINGFACEHUB_API_TOKEN",
+        ]
+
+        guard let token = _hfToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty else {
+            for key in envKeys {
+                unsetenv(key)
+            }
+            return
+        }
+
+        for key in envKeys {
+            setenv(key, token, 1)
+        }
     }
 }
 
@@ -588,11 +658,27 @@ private struct ParakeetSettingsView: View {
     @State private var modelState: ParakeetModelState = .notLoaded
     @State private var downloadProgress: Double = 0
     @State private var isPolling = false
+    @State private var hfTokenInput = ""
+    @State private var showHfToken = false
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
     @State private var boostingEnabled: Bool = false
     @State private var ctcModelState: CtcModelState = .notDownloaded
     @State private var boostingTermCount: Int = 0
 
     private let pollTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
+
+    private var trimmedHfTokenInput: String {
+        hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var storedHfToken: String {
+        plugin._hfToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private var hasStoredHfToken: Bool {
+        !storedHfToken.isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -602,6 +688,75 @@ private struct ParakeetSettingsView: View {
             Text(selectedVersion.settingsDescription(bundle: bundle))
                 .font(.callout)
                 .foregroundStyle(.secondary)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Hugging Face Token", bundle: bundle)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Text("Optional. Increases download rate limits. Free at huggingface.co/settings/tokens", bundle: bundle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    if showHfToken {
+                        TextField("hf_...", text: $hfTokenInput)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        SecureField("hf_...", text: $hfTokenInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showHfToken.toggle()
+                    } label: {
+                        Image(systemName: showHfToken ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if hasStoredHfToken {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            hfTokenInput = ""
+                            tokenValidationResult = nil
+                            isValidatingToken = false
+                            plugin.clearHuggingFaceToken()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Button(String(localized: "Save", bundle: bundle)) {
+                        validateAndSaveHuggingFaceToken()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
+                }
+
+                if isValidatingToken {
+                    HStack(spacing: 4) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Validating token...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let tokenValidationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        Text(
+                            tokenValidationResult
+                                ? String(localized: "Valid Hugging Face Token", bundle: bundle)
+                                : String(localized: "Invalid Hugging Face Token", bundle: bundle)
+                        )
+                        .font(.caption)
+                        .foregroundStyle(tokenValidationResult ? .green : .red)
+                    }
+                }
+            }
 
             Divider()
 
@@ -711,6 +866,9 @@ private struct ParakeetSettingsView: View {
             boostingEnabled = plugin.vocabularyBoostingEnabled
             ctcModelState = plugin.ctcModelState
             boostingTermCount = plugin.lastBoostingTermCount
+            if let token = plugin._hfToken, !token.isEmpty {
+                hfTokenInput = token
+            }
             if case .downloading = plugin.modelState { isPolling = true }
         }
         .onChange(of: selectedVersion) { _, newVersion in
@@ -742,6 +900,12 @@ private struct ParakeetSettingsView: View {
             boostingTermCount = plugin.lastBoostingTermCount
             if case .ready = pluginState { isPolling = false }
             else if case .error = pluginState { isPolling = false }
+        }
+        .onChange(of: hfTokenInput) { _, newValue in
+            let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedValue != storedHfToken {
+                tokenValidationResult = nil
+            }
         }
     }
 
@@ -825,6 +989,26 @@ private struct ParakeetSettingsView: View {
                         .buttonStyle(.bordered)
                         .controlSize(.mini)
                     }
+                }
+            }
+        }
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmedToken = trimmedHfTokenInput
+        guard !trimmedToken.isEmpty else { return }
+
+        isValidatingToken = true
+        tokenValidationResult = nil
+
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmedToken)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    plugin.setHuggingFaceToken(trimmedToken)
+                    hfTokenInput = trimmedToken
                 }
             }
         }

--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -24,6 +24,10 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     // Vocabulary Boosting
     fileprivate var ctcModels: CtcModels?
     fileprivate var ctcTokenizer: CtcTokenizer?
+    fileprivate var ctcSpotter: CtcKeywordSpotter?
+    fileprivate var customVocabulary: CustomVocabularyContext?
+    fileprivate var vocabularyRescorer: VocabularyRescorer?
+    fileprivate var vocabSizeConfig: ContextBiasingConstants.VocabSizeConfig?
     fileprivate var vocabularyBoostingEnabled: Bool = false
     fileprivate var ctcModelState: CtcModelState = .notDownloaded
     fileprivate var lastConfiguredPrompt: String?
@@ -44,14 +48,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     }
 
     func deactivate() {
-        if let manager = asrManager {
-            Task { await manager.disableVocabularyBoosting() }
-        }
-        ctcModels = nil
-        ctcTokenizer = nil
-        ctcModelState = .notDownloaded
-        lastConfiguredPrompt = nil
-        lastBoostingTermCount = 0
+        clearVocabularyBoostingState(resetModelState: true)
         asrManager = nil
         loadedModelId = nil
         modelState = .notLoaded
@@ -122,35 +119,58 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
             minimumDuration: 1.0,
             sampleRate: 16_000
         )
-        let result = try await asrManager.transcribe(normalizedSamples, source: .system)
-        let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fluidLanguage = Self.fluidAudioLanguage(for: language)
+        var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
+        let result = try await asrManager.transcribe(
+            normalizedSamples,
+            decoderState: &decoderState,
+            language: fluidLanguage
+        )
+        let finalResult = await applyVocabularyRescoringIfNeeded(
+            to: result,
+            audioSamples: normalizedSamples
+        )
+        let trimmedText = finalResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if audio.duration < Self.shortClipConfidenceGateDuration {
             Self.logger.info(
-                "Short clip transcription: rawDuration=\(String(format: "%.3f", audio.duration), privacy: .public)s, confidence=\(String(format: "%.3f", result.confidence), privacy: .public), textLength=\(trimmedText.count, privacy: .public)"
+                "Short clip transcription: rawDuration=\(String(format: "%.3f", audio.duration), privacy: .public)s, confidence=\(String(format: "%.3f", finalResult.confidence), privacy: .public), textLength=\(trimmedText.count, privacy: .public)"
             )
         }
 
         guard PluginAudioUtils.shouldAcceptShortClipTranscription(
             audioDuration: audio.duration,
-            confidence: result.confidence,
+            confidence: finalResult.confidence,
             minimumDuration: Self.shortClipConfidenceGateDuration,
             minimumConfidence: Self.shortClipConfidenceThreshold
         ) else {
             Self.logger.info(
-                "Discarding low-confidence short clip: rawDuration=\(String(format: "%.3f", audio.duration), privacy: .public)s, confidence=\(String(format: "%.3f", result.confidence), privacy: .public)"
+                "Discarding low-confidence short clip: rawDuration=\(String(format: "%.3f", audio.duration), privacy: .public)s, confidence=\(String(format: "%.3f", finalResult.confidence), privacy: .public)"
             )
             return PluginTranscriptionResult(text: "", detectedLanguage: nil, segments: [])
         }
 
         let segments: [PluginTranscriptionSegment]
-        if let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty {
+        if let tokenTimings = finalResult.tokenTimings, !tokenTimings.isEmpty {
             segments = Self.groupTokensIntoSegments(tokenTimings)
         } else {
             segments = []
         }
 
-        return PluginTranscriptionResult(text: result.text, detectedLanguage: nil, segments: segments)
+        return PluginTranscriptionResult(text: finalResult.text, detectedLanguage: nil, segments: segments)
+    }
+
+    private static func fluidAudioLanguage(for language: String?) -> Language? {
+        guard let language else { return nil }
+        let primaryCode = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(whereSeparator: { $0 == "-" || $0 == "_" })
+            .first
+            .map(String.init)
+
+        guard let primaryCode, !primaryCode.isEmpty else { return nil }
+        return Language(rawValue: primaryCode)
     }
     // MARK: - Token-to-Segment Grouping
 
@@ -245,14 +265,13 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     }
 
     private func configureBoostingIfNeeded(prompt: String?) async {
-        guard vocabularyBoostingEnabled, let asrManager else { return }
+        guard vocabularyBoostingEnabled else { return }
 
         if prompt == lastConfiguredPrompt { return }
         lastConfiguredPrompt = prompt
 
         guard let prompt, !prompt.isEmpty else {
-            await asrManager.disableVocabularyBoosting()
-            lastBoostingTermCount = 0
+            clearConfiguredVocabulary()
             return
         }
 
@@ -275,19 +294,84 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         }
 
         guard !terms.isEmpty else {
-            await asrManager.disableVocabularyBoosting()
-            lastBoostingTermCount = 0
+            clearConfiguredVocabulary()
             return
         }
 
         let cappedTerms = Array(terms.prefix(256))
         let vocab = CustomVocabularyContext(terms: cappedTerms)
+        let blankId = ctcModels.vocabulary.count
+        let spotter = CtcKeywordSpotter(models: ctcModels, blankId: blankId)
+        let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
         do {
-            try await asrManager.configureVocabularyBoosting(vocabulary: vocab, ctcModels: ctcModels)
+            let rescorer = try await VocabularyRescorer.create(
+                spotter: spotter,
+                vocabulary: vocab,
+                ctcModelDirectory: ctcModelDir
+            )
+            customVocabulary = vocab
+            ctcSpotter = spotter
+            vocabularyRescorer = rescorer
+            vocabSizeConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: cappedTerms.count)
             lastBoostingTermCount = cappedTerms.count
         } catch {
+            clearConfiguredVocabulary()
             lastBoostingTermCount = 0
             lastConfiguredPrompt = nil
+        }
+    }
+
+    private func applyVocabularyRescoringIfNeeded(
+        to result: ASRResult,
+        audioSamples: [Float]
+    ) async -> ASRResult {
+        guard vocabularyBoostingEnabled,
+              let spotter = ctcSpotter,
+              let rescorer = vocabularyRescorer,
+              let vocab = customVocabulary,
+              let tokenTimings = result.tokenTimings,
+              !tokenTimings.isEmpty
+        else {
+            return result
+        }
+
+        do {
+            let spotResult = try await spotter.spotKeywordsWithLogProbs(
+                audioSamples: audioSamples,
+                customVocabulary: vocab,
+                minScore: nil
+            )
+            guard !spotResult.logProbs.isEmpty else { return result }
+
+            let vocabConfig = vocabSizeConfig
+                ?? ContextBiasingConstants.rescorerConfig(forVocabSize: vocab.terms.count)
+            let rescoreOutput = rescorer.ctcTokenRescore(
+                transcript: result.text,
+                tokenTimings: tokenTimings,
+                logProbs: spotResult.logProbs,
+                frameDuration: spotResult.frameDuration,
+                cbw: vocabConfig.cbw,
+                marginSeconds: 0.5,
+                minSimilarity: max(vocabConfig.minSimilarity, vocab.minSimilarity)
+            )
+
+            guard rescoreOutput.wasModified else { return result }
+
+            let detectedTerms = spotResult.detections.map(\.term.text)
+            let appliedTerms = rescoreOutput.replacements.compactMap { replacement in
+                replacement.shouldReplace ? replacement.replacementWord : nil
+            }
+            Self.logger.info(
+                "Vocabulary rescoring applied \(rescoreOutput.replacements.count) replacement(s)"
+            )
+            return result.withRescoring(
+                text: rescoreOutput.text,
+                detected: detectedTerms,
+                applied: appliedTerms
+            )
+        } catch {
+            Self.logger.warning("Vocabulary rescoring failed: \(error.localizedDescription)")
+            return result
         }
     }
 
@@ -295,11 +379,25 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         vocabularyBoostingEnabled = enabled
         host?.setUserDefault(enabled, forKey: "vocabularyBoostingEnabled")
         if !enabled {
-            if let manager = asrManager {
-                Task { await manager.disableVocabularyBoosting() }
-            }
-            lastConfiguredPrompt = nil
-            lastBoostingTermCount = 0
+            clearConfiguredVocabulary()
+        }
+    }
+
+    private func clearConfiguredVocabulary() {
+        ctcSpotter = nil
+        customVocabulary = nil
+        vocabularyRescorer = nil
+        vocabSizeConfig = nil
+        lastConfiguredPrompt = nil
+        lastBoostingTermCount = 0
+    }
+
+    private func clearVocabularyBoostingState(resetModelState: Bool = false) {
+        clearConfiguredVocabulary()
+        ctcModels = nil
+        ctcTokenizer = nil
+        if resetModelState {
+            ctcModelState = .notDownloaded
         }
     }
 
@@ -314,7 +412,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
             downloadProgress = 0.7
 
             let manager = AsrManager(config: .default)
-            try await manager.initialize(models: models)
+            try await manager.loadModels(models)
             downloadProgress = 1.0
 
             asrManager = manager
@@ -341,14 +439,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
 
     func unloadModel(clearPersistence: Bool = true) {
-        if let manager = asrManager {
-            Task { await manager.disableVocabularyBoosting() }
-        }
-        ctcModels = nil
-        ctcTokenizer = nil
-        ctcModelState = .notDownloaded
-        lastConfiguredPrompt = nil
-        lastBoostingTermCount = 0
+        clearVocabularyBoostingState(resetModelState: true)
         asrManager = nil
         loadedModelId = nil
         modelState = .notLoaded

--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -40,7 +40,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     func activate(host: HostServices) {
         self.host = host
-        _hfToken = host.loadSecret(key: "hf-token")
+        _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
         vocabularyBoostingEnabled = host.userDefault(forKey: "vocabularyBoostingEnabled") as? Bool ?? false
         if let versionString = host.userDefault(forKey: "selectedVersion") as? String,
            let version = ParakeetVersion(rawValue: versionString) {
@@ -504,66 +504,23 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     var huggingFaceToken: String? { _hfToken }
 
     func setHuggingFaceToken(_ token: String) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        _hfToken = trimmed.isEmpty ? nil : trimmed
-        try? host?.storeSecret(key: "hf-token", value: trimmed)
+        _hfToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
     }
 
     func clearHuggingFaceToken() {
         _hfToken = nil
-        try? host?.storeSecret(key: "hf-token", value: "")
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
     }
 
     func validateHuggingFaceToken(
         _ token: String,
         dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
     ) async -> Bool {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await dataFetcher(request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return false
-            }
-
-            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
-        } catch {
-            return false
-        }
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
     }
 
     func applyHuggingFaceTokenToEnvironment() {
-        let envKeys = [
-            "HF_TOKEN",
-            "HUGGING_FACE_HUB_TOKEN",
-            "HUGGINGFACEHUB_API_TOKEN",
-        ]
-
-        guard let token = _hfToken?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !token.isEmpty else {
-            for key in envKeys {
-                unsetenv(key)
-            }
-            return
-        }
-
-        for key in envKeys {
-            setenv(key, token, 1)
-        }
+        PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
     }
 }
 

--- a/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -45,7 +45,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.availableModels.first?.id
-        _hfToken = host.loadSecret(key: "hf-token")
+        _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
         Task { await restoreLoadedModel(allowDownloads: false) }
     }
@@ -167,9 +167,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
             let cache = HubCache(cacheDirectory: modelsDir)
-            if let token = _hfToken, !token.isEmpty {
-                setenv("HF_TOKEN", token, 1)
-            }
+            PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
             let loaded = try await Qwen3ASRModel.fromPretrained(modelDef.repoId, cache: cache)
 
             model = loaded
@@ -246,46 +244,19 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     }
 
     func setHuggingFaceToken(_ token: String) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        _hfToken = trimmed.isEmpty ? nil : trimmed
-        try? host?.storeSecret(key: "hf-token", value: trimmed)
+        _hfToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
     }
 
     func clearHuggingFaceToken() {
         _hfToken = nil
-        try? host?.storeSecret(key: "hf-token", value: "")
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
     }
 
     func validateHuggingFaceToken(
         _ token: String,
         dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
     ) async -> Bool {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await dataFetcher(request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return false
-            }
-
-            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
-        } catch {
-            return false
-        }
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
     }
 
     // MARK: - Model Definitions

--- a/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -45,7 +45,7 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.availableModels.first?.id
-        _hfToken = host.loadSecret(key: "hf-token")
+        _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
         Task { await restoreLoadedModel(allowDownloads: false) }
     }
@@ -165,9 +165,7 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
             let cache = HubCache(cacheDirectory: modelsDir)
-            if let token = _hfToken, !token.isEmpty {
-                setenv("HF_TOKEN", token, 1)
-            }
+            PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
             guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                 throw NSError(
                     domain: "VoxtralPlugin", code: 1,
@@ -248,46 +246,19 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     }
 
     func setHuggingFaceToken(_ token: String) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        _hfToken = trimmed.isEmpty ? nil : trimmed
-        try? host?.storeSecret(key: "hf-token", value: trimmed)
+        _hfToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
     }
 
     func clearHuggingFaceToken() {
         _hfToken = nil
-        try? host?.storeSecret(key: "hf-token", value: "")
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
     }
 
     func validateHuggingFaceToken(
         _ token: String,
         dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
     ) async -> Bool {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await dataFetcher(request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return false
-            }
-
-            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
-        } catch {
-            return false
-        }
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
     }
 
     // MARK: - Model Definitions

--- a/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -28,7 +28,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
     func activate(host: HostServices) {
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
-        _hfToken = host.loadSecret(key: "hf-token")
+        _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
         if let persistedLoadedModel = host.userDefault(forKey: "loadedModel") as? String,
            !persistedLoadedModel.isEmpty {
             if _selectedModelId == nil {
@@ -642,46 +642,19 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
     }
 
     func setHuggingFaceToken(_ token: String) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        _hfToken = trimmed.isEmpty ? nil : trimmed
-        try? host?.storeSecret(key: "hf-token", value: trimmed)
+        _hfToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
     }
 
     func clearHuggingFaceToken() {
         _hfToken = nil
-        try? host?.storeSecret(key: "hf-token", value: "")
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
     }
 
     func validateHuggingFaceToken(
         _ token: String,
         dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
     ) async -> Bool {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
-
-        do {
-            let (data, response) = try await dataFetcher(request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return false
-            }
-
-            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
-        } catch {
-            return false
-        }
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
     }
 
     // MARK: - Model Definitions

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		C2300000000000000000000C /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000013 /* MLXAudioCore */; };
 		C2300000000000000000000D /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000015 /* WhisperKit */; };
 		C2300000000000000000000E /* WhisperKitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000154 /* WhisperKitPlugin.swift */; };
+		C23000000000000000000011 /* ParakeetPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000157 /* ParakeetPlugin.swift */; };
+		C23000000000000000000012 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000017 /* FluidAudio */; };
 		C2300000000000000000000F /* SpeechAnalyzerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000160 /* SpeechAnalyzerPlugin.swift */; };
 		C23000000000000000000010 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
@@ -733,6 +735,7 @@
 				C2300000000000000000000B /* MLXAudioSTT in Frameworks */,
 				C2300000000000000000000C /* MLXAudioCore in Frameworks */,
 				C2300000000000000000000D /* WhisperKit in Frameworks */,
+				C23000000000000000000012 /* FluidAudio in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1813,6 +1816,7 @@
 				PP00000000000000000012 /* MLXAudioSTT */,
 				PP00000000000000000013 /* MLXAudioCore */,
 				PP00000000000000000015 /* WhisperKit */,
+				PP00000000000000000017 /* FluidAudio */,
 			);
 			productName = TypeWhisperTests;
 			productReference = E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */;
@@ -2958,6 +2962,7 @@
 				C23000000000000000000009 /* VoxtralPlugin.swift in Sources */,
 				C2300000000000000000000A /* GranitePlugin.swift in Sources */,
 				C2300000000000000000000E /* WhisperKitPlugin.swift in Sources */,
+				C23000000000000000000011 /* ParakeetPlugin.swift in Sources */,
 				C2300000000000000000000F /* SpeechAnalyzerPlugin.swift in Sources */,
 				C23000000000000000000010 /* DeepgramPlugin.swift in Sources */,
 				C23000000000000000000003 /* Gemma4Plugin.swift in Sources */,

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "12ad53803592aa39bbcbdf655774cfe0ce361386"
+        "revision" : "2ea0727541135c34189194084531337a3518e1bf"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HuggingFaceTokenHelper.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HuggingFaceTokenHelper.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+public enum PluginHuggingFaceTokenHelper {
+    public static let storageKey = "hf-token"
+    public static let environmentKeys = [
+        "HF_TOKEN",
+        "HUGGING_FACE_HUB_TOKEN",
+        "HUGGINGFACEHUB_API_TOKEN",
+    ]
+
+    public static func normalizedToken(_ token: String?) -> String? {
+        guard let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    public static func loadToken(from host: HostServices?) -> String? {
+        guard let host else { return nil }
+        return normalizedToken(host.loadSecret(key: storageKey))
+    }
+
+    @discardableResult
+    public static func saveToken(_ token: String, to host: HostServices?) -> String? {
+        let normalized = normalizedToken(token)
+        guard let host else { return normalized }
+        try? host.storeSecret(key: storageKey, value: normalized ?? "")
+        return normalized
+    }
+
+    public static func clearToken(from host: HostServices?) {
+        guard let host else { return }
+        try? host.storeSecret(key: storageKey, value: "")
+    }
+
+    public static func validateToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        guard let normalized = normalizedToken(token),
+              let url = URL(string: "https://huggingface.co/api/whoami-v2") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(normalized)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await dataFetcher(request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return false
+            }
+
+            return json["name"] != nil || json["type"] != nil || json["auth"] != nil
+        } catch {
+            return false
+        }
+    }
+
+    public static func applyTokenToEnvironment(_ token: String?) {
+        guard let normalized = normalizedToken(token) else {
+            for key in environmentKeys {
+                unsetenv(key)
+            }
+            return
+        }
+
+        for key in environmentKeys {
+            setenv(key, normalized, 1)
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HuggingFaceTokenHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HuggingFaceTokenHelperTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+private final class MockHuggingFaceEventBus: EventBusProtocol, @unchecked Sendable {
+    func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID {
+        UUID()
+    }
+
+    func unsubscribe(id: UUID) {}
+}
+
+private struct MockHuggingFaceHostServices: HostServices {
+    private final class Storage: @unchecked Sendable {
+        var secrets: [String: String] = [:]
+    }
+
+    private let storage = Storage()
+
+    let pluginDataDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let activeAppBundleId: String? = nil
+    let activeAppName: String? = nil
+    let eventBus: EventBusProtocol = MockHuggingFaceEventBus()
+    let availableRuleNames: [String] = []
+
+    func storeSecret(key: String, value: String) throws {
+        storage.secrets[key] = value
+    }
+
+    func loadSecret(key: String) -> String? {
+        storage.secrets[key]
+    }
+
+    func userDefault(forKey: String) -> Any? { nil }
+    func setUserDefault(_ value: Any?, forKey key: String) {}
+    func notifyCapabilitiesChanged() {}
+    func setStreamingDisplayActive(_ active: Bool) {}
+}
+
+final class HuggingFaceTokenHelperTests: XCTestCase {
+    func testSaveLoadAndClearTokenRoundTripsThroughHostServices() {
+        let host = MockHuggingFaceHostServices()
+
+        XCTAssertNil(PluginHuggingFaceTokenHelper.loadToken(from: host))
+
+        let savedToken = PluginHuggingFaceTokenHelper.saveToken("  hf_test_token  ", to: host)
+
+        XCTAssertEqual(savedToken, "hf_test_token")
+        XCTAssertEqual(host.loadSecret(key: PluginHuggingFaceTokenHelper.storageKey), "hf_test_token")
+        XCTAssertEqual(PluginHuggingFaceTokenHelper.loadToken(from: host), "hf_test_token")
+
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
+
+        XCTAssertEqual(host.loadSecret(key: PluginHuggingFaceTokenHelper.storageKey), "")
+        XCTAssertNil(PluginHuggingFaceTokenHelper.loadToken(from: host))
+    }
+
+    func testValidateTokenAcceptsWhoAmIPayload() async throws {
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await PluginHuggingFaceTokenHelper.validateToken(" hf_test_token ") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","type":"user"}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let recordedRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(recordedRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_test_token")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testValidateTokenRejectsInvalidResponses() async {
+        let non200 = await PluginHuggingFaceTokenHelper.validateToken("hf_test_token") { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://huggingface.co")!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(), response)
+        }
+        XCTAssertFalse(non200)
+
+        let empty = await PluginHuggingFaceTokenHelper.validateToken("   ")
+        XCTAssertFalse(empty)
+    }
+}
+
+private actor RequestRecorder {
+    private var request: URLRequest?
+
+    func set(_ request: URLRequest) {
+        self.request = request
+    }
+
+    func get() -> URLRequest? {
+        request
+    }
+}

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -366,6 +366,85 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertFalse(isValid)
     }
 
+    func testParakeetActivationLoadsStoredHuggingFaceToken() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            secrets: ["hf-token": "hf_parakeet_saved"]
+        )
+        let plugin = ParakeetPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.huggingFaceToken, "hf_parakeet_saved")
+    }
+
+    func testParakeetStoresAndClearsHuggingFaceTokenSecret() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = ParakeetPlugin()
+        plugin.activate(host: host)
+
+        plugin.setHuggingFaceToken("  hf_parakeet_saved  ")
+        XCTAssertEqual(plugin.huggingFaceToken, "hf_parakeet_saved")
+        XCTAssertEqual(host.loadSecret(key: "hf-token"), "hf_parakeet_saved")
+
+        plugin.clearHuggingFaceToken()
+        XCTAssertNil(plugin.huggingFaceToken)
+        XCTAssertEqual(host.loadSecret(key: "hf-token"), "")
+    }
+
+    func testParakeetValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = ParakeetPlugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_parakeet_test") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"name":"typewhisper","type":"user"}"#.utf8)
+            return (data, response)
+        }
+
+        XCTAssertTrue(isValid)
+        let maybeRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(maybeRequest)
+        XCTAssertEqual(request.url?.absoluteString, "https://huggingface.co/api/whoami-v2")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer hf_parakeet_test")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testParakeetAppliesStoredHuggingFaceTokenToEnvironment() throws {
+        let originalToken = getenv("HF_TOKEN").map { String(cString: $0) }
+        defer {
+            if let originalToken {
+                setenv("HF_TOKEN", originalToken, 1)
+            } else {
+                unsetenv("HF_TOKEN")
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = ParakeetPlugin()
+        plugin.activate(host: host)
+        plugin.setHuggingFaceToken("hf_env_parakeet")
+
+        plugin.applyHuggingFaceTokenToEnvironment()
+
+        XCTAssertEqual(getenv("HF_TOKEN").map { String(cString: $0) }, "hf_env_parakeet")
+    }
+
     func testWhisperKitValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
         let plugin = WhisperKitPlugin()
         let requestRecorder = RequestRecorder()

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -423,12 +423,23 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
     }
 
     func testParakeetAppliesStoredHuggingFaceTokenToEnvironment() throws {
-        let originalToken = getenv("HF_TOKEN").map { String(cString: $0) }
+        let envKeys = [
+            "HF_TOKEN",
+            "HUGGING_FACE_HUB_TOKEN",
+            "HUGGINGFACEHUB_API_TOKEN",
+        ]
+        let originalTokens = Dictionary(
+            uniqueKeysWithValues: envKeys.map { key in
+                (key, getenv(key).map { String(cString: $0) })
+            }
+        )
         defer {
-            if let originalToken {
-                setenv("HF_TOKEN", originalToken, 1)
-            } else {
-                unsetenv("HF_TOKEN")
+            for key in envKeys {
+                if let originalToken = originalTokens[key] ?? nil {
+                    setenv(key, originalToken, 1)
+                } else {
+                    unsetenv(key)
+                }
             }
         }
 
@@ -442,7 +453,9 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
 
         plugin.applyHuggingFaceTokenToEnvironment()
 
-        XCTAssertEqual(getenv("HF_TOKEN").map { String(cString: $0) }, "hf_env_parakeet")
+        for key in envKeys {
+            XCTAssertEqual(getenv(key).map { String(cString: $0) }, "hf_env_parakeet")
+        }
     }
 
     func testWhisperKitValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {


### PR DESCRIPTION
## Summary
- Updates FluidAudio to upstream commit `2ea0727541135c34189194084531337a3518e1bf`, which includes the fix from FluidInference/FluidAudio#515 for FluidInference/FluidAudio#512.
- Maps TypeWhisper's optional language code to FluidAudio's `Language` enum and passes it into Parakeet transcription so FluidAudio can apply script-aware decoding.
- Keeps unsupported FluidAudio language codes as `nil`, preserving the existing fallback behavior.
- Migrates the Parakeet plugin to FluidAudio's current `loadModels(_:)` and transcription APIs, including local batch vocabulary rescoring because the old `AsrManager` vocabulary-boosting methods are no longer available.

## Issue Context
TypeWhisper #217 tracks Parakeet TDT v3 ignoring the selected language for short non-English utterances, especially Polish output being rendered in Cyrillic. The upstream fix is now available in FluidAudio, so this PR consumes that upstream commit and forwards the selected language to FluidAudio.

Closes #217

Upstream: https://github.com/FluidInference/FluidAudio/pull/515

## Test Plan
- `xcodebuild -project TypeWhisper.xcodeproj -scheme ParakeetPlugin -configuration Debug build`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug build`