### PR TITLE
fix: support large CLI transcriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Optional parameters:
 - `task` - `transcribe` (default) or `translate` (translates to English, WhisperKit only).
 - `target_language` - ISO 639-1 code for translation target language (e.g., `es`, `fr`). Uses Apple Translate.
 
+Uploads to `/v1/transcribe` are limited to 256 MiB, including stdin uploads from the CLI. Requests above that size return `413 Payload Too Large`. Local CLI file paths use a direct handoff to the running TypeWhisper app instead of uploading the file bytes.
+
 ### List Models
 
 ```bash
@@ -361,6 +363,8 @@ typewhisper transcribe meeting.m4a --json | jq -r '.text'
 ```
 
 The CLI requires the API server to be running (Settings > Advanced) and follows the documented command and flag surface for the current stable release.
+
+Local file paths are handed to the running TypeWhisper app directly, so large files do not need to fit inside an HTTP upload body. Stdin usage (`typewhisper transcribe -`) still uses the regular `/v1/transcribe` upload endpoint and is limited to 256 MiB.
 
 ## Workflows
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */; };
 		76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */; };
 		7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */; };
+		A40500000000000000000101 /* CLIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000104 /* CLIClient.swift */; };
 		7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */; };
 		7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */; };
 		86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BD305007A3A158038C75C /* ProfileServiceTests.swift */; };
@@ -2946,6 +2947,7 @@
 				7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */,
 				7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */,
