### PR TITLE
fix: disable live transcript auto-open by default

### DIFF
--- a/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
+++ b/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
@@ -22,7 +22,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     private var viewModel: LiveTranscriptViewModel?
     private var autoCloseTask: Task<Void, Never>?
 
-    fileprivate var _autoOpen: Bool = true
+    fileprivate var _autoOpen: Bool = false
     fileprivate var _fontSize: Double = 14.0
     private let autoCloseDelay: Double = 4.0
 
@@ -30,6 +30,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     private var globalMonitor: Any?
     private var localMonitor: Any?
     private var hotkeyIsDown: Bool = false
+    private var streamingDisplayActive = false
 
     required override init() {
         super.init()
@@ -37,7 +38,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
 
     func activate(host: HostServices) {
         self.host = host
-        _autoOpen = host.userDefault(forKey: "autoOpen") as? Bool ?? true
+        _autoOpen = host.userDefault(forKey: "autoOpen") as? Bool ?? false
         _fontSize = host.userDefault(forKey: "fontSize") as? Double ?? 14.0
 
         if let data = host.userDefault(forKey: "toggleHotkey") as? Data {
@@ -49,7 +50,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
             await self?.handleEvent(event)
         }
 
-        host.setStreamingDisplayActive(true)
+        setStreamingDisplayActiveIfNeeded(_autoOpen)
     }
 
     func deactivate() {
@@ -57,7 +58,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
             host?.eventBus.unsubscribe(id: id)
             subscriptionId = nil
         }
-        host?.setStreamingDisplayActive(false)
+        setStreamingDisplayActiveIfNeeded(false)
         tearDownHotkeyMonitor()
         autoCloseTask?.cancel()
         Task { @MainActor [weak self] in
@@ -70,6 +71,24 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
 
     var settingsView: AnyView? {
         AnyView(LiveTranscriptSettingsView(plugin: self))
+    }
+
+    @MainActor
+    func updateAutoOpenPreference(_ enabled: Bool) {
+        _autoOpen = enabled
+        host?.setUserDefault(enabled, forKey: "autoOpen")
+        refreshStreamingDisplayActive()
+    }
+
+    private func setStreamingDisplayActiveIfNeeded(_ active: Bool) {
+        guard streamingDisplayActive != active else { return }
+        streamingDisplayActive = active
+        host?.setStreamingDisplayActive(active)
+    }
+
+    @MainActor
+    private func refreshStreamingDisplayActive() {
+        setStreamingDisplayActiveIfNeeded(_autoOpen || panel?.isVisible == true)
     }
 
     // MARK: - Event Handling
@@ -104,6 +123,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
             panel = LiveTranscriptPanel(viewModel: vm, fontSize: _fontSize)
         }
         panel?.orderFront(nil)
+        refreshStreamingDisplayActive()
     }
 
     @MainActor
@@ -112,6 +132,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
         if let panel, panel.isVisible {
             panel.close()
             self.panel = nil
+            refreshStreamingDisplayActive()
         } else {
             showPanel()
         }
@@ -125,6 +146,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
             guard !Task.isCancelled else { return }
             self?.panel?.close()
             self?.panel = nil
+            self?.refreshStreamingDisplayActive()
         }
     }
 
@@ -549,7 +571,7 @@ private struct ScrollWheelDetector: NSViewRepresentable {
 
 private struct LiveTranscriptSettingsView: View {
     let plugin: LiveTranscriptPlugin
-    @State private var autoOpen: Bool = true
+    @State private var autoOpen: Bool = false
     @State private var fontSize: Double = 14.0
     @State private var currentHotkey: PluginHotkey?
     @State private var isRecording: Bool = false
@@ -567,8 +589,7 @@ private struct LiveTranscriptSettingsView: View {
                 }
             }
             .onChange(of: autoOpen) { _, newValue in
-                plugin._autoOpen = newValue
-                plugin.host?.setUserDefault(newValue, forKey: "autoOpen")
+                plugin.updateAutoOpenPreference(newValue)
             }
 
             Divider()

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */; };
 		1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */; };
 		4D980A5CFE1A4217A10C2101 /* WhisperKitPluginLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */; };
+		C42900000000000000000001 /* LiveTranscriptPluginBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42900000000000000000002 /* LiveTranscriptPluginBehaviorTests.swift */; };
+		C42900000000000000000003 /* LiveTranscriptPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000216 /* LiveTranscriptPlugin.swift */; };
 		204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E808D246301E36546EEB811F /* TestSupport.swift */; };
 		A1F000000000000000000102 /* PostUpdatePromptCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */; };
 		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
@@ -655,6 +657,7 @@
 		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppFormatterServiceTests.swift; sourceTree = "<group>"; };
 		4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperKitPluginLifecycleTests.swift; sourceTree = "<group>"; };
+		C42900000000000000000002 /* LiveTranscriptPluginBehaviorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveTranscriptPluginBehaviorTests.swift; sourceTree = "<group>"; };
 		D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryServiceTests.swift; sourceTree = "<group>"; };
 		D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		DD00000000000000000098 /* typewhisper-cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "typewhisper-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1789,6 +1792,7 @@
 				7D2E4F50617283946C1F7A8B /* SoundServiceTests.swift */,
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
 				D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */,
+				C42900000000000000000002 /* LiveTranscriptPluginBehaviorTests.swift */,
 				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
 				4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
@@ -2975,6 +2979,8 @@
 				C23000000000000000000010 /* DeepgramPlugin.swift in Sources */,
 				C23000000000000000000003 /* Gemma4Plugin.swift in Sources */,
 				C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */,
