### PR TITLE
fix: guard AirPods output volume during audio routing

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -121,6 +121,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     /// See issue #332.
     private let previewEngineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.preview-engine-teardown")
     private static let previewEngineTeardownRetentionInterval: TimeInterval = 0.3
+    private let outputVolumeGuard: AudioOutputVolumeGuard
     private var activePreviewDeviceID: AudioDeviceID?
     private var compatibilityCache: [String: AudioInputDeviceCompatibility] = [:]
     private var isApplyingValidatedSelection = false
@@ -155,8 +156,10 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     init(
         initialInputDevices: [AudioInputDevice]? = nil,
         monitorDeviceChanges: Bool = true,
-        probeCompatibilities: Bool = false
+        probeCompatibilities: Bool = false,
+        outputVolumeGuard: AudioOutputVolumeGuard = AudioOutputVolumeGuard()
     ) {
+        self.outputVolumeGuard = outputVolumeGuard
         previewNotificationQueue.underlyingQueue = previewRecoveryQueue
         isInitializingSelection = true
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -201,14 +204,22 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             return
         }
 
+        outputVolumeGuard.captureBaseline()
+
         if let startPreviewOverride {
             do {
                 try startPreviewOverride(preferredDeviceID)
+                outputVolumeGuard.restoreIfRaised(reason: "preview-start-override")
+                outputVolumeGuard.clear()
                 isPreviewActive = true
             } catch let error as SelectedInputDeviceError {
+                outputVolumeGuard.restoreIfRaised(reason: "preview-start-override-failed")
+                outputVolumeGuard.clear()
                 previewError = error
                 isPreviewActive = false
             } catch {
+                outputVolumeGuard.restoreIfRaised(reason: "preview-start-override-failed")
+                outputVolumeGuard.clear()
                 previewError = selectedDeviceUID == nil ? nil : .incompatible(.engineStartFailed)
                 isPreviewActive = false
             }
@@ -235,6 +246,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 schedulePreviewRecoveryIfNeeded(previewRecoveryCoordinator.finishRecovery())
             }
 