+				A40500000000000000000101 /* CLIClient.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */,
 				7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */,
 				E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -32,6 +32,7 @@ final class APIHandlers: @unchecked Sendable {
 
     func register(on router: APIRouter) {
         router.register("POST", "/v1/transcribe", handler: handleTranscribe)
+        router.register("POST", "/v1/transcribe/local-file", handler: handleTranscribeLocalFile)
         router.register("GET", "/v1/status", handler: handleStatus)
         router.register("GET", "/v1/models", handler: handleModels)
         router.register("GET", "/v1/history", handler: handleGetHistory)
@@ -51,17 +52,46 @@ final class APIHandlers: @unchecked Sendable {
 
     // MARK: - POST /v1/transcribe
 
+    private struct TranscribeOptions {
+        var language: String? = nil
+        var languageHints: [String] = []
+        var task: TranscriptionTask = .transcribe
+        var targetLanguage: String? = nil
+        var responseFormat = "json"
+        var requestPrompt: String? = nil
+        var engineOverride: String? = nil
+        var modelOverride: String? = nil
+        var awaitDownload = false
+    }
+
+    private struct LocalFileTranscribeRequest: Decodable {
+        let path: String
+        let language: String?
+        let languageHints: [String]?
+        let task: String?
+        let targetLanguage: String?
+        let responseFormat: String?
+        let prompt: String?
+        let engine: String?
+        let model: String?
+
+        enum CodingKeys: String, CodingKey {
+            case path
+            case language
+            case languageHints = "language_hints"
+            case task
+            case targetLanguage = "target_language"
+            case responseFormat = "response_format"
+            case prompt
+            case engine
+            case model
+        }
+    }
+
     private func handleTranscribe(_ request: HTTPRequest) async -> HTTPResponse {
         let audioData: Data
         var fileExtension = "wav"
-        var language: String?
-        var languageHints: [String] = []
-        var task: TranscriptionTask = .transcribe
-        var targetLanguage: String?
-        var responseFormat = "json"
-        var requestPrompt: String?
-        var engineOverride: String?
-        var modelOverride: String?
+        var options = TranscribeOptions(awaitDownload: request.queryParams["await_download"] == "1")
 
         let contentType = request.headers["content-type"] ?? ""
 
@@ -84,10 +114,10 @@ final class APIHandlers: @unchecked Sendable {
             if let langPart = parts.first(where: { $0.name == "language" }),
                let val = String(data: langPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !val.isEmpty {
-                language = val
+                options.language = val
             }
 
-            languageHints = parts
+            options.languageHints = parts
                 .filter { $0.name == "language_hint" }
                 .compactMap { String(data: $0.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty }
@@ -95,64 +125,64 @@ final class APIHandlers: @unchecked Sendable {
             if let taskPart = parts.first(where: { $0.name == "task" }),
                let val = String(data: taskPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                let parsed = TranscriptionTask(rawValue: val) {
-                task = parsed
+                options.task = parsed
             }
 
             if let targetPart = parts.first(where: { $0.name == "target_language" }),
                let val = String(data: targetPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !val.isEmpty {
-                targetLanguage = val
+                options.targetLanguage = val
             }
 
             if let formatPart = parts.first(where: { $0.name == "response_format" }),
                let val = String(data: formatPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !val.isEmpty {
-                responseFormat = val
+                options.responseFormat = val
             }
 
             if let promptPart = parts.first(where: { $0.name == "prompt" }),
                let val = String(data: promptPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !val.isEmpty {
-                requestPrompt = val
+                options.requestPrompt = val
             }
 
             if let enginePart = parts.first(where: { $0.name == "engine" }),
                let val = String(data: enginePart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !val.isEmpty {
-                engineOverride = val
+                options.engineOverride = val
             }
 
             if let modelPart = parts.first(where: { $0.name == "model" }),
                let val = String(data: modelPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !val.isEmpty {
-                modelOverride = val
+                options.modelOverride = val
             }
         } else if !request.body.isEmpty {
             audioData = request.body
             fileExtension = extensionFromMIME(contentType)
-            language = request.headers["x-language"]
-            languageHints = request.headers["x-language-hints"]?
+            options.language = request.headers["x-language"]
+            options.languageHints = request.headers["x-language-hints"]?
                 .split(separator: ",")
                 .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty } ?? []
             if let taskStr = request.headers["x-task"], let parsed = TranscriptionTask(rawValue: taskStr) {
-                task = parsed
+                options.task = parsed
             }
-            targetLanguage = request.headers["x-target-language"]
+            options.targetLanguage = request.headers["x-target-language"]
             if let format = request.headers["x-response-format"], !format.isEmpty {
-                responseFormat = format
+                options.responseFormat = format
             }
             if let prompt = request.headers["x-prompt"]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !prompt.isEmpty {
-                requestPrompt = prompt
+                options.requestPrompt = prompt
             }
             if let engine = request.headers["x-engine"]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !engine.isEmpty {
-                engineOverride = engine
+                options.engineOverride = engine
             }
             if let model = request.headers["x-model"]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !model.isEmpty {
-                modelOverride = model
+                options.modelOverride = model
             }
         } else {
             return .error(status: 400, message: "No audio data provided")
@@ -162,14 +192,72 @@ final class APIHandlers: @unchecked Sendable {
             return .error(status: 400, message: "Empty audio data")
         }
 
-        if language != nil, !languageHints.isEmpty {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".\(fileExtension)")
+
+        do {
+            try audioData.write(to: tempURL)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+            let samples = try await audioFileService.loadAudioSamples(from: tempURL)
+            return await transcribeLoadedSamples(samples, options: options)
+        } catch {
+            return .error(status: 500, message: "Transcription failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleTranscribeLocalFile(_ request: HTTPRequest) async -> HTTPResponse {
+        guard !request.body.isEmpty else {
+            return .error(status: 400, message: "Missing JSON body")
+        }
+
+        let payload: LocalFileTranscribeRequest
+        do {
+            payload = try JSONDecoder().decode(LocalFileTranscribeRequest.self, from: request.body)
+        } catch {
+            return .error(status: 400, message: "Invalid JSON body")
+        }
+
+        let fileURL = URL(fileURLWithPath: payload.path)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .error(status: 400, message: "File not found")
+        }
+
+        guard AudioFileService.supportedExtensions.contains(fileURL.pathExtension.lowercased()) else {
+            return .error(status: 400, message: "Unsupported audio format")
+        }
+
+        var options = TranscribeOptions(awaitDownload: request.queryParams["await_download"] == "1")
+        options.language = payload.language?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        options.languageHints = payload.languageHints?.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty } ?? []
+        if let task = payload.task.flatMap(TranscriptionTask.init(rawValue:)) {
+            options.task = task
+        }
+        options.targetLanguage = payload.targetLanguage?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        if let responseFormat = payload.responseFormat?.trimmingCharacters(in: .whitespacesAndNewlines), !responseFormat.isEmpty {
+            options.responseFormat = responseFormat
+        }
+        options.requestPrompt = payload.prompt?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        options.engineOverride = payload.engine?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        options.modelOverride = payload.model?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+
+        do {
+            let samples = try await audioFileService.loadAudioSamples(from: fileURL)
+            return await transcribeLoadedSamples(samples, options: options)
+        } catch {
+            return .error(status: 500, message: "Transcription failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func transcribeLoadedSamples(_ samples: [Float], options: TranscribeOptions) async -> HTTPResponse {
+        if options.language != nil, !options.languageHints.isEmpty {
             return .error(status: 400, message: "Use either 'language' or 'language_hint', not both")
         }
 
-        let awaitDownload = (request.queryParams["await_download"] == "1")
-
         let resolvedOverride: ResolvedOverride
-        switch await resolveEngineModelOverride(engine: engineOverride, model: modelOverride, awaitDownload: awaitDownload) {
+        switch await resolveEngineModelOverride(
+            engine: options.engineOverride,
+            model: options.modelOverride,
+            awaitDownload: options.awaitDownload
+        ) {
         case .use(let value):
             resolvedOverride = value
         case .reject(let response):
@@ -183,13 +271,7 @@ final class APIHandlers: @unchecked Sendable {
             }
         }
 
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".\(fileExtension)")
-
         do {
-            try audioData.write(to: tempURL)
-            defer { try? FileManager.default.removeItem(at: tempURL) }
-
-            let samples = try await audioFileService.loadAudioSamples(from: tempURL)
             let effectiveProviderId: String?
             if let engineId = resolvedOverride.engineId {
                 effectiveProviderId = engineId
@@ -199,11 +281,11 @@ final class APIHandlers: @unchecked Sendable {
             let dictionaryPrompt = await MainActor.run {
                 dictionaryService.getTermsForPrompt(providerId: effectiveProviderId)
             }
-            let prompt = mergedPrompt(requestPrompt: requestPrompt, dictionaryPrompt: dictionaryPrompt)
+            let prompt = mergedPrompt(requestPrompt: options.requestPrompt, dictionaryPrompt: dictionaryPrompt)
             let languageSelection: LanguageSelection
-            if !languageHints.isEmpty {
-                languageSelection = LanguageSelection.auto.withSelectedCodes(languageHints, nilBehavior: .auto)
-            } else if let language {
+            if !options.languageHints.isEmpty {
+                languageSelection = LanguageSelection.auto.withSelectedCodes(options.languageHints, nilBehavior: .auto)
+            } else if let language = options.language {
                 languageSelection = .exact(language)
             } else {
                 languageSelection = .auto
@@ -211,14 +293,14 @@ final class APIHandlers: @unchecked Sendable {
             let result = try await modelManager.transcribe(
                 audioSamples: samples,
                 languageSelection: languageSelection,
-                task: task,
+                task: options.task,
                 engineOverrideId: resolvedOverride.engineId,
                 cloudModelOverride: resolvedOverride.modelId,
                 prompt: prompt
             )
 
             var finalText = result.text
-            if let targetCode = targetLanguage {
+            if let targetCode = options.targetLanguage {
                 #if canImport(Translation)
                 if #available(macOS 15, *), let ts = translationService as? TranslationService {
                     if let targetNormalized = TranslationService.normalizedLanguageIdentifier(from: targetCode) {
@@ -259,7 +341,7 @@ final class APIHandlers: @unchecked Sendable {
                 engineUsed: result.engineUsed
             )
 
-            if responseFormat == "verbose_json" {
+            if options.responseFormat == "verbose_json" {
                 struct SegmentEntry: Encodable {
                     let start: Double
                     let end: Double
@@ -848,5 +930,11 @@ final class APIHandlers: @unchecked Sendable {
         if lower.contains("ogg") { return "ogg" }
         if lower.contains("aac") { return "aac" }
         return "wav"
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/TypeWhisper/Services/HTTPServer/HTTPRequestParser.swift
+++ b/TypeWhisper/Services/HTTPServer/HTTPRequestParser.swift
@@ -22,7 +22,7 @@ enum HTTPParseError: Error, Equatable {
 }
 
 enum HTTPRequestParser {
-    static let maxBodySize = 100 * 1024 * 1024 // 100 MB
+    static let maxBodySize = 256 * 1024 * 1024 // 256 MiB
 
     static func parse(_ data: Data) throws -> HTTPRequest {
         guard let headerEnd = data.findDoubleCRLF() else {

--- a/TypeWhisper/Services/HTTPServer/HTTPServer.swift
+++ b/TypeWhisper/Services/HTTPServer/HTTPServer.swift
@@ -83,6 +83,9 @@ final class HTTPServer: @unchecked Sendable {
                 } else {
                     self.receiveData(on: connection, buffer: accumulated)
                 }
+            } catch HTTPParseError.bodyTooLarge {
+                let response = HTTPResponse.error(status: 413, message: "Payload too large. Maximum request body size is 256 MiB.")
+                self.send(response, on: connection)
             } catch {
                 let response = HTTPResponse.error(status: 400, message: "Malformed request")
                 self.send(response, on: connection)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -778,6 +778,130 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
     }
 
+    func testTranscribeLocalFileEndpointTranscribesTemporaryWavFile() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let fileURL = audioDirectory.appendingPathComponent("large-file.wav")
+        try WavEncoder.encode(Array(repeating: Float(0), count: 1600)).write(to: fileURL)
+
+        let response = try Self.jsonObject(await XCTUnwrap(context?.router).route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["path": fileURL.path])
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "transcribed")
+        XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.languageHints, [])
+        XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
+    }
+
+    func testTranscribeLocalFileEndpointUsesLanguageHintsAndEngineModelOverrides() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let fileURL = audioDirectory.appendingPathComponent("hinted.wav")
+        try WavEncoder.encode(Array(repeating: Float(0), count: 1600)).write(to: fileURL)
+
+        let body: [String: Any] = [
+            "path": fileURL.path,
+            "language_hints": ["de", "en"],
+            "task": "transcribe",
+            "engine": "mock",
+            "model": "tiny"
+        ]
+        let response = try Self.jsonObject(await XCTUnwrap(context?.router).route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: body)
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "transcribed")
+        XCTAssertEqual(response["engine"] as? String, "mock")
+        XCTAssertEqual(response["model"] as? String, "tiny")
+        XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.languageHints, ["de", "en"])
+        XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
+    }
+
+    func testTranscribeLocalFileEndpointRejectsMissingAndUnsupportedFiles() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        let router = try XCTUnwrap(context?.router)
+
+        let missingResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: [
+                    "path": audioDirectory.appendingPathComponent("missing.wav").path
+                ])
+            )
+        )
+        let missingJSON = try Self.jsonObject(missingResponse)
+
+        XCTAssertEqual(missingResponse.status, 400)
+        XCTAssertEqual((missingJSON["error"] as? [String: Any])?["message"] as? String, "File not found")
+
+        let unsupportedURL = audioDirectory.appendingPathComponent("notes.txt")
+        try "not audio".write(to: unsupportedURL, atomically: true, encoding: .utf8)
+
+        let unsupportedResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["path": unsupportedURL.path])
+            )
+        )
+        let unsupportedJSON = try Self.jsonObject(unsupportedResponse)
+
+        XCTAssertEqual(unsupportedResponse.status, 400)
+        XCTAssertEqual((unsupportedJSON["error"] as? [String: Any])?["message"] as? String, "Unsupported audio format")
+    }
+
     func testTranscribeEndpointRejectsMixedLanguageAndHints() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -4,6 +4,21 @@ import XCTest
 @testable import TypeWhisper
 
 final class CLISupportTests: XCTestCase {
+    private final class RequestRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var request: URLRequest?
+
+        func record(_ request: URLRequest) {
+            lock.withLock {
+                self.request = request
+            }
+        }
+
+        var recordedRequest: URLRequest? {
+            lock.withLock { request }
+        }
+    }
+
     func testOutputFormatterRendersHumanReadableStatusAndModels() {
         let statusJSON = Data(#"{"status":"ready","engine":"parakeet","model":"tiny"}"#.utf8)
         let modelsJSON = Data(#"{"models":[{"id":"tiny","engine":"parakeet","name":"Tiny","status":"ready","selected":true}]}"#.utf8)
@@ -31,6 +46,81 @@ final class CLISupportTests: XCTestCase {
             options.validationError(),
             "Error: --language and --language-hint cannot be used together."
         )
+    }
+
+    func testCLIClientTranscribeLocalFileUsesLocalFileEndpointWithoutUploadingBytes() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(directory) }
+        let fileURL = directory.appendingPathComponent("large.mp4")
+        try Data("distinctive-video-bytes".utf8).write(to: fileURL)
+
+        let recorder = RequestRecorder()
+        let client = CLIClient(
+            port: 9876,
+            transport: { request in
+                recorder.record(request)
+                let body = #"{"text":"ok","language":null,"duration":1,"processing_time":0.1,"engine":"mock","model":"tiny"}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            }
+        )
+
+        _ = try await client.transcribe(
+            fileURL: fileURL,
+            language: nil,
+            languageHints: ["de", "en"],
+            task: "transcribe",
+            targetLanguage: nil,
+            engine: "mock",
+            model: "tiny"
+        )
+
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.url?.path, "/v1/transcribe/local-file")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let bodyData = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        XCTAssertEqual(body["path"] as? String, fileURL.path)
+        XCTAssertEqual(body["language_hints"] as? [String], ["de", "en"])
+        XCTAssertEqual(body["task"] as? String, "transcribe")
+        XCTAssertEqual(body["engine"] as? String, "mock")
+        XCTAssertEqual(body["model"] as? String, "tiny")
+        XCTAssertFalse(String(data: bodyData, encoding: .utf8)?.contains("distinctive-video-bytes") == true)
+    }
+
+    func testCLIClientTranscribeStdinKeepsMultipartUploadPath() async throws {
+        let recorder = RequestRecorder()
+        let client = CLIClient(
+            port: 9876,
+            transport: { request in
+                recorder.record(request)
+                let body = #"{"text":"ok","language":null,"duration":1,"processing_time":0.1,"engine":"mock","model":"tiny"}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            },
+            stdinReader: {
+                Data("stdin-audio-bytes".utf8)
+            }
+        )
+
+        _ = try await client.transcribe(
+            fileURL: nil,
+            language: "de",
+            languageHints: [],
+            task: "transcribe",
+            targetLanguage: nil,
+            engine: nil,
+            model: nil
+        )
+
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.url?.path, "/v1/transcribe")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertTrue(request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=") == true)
+
+        let bodyText = String(data: try XCTUnwrap(request.httpBody), encoding: .utf8)
+        XCTAssertTrue(bodyText?.contains("stdin-audio-bytes") == true)
+        XCTAssertTrue(bodyText?.contains("name=\"language\"") == true)
     }
 
     @MainActor

--- a/TypeWhisperTests/HTTPRequestParserTests.swift
+++ b/TypeWhisperTests/HTTPRequestParserTests.swift
@@ -3,6 +3,10 @@ import XCTest
 @testable import TypeWhisper
 
 final class HTTPRequestParserTests: XCTestCase {
+    func testMaxBodySizeIs256MiB() {
+        XCTAssertEqual(HTTPRequestParser.maxBodySize, 256 * 1024 * 1024)
+    }
+
     func testParseExtractsHeadersQueryAndBody() throws {
         let body = Data("hello".utf8)
         let requestData = Data("""

--- a/typewhisper-cli/CLIClient.swift
+++ b/typewhisper-cli/CLIClient.swift
@@ -46,8 +46,26 @@ enum CLIError: Error {
 }
 
 struct CLIClient {
+    typealias Transport = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
     let port: UInt16
+    private let transport: Transport
+    private let stdinReader: @Sendable () -> Data
     private var baseURL: String { "http://127.0.0.1:\(port)" }
+
+    init(
+        port: UInt16,
+        transport: @escaping Transport = { request in
+            try await URLSession.shared.data(for: request)
+        },
+        stdinReader: @escaping @Sendable () -> Data = {
+            FileHandle.standardInput.readDataToEndOfFile()
+        }
+    ) {
+        self.port = port
+        self.transport = transport
+        self.stdinReader = stdinReader
+    }
 
     func status() async throws -> Data {
         try await get("/v1/status")
@@ -67,23 +85,25 @@ struct CLIClient {
         model: String? = nil,
         awaitDownload: Bool = false
     ) async throws -> Data {
-        let audioData: Data
-        let filename: String
-
         if let fileURL {
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
                 throw CLIError.fileNotFound(fileURL.path)
             }
-            audioData = try Data(contentsOf: fileURL)
-            filename = fileURL.lastPathComponent
-        } else {
-            // Read from stdin
-            let stdinData = FileHandle.standardInput.readDataToEndOfFile()
-            guard !stdinData.isEmpty else {
-                throw CLIError.stdinEmpty
-            }
-            audioData = stdinData
-            filename = "audio.wav"
+            return try await transcribeLocalFile(
+                fileURL: fileURL,
+                language: language,
+                languageHints: languageHints,
+                task: task,
+                targetLanguage: targetLanguage,
+                engine: engine,
+                model: model,
+                awaitDownload: awaitDownload
+            )
+        }
+
+        let audioData = stdinReader()
+        guard !audioData.isEmpty else {
+            throw CLIError.stdinEmpty
         }
 
         let boundary = UUID().uuidString
@@ -91,7 +111,7 @@ struct CLIClient {
 
         // File field
         body.append("--\(boundary)\r\n")
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n")
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n")
         body.append("Content-Type: application/octet-stream\r\n\r\n")
         body.append(audioData)
         body.append("\r\n")
@@ -134,6 +154,52 @@ struct CLIClient {
 
     // MARK: - Private
 
+    private func transcribeLocalFile(
+        fileURL: URL,
+        language: String?,
+        languageHints: [String],
+        task: String?,
+        targetLanguage: String?,
+        engine: String?,
+        model: String?,
+        awaitDownload: Bool
+    ) async throws -> Data {
+        var payload: [String: Any] = [
+            "path": fileURL.path
+        ]
+        if let language {
+            payload["language"] = language
+        }
+        if !languageHints.isEmpty {
+            payload["language_hints"] = languageHints
+        }
+        if let task {
+            payload["task"] = task
+        }
+        if let targetLanguage {
+            payload["target_language"] = targetLanguage
+        }
+        if let engine {
+            payload["engine"] = engine
+        }
+        if let model {
+            payload["model"] = model
+        }
+
+        var transcribePath = "/v1/transcribe/local-file"
+        if awaitDownload {
+            transcribePath += "?await_download=1"
+        }
+        let url = URL(string: "\(baseURL)\(transcribePath)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        request.timeoutInterval = 300
+
+        return try await performRequest(request)
+    }
+
     private func get(_ path: String) async throws -> Data {
         let url = URL(string: "\(baseURL)\(path)")!
         var request = URLRequest(url: url)
@@ -145,7 +211,7 @@ struct CLIClient {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await transport(request)
         } catch {
             throw CLIError.connectionFailed(port: port)
         }


### PR DESCRIPTION
## Summary

Fixes #405, where `typewhisper transcribe large_file.mp4` failed with `400 Bad Request` while the same file worked through the app UI.

**CLI large-file handoff**
- Local CLI file paths now call `POST /v1/transcribe/local-file` with JSON containing the absolute path and transcription options.
- The CLI no longer loads local files with `Data(contentsOf:)` or uploads file bytes through multipart for normal file-path usage.
- Stdin usage with `typewhisper transcribe -` still uses the existing multipart upload path.

**Local API behavior**
- Added the internal `/v1/transcribe/local-file` route.
- Shared transcription handling now keeps multipart, raw-body, and local-file requests on the same engine/model override, dictionary prompt, translation, and JSON response path.
- Local-file requests validate file existence and supported audio/video extensions before loading samples through `AudioFileService`.

**Upload limits**
- Raised regular HTTP upload body limit from 100 MiB to 256 MiB.
- Oversized HTTP bodies now return `413 Payload too large` instead of falling through to a generic malformed-request response.

**Docs**
- Documented that `/v1/transcribe` uploads and CLI stdin uploads are limited to 256 MiB.
- Documented that CLI local file paths use direct handoff to the running TypeWhisper app.

Closes #405

## Documentation

Public docs PR: https://github.com/TypeWhisper/typewhisper.com/pull/47

Doc diff preview:
- `README.md`: documents the 256 MiB `/v1/transcribe` and stdin upload limit plus the local CLI file handoff.
- `typewhisper.com/src/pages/docs/mac/_cli.tsx`: adds a public macOS CLI section for large-file behavior.
- `typewhisper.com/src/pages/docs/mac/_api.tsx`: documents the 256 MiB upload limit and `413 Payload Too Large` response.
- `typewhisper.com/src/i18n/locales/en.json` and `de.json`: add English and German strings for the new public docs content.

## Test Coverage

All new code paths have targeted XCTest coverage:

- `/v1/transcribe/local-file` transcribes a temporary WAV file with the mock transcription plugin.
- `/v1/transcribe/local-file` passes `language_hints`, `task`, `engine`, and `model` through the shared transcription path.
- Missing paths and unsupported extensions return `400`.
- `HTTPRequestParser.maxBodySize` is asserted at 256 MiB, and existing oversize parsing coverage adapts to the new limit.
- `CLIClient.transcribe(fileURL:)` sends JSON to `/v1/transcribe/local-file` without embedding file bytes.
- `CLIClient.transcribe(fileURL: nil)` keeps the multipart stdin upload path.

## Pre-Landing Review

No issues found.

## Design Review

No frontend UI files changed. SwiftUI/web design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: Fix CLI transcription failures for large local files while keeping conventional HTTP/stdin uploads bounded.

Delivered: Added a local-file API handoff for CLI file paths, a documented 256 MiB upload limit, 413 handling, and focused regression tests.

## Plan Completion

All issue #405 plan items were addressed except a live manual smoke with a real file over 100 MiB, which requires a running local TypeWhisper API server and a suitable local test asset.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/HTTPRequestParserTests -only-testing:TypeWhisperTests/CLISupportTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`

Manual smoke not run:

```bash
/usr/local/bin/typewhisper transcribe /path/to/large_file_over_100mb.mp4 --json
```
