### PR TITLE
fix: classify plugin hosting explicitly

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -316,7 +316,7 @@ jobs:
               plugin["category"] = manifest.get("category", plugin.get("category", "utility"))
               plugin["downloadCount"] = plugin.get("downloadCount", 0)
 
-              for field in ["iconSystemName", "requiresAPIKey"]:
+              for field in ["iconSystemName", "requiresAPIKey", "hosting"]:
                   if field in manifest and manifest[field] is not None:
                       plugin[field] = manifest[field]
                   else:

--- a/Plugins/OpenAIPlugin/manifest.json
+++ b/Plugins/OpenAIPlugin/manifest.json
@@ -11,6 +11,7 @@
         "de": "Cloud-Transkription plus OpenAI-/ChatGPT-Prompts. Nutzbar per API-Key oder ChatGPT-Login."
     },
     "category": "transcription",
+    "hosting": "cloud",
     "iconSystemName": "brain",
     "principalClass": "OpenAIPlugin",
     "requiresAPIKey": false

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -86,6 +86,7 @@ struct RegistryPlugin: Codable, Identifiable {
     let downloadURL: String
     let iconSystemName: String?
     let requiresAPIKey: Bool?
+    let hosting: PluginHosting?
     let descriptions: [String: String]?
     let downloadCount: Int?
 
@@ -103,6 +104,10 @@ struct RegistryPlugin: Codable, Identifiable {
             minOSVersion: minOSVersion,
             supportedArchitectures: supportedArchitectures
         )
+    }
+
+    var resolvedHosting: PluginHosting {
+        hosting ?? PluginHosting.fallback(requiresAPIKey: requiresAPIKey)
     }
 }
 
