### PR TITLE
Support filler words plugin release

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -78,6 +78,7 @@ jobs:
             cohere) TARGET="CoherePlugin" ;;
             speechmatics) TARGET="SpeechmaticsPlugin" ;;
             system-tts) TARGET="SystemTTSPlugin" ;;
+            filler-words) TARGET="FillerWordsPlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin


### PR DESCRIPTION
## Summary
- Add the `filler-words` plugin slug to the plugin release workflow target mapping.
- This allows the existing `Build and Release Plugin` workflow to build and publish `FillerWordsPlugin`.

## Test Plan
- `git diff --check`
- Verified the workflow mapping resolves `filler-words` to `FillerWordsPlugin`.