+            outputVolumeGuard.restoreIfRaised(reason: "preview-start")
+            outputVolumeGuard.clear()
             isPreviewActive = true
         } catch let error as SelectedInputDeviceError {
             if case .incompatible(let issue) = error {
@@ -262,9 +275,12 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             return engine
         }
         if let engine {
+            outputVolumeGuard.captureBaseline()
             teardownPreviewEngine(engine)
             previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
+            outputVolumeGuard.restoreIfRaised(reason: "preview-stop")
         }
+        outputVolumeGuard.clear()
         isPreviewActive = false
         previewAudioLevel = 0
         previewRawLevel = 0
@@ -347,6 +363,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private func failActivePreviewDueToRecovery(_ error: SelectedInputDeviceError) {
         previewRecoveryCoordinator.transitionToIdle()
         removePreviewConfigurationObserver()
+        outputVolumeGuard.captureBaselineIfNeeded()
         let engine: AVAudioEngine? = previewLock.withLock {
             let engine = previewEngine
             previewEngine = nil
@@ -357,6 +374,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             teardownPreviewEngine(engine)
             previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
         }
+        outputVolumeGuard.restoreIfRaised(reason: "preview-recovery-failure")
+        outputVolumeGuard.clear()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.isPreviewActive = false
@@ -426,11 +445,16 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         preferredDeviceID: AudioDeviceID?,
         label: String
     ) throws {
+        outputVolumeGuard.captureBaselineIfNeeded()
         // Swap in a fresh AVAudioEngine instead of reusing the stuck one.
         // Reusing the same engine after CoreAudio flagged its AUHAL mid-switch
         // causes `AudioUnitSetProperty` to return 'nope'
         // (kAudioHardwareIllegalOperationError). See issue #332.
         guard let replacementEngine = replacePreviewAudioEngineForRecoveryIfNeeded(engine) else { return }
+        defer {
+            outputVolumeGuard.restoreIfRaised(reason: "\(label)-engine-restart")
+            outputVolumeGuard.clear()
+        }
 
         installPreviewConfigurationObserver(for: replacementEngine)
         teardownPreviewEngine(engine)
@@ -543,6 +567,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
         teardownPreviewEngine(engine)
         previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
+        outputVolumeGuard.restoreIfRaised(reason: "preview-start-failed")
+        outputVolumeGuard.clear()
         isPreviewActive = false
         previewAudioLevel = 0
         previewRawLevel = 0

--- a/TypeWhisper/Services/AudioDuckingService.swift
+++ b/TypeWhisper/Services/AudioDuckingService.swift
@@ -237,7 +237,12 @@ class AudioDuckingService {
 
         savedSnapshot = current
         let targetVolume = max(0, min(1, current.volume * factor))
-        volumeController.setVolume(targetVolume, for: current.deviceID)
+        guard volumeController.setVolume(targetVolume, for: current.deviceID) else {
+            savedSnapshot = nil
+            logger.warning("Could not duck audio output volume")
+            return
+        }
+
         isDucked = true
         logger.info("Audio ducked: \(current.volume, privacy: .public) -> \(targetVolume, privacy: .public)")
     }
@@ -247,8 +252,11 @@ class AudioDuckingService {
         guard isDucked, let savedSnapshot else { return }
 
         let restoreDeviceID = volumeController.defaultOutputSnapshot()?.deviceID ?? savedSnapshot.deviceID
-        volumeController.setVolume(savedSnapshot.volume, for: restoreDeviceID)
-        logger.info("Audio restored to \(savedSnapshot.volume, privacy: .public)")
+        if volumeController.setVolume(savedSnapshot.volume, for: restoreDeviceID) {
+            logger.info("Audio restored to \(savedSnapshot.volume, privacy: .public)")
+        } else {
+            logger.warning("Could not restore audio output volume")
+        }
         self.savedSnapshot = nil
         isDucked = false
     }

--- a/TypeWhisper/Services/AudioDuckingService.swift
+++ b/TypeWhisper/Services/AudioDuckingService.swift
@@ -5,50 +5,70 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioDuckingService")
 
-@MainActor
-class AudioDuckingService {
-    private var savedVolume: Float?
-    private var isDucked = false
+struct AudioOutputVolumeSnapshot: Equatable {
+    let deviceID: AudioDeviceID
+    let deviceUID: String?
+    let deviceName: String?
+    let volume: Float
+    let transportType: String?
 
-    /// Reduces the system output volume to the given factor (0.0–1.0)
-    func duckAudio(to factor: Float) {
-        guard !isDucked else { return }
+    init(
+        deviceID: AudioDeviceID,
+        deviceUID: String?,
+        deviceName: String?,
+        volume: Float,
+        transportType: String? = nil
+    ) {
+        self.deviceID = deviceID
+        self.deviceUID = deviceUID
+        self.deviceName = deviceName
+        self.volume = volume
+        self.transportType = transportType
+    }
+}
 
-        guard let deviceID = defaultOutputDevice() else {
-            logger.warning("No default output device found")
-            return
+protocol AudioOutputVolumeControlling: AnyObject {
+    func defaultOutputSnapshot() -> AudioOutputVolumeSnapshot?
+    func setVolume(_ volume: Float, for deviceID: AudioDeviceID) -> Bool
+}
+
+final class CoreAudioOutputVolumeController: AudioOutputVolumeControlling {
+    func defaultOutputSnapshot() -> AudioOutputVolumeSnapshot? {
+        guard let deviceID = defaultOutputDevice(),
+              let volume = getVolume(for: deviceID) else {
+            return nil
         }
 
-        guard let currentVolume = getVolume(for: deviceID) else {
-            logger.warning("Could not read current volume")
-            return
-        }
-
-        savedVolume = currentVolume
-        let targetVolume = currentVolume * factor
-        setVolume(targetVolume, for: deviceID)
-        isDucked = true
-        logger.info("Audio ducked: \(currentVolume, privacy: .public) → \(targetVolume, privacy: .public)")
+        return AudioOutputVolumeSnapshot(
+            deviceID: deviceID,
+            deviceUID: getStringProperty(
+                for: deviceID,
+                selector: kAudioDevicePropertyDeviceUID
+            ),
+            deviceName: getStringProperty(
+                for: deviceID,
+                selector: kAudioDevicePropertyDeviceNameCFString
+            ),
+            volume: volume,
+            transportType: transportType(for: deviceID)
+        )
     }
 
-    /// Restores the previously saved volume
-    func restoreAudio() {
-        guard isDucked, let savedVolume else { return }
+    func setVolume(_ volume: Float, for deviceID: AudioDeviceID) -> Bool {
+        var volume = max(0, min(1, volume))
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
 
-        guard let deviceID = defaultOutputDevice() else {
-            logger.warning("No default output device found for restore")
-            self.savedVolume = nil
-            isDucked = false
-            return
+        let size = UInt32(MemoryLayout<Float>.size)
+        let status = AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &volume)
+        if status != noErr {
+            logger.error("Failed to set output volume: \(status)")
         }
-
-        setVolume(savedVolume, for: deviceID)
-        logger.info("Audio restored to \(savedVolume, privacy: .public)")
-        self.savedVolume = nil
-        isDucked = false
+        return status == noErr
     }
-
-    // MARK: - CoreAudio Helpers
 
     private func defaultOutputDevice() -> AudioDeviceID? {
         var deviceID = AudioDeviceID(0)
@@ -67,7 +87,8 @@ class AudioDuckingService {
             &deviceID
         )
 
-        return status == noErr ? deviceID : nil
+        guard status == noErr, deviceID != 0 else { return nil }
+        return deviceID
     }
 
     private func getVolume(for deviceID: AudioDeviceID) -> Float? {
@@ -83,18 +104,152 @@ class AudioDuckingService {
         return status == noErr ? volume : nil
     }
 
-    private func setVolume(_ volume: Float, for deviceID: AudioDeviceID) {
-        var volume = volume
+    private func getStringProperty(for deviceID: AudioDeviceID, selector: AudioObjectPropertySelector) -> String? {
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
-            mScope: kAudioDevicePropertyScopeOutput,
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
+        var value: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value)
+        guard status == noErr, let cf = value else { return nil }
+        return cf.takeUnretainedValue() as String
+    }
 
-        let size = UInt32(MemoryLayout<Float>.size)
-        let status = AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &volume)
-        if status != noErr {
-            logger.error("Failed to set volume: \(status)")
+    private func transportType(for deviceID: AudioDeviceID) -> String? {
+        var transportType: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transportType)
+        guard status == noErr else { return nil }
+
+        switch transportType {
+        case kAudioDeviceTransportTypeBuiltIn:
+            return "builtIn"
+        case kAudioDeviceTransportTypeAggregate:
+            return "aggregate"
+        case kAudioDeviceTransportTypeVirtual:
+            return "virtual"
+        case kAudioDeviceTransportTypePCI:
+            return "pci"
+        case kAudioDeviceTransportTypeUSB:
+            return "usb"
+        case kAudioDeviceTransportTypeFireWire:
+            return "fireWire"
+        case kAudioDeviceTransportTypeBluetooth:
+            return "bluetooth"
+        case kAudioDeviceTransportTypeBluetoothLE:
+            return "bluetoothLE"
+        case kAudioDeviceTransportTypeHDMI:
+            return "hdmi"
+        case kAudioDeviceTransportTypeDisplayPort:
+            return "displayPort"
+        case kAudioDeviceTransportTypeAirPlay:
+            return "airPlay"
+        case kAudioDeviceTransportTypeAVB:
+            return "avb"
+        default:
+            return "unknown(\(transportType))"
         }
+    }
+}
+
+final class AudioOutputVolumeGuard: @unchecked Sendable {
+    private let volumeController: AudioOutputVolumeControlling
+    private let tolerance: Float
+    private let lock = NSLock()
+    private var baseline: AudioOutputVolumeSnapshot?
+
+    init(
+        volumeController: AudioOutputVolumeControlling = CoreAudioOutputVolumeController(),
+        tolerance: Float = 0.02
+    ) {
+        self.volumeController = volumeController
+        self.tolerance = tolerance
+    }
+
+    func captureBaseline() {
+        let snapshot = volumeController.defaultOutputSnapshot()
+        lock.withLock {
+            baseline = snapshot
+        }
+
+        guard let snapshot else {
+            logger.warning("Could not capture output volume baseline")
+            return
+        }
+
+        logger.info("Captured output volume baseline \(snapshot.volume, privacy: .public) for \(snapshot.deviceName ?? "unknown", privacy: .public)")
+    }
+
+    func captureBaselineIfNeeded() {
+        let alreadyCaptured = lock.withLock { baseline != nil }
+        guard !alreadyCaptured else { return }
+        captureBaseline()
+    }
+
+    func restoreIfRaised(reason: String) {
+        let capturedBaseline = lock.withLock { baseline }
+        guard let capturedBaseline else { return }
+
+        guard let current = volumeController.defaultOutputSnapshot() else {
+            logger.warning("Could not read output volume for guarded restore: \(reason, privacy: .public)")
+            return
+        }
+
+        guard current.volume > capturedBaseline.volume + tolerance else { return }
+
+        if volumeController.setVolume(capturedBaseline.volume, for: current.deviceID) {
+            logger.info("Restored output volume after \(reason, privacy: .public): \(current.volume, privacy: .public) -> \(capturedBaseline.volume, privacy: .public)")
+        }
+    }
+
+    func clear() {
+        lock.withLock {
+            baseline = nil
+        }
+    }
+}
+
+@MainActor
+class AudioDuckingService {
+    private let volumeController: AudioOutputVolumeControlling
+    private var savedSnapshot: AudioOutputVolumeSnapshot?
+    private var isDucked = false
+
+    init(volumeController: AudioOutputVolumeControlling = CoreAudioOutputVolumeController()) {
+        self.volumeController = volumeController
+    }
+
+    /// Reduces the system output volume to the given factor (0.0–1.0)
+    func duckAudio(to factor: Float) {
+        guard !isDucked else { return }
+
+        guard let current = volumeController.defaultOutputSnapshot() else {
+            logger.warning("No default output device found")
+            return
+        }
+
+        savedSnapshot = current
+        let targetVolume = max(0, min(1, current.volume * factor))
+        volumeController.setVolume(targetVolume, for: current.deviceID)
+        isDucked = true
+        logger.info("Audio ducked: \(current.volume, privacy: .public) -> \(targetVolume, privacy: .public)")
+    }
+
+    /// Restores the previously saved volume
+    func restoreAudio() {
+        guard isDucked, let savedSnapshot else { return }
+
+        let restoreDeviceID = volumeController.defaultOutputSnapshot()?.deviceID ?? savedSnapshot.deviceID
+        volumeController.setVolume(savedSnapshot.volume, for: restoreDeviceID)
+        logger.info("Audio restored to \(savedSnapshot.volume, privacy: .public)")
+        self.savedSnapshot = nil
+        isDucked = false
     }
 }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -135,13 +135,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let recoveryQueue = DispatchQueue(label: "com.typewhisper.audio-recovery", qos: .userInitiated)
     private let engineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.audio-engine-teardown")
     private let recoveryCoordinator = AudioEngineRecoveryCoordinator()
+    private let outputVolumeGuard: AudioOutputVolumeGuard
     private var _lastStopGraceCaptureApplied = false
 
     static let targetSampleRate: Double = 16000
     private static let captureTapFrames: AVAudioFrameCount = 1024
     private static let engineTeardownRetentionInterval: TimeInterval = 0.3
 
-    init() {
+    init(outputVolumeGuard: AudioOutputVolumeGuard = AudioOutputVolumeGuard()) {
+        self.outputVolumeGuard = outputVolumeGuard
         recoveryNotificationQueue.underlyingQueue = recoveryQueue
     }
 
@@ -244,14 +246,23 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         recoveryError = nil
 
         try validateRecordingInputAvailability()
+        outputVolumeGuard.captureBaseline()
 
         if let startRecordingOverride {
             bufferLock.lock()
             sampleBuffer.removeAll()
             _peakRawAudioLevel = 0
             bufferLock.unlock()
-            try startRecordingOverride()
-            isRecording = true
+            do {
+                try startRecordingOverride()
+                outputVolumeGuard.restoreIfRaised(reason: "recording-start-override")
+                outputVolumeGuard.clear()
+                isRecording = true
+            } catch {
+                outputVolumeGuard.restoreIfRaised(reason: "recording-start-override-failed")
+                outputVolumeGuard.clear()
+                throw error
+            }
             return
         }
 
@@ -281,6 +292,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                 scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
             }
 
+            outputVolumeGuard.restoreIfRaised(reason: "recording-start")
+            outputVolumeGuard.clear()
             isRecording = true
         } catch {
             cleanupAfterFailedStart(engine)
@@ -290,7 +303,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     func stopRecording(policy: StopPolicy) async -> [Float] {
         if let stopRecordingOverride {
+            outputVolumeGuard.captureBaseline()
             let samples = await stopRecordingOverride(policy)
+            outputVolumeGuard.restoreIfRaised(reason: "recording-stop-override")
+            outputVolumeGuard.clear()
             let rms: Float
             if samples.isEmpty {
                 rms = 0
@@ -319,7 +335,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             startupConfigurationChangeGuard = nil
             return e
         }
-        guard let engine else { return [] }
+        guard let engine else {
+            outputVolumeGuard.clear()
+            return []
+        }
 
         let bufferedDuration = totalBufferDuration
         var graceApplied = false
@@ -338,10 +357,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         recoveryCoordinator.transitionToIdle()
 
         removeConfigurationObserver()
+        outputVolumeGuard.captureBaseline()
         teardownEngine(engine)
         // Keep the engine alive briefly so CoreAudio's internal teardown callbacks
         // cannot outlive the AVAudioEngine objects they still reference.
         engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        outputVolumeGuard.restoreIfRaised(reason: "recording-stop")
+        outputVolumeGuard.clear()
 
         // Flush pending audio processing before grabbing the buffer
         processingQueue.sync { }
@@ -416,6 +438,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func failActiveRecordingDueToRecovery(_ error: AudioRecordingError) {
         recoveryCoordinator.transitionToIdle()
         removeConfigurationObserver()
+        outputVolumeGuard.captureBaselineIfNeeded()
         let engine: AVAudioEngine? = engineLock.withLock {
             let engine = audioEngine
             audioEngine = nil
@@ -426,6 +449,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             teardownEngine(engine)
             engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
         }
+        outputVolumeGuard.restoreIfRaised(reason: "recording-recovery-failure")
+        outputVolumeGuard.clear()
         clearRecordingBuffer()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -496,7 +521,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func restartEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+        outputVolumeGuard.captureBaselineIfNeeded()
         guard let replacementEngine = replaceAudioEngineForRecoveryIfNeeded(engine) else { return }
+        defer {
+            outputVolumeGuard.restoreIfRaised(reason: "\(label)-engine-restart")
+            outputVolumeGuard.clear()
+        }
 
         installConfigurationObserver(for: replacementEngine)
         teardownEngine(engine)
@@ -607,6 +637,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
         teardownEngine(engine)
         engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        outputVolumeGuard.restoreIfRaised(reason: "recording-start-failed")
+        outputVolumeGuard.clear()
         DispatchQueue.main.async { [weak self] in
             self?.isRecording = false
             self?.audioLevel = 0

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -40,6 +40,23 @@ private struct DiagnosticsReport: Encodable {
         let remoteAccessAllowed: Bool
     }
 
+    struct AudioOutputInfo: Encodable {
+        let deviceID: UInt32
+        let uid: String?
+        let name: String?
+        let volume: Float
+        let transportType: String?
+    }
+
+    struct AudioInfo: Encodable {
+        let selectedInputDeviceUID: String?
+        let selectedInputDeviceName: String?
+        let audioDuckingEnabled: Bool
+        let audioDuckingLevel: Double
+        let mediaPauseEnabled: Bool
+        let defaultOutput: AudioOutputInfo?
+    }
+
     struct PluginInfo: Encodable {
         let id: String
         let name: String
@@ -91,6 +108,7 @@ private struct DiagnosticsReport: Encodable {
     let permissions: PermissionsInfo
     let model: ModelInfo
     let api: APIInfo
+    let audio: AudioInfo
     let plugins: [PluginInfo]
     let settings: SettingsSnapshot
     let counts: Counts
@@ -141,6 +159,7 @@ final class ErrorLogService: ObservableObject {
         let container = ServiceContainer.shared
         let defaults = UserDefaults.standard
         let pluginManager = PluginManager.shared ?? container.pluginManager
+        let outputSnapshot = CoreAudioOutputVolumeController().defaultOutputSnapshot()
 
         return DiagnosticsReport(
             exportedAt: Date(),
@@ -173,6 +192,22 @@ final class ErrorLogService: ObservableObject {
                 port: container.apiServerViewModel.port,
                 loopbackOnly: true,
                 remoteAccessAllowed: false
+            ),
+            audio: .init(
+                selectedInputDeviceUID: defaults.string(forKey: UserDefaultsKeys.selectedInputDeviceUID),
+                selectedInputDeviceName: container.audioDeviceService.selectedDevice?.name,
+                audioDuckingEnabled: defaults.bool(forKey: UserDefaultsKeys.audioDuckingEnabled),
+                audioDuckingLevel: defaults.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2,
+                mediaPauseEnabled: defaults.bool(forKey: UserDefaultsKeys.mediaPauseEnabled),
+                defaultOutput: outputSnapshot.map {
+                    .init(
+                        deviceID: $0.deviceID,
+                        uid: $0.deviceUID,
+                        name: $0.deviceName,
+                        volume: $0.volume,
+                        transportType: $0.transportType
+                    )
+                }
             ),
             plugins: pluginManager.loadedPlugins.map {
                 .init(

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -461,3 +461,227 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: expectedFormat))
     }
 }
+
+final class AudioOutputVolumeGuardTests: XCTestCase {
+    func testRestoreIfRaisedRestoresCurrentOutputToCapturedUserVolume() {
+        let controller = FakeAudioOutputVolumeController(
+            defaultDeviceID: AudioDeviceID(1),
+            snapshots: [
+                AudioDeviceID(1): AudioOutputVolumeSnapshot(
+                    deviceID: AudioDeviceID(1),
+                    deviceUID: "airpods-output",
+                    deviceName: "AirPods Pro",
+                    volume: 0.10
+                )
+            ]
+        )
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+
+        guardService.captureBaseline()
+        controller.updateVolume(0.42, for: AudioDeviceID(1))
+        guardService.restoreIfRaised(reason: "test")
+
+        XCTAssertEqual(controller.setCalls, [
+            .init(deviceID: AudioDeviceID(1), volume: 0.10)
+        ])
+    }
+
+    func testRestoreIfRaisedDoesNotIncreaseLowerCurrentVolume() {
+        let controller = FakeAudioOutputVolumeController(
+            defaultDeviceID: AudioDeviceID(1),
+            snapshots: [
+                AudioDeviceID(1): AudioOutputVolumeSnapshot(
+                    deviceID: AudioDeviceID(1),
+                    deviceUID: "speakers",
+                    deviceName: "Speakers",
+                    volume: 0.50
+                )
+            ]
+        )
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+
+        guardService.captureBaseline()
+        controller.updateVolume(0.20, for: AudioDeviceID(1))
+        guardService.restoreIfRaised(reason: "test")
+
+        XCTAssertTrue(controller.setCalls.isEmpty)
+    }
+
+    func testRestoreIfRaisedTargetsCurrentDefaultOutputAfterDeviceSwitch() {
+        let controller = FakeAudioOutputVolumeController(
+            defaultDeviceID: AudioDeviceID(1),
+            snapshots: [
+                AudioDeviceID(1): AudioOutputVolumeSnapshot(
+                    deviceID: AudioDeviceID(1),
+                    deviceUID: "airpods-output",
+                    deviceName: "AirPods Pro",
+                    volume: 0.12
+                ),
+                AudioDeviceID(2): AudioOutputVolumeSnapshot(
+                    deviceID: AudioDeviceID(2),
+                    deviceUID: "built-in-output",
+                    deviceName: "MacBook Pro Speakers",
+                    volume: 0.46
+                )
+            ]
+        )
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+
+        guardService.captureBaseline()
+        controller.defaultDeviceID = AudioDeviceID(2)
+        guardService.restoreIfRaised(reason: "test")
+
+        XCTAssertEqual(controller.setCalls, [
+            .init(deviceID: AudioDeviceID(2), volume: 0.12)
+        ])
+    }
+
+    func testClearPreventsLaterVolumeWrites() {
+        let controller = FakeAudioOutputVolumeController(
+            defaultDeviceID: AudioDeviceID(1),
+            snapshots: [
+                AudioDeviceID(1): AudioOutputVolumeSnapshot(
+                    deviceID: AudioDeviceID(1),
+                    deviceUID: "airpods-output",
+                    deviceName: "AirPods Pro",
+                    volume: 0.10
+                )
+            ]
+        )
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+
+        guardService.captureBaseline()
+        guardService.clear()
+        controller.updateVolume(0.40, for: AudioDeviceID(1))
+        guardService.restoreIfRaised(reason: "test")
+
+        XCTAssertTrue(controller.setCalls.isEmpty)
+    }
+}
+
+final class AudioOutputVolumeIntegrationTests: XCTestCase {
+    func testStartRecordingRestoresOutputVolumeRaisedDuringAudioStart() {
+        let controller = FakeAudioOutputVolumeController.airPods(volume: 0.10)
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+        let service = AudioRecordingService(outputVolumeGuard: guardService)
+        service.hasMicrophonePermissionOverride = true
+        service.inputAvailabilityOverride = { _ in true }
+        service.startRecordingOverride = {
+            controller.updateVolume(0.40, for: AudioDeviceID(1))
+        }
+
+        XCTAssertNoThrow(try service.startRecording())
+
+        XCTAssertEqual(controller.setCalls, [
+            .init(deviceID: AudioDeviceID(1), volume: 0.10)
+        ])
+    }
+
+    func testStopRecordingRestoresRaisedOutputVolumeAndClearsGuard() async {
+        let controller = FakeAudioOutputVolumeController.airPods(volume: 0.10)
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+        let service = AudioRecordingService(outputVolumeGuard: guardService)
+        service.hasMicrophonePermissionOverride = true
+        service.inputAvailabilityOverride = { _ in true }
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in
+            controller.updateVolume(0.70, for: AudioDeviceID(1))
+            return []
+        }
+
+        XCTAssertNoThrow(try service.startRecording())
+        controller.updateVolume(0.45, for: AudioDeviceID(1))
+        _ = await service.stopRecording(policy: .immediate)
+
+        XCTAssertEqual(controller.setCalls, [
+            .init(deviceID: AudioDeviceID(1), volume: 0.45)
+        ])
+    }
+
+    @MainActor
+    func testStartPreviewRestoresOutputVolumeRaisedDuringPreviewStart() {
+        let controller = FakeAudioOutputVolumeController.airPods(volume: 0.10)
+        let guardService = AudioOutputVolumeGuard(volumeController: controller)
+        let service = AudioDeviceService(
+            initialInputDevices: [],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            outputVolumeGuard: guardService
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.startPreviewOverride = { _ in
+            controller.updateVolume(0.40, for: AudioDeviceID(1))
+        }
+
+        service.startPreview()
+
+        XCTAssertEqual(controller.setCalls, [
+            .init(deviceID: AudioDeviceID(1), volume: 0.10)
+        ])
+    }
+
+    @MainActor
+    func testAudioDuckingUsesCurrentOutputVolumeAsBaseline() {
+        let controller = FakeAudioOutputVolumeController.airPods(volume: 0.10)
+        let service = AudioDuckingService(volumeController: controller)
+
+        service.duckAudio(to: 0.20)
+        service.restoreAudio()
+
+        XCTAssertEqual(controller.setCalls.count, 2)
+        XCTAssertEqual(controller.setCalls[0].deviceID, AudioDeviceID(1))
+        XCTAssertEqual(controller.setCalls[0].volume, 0.02, accuracy: 0.0001)
+        XCTAssertEqual(controller.setCalls[1], .init(deviceID: AudioDeviceID(1), volume: 0.10))
+    }
+}
+
+private final class FakeAudioOutputVolumeController: AudioOutputVolumeControlling {
+    struct SetCall: Equatable {
+        let deviceID: AudioDeviceID
+        let volume: Float
+    }
+
+    var defaultDeviceID: AudioDeviceID?
+    private var snapshots: [AudioDeviceID: AudioOutputVolumeSnapshot]
+    private(set) var setCalls: [SetCall] = []
+
+    init(defaultDeviceID: AudioDeviceID?, snapshots: [AudioDeviceID: AudioOutputVolumeSnapshot]) {
+        self.defaultDeviceID = defaultDeviceID
+        self.snapshots = snapshots
+    }
+
+    static func airPods(volume: Float) -> FakeAudioOutputVolumeController {
+        FakeAudioOutputVolumeController(
+            defaultDeviceID: AudioDeviceID(1),
+            snapshots: [
+                AudioDeviceID(1): AudioOutputVolumeSnapshot(
+                    deviceID: AudioDeviceID(1),
+                    deviceUID: "airpods-output",
+                    deviceName: "AirPods Pro",
+                    volume: volume
+                )
+            ]
+        )
+    }
+
+    func defaultOutputSnapshot() -> AudioOutputVolumeSnapshot? {
+        guard let defaultDeviceID else { return nil }
+        return snapshots[defaultDeviceID]
+    }
+
+    func setVolume(_ volume: Float, for deviceID: AudioDeviceID) -> Bool {
+        setCalls.append(.init(deviceID: deviceID, volume: volume))
+        updateVolume(volume, for: deviceID)
+        return true
+    }
+
+    func updateVolume(_ volume: Float, for deviceID: AudioDeviceID) {
+        guard let snapshot = snapshots[deviceID] else { return }
+        snapshots[deviceID] = AudioOutputVolumeSnapshot(
+            deviceID: snapshot.deviceID,
+            deviceUID: snapshot.deviceUID,
+            deviceName: snapshot.deviceName,
+            volume: volume
+        )
+    }
+}


### PR DESCRIPTION
## Issue Context

Closes #396

Issue #396 reports an AirPods/Bluetooth-output-specific volume jump when dictation starts or stops while media is already playing at a low volume. Follow-up testing on `1.3.0-rc5 / 669` narrowed the remaining problem down further:

- `Media Pause` now works, but the volume jump remains with and without Audio Ducking.
- Built-in speakers as output plus AirPods as microphone works correctly.
- The issue reproduces in both dictation recording and `Settings -> Microphone -> Test Microphone`.
- It reproduces with `Input Device = System Default` and with AirPods selected explicitly.
- Diagnostics did not show errors, and `soundFeedbackEnabled` was `false`.

## Summary

- Add a shared CoreAudio output-volume snapshot/controller/guard.
- Capture the current default output volume around recording start/stop/recovery/failure paths and restore only if the route increased above the captured baseline.
- Apply the same guard to microphone preview start/stop/recovery/failure paths.
- Keep Audio Ducking on the shared output-volume controller so ducking baselines are taken from the user's actual current volume.
- Extend diagnostics with selected input details and current default output route/volume details.
- Add regression coverage for the guard and for recording, microphone preview, and ducking integration paths.

## Coverage

- New guard behavior is covered for raised-volume restore, no-raise restore when the current volume is lower, default-output device switches, and clear/no-op behavior.
- Recording integration is covered for start-time protection and stop-time protection with a fresh stop baseline.
- Microphone preview integration is covered for preview start-time protection.
- Audio Ducking integration is covered for using the current output volume as its baseline.

## Ship Checklist

- Pre-landing review: no issues found.
- Scope drift: clean; changes are limited to the AirPods/Bluetooth output-volume guard, diagnostics, and tests for #396.
- Plan completion: no separate plan file detected; implementation follows the GitHub issue context and the follow-up replies summarized above.
- Version/changelog: skipped because this repository has no root `VERSION` or `CHANGELOG.md`; app marketing version is unchanged.
- Design review: skipped; no UI/frontend files changed.
- Eval results: skipped; no prompt or model-evaluation files changed.

## Test Plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/AudioOutputVolumeGuardTests -only-testing:TypeWhisperTests/AudioOutputVolumeIntegrationTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`

Manual AirPods hardware validation was not run in this environment.
