### PR TITLE
Fix Parakeet live preview fallback race

### DIFF
--- a/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -7,7 +7,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(ParakeetPlugin)
-final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
     private static let logger = Logger(subsystem: "com.typewhisper.plugin.parakeet", category: "Transcription")
@@ -80,6 +80,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     }
 
     var selectedModelId: String? { loadedModelId }
+    var allowsTranscriptPreviewFallback: Bool { false }
 
     func selectModel(_ modelId: String) {
         guard let version = ParakeetVersion.from(modelId: modelId) else { return }

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -144,6 +144,14 @@ final class ModelManagerService: ObservableObject {
         return loadedPlugin.manifest.requiresAPIKey == true
     }
 
+    func allowsTranscriptPreviewFallback(engineOverrideId: String? = nil, selectedProviderId: String? = nil) -> Bool {
+        guard let providerId = engineOverrideId ?? selectedProviderId ?? self.selectedProviderId,
+              let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
+            return false
+        }
+        return (plugin as? any TranscriptPreviewFallbackPolicyProviding)?.allowsTranscriptPreviewFallback ?? true
+    }
+
     /// Resolve display name for a given engine/model override combination
     func resolvedModelDisplayName(engineOverrideId: String? = nil, cloudModelOverride: String? = nil) -> String? {
         let providerId = engineOverrideId ?? selectedProviderId

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -54,11 +54,17 @@ final class StreamingHandler: @unchecked Sendable {
     ) {
         stop()
 
-        guard allowLiveTranscription else { return }
+        guard allowLiveTranscription else {
+            logger.info("Live transcript preview skipped: disabled")
+            return
+        }
 
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
-              PluginManager.shared.transcriptionEngine(for: providerId) != nil else { return }
+              PluginManager.shared.transcriptionEngine(for: providerId) != nil else {
+            logger.info("Live transcript preview skipped: provider unavailable")
+            return
+        }
 
         resetStreamingState()
         onStreamingStateChange?(true)
@@ -84,11 +90,24 @@ final class StreamingHandler: @unchecked Sendable {
                     return true
                 }
             ) {
+                logger.info("Live transcript preview using live session providerId=\(handle.providerId, privacy: .public)")
                 self.sharedState.withLock { $0.liveSessionHandle = handle }
                 await self.runLiveSessionLoop(stateCheck: stateCheck)
                 return
             }
 
+            guard self.modelManager.allowsTranscriptPreviewFallback(
+                engineOverrideId: engineOverrideId,
+                selectedProviderId: selectedProviderId
+            ) else {
+                logger.info("Live transcript preview fallback skipped providerId=\(providerId, privacy: .public) reason=policy-opt-out")
+                await MainActor.run { [weak self] in
+                    self?.clearStreamingState(notifyStreamingStopped: true)
+                }
+                return
+            }
+
+            logger.info("Live transcript preview using fallback batch providerId=\(providerId, privacy: .public)")
             await self.runFallbackLoop(
                 streamPrompt: streamPrompt,
                 engineOverrideId: engineOverrideId,

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -388,6 +388,14 @@ public protocol TranscriptionModelCatalogProviding: TranscriptionEnginePlugin {
     var availableModels: [PluginModelInfo] { get }
 }
 
+public protocol TranscriptPreviewFallbackPolicyProviding: TranscriptionEnginePlugin {
+    var allowsTranscriptPreviewFallback: Bool { get }
+}
+
+public extension TranscriptPreviewFallbackPolicyProviding {
+    var allowsTranscriptPreviewFallback: Bool { true }
+}
+
 public extension TranscriptionEnginePlugin {
     var modelCatalog: [PluginModelInfo] {
         (self as? any TranscriptionModelCatalogProviding)?.availableModels ?? transcriptionModels

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -382,8 +382,7 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
     }
 
     func testParakeetDisablesTranscriptPreviewFallback() throws {
-        let plugin = ParakeetPlugin()
-        let fallbackPolicy = try XCTUnwrap(plugin as? any TranscriptPreviewFallbackPolicyProviding)
+        let fallbackPolicy: any TranscriptPreviewFallbackPolicyProviding = ParakeetPlugin()
 
         XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
     }

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -381,6 +381,13 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.huggingFaceToken, "hf_parakeet_saved")
     }
 
+    func testParakeetDisablesTranscriptPreviewFallback() throws {
+        let plugin = ParakeetPlugin()
+        let fallbackPolicy = try XCTUnwrap(plugin as? any TranscriptPreviewFallbackPolicyProviding)
+
+        XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
+    }
+
     func testParakeetDictionaryTermsSupportReflectsStoredBoostingPreference() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -73,6 +73,58 @@ final class StreamingHandlerTests: XCTestCase {
         }
     }
 
