### PR TITLE
feat: add manual workflow trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 - **Unified Workflows** - Prompt actions and matching rules now live in one dedicated workflow surface with a native editor and guided creation flow
 - **Always fallback trigger** - Create a global workflow that runs when no more specific app, website, or hotkey workflow matches
+- **Manual workflow palette** - Keep workflows out of automatic dictation matching and run them from one global Workflow Palette shortcut
 - **Safer prompt boundaries** - Workflow prompts treat dictated text as source content to transform, not instructions to execute
 - **Focus-safe local processing** - On-device workflows keep focus in the original target app instead of foregrounding TypeWhisper unexpectedly
 - **Snippets and dictionary polish** - Snippets are first-class settings, dictionary term packs are easier to review, and corrections stay engine-aware
@@ -70,14 +71,14 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 ### AI Processing
 
-- **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app or website, from a dedicated hotkey, or as a global fallback
+- **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app or website, from a dedicated hotkey, as a global fallback, or manually from the Workflow Palette
 - **LLM providers** - Apple Intelligence (macOS 26+), Groq, OpenAI / ChatGPT, Gemini, and OpenAI Compatible with per-prompt provider and model override
 - **Local prompt processing** - Gemma 4 via MLX runs on-device on Apple Silicon, with the current verified release path limited to the E2B/E4B 4-bit models
 - **Translation** - Translate transcriptions on-device using Apple Translate
 
 ### Personalization
 
-- **Workflow triggers** - Per-app, per-website, hotkey, and global fallback triggers for language, task, engine, prompt, and auto-submit behavior. Website matching supports subdomains
+- **Workflow triggers** - Per-app, per-website, hotkey, global fallback, and manual palette-only triggers for language, task, engine, prompt, and auto-submit behavior. Website matching supports subdomains
 - **Dictionary** - Terms improve cloud recognition accuracy. Corrections fix common transcription mistakes automatically. Auto-learns from manual corrections. Includes importable term packs
 - **Localized term packs** - Built-in term pack names and descriptions are localized in English and German
 - **Snippets** - Text shortcuts with trigger/replacement. Supports placeholders like `{{DATE}}`, `{{TIME}}`, and `{{CLIPBOARD}}`
@@ -364,7 +365,7 @@ The CLI requires the API server to be running (Settings > Advanced) and follows 
 
 ## Workflows
 
-Workflows let you configure transcription, transformation, and automation behavior per application, website, hotkey, or global fallback. For example:
+Workflows let you configure transcription, transformation, and automation behavior per application, website, hotkey, global fallback, or manual palette-only workflow. For example:
 
 - **Mail** - German language, Whisper Large v3
 - **Slack** - English language, Parakeet TDT v3
@@ -372,13 +373,15 @@ Workflows let you configure transcription, transformation, and automation behavi
 - **github.com** - English cleanup workflow that matches in any browser
 - **docs.google.com** - German dictation workflow that translates to English
 
-Create workflows in Settings > Workflows. Choose a template, assign an app, website, hotkey, or Always trigger, then configure language/task/engine overrides, prompt processing, auto-submit behavior, and priority. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. Website patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`.
+Create workflows in Settings > Workflows. Choose a template, assign an app, website, hotkey, Always, or Manual trigger, then configure language/task/engine overrides, prompt processing, auto-submit behavior, and priority. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. Website patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`.
 
 When you start dictating, TypeWhisper matches the active app and browser URL against enabled workflows with the following priority:
 1. **App + URL match** - highest specificity (e.g. Chrome + github.com)
 2. **URL-only match** - cross-browser workflows (e.g. github.com in any browser)
 3. **App-only match** - generic app workflows (e.g. all of Chrome)
 4. **Always fallback** - global workflow when no more specific workflow matches
+
+Manual workflows are excluded from automatic dictation matching. They appear only in the Workflow Palette and use the existing Workflow Palette hotkey.
 
 The active workflow name is shown as a badge in the indicator, together with a short explanation of why it matched.
 

--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -116,6 +116,7 @@ enum WorkflowTriggerKind: String, CaseIterable, Codable, Sendable {
     case website
     case hotkey
     case global
+    case manual
 }
 
 struct WorkflowTrigger: Codable, Equatable, Sendable {
@@ -164,6 +165,10 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
         WorkflowTrigger(kind: .global)
     }
 
