### PR TITLE
fix: support right-side modifier hotkeys

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -9,6 +9,9 @@ struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
     let modifierFlags: UInt
     let isFn: Bool
     let isDoubleTap: Bool
+    /// Physical modifier key codes for side-specific modifier combos.
+    /// Empty means legacy/generic matching by modifier flags only.
+    let modifierKeyCodes: Set<UInt16>
     /// nil = keyboard hotkey; 0..N = mouse button number (macOS convention: 2=middle, 3=back, 4=forward)
     let mouseButton: UInt16?
 
@@ -34,11 +37,18 @@ struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
         return .bareKey
     }
 
-    init(keyCode: UInt16, modifierFlags: UInt, isFn: Bool, isDoubleTap: Bool = false) {
+    init(
+        keyCode: UInt16,
+        modifierFlags: UInt,
+        isFn: Bool,
+        isDoubleTap: Bool = false,
+        modifierKeyCodes: Set<UInt16> = []
+    ) {
         self.keyCode = keyCode
         self.modifierFlags = modifierFlags
         self.isFn = isFn
         self.isDoubleTap = isDoubleTap
+        self.modifierKeyCodes = modifierKeyCodes
         self.mouseButton = nil
     }
 
@@ -47,17 +57,37 @@ struct UnifiedHotkey: Equatable, Hashable, Sendable, Codable {
         self.modifierFlags = 0
         self.isFn = false
         self.isDoubleTap = isDoubleTap
+        self.modifierKeyCodes = []
         self.mouseButton = mouseButton
     }
 
-    // Backward-compatible decoding: old hotkeys without isDoubleTap/mouseButton decode correctly
+    // Backward-compatible decoding: old hotkeys without isDoubleTap/modifierKeyCodes/mouseButton decode correctly
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         keyCode = try container.decode(UInt16.self, forKey: .keyCode)
         modifierFlags = try container.decode(UInt.self, forKey: .modifierFlags)
         isFn = try container.decode(Bool.self, forKey: .isFn)
         isDoubleTap = try container.decodeIfPresent(Bool.self, forKey: .isDoubleTap) ?? false
+        modifierKeyCodes = try container.decodeIfPresent(Set<UInt16>.self, forKey: .modifierKeyCodes) ?? []
         mouseButton = try container.decodeIfPresent(UInt16.self, forKey: .mouseButton)
+    }
+
+    func conflicts(with other: UnifiedHotkey) -> Bool {
+        if self == other { return true }
+        guard keyCode == other.keyCode,
+              modifierFlags == other.modifierFlags,
+              isFn == other.isFn,
+              mouseButton == other.mouseButton else {
+            return false
+        }
+
+        if kind == .modifierCombo, other.kind == .modifierCombo {
+            return modifierKeyCodes.isEmpty
+                || other.modifierKeyCodes.isEmpty
+                || modifierKeyCodes == other.modifierKeyCodes
+        }
+
+        return isDoubleTap != other.isDoubleTap
     }
 }
 
