### PR TITLE
Add filler words post-processor plugin

### DIFF
--- a/Plugins/FillerWordsPlugin/FillerWordsPlugin.swift
+++ b/Plugins/FillerWordsPlugin/FillerWordsPlugin.swift
@@ -1,0 +1,240 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+@objc(FillerWordsPlugin)
+final class FillerWordsPlugin: NSObject, PostProcessorPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.filler-words"
+    static let pluginName = "Filler Words"
+
+    let processorName = "Filler Words"
+    let priority = 250
+
+    private var settingsStore: FillerWordsSettingsStore?
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        settingsStore = FillerWordsSettingsStore(host: host)
+    }
+
+    func deactivate() {
+        settingsStore = nil
+    }
+
+    var settingsView: AnyView? {
+        guard let settingsStore else { return nil }
+        return AnyView(FillerWordsSettingsView(store: settingsStore))
+    }
+
+    @MainActor
+    func process(text: String, context: PostProcessingContext) async throws -> String {
+        Self.removeFillerWords(from: text, words: settingsStore?.words ?? Self.defaultFillerWords)
+    }
+
+    static func removeFillerWords(from text: String) -> String {
+        removeFillerWords(from: text, words: defaultFillerWords)
+    }
+
+    static func removeFillerWords(from text: String, words: [String]) -> String {
+        guard !text.isEmpty else { return text }
+
+        let normalizedWords = normalizedWords(from: words)
+        guard !normalizedWords.isEmpty else { return text }
+
+        let escapedWords = normalizedWords
+            .map(NSRegularExpression.escapedPattern(for:))
+            .joined(separator: "|")
+        let pattern = #"(?i)(?<![\p{L}\p{N}_])[,.!?]?[ \t]*(?:"# + escapedWords + #")(?![\p{L}\p{N}_])[ \t]*[,.!?]?"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return text
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let stripped = regex.stringByReplacingMatches(in: text, range: range, withTemplate: " ")
+        guard stripped != text else { return text }
+
+        return normalizeWhitespaceAfterRemoval(stripped, preservingPrefixFrom: text)
+    }
+
+    static let defaultFillerWords: [String] = [
+        "ah",
+        "ahh",
+        "eh",
+        "ehm",
+        "hm",
+        "hmm",
+        "uh",
+        "uhh",
+        "um",
+        "umm",
+        "äh",
+        "ähm"
+    ]
+
+    static func normalizedWords(from text: String) -> [String] {
+        normalizedWords(from: text.split { separator in
+            separator.isNewline || separator == "," || separator == ";"
+        }.map(String.init))
+    }
+
+    private static func normalizedWords(from words: [String]) -> [String] {
+        var seen = Set<String>()
+        var normalized: [String] = []
+
+        for word in words {
+            let cleaned = word.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !cleaned.isEmpty, seen.insert(cleaned).inserted else { continue }
+            normalized.append(cleaned)
+        }
+
+        return normalized.sorted { $0.count > $1.count || ($0.count == $1.count && $0 < $1) }
+    }
+
+    private static func normalizeWhitespaceAfterRemoval(_ text: String, preservingPrefixFrom original: String) -> String {
+        var result = text.replacingOccurrences(
+            of: #"(?<=[^\s]) {2,}(?=[^\s])"#,
+            with: " ",
+            options: .regularExpression
+        )
+
+        result = result.replacingOccurrences(
+            of: #"(?m)^ +"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #" +$"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        if original.first?.isWhitespace == true, result.first == " " {
+            return result
+        }
+
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+}
+
+private final class FillerWordsSettingsStore: ObservableObject, @unchecked Sendable {
+    private static let wordsKey = "words"
+    private static let defaultsVersionKey = "wordsDefaultsVersion"
+    private static let currentDefaultsVersion = 2
+    private static let legacyDefaultFillerWords = [
+        "ah",
+        "ahh",
+        "hm",
+        "hmm",
+        "uh",
+        "uhh",
+        "um",
+        "umm"
+    ]
+
+    private let host: HostServices
+
+    @Published var wordsText: String {
+        didSet {
+            host.setUserDefault(wordsText, forKey: Self.wordsKey)
+        }
+    }
+
+    init(host: HostServices) {
+        self.host = host
+
+        if let storedWords = host.userDefault(forKey: Self.wordsKey) as? String {
+            wordsText = Self.migratedWordsTextIfNeeded(storedWords, host: host)
+        } else {
+            wordsText = Self.defaultWordsText
+            host.setUserDefault(wordsText, forKey: Self.wordsKey)
+            host.setUserDefault(Self.currentDefaultsVersion, forKey: Self.defaultsVersionKey)
+        }
+    }
+
+    var words: [String] {
+        FillerWordsPlugin.normalizedWords(from: wordsText)
+    }
+
+    var wordCount: Int {
+        words.count
+    }
+
+    func resetToDefaults() {
+        wordsText = Self.defaultWordsText
+    }
+
+    private static var defaultWordsText: String {
+        FillerWordsPlugin.defaultFillerWords.joined(separator: "\n")
+    }
+
+    private static var legacyDefaultWordsText: String {
+        legacyDefaultFillerWords.joined(separator: "\n")
+    }
+
+    private static func migratedWordsTextIfNeeded(_ storedWords: String, host: HostServices) -> String {
+        let storedVersion = host.userDefault(forKey: defaultsVersionKey) as? Int ?? 1
+        guard storedVersion < currentDefaultsVersion else { return storedWords }
+
+        let storedNormalized = Set(FillerWordsPlugin.normalizedWords(from: storedWords))
+        let legacyNormalized = Set(FillerWordsPlugin.normalizedWords(from: legacyDefaultWordsText))
+        guard storedNormalized.isSuperset(of: legacyNormalized) else {
+            host.setUserDefault(currentDefaultsVersion, forKey: defaultsVersionKey)
+            return storedWords
+        }
+
+        let migratedWords: String
+        if storedNormalized == legacyNormalized {
+            migratedWords = defaultWordsText
+        } else {
+            let missingDefaults = FillerWordsPlugin.defaultFillerWords.filter { word in
+                !storedNormalized.contains(word.lowercased())
+            }
+            migratedWords = storedWords + "\n" + missingDefaults.joined(separator: "\n")
+        }
+
+        host.setUserDefault(migratedWords, forKey: wordsKey)
+        host.setUserDefault(currentDefaultsVersion, forKey: defaultsVersionKey)
+        return migratedWords
+    }
+}
+
+private struct FillerWordsSettingsView: View {
+    @ObservedObject var store: FillerWordsSettingsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Filler words")
+                .font(.headline)
+
+            Text("One word per line. Commas and semicolons are also accepted.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: $store.wordsText)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 150)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(.separator, lineWidth: 1)
+                )
+
+            HStack {
+                Text("\(store.wordCount) words")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button("Reset Defaults") {
+                    store.resetToDefaults()
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 360, minHeight: 260)
+    }
+}