+    static func manual() -> WorkflowTrigger {
+        WorkflowTrigger(kind: .manual)
+    }
+
     var appBundleIdentifier: String? {
         appBundleIdentifiers.first
     }
@@ -184,7 +189,7 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
             !websitePatterns.isEmpty
         case .hotkey:
             !hotkeys.isEmpty
-        case .global:
+        case .global, .manual:
             true
         }
     }
@@ -286,6 +291,8 @@ final class Workflow {
                 return .hotkey(hotkey)
             case .global:
                 return .global()
+            case .manual:
+                return .manual()
             }
         }
         set {
@@ -314,7 +321,7 @@ final class Workflow {
                 triggerAppBundleIdentifier = nil
                 triggerWebsitePattern = nil
                 triggerHotkeyData = newValue.hotkeys.first.flatMap { try? JSONEncoder().encode($0) }
-            case .global:
+            case .global, .manual:
                 triggerAppBundleIdentifier = nil
                 triggerWebsitePattern = nil
                 triggerHotkeyData = nil
@@ -384,6 +391,8 @@ extension WorkflowTriggerKind {
             localizedAppText("Hotkey", de: "Hotkey")
         case .global:
             localizedAppText("Always", de: "Immer")
+        case .manual:
+            localizedAppText("Manual", de: "Manuell")
         }
     }
 }

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -60,8 +60,8 @@ struct HotkeySettingsView: View {
                 )
 
                 Text(localizedAppText(
-                    "Select text in any app, press the shortcut, and choose a workflow to process the text.",
-                    de: "Markiere Text in einer App, drücke den Shortcut und wähle einen Workflow für die Verarbeitung."
+                    "Select or copy text in any app, press the shortcut, and choose a manual workflow to process the text.",
+                    de: "Markiere oder kopiere Text in einer App, drücke den Shortcut und wähle einen manuellen Workflow für die Verarbeitung."
                 ))
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -67,7 +67,7 @@ final class PromptPaletteController: PromptPaletteControlling {
             triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.websitePatterns.joined(separator: ", "))"
         case .hotkey:
             triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", "))"
