### PR TITLE
Add WhisperKit lifecycle regression tests for issue #400

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */; };
 		1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */; };
 		1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */; };
+		4D980A5CFE1A4217A10C2101 /* WhisperKitPluginLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		A1F000000000000000000102 /* PostUpdatePromptCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */; };
 		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
@@ -650,6 +651,7 @@
 		BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnippetServiceTests.swift; sourceTree = "<group>"; };
 		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppFormatterServiceTests.swift; sourceTree = "<group>"; };
+		4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperKitPluginLifecycleTests.swift; sourceTree = "<group>"; };
 		D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryServiceTests.swift; sourceTree = "<group>"; };
 		D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		DD00000000000000000098 /* typewhisper-cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "typewhisper-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1784,6 +1786,7 @@
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
 				D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */,
 				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
+				4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
 				05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */,
 			);
@@ -2983,6 +2986,7 @@
 				91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */,
 				204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */,
 				76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */,
+				4D980A5CFE1A4217A10C2101 /* WhisperKitPluginLifecycleTests.swift in Sources */,
 				E2DA879FDEFA04FBD013E837 /* OutputFormatter.swift in Sources */,
 				BA68B1E282D5D714132FEA24 /* PortDiscovery.swift in Sources */,
 			);

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+@MainActor
+final class WhisperKitPluginLifecycleTests: XCTestCase {
+    private final class MockEventBus: EventBusProtocol {
+        @discardableResult
+        func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID { UUID() }
+        func unsubscribe(id: UUID) {}
+    }
+
+    private final class MockHostServices: HostServices, @unchecked Sendable {
+        private var defaults: [String: Any]
+        private var secrets: [String: String] = [:]
+
+        let pluginDataDirectory: URL
+        let eventBus: EventBusProtocol = MockEventBus()
+        var activeAppBundleId: String?
+        var activeAppName: String?
+        var availableRuleNames: [String] = []
+        private(set) var capabilitiesChangedCount = 0
+
+        init(pluginDataDirectory: URL, defaults: [String: Any] = [:]) {
+            self.pluginDataDirectory = pluginDataDirectory
+            self.defaults = defaults
+        }
+
+        func storeSecret(key: String, value: String) throws { secrets[key] = value }
+        func loadSecret(key: String) -> String? { secrets[key] }
+        func userDefault(forKey key: String) -> Any? { defaults[key] }
+        func setUserDefault(_ value: Any?, forKey key: String) { defaults[key] = value }
+        func notifyCapabilitiesChanged() { capabilitiesChangedCount += 1 }
+        func setStreamingDisplayActive(_ active: Bool) {}
+    }
+
+    private func makeHost(defaults: [String: Any] = [:]) throws -> MockHostServices {
+        let pluginDataDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WhisperKitLifecycleTests")
+        return MockHostServices(pluginDataDirectory: pluginDataDirectory, defaults: defaults)
+    }
+
+    func testActivationPromotesPersistedLoadedModelToSelectedModelWhenSelectionMissing() async throws {
+        let host = try makeHost(defaults: ["loadedModel": "openai_whisper-tiny"])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai_whisper-tiny")
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+    }
+
+    func testUnloadWithoutClearingPersistenceKeepsLoadedModelMarker() throws {
+        let host = try makeHost(defaults: [
+            "selectedModel": "openai_whisper-tiny",
+            "loadedModel": "openai_whisper-tiny",
+        ])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        plugin.unloadModel(clearPersistence: false)
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
+    }
+
+    func testUnloadClearingPersistenceRemovesLoadedModelMarker() throws {
+        let host = try makeHost(defaults: [
+            "selectedModel": "openai_whisper-tiny",
+            "loadedModel": "openai_whisper-tiny",
+        ])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        plugin.unloadModel(clearPersistence: true)
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+    }
+
+    func testActivationDoesNotMarkPluginConfiguredBeforeRestoreSucceeds() async throws {
+        let host = try makeHost(defaults: [
+            "selectedModel": "openai_whisper-tiny",
+            "loadedModel": "openai_whisper-tiny",
+        ])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.isConfigured)
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
+    }
+}


### PR DESCRIPTION
## Summary
Issue #400 reported a WhisperKit file-transcription crash from TypeWhisper 1.2.2 (555) that was tied to the old restore/unload lifecycle, not to video decoding.

Current `main` already contains the production fix from `828dc2a7` (`Fix WhisperKit restore and unload handling`, shipped in `v1.3.0-rc4+` / `v1.3.0-rc5`).

This PR adds focused regression coverage for that lifecycle contract:
- promote a persisted `loadedModel` into `selectedModel` during activation when needed
- keep `loadedModel` when unloading runtime state without clearing persistence
- clear `loadedModel` when unloading with persistence reset
- avoid reporting WhisperKit as configured before a real restore succeeds

No production code changes are included.

Closes #400

## Validation
Automated checks completed successfully:
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`

## Manual QA Note
I verified the current `main` branch is carrying the existing WhisperKit lifecycle fix and confirmed the local dev app reaches the expected WhisperKit setup state. However, the final file-import/file-transcription UI repro could not be completed end-to-end in this specific Conductor session because the local macOS automation path was blocked by Finder/file-picker accessibility behavior.

That means this PR intentionally limits itself to regression coverage around the already-landed fix, and does not claim a fresh end-to-end manual UI repro in this environment.