### PR TITLE
Fix local LLM auto-unload and workflow LLM defaults

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -98,6 +98,7 @@ final class ServiceContainer: ObservableObject {
         appFormatterService = AppFormatterService()
         audioRecorderService = AudioRecorderService()
         promptProcessingService.memoryService = memoryService
+        promptProcessingService.modelManagerService = modelManagerService
         watchFolderService = WatchFolderService(audioFileService: audioFileService, modelManagerService: modelManagerService)
         accessibilityAnnouncementService = AccessibilityAnnouncementService()
         speechFeedbackService = SpeechFeedbackService()

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -108,6 +108,10 @@ enum UserDefaultsKeys {
     static let watchFolderEngine = "watchFolderEngine"
     static let watchFolderModel = "watchFolderModel"
 
+    // MARK: - Workflows
+    static let workflowDefaultLLMProviderId = "workflowDefaultLLMProviderId"
+    static let workflowDefaultLLMCloudModel = "workflowDefaultLLMCloudModel"
+
     // MARK: - Licensing
     static let usageIntent = "usageIntent"
     static let userType = "userType"

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -32,16 +32,26 @@ final class ModelManagerService: ObservableObject {
         let session: any LiveTranscriptionSession
     }
 
+    private final class AutoUnloadTarget {
+        weak var plugin: NSObject?
+
+        init(plugin: NSObject) {
+            self.plugin = plugin
+        }
+    }
+
     @Published private(set) var selectedProviderId: String?
 
     @Published var autoUnloadSeconds: Int {
         didSet {
             UserDefaults.standard.set(autoUnloadSeconds, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            cancelAutoUnloadTimer()
             scheduleAutoUnloadIfNeeded()
         }
     }
 
-    private var autoUnloadTask: Task<Void, Never>?
+    private var autoUnloadTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+    private var autoUnloadTargets: [ObjectIdentifier: AutoUnloadTarget] = [:]
     private var cancellables = Set<AnyCancellable>()
 
     private let providerKey = UserDefaultsKeys.selectedEngine
@@ -443,13 +453,26 @@ final class ModelManagerService: ObservableObject {
     // MARK: - Auto-Unload
 
     func scheduleAutoUnloadIfNeeded() {
-        autoUnloadTask?.cancel()
-        autoUnloadTask = nil
+        guard let providerId = selectedProviderId,
+              let plugin = PluginManager.shared.transcriptionEngine(for: providerId),
+              plugin.isConfigured else { return }
+
+        scheduleAutoUnloadIfNeeded(for: plugin)
+    }
+
+    func scheduleAutoUnloadIfNeeded(for plugin: any TypeWhisperPlugin) {
+        guard let nsPlugin = plugin as? NSObject else { return }
+        let key = ObjectIdentifier(nsPlugin)
+
+        autoUnloadTasks[key]?.cancel()
+        autoUnloadTasks[key] = nil
+        autoUnloadTargets[key] = nil
 
         let seconds = autoUnloadSeconds
         guard seconds != 0 else { return }
 
-        autoUnloadTask = Task { [weak self] in
+        autoUnloadTargets[key] = AutoUnloadTarget(plugin: nsPlugin)
+        autoUnloadTasks[key] = Task { [weak self] in
             if seconds == -1 {
                 // Small delay to let transcription call stack fully unwind
                 // before releasing the model (avoids EXC_BAD_ACCESS from MLX cleanup)
@@ -458,20 +481,25 @@ final class ModelManagerService: ObservableObject {
                 try? await Task.sleep(for: .seconds(seconds))
             }
             guard !Task.isCancelled else { return }
-            self?.performAutoUnload()
+            self?.performAutoUnload(for: key)
         }
     }
 
     func cancelAutoUnloadTimer() {
-        autoUnloadTask?.cancel()
-        autoUnloadTask = nil
+        for task in autoUnloadTasks.values {
+            task.cancel()
+        }
+        autoUnloadTasks.removeAll()
+        autoUnloadTargets.removeAll()
     }
 
-    private func performAutoUnload() {
-        guard let providerId = selectedProviderId,
-              let plugin = PluginManager.shared.transcriptionEngine(for: providerId),
-              plugin.isConfigured else { return }
-        guard let nsPlugin = plugin as? NSObject else { return }
+    private func performAutoUnload(for key: ObjectIdentifier) {
+        defer {
+            autoUnloadTasks[key] = nil
+            autoUnloadTargets[key] = nil
+        }
+
+        guard let nsPlugin = autoUnloadTargets[key]?.plugin else { return }
         let sel = NSSelectorFromString("triggerAutoUnload")
         guard nsPlugin.responds(to: sel) else { return }
         nsPlugin.perform(sel)

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -50,6 +50,7 @@ class PromptProcessingService: ObservableObject {
     }
 
     weak var memoryService: MemoryService?
+    weak var modelManagerService: ModelManagerService?
     private var appleIntelligenceProvider: LLMProvider?
     private var cancellables = Set<AnyCancellable>()
     var processActivityManager: any ProcessActivityManaging = DefaultProcessActivityManager()
@@ -201,6 +202,7 @@ class PromptProcessingService: ObservableObject {
         guard let plugin = PluginManager.shared.llmProvider(for: effectiveId) else {
             throw LLMError.noProviderConfigured
         }
+        await restoreLocalProviderIfNeeded(plugin)
         guard plugin.isAvailable else {
             if let setupStatus = plugin as? any LLMProviderSetupStatusProviding,
                !setupStatus.requiresExternalCredentials {
@@ -218,6 +220,13 @@ class PromptProcessingService: ObservableObject {
             requestedModel: requestedModel?.isEmpty == false ? requestedModel : nil,
             persistGlobalSelection: false
         )
+        let shouldAutoUnloadAfterProcessing = Self.requiresProcessActivityBudget(for: plugin)
+        defer {
+            if shouldAutoUnloadAfterProcessing {
+                modelManagerService?.scheduleAutoUnloadIfNeeded(for: plugin)
+            }
+        }
+
         logger.info("Processing prompt with plugin \(effectiveId)")
         let result = try await withProcessActivityIfNeeded(for: plugin, providerId: effectiveId) {
             try await processWithPlugin(
@@ -253,6 +262,26 @@ class PromptProcessingService: ObservableObject {
             userText: text,
             model: model
         )
+    }
+
+    private func restoreLocalProviderIfNeeded(_ plugin: any LLMProviderPlugin) async {
+        guard Self.requiresProcessActivityBudget(for: plugin),
+              !plugin.isAvailable,
+              let nsPlugin = plugin as? NSObject else { return }
+
+        let selector = NSSelectorFromString("triggerRestoreModel")
+        guard nsPlugin.responds(to: selector) else { return }
+
+        nsPlugin.perform(selector)
+        for _ in 0..<300 {
+            try? await Task.sleep(for: .milliseconds(100))
+            if plugin.isAvailable { return }
+
+            if let activityReporter = plugin as? any PluginSettingsActivityReporting {
+                guard let activity = activityReporter.currentSettingsActivity,
+                      !activity.isError else { return }
+            }
+        }
     }
 
     private func withProcessActivityIfNeeded<T>(

--- a/TypeWhisper/Services/WorkflowService.swift
+++ b/TypeWhisper/Services/WorkflowService.swift
@@ -39,11 +39,36 @@ struct WorkflowMatchResult {
 @MainActor
 final class WorkflowService: ObservableObject {
     @Published private(set) var workflows: [Workflow] = []
+    @Published var defaultProviderId: String {
+        didSet {
+            userDefaults.set(defaultProviderId, forKey: UserDefaultsKeys.workflowDefaultLLMProviderId)
+            if oldValue != defaultProviderId {
+                defaultCloudModel = ""
+            }
+        }
+    }
+    @Published var defaultCloudModel: String {
+        didSet {
+            userDefaults.set(defaultCloudModel, forKey: UserDefaultsKeys.workflowDefaultLLMCloudModel)
+        }
+    }
 
     private let modelContainer: ModelContainer
     private let modelContext: ModelContext
+    private let userDefaults: UserDefaults
 
-    init(appSupportDirectory: URL = AppConstants.appSupportDirectory) {
+    init(
+        appSupportDirectory: URL = AppConstants.appSupportDirectory,
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.userDefaults = userDefaults
+        self.defaultProviderId = userDefaults.string(forKey: UserDefaultsKeys.workflowDefaultLLMProviderId)
+            ?? userDefaults.string(forKey: "llmProviderType")
+            ?? PromptProcessingService.appleIntelligenceId
+        self.defaultCloudModel = userDefaults.string(forKey: UserDefaultsKeys.workflowDefaultLLMCloudModel)
+            ?? userDefaults.string(forKey: "llmCloudModel")
+            ?? ""
+
         let schema = Schema([Workflow.self])
         let storeDir = appSupportDirectory
         try? FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
@@ -143,6 +168,24 @@ final class WorkflowService: ObservableObject {
             competingWorkflowCount: 0,
             wonBySortOrder: false
         )
+    }
+
+    func llmProviderId(for workflow: Workflow) -> String? {
+        let providerId = workflow.behavior.providerId ?? defaultProviderId
+        let trimmed = providerId.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    func llmCloudModel(for workflow: Workflow) -> String? {
+        let modelId: String?
+        if workflow.behavior.providerId == nil {
+            modelId = defaultCloudModel
+        } else {
+            modelId = workflow.behavior.cloudModel
+        }
+
+        let trimmed = modelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 
     func matchWorkflow(bundleIdentifier: String?, url: String? = nil) -> WorkflowMatchResult? {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1514,15 +1514,16 @@ final class DictationViewModel: ObservableObject {
                 fallbackTranslationTarget: translationTarget,
                 detectedLanguage: detectedLanguage,
                 configuredLanguage: configuredLanguage
-           ) {
+        ) {
             let pps = promptProcessingService
+            let workflowService = workflowService
             let behavior = matchedWorkflow.behavior
             return { text in
                 try await pps.process(
                     prompt: systemPrompt,
                     text: text,
-                    providerOverride: behavior.providerId,
-                    cloudModelOverride: behavior.cloudModel,
+                    providerOverride: workflowService.llmProviderId(for: matchedWorkflow),
+                    cloudModelOverride: workflowService.llmCloudModel(for: matchedWorkflow),
                     temperatureDirective: behavior.temperatureDirective
                 )
             }

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -164,8 +164,8 @@ final class PromptPaletteHandler {
                     result = try await promptProcessingService.process(
                         prompt: systemPrompt,
                         text: ctx.text,
-                        providerOverride: workflow.behavior.providerId,
-                        cloudModelOverride: workflow.behavior.cloudModel,
+                        providerOverride: workflowService.llmProviderId(for: workflow),
+                        cloudModelOverride: workflowService.llmCloudModel(for: workflow),
                         temperatureDirective: workflow.behavior.temperatureDirective
                     )
                 } else {

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -217,14 +217,14 @@ private struct MyWorkflowsPage: View {
                         .controlSize(.small)
                     }
                 } else {
-                    let models = promptProcessingService.modelsForProvider(promptProcessingService.selectedProviderId)
+                    let models = promptProcessingService.modelsForProvider(workflowService.defaultProviderId)
 
                     ViewThatFits(in: .horizontal) {
                         HStack(alignment: .top, spacing: 12) {
                             compactDefaultLLMField(title: localizedAppText("Provider", de: "Provider")) {
                                 Picker(
                                     localizedAppText("Provider", de: "Provider"),
-                                    selection: $promptProcessingService.selectedProviderId
+                                    selection: workflowDefaultProviderBinding
                                 ) {
                                     ForEach(providers, id: \.id) { provider in
                                         Text(provider.displayName).tag(provider.id)
@@ -236,8 +236,10 @@ private struct MyWorkflowsPage: View {
                                 compactDefaultLLMField(title: localizedAppText("Model", de: "Modell")) {
                                     Picker(
                                         localizedAppText("Model", de: "Modell"),
-                                        selection: $promptProcessingService.selectedCloudModel
+                                        selection: $workflowService.defaultCloudModel
                                     ) {
+                                        Text(localizedAppText("Provider Default", de: "Provider-Standard"))
+                                            .tag("")
                                         ForEach(models, id: \.id) { model in
                                             Text(model.displayName).tag(model.id)
                                         }
@@ -250,7 +252,7 @@ private struct MyWorkflowsPage: View {
                             compactDefaultLLMField(title: localizedAppText("Provider", de: "Provider")) {
                                 Picker(
                                     localizedAppText("Provider", de: "Provider"),
-                                    selection: $promptProcessingService.selectedProviderId
+                                    selection: workflowDefaultProviderBinding
                                 ) {
                                     ForEach(providers, id: \.id) { provider in
                                         Text(provider.displayName).tag(provider.id)
@@ -262,8 +264,10 @@ private struct MyWorkflowsPage: View {
                                 compactDefaultLLMField(title: localizedAppText("Model", de: "Modell")) {
                                     Picker(
                                         localizedAppText("Model", de: "Modell"),
-                                        selection: $promptProcessingService.selectedCloudModel
+                                        selection: $workflowService.defaultCloudModel
                                     ) {
+                                        Text(localizedAppText("Provider Default", de: "Provider-Standard"))
+                                            .tag("")
                                         ForEach(models, id: \.id) { model in
                                             Text(model.displayName).tag(model.id)
                                         }
@@ -275,7 +279,7 @@ private struct MyWorkflowsPage: View {
 
                     HStack(alignment: .firstTextBaseline, spacing: 12) {
                         Text(
-                            promptProcessingService.isProviderReady(promptProcessingService.selectedProviderId)
+                            promptProcessingService.isProviderReady(workflowService.defaultProviderId)
                                 ? localizedAppText(
                                     "Ready for new workflows.",
                                     de: "Bereit für neue Workflows."
@@ -299,6 +303,20 @@ private struct MyWorkflowsPage: View {
                 }
             }
         }
+    }
+
+    private var workflowDefaultProviderBinding: Binding<String> {
+        Binding(
+            get: { workflowService.defaultProviderId },
+            set: { providerId in
+                workflowService.defaultProviderId = providerId
+                let models = promptProcessingService.modelsForProvider(providerId)
+                if !workflowService.defaultCloudModel.isEmpty,
+                   !models.contains(where: { $0.id == workflowService.defaultCloudModel }) {
+                    workflowService.defaultCloudModel = ""
+                }
+            }
+        )
     }
 
     @ViewBuilder
@@ -964,8 +982,8 @@ private struct WorkflowEditorPage: View {
                 ) {
                     Text(
                         localizedAppText(
-                            "Use Workflow Default (\(promptProcessingService.displayName(for: promptProcessingService.selectedProviderId)))",
-                            de: "Workflow-Standard verwenden (\(promptProcessingService.displayName(for: promptProcessingService.selectedProviderId)))"
+                            "Use Workflow Default (\(promptProcessingService.displayName(for: workflowService.defaultProviderId)))",
+                            de: "Workflow-Standard verwenden (\(promptProcessingService.displayName(for: workflowService.defaultProviderId)))"
                         )
                     )
                     .tag(nil as String?)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7,7 +7,7 @@ import TypeWhisperPluginSDK
 
 final class APIRouterAndHandlersTests: XCTestCase {
     @objc(APIRouterMockLLMProviderPlugin)
-    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, LLMTemperatureControllableProvider, @unchecked Sendable {
+    private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, LLMTemperatureControllableProvider, PluginSettingsActivityReporting, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.llm" }
         static var pluginName: String { "Mock LLM" }
 
@@ -18,8 +18,11 @@ final class APIRouterAndHandlersTests: XCTestCase {
         var configuredProviderName = "Gemini"
         var requiresExternalCredentials = true
         var unavailableReason: String?
+        var restoreMakesAvailable = false
         nonisolated(unsafe) private var _lastRequestedModel: String?
         nonisolated(unsafe) private var _lastTemperatureDirective: PluginLLMTemperatureDirective?
+        nonisolated(unsafe) private var _autoUnloadCount = 0
+        nonisolated(unsafe) private var _restoreCount = 0
 
         var lastRequestedModel: String? {
             requestLock.withLock { _lastRequestedModel }
@@ -27,6 +30,14 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         var lastTemperatureDirective: PluginLLMTemperatureDirective? {
             requestLock.withLock { _lastTemperatureDirective }
+        }
+
+        var autoUnloadCount: Int {
+            requestLock.withLock { _autoUnloadCount }
+        }
+
+        var restoreCount: Int {
+            requestLock.withLock { _restoreCount }
         }
 
         required override init() {}
@@ -37,6 +48,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         var providerName: String { configuredProviderName }
         var isAvailable: Bool { available }
         var supportedModels: [PluginModelInfo] { models }
+        var currentSettingsActivity: PluginSettingsActivity? { nil }
 
         func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
             requestLock.withLock {
@@ -56,6 +68,21 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 _lastTemperatureDirective = temperatureDirective
             }
             return responseText
+        }
+
+        @objc func triggerAutoUnload() {
+            requestLock.withLock {
+                _autoUnloadCount += 1
+            }
+        }
+
+        @objc func triggerRestoreModel() {
+            requestLock.withLock {
+                _restoreCount += 1
+            }
+            if restoreMakesAvailable {
+                available = true
+            }
         }
     }
 
@@ -2504,6 +2531,47 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testPromptProcessingRestoresLocalProviderBeforeProcessingWhenModelWasAutoUnloaded() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.available = false
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+        plugin.restoreMakesAvailable = true
+        plugin.unavailableReason = "Load a Gemma 4 model in Integrations before using it for prompts."
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.local-llm",
+                    name: "Mock Local LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let service = PromptProcessingService()
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            providerOverride: "Gemma 4 (MLX)"
+        )
+
+        XCTAssertEqual(result, "processed")
+        XCTAssertEqual(plugin.restoreCount, 1)
+    }
+
+    @MainActor
     func testPromptProcessingUsesHighPriorityActivityForLocalProviders() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -2543,6 +2611,162 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(result, "processed")
         XCTAssertEqual(activityManager.reasons, ["Local prompt processing with Gemma 4 (MLX)"])
+    }
+
+    @MainActor
+    func testPromptProcessingSchedulesImmediateAutoUnloadForLocalProvider() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.local-llm",
+                    name: "Mock Local LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        let service = PromptProcessingService()
+        service.modelManagerService = modelManager
+
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            providerOverride: "Gemma 4 (MLX)"
+        )
+
+        XCTAssertEqual(result, "processed")
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(plugin.autoUnloadCount, 1)
+    }
+
+    @MainActor
+    func testPromptProcessingDoesNotAutoUnloadRemoteProvider() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemini"
+        plugin.requiresExternalCredentials = true
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.llm",
+                    name: "Mock LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        let service = PromptProcessingService()
+        service.modelManagerService = modelManager
+
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            providerOverride: "Gemini"
+        )
+
+        XCTAssertEqual(result, "processed")
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(plugin.autoUnloadCount, 0)
+    }
+
+    @MainActor
+    func testPromptProcessingDoesNotAutoUnloadLocalProviderWhenDisabled() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.local-llm",
+                    name: "Mock Local LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        let service = PromptProcessingService()
+        service.modelManagerService = modelManager
+
+        let result = try await service.process(
+            prompt: "Fix grammar",
+            text: "hello world",
+            providerOverride: "Gemma 4 (MLX)"
+        )
+
+        XCTAssertEqual(result, "processed")
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(plugin.autoUnloadCount, 0)
     }
 
     @MainActor

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -58,6 +58,51 @@ final class WorkflowServiceTests: XCTestCase {
         )
     }
 
+    func testWorkflowServicePersistsDefaultLLMProviderAndModel() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+        let suiteName = "WorkflowServiceTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory, userDefaults: defaults)
+        service.defaultProviderId = "Gemma 4 (MLX)"
+        service.defaultCloudModel = "gemma-4-large"
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory, userDefaults: defaults)
+
+        XCTAssertEqual(reloaded.defaultProviderId, "Gemma 4 (MLX)")
+        XCTAssertEqual(reloaded.defaultCloudModel, "gemma-4-large")
+    }
+
+    func testWorkflowServiceResolvesWorkflowDefaultLLMUnlessWorkflowOverridesIt() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+        let suiteName = "WorkflowServiceTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory, userDefaults: defaults)
+        service.defaultProviderId = "Gemma 4 (MLX)"
+        service.defaultCloudModel = "gemma-4-large"
+        let inheritedWorkflow = Workflow(
+            name: "Inherited",
+            template: .summary,
+            trigger: .manual()
+        )
+        let overrideWorkflow = Workflow(
+            name: "Override",
+            template: .summary,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(providerId: "Groq", cloudModel: "llama-3.3")
+        )
+
+        XCTAssertEqual(service.llmProviderId(for: inheritedWorkflow), "Gemma 4 (MLX)")
+        XCTAssertEqual(service.llmCloudModel(for: inheritedWorkflow), "gemma-4-large")
+        XCTAssertEqual(service.llmProviderId(for: overrideWorkflow), "Groq")
+        XCTAssertEqual(service.llmCloudModel(for: overrideWorkflow), "llama-3.3")
+    }
+
     func testReorderWorkflowsUsesProvidedOrder() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary

This fixes #417, where `Auto-unload model` only covered transcription engines and did not unload local LLM post-processing providers such as Gemma 4. During manual QA for the same path, a second local-provider issue surfaced: after an immediate unload, local LLM prompt processing could show `Load a Gemma 4 model in Integrations before using it for prompts.` instead of restoring the previously loaded model.

Changes:
- Extend `ModelManagerService` auto-unload scheduling so it can target concrete plugin instances, not only the currently selected transcription engine.
- Wire `PromptProcessingService` to `ModelManagerService` and schedule auto-unload after local LLM prompt processing completes or fails.
- Restore local LLM providers via their existing `triggerRestoreModel` hook before processing when the model was auto-unloaded.
- Leave cloud LLM providers unchanged: no auto-unload or restore attempts for providers that require external credentials.
- Persist Workflow Settings' default LLM provider/model separately from the global prompt default, and use that default for workflows without an explicit Advanced override.

Closes #417

## Test Plan

- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/conductor/workspaces/typewhisper-mac/prague-v1`

Manual QA:
- With Workflow Settings' default LLM set to Gemma 4, restart the dev app and confirm the provider selection persists.
- With auto-unload set to Immediate, run local Gemma 4 prompt processing, wait for memory to drop, then run the prompt again and confirm the provider restores instead of showing the setup-required message.