-        case .global:
+        case .global, .manual:
             triggerSummary = trigger.kind.paletteLabel
         }
 

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1032,12 +1032,13 @@ private struct WorkflowEditorPage: View {
         WorkflowSectionCard(
             title: localizedAppText("Trigger", de: "Trigger"),
             description: localizedAppText(
-                "Choose how this workflow starts. Always runs when no specific workflow matches.",
-                de: "Wähle, wie dieser Workflow startet. Immer greift, wenn kein spezifischer Workflow passt."
+                "Choose how this workflow starts. Manual workflows are available from the Workflow Palette only.",
+                de: "Wähle, wie dieser Workflow startet. Manuelle Workflows sind nur über die Workflow-Palette verfügbar."
             )
         ) {
             VStack(alignment: .leading, spacing: 14) {
                 Picker(localizedAppText("Trigger", de: "Trigger"), selection: $draft.triggerKind) {
+                    Text(localizedAppText("Manual", de: "Manuell")).tag(WorkflowTriggerKind.manual)
                     Text(localizedAppText("App", de: "App")).tag(WorkflowTriggerKind.app)
                     Text(localizedAppText("Website", de: "Website")).tag(WorkflowTriggerKind.website)
                     Text(localizedAppText("Hotkey", de: "Hotkey")).tag(WorkflowTriggerKind.hotkey)
@@ -1046,6 +1047,8 @@ private struct WorkflowEditorPage: View {
                 .pickerStyle(.segmented)
 
                 switch draft.triggerKind {
+                case .manual:
+                    manualTriggerEditor
                 case .app:
                     appTriggerEditor
                 case .website:
@@ -1074,6 +1077,34 @@ private struct WorkflowEditorPage: View {
                         .fill(Color.accentColor.opacity(0.08))
                 }
         }
+    }
+
+    private var manualTriggerEditor: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "list.bullet.rectangle")
+                .foregroundStyle(.secondary)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(localizedAppText("Manual", de: "Manuell"))
+                    .font(.subheadline.weight(.medium))
+
+                Text(
+                    localizedAppText(
+                        "Available from the Workflow Palette. It never runs automatically after dictation.",
+                        de: "Verfügbar über die Workflow-Palette. Läuft nach dem Diktat nie automatisch."
+                    )
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(workflowsGroupedSurface(cornerRadius: 12))
     }
 
     private var appTriggerEditor: some View {
@@ -1732,7 +1763,7 @@ private struct WorkflowDraft {
         self.name = template.definition.name
         self.isEnabled = true
         self.template = template
-        self.triggerKind = .hotkey
+        self.triggerKind = .manual
         self.appBundleIdentifiers = []
         self.websitePatterns = []
         self.hotkeys = []
@@ -1790,9 +1821,14 @@ private struct WorkflowDraft {
                 self.appBundleIdentifiers = []
                 self.websitePatterns = []
                 self.hotkeys = []
+            case .manual:
+                self.triggerKind = .manual
+                self.appBundleIdentifiers = []
+                self.websitePatterns = []
+                self.hotkeys = []
             }
         } else {
-            self.triggerKind = .app
+            self.triggerKind = .manual
             self.appBundleIdentifiers = []
             self.websitePatterns = []
             self.hotkeys = []
@@ -1805,6 +1841,13 @@ private struct WorkflowDraft {
     }
 
     var reviewText: String {
+        if triggerKind == .manual {
+            return localizedAppText(
+                "\(resolvedName) is available as \(template.definition.name) from the Workflow Palette.",
+                de: "\(resolvedName) ist als \(template.definition.name) über die Workflow-Palette verfügbar."
+            )
+        }
+
         if triggerKind == .global {
             return localizedAppText(
                 "\(resolvedName) runs always as \(template.definition.name).",
@@ -1902,7 +1945,7 @@ private struct WorkflowDraft {
                     )
                 }
             }
-        case .global:
+        case .global, .manual:
             break
         }
 
@@ -1940,6 +1983,8 @@ private struct WorkflowDraft {
             return .hotkeys(hotkeys)
         case .global:
             return .global()
+        case .manual:
+            return .manual()
         }
     }
 
@@ -2011,6 +2056,8 @@ private struct WorkflowDraft {
             return localizedAppText("a hotkey", de: "einen Hotkey")
         case .global:
             return localizedAppText("always", de: "immer")
+        case .manual:
+            return localizedAppText("the Workflow Palette", de: "die Workflow-Palette")
         }
     }
 
@@ -2059,6 +2106,8 @@ private func workflowTriggerSummary(for workflow: Workflow) -> String {
     }
 
     switch trigger.kind {
+    case .manual:
+        return localizedAppText("Manual", de: "Manuell")
     case .app:
         return trigger.appBundleIdentifiers.count == 1
             ? localizedAppText("App", de: "App")
@@ -2080,6 +2129,8 @@ private func workflowTriggerDetail(for workflow: Workflow) -> String {
     guard let trigger = workflow.trigger else { return "" }
 
     switch trigger.kind {
+    case .manual:
+        return localizedAppText("Workflow Palette", de: "Workflow-Palette")
     case .app:
         return workflowCompactList(trigger.appBundleIdentifiers.map(workflowAppDisplayName(for:)))
     case .website:
@@ -2100,6 +2151,13 @@ private func workflowReviewText(for workflow: Workflow) -> String {
         return localizedAppText(
             "\(summary) runs always",
             de: "\(summary) läuft immer"
+        )
+    }
+
+    if workflow.trigger?.kind == .manual {
+        return localizedAppText(
+            "\(summary) is available from the Workflow Palette",
+            de: "\(summary) ist über die Workflow-Palette verfügbar"
         )
     }
 

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -142,6 +142,44 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(returnCount, 0)
         XCTAssertEqual(pasteboard.string(forType: .string), "Insert me")
     }
+
+    func testWorkflowPaletteIncludesManualWorkflows() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", nil, nil) }
+        textInsertionService.textSelectionOverride = {
+            TextInsertionService.TextSelection(
+                text: "Selected text",
+                element: AXUIElementCreateSystemWide()
+            )
+        }
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = workflowService.addWorkflow(
+            name: "Manual Summary",
+            template: .summary,
+            trigger: .manual()
+        )
+
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            promptProcessingService: PromptProcessingService(),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller
+        )
+
+        handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
+
+        XCTAssertTrue(controller.isVisible)
+        XCTAssertEqual(controller.lastWorkflows?.map(\.name), ["Manual Summary"])
+        XCTAssertEqual(controller.lastSourceText, "Selected text")
+    }
 }
 
 @MainActor

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -312,6 +312,24 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(workflow.trigger, try globalTrigger())
     }
 
+    func testWorkflowServicePersistsManualTrigger() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        service.addWorkflow(
+            name: "Manual Summary",
+            template: .summary,
+            trigger: try manualTrigger()
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(workflow.trigger?.kind.rawValue, "manual")
+        XCTAssertEqual(workflow.trigger, try manualTrigger())
+    }
+
     func testMatchWorkflowUsesGlobalAsFallback() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }
