### PR TITLE
docs: prepare 1.3.0-rc5 release notes

### DIFF
--- a/docs/release-notes/1.3.0-rc5.md
+++ b/docs/release-notes/1.3.0-rc5.md
@@ -1,0 +1,18 @@
+TypeWhisper `1.3.0-rc5` is planned as the final release candidate before `1.3.0`. This update tightens the new Workflows experience with a global fallback trigger and safer prompt boundaries, adds a round of menu bar and indicator polish, and refreshes the local-model path with the Parakeet language-filter fix plus shared Hugging Face token handling.
+
+## New Features
+
+- Added a global `Always` workflow trigger that acts as the fallback after website and app-specific workflow matches.
+- Grouped the menu bar actions into clearer sections so the most common dictation and app actions are faster to scan.
+
+## Bug Fixes
+
+- Hardened workflow prompts so dictated text is treated as source content to transform instead of instructions to execute.
+- Preserved focus in the original target app during local prompt processing so on-device workflows do not foreground TypeWhisper unexpectedly.
+- Fixed notch timer wrapping so longer timers stay readable without breaking the indicator layout.
+- Fixed Parakeet language filtering to match the current FluidAudio upstream behavior more reliably.
+
+## Other Changes
+
+- Added a shared Hugging Face token helper for the bundled local-model plugins, including Parakeet, Gemma 4, Granite, Qwen3, Voxtral, and WhisperKit.
+- Expanded automated coverage around workflow matching, workflow prompt boundaries, menu bar indicator settings, notch layout, and plugin manifest validation.

--- a/docs/release-notes/1.3.0.md
+++ b/docs/release-notes/1.3.0.md
@@ -1,0 +1,43 @@
+TypeWhisper 1.3 is the next stable macOS release, centered on the new Workflows experience, more capable automation surfaces, and a broad round of dictation, UI, and local-model reliability work across the `1.3.0-rc*` cycle.
+
+## Highlights
+
+- **Unified Workflows** - TypeWhisper now brings prompt actions and matching rules into one dedicated Workflows surface, with a native editor, wizard flow, and a global `Always` fallback trigger.
+- **Better automation control** - The local HTTP API and CLI now support per-request STT engine and model selection, while multilingual language hints make mixed-language dictation easier to steer.
+- **More polished dictation feedback** - Spoken feedback, adjustable transcript sizing, faster recent-transcription recovery, and grouped menu bar actions make day-to-day use smoother.
+- **Stronger local-model path** - The `1.3` cycle hardens local plugin downloads, Hugging Face token handling, model restore behavior, and Parakeet language filtering.
+
+## Workflows & Prompt Processing
+
+- Replaced the old Prompt Actions and Rules settings surfaces with the new unified Workflows experience.
+- Added a native macOS sidebar and wizard-style create/edit flow for workflows.
+- Added a global `Always` workflow trigger that acts as the fallback after website and app-specific matches.
+- Hardened workflow prompts so dictated text is always treated as source text to transform, not instructions to execute.
+- Added per-workflow temperature controls for supported LLM providers.
+- Preserved focus in the original target app during local prompt processing.
+
+## Dictation, Feedback & UI Polish
+
+- Added spoken feedback through the bundled `System Voice` plugin, scoped to transcription readback only.
+- Added multilingual language hints with multi-select search and selected-count feedback.
+- Added shortcuts for reopening recent transcriptions and a recovery palette for recent results.
+- Added adjustable live transcript preview sizing for dictation overlays.
+- Improved the notch and overlay indicator behavior, including active-screen re-anchoring and timer layout fixes.
+- Grouped menu bar actions into clearer sections for faster navigation.
+- Fixed Fn hotkey handling so both press-and-release and press-and-hold strategies work reliably.
+
+## Local Models, Plugins & Reliability
+
+- Upgraded the local model runtime and download flows for bundled on-device plugins.
+- Added shared Hugging Face token handling for the bundled local-model plugins and clearer validation where required.
+- Fixed Parakeet language filtering against the current FluidAudio upstream behavior.
+- Improved WhisperKit restore and unload handling.
+- Split the marketplace feeds by compatibility line and hardened plugin loading so incompatible external bundles are skipped instead of breaking launch.
+- Made dictionary prompts engine-aware and kept streaming dictionary terms working across AssemblyAI, Soniox, and SpeechAnalyzer.
+- Added subtitle exports for Watch Folder jobs.
+
+## Power Users & Automation
+
+- Added per-request STT engine and model selection through the local HTTP API and the `typewhisper` CLI.
+- Kept the documented `/v1/*` API and CLI command surface stable for the `1.x` line.
+- Improved plugin compatibility validation and diagnostics for marketplace and bundled plugins.


### PR DESCRIPTION
## Summary
- add curated release notes for `1.3.0-rc5` based on the changes merged since `1.3.0-rc4`
- add the initial stable draft for `1.3.0` so the final release handoff can happen after the last RC soak

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee build.log`
- [x] `bash scripts/check_first_party_warnings.sh build.log`
