### PR TITLE
fix: preserve focus during local prompt processing

### DIFF
--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -7,6 +7,31 @@ import os.log
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "PromptProcessingService")
 
 @MainActor
+protocol ProcessActivityManaging {
+    func withActivity<T>(
+        options: ProcessInfo.ActivityOptions,
+        reason: String,
+        operation: () async throws -> T
+    ) async rethrows -> T
+}
+
+@MainActor
+struct DefaultProcessActivityManager: ProcessActivityManaging {
+    func withActivity<T>(
+        options: ProcessInfo.ActivityOptions,
+        reason: String,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        let activity = ProcessInfo.processInfo.beginActivity(options: options, reason: reason)
+        defer {
+            ProcessInfo.processInfo.endActivity(activity)
+        }
+
+        return try await operation()
+    }
+}
+
+@MainActor
 class PromptProcessingService: ObservableObject {
     @Published var selectedProviderId: String {
         didSet {
@@ -27,6 +52,7 @@ class PromptProcessingService: ObservableObject {
     weak var memoryService: MemoryService?
     private var appleIntelligenceProvider: LLMProvider?
     private var cancellables = Set<AnyCancellable>()
+    var processActivityManager: any ProcessActivityManaging = DefaultProcessActivityManager()
 
     static let appleIntelligenceId = "appleIntelligence"
 
@@ -135,7 +161,7 @@ class PromptProcessingService: ObservableObject {
         )
     }
 
-    static func requiresForegroundActivation(for plugin: any LLMProviderPlugin) -> Bool {
+    static func requiresProcessActivityBudget(for plugin: any LLMProviderPlugin) -> Bool {
         guard let setupStatus = plugin as? any LLMProviderSetupStatusProviding else {
             return false
         }
@@ -193,7 +219,7 @@ class PromptProcessingService: ObservableObject {
             persistGlobalSelection: false
         )
         logger.info("Processing prompt with plugin \(effectiveId)")
-        let result = try await withForegroundActivationIfNeeded(for: plugin, providerId: effectiveId) {
+        let result = try await withProcessActivityIfNeeded(for: plugin, providerId: effectiveId) {
             try await processWithPlugin(
                 plugin,
                 prompt: effectivePrompt,
@@ -229,27 +255,24 @@ class PromptProcessingService: ObservableObject {
         )
     }
 
-    private func withForegroundActivationIfNeeded<T>(
+    private func withProcessActivityIfNeeded<T>(
         for plugin: any LLMProviderPlugin,
         providerId: String,
         operation: () async throws -> T
     ) async throws -> T {
-        guard Self.requiresForegroundActivation(for: plugin) else {
+        guard Self.requiresProcessActivityBudget(for: plugin) else {
             return try await operation()
         }
 
         // Keep local prompt processing on a high-priority activity budget, but do not
         // activate the app window. Stealing focus here breaks insertion because the
         // original target text field is no longer frontmost once the LLM step finishes.
-        let activity = ProcessInfo.processInfo.beginActivity(
+        return try await processActivityManager.withActivity(
             options: [.userInitiated, .latencyCritical],
             reason: "Local prompt processing with \(providerId)"
-        )
-        defer {
-            ProcessInfo.processInfo.endActivity(activity)
+        ) {
+            try await operation()
         }
-
-        return try await operation()
     }
 
     private func normalizeSelectedCloudModelIfNeeded(for providerId: String) {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -59,6 +59,20 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @MainActor
+    private final class ProcessActivityManagerSpy: ProcessActivityManaging {
+        private(set) var reasons: [String] = []
+
+        func withActivity<T>(
+            options: ProcessInfo.ActivityOptions,
+            reason: String,
+            operation: () async throws -> T
+        ) async rethrows -> T {
+            reasons.append(reason)
+            return try await operation()
+        }
+    }
+
     @objc(APIRouterMockLegacyLLMProviderPlugin)
     private final class MockLegacyLLMProviderPlugin: NSObject, LLMProviderPlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.legacy-llm" }
@@ -2366,7 +2380,91 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testPromptProcessingRequiresForegroundActivationOnlyForLocalProviders() {
+    func testPromptProcessingUsesHighPriorityActivityForLocalProviders() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.local-llm",
+            name: "Mock Local LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+        let activityManager = ProcessActivityManagerSpy()
+        service.processActivityManager = activityManager
+
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            providerOverride: "Gemma 4 (MLX)"
+        )
+
+        XCTAssertEqual(result, "processed")
+        XCTAssertEqual(activityManager.reasons, ["Local prompt processing with Gemma 4 (MLX)"])
+    }
+
+    @MainActor
+    func testPromptProcessingSkipsHighPriorityActivityForRemoteProviders() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemini"
+        plugin.requiresExternalCredentials = true
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.llm",
+            name: "Mock LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+        let activityManager = ProcessActivityManagerSpy()
+        service.processActivityManager = activityManager
+
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            providerOverride: "Gemini"
+        )
+
+        XCTAssertEqual(result, "processed")
+        XCTAssertTrue(activityManager.reasons.isEmpty)
+    }
+
+    @MainActor
+    func testPromptProcessingRequiresProcessActivityOnlyForLocalProviders() {
         let remotePlugin = MockLLMProviderPlugin()
         remotePlugin.requiresExternalCredentials = true
 
@@ -2375,9 +2473,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         let legacyPlugin = MockLegacyLLMProviderPlugin()
 
-        XCTAssertFalse(PromptProcessingService.requiresForegroundActivation(for: remotePlugin))
-        XCTAssertTrue(PromptProcessingService.requiresForegroundActivation(for: localPlugin))
-        XCTAssertFalse(PromptProcessingService.requiresForegroundActivation(for: legacyPlugin))
+        XCTAssertFalse(PromptProcessingService.requiresProcessActivityBudget(for: remotePlugin))
+        XCTAssertTrue(PromptProcessingService.requiresProcessActivityBudget(for: localPlugin))
+        XCTAssertFalse(PromptProcessingService.requiresProcessActivityBudget(for: legacyPlugin))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Fix `#377`, where global Rewrite prompt processing on local LLMs could steal focus from the active app and cause paste insertion to fail after dictation.
- Replace the ambiguous foreground-activation wrapper in `PromptProcessingService` with an explicit process-activity manager that is used only for local providers.
- Add regression tests covering local provider activity wrapping, remote provider bypass, and provider classification.

## Issue Context
The reporter could reproduce a failed paste flow whenever a global rule used the Rewrite prompt with a local LLM. Dictation completed and the notch showed `Processing...`, but the target app lost focus during prompt processing, so insertion failed and TypeWhisper could jump to the front.

Closes #377

## Test Coverage
All new code paths in `PromptProcessingService` now have regression coverage:
- local providers enter the high-priority process activity path
- remote providers skip that path
- only local providers are classified as requiring the process activity budget

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed, design review skipped.

## Eval Results
No prompt eval suite was applicable for this app-service bugfix.

## Plan Completion
Conversation plan implemented in full.

## Test plan
- [x] Primary verification command(s) pass
- [x] Fresh verification rerun completed after final code changes
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