+    private actor SlowPreviewFallbackRecorder {
+        private var activeTranscriptions = 0
+        private var maxConcurrentTranscriptions = 0
+        private var prompts: [String?] = []
+
+        func begin(prompt: String?) {
+            activeTranscriptions += 1
+            maxConcurrentTranscriptions = max(maxConcurrentTranscriptions, activeTranscriptions)
+            prompts.append(prompt)
+        }
+
+        func end() {
+            activeTranscriptions -= 1
+        }
+
+        func snapshot() -> (callCount: Int, maxConcurrentTranscriptions: Int, prompts: [String?]) {
+            (prompts.count, maxConcurrentTranscriptions, prompts)
+        }
+    }
+
+    private final class MockPreviewFallbackOptOutPlugin: NSObject, TranscriptionEnginePlugin, TranscriptPreviewFallbackPolicyProviding, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.preview-opt-out" }
+        static var pluginName: String { "Mock Preview Opt Out" }
+
+        var providerId: String { "mock-preview-opt-out" }
+        var providerDisplayName: String { "Mock Preview Opt Out" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { false }
+        var supportedLanguages: [String] { ["en"] }
+        var allowsTranscriptPreviewFallback: Bool { false }
+
+        private let recorder = SlowPreviewFallbackRecorder()
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            await recorder.begin(prompt: prompt)
+            try await Task.sleep(for: .milliseconds(500))
+            await recorder.end()
+            return PluginTranscriptionResult(text: "final-\(prompt ?? "none")", detectedLanguage: language)
+        }
+
+        func snapshot() async -> (callCount: Int, maxConcurrentTranscriptions: Int, prompts: [String?]) {
+            await recorder.snapshot()
+        }
+    }
+
     private final class MockHintPlugin: NSObject, LanguageHintTranscriptionEnginePlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.hints" }
         static var pluginName: String { "Mock Hints" }
@@ -506,6 +558,71 @@ final class StreamingHandlerTests: XCTestCase {
 
         XCTAssertEqual(finalRequestedWindow, 10)
         XCTAssertEqual(plugin.recordedSampleCounts, [16_000])
+    }
+
+    func testPreviewFallbackOptOutSkipsIntermediateWorkAndAllowsFinalTranscription() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockPreviewFallbackOptOutPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.preview-opt-out",
+                    name: "Mock Preview Opt Out",
+                    version: "1.0.0",
+                    principalClass: "MockPreviewFallbackOptOutPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: {
+                XCTFail("full buffer provider should not be used for fallback previews")
+                return Array(repeating: 0.5, count: 160_000)
+            },
+            recentBufferProvider: { _ in Array(repeating: 0.5, count: 16_000) },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 10.0 }
+        )
+
+        handler.start(
+            streamPrompt: "Preview Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("en"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(3400))
+        let liveResult = await handler.finish()
+        let finalResult = try await modelManager.transcribe(
+            audioSamples: Array(repeating: 0.5, count: 16_000),
+            languageSelection: .exact("en"),
+            task: .transcribe,
+            engineOverrideId: plugin.providerId,
+            cloudModelOverride: nil,
+            prompt: "Final Terms"
+        )
+        let snapshot = await plugin.snapshot()
+
+        XCTAssertNil(liveResult)
+        XCTAssertEqual(finalResult.text, "final-Final Terms")
+        XCTAssertEqual(snapshot.callCount, 1)
+        XCTAssertEqual(snapshot.maxConcurrentTranscriptions, 1)
+        XCTAssertEqual(snapshot.prompts, ["Final Terms"])
     }
 
     func testLiveSessionConsumesOnlyIncrementalAudioDeltas() async throws {


### PR DESCRIPTION
## Summary

- Add an optional transcript preview fallback policy to the plugin SDK, defaulting to allowing existing batch-preview fallback behavior.
- Add StreamingHandler diagnostics for disabled preview, provider unavailability, live-session preview, batch fallback preview, and policy-based fallback skips.
- Opt Parakeet out of the risky batch-preview fallback while keeping final dictation on the normal `modelManager.transcribe(...)` path.
- Add regression coverage for a slow batch-only opt-out plugin and a Parakeet policy assertion.

## Issue context

Issue #433 reports that on macOS 26 with Parakeet TDT v3, enabling "Show live transcript preview" can result in no live preview and no final dictation/text insertion. Disabling live transcript preview restores normal dictation. The likely failure mode is a timing-dependent overlap between the periodic batch preview fallback and the final transcription path for a plugin that does not provide a true live transcription session.

Closes #433

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/StreamingHandlerTests -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests/testParakeetDisablesTranscriptPreviewFallback`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/StreamingHandlerTests/testPreviewFallbackOptOutSkipsIntermediateWorkAndAllowsFinalTranscription -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests/testParakeetDisablesTranscriptPreviewFallback`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh ParakeetPlugin "$(pwd)"`
- `git diff --check`
