### PR TITLE
feat: add direct workflow text hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 ### AI Processing
 
-- **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app or website, from a dedicated hotkey, as a global fallback, or manually from the Workflow Palette
+- **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app or website, from a dedicated hotkey, as a global fallback, or manually from the Workflow Palette. Hotkey workflows can either start dictation or process the current selection/clipboard directly.
 - **LLM providers** - Apple Intelligence (macOS 26+), Groq, OpenAI / ChatGPT, Gemini, and OpenAI Compatible with per-prompt provider and model override
 - **Local prompt processing** - Gemma 4 via MLX runs on-device on Apple Silicon, with the current verified release path limited to the E2B/E4B 4-bit models
 - **Translation** - Translate transcriptions on-device using Apple Translate
@@ -377,7 +377,7 @@ Workflows let you configure transcription, transformation, and automation behavi
 - **github.com** - English cleanup workflow that matches in any browser
 - **docs.google.com** - German dictation workflow that translates to English
 
-Create workflows in Settings > Workflows. Choose a template, assign an app, website, hotkey, Always, or Manual trigger, then configure language/task/engine overrides, prompt processing, auto-submit behavior, and priority. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. Website patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`.
+Create workflows in Settings > Workflows. Choose a template, assign an app, website, hotkey, Always, or Manual trigger, then configure language/task/engine overrides, prompt processing, auto-submit behavior, and priority. Hotkey workflows choose whether the shortcut starts dictation or processes the current selection/clipboard through the same insertion path as the Workflow Palette. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. Website patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`.
 
 When you start dictating, TypeWhisper matches the active app and browser URL against enabled workflows with the following priority:
 1. **App + URL match** - highest specificity (e.g. Chrome + github.com)

--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -133,22 +133,80 @@ enum WorkflowTriggerKind: String, CaseIterable, Codable, Sendable {
     case manual
 }
 