@@ -387,6 +405,32 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertNil(service.matchWorkflow(bundleIdentifier: "com.apple.TextEdit", url: nil))
     }
 
+    func testMatchWorkflowNeverUsesManualTrigger() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Manual Summary",
+            template: .summary,
+            trigger: try manualTrigger(),
+            sortOrder: 0
+        )
+
+        XCTAssertNil(service.matchWorkflow(bundleIdentifier: "com.apple.TextEdit", url: nil))
+
+        _ = service.addWorkflow(
+            name: "Always Cleanup",
+            template: .custom,
+            trigger: try globalTrigger(),
+            sortOrder: 1
+        )
+
+        let match = try XCTUnwrap(service.matchWorkflow(bundleIdentifier: "com.apple.TextEdit", url: nil))
+        XCTAssertEqual(match.workflow.name, "Always Cleanup")
+        XCTAssertEqual(match.kind, .globalFallback)
+    }
+
     func testMatchWorkflowUsesSortOrderForMultipleGlobalFallbacks() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }
@@ -426,6 +470,20 @@ private func globalTrigger(
     )
     XCTAssertEqual(kind, .global, file: file, line: line)
     return .global()
+}
+
+private func manualTrigger(
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> WorkflowTrigger {
+    let kind = try XCTUnwrap(
+        WorkflowTriggerKind(rawValue: "manual"),
+        "WorkflowTriggerKind.manual should decode from the persisted raw value.",
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(kind, .manual, file: file, line: line)
+    return .manual()
 }
 
 final class WatchFolderExportTests: XCTestCase {


### PR DESCRIPTION
## Summary

This restores the universal workflow-menu use case from #406 by adding a palette-only manual workflow trigger.

- Add a persisted `manual` workflow trigger kind and factory helper.
- Default newly created workflows to Manual so they can be saved without app, website, hotkey, or Always trigger details.
- Show manual workflows in the Workflow Palette with localized labels and search metadata.
- Keep dictation-time automatic matching limited to website, app, and global fallback workflows; manual workflows never match automatically.
- Keep workflow hotkey sync limited to dedicated hotkey workflows.
- Update settings and README copy to describe Manual as palette-only.

Closes #406

## Issue Context

Issue #406 reports that after the workflow update every workflow appeared to require an app, website, individual hotkey, or Always trigger. The user wanted the old universal workflow menu behavior: one global shortcut opens the workflow selection panel, and workflows can be run manually without being automatically applied after dictation.

## Test Coverage

Manual workflow paths covered:

- Persist and reload the `manual` trigger raw value.
- Verify `matchWorkflow(bundleIdentifier:url:)` never returns manual workflows, including as fallback.
- Verify enabled manual workflows appear in the Workflow Palette.
- Existing hotkey compatibility tests confirm dedicated workflow hotkey behavior remains unchanged.

## Pre-Landing Review

No issues found.

## Design Review

SwiftUI settings copy changed, but web-oriented design review was skipped for this macOS app workflow. Dedicated visual QA can be run separately if needed.

## Eval Results

No prompt-eval suites are configured for this TypeWhisper app change.

## Scope Drift

Scope Check: CLEAN. Delivered the requested Manual/Palette-only workflow type without adding a new API route or global hotkey slot.

## Plan Completion

No plan file detected. The implementation matches the issue plan in the conversation: manual trigger, settings UI, palette availability, no automatic matching, hotkey sync unchanged, docs/tests updated.

## Verification Results

- Full app XCTest suite passed: 415 tests, 0 failures.
- Fresh dev build passed and produced `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

## Test Plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/conductor/workspaces/typewhisper-mac/kabul-v1`
- [x] `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests`
