### PR TITLE
feat: add Apple Translate workflow processor

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		AA00000000000000000357 /* WorkflowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000357 /* WorkflowService.swift */; };
 		AA00000000000000000358 /* LegacyWorkflowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000358 /* LegacyWorkflowService.swift */; };
 		AA00000000000000000359 /* WorkflowsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000359 /* WorkflowsSettingsView.swift */; };
+		AA00000000000000000360 /* WorkflowTextProcessingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000360 /* WorkflowTextProcessingService.swift */; };
 		C23000000000000000000001 /* OpenAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000139 /* OpenAIPlugin.swift */; };
 		C23000000000000000000002 /* Qwen3ContextBiasFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000321 /* Qwen3ContextBiasFormatter.swift */; };
 		C23000000000000000000003 /* Gemma4Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000295 /* Gemma4Plugin.swift */; };
@@ -453,6 +454,7 @@
 		BB00000000000000000357 /* WorkflowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowService.swift; sourceTree = "<group>"; };
 		BB00000000000000000358 /* LegacyWorkflowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyWorkflowService.swift; sourceTree = "<group>"; };
 		BB00000000000000000359 /* WorkflowsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsSettingsView.swift; sourceTree = "<group>"; };
+		BB00000000000000000360 /* WorkflowTextProcessingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowTextProcessingService.swift; sourceTree = "<group>"; };
 		BB00000000000000000040 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		BB00000000000000000041 /* HTTPRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestParser.swift; sourceTree = "<group>"; };
 		BB00000000000000000042 /* APIRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRouter.swift; sourceTree = "<group>"; };
@@ -1174,6 +1176,7 @@
 				BB00000000000000000062 /* TextDiffService.swift */,
 				BB00000000000000000066 /* ProfileService.swift */,
 				BB00000000000000000357 /* WorkflowService.swift */,
+				BB00000000000000000360 /* WorkflowTextProcessingService.swift */,
 				BB00000000000000000358 /* LegacyWorkflowService.swift */,
 				BB00000000000000000073 /* TranslationService.swift */,
 				BB00000000000000000074 /* AudioDuckingService.swift */,
@@ -3051,6 +3054,7 @@
 				AA00000000000000000356 /* Workflow.swift in Sources */,
 				AA00000000000000000066 /* ProfileService.swift in Sources */,
 				AA00000000000000000357 /* WorkflowService.swift in Sources */,
+				AA00000000000000000360 /* WorkflowTextProcessingService.swift in Sources */,
 				AA00000000000000000358 /* LegacyWorkflowService.swift in Sources */,
 				AA00000000000000000067 /* ProfilesViewModel.swift in Sources */,
 				AA00000000000000000068 /* ProfilesSettingsView.swift in Sources */,

--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -111,6 +111,20 @@ struct WorkflowTemplateDefinition: Identifiable, Equatable, Sendable {
     var id: WorkflowTemplate { template }
 }
 
