### PR TITLE
feat: add Always workflow trigger

### DIFF
--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -115,6 +115,7 @@ enum WorkflowTriggerKind: String, CaseIterable, Codable, Sendable {
     case app
     case website
     case hotkey
+    case global
 }
 
 struct WorkflowTrigger: Codable, Equatable, Sendable {
@@ -159,6 +160,10 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
         WorkflowTrigger(kind: .hotkey, hotkeys: hotkeys)
     }
 
+    static func global() -> WorkflowTrigger {
+        WorkflowTrigger(kind: .global)
+    }
+
     var appBundleIdentifier: String? {
         appBundleIdentifiers.first
     }
@@ -179,6 +184,8 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
             !websitePatterns.isEmpty
         case .hotkey:
             !hotkeys.isEmpty
+        case .global:
+            true
         }
     }
 }
@@ -277,6 +284,8 @@ final class Workflow {
                     return nil
                 }
                 return .hotkey(hotkey)
+            case .global:
+                return .global()
             }
         }
         set {
@@ -305,6 +314,10 @@ final class Workflow {
                 triggerAppBundleIdentifier = nil
                 triggerWebsitePattern = nil
                 triggerHotkeyData = newValue.hotkeys.first.flatMap { try? JSONEncoder().encode($0) }
+            case .global:
+                triggerAppBundleIdentifier = nil
+                triggerWebsitePattern = nil
+                triggerHotkeyData = nil
             }
         }
     }
@@ -369,6 +382,8 @@ extension WorkflowTriggerKind {
             localizedAppText("Website", de: "Website")
         case .hotkey:
             localizedAppText("Hotkey", de: "Hotkey")
+        case .global:
+            localizedAppText("Always", de: "Immer")
         }
     }
 }

--- a/TypeWhisper/Services/WorkflowService.swift
+++ b/TypeWhisper/Services/WorkflowService.swift
@@ -11,6 +11,7 @@ private let workflowLogger = Logger(
 enum WorkflowMatchKind: String, Sendable {
     case website
     case app
+    case globalFallback
     case manualOverride
 
     var label: String {
@@ -19,6 +20,8 @@ enum WorkflowMatchKind: String, Sendable {
             localizedAppText("Website", de: "Website")
         case .app:
             localizedAppText("App", de: "App")
+        case .globalFallback:
+            localizedAppText("Always", de: "Immer")
         case .manualOverride:
             localizedAppText("Manually triggered", de: "Manuell ausgeloest")
         }
@@ -167,6 +170,13 @@ final class WorkflowService: ObservableObject {
             if let result = bestMatch(from: matches, kind: .app, matchedDomain: nil) {
                 return result
             }
+        }
+
+        let globalMatches = enabled.filter { workflow in
+            workflow.trigger?.kind == .global
+        }
+        if let result = bestMatch(from: globalMatches, kind: .globalFallback, matchedDomain: nil) {
+            return result
         }
 
         return nil

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1424,6 +1424,11 @@ final class DictationViewModel: ObservableObject {
                 "This workflow applies because \(appDescriptor) was detected.",
                 de: "Dieser Workflow greift, weil \(appDescriptor) erkannt wurde."
             )
+        case .globalFallback:
+            base = localizedAppText(
+                "This workflow applies because no more specific workflow matched.",
+                de: "Dieser Workflow greift, weil kein spezifischerer Workflow gepasst hat."
+            )
         case .manualOverride:
             base = localizedAppText(
                 "This workflow was manually triggered via its keyboard shortcut.",

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -67,6 +67,8 @@ final class PromptPaletteController: PromptPaletteControlling {
             triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.websitePatterns.joined(separator: ", "))"
         case .hotkey:
             triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", "))"
+        case .global:
+            triggerSummary = trigger.kind.paletteLabel
         }
 
         if workflow.name.localizedCaseInsensitiveCompare(workflow.definition.name) == .orderedSame {

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1032,8 +1032,8 @@ private struct WorkflowEditorPage: View {
         WorkflowSectionCard(
             title: localizedAppText("Trigger", de: "Trigger"),
             description: localizedAppText(
-                "Choose one trigger category. Inside it, you can add multiple apps, websites, or shortcuts.",
-                de: "Wähle eine Trigger-Kategorie. Darin kannst du mehrere Apps, Websites oder Shortcuts ergänzen."
+                "Choose how this workflow starts. Always runs when no specific workflow matches.",
+                de: "Wähle, wie dieser Workflow startet. Immer greift, wenn kein spezifischer Workflow passt."
             )
         ) {
             VStack(alignment: .leading, spacing: 14) {
@@ -1041,6 +1041,7 @@ private struct WorkflowEditorPage: View {
                     Text(localizedAppText("App", de: "App")).tag(WorkflowTriggerKind.app)
                     Text(localizedAppText("Website", de: "Website")).tag(WorkflowTriggerKind.website)
                     Text(localizedAppText("Hotkey", de: "Hotkey")).tag(WorkflowTriggerKind.hotkey)
+                    Text(localizedAppText("Always", de: "Immer")).tag(WorkflowTriggerKind.global)
                 }
                 .pickerStyle(.segmented)
 
@@ -1051,6 +1052,8 @@ private struct WorkflowEditorPage: View {
                     websiteTriggerEditor
                 case .hotkey:
                     hotkeyTriggerEditor
+                case .global:
+                    alwaysTriggerEditor
                 }
             }
         }
@@ -1189,6 +1192,34 @@ private struct WorkflowEditorPage: View {
                 onClear: {}
             )
         }
+    }
+
+    private var alwaysTriggerEditor: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "infinity")
+                .foregroundStyle(.secondary)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(localizedAppText("Always", de: "Immer"))
+                    .font(.subheadline.weight(.medium))
+
+                Text(
+                    localizedAppText(
+                        "Runs when no app, website, or hotkey workflow matches.",
+                        de: "Läuft, wenn kein App-, Website- oder Hotkey-Workflow passt."
+                    )
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(workflowsGroupedSurface(cornerRadius: 12))
     }
 
     private var websiteSuggestions: [String] {
@@ -1754,6 +1785,11 @@ private struct WorkflowDraft {
                 self.appBundleIdentifiers = []
                 self.websitePatterns = []
                 self.hotkeys = trigger.hotkeys
+            case .global:
+                self.triggerKind = .global
+                self.appBundleIdentifiers = []
+                self.websitePatterns = []
+                self.hotkeys = []
             }
         } else {
             self.triggerKind = .app
@@ -1769,7 +1805,14 @@ private struct WorkflowDraft {
     }
 
     var reviewText: String {
-        localizedAppText(
+        if triggerKind == .global {
+            return localizedAppText(
+                "\(resolvedName) runs always as \(template.definition.name).",
+                de: "\(resolvedName) läuft immer als \(template.definition.name)."
+            )
+        }
+
+        return localizedAppText(
             "\(resolvedName) runs as \(template.definition.name) via \(triggerReviewText).",
             de: "\(resolvedName) läuft als \(template.definition.name) über \(triggerReviewText)."
         )
@@ -1859,6 +1902,8 @@ private struct WorkflowDraft {
                     )
                 }
             }
+        case .global:
+            break
         }
 
         if template == .translation && translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -1893,6 +1938,8 @@ private struct WorkflowDraft {
         case .hotkey:
             guard !hotkeys.isEmpty else { return nil }
             return .hotkeys(hotkeys)
+        case .global:
+            return .global()
         }
     }
 
