### PR TITLE
fix: keep language list available before plugins load

### DIFF
--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -32,6 +32,20 @@ struct LocalizedAppLanguageOption: Equatable {
     let name: String
 }
 
+let defaultSpokenLanguageCodes: [String] = [
+    "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo",
+    "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es",
+    "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw",
+    "he", "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja",
+    "jw", "ka", "kk", "km", "kn", "ko", "la", "lb", "ln", "lo",
+    "lt", "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt",
+    "my", "ne", "nl", "nn", "no", "oc", "pa", "pl", "ps", "pt",
+    "ro", "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq",
+    "sr", "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl",
+    "tr", "tt", "uk", "ur", "uz", "vi", "vo", "yi", "yo", "yue",
+    "zh",
+]
+
 func localizedAppLanguageOptions(for codes: [String]) -> [LocalizedAppLanguageOption] {
     codes.map { code in
         LocalizedAppLanguageOption(code: code, name: localizedAppLanguageName(for: code))

--- a/TypeWhisper/ViewModels/SettingsViewModel.swift
+++ b/TypeWhisper/ViewModels/SettingsViewModel.swift
@@ -237,6 +237,9 @@ final class SettingsViewModel: ObservableObject {
                 codes.insert(code)
             }
         }
+        if codes.isEmpty {
+            codes = Set(defaultSpokenLanguageCodes)
+        }
         return localizedAppLanguageOptions(for: Array(codes))
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
             .map { (code: $0.code, name: $0.name) }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -287,10 +287,12 @@ final class MenuBarGroupingTests: XCTestCase {
 
 final class LanguageLocalizationTests: XCTestCase {
     private var originalPreferredAppLanguage: String?
+    private var originalPluginManager: PluginManager?
 
     override func setUp() {
         super.setUp()
         originalPreferredAppLanguage = UserDefaults.standard.string(forKey: UserDefaultsKeys.preferredAppLanguage)
+        originalPluginManager = PluginManager.shared
     }
 
     override func tearDown() {
@@ -299,6 +301,8 @@ final class LanguageLocalizationTests: XCTestCase {
         } else {
             UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.preferredAppLanguage)
         }
+        PluginManager.shared = originalPluginManager
+        originalPluginManager = nil
         super.tearDown()
     }
 
@@ -318,5 +322,19 @@ final class LanguageLocalizationTests: XCTestCase {
 
         XCTAssertTrue(searchTerms.contains(where: { $0.localizedCaseInsensitiveContains("english") }))
         XCTAssertTrue(searchTerms.contains(where: { $0.localizedCaseInsensitiveContains("englisch") }))
+    }
+
+    @MainActor
+    func testSettingsLanguageOptionsDoNotGoEmptyBeforePluginsLoad() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LanguageFallbackTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let settingsViewModel = SettingsViewModel(modelManager: ModelManagerService())
+        let codes = Set(settingsViewModel.availableLanguages.map(\.code))
+
+        XCTAssertTrue(codes.contains("en"))
+        XCTAssertTrue(codes.contains("de"))
+        XCTAssertTrue(codes.contains("fr"))
     }
 }


### PR DESCRIPTION
## Summary

Closes #312

- add a fallback spoken-language catalog when transcription plugins have not loaded their supported language lists yet
- keep the language picker populated before plugin startup finishes, so the popover is not empty regardless of search text or system language
- add a regression test for an empty `PluginManager` language source

## Issue Context

The reporter confirmed the spoken-language popover is black/empty both when the search field has text and when it is empty. Their existing English selection can still appear because it is persisted, but the selectable language list is built from currently loaded transcription engines. If that plugin-derived source is empty during settings rendering, the list had no rows to display.

## Test Coverage

All new code paths have test coverage.

- Added `LanguageLocalizationTests.testSettingsLanguageOptionsDoNotGoEmptyBeforePluginsLoad`
- The test replaces `PluginManager.shared` with an empty plugin manager and verifies common spoken languages (`en`, `de`, `fr`) remain available.

## Pre-Landing Review

No issues found.

## Design Review

No SwiftUI view files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: fix the empty spoken-language picker reported in #312.

Delivered: adds a fallback language source and a regression test for the empty plugin-manager state.

## Plan Completion

No plan file detected.

## Verification Results

- [x] App XCTest suite passed: 404 tests, 0 failures
- [x] TypeWhisper dev app build succeeded

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