+enum WorkflowTranslationProcessor: String, CaseIterable, Codable, Sendable {
+    case appleTranslate
+    case llmPrompt
+
+    var label: String {
+        switch self {
+        case .appleTranslate:
+            localizedAppText("Apple Translate (On-Device)", de: "Apple Translate (On-Device)")
+        case .llmPrompt:
+            localizedAppText("LLM Prompt", de: "LLM-Prompt")
+        }
+    }
+}
+
 enum WorkflowTriggerKind: String, CaseIterable, Codable, Sendable {
     case app
     case website
@@ -196,6 +210,9 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
 }
 
 struct WorkflowBehavior: Codable, Equatable, Sendable {
+    static let translationProcessorSettingKey = "translationProcessor"
+    static let targetLanguageSettingKey = "targetLanguage"
+
     var settings: [String: String]
     var fineTuning: String
     var providerId: String?
@@ -402,8 +419,25 @@ extension Workflow {
         template.definition
     }
 
+    var translationProcessor: WorkflowTranslationProcessor {
+        guard template == .translation else { return .llmPrompt }
+        let rawValue = behavior.settings[WorkflowBehavior.translationProcessorSettingKey]
+        return rawValue.flatMap(WorkflowTranslationProcessor.init(rawValue:)) ?? .llmPrompt
+    }
+
+    var translationTargetLanguage: String? {
+        let rawValue = behavior.settings[WorkflowBehavior.targetLanguageSettingKey]
+            ?? behavior.settings["target"]
+        let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    var usesAppleTranslate: Bool {
+        template == .translation && translationProcessor == .appleTranslate
+    }
+
     var isManuallyRunnable: Bool {
-        systemPrompt() != nil || output.targetActionPluginId != nil
+        usesAppleTranslate || systemPrompt() != nil || output.targetActionPluginId != nil
     }
 
     func systemPrompt(
@@ -427,8 +461,10 @@ extension Workflow {
             \(inputBoundaryInstruction)\(languageHint)\(settingsInstruction)\(fineTuningInstruction)\(outputInstruction)
             """
         case .translation:
-            let targetLanguage = behavior.settings["targetLanguage"]
-                ?? behavior.settings["target"]
+            if usesAppleTranslate {
+                return nil
+            }
+            let targetLanguage = translationTargetLanguage
                 ?? fallbackTranslationTarget
                 ?? "English"
             return """

--- a/TypeWhisper/Services/WorkflowTextProcessingService.swift
+++ b/TypeWhisper/Services/WorkflowTextProcessingService.swift
@@ -1,0 +1,224 @@
+import Foundation
+import TypeWhisperPluginSDK
+import os.log
+
+private let workflowTextProcessingLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper",
+    category: "WorkflowTextProcessingService"
+)
+
+@MainActor
+struct WorkflowTextProcessingService {
+    typealias PromptProcessor = (
+        _ prompt: String,
+        _ text: String,
+        _ providerId: String?,
+        _ cloudModel: String?,
+        _ temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String
+
+    typealias AppleTranslator = (
+        _ text: String,
+        _ targetLanguageCode: String,
+        _ sourceLanguageCode: String?
+    ) async throws -> String
+
+    private let promptProcessor: PromptProcessor
+    private let appleTranslator: AppleTranslator?
+
+    init(
+        promptProcessor: @escaping PromptProcessor,
+        appleTranslator: AppleTranslator?
+    ) {
+        self.promptProcessor = promptProcessor
+        self.appleTranslator = appleTranslator
+    }
+
+    init(promptProcessingService: PromptProcessingService, translationService: AnyObject?) {
+        self.promptProcessor = { prompt, text, providerId, cloudModel, temperatureDirective in
+            try await promptProcessingService.process(
+                prompt: prompt,
+                text: text,
+                providerOverride: providerId,
+                cloudModelOverride: cloudModel,
+                temperatureDirective: temperatureDirective
+            )
+        }
+
+        #if canImport(Translation)
+        if #available(macOS 15, *), let translationService = translationService as? TranslationService {
+            self.appleTranslator = { text, targetLanguageCode, sourceLanguageCode in
+                let targetLanguage = Locale.Language(identifier: targetLanguageCode)
+                let sourceLanguage = sourceLanguageCode.map { Locale.Language(identifier: $0) }
+                return try await translationService.translate(
+                    text: text,
+                    to: targetLanguage,
+                    source: sourceLanguage
+                )
+            }
+        } else {
+            self.appleTranslator = nil
+        }
+        #else
+        self.appleTranslator = nil
+        #endif
+    }
+
+    func process(
+        workflow: Workflow,
+        text: String,
+        fallbackTranslationTarget: String? = nil,
+        detectedLanguage: String? = nil,
+        configuredLanguage: String? = nil
+    ) async throws -> String {
+        if workflow.usesAppleTranslate {
+            return try await processAppleTranslate(
+                workflow: workflow,
+                text: text,
+                fallbackTranslationTarget: fallbackTranslationTarget,
+                detectedLanguage: detectedLanguage,
+                configuredLanguage: configuredLanguage
+            )
+        }
+
+        guard let systemPrompt = workflow.systemPrompt(
+            fallbackTranslationTarget: fallbackTranslationTarget,
+            detectedLanguage: detectedLanguage,
+            configuredLanguage: configuredLanguage
+        ) else {
+            return text
+        }
+
+        let behavior = workflow.behavior
+        return try await promptProcessor(
+            systemPrompt,
+            text,
+            behavior.providerId,
+            behavior.cloudModel,
+            behavior.temperatureDirective
+        )
+    }
+
+    func canProcess(
+        workflow: Workflow,
+        fallbackTranslationTarget: String? = nil,
+        detectedLanguage: String? = nil,
+        configuredLanguage: String? = nil
+    ) -> Bool {
+        if workflow.usesAppleTranslate {
+            return true
+        }
+
+        return workflow.systemPrompt(
+            fallbackTranslationTarget: fallbackTranslationTarget,
+            detectedLanguage: detectedLanguage,
+            configuredLanguage: configuredLanguage
+        ) != nil
+    }
+
+    private func processAppleTranslate(
+        workflow: Workflow,
+        text: String,
+        fallbackTranslationTarget: String?,
+        detectedLanguage: String?,
+        configuredLanguage: String?
+    ) async throws -> String {
+        guard let appleTranslator else {
+            workflowTextProcessingLogger.warning("Apple Translate workflow requested but TranslationService is unavailable")
+            return text
+        }
+
+        let targetRaw = workflow.translationTargetLanguage ?? fallbackTranslationTarget
+        guard let targetLanguageCode = WorkflowTranslationLanguageNormalizer.normalizedLanguageIdentifier(from: targetRaw) else {
+            workflowTextProcessingLogger.error("Apple Translate target language invalid")
+            return text
+        }
+
+        let sourceRaw = detectedLanguage ?? configuredLanguage
+        let sourceLanguageCode = WorkflowTranslationLanguageNormalizer.normalizedLanguageIdentifier(from: sourceRaw)
+
+        return try await appleTranslator(text, targetLanguageCode, sourceLanguageCode)
+    }
+}
+
+enum WorkflowTranslationLanguageNormalizer {
+    nonisolated static func normalizedLanguageIdentifier(from rawIdentifier: String?) -> String? {
+        normalizeLanguageIdentifier(rawIdentifier)
+    }
+
+    nonisolated private static func normalizeLanguageIdentifier(_ rawIdentifier: String?) -> String? {
+        guard var raw = rawIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else { return nil }
+
+        raw = raw.replacingOccurrences(of: "_", with: "-")
+
+        let scriptSpecific = ["zh-Hans", "zh-Hant"]
+        if let exact = scriptSpecific.first(where: { $0.caseInsensitiveCompare(raw) == .orderedSame }) {
+            return exact
+        }
+
+        let foldedRaw = foldLanguageToken(raw)
+        if foldedRaw == "auto" { return nil }
+
+        let primary = raw.split(separator: "-").first.map(String.init) ?? raw
+        let primaryLower = primary.lowercased()
+        if isoLanguageCodes.contains(primaryLower) {
+            return primaryLower
+        }
+
+        return languageAliasMap[foldedRaw]
+    }
+
+    nonisolated private static func foldLanguageToken(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .lowercased()
+    }
+
+    nonisolated private static let languageAliasMap: [String: String] = {
+        var map: [String: String] = [:]
+        let helperLocales = [
+            Locale(identifier: "en_US"),
+            Locale(identifier: "de_DE"),
+            Locale.current,
+        ]
+
+        for code in isoLanguageCodes {
+            map[foldLanguageToken(code)] = code
+
+            for locale in helperLocales {
+                if let localized = locale.localizedString(forIdentifier: code) {
+                    map[foldLanguageToken(localized)] = code
+                }
+            }
+
+            if let autonym = Locale(identifier: code).localizedString(forIdentifier: code) {
+                map[foldLanguageToken(autonym)] = code
+            }
+        }
+
+        map[foldLanguageToken("german")] = "de"
+        map[foldLanguageToken("deutsch")] = "de"
+        map[foldLanguageToken("english")] = "en"
+        map[foldLanguageToken("englisch")] = "en"
+        map[foldLanguageToken("spanish")] = "es"
+        map[foldLanguageToken("spanisch")] = "es"
+        map[foldLanguageToken("espanol")] = "es"
+        map[foldLanguageToken("español")] = "es"
+        map[foldLanguageToken("chinese simplified")] = "zh-Hans"
+        map[foldLanguageToken("simplified chinese")] = "zh-Hans"
+        map[foldLanguageToken("chinese traditional")] = "zh-Hant"
+        map[foldLanguageToken("traditional chinese")] = "zh-Hant"
+
+        return map
+    }()
+
+    nonisolated private static var isoLanguageCodes: [String] {
+        Locale.LanguageCode.isoLanguageCodes.map(\.identifier)
+    }
+}

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -159,6 +159,7 @@ final class DictationViewModel: ObservableObject {
     private let audioDeviceService: AudioDeviceService
     private let promptActionService: PromptActionService
     private let promptProcessingService: PromptProcessingService
+    private let workflowTextProcessingService: WorkflowTextProcessingService
     private let speechFeedbackService: SpeechFeedbackService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
     private let errorLogService: ErrorLogService
@@ -230,6 +231,7 @@ final class DictationViewModel: ObservableObject {
         audioDeviceService: AudioDeviceService,
         promptActionService: PromptActionService,
         promptProcessingService: PromptProcessingService,
+        workflowTextProcessingService: WorkflowTextProcessingService? = nil,
         appFormatterService: AppFormatterService,
         speechFeedbackService: SpeechFeedbackService,
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
@@ -253,6 +255,11 @@ final class DictationViewModel: ObservableObject {
         self.audioDeviceService = audioDeviceService
         self.promptActionService = promptActionService
         self.promptProcessingService = promptProcessingService
+        self.workflowTextProcessingService = workflowTextProcessingService
+            ?? WorkflowTextProcessingService(
+                promptProcessingService: promptProcessingService,
+                translationService: translationService
+            )
         self.speechFeedbackService = speechFeedbackService
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
         self.errorLogService = errorLogService
@@ -281,6 +288,7 @@ final class DictationViewModel: ObservableObject {
             textInsertionService: textInsertionService,
             workflowService: workflowService,
             promptProcessingService: promptProcessingService,
+            workflowTextProcessingService: self.workflowTextProcessingService,
             soundService: soundService,
             accessibilityAnnouncementService: accessibilityAnnouncementService
         )
@@ -1509,23 +1517,12 @@ final class DictationViewModel: ObservableObject {
         detectedLanguage: String?,
         configuredLanguage: String?
     ) -> ((String) async throws -> String)? {
-        if let matchedWorkflow,
-           let systemPrompt = matchedWorkflow.systemPrompt(
-                fallbackTranslationTarget: translationTarget,
-                detectedLanguage: detectedLanguage,
-                configuredLanguage: configuredLanguage
-           ) {
-            let pps = promptProcessingService
-            let behavior = matchedWorkflow.behavior
-            return { text in
-                try await pps.process(
-                    prompt: systemPrompt,
-                    text: text,
-                    providerOverride: behavior.providerId,
-                    cloudModelOverride: behavior.cloudModel,
-                    temperatureDirective: behavior.temperatureDirective
-                )
-            }
+        if let workflowHandler = buildWorkflowTextProcessingHandler(
+            translationTarget: translationTarget,
+            detectedLanguage: detectedLanguage,
+            configuredLanguage: configuredLanguage
+        ) {
+            return workflowHandler
         }
 
         // Inline commands compose with profile prompt; otherwise use prompt action directly
@@ -1579,6 +1576,34 @@ final class DictationViewModel: ObservableObject {
         #endif
 
         return nil
+    }
+
+    private func buildWorkflowTextProcessingHandler(
+        translationTarget: String?,
+        detectedLanguage: String?,
+        configuredLanguage: String?
+    ) -> ((String) async throws -> String)? {
+        guard let workflow = matchedWorkflow else { return nil }
+
+        let workflowProcessor = workflowTextProcessingService
+        guard workflowProcessor.canProcess(
+            workflow: workflow,
+            fallbackTranslationTarget: translationTarget,
+            detectedLanguage: detectedLanguage,
+            configuredLanguage: configuredLanguage
+        ) else {
+            return nil
+        }
+
+        return { text in
+            try await workflowProcessor.process(
+                workflow: workflow,
+                text: text,
+                fallbackTranslationTarget: translationTarget,
+                detectedLanguage: detectedLanguage,
+                configuredLanguage: configuredLanguage
+            )
+        }
     }
 
     /// Builds the system prompt for inline command detection.

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -27,7 +27,7 @@ final class PromptPaletteHandler {
     private let promptPaletteController: any PromptPaletteControlling
     private let textInsertionService: TextInsertionService
     private let workflowService: WorkflowService
-    private let promptProcessingService: PromptProcessingService
+    private let workflowTextProcessingService: WorkflowTextProcessingService
     private let soundService: SoundService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
 
@@ -44,6 +44,7 @@ final class PromptPaletteHandler {
         textInsertionService: TextInsertionService,
         workflowService: WorkflowService,
         promptProcessingService: PromptProcessingService,
+        workflowTextProcessingService: WorkflowTextProcessingService? = nil,
         soundService: SoundService,
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
         promptPaletteController: any PromptPaletteControlling = PromptPaletteController()
@@ -51,7 +52,11 @@ final class PromptPaletteHandler {
         self.promptPaletteController = promptPaletteController
         self.textInsertionService = textInsertionService
         self.workflowService = workflowService
-        self.promptProcessingService = promptProcessingService
+        self.workflowTextProcessingService = workflowTextProcessingService
+            ?? WorkflowTextProcessingService(
+                promptProcessingService: promptProcessingService,
+                translationService: nil
+            )
         self.soundService = soundService
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
     }
@@ -159,18 +164,10 @@ final class PromptPaletteHandler {
         Task { [weak self] in
             guard let self else { return }
             do {
-                let result: String
-                if let systemPrompt = workflow.systemPrompt() {
-                    result = try await promptProcessingService.process(
-                        prompt: systemPrompt,
-                        text: ctx.text,
-                        providerOverride: workflow.behavior.providerId,
-                        cloudModelOverride: workflow.behavior.cloudModel,
-                        temperatureDirective: workflow.behavior.temperatureDirective
-                    )
-                } else {
-                    result = ctx.text
-                }
+                let result = try await workflowTextProcessingService.process(
+                    workflow: workflow,
+                    text: ctx.text
+                )
                 guard !Task.isCancelled else { return }
 
                 // Route to action plugin if configured

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -861,12 +861,7 @@ private struct WorkflowEditorPage: View {
                 }
 
                 if draft.template == .translation {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(localizedAppText("Target Language", de: "Zielsprache"))
-                            .font(.subheadline.weight(.semibold))
-                        TextField(localizedAppText("e.g. English", de: "z. B. Englisch"), text: $draft.translationTargetLanguage)
-                            .textFieldStyle(.roundedBorder)
-                    }
+                    translationProcessorSection
                 }
 
                 if draft.template == .custom {
@@ -880,14 +875,16 @@ private struct WorkflowEditorPage: View {
                     )
                 }
 
-                WorkflowTextEditorField(
-                    title: localizedAppText("Fine-Tuning", de: "Feinabstimmung"),
-                    placeholder: localizedAppText(
-                        "Optional: add tone, length, or wording hints.",
-                        de: "Optional: ergänze Hinweise zu Ton, Länge oder Formulierung."
-                    ),
-                    text: $draft.fineTuning
-                )
+                if !draft.usesAppleTranslate {
+                    WorkflowTextEditorField(
+                        title: localizedAppText("Fine-Tuning", de: "Feinabstimmung"),
+                        placeholder: localizedAppText(
+                            "Optional: add tone, length, or wording hints.",
+                            de: "Optional: ergänze Hinweise zu Ton, Länge oder Formulierung."
+                        ),
+                        text: $draft.fineTuning
+                    )
+                }
 
                 VStack(alignment: .leading, spacing: 0) {
                     Button {
@@ -913,9 +910,11 @@ private struct WorkflowEditorPage: View {
 
                     if isAdvancedExpanded {
                         VStack(alignment: .leading, spacing: 14) {
-                            workflowProviderOverrideSection
+                            if !draft.usesAppleTranslate {
+                                workflowProviderOverrideSection
 
-                            Divider()
+                                Divider()
+                            }
 
                             VStack(alignment: .leading, spacing: 6) {
                                 Text(localizedAppText("Output Format", de: "Ausgabeformat"))
@@ -928,6 +927,63 @@ private struct WorkflowEditorPage: View {
                         }
                         .padding(.top, 4)
                     }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var translationProcessorSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localizedAppText("Translation Mode", de: "Übersetzungsmodus"))
+                    .font(.subheadline.weight(.semibold))
+                Picker(localizedAppText("Translation Mode", de: "Übersetzungsmodus"), selection: $draft.translationProcessor) {
+                    ForEach(WorkflowTranslationProcessor.allCases, id: \.self) { processor in
+                        Text(processor.label).tag(processor)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: draft.translationProcessor) { _, newValue in
+                    draft.normalizeTranslationTarget(for: newValue)
+                }
+            }
+
+            if draft.usesAppleTranslate {
+                #if canImport(Translation)
+                if #available(macOS 15, *) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(localizedAppText("Target Language", de: "Zielsprache"))
+                            .font(.subheadline.weight(.semibold))
+                        Picker(localizedAppText("Target Language", de: "Zielsprache"), selection: $draft.translationTargetLanguage) {
+                            ForEach(TranslationService.availableTargetLanguages, id: \.code) { language in
+                                Text(language.name).tag(language.code)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                } else {
+                    Text(localizedAppText(
+                        "Apple Translate requires macOS 15 or later. Choose LLM Prompt on this Mac.",
+                        de: "Apple Translate benötigt macOS 15 oder neuer. Wähle auf diesem Mac LLM-Prompt."
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                }
+                #else
+                Text(localizedAppText(
+                    "Apple Translate is not available in this build. Choose LLM Prompt instead.",
+                    de: "Apple Translate ist in diesem Build nicht verfügbar. Wähle stattdessen LLM-Prompt."
+                ))
+                .font(.caption)
+                .foregroundStyle(.orange)
+                #endif
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(localizedAppText("Target Language", de: "Zielsprache"))
+                        .font(.subheadline.weight(.semibold))
+                    TextField(localizedAppText("e.g. English", de: "z. B. Englisch"), text: $draft.translationTargetLanguage)
+                        .textFieldStyle(.roundedBorder)
                 }
             }
         }
@@ -1748,6 +1804,7 @@ private struct WorkflowDraft {
     var hotkeys: [UnifiedHotkey]
     var fineTuning: String
     var translationTargetLanguage: String
+    var translationProcessor: WorkflowTranslationProcessor
     var customInstruction: String
     var outputFormat: String
     var autoEnter: Bool
@@ -1768,7 +1825,10 @@ private struct WorkflowDraft {
         self.websitePatterns = []
         self.hotkeys = []
         self.fineTuning = ""
-        self.translationTargetLanguage = template == .translation ? "English" : ""
+        self.translationProcessor = template == .translation ? Self.defaultTranslationProcessor : .llmPrompt
+        self.translationTargetLanguage = template == .translation
+            ? Self.defaultTranslationTargetLanguage(for: translationProcessor)
+            : ""
         self.customInstruction = ""
         self.outputFormat = ""
         self.autoEnter = false
@@ -1788,7 +1848,14 @@ private struct WorkflowDraft {
         self.isEnabled = workflow.isEnabled
         self.template = workflow.template
         self.fineTuning = behavior.fineTuning
-        self.translationTargetLanguage = behavior.settings["targetLanguage"] ?? behavior.settings["target"] ?? ""
+        self.translationProcessor = workflow.translationProcessor
+        let rawTranslationTargetLanguage = workflow.translationTargetLanguage ?? ""
+        if workflow.usesAppleTranslate,
+           let normalized = WorkflowTranslationLanguageNormalizer.normalizedLanguageIdentifier(from: rawTranslationTargetLanguage) {
+            self.translationTargetLanguage = normalized
+        } else {
+            self.translationTargetLanguage = rawTranslationTargetLanguage
+        }
         self.customInstruction = behavior.settings["instruction"] ?? behavior.settings["goal"] ?? behavior.settings["prompt"] ?? ""
         self.outputFormat = output.format ?? ""
         self.autoEnter = output.autoEnter
@@ -1840,6 +1907,10 @@ private struct WorkflowDraft {
         return trimmed.isEmpty ? template.definition.name : trimmed
     }
 
+    var usesAppleTranslate: Bool {
+        template == .translation && translationProcessor == .appleTranslate
+    }
+
     var reviewText: String {
         if triggerKind == .manual {
             return localizedAppText(
@@ -1872,9 +1943,13 @@ private struct WorkflowDraft {
         }
 
         if newTemplate != .translation {
+            translationProcessor = .llmPrompt
             translationTargetLanguage = ""
-        } else if translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            translationTargetLanguage = "English"
+        } else {
+            translationProcessor = Self.defaultTranslationProcessor
+            if translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                translationTargetLanguage = Self.defaultTranslationTargetLanguage(for: translationProcessor)
+            }
         }
 
         if newTemplate != .custom {
@@ -1956,6 +2031,23 @@ private struct WorkflowDraft {
             )
         }
 
+        if usesAppleTranslate {
+            #if canImport(Translation)
+            if #available(macOS 15, *) {
+            } else {
+                return localizedAppText(
+                    "Apple Translate workflows require macOS 15 or later.",
+                    de: "Apple-Translate-Workflows benötigen macOS 15 oder neuer."
+                )
+            }
+            #else
+            return localizedAppText(
+                "Apple Translate is not available in this build.",
+                de: "Apple Translate ist in diesem Build nicht verfügbar."
+            )
+            #endif
+        }
+
         if template == .custom {
             let hasCustomInstruction = !customInstruction.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             let hasFineTuning = !fineTuning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -1992,13 +2084,15 @@ private struct WorkflowDraft {
         var settings = preservedBehaviorSettings
         settings.removeValue(forKey: "targetLanguage")
         settings.removeValue(forKey: "target")
+        settings.removeValue(forKey: WorkflowBehavior.translationProcessorSettingKey)
         settings.removeValue(forKey: "instruction")
         settings.removeValue(forKey: "goal")
         settings.removeValue(forKey: "prompt")
 
         let trimmedTargetLanguage = translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
         if template == .translation && !trimmedTargetLanguage.isEmpty {
-            settings["targetLanguage"] = trimmedTargetLanguage
+            settings[WorkflowBehavior.targetLanguageSettingKey] = trimmedTargetLanguage
+            settings[WorkflowBehavior.translationProcessorSettingKey] = translationProcessor.rawValue
         }
 
         let trimmedInstruction = customInstruction.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2072,15 +2166,56 @@ private struct WorkflowDraft {
             workflowHotkeysConflict(candidate, hotkey)
         }
     }
+
+    mutating func normalizeTranslationTarget(for processor: WorkflowTranslationProcessor) {
+        guard template == .translation else { return }
+        let current = translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch processor {
+        case .appleTranslate:
+            if let normalized = WorkflowTranslationLanguageNormalizer.normalizedLanguageIdentifier(from: current) {
+                translationTargetLanguage = normalized
+            } else {
+                translationTargetLanguage = Self.defaultTranslationTargetLanguage(for: processor)
+            }
+        case .llmPrompt:
+            if current.isEmpty || current == "en" {
+                translationTargetLanguage = Self.defaultTranslationTargetLanguage(for: processor)
+            }
+        }
+    }
+
+    private static var defaultTranslationProcessor: WorkflowTranslationProcessor {
+        #if canImport(Translation)
+        if #available(macOS 15, *) {
+            return .appleTranslate
+        }
+        #endif
+        return .llmPrompt
+    }
+
+    private static func defaultTranslationTargetLanguage(for processor: WorkflowTranslationProcessor) -> String {
+        switch processor {
+        case .appleTranslate:
+            "en"
+        case .llmPrompt:
+            "English"
+        }
+    }
 }
 
 private func workflowSummaryText(for workflow: Workflow) -> String {
     let templateName = workflow.template.definition.name
     switch workflow.template {
     case .translation:
-        let targetLanguage = workflow.behavior.settings["targetLanguage"]
-            ?? workflow.behavior.settings["target"]
+        let targetLanguage = workflow.translationTargetLanguage
         if let targetLanguage, !targetLanguage.isEmpty {
+            if workflow.usesAppleTranslate {
+                return localizedAppText(
+                    "Apple Translate to \(localizedAppLanguageName(for: targetLanguage))",
+                    de: "Apple Translate nach \(localizedAppLanguageName(for: targetLanguage))"
+                )
+            }
             return localizedAppText(
                 "\(templateName) to \(targetLanguage)",
                 de: "\(templateName) nach \(targetLanguage)"

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -185,6 +185,184 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertFalse(prompt.contains("unless the instruction explicitly says otherwise"))
     }
 
+    func testLegacyTranslationWorkflowWithoutProcessorKeepsLLMPrompt() throws {
+        let workflow = Workflow(
+            name: "Legacy Translate",
+            template: .translation,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(settings: ["targetLanguage": "German"])
+        )
+
+        XCTAssertEqual(workflow.translationProcessor, .llmPrompt)
+        XCTAssertEqual(workflow.translationTargetLanguage, "German")
+        XCTAssertFalse(workflow.usesAppleTranslate)
+
+        let prompt = try XCTUnwrap(workflow.systemPrompt())
+        XCTAssertTrue(prompt.contains("Translate the dictated text into German."))
+    }
+
+    func testAppleTranslateWorkflowHasNoLLMPromptButIsManuallyRunnable() {
+        let workflow = Workflow(
+            name: "Apple Translate",
+            template: .translation,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(settings: [
+                "translationProcessor": WorkflowTranslationProcessor.appleTranslate.rawValue,
+                "targetLanguage": "en",
+            ])
+        )
+
+        XCTAssertEqual(workflow.translationProcessor, .appleTranslate)
+        XCTAssertEqual(workflow.translationTargetLanguage, "en")
+        XCTAssertTrue(workflow.usesAppleTranslate)
+        XCTAssertTrue(workflow.isManuallyRunnable)
+        XCTAssertNil(workflow.systemPrompt())
+    }
+
+    func testWorkflowServicePersistsTranslationProcessorAndTargetLanguage() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        service.addWorkflow(
+            name: "Apple Translate",
+            template: .translation,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(settings: [
+                "translationProcessor": WorkflowTranslationProcessor.appleTranslate.rawValue,
+                "targetLanguage": "en",
+            ])
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(workflow.translationProcessor, .appleTranslate)
+        XCTAssertEqual(workflow.translationTargetLanguage, "en")
+        XCTAssertTrue(workflow.usesAppleTranslate)
+    }
+
+    func testWorkflowTextProcessingServiceUsesAppleTranslatorWithNormalizedLanguages() async throws {
+        let workflow = Workflow(
+            name: "Apple Translate",
+            template: .translation,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(settings: [
+                "translationProcessor": WorkflowTranslationProcessor.appleTranslate.rawValue,
+                "targetLanguage": "German",
+            ])
+        )
+
+        var capturedText: String?
+        var capturedTargetLanguage: String?
+        var capturedSourceLanguage: String?
+        let service = WorkflowTextProcessingService(
+            promptProcessor: { _, _, _, _, _ in
+                XCTFail("Apple Translate workflows must not use the LLM prompt processor")
+                return ""
+            },
+            appleTranslator: { text, targetLanguage, sourceLanguage in
+                capturedText = text
+                capturedTargetLanguage = targetLanguage
+                capturedSourceLanguage = sourceLanguage
+                return "Hallo Welt"
+            }
+        )
+
+        let result = try await service.process(
+            workflow: workflow,
+            text: "Hello world",
+            fallbackTranslationTarget: nil,
+            detectedLanguage: "English",
+            configuredLanguage: nil
+        )
+
+        XCTAssertEqual(result, "Hallo Welt")
+        XCTAssertEqual(capturedText, "Hello world")
+        XCTAssertEqual(capturedTargetLanguage, "de")
+        XCTAssertEqual(capturedSourceLanguage, "en")
+    }
+
+    func testWorkflowTextProcessingServiceUsesLLMPromptPathForLegacyTranslationWorkflows() async throws {
+        let workflow = Workflow(
+            name: "LLM Translate",
+            template: .translation,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(
+                settings: ["targetLanguage": "German"],
+                providerId: "Groq",
+                cloudModel: "llama-3.3",
+                temperatureModeRaw: "custom",
+                temperatureValue: 0.2
+            )
+        )
+
+        var capturedPrompt: String?
+        var capturedText: String?
+        var capturedProvider: String?
+        var capturedModel: String?
+        var capturedTemperature = workflow.behavior.temperatureDirective
+        let service = WorkflowTextProcessingService(
+            promptProcessor: { prompt, text, providerId, cloudModel, temperatureDirective in
+                capturedPrompt = prompt
+                capturedText = text
+                capturedProvider = providerId
+                capturedModel = cloudModel
+                capturedTemperature = temperatureDirective
+                return "Verarbeiteter Text"
+            },
+            appleTranslator: { _, _, _ in
+                XCTFail("Legacy translation workflows must use the LLM prompt processor")
+                return ""
+            }
+        )
+
+        let result = try await service.process(
+            workflow: workflow,
+            text: "Hello world",
+            fallbackTranslationTarget: nil,
+            detectedLanguage: "English",
+            configuredLanguage: nil
+        )
+
+        XCTAssertEqual(result, "Verarbeiteter Text")
+        XCTAssertTrue(capturedPrompt?.contains("Translate the dictated text into German.") == true)
+        XCTAssertEqual(capturedText, "Hello world")
+        XCTAssertEqual(capturedProvider, "Groq")
+        XCTAssertEqual(capturedModel, "llama-3.3")
+        XCTAssertEqual(capturedTemperature, workflow.behavior.temperatureDirective)
+    }
+
+    func testWorkflowTextProcessingServiceMissingAppleTranslatorReturnsOriginalText() async throws {
+        let workflow = Workflow(
+            name: "Apple Translate",
+            template: .translation,
+            trigger: .manual(),
+            behavior: WorkflowBehavior(settings: [
+                "translationProcessor": WorkflowTranslationProcessor.appleTranslate.rawValue,
+                "targetLanguage": "en",
+            ])
+        )
+
+        let service = WorkflowTextProcessingService(
+            promptProcessor: { _, _, _, _, _ in
+                XCTFail("Apple Translate workflows must not use the LLM prompt processor when translator is unavailable")
+                return ""
+            },
+            appleTranslator: nil
+        )
+
+        let result = try await service.process(
+            workflow: workflow,
+            text: "Bonjour",
+            fallbackTranslationTarget: nil,
+            detectedLanguage: "French",
+            configuredLanguage: nil
+        )
+
+        XCTAssertEqual(result, "Bonjour")
+    }
+
     func testMatchWorkflowSupportsMultipleAppsAndWebsitesPerWorkflow() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary
Implements issue #424 by making Apple Translate an on-device processing path inside the existing Translation workflow template, instead of adding it as a separate LLM provider.

- Adds `WorkflowTranslationProcessor` with `appleTranslate` and `llmPrompt`, persisted in `WorkflowBehavior.settings["translationProcessor"]`.
- Adds `WorkflowTextProcessingService` to route translation workflows through Apple Translate or the existing LLM prompt path.
- Uses the shared workflow processor for automatic dictation post-processing and Workflow Palette execution.
- Updates Workflows settings so new translation workflows default to Apple Translate on macOS 15+, legacy translation workflows remain LLM prompt workflows, Apple Translate uses target language codes, and LLM-only controls are hidden in Apple mode.
- Adds XCTest coverage for legacy compatibility, Apple Translate prompt suppression/manual runnability, persistence, translator normalization, LLM routing, and unsupported-system fallback.

Closes #424

## Test Coverage
New coverage was added in `TypeWhisperTests/WorkflowServiceTests.swift` for model compatibility, persistence, and workflow processing behavior.

## Pre-Landing Review
No issues found.

## Design Review
This PR changes SwiftUI settings UI. The web-focused design review flow was skipped for TypeWhisper; a dedicated macOS visual pass can be done separately if needed.

## Eval Results
No prompt eval suite applies to this TypeWhisper change.

## Scope Drift
Scope Check: CLEAN. Delivered native Apple Translate support for existing translation workflows without creating a new provider/template.

## Plan Completion
Implementation plan addressed: model/settings persistence, shared processor, dictation and palette integration, settings UI, macOS availability guard, and tests.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/conductor/workspaces/typewhisper-mac/irvine-v1`


## Documentation
Documentation synced in companion repo PR: https://github.com/TypeWhisper/typewhisper.com/pull/48

Doc diff preview:
- `src/i18n/locales/en.json`: documented Apple Translate vs LLM Prompt translation modes in macOS workflow docs.
- `src/i18n/locales/de.json`: added the matching German workflow translation documentation.
- `src/pages/docs/mac/_rules.tsx`: added Translation mode to the workflow creation list and added a Translation workflow example.
