### PR TITLE
fix: reduce workflow post-processing latency

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AVFoundation
 import Combine
+import TypeWhisperPluginSDK
 @preconcurrency import Sparkle
 
 extension UserDefaults {
@@ -326,6 +327,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var menuBarIconObserver: NSKeyValueObservation?
     private var dockIconBehaviorObserver: NSKeyValueObservation?
     private var appActivationObserver: NSObjectProtocol?
+    private var workspaceWakeObserver: NSObjectProtocol?
     private var hasInteractiveForegroundContent = false
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
@@ -434,6 +436,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             Task { @MainActor in
                 ActivationSourceTracker.shared.recordActivation(application)
             }
+        }
+
+        workspaceWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            PluginHTTPClient.resetSharedSession(reason: "macOS wake")
         }
 
         // Observe settings window lifecycle

--- a/TypeWhisper/Services/MemoryService.swift
+++ b/TypeWhisper/Services/MemoryService.swift
@@ -5,7 +5,7 @@ import os.log
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "MemoryService")
 
 @MainActor
-final class MemoryService: ObservableObject {
+final class MemoryService: ObservableObject, MemoryRetrieving {
     @Published var isEnabled: Bool {
         didSet { UserDefaults.standard.set(isEnabled, forKey: UserDefaultsKeys.memoryEnabled) }
     }

--- a/TypeWhisper/Services/PostProcessingPipeline.swift
+++ b/TypeWhisper/Services/PostProcessingPipeline.swift
@@ -53,8 +53,21 @@ final class PostProcessingPipeline {
 
         var result = text
         var appliedSteps: [String] = []
+
+        func stepName(for id: Int) -> String {
+            switch id {
+            case -4: return "Formatting"
+            case -1: return llmStepName ?? "Prompt"
+            case -2: return "Snippets"
+            case -3: return "Corrections"
+            default: return plugins[id].processorName
+            }
+        }
+
         for step in steps {
             let before = result
+            let name = stepName(for: step.id)
+            let stepStart = ContinuousClock.now
             do {
                 switch step.id {
                 case -4:
@@ -72,27 +85,13 @@ final class PostProcessingPipeline {
                 default:
                     result = try await plugins[step.id].process(text: result, context: context)
                 }
-                if result != before {
-                    let name: String
-                    switch step.id {
-                    case -4: name = "Formatting"
-                    case -1: name = llmStepName ?? "Prompt"
-                    case -2: name = "Snippets"
-                    case -3: name = "Corrections"
-                    default: name = plugins[step.id].processorName
-                    }
+                let changed = result != before
+                logger.info("Post-processing step '\(name)' finished in \(ContinuousClock.now - stepStart), changed: \(changed)")
+                if changed {
                     appliedSteps.append(name)
                 }
             } catch {
-                let name: String
-                switch step.id {
-                case -4: name = "AppFormatter"
-                case -1: name = "LLM/Translation"
-                case -2: name = "Snippets"
-                case -3: name = "Dictionary"
-                default: name = plugins[step.id].processorName
-                }
-                logger.error("Post-processor '\(name)' failed: \(error.localizedDescription)")
+                logger.error("Post-processing step '\(name)' failed after \(ContinuousClock.now - stepStart): \(error.localizedDescription)")
                 // Only re-throw for LLM step
                 if step.id == -1 {
                     throw error

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -16,6 +16,11 @@ protocol ProcessActivityManaging {
 }
 
 @MainActor
+protocol MemoryRetrieving: AnyObject {
+    func retrieveRelevantMemories(for text: String) async -> String
+}
+
+@MainActor
 struct DefaultProcessActivityManager: ProcessActivityManaging {
     func withActivity<T>(
         options: ProcessInfo.ActivityOptions,
@@ -49,7 +54,7 @@ class PromptProcessingService: ObservableObject {
         didSet { UserDefaults.standard.set(selectedCloudModel, forKey: "llmCloudModel") }
     }
 
-    weak var memoryService: MemoryService?
+    weak var memoryService: (any MemoryRetrieving)?
     private var appleIntelligenceProvider: LLMProvider?
     private var cancellables = Set<AnyCancellable>()
     var processActivityManager: any ProcessActivityManaging = DefaultProcessActivityManager()
@@ -161,6 +166,17 @@ class PromptProcessingService: ObservableObject {
         )
     }
 
+    func processWorkflow(prompt: String, text: String, behavior: WorkflowBehavior) async throws -> String {
+        try await process(
+            prompt: prompt,
+            text: text,
+            providerOverride: behavior.providerId,
+            cloudModelOverride: behavior.cloudModel,
+            temperatureDirective: behavior.temperatureDirective,
+            skipMemoryInjection: true
+        )
+    }
+
     static func requiresProcessActivityBudget(for plugin: any LLMProviderPlugin) -> Bool {
         guard let setupStatus = plugin as? any LLMProviderSetupStatusProviding else {
             return false
@@ -176,13 +192,19 @@ class PromptProcessingService: ObservableObject {
         temperatureDirective: PluginLLMTemperatureDirective = .inheritProviderSetting,
         skipMemoryInjection: Bool = false
     ) async throws -> String {
+        let totalStart = ContinuousClock.now
+
         // Inject memory context into prompt if available
         var effectivePrompt = prompt
         if !skipMemoryInjection, let memoryService {
+            let memoryStart = ContinuousClock.now
             let memoryContext = await memoryService.retrieveRelevantMemories(for: text)
+            logger.info("Prompt memory retrieval finished in \(ContinuousClock.now - memoryStart)")
             if !memoryContext.isEmpty {
                 effectivePrompt = memoryContext + "\n\n" + prompt
             }
+        } else if skipMemoryInjection {
+            logger.info("Prompt memory retrieval skipped")
         }
 
         let effectiveId = normalizeProviderId(providerOverride ?? selectedProviderId)
@@ -192,9 +214,17 @@ class PromptProcessingService: ObservableObject {
                 throw LLMError.notAvailable
             }
             logger.info("Processing prompt with Apple Intelligence")
-            let result = try await provider.process(systemPrompt: effectivePrompt, userText: text)
-            logger.info("Prompt processing complete, result length: \(result.count)")
-            return result
+            let providerStart = ContinuousClock.now
+            do {
+                let result = try await provider.process(systemPrompt: effectivePrompt, userText: text)
+                logger.info("Prompt provider call finished in \(ContinuousClock.now - providerStart)")
+                logger.info("Prompt processing complete in \(ContinuousClock.now - totalStart), result length: \(result.count)")
+                return result
+            } catch {
+                logger.error("Prompt provider call failed after \(ContinuousClock.now - providerStart): \(error.localizedDescription)")
+                logger.error("Prompt processing failed after \(ContinuousClock.now - totalStart): \(error.localizedDescription)")
+                throw error
+            }
         }
 
         // Plugin provider
@@ -219,17 +249,25 @@ class PromptProcessingService: ObservableObject {
             persistGlobalSelection: false
         )
         logger.info("Processing prompt with plugin \(effectiveId)")
-        let result = try await withProcessActivityIfNeeded(for: plugin, providerId: effectiveId) {
-            try await processWithPlugin(
-                plugin,
-                prompt: effectivePrompt,
-                text: text,
-                model: model,
-                temperatureDirective: temperatureDirective
-            )
+        let providerStart = ContinuousClock.now
+        do {
+            let result = try await withProcessActivityIfNeeded(for: plugin, providerId: effectiveId) {
+                try await processWithPlugin(
+                    plugin,
+                    prompt: effectivePrompt,
+                    text: text,
+                    model: model,
+                    temperatureDirective: temperatureDirective
+                )
+            }
+            logger.info("Prompt provider call finished in \(ContinuousClock.now - providerStart)")
+            logger.info("Prompt processing complete in \(ContinuousClock.now - totalStart), result length: \(result.count)")
+            return result
+        } catch {
+            logger.error("Prompt provider call failed after \(ContinuousClock.now - providerStart): \(error.localizedDescription)")
+            logger.error("Prompt processing failed after \(ContinuousClock.now - totalStart): \(error.localizedDescription)")
+            throw error
         }
-        logger.info("Prompt processing complete, result length: \(result.count)")
-        return result
     }
 
     private func processWithPlugin(

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1518,12 +1518,10 @@ final class DictationViewModel: ObservableObject {
             let pps = promptProcessingService
             let behavior = matchedWorkflow.behavior
             return { text in
-                try await pps.process(
+                try await pps.processWorkflow(
                     prompt: systemPrompt,
                     text: text,
-                    providerOverride: behavior.providerId,
-                    cloudModelOverride: behavior.cloudModel,
-                    temperatureDirective: behavior.temperatureDirective
+                    behavior: behavior
                 )
             }
         }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -38,22 +38,63 @@ public extension HostServices {
     var availableProfileNames: [String] { availableRuleNames }
 }
 
-// MARK: - HTTP Client (Ephemeral Sessions)
+// MARK: - HTTP Client (Reusable Ephemeral Session)
 
-/// Drop-in replacement for `URLSession.shared.data(for:)` that creates a fresh ephemeral
-/// session per call. This prevents stale HTTP/2 connections after sleep/wake or network changes
-/// from hanging indefinitely.
+internal protocol PluginHTTPSession: AnyObject {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+    func finishTasksAndInvalidate()
+}
+
+extension URLSession: PluginHTTPSession {}
+
+/// Drop-in replacement for `URLSession.shared.data(for:)` that reuses one ephemeral
+/// session so fast plugin requests can keep DNS/TLS/HTTP connections warm.
 public enum PluginHTTPClient {
     private static let logger = Logger(subsystem: "com.typewhisper.sdk", category: "HTTP")
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var sharedSession: (any PluginHTTPSession)?
+    nonisolated(unsafe) private static var sessionFactory: (URLSessionConfiguration) -> any PluginHTTPSession = {
+        URLSession(configuration: $0)
+    }
 
     public static func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        let config = URLSessionConfiguration.ephemeral
-        let timeout = request.timeoutInterval > 0 ? request.timeoutInterval : 30
-        config.timeoutIntervalForRequest = timeout
-        config.timeoutIntervalForResource = max(timeout * 2, 90)
-        let session = URLSession(configuration: config)
-        defer { session.finishTasksAndInvalidate() }
+        try await data(for: request, allowsRetry: true)
+    }
 
+    public static func resetSharedSession(reason: String? = nil) {
+        let session = lock.withLock {
+            let existing = sharedSession
+            sharedSession = nil
+            return existing
+        }
+
+        session?.finishTasksAndInvalidate()
+        if let reason {
+            logger.info("Reset shared plugin HTTP session: \(reason)")
+        } else {
+            logger.info("Reset shared plugin HTTP session")
+        }
+    }
+
+    internal static func configureForTesting(_ factory: @escaping (URLSessionConfiguration) -> any PluginHTTPSession) {
+        resetSharedSession(reason: "test reconfiguration")
+        lock.withLock {
+            sessionFactory = factory
+        }
+    }
+
+    internal static func resetTestingHooks() {
+        resetSharedSession(reason: "test cleanup")
+        lock.withLock {
+            sessionFactory = { URLSession(configuration: $0) }
+        }
+    }
+
+    private static func data(
+        for request: URLRequest,
+        allowsRetry: Bool
+    ) async throws -> (Data, URLResponse) {
+        let session = sharedOrCreateSession()
         let method = request.httpMethod ?? "GET"
         let url = request.url?.absoluteString ?? "unknown"
         logger.info("\(method) \(url)")
@@ -67,8 +108,68 @@ public enum PluginHTTPClient {
             return (data, response)
         } catch {
             let elapsed = ContinuousClock.now - start
+            if allowsRetry, isTransientNetworkError(error) {
+                logger.warning("\(method) \(url) transient failure after \(elapsed), resetting session and retrying once: \(error.localizedDescription)")
+                resetSharedSession(matching: session, reason: "transient network error")
+                return try await data(for: request, allowsRetry: false)
+            }
+
             logger.error("\(method) \(url) failed after \(elapsed): \(error.localizedDescription)")
             throw error
+        }
+    }
+
+    private static func sharedOrCreateSession() -> any PluginHTTPSession {
+        lock.withLock {
+            if let sharedSession {
+                return sharedSession
+            }
+
+            let session = sessionFactory(makeConfiguration())
+            sharedSession = session
+            return session
+        }
+    }
+
+    private static func makeConfiguration() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 90
+        return config
+    }
+
+    private static func resetSharedSession(matching session: any PluginHTTPSession, reason: String) {
+        let didRemoveSharedSession = lock.withLock {
+            guard let current = sharedSession, current === session else {
+                return false
+            }
+            sharedSession = nil
+            return true
+        }
+
+        session.finishTasksAndInvalidate()
+        if didRemoveSharedSession {
+            logger.info("Reset shared plugin HTTP session: \(reason)")
+        } else {
+            logger.info("Invalidated plugin HTTP session after \(reason)")
+        }
+    }
+
+    private static func isTransientNetworkError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else {
+            return false
+        }
+
+        switch urlError.code {
+        case .networkConnectionLost,
+             .timedOut,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .notConnectedToInternet:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class PluginHTTPClientTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClient.resetTestingHooks()
+        super.tearDown()
+    }
+
+    func testHTTPClientReusesSharedSessionAcrossRequests() async throws {
+        let store = MockHTTPSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [.success(Self.okResponse())])
+        }
+
+        _ = try await PluginHTTPClient.data(for: Self.request(path: "/first"))
+        _ = try await PluginHTTPClient.data(for: Self.request(path: "/second"))
+
+        XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertEqual(store.sessions.first?.requestedPaths, ["/first", "/second"])
+    }
+
+    func testHTTPClientResetInvalidatesSharedSessionAndCreatesNewOne() async throws {
+        let store = MockHTTPSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [.success(Self.okResponse())])
+        }
+
+        _ = try await PluginHTTPClient.data(for: Self.request(path: "/before-reset"))
+        PluginHTTPClient.resetSharedSession(reason: "test reset")
+        _ = try await PluginHTTPClient.data(for: Self.request(path: "/after-reset"))
+
+        XCTAssertEqual(store.sessions.count, 2)
+        XCTAssertTrue(store.sessions[0].didInvalidate)
+        XCTAssertEqual(store.sessions[0].requestedPaths, ["/before-reset"])
+        XCTAssertEqual(store.sessions[1].requestedPaths, ["/after-reset"])
+    }
+
+    func testHTTPClientRetriesTransientURLErrorAfterResettingSession() async throws {
+        let store = MockHTTPSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            if store.sessions.isEmpty {
+                return store.makeSession(outcomes: [.failure(URLError(.networkConnectionLost))])
+            }
+            return store.makeSession(outcomes: [.success(Self.okResponse())])
+        }
+
+        let (data, response) = try await PluginHTTPClient.data(for: Self.request(path: "/retry"))
+
+        XCTAssertEqual(String(data: data, encoding: .utf8), "ok")
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual(store.sessions.count, 2)
+        XCTAssertTrue(store.sessions[0].didInvalidate)
+        XCTAssertEqual(store.sessions[0].requestedPaths, ["/retry"])
+        XCTAssertEqual(store.sessions[1].requestedPaths, ["/retry"])
+    }
+
+    private static func request(path: String) -> URLRequest {
+        var request = URLRequest(url: URL(string: "https://example.test\(path)")!)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 5
+        request.httpBody = Data("payload".utf8)
+        return request
+    }
+
+    private static func okResponse() -> (Data, URLResponse) {
+        let url = URL(string: "https://example.test/ok")!
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (Data("ok".utf8), response)
+    }
+}
+
+private final class MockHTTPSessionStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var sessions: [MockHTTPSession] = []
+
+    func makeSession(outcomes: [Result<(Data, URLResponse), Error>]) -> MockHTTPSession {
+        let session = MockHTTPSession(outcomes: outcomes)
+        lock.withLock {
+            sessions.append(session)
+        }
+        return session
+    }
+}
+
+private final class MockHTTPSession: PluginHTTPSession, @unchecked Sendable {
+    private let lock = NSLock()
+    private var outcomes: [Result<(Data, URLResponse), Error>]
+    private(set) var requestedPaths: [String] = []
+    private(set) var didInvalidate = false
+
+    init(outcomes: [Result<(Data, URLResponse), Error>]) {
+        self.outcomes = outcomes
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let outcome = lock.withLock {
+            requestedPaths.append(request.url?.path ?? "")
+            if outcomes.count > 1 {
+                return outcomes.removeFirst()
+            }
+            return outcomes.first ?? .failure(URLError(.badServerResponse))
+        }
+
+        return try outcome.get()
+    }
+
+    func finishTasksAndInvalidate() {
+        lock.withLock {
+            didInvalidate = true
+        }
+    }
+}

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -18,8 +18,18 @@ final class APIRouterAndHandlersTests: XCTestCase {
         var configuredProviderName = "Gemini"
         var requiresExternalCredentials = true
         var unavailableReason: String?
+        nonisolated(unsafe) private var _lastSystemPrompt: String?
+        nonisolated(unsafe) private var _lastUserText: String?
         nonisolated(unsafe) private var _lastRequestedModel: String?
         nonisolated(unsafe) private var _lastTemperatureDirective: PluginLLMTemperatureDirective?
+
+        var lastSystemPrompt: String? {
+            requestLock.withLock { _lastSystemPrompt }
+        }
+
+        var lastUserText: String? {
+            requestLock.withLock { _lastUserText }
+        }
 
         var lastRequestedModel: String? {
             requestLock.withLock { _lastRequestedModel }
@@ -40,6 +50,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
             requestLock.withLock {
+                _lastSystemPrompt = systemPrompt
+                _lastUserText = userText
                 _lastRequestedModel = model
             }
             return responseText
@@ -52,10 +64,27 @@ final class APIRouterAndHandlersTests: XCTestCase {
             temperatureDirective: PluginLLMTemperatureDirective
         ) async throws -> String {
             requestLock.withLock {
+                _lastSystemPrompt = systemPrompt
+                _lastUserText = userText
                 _lastRequestedModel = model
                 _lastTemperatureDirective = temperatureDirective
             }
             return responseText
+        }
+    }
+
+    @MainActor
+    private final class MemoryRetrieverSpy: MemoryRetrieving {
+        private(set) var requestedTexts: [String] = []
+        var context = """
+        <memory_context>
+        The user prefers concise wording.
+        </memory_context>
+        """
+
+        func retrieveRelevantMemories(for text: String) async -> String {
+            requestedTexts.append(text)
+            return context
         }
     }
 
@@ -2258,6 +2287,138 @@ final class APIRouterAndHandlersTests: XCTestCase {
     private static func jsonObject(_ response: HTTPResponse) throws -> [String: Any] {
         let object = try JSONSerialization.jsonObject(with: response.body)
         return try XCTUnwrap(object as? [String: Any])
+    }
+
+    @MainActor
+    func testPromptProcessingInjectsMemoryByDefault() async throws {
+        let providerKey = "llmProviderType"
+        let modelKey = "llmCloudModel"
+        let originalProvider = UserDefaults.standard.object(forKey: providerKey)
+        let originalModel = UserDefaults.standard.object(forKey: modelKey)
+        defer {
+            if let originalProvider {
+                UserDefaults.standard.set(originalProvider, forKey: providerKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: providerKey)
+            }
+            if let originalModel {
+                UserDefaults.standard.set(originalModel, forKey: modelKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: modelKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.models = [PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash")]
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.llm",
+            name: "Mock LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let memoryRetriever = MemoryRetrieverSpy()
+        let service = PromptProcessingService()
+        service.memoryService = memoryRetriever
+
+        _ = try await service.process(
+            prompt: "Fix grammar.",
+            text: "hello world",
+            providerOverride: "Gemini"
+        )
+
+        XCTAssertEqual(memoryRetriever.requestedTexts, ["hello world"])
+        XCTAssertTrue(plugin.lastSystemPrompt?.contains("<memory_context>") == true)
+        XCTAssertTrue(plugin.lastSystemPrompt?.contains("The user prefers concise wording.") == true)
+        XCTAssertTrue(plugin.lastSystemPrompt?.contains("Fix grammar.") == true)
+        XCTAssertEqual(plugin.lastUserText, "hello world")
+    }
+
+    @MainActor
+    func testWorkflowPromptProcessingSkipsMemoryAndUsesWorkflowBehavior() async throws {
+        let providerKey = "llmProviderType"
+        let modelKey = "llmCloudModel"
+        let originalProvider = UserDefaults.standard.object(forKey: providerKey)
+        let originalModel = UserDefaults.standard.object(forKey: modelKey)
+        defer {
+            if let originalProvider {
+                UserDefaults.standard.set(originalProvider, forKey: providerKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: providerKey)
+            }
+            if let originalModel {
+                UserDefaults.standard.set(originalModel, forKey: modelKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: modelKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.models = [
+            PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+            PluginModelInfo(id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro")
+        ]
+
+        let manifest = PluginManifest(
+            id: "com.typewhisper.mock.llm",
+            name: "Mock LLM",
+            version: "1.0.0",
+            principalClass: "APIRouterMockLLMProviderPlugin"
+        )
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: manifest,
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let memoryRetriever = MemoryRetrieverSpy()
+        let service = PromptProcessingService()
+        service.memoryService = memoryRetriever
+
+        let behavior = WorkflowBehavior(
+            providerId: "Gemini",
+            cloudModel: "gemini-2.5-pro",
+            temperatureModeRaw: PluginLLMTemperatureMode.custom.rawValue,
+            temperatureValue: 0.8
+        )
+
+        _ = try await service.processWorkflow(
+            prompt: "Clean up the dictated text.",
+            text: "hello world",
+            behavior: behavior
+        )
+
+        XCTAssertTrue(memoryRetriever.requestedTexts.isEmpty)
+        XCTAssertEqual(plugin.lastSystemPrompt, "Clean up the dictated text.")
+        XCTAssertEqual(plugin.lastUserText, "hello world")
+        XCTAssertEqual(plugin.lastRequestedModel, "gemini-2.5-pro")
+        XCTAssertEqual(plugin.lastTemperatureDirective, .custom(0.8))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Issue #419 reports that the built-in cleaned text workflow adds roughly 2-3 seconds of latency even with fast cloud models such as Gemini 2.5 Flash Lite.

This PR reduces two avoidable sources of latency in the workflow path:

- Workflow LLM post-processing now uses a workflow-specific `PromptProcessingService` path that preserves provider, model, and temperature settings while skipping memory retrieval.
- The plugin SDK HTTP client now reuses one ephemeral `URLSession` across requests, adds a public reset hook, resets on macOS wake, and retries transient `URLError`s once after invalidating the session.
- Prompt processing and post-processing pipeline steps now log timing data without logging transcript text or prompts.
- Regression tests cover default memory injection, workflow memory skipping, workflow model/temperature forwarding, shared HTTP session reuse, reset, and retry behavior.

Closes #419

## Test Coverage

All new code paths have test coverage.

## Pre-Landing Review

Self-reviewed the diff for workflow behavior preservation, memory skip scope, SDK session lifecycle, transient retry behavior, and logging privacy. No in-branch issues found.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No eval lane applies to this TypeWhisper app/SDK change.

## Plan Completion

No plan file detected.

## Verification Results

- `swift test --package-path TypeWhisperPluginSDK` passed, 37 tests.
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPromptProcessingInjectsMemoryByDefault -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testWorkflowPromptProcessingSkipsMemoryAndUsesWorkflowBehavior -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests` passed.
- `xcodebuild build -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` passed.
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"` passed.
- Full app XCTest command was attempted locally, but the run hung in existing environment-dependent tests outside this change. First it blocked in `AudioDeviceServiceCompatibilityTests.testPreviewRecoveryEngineSwap_replacesStoredEngineInstance`; after skipping that test, it later blocked while `ProfileServiceTests.testPrepareNewProfilePrefillsPromptActionAndKeepsEmptyScope` initialized `ServiceContainer` and `AudioRecorderViewModel.loadRecordings()`.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPromptProcessingInjectsMemoryByDefault -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testWorkflowPromptProcessingSkipsMemoryAndUsesWorkflowBehavior -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests`
- [x] `xcodebuild build -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
- [ ] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