@@ -153,6 +158,7 @@ struct RegistryPluginEntry: Decodable {
     let category: String
     let iconSystemName: String?
     let requiresAPIKey: Bool?
+    let hosting: PluginHosting?
     let descriptions: [String: String]?
     let downloadCount: Int?
     let releases: [RegistryPluginRelease]
@@ -165,6 +171,7 @@ struct RegistryPluginEntry: Decodable {
         case category
         case iconSystemName
         case requiresAPIKey
+        case hosting
         case descriptions
         case downloadCount
         case releases
@@ -187,6 +194,7 @@ struct RegistryPluginEntry: Decodable {
         category = try container.decode(String.self, forKey: .category)
         iconSystemName = try container.decodeIfPresent(String.self, forKey: .iconSystemName)
         requiresAPIKey = try container.decodeIfPresent(Bool.self, forKey: .requiresAPIKey)
+        hosting = try container.decodeIfPresent(PluginHosting.self, forKey: .hosting)
         descriptions = try container.decodeIfPresent([String: String].self, forKey: .descriptions)
         downloadCount = try container.decodeIfPresent(Int.self, forKey: .downloadCount)
 
@@ -258,6 +266,7 @@ struct RegistryPluginEntry: Decodable {
             downloadURL: compatibleRelease.downloadURL,
             iconSystemName: iconSystemName,
             requiresAPIKey: requiresAPIKey,
+            hosting: hosting,
             descriptions: descriptions,
             downloadCount: compatibleRelease.downloadCount ?? downloadCount
         )

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -168,6 +168,17 @@ struct PluginSettingsView: View {
         return .utility
     }
 
+    private func resolvedHosting(for plugin: LoadedPlugin, registryPlugin: RegistryPlugin?) -> PluginHosting {
+        if let hosting = registryPlugin?.hosting {
+            return hosting
+        }
+        if let hosting = plugin.manifest.hosting {
+            return hosting
+        }
+        let requiresAPIKey = registryPlugin?.requiresAPIKey == true || plugin.manifest.requiresAPIKey == true
+        return PluginHosting.fallback(requiresAPIKey: requiresAPIKey)
+    }
+
     private var groupedInstalledPlugins: [(category: PluginCategory, plugins: [LoadedPlugin])] {
         let grouped = Dictionary(grouping: pluginManager.loadedPlugins) { categoryForPlugin($0) }
         return grouped
@@ -208,15 +219,17 @@ struct PluginSettingsView: View {
 
                         if expandedCategories.contains(group.category.rawValue) {
                             ForEach(group.plugins) { plugin in
+                                let registryPlugin = registryService.registry.first(where: { $0.id == plugin.id })
                                 InstalledPluginRow(
                                     plugin: plugin,
                                     installInfo: registryService.installInfo(for: plugin.id),
                                     installState: registryService.installStates[plugin.id],
                                     externalNotice: pluginManager.externalBundleNotice(
                                         for: plugin.id,
-                                        registryPlugin: registryService.registry.first(where: { $0.id == plugin.id })
+                                        registryPlugin: registryPlugin
                                     ),
-                                    registryPlugin: registryService.registry.first(where: { $0.id == plugin.id }),
+                                    hosting: resolvedHosting(for: plugin, registryPlugin: registryPlugin),
+                                    registryPlugin: registryPlugin,
                                     onUpdate: {
                                         if let registryPlugin = registryService.registry.first(where: { $0.id == plugin.id }) {
                                             startInstall(registryPlugin)
@@ -262,8 +275,8 @@ struct PluginSettingsView: View {
             return false
         }
         switch hostingFilter {
-        case 1: return available.filter { $0.requiresAPIKey != true }
-        case 2: return available.filter { $0.requiresAPIKey == true }
+        case 1: return available.filter { $0.resolvedHosting == .local }
+        case 2: return available.filter { $0.resolvedHosting == .cloud }
         default: return available
         }
     }
@@ -421,10 +434,10 @@ struct PluginSettingsView: View {
 // MARK: - Shared Components
 
 private struct HostingBadge: View {
-    let isCloud: Bool
+    let hosting: PluginHosting
 
     var body: some View {
-        if isCloud {
+        if hosting == .cloud {
             Text("Cloud")
                 .font(.caption2)
                 .fontWeight(.medium)
@@ -493,16 +506,13 @@ private struct InstalledPluginRow: View {
     let installInfo: PluginInstallInfo
     let installState: PluginRegistryService.InstallState?
     let externalNotice: ExternalBundleNotice?
+    let hosting: PluginHosting
     let registryPlugin: RegistryPlugin?
     let onUpdate: () -> Void
     let onUninstall: () -> Void
     @State private var pluginActivity: PluginSettingsActivity?
 
     private let activityTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
-
-    private var isCloud: Bool {
-        registryPlugin?.requiresAPIKey == true || plugin.manifest.requiresAPIKey == true
-    }
 
     var body: some View {
         HStack {
@@ -526,7 +536,7 @@ private struct InstalledPluginRow: View {
                             .clipShape(Capsule())
                     }
                     if !plugin.isBundled {
-                        HostingBadge(isCloud: isCloud)
+                        HostingBadge(hosting: hosting)
                     }
                     if plugin.isBundled {
                         Text(String(localized: "Built-in"))
@@ -711,7 +721,7 @@ struct AvailablePluginRow: View {
                 HStack(spacing: 6) {
                     Text(plugin.name)
                         .font(.headline)
-                    HostingBadge(isCloud: plugin.requiresAPIKey == true)
+                    HostingBadge(hosting: plugin.resolvedHosting)
                 }
                 Text(plugin.localizedDescription)
                     .font(.caption)

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -485,6 +485,10 @@ let wavData = PluginWavEncoder.encode(samples, sampleRate: 16000)
 | `minOSVersion` | No | Minimum macOS version (e.g. `14.0`, `26.0`). Plugin is skipped on older systems. |
 | `author` | No | Author name |
 | `principalClass` | Yes | Objective-C class name, must match `@objc(Name)` |
+| `category` | No | Marketplace category: `transcription`, `tts`, `llm`, `post-processor`, `action`, `memory`, or `utility`. |
+| `hosting` | No | Marketplace hosting classification: `local` or `cloud`. If omitted, TypeWhisper falls back to `requiresAPIKey == true` as cloud and otherwise local. |
+| `requiresAPIKey` | No | Whether the plugin specifically needs an API key credential. This is not the Local/Cloud category; use `hosting` for that. |
+| `iconSystemName` | No | SF Symbol name for marketplace and settings UI. |
 
 ---
 
@@ -510,6 +514,8 @@ Registry entry format:
   "author": "Your Name",
   "description": "What your plugin does.",
   "category": "transcription|tts|llm|post-processor|action|memory|utility",
+  "hosting": "local|cloud",
+  "requiresAPIKey": false,
   "size": 12345678,
   "downloadURL": "https://example.com/MyPlugin.zip",
   "iconSystemName": "star.fill"

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+public enum PluginHosting: String, Codable, Sendable {
+    case local
+    case cloud
+
+    public static func fallback(requiresAPIKey: Bool?) -> PluginHosting {
+        requiresAPIKey == true ? .cloud : .local
+    }
+}
+
 public struct PluginManifest: Codable, Equatable, Sendable {
     public let id: String
     public let name: String
@@ -11,6 +20,7 @@ public struct PluginManifest: Codable, Equatable, Sendable {
     public let author: String?
     public let principalClass: String
     public let requiresAPIKey: Bool?
+    public let hosting: PluginHosting?
     public let iconSystemName: String?
     public let category: String?
 
@@ -25,6 +35,7 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         author: String? = nil,
         principalClass: String,
         requiresAPIKey: Bool? = nil,
+        hosting: PluginHosting? = nil,
         iconSystemName: String? = nil,
         category: String? = nil
     ) {
@@ -38,7 +49,14 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         self.author = author
         self.principalClass = principalClass
         self.requiresAPIKey = requiresAPIKey
+        self.hosting = hosting
         self.iconSystemName = iconSystemName
         self.category = category
+    }
+}
+
+public extension PluginManifest {
+    var resolvedHosting: PluginHosting {
+        hosting ?? PluginHosting.fallback(requiresAPIKey: requiresAPIKey)
     }
 }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
@@ -70,4 +70,44 @@ final class PluginManifestTests: XCTestCase {
 
         XCTAssertEqual(manifest.sdkCompatibilityVersion, "v1")
     }
+
+    func testPluginManifestDecodesHostingWhenPresent() throws {
+        let data = Data(
+            """
+            {
+              "id": "com.typewhisper.cloud",
+              "name": "Cloud Plugin",
+              "version": "1.2.3",
+              "principalClass": "CloudPlugin",
+              "hosting": "cloud",
+              "requiresAPIKey": false
+            }
+            """.utf8
+        )
+
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.hosting, .cloud)
+        XCTAssertEqual(manifest.requiresAPIKey, false)
+        XCTAssertEqual(manifest.resolvedHosting, .cloud)
+    }
+
+    func testPluginManifestResolvedHostingFallsBackToAPIKeyRequirement() {
+        let cloudManifest = PluginManifest(
+            id: "com.typewhisper.remote",
+            name: "Remote Plugin",
+            version: "1.0.0",
+            principalClass: "RemotePlugin",
+            requiresAPIKey: true
+        )
+        let localManifest = PluginManifest(
+            id: "com.typewhisper.local",
+            name: "Local Plugin",
+            version: "1.0.0",
+            principalClass: "LocalPlugin"
+        )
+
+        XCTAssertEqual(cloudManifest.resolvedHosting, .cloud)
+        XCTAssertEqual(localManifest.resolvedHosting, .local)
+    }
 }

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -52,6 +52,16 @@ final class PluginManifestValidationTests: XCTestCase {
             XCTAssertEqual(manifest.supportedArchitectures, ["arm64"], relativePath)
         }
     }
+
+    func testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement() throws {
+        let manifestURL = TestSupport.repoRoot.appendingPathComponent("Plugins/OpenAIPlugin/manifest.json")
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.hosting, .cloud)
+        XCTAssertEqual(manifest.requiresAPIKey, false)
+        XCTAssertEqual(manifest.resolvedHosting, .cloud)
+    }
 }
 
 @MainActor
@@ -962,6 +972,7 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
                 downloadURL: "https://example.com/replacement.zip",
                 iconSystemName: nil,
                 requiresAPIKey: nil,
+                hosting: nil,
                 descriptions: nil,
                 downloadCount: nil
             ),
@@ -999,6 +1010,7 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
             downloadURL: "https://example.com/plugin.zip",
             iconSystemName: nil,
             requiresAPIKey: nil,
+            hosting: nil,
             descriptions: nil,
             downloadCount: nil
         )

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -180,6 +180,104 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(plugins.first?.downloadURL, "https://example.com/intel-compatible.zip")
     }
 
+    func testRegistryEntryWithCloudHostingOverridesAPIKeyRequirementForClassification() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.openai",
+                  "name": "OpenAI / ChatGPT",
+                  "author": "TypeWhisper",
+                  "description": "Cloud transcription plus OpenAI/ChatGPT prompts.",
+                  "category": "transcription",
+                  "hosting": "cloud",
+                  "requiresAPIKey": false,
+                  "releases": [
+                    {
+                      "version": "1.1.5",
+                      "minHostVersion": "1.2.2",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 20,
+                      "downloadURL": "https://example.com/openai.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let plugin = try XCTUnwrap(response.resolvedPlugins(
+            appVersion: "1.3.0",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        ).first)
+
+        XCTAssertEqual(plugin.hosting, .cloud)
+        XCTAssertEqual(plugin.requiresAPIKey, false)
+        XCTAssertEqual(plugin.resolvedHosting, .cloud)
+    }
+
+    func testRegistryEntryWithoutHostingFallsBackToAPIKeyRequirementForClassification() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.remote",
+                  "name": "Remote Plugin",
+                  "author": "TypeWhisper",
+                  "description": "Remote entry",
+                  "category": "transcription",
+                  "requiresAPIKey": true,
+                  "releases": [
+                    {
+                      "version": "1.0.0",
+                      "minHostVersion": "1.0.0",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 10,
+                      "downloadURL": "https://example.com/remote.zip"
+                    }
+                  ]
+                },
+                {
+                  "id": "com.typewhisper.local",
+                  "name": "Local Plugin",
+                  "author": "TypeWhisper",
+                  "description": "Local entry",
+                  "category": "transcription",
+                  "releases": [
+                    {
+                      "version": "1.0.0",
+                      "minHostVersion": "1.0.0",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 10,
+                      "downloadURL": "https://example.com/local.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let plugins = response.resolvedPlugins(
+            appVersion: "1.3.0",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
+
+        let remote = try XCTUnwrap(plugins.first { $0.id == "com.typewhisper.remote" })
+        let local = try XCTUnwrap(plugins.first { $0.id == "com.typewhisper.local" })
+        XCTAssertNil(remote.hosting)
+        XCTAssertEqual(remote.resolvedHosting, .cloud)
+        XCTAssertNil(local.hosting)
+        XCTAssertEqual(local.resolvedHosting, .local)
+    }
+
     func testMalformedPluginEntryIsSkippedInsteadOfFailingEntireRegistry() throws {
         // A single bad entry (wrong type on a required field) must not empty
         // the marketplace: the decoder reports the error and keeps the rest.


### PR DESCRIPTION
## Summary
- Adds explicit `local`/`cloud` plugin hosting metadata to the SDK manifest model and registry models.
- Uses hosting metadata in Integrations filtering and badges instead of using `requiresAPIKey` as the Local/Cloud proxy.
- Marks OpenAI/ChatGPT as `hosting: "cloud"` while keeping `requiresAPIKey: false` for ChatGPT Login.
- Syncs `hosting` from plugin manifests into generated registry feeds during plugin release.
- Documents `hosting` in the SDK README and adds regression coverage for explicit hosting and legacy fallback behavior.

## Issue Context
Issue #444 reports that OpenAI/ChatGPT appears under `Integrations > Available > Local` because the settings UI classified plugins by `requiresAPIKey`. OpenAI/ChatGPT can use ChatGPT Login without an API key, so `requiresAPIKey` must stay false, but the plugin is still cloud-hosted.

Closes #444

## Test Coverage
All new code paths have regression coverage:
- Registry entries with `hosting: "cloud"` and `requiresAPIKey: false` resolve as cloud.
- Legacy registry entries without `hosting` still fall back to `requiresAPIKey`.
- OpenAI manifest decodes with `hosting == .cloud` and `requiresAPIKey == false`.
- SDK `PluginManifest` decodes explicit hosting and resolves fallback hosting directly in SwiftPM tests.

## Pre-Landing Review
No issues found.

## Design Review
SwiftUI surface changed, but only classification data passed into existing badge/filter UI changed. No visual-design findings.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN

Intent: fix OpenAI/ChatGPT Local/Cloud classification without changing credential behavior.
Delivered: explicit hosting metadata, UI classification update, manifest/workflow/docs updates, and regression tests.

## Plan Completion
Implemented:
- SDK `PluginHosting` metadata and manifest support.
- Registry `hosting` decode and resolved fallback.
- `PluginSettingsView` classification based on hosting metadata.
- OpenAI manifest declares `hosting: "cloud"` with `requiresAPIKey: false`.
- Release workflow syncs `hosting` into registry feeds.
- SDK docs updated.
- Requested regression tests added.

Remaining rollout note:
- The published `gh-pages` registry still needs `hosting: "cloud"` for `com.typewhisper.openai`. This PR makes the next OpenAI plugin release publish that metadata automatically; a targeted registry update can also apply it sooner.

## Documentation
- SDK README updated in this PR.
- Public website docs follow-up opened: TypeWhisper/typewhisper.com#51.

## Verification Results
Passed:
- `swift test --package-path TypeWhisperPluginSDK`
  - 39 tests, 0 failures.
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh OpenAIPlugin "$(pwd)"`
  - OpenAIPlugin build/install succeeded.
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - 511 tests, 0 failures.
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
  - Dev app build succeeded.
- `git diff --check`
  - No whitespace errors.

## Test plan
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh OpenAIPlugin "$(pwd)"`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
- [x] `git diff --check`