+enum WorkflowHotkeyBehavior: String, CaseIterable, Codable, Hashable, Sendable {
+    case startDictation
+    case processSelectedText
+
+    var editorLabel: String {
+        switch self {
+        case .startDictation:
+            localizedAppText("Start Dictation", de: "Diktat starten")
+        case .processSelectedText:
+            localizedAppText("Process Selected Text", de: "Markierten Text verarbeiten")
+        }
+    }
+
+    var editorDescription: String {
+        switch self {
+        case .startDictation:
+            localizedAppText(
+                "Pressing the shortcut starts recording and applies this workflow to the dictation.",
+                de: "Der Shortcut startet eine Aufnahme und wendet diesen Workflow auf das Diktat an."
+            )
+        case .processSelectedText:
+            localizedAppText(
+                "Pressing the shortcut transforms the current selection or clipboard without recording.",
+                de: "Der Shortcut verarbeitet die aktuelle Auswahl oder Zwischenablage ohne Aufnahme."
+            )
+        }
+    }
+
+    var shortcutSubtitle: String {
+        switch self {
+        case .startDictation:
+            localizedAppText("Starts dictation", de: "Startet Diktat")
+        case .processSelectedText:
+            localizedAppText("Processes selected text", de: "Verarbeitet markierten Text")
+        }
+    }
+}
+
 struct WorkflowTrigger: Codable, Equatable, Sendable {
     let kind: WorkflowTriggerKind
     var appBundleIdentifiers: [String]
     var websitePatterns: [String]
     var hotkeys: [UnifiedHotkey]
+    var hotkeyBehavior: WorkflowHotkeyBehavior
 
     init(
         kind: WorkflowTriggerKind,
         appBundleIdentifiers: [String] = [],
         websitePatterns: [String] = [],
-        hotkeys: [UnifiedHotkey] = []
+        hotkeys: [UnifiedHotkey] = [],
+        hotkeyBehavior: WorkflowHotkeyBehavior = .startDictation
     ) {
         self.kind = kind
         self.appBundleIdentifiers = appBundleIdentifiers
         self.websitePatterns = websitePatterns
         self.hotkeys = hotkeys
+        self.hotkeyBehavior = hotkeyBehavior
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case appBundleIdentifiers
+        case websitePatterns
+        case hotkeys
+        case hotkeyBehavior
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.kind = try container.decode(WorkflowTriggerKind.self, forKey: .kind)
+        self.appBundleIdentifiers = try container.decodeIfPresent([String].self, forKey: .appBundleIdentifiers) ?? []
+        self.websitePatterns = try container.decodeIfPresent([String].self, forKey: .websitePatterns) ?? []
+        self.hotkeys = try container.decodeIfPresent([UnifiedHotkey].self, forKey: .hotkeys) ?? []
+        self.hotkeyBehavior = try container.decodeIfPresent(WorkflowHotkeyBehavior.self, forKey: .hotkeyBehavior) ?? .startDictation
     }
 
     static func app(_ bundleIdentifier: String) -> WorkflowTrigger {
@@ -167,12 +225,18 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
         WorkflowTrigger(kind: .website, websitePatterns: patterns)
     }
 
-    static func hotkey(_ hotkey: UnifiedHotkey) -> WorkflowTrigger {
-        hotkeys([hotkey])
+    static func hotkey(
+        _ hotkey: UnifiedHotkey,
+        behavior: WorkflowHotkeyBehavior = .startDictation
+    ) -> WorkflowTrigger {
+        hotkeys([hotkey], behavior: behavior)
     }
 
-    static func hotkeys(_ hotkeys: [UnifiedHotkey]) -> WorkflowTrigger {
-        WorkflowTrigger(kind: .hotkey, hotkeys: hotkeys)
+    static func hotkeys(
+        _ hotkeys: [UnifiedHotkey],
+        behavior: WorkflowHotkeyBehavior = .startDictation
+    ) -> WorkflowTrigger {
+        WorkflowTrigger(kind: .hotkey, hotkeys: hotkeys, hotkeyBehavior: behavior)
     }
 
     static func global() -> WorkflowTrigger {

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -162,6 +162,7 @@ final class HotkeyService: ObservableObject {
     var onRecorderToggle: (() -> Void)?
     var onProfileDictationStart: ((UUID) -> Void)?
     var onWorkflowDictationStart: ((UUID) -> Void)?
+    var onWorkflowTextProcessing: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
     var onPushToTalkInterruption: (() -> Void)?
     var discardPushToTalkRecordingOnExtraKeyPress = false
@@ -243,6 +244,7 @@ final class HotkeyService: ObservableObject {
     private struct WorkflowHotkeyState {
         let workflowId: UUID
         var hotkey: UnifiedHotkey
+        var behavior: WorkflowHotkeyBehavior
         var fnWasDown = false
         var fnComboKeyPressed = false
         var modifierWasDown = false
@@ -343,11 +345,11 @@ final class HotkeyService: ObservableObject {
         setupMonitor()
     }
 
-    func registerWorkflowHotkeys(_ entries: [(id: UUID, hotkey: UnifiedHotkey)]) {
+    func registerWorkflowHotkeys(_ entries: [(id: UUID, hotkey: UnifiedHotkey, behavior: WorkflowHotkeyBehavior)]) {
         workflowSlots.removeAll()
         for entry in entries {
             workflowSlots[entry.id, default: []].append(
-                WorkflowHotkeyState(workflowId: entry.id, hotkey: entry.hotkey)
+                WorkflowHotkeyState(workflowId: entry.id, hotkey: entry.hotkey, behavior: entry.behavior)
             )
         }
         tearDownMonitor()
@@ -643,6 +645,7 @@ final class HotkeyService: ObservableObject {
                 dispatchWorkflowMatch(
                     workflowId: workflowId,
                     hotkey: wState.hotkey,
+                    behavior: wState.behavior,
                     keyDown: keyDown,
                     keyUp: keyUp,
                     source: source
@@ -747,6 +750,7 @@ final class HotkeyService: ObservableObject {
     private func dispatchWorkflowMatch(
         workflowId: UUID,
         hotkey: UnifiedHotkey,
+        behavior: WorkflowHotkeyBehavior,
         keyDown: Bool,
         keyUp: Bool,
         source: HotkeyEventSource
@@ -760,14 +764,14 @@ final class HotkeyService: ObservableObject {
             if source != .eventTap {
                 logFallbackMatchIfNeeded(hotkey: hotkey, source: source)
             }
-            handleWorkflowKeyDown(workflowId: workflowId)
+            handleWorkflowKeyDown(workflowId: workflowId, behavior: behavior)
         } else if keyUp, shouldDispatch(
             target: .workflow(workflowId),
             phase: .up,
             hotkey: hotkey,
             source: source
         ) {
-            handleWorkflowKeyUp(workflowId: workflowId)
+            handleWorkflowKeyUp(workflowId: workflowId, behavior: behavior)
         }
     }
 
@@ -1228,7 +1232,12 @@ final class HotkeyService: ObservableObject {
 
     // MARK: - Key Down / Up (Workflow Slots)
 
-    private func handleWorkflowKeyDown(workflowId: UUID) {
+    private func handleWorkflowKeyDown(workflowId: UUID, behavior: WorkflowHotkeyBehavior) {
+        guard behavior == .startDictation else {
+            onWorkflowTextProcessing?(workflowId)
+            return
+        }
+
         if isActive {
             isActive = false
             activeSlotType = nil
@@ -1250,7 +1259,8 @@ final class HotkeyService: ObservableObject {
         }
     }
 
-    private func handleWorkflowKeyUp(workflowId: UUID) {
+    private func handleWorkflowKeyUp(workflowId: UUID, behavior: WorkflowHotkeyBehavior) {
+        guard behavior == .startDictation else { return }
         guard isActive, activeWorkflowId == workflowId else { return }
 
         guard let downTime = keyDownTime else { return }

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -23,6 +23,7 @@ final class TextInsertionService {
     var returnSimulatorOverride: (() -> Void)?
     var captureActiveAppOverride: (() -> (name: String?, bundleId: String?, url: String?))?
     var selectedTextOverride: (() -> String?)?
+    var textSelectionViaCopyOverride: (() -> String?)?
 
 enum InsertionResult {
         case pasted
@@ -584,6 +585,10 @@ enum InsertionResult {
 
     /// Attempts to get selected text by simulating Cmd+C. Saves and restores the clipboard.
     func getTextSelectionViaCopy() async -> String? {
+        if let textSelectionViaCopyOverride {
+            return textSelectionViaCopyOverride()
+        }
+
         let pasteboard = NSPasteboard.general
 
         // Save current clipboard contents (all types)

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -95,12 +95,12 @@ final class DictationSettingsHandler {
     func syncWorkflowHotkeys(_ workflows: [Workflow]) {
         let entries = workflows
             .filter(\.isEnabled)
-            .flatMap { workflow -> [(id: UUID, hotkey: UnifiedHotkey)] in
+            .flatMap { workflow -> [(id: UUID, hotkey: UnifiedHotkey, behavior: WorkflowHotkeyBehavior)] in
                 guard let trigger = workflow.trigger, trigger.kind == .hotkey else {
                     return []
                 }
                 return trigger.hotkeys.map { hotkey in
-                    (id: workflow.id, hotkey: hotkey)
+                    (id: workflow.id, hotkey: hotkey, behavior: trigger.hotkeyBehavior)
                 }
             }
         hotkeyService.registerWorkflowHotkeys(entries)

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -578,6 +578,10 @@ final class DictationViewModel: ObservableObject {
             self?.startRecording(forcedWorkflowId: workflowId)
         }
 
+        hotkeyService.onWorkflowTextProcessing = { [weak self] workflowId in
+            self?.processWorkflowHotkeyText(workflowId: workflowId)
+        }
+
         hotkeyService.onCancelPressed = { [weak self] in
             self?.handleCancelHotkey()
         }
@@ -1684,6 +1688,17 @@ final class DictationViewModel: ObservableObject {
     func triggerWorkflowPalette() {
         recentTranscriptionPaletteHandler.hide()
         promptPaletteHandler.triggerSelection(currentState: state, soundFeedbackEnabled: soundFeedbackEnabled)
+    }
+
+    func processWorkflowHotkeyText(workflowId: UUID) {
+        recentTranscriptionPaletteHandler.hide()
+        promptPaletteHandler.hide()
+        guard let workflow = workflowService.workflow(id: workflowId) else { return }
+        promptPaletteHandler.processWorkflowDirectly(
+            workflow: workflow,
+            currentState: state,
+            soundFeedbackEnabled: soundFeedbackEnabled
+        )
     }
 
     func triggerRecentTranscriptionsPalette() {

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -77,48 +77,99 @@ final class PromptPaletteHandler {
         let workflows = workflowService.workflows.filter { $0.isEnabled && $0.isManuallyRunnable }
         guard !workflows.isEmpty else { return }
 
-        // Capture active app BEFORE the palette steals focus
         let activeApp = textInsertionService.captureActiveApp()
+        let browserInfoTask = makeBrowserInfoTask(activeApp: activeApp)
 
-        // Start resolving browser URL + title asynchronously
-        var browserInfoTask: Task<(url: String?, title: String?), Never>?
-        if let bundleId = activeApp.bundleId {
-            let tis = textInsertionService
-            browserInfoTask = Task {
-                await tis.resolveBrowserInfo(bundleId: bundleId)
-            }
-        }
-
-        // 3-tier fallback: AX selection -> Cmd+C simulation -> clipboard
-        if let sel = textInsertionService.getTextSelection() {
-            logger.info("[PromptPalette] Got selected text via AX: \(sel.text.prefix(80))")
-            showPalette(
-                text: sel.text, selection: sel, focusedElement: nil,
-                selectionViaCopy: false, activeApp: activeApp,
-                browserInfoTask: browserInfoTask, workflows: workflows,
+        resolveTextContext(
+            activeApp: activeApp,
+            browserInfoTask: browserInfoTask,
+            soundFeedbackEnabled: soundFeedbackEnabled
+        ) { [weak self] context in
+            self?.showPalette(
+                context: context,
+                workflows: workflows,
                 soundFeedbackEnabled: soundFeedbackEnabled
             )
+        }
+    }
+
+    func processWorkflowDirectly(
+        workflow: Workflow,
+        currentState: DictationViewModel.State,
+        soundFeedbackEnabled: Bool
+    ) {
+        guard currentState == .idle,
+              workflow.isEnabled,
+              workflow.isManuallyRunnable else {
+            return
+        }
+
+        let activeApp = textInsertionService.captureActiveApp()
+        let browserInfoTask = makeBrowserInfoTask(activeApp: activeApp)
+
+        resolveTextContext(
+            activeApp: activeApp,
+            browserInfoTask: browserInfoTask,
+            soundFeedbackEnabled: soundFeedbackEnabled
+        ) { [weak self] context in
+            self?.processStandaloneWorkflow(
+                workflow: workflow,
+                context: context,
+                soundFeedbackEnabled: soundFeedbackEnabled
+            )
+        }
+    }
+
+    private func makeBrowserInfoTask(
+        activeApp: (name: String?, bundleId: String?, url: String?)
+    ) -> Task<(url: String?, title: String?), Never>? {
+        guard let bundleId = activeApp.bundleId else { return nil }
+        let tis = textInsertionService
+        return Task {
+            await tis.resolveBrowserInfo(bundleId: bundleId)
+        }
+    }
+
+    private func resolveTextContext(
+        activeApp: (name: String?, bundleId: String?, url: String?),
+        browserInfoTask: Task<(url: String?, title: String?), Never>?,
+        soundFeedbackEnabled: Bool,
+        completion: @escaping (PaletteContext) -> Void
+    ) {
+        if let sel = textInsertionService.getTextSelection() {
+            logger.info("[PromptPalette] Got selected text via AX: \(sel.text.prefix(80))")
+            completion(PaletteContext(
+                text: sel.text,
+                selection: sel,
+                focusedElement: nil,
+                activeApp: activeApp,
+                browserInfoTask: browserInfoTask,
+                selectionViaCopy: false
+            ))
         } else {
-            // AX failed - try Cmd+C simulation (async) before falling back to clipboard
             let tis = textInsertionService
             Task {
                 if let copied = await tis.getTextSelectionViaCopy() {
                     logger.info("[PromptPalette] Got selected text via Cmd+C: \(copied.prefix(80))")
-                    showPalette(
-                        text: copied, selection: nil, focusedElement: nil,
-                        selectionViaCopy: true, activeApp: activeApp,
-                        browserInfoTask: browserInfoTask, workflows: workflows,
-                        soundFeedbackEnabled: soundFeedbackEnabled
-                    )
+                    completion(PaletteContext(
+                        text: copied,
+                        selection: nil,
+                        focusedElement: nil,
+                        activeApp: activeApp,
+                        browserInfoTask: browserInfoTask,
+                        selectionViaCopy: true
+                    ))
                 } else if let clipboard = NSPasteboard.general.string(forType: .string), !clipboard.isEmpty {
                     let focusedElement = tis.getFocusedTextElement()
                     logger.info("[PromptPalette] No selection, using clipboard: \(clipboard.prefix(80))")
-                    showPalette(
-                        text: clipboard, selection: nil, focusedElement: focusedElement,
-                        selectionViaCopy: false, activeApp: activeApp,
-                        browserInfoTask: browserInfoTask, workflows: workflows,
-                        soundFeedbackEnabled: soundFeedbackEnabled
-                    )
+                    completion(PaletteContext(
+                        text: clipboard,
+                        selection: nil,
+                        focusedElement: focusedElement,
+                        activeApp: activeApp,
+                        browserInfoTask: browserInfoTask,
+                        selectionViaCopy: false
+                    ))
                 } else {
                     logger.info("[PromptPalette] No text available, aborting")
                     let message = "Please select or copy some text first."
@@ -132,25 +183,13 @@ final class PromptPaletteHandler {
     }
 
     private func showPalette(
-        text: String,
-        selection: TextInsertionService.TextSelection?,
-        focusedElement: AXUIElement?,
-        selectionViaCopy: Bool,
-        activeApp: (name: String?, bundleId: String?, url: String?),
-        browserInfoTask: Task<(url: String?, title: String?), Never>?,
+        context: PaletteContext,
         workflows: [Workflow],
         soundFeedbackEnabled: Bool
     ) {
-        paletteContext = PaletteContext(
-            text: text,
-            selection: selection,
-            focusedElement: focusedElement,
-            activeApp: activeApp,
-            browserInfoTask: browserInfoTask,
-            selectionViaCopy: selectionViaCopy
-        )
+        paletteContext = context
 
-        promptPaletteController.show(workflows: workflows, sourceText: text) { [weak self] workflow in
+        promptPaletteController.show(workflows: workflows, sourceText: context.text) { [weak self] workflow in
             self?.processStandaloneWorkflow(workflow: workflow, soundFeedbackEnabled: soundFeedbackEnabled)
         }
     }
@@ -159,6 +198,18 @@ final class PromptPaletteHandler {
         guard let ctx = paletteContext else { return }
         paletteContext = nil
 
+        processStandaloneWorkflow(
+            workflow: workflow,
+            context: ctx,
+            soundFeedbackEnabled: soundFeedbackEnabled
+        )
+    }
+
+    private func processStandaloneWorkflow(
+        workflow: Workflow,
+        context ctx: PaletteContext,
+        soundFeedbackEnabled: Bool
+    ) {
         onShowNotchFeedback?(workflow.name + "...", "ellipsis.circle", 30, false, nil)
         accessibilityAnnouncementService.announcePromptProcessing(workflow.name)
 

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -66,7 +66,7 @@ final class PromptPaletteController: PromptPaletteControlling {
         case .website:
             triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.websitePatterns.joined(separator: ", "))"
         case .hotkey:
-            triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", "))"
+            triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", ")) · \(trigger.hotkeyBehavior.shortcutSubtitle)"
         case .global, .manual:
             triggerSummary = trigger.kind.paletteLabel
         }
@@ -85,6 +85,7 @@ final class PromptPaletteController: PromptPaletteControlling {
             tokens.append(contentsOf: trigger.appBundleIdentifiers)
             tokens.append(contentsOf: trigger.websitePatterns)
             tokens.append(contentsOf: trigger.hotkeys.map(HotkeyService.displayName(for:)))
+            tokens.append(trigger.hotkeyBehavior.shortcutSubtitle)
         }
         return tokens
     }

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1269,6 +1269,27 @@ private struct WorkflowEditorPage: View {
 
     private var hotkeyTriggerEditor: some View {
         VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(localizedAppText("Shortcut Behavior", de: "Shortcut-Verhalten"))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Picker(
+                    localizedAppText("Shortcut Behavior", de: "Shortcut-Verhalten"),
+                    selection: $draft.hotkeyBehavior
+                ) {
+                    ForEach(WorkflowHotkeyBehavior.allCases, id: \.self) { behavior in
+                        Text(behavior.editorLabel).tag(behavior)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text(draft.hotkeyBehavior.editorDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             if draft.hotkeys.isEmpty {
                 Text(localizedAppText("No shortcuts recorded yet.", de: "Noch keine Shortcuts aufgenommen."))
                     .font(.subheadline)
@@ -1278,7 +1299,7 @@ private struct WorkflowEditorPage: View {
                     ForEach(draft.hotkeys, id: \.self) { hotkey in
                         WorkflowSelectionRow(
                             title: HotkeyService.displayName(for: hotkey),
-                            subtitle: localizedAppText("Workflow shortcut", de: "Workflow-Shortcut"),
+                            subtitle: draft.hotkeyBehavior.shortcutSubtitle,
                             iconSystemName: "keyboard"
                         ) {
                             draft.hotkeys.removeAll { $0 == hotkey }
@@ -1820,6 +1841,7 @@ private struct WorkflowDraft {
     var appBundleIdentifiers: [String]
     var websitePatterns: [String]
     var hotkeys: [UnifiedHotkey]
+    var hotkeyBehavior: WorkflowHotkeyBehavior
     var fineTuning: String
     var translationTargetLanguage: String
     var translationProcessor: WorkflowTranslationProcessor
@@ -1842,6 +1864,7 @@ private struct WorkflowDraft {
         self.appBundleIdentifiers = []
         self.websitePatterns = []
         self.hotkeys = []
+        self.hotkeyBehavior = .startDictation
         self.fineTuning = ""
         self.translationProcessor = template == .translation ? Self.defaultTranslationProcessor : .llmPrompt
         self.translationTargetLanguage = template == .translation
@@ -1877,6 +1900,7 @@ private struct WorkflowDraft {
         self.customInstruction = behavior.settings["instruction"] ?? behavior.settings["goal"] ?? behavior.settings["prompt"] ?? ""
         self.outputFormat = output.format ?? ""
         self.autoEnter = output.autoEnter
+        self.hotkeyBehavior = .startDictation
         self.preservedBehaviorSettings = behavior.settings
         self.providerId = behavior.providerId
         self.cloudModel = behavior.cloudModel
@@ -1901,6 +1925,7 @@ private struct WorkflowDraft {
                 self.appBundleIdentifiers = []
                 self.websitePatterns = []
                 self.hotkeys = trigger.hotkeys
+                self.hotkeyBehavior = trigger.hotkeyBehavior
             case .global:
                 self.triggerKind = .global
                 self.appBundleIdentifiers = []
@@ -2090,7 +2115,7 @@ private struct WorkflowDraft {
             return .websites(websitePatterns)
         case .hotkey:
             guard !hotkeys.isEmpty else { return nil }
-            return .hotkeys(hotkeys)
+            return .hotkeys(hotkeys, behavior: hotkeyBehavior)
         case .global:
             return .global()
         case .manual:
@@ -2160,10 +2185,22 @@ private struct WorkflowDraft {
             )
         case .hotkey:
             if !hotkeys.isEmpty {
-                return localizedAppText(
-                    "the shortcuts \(workflowCompactList(hotkeys.map(HotkeyService.displayName(for:)), conjunction: localizedAppText("and", de: "und")))",
-                    de: "die Shortcuts \(workflowCompactList(hotkeys.map(HotkeyService.displayName(for:)), conjunction: "und"))"
+                let shortcuts = workflowCompactList(
+                    hotkeys.map(HotkeyService.displayName(for:)),
+                    conjunction: localizedAppText("and", de: "und")
                 )
+                switch hotkeyBehavior {
+                case .startDictation:
+                    return localizedAppText(
+                        "the shortcuts \(shortcuts) to start dictation",
+                        de: "die Shortcuts \(shortcuts) zum Starten des Diktats"
+                    )
+                case .processSelectedText:
+                    return localizedAppText(
+                        "the shortcuts \(shortcuts) to process selected text",
+                        de: "die Shortcuts \(shortcuts) zum Verarbeiten markierten Texts"
+                    )
+                }
             }
             return localizedAppText("a hotkey", de: "einen Hotkey")
         case .global:
@@ -2289,7 +2326,9 @@ private func workflowTriggerDetail(for workflow: Workflow) -> String {
     case .website:
         return workflowCompactList(trigger.websitePatterns)
     case .hotkey:
-        return workflowCompactList(trigger.hotkeys.map(HotkeyService.displayName(for:)))
+        let shortcuts = workflowCompactList(trigger.hotkeys.map(HotkeyService.displayName(for:)))
+        guard !shortcuts.isEmpty else { return trigger.hotkeyBehavior.shortcutSubtitle }
+        return "\(shortcuts) · \(trigger.hotkeyBehavior.shortcutSubtitle)"
     case .global:
         return ""
     }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -4631,7 +4631,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.suspendMonitoring()
 
         let workflowId = UUID()
-        service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey())])
+        service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey(), behavior: .startDictation)])
 
         var startedWorkflowId: UUID?
         service.onWorkflowDictationStart = { startedWorkflowId = $0 }
@@ -4650,14 +4650,41 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testWorkflowHotkeyTextProcessingCallbackDoesNotStartDictation() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let workflowId = UUID()
+        service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey(), behavior: .processSelectedText)])
+
+        var textWorkflowId: UUID?
+        var startedWorkflowId: UUID?
+        service.onWorkflowTextProcessing = { textWorkflowId = $0 }
+        service.onWorkflowDictationStart = { startedWorkflowId = $0 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        let keyUp = try makeKeyboardEvent(keyCode: 0x31, keyDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(textWorkflowId, workflowId)
+        XCTAssertNil(startedWorkflowId)
+        XCTAssertNil(service.currentMode)
+        XCTAssertNil(service.activeWorkflowId)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertNil(service.currentMode)
+        XCTAssertNil(service.activeWorkflowId)
+    }
+
+    @MainActor
     func testWorkflowCanRegisterMultipleHotkeysForSameWorkflow() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
 
         let workflowId = UUID()
         service.registerWorkflowHotkeys([
-            (id: workflowId, hotkey: spaceHotkey()),
-            (id: workflowId, hotkey: alternateSpaceHotkey())
+            (id: workflowId, hotkey: spaceHotkey(), behavior: .startDictation),
+            (id: workflowId, hotkey: alternateSpaceHotkey(), behavior: .startDictation)
         ])
 
         var startedWorkflowIds: [UUID] = []

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -184,6 +184,176 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
 
 @MainActor
 final class PromptPaletteHandlerTests: XCTestCase {
+    func testDirectWorkflowHotkeyProcessesAccessibilitySelectionWithoutShowingPalette() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        let selectedElement = AXUIElementCreateSystemWide()
+        textInsertionService.textSelectionOverride = {
+            TextInsertionService.TextSelection(text: "Selected source", element: selectedElement)
+        }
+
+        var insertedText: String?
+        textInsertionService.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = Workflow(
+            name: "Direct Summary",
+            template: .summary,
+            trigger: .hotkeys([
+                UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)
+            ], behavior: .processSelectedText)
+        )
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            promptProcessingService: PromptProcessingService(),
+            workflowTextProcessingService: WorkflowTextProcessingService(
+                promptProcessor: { _, text, _, _, _ in "Processed: \(text)" },
+                appleTranslator: nil
+            ),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller
+        )
+
+        handler.processWorkflowDirectly(
+            workflow: workflow,
+            currentState: .idle,
+            soundFeedbackEnabled: false
+        )
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertFalse(controller.isVisible)
+        XCTAssertEqual(insertedText, "Processed: Selected source")
+    }
+
+    func testDirectWorkflowHotkeyUsesClipboardFallbackWhenSelectionIsUnavailable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        textInsertionService.textSelectionOverride = { nil }
+        textInsertionService.textSelectionViaCopyOverride = { nil }
+        textInsertionService.focusedTextElementOverride = { AXUIElementCreateSystemWide() }
+
+        var insertedText: String?
+        textInsertionService.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        let pasteboard = NSPasteboard.general
+        let savedClipboard = textInsertionService.saveClipboard(from: pasteboard)
+        defer { textInsertionService.restoreClipboard(savedClipboard, to: pasteboard) }
+        pasteboard.clearContents()
+        pasteboard.setString("Clipboard source", forType: .string)
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = Workflow(
+            name: "Direct Cleanup",
+            template: .cleanedText,
+            trigger: .hotkeys([
+                UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)
+            ], behavior: .processSelectedText)
+        )
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            promptProcessingService: PromptProcessingService(),
+            workflowTextProcessingService: WorkflowTextProcessingService(
+                promptProcessor: { _, text, _, _, _ in "Processed: \(text)" },
+                appleTranslator: nil
+            ),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: PromptPaletteControllerSpy()
+        )
+
+        handler.processWorkflowDirectly(
+            workflow: workflow,
+            currentState: .idle,
+            soundFeedbackEnabled: false
+        )
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(insertedText, "Processed: Clipboard source")
+    }
+
+    func testDirectWorkflowHotkeyShowsErrorWhenNoSelectionOrClipboardIsAvailable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        textInsertionService.textSelectionOverride = { nil }
+        textInsertionService.textSelectionViaCopyOverride = { nil }
+
+        let pasteboard = NSPasteboard.general
+        let savedClipboard = textInsertionService.saveClipboard(from: pasteboard)
+        defer { textInsertionService.restoreClipboard(savedClipboard, to: pasteboard) }
+        pasteboard.clearContents()
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = Workflow(
+            name: "Direct Empty",
+            template: .cleanedText,
+            trigger: .hotkeys([
+                UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)
+            ], behavior: .processSelectedText)
+        )
+
+        var processedText: String?
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            promptProcessingService: PromptProcessingService(),
+            workflowTextProcessingService: WorkflowTextProcessingService(
+                promptProcessor: { _, text, _, _, _ in
+                    processedText = text
+                    return "Processed: \(text)"
+                },
+                appleTranslator: nil
+            ),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: PromptPaletteControllerSpy()
+        )
+
+        var feedbackMessage: String?
+        var errorMessage: String?
+        handler.onShowNotchFeedback = { message, _, _, _, _ in
+            feedbackMessage = message
+        }
+        handler.onShowError = { message in
+            errorMessage = message
+        }
+
+        handler.processWorkflowDirectly(
+            workflow: workflow,
+            currentState: .idle,
+            soundFeedbackEnabled: false
+        )
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertNil(processedText)
+        XCTAssertEqual(feedbackMessage, "Please select or copy some text first.")
+        XCTAssertEqual(errorMessage, "Please select or copy some text first.")
+    }
+
     func testTriggerSelectionStillOpensPaletteWhenCurrentProviderIsNotReady() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -58,6 +58,46 @@ final class WorkflowServiceTests: XCTestCase {
         )
     }
 
+    func testLegacyWorkflowTriggerWithoutHotkeyBehaviorDefaultsToStartDictation() throws {
+        let payload: [String: Any] = [
+            "kind": "hotkey",
+            "appBundleIdentifiers": [],
+            "websitePatterns": [],
+            "hotkeys": [
+                [
+                    "keyCode": 15,
+                    "modifierFlags": 0,
+                    "isFn": false
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+
+        let trigger = try JSONDecoder().decode(WorkflowTrigger.self, from: data)
+
+        XCTAssertEqual(trigger.hotkeyBehavior, .startDictation)
+    }
+
+    func testWorkflowServicePersistsHotkeyTextProcessingBehavior() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let hotkey = UnifiedHotkey(keyCode: 15, modifierFlags: 0, isFn: false)
+
+        service.addWorkflow(
+            name: "Direct Summary",
+            template: .summary,
+            trigger: .hotkeys([hotkey], behavior: .processSelectedText)
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(workflow.trigger?.hotkeys, [hotkey])
+        XCTAssertEqual(workflow.trigger?.hotkeyBehavior, .processSelectedText)
+    }
+
     func testWorkflowServicePersistsDefaultLLMProviderAndModel() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary

This PR implements Issue #428: workflow hotkeys can now either start dictation or directly process the current selection/clipboard.

- Adds `WorkflowHotkeyBehavior` with a legacy-safe default of `startDictation`.
- Persists the hotkey behavior on `WorkflowTrigger` and registers workflow hotkeys with that behavior.
- Keeps `startDictation` on the existing push-to-talk/toggle recording path.
- Adds `processSelectedText` as a one-shot key-down path that does not enter recording state and ignores key-up.
- Routes direct workflow text processing through the same selection, clipboard fallback, workflow processing, action plugin, insertion, clipboard preservation, and feedback path used by the workflow palette.
- Updates the Workflow editor and palette copy so dictation-start hotkeys and selected-text hotkeys are clearly distinguished.
- Adds XCTest coverage for legacy decoding, persistence, hotkey dispatch, direct AX selection processing, clipboard fallback, and empty-text feedback.

Closes #428

## Issue Context

Issue #428 asks for direct workflow hotkeys for selected text. The selected UX model is one behavior per workflow hotkey: either start dictation or process selected text/clipboard. Existing and new hotkey workflows default to starting dictation for backwards compatibility.

## Test Coverage

All new code paths have XCTest coverage:

- Legacy `WorkflowTrigger` payloads without `hotkeyBehavior` decode as `startDictation`.
- Saved workflow hotkey behavior survives save/fetch.
- `startDictation` workflow hotkeys still call `onWorkflowDictationStart`.
- `processSelectedText` workflow hotkeys call the text-processing callback and do not set recording state.
- Direct workflow text processing handles AX selection.
- Direct workflow text processing falls back to clipboard.
- Direct workflow text processing shows clear feedback when neither selection nor clipboard text is available.

## Pre-Landing Review

No issues found.

## Design Review

SwiftUI surface changed in `WorkflowsSettingsView`; web design review is not applicable for this macOS app workflow.

## Verification Results

Primary XCTest suite passed:

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Result: `** TEST SUCCEEDED **`, 518 tests, 0 failures.

Dev build passed:

```sh
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/conductor/workspaces/typewhisper-mac/dhaka
```

Result: `** BUILD SUCCEEDED **`.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/conductor/workspaces/typewhisper-mac/dhaka`


## Documentation

- `README.md`: added a direct workflow hotkey note so the GitHub docs say hotkey workflows can start dictation or process the current selection/clipboard directly.
- `typewhisper.com`: public macOS Workflows docs updated in EN/DE to describe the two hotkey behaviors, selected-text mode, Cmd+C fallback, clipboard fallback, and Workflow Palette insertion path. Docs PR: https://github.com/TypeWhisper/typewhisper.com/pull/52