@@ -275,12 +305,7 @@ final class HotkeyService: ObservableObject {
     func isHotkeyAssigned(_ hotkey: UnifiedHotkey, excluding: HotkeySlotType) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases where slotType != excluding {
             guard let existing = slots[slotType]?.hotkey else { continue }
-            if existing == hotkey { return slotType }
-            if existing.keyCode == hotkey.keyCode
-                && existing.modifierFlags == hotkey.modifierFlags
-                && existing.isFn == hotkey.isFn
-                && existing.mouseButton == hotkey.mouseButton
-                && existing.isDoubleTap != hotkey.isDoubleTap {
+            if existing.conflicts(with: hotkey) {
                 return slotType
             }
         }
@@ -327,12 +352,7 @@ final class HotkeyService: ObservableObject {
 
     func isHotkeyAssignedToProfile(_ hotkey: UnifiedHotkey, excludingProfileId: UUID?) -> UUID? {
         for (id, state) in profileSlots where id != excludingProfileId {
-            if state.hotkey == hotkey { return id }
-            if state.hotkey.keyCode == hotkey.keyCode
-                && state.hotkey.modifierFlags == hotkey.modifierFlags
-                && state.hotkey.isFn == hotkey.isFn
-                && state.hotkey.mouseButton == hotkey.mouseButton
-                && state.hotkey.isDoubleTap != hotkey.isDoubleTap {
+            if state.hotkey.conflicts(with: hotkey) {
                 return id
             }
         }
@@ -342,12 +362,7 @@ final class HotkeyService: ObservableObject {
     func isHotkeyAssignedToWorkflow(_ hotkey: UnifiedHotkey, excludingWorkflowId: UUID?) -> UUID? {
         for (id, states) in workflowSlots where id != excludingWorkflowId {
             for state in states {
-                if state.hotkey == hotkey { return id }
-                if state.hotkey.keyCode == hotkey.keyCode
-                    && state.hotkey.modifierFlags == hotkey.modifierFlags
-                    && state.hotkey.isFn == hotkey.isFn
-                    && state.hotkey.mouseButton == hotkey.mouseButton
-                    && state.hotkey.isDoubleTap != hotkey.isDoubleTap {
+                if state.hotkey.conflicts(with: hotkey) {
                     return id
                 }
             }
@@ -358,12 +373,7 @@ final class HotkeyService: ObservableObject {
     func isHotkeyAssignedToGlobalSlot(_ hotkey: UnifiedHotkey) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases {
             guard let existing = slots[slotType]?.hotkey else { continue }
-            if existing == hotkey { return slotType }
-            if existing.keyCode == hotkey.keyCode
-                && existing.modifierFlags == hotkey.modifierFlags
-                && existing.isFn == hotkey.isFn
-                && existing.mouseButton == hotkey.mouseButton
-                && existing.isDoubleTap != hotkey.isDoubleTap {
+            if existing.conflicts(with: hotkey) {
                 return slotType
             }
         }
@@ -1040,8 +1050,13 @@ final class HotkeyService: ObservableObject {
             let requiredFlags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
             let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
             let current = event.modifierFlags.intersection(relevantMask)
-            let allDown = current.contains(requiredFlags)
-            let anyRequiredStillDown = !current.intersection(requiredFlags).isEmpty
+            let activeModifierKeyCodes = Self.modifierKeyCodes(from: event.modifierFlags)
+            let physicalModifiersMatch = hotkey.modifierKeyCodes.isEmpty
+                || hotkey.modifierKeyCodes.isSubset(of: activeModifierKeyCodes)
+            let allDown = current.contains(requiredFlags) && physicalModifiersMatch
+            let anyRequiredStillDown = hotkey.modifierKeyCodes.isEmpty
+                ? !current.intersection(requiredFlags).isEmpty
+                : !activeModifierKeyCodes.intersection(hotkey.modifierKeyCodes).isEmpty
             if allDown, !modifierWasDown { return .down }
             if allDown, modifierWasDown { return .repeatDown }
             if modifierWasDown {
@@ -1270,6 +1285,14 @@ final class HotkeyService: ObservableObject {
         }
         if hotkey.isFn { return hotkey.isDoubleTap ? "Fn x2" : "Fn" }
 
+        if hotkey.kind == .modifierCombo, !hotkey.modifierKeyCodes.isEmpty {
+            let baseName = displayName(
+                forModifierKeyCodes: hotkey.modifierKeyCodes,
+                modifierFlags: NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
+            )
+            return hotkey.isDoubleTap ? "\(baseName) x2" : baseName
+        }
+
         var parts: [String] = []
 
         let flags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
@@ -1420,13 +1443,66 @@ final class HotkeyService: ObservableObject {
 
     // MARK: - Helpers
 
-    private static func modifierFlagForKeyCode(_ keyCode: UInt16) -> NSEvent.ModifierFlags? {
+    nonisolated static func displayName(forModifierKeyCodes keyCodes: Set<UInt16>) -> String {
+        keyCodes
+            .sorted(by: modifierKeyCodeComesBefore)
+            .map(keyName(for:))
+            .joined(separator: " + ")
+    }
+
+    nonisolated static func displayName(
+        forModifierKeyCodes keyCodes: Set<UInt16>,
+        modifierFlags: NSEvent.ModifierFlags
+    ) -> String {
+        var parts: [String] = []
+        if modifierFlags.contains(.function) { parts.append("Fn") }
+        parts.append(contentsOf: keyCodes.sorted(by: modifierKeyCodeComesBefore).map(keyName(for:)))
+        return parts.joined(separator: " + ")
+    }
+
+    nonisolated static func modifierKeyCodes(from flags: NSEvent.ModifierFlags) -> Set<UInt16> {
+        let rawValue = flags.rawValue
+        return Set(deviceModifierKeyMasks.compactMap { entry in
+            rawValue & entry.mask == entry.mask ? entry.keyCode : nil
+        })
+    }
+
+    nonisolated static func modifierFlagForKeyCode(_ keyCode: UInt16) -> NSEvent.ModifierFlags? {
         switch keyCode {
         case 0x37, 0x36: return .command
         case 0x38, 0x3C: return .shift
         case 0x3A, 0x3D: return .option
         case 0x3B, 0x3E: return .control
         default: return nil
+        }
+    }
+
+    private nonisolated static let deviceModifierKeyMasks: [(mask: UInt, keyCode: UInt16)] = [
+        (0x00000008, 0x37), // Left Command
+        (0x00000010, 0x36), // Right Command
+        (0x00000002, 0x38), // Left Shift
+        (0x00000004, 0x3C), // Right Shift
+        (0x00000020, 0x3A), // Left Option
+        (0x00000040, 0x3D), // Right Option
+        (0x00000001, 0x3B), // Left Control
+        (0x00002000, 0x3E), // Right Control
+    ]
+
+    private nonisolated static func modifierKeyCodeComesBefore(_ lhs: UInt16, _ rhs: UInt16) -> Bool {
+        modifierKeyCodeSortIndex(lhs) < modifierKeyCodeSortIndex(rhs)
+    }
+
+    private nonisolated static func modifierKeyCodeSortIndex(_ keyCode: UInt16) -> Int {
+        switch keyCode {
+        case 0x37: return 0 // Left Command
+        case 0x36: return 1 // Right Command
+        case 0x3A: return 2 // Left Option
+        case 0x3D: return 3 // Right Option
+        case 0x3B: return 4 // Left Control
+        case 0x3E: return 5 // Right Control
+        case 0x38: return 6 // Left Shift
+        case 0x3C: return 7 // Right Shift
+        default: return Int(keyCode) + 100
         }
     }
 }

--- a/TypeWhisper/Views/HotkeyRecorderView.swift
+++ b/TypeWhisper/Views/HotkeyRecorderView.swift
@@ -10,6 +10,8 @@ struct HotkeyRecorderView: View {
     @State private var isRecording = false
     @State private var pendingModifiers: NSEvent.ModifierFlags = []
     @State private var peakModifiers: NSEvent.ModifierFlags = []
+    @State private var pendingModifierKeyCodes: Set<UInt16> = []
+    @State private var peakModifierKeyCodes: Set<UInt16> = []
     @State private var localMonitor: Any?
     @State private var globalMonitor: Any?
     @State private var modifierReleaseTimer: DispatchWorkItem?
@@ -83,6 +85,13 @@ struct HotkeyRecorderView: View {
     }
 
     private var pendingModifierString: String {
+        if !pendingModifierKeyCodes.isEmpty {
+            return HotkeyService.displayName(
+                forModifierKeyCodes: pendingModifierKeyCodes,
+                modifierFlags: pendingModifiers
+            )
+        }
+
         var parts: [String] = []
         if pendingModifiers.contains(.function) { parts.append("Fn") }
         if pendingModifiers.contains(.control) { parts.append("⌃") }
@@ -100,6 +109,8 @@ struct HotkeyRecorderView: View {
         isRecording = true
         pendingModifiers = []
         peakModifiers = []
+        pendingModifierKeyCodes = []
+        peakModifierKeyCodes = []
         ServiceContainer.shared.hotkeyService.suspendMonitoring()
 
         // Local monitor - can swallow events (return nil)
@@ -123,10 +134,12 @@ struct HotkeyRecorderView: View {
         if event.type == .flagsChanged {
             let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
             let current = event.modifierFlags.intersection(relevantMask)
+            let currentModifierKeyCodes = modifierKeyCodes(for: event, currentModifiers: current)
 
             // Track peak modifier set (most modifiers held simultaneously)
             if current.isSuperset(of: peakModifiers) {
                 peakModifiers = current
+                peakModifierKeyCodes.formUnion(currentModifierKeyCodes)
             }
 
             if current.isEmpty, !pendingModifiers.isEmpty {
@@ -136,7 +149,12 @@ struct HotkeyRecorderView: View {
                 // Build the candidate single-tap hotkey for this release
                 let candidateHotkey: UnifiedHotkey?
                 if peakCount > 1 {
-                    candidateHotkey = UnifiedHotkey(keyCode: UnifiedHotkey.modifierComboKeyCode, modifierFlags: peakModifiers.rawValue, isFn: false)
+                    candidateHotkey = UnifiedHotkey(
+                        keyCode: UnifiedHotkey.modifierComboKeyCode,
+                        modifierFlags: peakModifiers.rawValue,
+                        isFn: false,
+                        modifierKeyCodes: modifierKeyCodesForRecordedCombo()
+                    )
                 } else if peakModifiers.contains(.function) {
                     candidateHotkey = UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
                 } else if HotkeyService.modifierKeyCodes.contains(event.keyCode) {
@@ -151,7 +169,13 @@ struct HotkeyRecorderView: View {
                         // Second tap - finish as double-tap
                         doubleTapTimer?.cancel()
                         doubleTapTimer = nil
-                        let doubleTapHotkey = UnifiedHotkey(keyCode: candidate.keyCode, modifierFlags: candidate.modifierFlags, isFn: candidate.isFn, isDoubleTap: true)
+                        let doubleTapHotkey = UnifiedHotkey(
+                            keyCode: candidate.keyCode,
+                            modifierFlags: candidate.modifierFlags,
+                            isFn: candidate.isFn,
+                            isDoubleTap: true,
+                            modifierKeyCodes: candidate.modifierKeyCodes
+                        )
                         let work = DispatchWorkItem { [self] in
                             finishRecording(doubleTapHotkey)
                         }
@@ -174,11 +198,14 @@ struct HotkeyRecorderView: View {
                     }
                     pendingModifiers = []
                     peakModifiers = []
+                    pendingModifierKeyCodes = []
+                    peakModifierKeyCodes = []
                     return true
                 }
             }
 
             pendingModifiers = current
+            pendingModifierKeyCodes = currentModifierKeyCodes
             return true
         }
 
@@ -247,6 +274,8 @@ struct HotkeyRecorderView: View {
         isRecording = false
         pendingModifiers = []
         peakModifiers = []
+        pendingModifierKeyCodes = []
+        peakModifierKeyCodes = []
         removeMonitors()
         ServiceContainer.shared.hotkeyService.resumeMonitoring()
         onRecord(hotkey)
@@ -265,6 +294,8 @@ struct HotkeyRecorderView: View {
         isRecording = false
         pendingModifiers = []
         peakModifiers = []
+        pendingModifierKeyCodes = []
+        peakModifierKeyCodes = []
         removeMonitors()
         ServiceContainer.shared.hotkeyService.resumeMonitoring()
     }
@@ -278,5 +309,50 @@ struct HotkeyRecorderView: View {
             NSEvent.removeMonitor(monitor)
             globalMonitor = nil
         }
+    }
+
+    private func modifierKeyCodes(
+        for event: NSEvent,
+        currentModifiers: NSEvent.ModifierFlags
+    ) -> Set<UInt16> {
+        let deviceKeyCodes = HotkeyService.modifierKeyCodes(from: event.modifierFlags)
+        if !deviceKeyCodes.isEmpty || currentModifiers.isEmpty {
+            return deviceKeyCodes
+        }
+
+        var updated = pendingModifierKeyCodes
+        if HotkeyService.modifierKeyCodes.contains(event.keyCode),
+           let flag = HotkeyService.modifierFlagForKeyCode(event.keyCode) {
+            if currentModifiers.contains(flag) {
+                updated.insert(event.keyCode)
+            } else {
+                updated.remove(event.keyCode)
+            }
+        }
+
+        return updated.filter { keyCode in
+            guard let flag = HotkeyService.modifierFlagForKeyCode(keyCode) else { return false }
+            return currentModifiers.contains(flag)
+        }
+    }
+
+    private func modifierKeyCodesForRecordedCombo() -> Set<UInt16> {
+        let sideAwareFlags: [NSEvent.ModifierFlags] = [.command, .option, .control, .shift]
+        let expectedKeyCodeCount = sideAwareFlags.filter { peakModifiers.contains($0) }.count
+        guard expectedKeyCodeCount > 0,
+              peakModifierKeyCodes.count == expectedKeyCodeCount else {
+            return []
+        }
+
+        let recordedFlagRawValues = Set(peakModifierKeyCodes.compactMap {
+            HotkeyService.modifierFlagForKeyCode($0)?.rawValue
+        })
+        guard recordedFlagRawValues.count == expectedKeyCodeCount,
+              recordedFlagRawValues.allSatisfy({
+                  peakModifiers.contains(NSEvent.ModifierFlags(rawValue: $0))
+              }) else {
+            return []
+        }
+        return peakModifierKeyCodes
     }
 }

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -2202,13 +2202,7 @@ private func workflowCompactList(_ values: [String], conjunction: String = local
 }
 
 private func workflowHotkeysConflict(_ lhs: UnifiedHotkey, _ rhs: UnifiedHotkey) -> Bool {
-    lhs == rhs || (
-        lhs.keyCode == rhs.keyCode
-            && lhs.modifierFlags == rhs.modifierFlags
-            && lhs.isFn == rhs.isFn
-            && lhs.mouseButton == rhs.mouseButton
-            && lhs.isDoubleTap != rhs.isDoubleTap
-    )
+    lhs.conflicts(with: rhs)
 }
 
 private func workflowNormalizedDomainFromInput(_ value: String) -> String {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3437,6 +3437,157 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testRightSpecificModifierComboDoesNotTriggerFromLeftSide() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(try rightCommandRightOptionComboHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        service.onDictationStart = { startCount += 1 }
+
+        let leftCommandDown = try makeFlagsChangedEvent(
+            keyCode: 0x37,
+            modifierFlags: flags(generic: [.command], deviceKeyCodes: [0x37])
+        )
+        let leftOptionDown = try makeFlagsChangedEvent(
+            keyCode: 0x3A,
+            modifierFlags: flags(generic: [.command, .option], deviceKeyCodes: [0x37, 0x3A])
+        )
+
+        XCTAssertFalse(service.processEventForTesting(leftCommandDown, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(leftOptionDown, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testRightSpecificModifierComboTriggersFromRightSide() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(try rightCommandRightOptionComboHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let rightCommandDown = try makeFlagsChangedEvent(
+            keyCode: 0x36,
+            modifierFlags: flags(generic: [.command], deviceKeyCodes: [0x36])
+        )
+        let rightOptionDown = try makeFlagsChangedEvent(
+            keyCode: 0x3D,
+            modifierFlags: flags(generic: [.command, .option], deviceKeyCodes: [0x36, 0x3D])
+        )
+        let finalRelease = try makeFlagsChangedEvent(keyCode: 0x36, modifierFlags: [])
+
+        XCTAssertFalse(service.processEventForTesting(rightCommandDown, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(rightOptionDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        XCTAssertTrue(service.processEventForTesting(finalRelease, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
+    func testRightSpecificModifierComboDoesNotTriggerFromMixedSides() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(try rightCommandRightOptionComboHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        service.onDictationStart = { startCount += 1 }
+
+        let rightCommandDown = try makeFlagsChangedEvent(
+            keyCode: 0x36,
+            modifierFlags: flags(generic: [.command], deviceKeyCodes: [0x36])
+        )
+        let leftOptionDown = try makeFlagsChangedEvent(
+            keyCode: 0x3A,
+            modifierFlags: flags(generic: [.command, .option], deviceKeyCodes: [0x36, 0x3A])
+        )
+
+        XCTAssertFalse(service.processEventForTesting(rightCommandDown, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(leftOptionDown, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testLegacyGenericModifierComboStillTriggersFromLeftAndRightSides() throws {
+        let leftService = HotkeyService()
+        leftService.suspendMonitoring()
+        leftService.setHotkeyForTesting(try legacyCommandOptionComboHotkey(), for: .toggle)
+
+        var leftStartCount = 0
+        leftService.onDictationStart = { leftStartCount += 1 }
+
+        let leftOptionDown = try makeFlagsChangedEvent(
+            keyCode: 0x3A,
+            modifierFlags: flags(generic: [.command, .option], deviceKeyCodes: [0x37, 0x3A])
+        )
+        XCTAssertTrue(leftService.processEventForTesting(leftOptionDown, source: .monitor))
+        XCTAssertEqual(leftStartCount, 1)
+
+        let rightService = HotkeyService()
+        rightService.suspendMonitoring()
+        rightService.setHotkeyForTesting(try legacyCommandOptionComboHotkey(), for: .toggle)
+
+        var rightStartCount = 0
+        rightService.onDictationStart = { rightStartCount += 1 }
+
+        let rightOptionDown = try makeFlagsChangedEvent(
+            keyCode: 0x3D,
+            modifierFlags: flags(generic: [.command, .option], deviceKeyCodes: [0x36, 0x3D])
+        )
+        XCTAssertTrue(rightService.processEventForTesting(rightOptionDown, source: .monitor))
+        XCTAssertEqual(rightStartCount, 1)
+    }
+
+    @MainActor
+    func testSideSpecificModifierComboDisplayNameIncludesSides() throws {
+        let hotkey = try rightCommandRightOptionComboHotkey()
+
+        XCTAssertEqual(HotkeyService.displayName(for: hotkey), "Right Command + Right Option")
+    }
+
+    @MainActor
+    func testSideSpecificModifierComboDisplayNameKeepsFnModifier() throws {
+        let hotkey = UnifiedHotkey(
+            keyCode: UnifiedHotkey.modifierComboKeyCode,
+            modifierFlags: NSEvent.ModifierFlags([.function, .command]).rawValue,
+            isFn: false,
+            modifierKeyCodes: [0x36]
+        )
+
+        XCTAssertEqual(HotkeyService.displayName(for: hotkey), "Fn + Right Command")
+    }
+
+    @MainActor
+    func testGenericModifierComboConflictsWithSideSpecificCombo() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(try legacyCommandOptionComboHotkey(), for: .toggle)
+
+        XCTAssertEqual(
+            service.isHotkeyAssigned(try rightCommandRightOptionComboHotkey(), excluding: .pushToTalk),
+            .toggle
+        )
+    }
+
+    @MainActor
+    func testDistinctSideSpecificModifierCombosDoNotConflict() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(try leftCommandLeftOptionComboHotkey(), for: .toggle)
+
+        XCTAssertNil(service.isHotkeyAssigned(try rightCommandRightOptionComboHotkey(), excluding: .pushToTalk))
+    }
+
+    @MainActor
     func testPushToTalkExtraKeyInterruptionSignalsDiscardWithoutImmediateStop() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -3889,6 +4040,32 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
     }
 
+    private func rightCommandRightOptionComboHotkey() throws -> UnifiedHotkey {
+        try decodedCommandOptionComboHotkey(modifierKeyCodes: [0x36, 0x3D])
+    }
+
+    private func leftCommandLeftOptionComboHotkey() throws -> UnifiedHotkey {
+        try decodedCommandOptionComboHotkey(modifierKeyCodes: [0x37, 0x3A])
+    }
+
+    private func legacyCommandOptionComboHotkey() throws -> UnifiedHotkey {
+        try decodedCommandOptionComboHotkey(modifierKeyCodes: nil)
+    }
+
+    private func decodedCommandOptionComboHotkey(modifierKeyCodes: [UInt16]?) throws -> UnifiedHotkey {
+        var payload: [String: Any] = [
+            "keyCode": Int(UnifiedHotkey.modifierComboKeyCode),
+            "modifierFlags": Int(NSEvent.ModifierFlags([.command, .option]).rawValue),
+            "isFn": false,
+            "isDoubleTap": false,
+        ]
+        if let modifierKeyCodes {
+            payload["modifierKeyCodes"] = modifierKeyCodes.map(Int.init)
+        }
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        return try JSONDecoder().decode(UnifiedHotkey.self, from: data)
+    }
+
     @MainActor
     private func commandOptionAHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
@@ -3955,6 +4132,30 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
                 keyCode: keyCode
             )
         )
+    }
+
+    private func flags(
+        generic: NSEvent.ModifierFlags,
+        deviceKeyCodes: [UInt16]
+    ) -> NSEvent.ModifierFlags {
+        let deviceRawValue = deviceKeyCodes.reduce(UInt(0)) { partial, keyCode in
+            partial | deviceModifierMask(for: keyCode)
+        }
+        return NSEvent.ModifierFlags(rawValue: generic.rawValue | deviceRawValue)
+    }
+
+    private func deviceModifierMask(for keyCode: UInt16) -> UInt {
+        switch keyCode {
+        case 0x37: return 0x00000008
+        case 0x36: return 0x00000010
+        case 0x38: return 0x00000002
+        case 0x3C: return 0x00000004
+        case 0x3A: return 0x00000020
+        case 0x3D: return 0x00000040
+        case 0x3B: return 0x00000001
+        case 0x3E: return 0x00002000
+        default: return 0
+        }
     }
 
     private func makeFnEvent(isDown: Bool) throws -> NSEvent {


### PR DESCRIPTION
## Issue Context

Issue #286 reports that modifier-only combinations using the right-side modifier keys are not recorded or matched correctly. In particular, combinations such as Right Command + Right Option should be usable as right-side-specific hotkeys, while older generic Command + Option hotkeys must keep working from either side.

Closes #286

## Summary

- Adds optional physical modifier key codes to `UnifiedHotkey`, with backward-compatible decoding for existing saved hotkeys.
- Records physical modifier key codes in `HotkeyRecorderView` for modifier-only combos.
- Matches side-specific modifier-only hotkeys by physical keys while preserving legacy generic modifier-flag matching.
- Adds a shared hotkey conflict helper so generic Command + Option conflicts with side-specific Command + Option, while distinct left/right side-specific combos can coexist.
- Updates display names for side-specific modifier combos, including `Right Command + Right Option`.

## Test Coverage

- Added coverage in `HotkeyServiceCompatibilityTests` for right-side matching, left-side rejection, mixed-side rejection, legacy generic matching from either side, backward-compatible JSON decoding, side-specific display names, and modifier-combo conflict behavior.
- Pre-landing review found no remaining issues. One display edge case for Fn + side-specific modifier combos was fixed during review and covered by test.

## Verification

```bash
xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"
```

Results:

- Targeted hotkey compatibility tests passed: 34 tests, 0 failures.
- Full TypeWhisper XCTest suite passed: 429 tests, 0 failures.
- Dev app build succeeded.
