### PR TITLE
Prepare TypeWhisper 1.3.1-rc1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,6 +536,7 @@ jobs:
           git push origin gh-pages
 
   trigger-website:
+    if: "!contains(needs.prepare.outputs.tag, '-')"
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -3702,7 +3702,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
@@ -3731,7 +3731,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
@@ -3747,7 +3747,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_NAME = "typewhisper-cli";
 				SWIFT_VERSION = 6.0;
 			};
@@ -3759,7 +3759,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_NAME = "typewhisper-cli";
 				SWIFT_VERSION = 6.0;
 			};
@@ -4245,7 +4245,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -4272,7 +4272,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/docs/release-notes/1.3.1-rc1.md
+++ b/docs/release-notes/1.3.1-rc1.md
@@ -1,0 +1,24 @@
+TypeWhisper `1.3.1-rc1` starts the `1.3.1` release-candidate line with new workflow processors, manual workflow controls, plugin improvements, and a focused reliability pass for Bluetooth audio, indicators, local LLM post-processing, and large automation requests.
+
+## New Features
+
+- Added the bundled Filler Words plugin for cleaning filler words from dictated text and plugin workflows.
+- Added an Apple Translate workflow processor for local translation workflows on supported macOS configurations.
+- Added a manual workflow trigger so workflows can stay out of automatic dictation matching and run from the Workflow Palette instead.
+- Added a recorder toggle in the menu bar for faster access to app audio recording.
+
+## Bug Fixes
+
+- Reduced workflow post-processing latency so prompt and processor workflows return results faster after transcription.
+- Wrapped Apple Intelligence workflow input so dictated text is treated as source content instead of executable instructions.
+- Stabilized Bluetooth dictation capture and guarded AirPods output volume during audio routing changes.
+- Opted indicators out of fullscreen spaces to avoid unexpected overlay behavior when apps use fullscreen mode.
+- Disabled automatic Live Transcript opening by default.
+- Auto-unloaded local LLM post-processing resources after use to reduce background memory pressure.
+- Supported large CLI transcriptions without truncating or failing oversized requests.
+- Kept the language list available before transcription plugins finish loading.
+
+## Other Changes
+
+- Updated Parakeet vocabulary boosting capability detection for current local-model behavior.
+- Added release support for the Filler Words plugin package.


### PR DESCRIPTION
## Summary
- Bump the TypeWhisper app, CLI, and widget marketing version to 1.3.1.
- Add curated release notes for `v1.3.1-rc1` covering the workflow, plugin, Bluetooth, indicator, LLM unload, CLI, and Parakeet changes since `v1.3.0`.
- Restrict the website rebuild dispatch in the release workflow to stable tags so RC and daily tags do not trigger stable website messaging.

## Issue Context
No GitHub issue is associated with this release-prep PR.

## Test Plan
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee build.log`
- [x] `bash scripts/check_first_party_warnings.sh build.log`