+				C42900000000000000000003 /* LiveTranscriptPlugin.swift in Sources */,
+				C42900000000000000000001 /* LiveTranscriptPluginBehaviorTests.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */,

--- a/TypeWhisperTests/LiveTranscriptPluginBehaviorTests.swift
+++ b/TypeWhisperTests/LiveTranscriptPluginBehaviorTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import TypeWhisperPluginSDK
+
+@MainActor
+final class LiveTranscriptPluginBehaviorTests: XCTestCase {
+    private final class MockEventBus: EventBusProtocol, @unchecked Sendable {
+        private var handlers: [UUID: @Sendable (TypeWhisperEvent) async -> Void] = [:]
+
+        @discardableResult
+        func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID {
+            let id = UUID()
+            handlers[id] = handler
+            return id
+        }
+
+        func unsubscribe(id: UUID) {
+            handlers.removeValue(forKey: id)
+        }
+    }
+
+    private final class MockHostServices: HostServices, @unchecked Sendable {
+        private var defaults: [String: Any]
+
+        let pluginDataDirectory: URL
+        let eventBus: EventBusProtocol = MockEventBus()
+        var activeAppBundleId: String?
+        var activeAppName: String?
+        var availableRuleNames: [String] = []
+        private(set) var streamingDisplayActiveValues: [Bool] = []
+
+        init(defaults: [String: Any] = [:]) throws {
+            self.defaults = defaults
+            pluginDataDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LiveTranscriptPlugin")
+        }
+
+        deinit {
+            TestSupport.remove(pluginDataDirectory)
+        }
+
+        func storeSecret(key: String, value: String) throws {}
+        func loadSecret(key: String) -> String? { nil }
+        func userDefault(forKey key: String) -> Any? { defaults[key] }
+        func setUserDefault(_ value: Any?, forKey key: String) { defaults[key] = value }
+        func notifyCapabilitiesChanged() {}
+        func setStreamingDisplayActive(_ active: Bool) {
+            streamingDisplayActiveValues.append(active)
+        }
+    }
+
+    func testAutoOpenDefaultsToDisabledWhenUnset() throws {
+        let host = try MockHostServices()
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        XCTAssertNil(host.userDefault(forKey: "autoOpen"))
+        XCTAssertEqual(host.streamingDisplayActiveValues, [])
+    }
+
+    func testStoredAutoOpenTrueIsPreservedOnActivation() throws {
+        let host = try MockHostServices(defaults: ["autoOpen": true])
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        XCTAssertEqual(host.streamingDisplayActiveValues, [true])
+    }
+
+    func testActivationWithDefaultSettingsDoesNotRegisterStreamingDisplay() throws {
+        let host = try MockHostServices()
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        XCTAssertTrue(host.streamingDisplayActiveValues.isEmpty)
+    }
+
+    func testEnablingAutoOpenRegistersStreamingDisplayExactlyOnce() throws {
+        let host = try MockHostServices()
+        let plugin = LiveTranscriptPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        plugin.updateAutoOpenPreference(true)
+        plugin.updateAutoOpenPreference(true)
+
+        XCTAssertEqual(host.userDefault(forKey: "autoOpen") as? Bool, true)
+        XCTAssertEqual(host.streamingDisplayActiveValues, [true])
+    }
+
+    func testDeactivationUnregistersActiveStreamingDisplay() throws {
+        let host = try MockHostServices()
+        let plugin = LiveTranscriptPlugin()
+        plugin.activate(host: host)
+
+        plugin.updateAutoOpenPreference(true)
+        plugin.deactivate()
+
+        XCTAssertEqual(host.streamingDisplayActiveValues, [true, false])
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the Live Transcript auto-open behavior behind Issue #429.

Issue context: when the Live Transcript plugin was enabled, it could automatically open its floating transcript panel during push-to-talk recording. In the reported failure mode this appeared as a black floating square and could interfere with the normal streaming indicator behavior.

Changes shipped:
- Default `plugin.com.typewhisper.livetranscript.autoOpen` to `false` when no user preference exists.
- Preserve the existing explicit preference when `autoOpen = true` is already stored.
- Add an idempotent streaming-display helper so the plugin only suppresses the built-in indicator preview when auto-open is enabled or the transcript panel is visible.
- Update the settings UI initial state and preference handling to match the new default.
- Ensure plugin deactivation unregisters the external streaming display and closes the panel cleanly.
- Add focused behavior tests for activation, explicit preference preservation, streaming-display registration, and deactivation cleanup.

Closes #429

## Test Coverage
All new Live Transcript activation behavior is covered by focused XCTest coverage.

New tests cover:
- no stored `autoOpen` value defaults to `false`
- stored `autoOpen = true` is preserved
- activation with default settings does not register an external streaming display
- enabling auto-open registers the external streaming display exactly once
- deactivation unregisters the external streaming display

## Pre-Landing Review
No issues found.

## Design Review
No standalone design review was run. The UI change is limited to the existing Live Transcript settings toggle state and preference handling.

## Eval Results
No prompt-related files changed — evals skipped.

## Plan Completion
Implemented the requested Issue #429 plan:
- [x] Changed Live Transcript default auto-open behavior
- [x] Preserved explicit stored `autoOpen = true`
- [x] Added idempotent streaming-display activation helper
- [x] Updated settings behavior
- [x] Hardened deactivation cleanup
- [x] Added focused behavior tests
- [x] Verified with targeted and full test runs

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/LiveTranscriptPluginBehaviorTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh LiveTranscriptPlugin "$(pwd)"`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`


## Documentation
No documentation files changed. Audit result: app repo docs and public `typewhisper.com` docs do not describe Live Transcript plugin auto-open behavior, so there was nothing stale to update.
