### PR TITLE
fix: keep indicator panels out of fullscreen spaces

### DIFF
--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -8,6 +8,7 @@ enum FloatingPanelSpacePolicy {
 
     static let indicatorCollectionBehavior: NSWindow.CollectionBehavior = [
         .canJoinAllSpaces,
+        .fullScreenNone,
         .stationary,
         .ignoresCycle
     ]

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -15,6 +15,9 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
         XCTAssertFalse(
             FloatingPanelSpacePolicy.indicatorCollectionBehavior.contains(.fullScreenAuxiliary)
         )
+        XCTAssertTrue(
+            FloatingPanelSpacePolicy.indicatorCollectionBehavior.contains(.fullScreenNone)
+        )
     }
 
     func testSelectionPaletteStillSupportsFullscreenUsage() {


### PR DESCRIPTION
## Summary

- Adds `.fullScreenNone` to the shared indicator panel collection behavior so passive indicators keep their normal-space behavior without joining another app's fullscreen space.
- Keeps `.canJoinAllSpaces` in place to preserve multi-desktop indicator behavior from #165.
- Extends `FloatingPanelSpacePolicyTests` to assert the fullscreen opt-out.

## Issue Context

Issue #373 reports that TypeWhisper's indicator panel can still bleed into the notch strip area over another app running fullscreen. The earlier fix removed `.fullScreenAuxiliary`, but the shared indicator policy still used `.canJoinAllSpaces` at `CGShieldingWindowLevel()`. This PR makes the fullscreen opt-out explicit with `.fullScreenNone`.

Closes #373

## Test Coverage

All new code paths have test coverage.

## Pre-Landing Review

No issues found.

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