@@ -1962,6 +2009,8 @@ private struct WorkflowDraft {
                 )
             }
             return localizedAppText("a hotkey", de: "einen Hotkey")
+        case .global:
+            return localizedAppText("always", de: "immer")
         }
     }
 
@@ -2022,6 +2071,8 @@ private func workflowTriggerSummary(for workflow: Workflow) -> String {
         return trigger.hotkeys.count == 1
             ? localizedAppText("Hotkey", de: "Hotkey")
             : localizedAppText("Hotkeys", de: "Hotkeys")
+    case .global:
+        return localizedAppText("Always", de: "Immer")
     }
 }
 
@@ -2035,6 +2086,8 @@ private func workflowTriggerDetail(for workflow: Workflow) -> String {
         return workflowCompactList(trigger.websitePatterns)
     case .hotkey:
         return workflowCompactList(trigger.hotkeys.map(HotkeyService.displayName(for:)))
+    case .global:
+        return ""
     }
 }
 
@@ -2042,6 +2095,13 @@ private func workflowReviewText(for workflow: Workflow) -> String {
     let summary = workflowSummaryText(for: workflow)
     let triggerSummary = workflowTriggerSummary(for: workflow)
     let triggerDetail = workflowTriggerDetail(for: workflow)
+
+    if workflow.trigger?.kind == .global {
+        return localizedAppText(
+            "\(summary) runs always",
+            de: "\(summary) läuft immer"
+        )
+    }
 
     if triggerDetail.isEmpty {
         return localizedAppText(

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -222,6 +222,140 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(match.competingWorkflowCount, 0)
         XCTAssertFalse(match.wonBySortOrder)
     }
+
+    func testWorkflowServicePersistsGlobalTrigger() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        service.addWorkflow(
+            name: "Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            behavior: WorkflowBehavior(settings: ["instruction": "Clean up every transcript."])
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(workflow.trigger?.kind.rawValue, "global")
+        XCTAssertEqual(workflow.trigger, try globalTrigger())
+    }
+
+    func testMatchWorkflowUsesGlobalAsFallback() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            behavior: WorkflowBehavior(settings: ["instruction": "Clean up every transcript."])
+        )
+
+        let match = try XCTUnwrap(service.matchWorkflow(bundleIdentifier: "com.apple.TextEdit", url: nil))
+
+        XCTAssertEqual(match.workflow.name, "Always Cleanup")
+        XCTAssertEqual(match.kind.rawValue, "globalFallback")
+        XCTAssertNil(match.matchedDomain)
+        XCTAssertEqual(match.competingWorkflowCount, 0)
+        XCTAssertFalse(match.wonBySortOrder)
+    }
+
+    func testMatchWorkflowPrefersWebsiteAndAppBeforeGlobalFallback() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            sortOrder: 0
+        )
+        _ = service.addWorkflow(
+            name: "Mail Cleanup",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail"),
+            sortOrder: 1
+        )
+        _ = service.addWorkflow(
+            name: "Docs Summary",
+            template: .summary,
+            trigger: .website("docs.github.com"),
+            sortOrder: 2
+        )
+
+        let appMatch = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "com.apple.mail",
+            url: "https://example.com"
+        ))
+        XCTAssertEqual(appMatch.workflow.name, "Mail Cleanup")
+        XCTAssertEqual(appMatch.kind, .app)
+
+        let websiteMatch = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "com.apple.mail",
+            url: "https://docs.github.com/en/actions"
+        ))
+        XCTAssertEqual(websiteMatch.workflow.name, "Docs Summary")
+        XCTAssertEqual(websiteMatch.kind, .website)
+    }
+
+    func testMatchWorkflowIgnoresDisabledGlobalFallback() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Disabled Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            isEnabled: false
+        )
+
+        XCTAssertNil(service.matchWorkflow(bundleIdentifier: "com.apple.TextEdit", url: nil))
+    }
+
+    func testMatchWorkflowUsesSortOrderForMultipleGlobalFallbacks() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Lower Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            sortOrder: 5
+        )
+        _ = service.addWorkflow(
+            name: "Top Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            sortOrder: 0
+        )
+
+        let match = try XCTUnwrap(service.matchWorkflow(bundleIdentifier: nil, url: nil))
+
+        XCTAssertEqual(match.workflow.name, "Top Always Cleanup")
+        XCTAssertEqual(match.kind.rawValue, "globalFallback")
+        XCTAssertEqual(match.competingWorkflowCount, 1)
+        XCTAssertTrue(match.wonBySortOrder)
+    }
+}
+
+private func globalTrigger(
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> WorkflowTrigger {
+    let kind = try XCTUnwrap(
+        WorkflowTriggerKind(rawValue: "global"),
+        "WorkflowTriggerKind.global should decode from the persisted raw value.",
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(kind, .global, file: file, line: line)
+    return .global()
 }
 
 final class WatchFolderExportTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Add a persisted `global` workflow trigger surfaced as `Always` / `Immer` in the workflow builder.
- Match workflows in the runtime order Website > App > Always, while keeping hotkeys as manual overrides.
- Update workflow settings, prompt palette, and dictation runtime switch handling for the new trigger kind.
- Cover persistence, fallback priority, disabled global workflows, and multiple global workflows by `sortOrder`.

## Issue Context
Issue #393 asks for a universal workflow for all transcribed audio so users can configure global post-processing transcription behavior. This PR implements that as an `Always` workflow trigger backed by the persisted internal value `global`. It acts as the fallback for normal dictation when no website or app workflow is active.

Closes #393

## Test Coverage
Pre-landing review found no issues.

Scope check: CLEAN

Intent: Add a universal workflow trigger for global post-processing fallback.
Delivered: Adds persisted global trigger support, Website > App > Always matching, builder/palette/runtime UI coverage, and WorkflowService regression tests.

Covered paths:
- `WorkflowTriggerKind.global` persistence: `WorkflowServiceTests.testWorkflowServicePersistsGlobalTrigger`
- Always fallback when no app or website matches: `testMatchWorkflowUsesGlobalAsFallback`
- Website/App precedence over Always: `testMatchWorkflowPrefersWebsiteAndAppBeforeGlobalFallback`
- Disabled Always workflow ignored: `testMatchWorkflowIgnoresDisabledGlobalFallback`
- Multiple Always workflows ordered by `sortOrder`: `testMatchWorkflowUsesSortOrderForMultipleGlobalFallbacks`
- Exhaustive Swift switch coverage via the full app XCTest run.

Coverage gate: PASS.

## Verification Results
- TypeWhisper XCTest suite passed: 387 tests, 0 failures.
- TypeWhisperPluginSDK Swift Package tests passed: 31 tests, 0 failures.
- TypeWhisper dev app build passed and produced `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.
- Browser/web verification was not applicable for this macOS SwiftUI change.
- Eval runners were not applicable; this change does not alter prompt source behavior.

## Plan Completion
- [x] Extend `WorkflowTriggerKind` with `global` and UI labels `Always` / `Immer`.
- [x] Add `WorkflowTrigger.global()` without configuration data.
- [x] Update `WorkflowService` matching order to Website > App > Always.
- [x] Keep hotkeys as manual overrides.
- [x] Update `WorkflowsSettingsView` with an `Always` segment and no input fields.
- [x] Update runtime switches in `DictationViewModel` and `PromptPalettePanel`.
- [x] Keep custom prompts on the existing Custom Workflow template fields.
- [x] Add WorkflowService regression tests for persistence, fallback, priority, disabled workflows, and sort order.

## Test Plan
```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
swift test --package-path TypeWhisperPluginSDK
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/.codex/worktrees/e2bf/typewhisper-mac
```