--- a/Plugins/FillerWordsPlugin/manifest.json
+++ b/Plugins/FillerWordsPlugin/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "com.typewhisper.filler-words",
+  "name": "Filler Words",
+  "version": "1.0.0",
+  "minHostVersion": "1.0.0",
+  "sdkCompatibilityVersion": "v1",
+  "minOSVersion": "14.0",
+  "author": "TypeWhisper",
+  "principalClass": "FillerWordsPlugin",
+  "requiresAPIKey": false,
+  "iconSystemName": "text.badge.minus",
+  "category": "post-processor"
+}

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -78,6 +78,11 @@
 		86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BD305007A3A158038C75C /* ProfileServiceTests.swift */; };
 		928A1F1B7A0D4C62A2B90761 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000034 /* TypeWhisperPluginSDK */; };
 		A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */; };
+		F18A00000000000000000001 /* FillerWordsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000010 /* FillerWordsPlugin.swift */; };
+		F18A00000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000011 /* manifest.json */; };
+		F18A00000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F18A00000000000000000037 /* TypeWhisperPluginSDK */; };
+		F18A00000000000000000005 /* FillerWordsPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000013 /* FillerWordsPluginTests.swift */; };
+		F18A00000000000000000006 /* FillerWordsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000010 /* FillerWordsPlugin.swift */; };
 		AA00000000000000000001 /* TypeWhisperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000001 /* TypeWhisperApp.swift */; };
 		AA00000000000000000002 /* ServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000002 /* ServiceContainer.swift */; };
 		AA00000000000000000005 /* TranscriptionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000005 /* TranscriptionResult.swift */; };
