### PR TITLE
fix: update Parakeet vocabulary boosting capability

### DIFF
--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -30,9 +30,9 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     fileprivate var vocabularyRescorer: VocabularyRescorer?
     fileprivate var vocabSizeConfig: ContextBiasingConstants.VocabSizeConfig?
     fileprivate var vocabularyBoostingEnabled: Bool = false
-    fileprivate var ctcModelState: CtcModelState = .notDownloaded
-    fileprivate var lastConfiguredPrompt: String?
-    fileprivate var lastBoostingTermCount: Int = 0
+    var ctcModelState: CtcModelState = .notDownloaded
+    var lastConfiguredPrompt: String?
+    var lastBoostingTermCount: Int = 0
 
     required override init() {
         super.init()
@@ -93,7 +93,9 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     }
 
     var supportsTranslation: Bool { false }
-    var dictionaryTermsSupport: DictionaryTermsSupport { .requiresPluginSetting }
+    var dictionaryTermsSupport: DictionaryTermsSupport {
+        vocabularyBoostingEnabled ? .supported : .requiresPluginSetting
+    }
 
     var supportedLanguages: [String] {
         selectedVersion.supportedLanguages
@@ -379,12 +381,14 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         }
     }
 
-    fileprivate func setBoostingEnabled(_ enabled: Bool) {
+    func setBoostingEnabled(_ enabled: Bool) {
+        guard vocabularyBoostingEnabled != enabled else { return }
         vocabularyBoostingEnabled = enabled
         host?.setUserDefault(enabled, forKey: "vocabularyBoostingEnabled")
         if !enabled {
             clearConfiguredVocabulary()
         }
+        host?.notifyCapabilitiesChanged()
     }
 
     private func clearConfiguredVocabulary() {
@@ -486,6 +490,8 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         case .error(let message):
             return PluginSettingsActivity(message: message, isError: true)
         }
+
+        guard vocabularyBoostingEnabled else { return nil }
 
         switch ctcModelState {
         case .notDownloaded, .ready:

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -381,6 +381,74 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.huggingFaceToken, "hf_parakeet_saved")
     }
 
+    func testParakeetDictionaryTermsSupportReflectsStoredBoostingPreference() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let defaultHost = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let defaultPlugin = ParakeetPlugin()
+        defaultPlugin.activate(host: defaultHost)
+        XCTAssertEqual(defaultPlugin.dictionaryTermsSupport, .requiresPluginSetting)
+
+        let enabledHost = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: ["vocabularyBoostingEnabled": true]
+        )
+        let enabledPlugin = ParakeetPlugin()
+        enabledPlugin.activate(host: enabledHost)
+        XCTAssertEqual(enabledPlugin.dictionaryTermsSupport, .supported)
+    }
+
+    func testParakeetEnablingVocabularyBoostingPersistsAndNotifiesCapabilityChange() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = ParakeetPlugin()
+        plugin.activate(host: host)
+
+        plugin.setBoostingEnabled(true)
+
+        XCTAssertEqual(host.userDefault(forKey: "vocabularyBoostingEnabled") as? Bool, true)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .supported)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        plugin.setBoostingEnabled(true)
+
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    func testParakeetDisablingVocabularyBoostingPersistsClearsVocabularyAndHidesCtcActivity() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: ["vocabularyBoostingEnabled": true]
+        )
+        let plugin = ParakeetPlugin()
+        plugin.activate(host: host)
+        plugin.lastConfiguredPrompt = "TypeWhisper Madison"
+        plugin.lastBoostingTermCount = 2
+        plugin.ctcModelState = .downloading
+        XCTAssertEqual(plugin.currentSettingsActivity?.message, "Downloading vocabulary model")
+
+        plugin.setBoostingEnabled(false)
+
+        XCTAssertEqual(host.userDefault(forKey: "vocabularyBoostingEnabled") as? Bool, false)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .requiresPluginSetting)
+        XCTAssertNil(plugin.lastConfiguredPrompt)
+        XCTAssertEqual(plugin.lastBoostingTermCount, 0)
+        XCTAssertNil(plugin.currentSettingsActivity)
+        plugin.ctcModelState = .error("Vocabulary model failed")
+        XCTAssertNil(plugin.currentSettingsActivity)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        plugin.setBoostingEnabled(false)
+
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+    }
+
     func testParakeetStoresAndClearsHuggingFaceTokenSecret() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary

Fixes Issue #420, where Parakeet's Dictionary Engine Support continued to show dictionary terms as requiring a plugin setting even after Vocabulary Boosting was enabled. The root cause was that `dictionaryTermsSupport` was hard-coded to `.requiresPluginSetting`, and toggling Vocabulary Boosting did not notify the host that plugin capabilities changed.

This PR makes Parakeet's dictionary-term capability reflect the actual Vocabulary Boosting preference immediately while keeping the vocabulary CTC model download lazy.

Closes #420

## Changes

- Return `.supported` from `dictionaryTermsSupport` when Vocabulary Boosting is enabled, otherwise `.requiresPluginSetting`.
- Make `setBoostingEnabled(_:)` testable internally, persist only actual preference changes, clear configured vocabulary state when disabling, and notify the host only when capabilities changed.
- Keep CTC model preparation lazy: enabling the checkbox does not download or load the vocabulary model.
- Hide CTC vocabulary model download/error activity when Vocabulary Boosting is disabled while preserving normal Parakeet model activity.
- Add Parakeet unit coverage for stored/default activation, toggle-on behavior, toggle-off behavior, capability notifications, persistence, and configured vocabulary cleanup.

## Plan Completion

- [x] Dictionary Engine Support updates immediately after enabling Vocabulary Boosting.
- [x] Disabling Vocabulary Boosting returns dictionary-term support to "requires plugin setting".
- [x] Capability-change notifications fire only when the preference actually changes.
- [x] Disabling clears configured vocabulary state.
- [x] CTC model download behavior remains lazy.
- [x] CTC vocabulary activity is hidden while Vocabulary Boosting is disabled.

## Review

Pre-landing review completed. No blocking issues found.

## Verification Results

All verification completed successfully.

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

```bash
swift test --package-path TypeWhisperPluginSDK
```

```bash
xcodebuild -project TypeWhisper.xcodeproj -target ParakeetPlugin -configuration Release SYMROOT="$(pwd)/build" CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0
```

Additional dev plugin verification:

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh ParakeetPlugin "$(pwd)"
```

## Release Note

Do not edit `gh-pages` manually in this PR. After merge, release Parakeet via `.github/workflows/plugin-release.yml` with `plugin_name=parakeet` and the next version after `1.2.10`.