@@ -675,6 +680,10 @@
 		E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayout.swift; sourceTree = "<group>"; };
 		E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotchIndicatorLayoutTests.swift; sourceTree = "<group>"; };
 		E808D246301E36546EEB811F /* TestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestSupport.swift; sourceTree = "<group>"; };
+		F18A00000000000000000010 /* FillerWordsPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillerWordsPlugin.swift; sourceTree = "<group>"; };
+		F18A00000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		F18A00000000000000000012 /* FillerWordsPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FillerWordsPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		F18A00000000000000000013 /* FillerWordsPluginTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FillerWordsPluginTests.swift; sourceTree = "<group>"; };
 		F41BD305007A3A158038C75C /* ProfileServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProfileServiceTests.swift; sourceTree = "<group>"; };
 		FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CLISupportTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000248 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
@@ -897,6 +906,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F18A00000000000000000032 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F18A00000000000000000003 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000104 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1087,6 +1104,7 @@
 				CC00000000000000000029 /* AssemblyAIPlugin */,
 				CC00000000000000000030 /* ObsidianPlugin */,
 				CC00000000000000000031 /* ScriptPlugin */,
+				F18A00000000000000000020 /* FillerWordsPlugin */,
 				CC00000000000000000032 /* LiveTranscriptPlugin */,
 				CC00000000000000000033 /* GranitePlugin */,
 				CC00000000000000000034 /* CloudflareASRPlugin */,
@@ -1535,6 +1553,16 @@
 			path = Plugins/ScriptPlugin;
 			sourceTree = "<group>";
 		};
+		F18A00000000000000000020 /* FillerWordsPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				F18A00000000000000000010 /* FillerWordsPlugin.swift */,
+				F18A00000000000000000011 /* manifest.json */,
+			);
+			name = FillerWordsPlugin;
+			path = Plugins/FillerWordsPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000032 /* LiveTranscriptPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -1738,6 +1766,7 @@
 				BB00000000000000000203 /* AssemblyAIPlugin.bundle */,
 				BB00000000000000000211 /* ObsidianPlugin.bundle */,
 				BB00000000000000000215 /* ScriptPlugin.bundle */,
+				F18A00000000000000000012 /* FillerWordsPlugin.bundle */,
 				BB00000000000000000219 /* LiveTranscriptPlugin.bundle */,
 				BB00000000000000000224 /* GranitePlugin.bundle */,
 				BB00000000000000000227 /* CloudflareASRPlugin.bundle */,
@@ -1769,6 +1798,7 @@
 				CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */,
 				FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
+				F18A00000000000000000013 /* FillerWordsPluginTests.swift */,
 				6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
 				E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
 				AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
@@ -2199,6 +2229,26 @@
 			productReference = BB00000000000000000215 /* ScriptPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		F18A00000000000000000030 /* FillerWordsPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F18A00000000000000000036 /* Build configuration list for PBXNativeTarget "FillerWordsPlugin" */;
+			buildPhases = (
+				F18A00000000000000000031 /* Sources */,
+				F18A00000000000000000032 /* Frameworks */,
+				F18A00000000000000000033 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FillerWordsPlugin;
+			packageProductDependencies = (
+				F18A00000000000000000037 /* TypeWhisperPluginSDK */,
+			);
+			productName = FillerWordsPlugin;
+			productReference = F18A00000000000000000012 /* FillerWordsPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000020 /* LiveTranscriptPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000106 /* Build configuration list for PBXNativeTarget "LiveTranscriptPlugin" */;
@@ -2606,6 +2656,7 @@
 				DD00000000000000000017 /* AssemblyAIPlugin */,
 				DD00000000000000000018 /* ObsidianPlugin */,
 				DD00000000000000000019 /* ScriptPlugin */,
+				F18A00000000000000000030 /* FillerWordsPlugin */,
 				DD00000000000000000020 /* LiveTranscriptPlugin */,
 				DD00000000000000000021 /* GranitePlugin */,
 				DD00000000000000000022 /* CloudflareASRPlugin */,
@@ -2790,6 +2841,14 @@
 			files = (
 				AA00000000000000000223 /* manifest.json in Resources */,
 				AA00000000000000000224 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F18A00000000000000000033 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F18A00000000000000000002 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2982,6 +3041,8 @@
 				C42900000000000000000003 /* LiveTranscriptPlugin.swift in Sources */,
 				C42900000000000000000001 /* LiveTranscriptPluginBehaviorTests.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
+				F18A00000000000000000006 /* FillerWordsPlugin.swift in Sources */,
+				F18A00000000000000000005 /* FillerWordsPluginTests.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */,
 				1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */,
@@ -3287,6 +3348,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000222 /* ScriptPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F18A00000000000000000031 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F18A00000000000000000001 /* FillerWordsPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4442,6 +4511,52 @@
 			};
 			name = Release;
 		};
+		F18A00000000000000000034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Filler Words";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FillerWordsPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.filler-words";
+				PRODUCT_NAME = FillerWordsPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		F18A00000000000000000035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Filler Words";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FillerWordsPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.filler-words";
+				PRODUCT_NAME = FillerWordsPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		XX00000000000000000081 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5437,6 +5552,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		F18A00000000000000000036 /* Build configuration list for PBXNativeTarget "FillerWordsPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F18A00000000000000000034 /* Debug */,
+				F18A00000000000000000035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000106 /* Build configuration list for PBXNativeTarget "LiveTranscriptPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -5758,6 +5882,10 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000026 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		F18A00000000000000000037 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisperTests/FillerWordsPluginTests.swift
+++ b/TypeWhisperTests/FillerWordsPluginTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import TypeWhisperPluginSDK
+import XCTest
+
+final class FillerWordsPluginTests: XCTestCase {
+    private final class MockEventBus: EventBusProtocol {
+        @discardableResult
+        func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID { UUID() }
+        func unsubscribe(id: UUID) {}
+    }
+
+    private final class MockHostServices: HostServices, @unchecked Sendable {
+        private var defaults: [String: Any]
+        private var secrets: [String: String] = [:]
+
+        let pluginDataDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+        let eventBus: EventBusProtocol = MockEventBus()
+        var activeAppBundleId: String?
+        var activeAppName: String?
+        var availableRuleNames: [String] = []
+
+        init(defaults: [String: Any] = [:]) {
+            self.defaults = defaults
+        }
+
+        func storeSecret(key: String, value: String) throws { secrets[key] = value }
+        func loadSecret(key: String) -> String? { secrets[key] }
+        func userDefault(forKey key: String) -> Any? { defaults[key] }
+        func setUserDefault(_ value: Any?, forKey key: String) { defaults[key] = value }
+        func notifyCapabilitiesChanged() {}
+        func setStreamingDisplayActive(_ active: Bool) {}
+    }
+
+    func testMetadataPlacesProcessorBeforePromptProcessing() {
+        let plugin = FillerWordsPlugin()
+
+        XCTAssertEqual(FillerWordsPlugin.pluginId, "com.typewhisper.filler-words")
+        XCTAssertEqual(plugin.processorName, "Filler Words")
+        XCTAssertLessThan(plugin.priority, 300)
+    }
+
+    func testRemovesBuiltInFillerWordsCaseInsensitively() async throws {
+        let plugin = FillerWordsPlugin()
+
+        let result = try await plugin.process(
+            text: "Ähm, um uh hello?",
+            context: PostProcessingContext()
+        )
+
+        XCTAssertEqual(result, "hello?")
+    }
+
+    func testActivationSeedsPluginScopedDefaultWordsAndSettingsView() {
+        let host = MockHostServices()
+        let plugin = FillerWordsPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertNotNil(plugin.settingsView)
+        XCTAssertEqual(
+            host.userDefault(forKey: "words") as? String,
+            FillerWordsPlugin.defaultFillerWords.joined(separator: "\n")
+        )
+    }
+
+    func testActivationMigratesUnchangedLegacyDefaultsToGermanFillers() {
+        let legacyWords = [
+            "ah",
+            "ahh",
+            "hm",
+            "hmm",
+            "uh",
+            "uhh",
+            "um",
+            "umm"
+        ].joined(separator: "\n")
+        let host = MockHostServices(defaults: ["words": legacyWords])
+        let plugin = FillerWordsPlugin()
+
+        plugin.activate(host: host)
+
+        let storedWords = host.userDefault(forKey: "words") as? String
+        XCTAssertTrue(storedWords?.contains("ähm") == true)
+        XCTAssertTrue(storedWords?.contains("ehm") == true)
+        XCTAssertEqual(host.userDefault(forKey: "wordsDefaultsVersion") as? Int, 2)
+    }
+
+    func testActivationMigratesLegacyDefaultsWithoutDroppingCustomWords() {
+        let legacyWordsWithCustom = [
+            "ah",
+            "ahh",
+            "hm",
+            "hmm",
+            "uh",
+            "uhh",
+            "um",
+            "umm",
+            "basically"
+        ].joined(separator: "\n")
+        let host = MockHostServices(defaults: ["words": legacyWordsWithCustom])
+        let plugin = FillerWordsPlugin()
+
+        plugin.activate(host: host)
+
+        let storedWords = host.userDefault(forKey: "words") as? String
+        XCTAssertTrue(storedWords?.contains("basically") == true)
+        XCTAssertTrue(storedWords?.contains("ähm") == true)
+        XCTAssertEqual(host.userDefault(forKey: "wordsDefaultsVersion") as? Int, 2)
+    }
+
+    func testProcessUsesPluginScopedCustomWords() async throws {
+        let host = MockHostServices(defaults: ["words": "basically\nlike"])
+        let plugin = FillerWordsPlugin()
+
+        plugin.activate(host: host)
+
+        let result = try await plugin.process(
+            text: "basically hello um",
+            context: PostProcessingContext()
+        )
+
+        XCTAssertEqual(result, "hello um")
+    }
+
+    func testCustomWordsMatchGermanUmlautsCaseInsensitively() async throws {
+        let host = MockHostServices(defaults: ["words": "Ähm"])
+        let plugin = FillerWordsPlugin()
+
+        plugin.activate(host: host)
+
+        let result = try await plugin.process(
+            text: "ähm hallo",
+            context: PostProcessingContext()
+        )
+
+        XCTAssertEqual(result, "hallo")
+    }
+
+    func testEmptyPluginScopedWordListDisablesRemoval() async throws {
+        let host = MockHostServices(defaults: ["words": ""])
+        let plugin = FillerWordsPlugin()
+
+        plugin.activate(host: host)
+
+        let result = try await plugin.process(
+            text: "um hello",
+            context: PostProcessingContext()
+        )
+
+        XCTAssertEqual(result, "um hello")
+    }
+
+    func testPreservesWordBoundariesAndExistingSpacing() {
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "umbrella"), "umbrella")
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "summer humor"), "summer humor")
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "hello  world"), "hello  world")
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "\n\num hello"), "\n\nhello")
+    }
+
+    func testRemovesAdjacentPunctuation() {
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "Ähm, hallo"), "hallo")
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "um, hello"), "hello")
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "well, um, hello"), "well, hello")
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "hello uh."), "hello")
+    }
+
+    func testDoesNotRemoveGermanPronounEr() {
+        XCTAssertEqual(FillerWordsPlugin.removeFillerWords(from: "er ist hier"), "er ist hier")
+    }
+}


### PR DESCRIPTION
## Summary
- Add a standalone Filler Words post-processor plugin instead of baking filler-word removal into global app settings.
- Add plugin-scoped settings so users can edit the filler-word list independently from other transcription settings.
- Seed defaults with English and German filler words, including `äh` and `ähm`, while explicitly avoiding `er` as a default.
- Migrate old saved plugin defaults to include the new German filler words without dropping user-added custom words.
- Register the new plugin target in the Xcode project and cover it with focused XCTest coverage.

## Related PR
Related to #435.

This PR intentionally supersedes only the filler-word removal portion of #435. It leaves the unrelated behavior changes from #435 out of scope: auto-spacing, cursor context, capitalization changes, ESC handling, raw transcript fallback, paste-last-transcription hotkey, compact indicator mode, snippet regex behavior changes, and localization churn.

## Test Plan
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh FillerWordsPlugin /Users/marco/conductor/workspaces/typewhisper-mac/istanbul`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/FillerWordsPluginTests -only-testing:TypeWhisperTests/PluginManifestValidationTests/testAllPluginManifestsDecodeAndDeclareCompatibility`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `git diff --check origin/main...HEAD`

## Results
- Plugin build/install succeeded and the installed bundle is signed with the Apple Development identity.
- Targeted XCTest run passed: 12 tests, 0 failures.
- Full TypeWhisper XCTest run passed: 472 tests, 0 failures.
- Diff check passed.
