### PR TITLE
feat: add workflow spoken language dictation template

### DIFF
--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -10,6 +10,7 @@ enum WorkflowTemplate: String, CaseIterable, Codable, Sendable {
     case checklist
     case json
     case summary
+    case dictation
     case custom
 
     static var catalog: [WorkflowTemplateDefinition] {
@@ -18,6 +19,16 @@ enum WorkflowTemplate: String, CaseIterable, Codable, Sendable {
 
     var definition: WorkflowTemplateDefinition {
         switch self {
+        case .dictation:
+            WorkflowTemplateDefinition(
+                template: self,
+                name: localizedAppText("Dictation Only", de: "Nur Diktat"),
+                description: localizedAppText(
+                    "Transcribe and insert without LLM processing.",
+                    de: "Transkribiert und fuegt ohne LLM-Verarbeitung ein."
+                ),
+                systemImage: "mic"
+            )
         case .cleanedText:
             WorkflowTemplateDefinition(
                 template: self,
@@ -212,6 +223,7 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
 struct WorkflowBehavior: Codable, Equatable, Sendable {
     static let translationProcessorSettingKey = "translationProcessor"
     static let targetLanguageSettingKey = "targetLanguage"
+    static let inputLanguageSettingKey = "inputLanguage"
 
     var settings: [String: String]
     var fineTuning: String
@@ -436,6 +448,24 @@ extension Workflow {
         template == .translation && translationProcessor == .appleTranslate
     }
 
+    var inputLanguageSelection: LanguageSelection {
+        get {
+            LanguageSelection(
+                storedValue: behavior.settings[WorkflowBehavior.inputLanguageSettingKey],
+                nilBehavior: .inheritGlobal
+            )
+        }
+        set {
+            var updatedBehavior = behavior
+            if let storedValue = newValue.storedValue(nilBehavior: .inheritGlobal) {
+                updatedBehavior.settings[WorkflowBehavior.inputLanguageSettingKey] = storedValue
+            } else {
+                updatedBehavior.settings.removeValue(forKey: WorkflowBehavior.inputLanguageSettingKey)
+            }
+            behavior = updatedBehavior
+        }
+    }
+
     var isManuallyRunnable: Bool {
         usesAppleTranslate || systemPrompt() != nil || output.targetActionPluginId != nil
     }
@@ -455,6 +485,8 @@ extension Workflow {
         )
 
         switch template {
+        case .dictation:
+            return nil
         case .cleanedText:
             return """
             Clean up the dictated text for readability. Fix punctuation, grammar, and formatting while preserving the original meaning and language. Return only the cleaned text.
@@ -530,7 +562,7 @@ extension Workflow {
     private func workflowSettingsInstruction(for settings: [String: String]) -> String {
         let relevantSettings = settings
             .filter { key, value in
-                !["instruction", "goal", "prompt", "targetLanguage", "target"].contains(key)
+                !["instruction", "goal", "prompt", "targetLanguage", "target", WorkflowBehavior.inputLanguageSettingKey].contains(key)
                 && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }
             .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -35,6 +35,31 @@ struct DictationSessionSnapshot: Sendable, Equatable {
     let error: String?
 }
 
+@MainActor
+enum DictationLanguageResolver {
+    static func resolve(
+        workflow: Workflow?,
+        profile: Profile?,
+        globalLanguageSelection: LanguageSelection
+    ) -> LanguageSelection {
+        if let workflow {
+            let workflowSelection = workflow.inputLanguageSelection
+            if workflowSelection != .inheritGlobal {
+                return workflowSelection
+            }
+        }
+
+        if let profile {
+            let profileSelection = profile.inputLanguageSelection
+            if profileSelection != .inheritGlobal {
+                return profileSelection
+            }
+        }
+
+        return globalLanguageSelection
+    }
+}
+
 /// Orchestrates the dictation flow: recording → transcription → text insertion.
 @MainActor
 final class DictationViewModel: ObservableObject {
@@ -899,16 +924,11 @@ final class DictationViewModel: ObservableObject {
     }
 
     private var effectiveLanguageSelection: LanguageSelection {
-        if let profileLang = matchedProfile?.inputLanguage {
-            let profileSelection = LanguageSelection(
-                storedValue: profileLang,
-                nilBehavior: .inheritGlobal
-            )
-            if profileSelection != .inheritGlobal {
-                return profileSelection
-            }
-        }
-        return settingsViewModel.languageSelection
+        DictationLanguageResolver.resolve(
+            workflow: matchedWorkflow,
+            profile: matchedProfile,
+            globalLanguageSelection: settingsViewModel.languageSelection
+        )
     }
 
     private var effectiveLanguage: String? {

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -94,6 +94,7 @@ private struct MyWorkflowsPage: View {
                 || workflow.template.definition.name.localizedCaseInsensitiveContains(trimmedQuery)
                 || workflowTriggerSummary(for: workflow).localizedCaseInsensitiveContains(trimmedQuery)
                 || workflowTriggerDetail(for: workflow).localizedCaseInsensitiveContains(trimmedQuery)
+                || workflowInputLanguageSummary(for: workflow.inputLanguageSelection).localizedCaseInsensitiveContains(trimmedQuery)
         }
     }
 
@@ -488,6 +489,12 @@ private struct WorkflowRow: View {
                             foreground: .secondary
                         )
                     }
+                    WorkflowBadge(
+                        title: workflowInputLanguageSummary(for: workflow.inputLanguageSelection),
+                        compact: true,
+                        tint: .secondary.opacity(0.12),
+                        foreground: .secondary
+                    )
                     Spacer(minLength: 0)
                 }
             }
@@ -759,6 +766,7 @@ private struct WorkflowEditorPage: View {
     @ObservedObject private var profilesViewModel = ServiceContainer.shared.profilesViewModel
     @ObservedObject private var historyService = ServiceContainer.shared.historyService
     @ObservedObject private var promptProcessingService = ServiceContainer.shared.promptProcessingService
+    @ObservedObject private var settingsViewModel = SettingsViewModel.shared
     @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
 
     @State private var draft: WorkflowDraft
@@ -878,6 +886,10 @@ private struct WorkflowEditorPage: View {
                         .textFieldStyle(.roundedBorder)
                 }
 
+                if draft.template == .dictation {
+                    workflowInputLanguageEditor
+                }
+
                 if draft.template == .translation {
                     translationProcessorSection
                 }
@@ -893,7 +905,7 @@ private struct WorkflowEditorPage: View {
                     )
                 }
 
-                if !draft.usesAppleTranslate {
+                if draft.usesLLMProcessing {
                     WorkflowTextEditorField(
                         title: localizedAppText("Fine-Tuning", de: "Feinabstimmung"),
                         placeholder: localizedAppText(
@@ -928,17 +940,25 @@ private struct WorkflowEditorPage: View {
 
                     if isAdvancedExpanded {
                         VStack(alignment: .leading, spacing: 14) {
-                            if !draft.usesAppleTranslate {
-                                workflowProviderOverrideSection
+                            if draft.template != .dictation {
+                                workflowInputLanguageEditor
 
                                 Divider()
                             }
 
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(localizedAppText("Output Format", de: "Ausgabeformat"))
-                                    .font(.subheadline.weight(.semibold))
-                                TextField(localizedAppText("e.g. Markdown, JSON, plain text", de: "z. B. Markdown, JSON, Plain Text"), text: $draft.outputFormat)
-                                    .textFieldStyle(.roundedBorder)
+                            if draft.usesLLMProcessing {
+                                workflowProviderOverrideSection
+
+                                Divider()
+
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text(localizedAppText("Output Format", de: "Ausgabeformat"))
+                                        .font(.subheadline.weight(.semibold))
+                                    TextField(localizedAppText("e.g. Markdown, JSON, plain text", de: "z. B. Markdown, JSON, Plain Text"), text: $draft.outputFormat)
+                                        .textFieldStyle(.roundedBorder)
+                                }
+
+                                Divider()
                             }
 
                             Toggle(localizedAppText("Press Enter after inserting", de: "Nach dem Einfügen Enter drücken"), isOn: $draft.autoEnter)
@@ -947,6 +967,19 @@ private struct WorkflowEditorPage: View {
                     }
                 }
             }
+        }
+    }
+
+    private var workflowInputLanguageEditor: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(localizedAppText("Spoken Language", de: "Gesprochene Sprache"))
+                .font(.subheadline.weight(.semibold))
+            LanguageSelectionEditor(
+                selection: $draft.inputLanguageSelection,
+                availableLanguages: settingsViewModel.availableLanguages,
+                nilBehavior: .inheritGlobal,
+                inheritTitle: localizedAppText("Global Setting", de: "Globale Einstellung")
+            )
         }
     }
 
@@ -1112,7 +1145,9 @@ private struct WorkflowEditorPage: View {
         ) {
             VStack(alignment: .leading, spacing: 14) {
                 Picker(localizedAppText("Trigger", de: "Trigger"), selection: $draft.triggerKind) {
-                    Text(localizedAppText("Manual", de: "Manuell")).tag(WorkflowTriggerKind.manual)
+                    if draft.template != .dictation {
+                        Text(localizedAppText("Manual", de: "Manuell")).tag(WorkflowTriggerKind.manual)
+                    }
                     Text(localizedAppText("App", de: "App")).tag(WorkflowTriggerKind.app)
                     Text(localizedAppText("Website", de: "Website")).tag(WorkflowTriggerKind.website)
                     Text(localizedAppText("Hotkey", de: "Hotkey")).tag(WorkflowTriggerKind.hotkey)
@@ -1821,6 +1856,7 @@ private struct WorkflowDraft {
     var websitePatterns: [String]
     var hotkeys: [UnifiedHotkey]
     var fineTuning: String
+    var inputLanguageSelection: LanguageSelection
     var translationTargetLanguage: String
     var translationProcessor: WorkflowTranslationProcessor
     var customInstruction: String
@@ -1838,11 +1874,12 @@ private struct WorkflowDraft {
         self.name = template.definition.name
         self.isEnabled = true
         self.template = template
-        self.triggerKind = .manual
+        self.triggerKind = template == .dictation ? .hotkey : .manual
         self.appBundleIdentifiers = []
         self.websitePatterns = []
         self.hotkeys = []
         self.fineTuning = ""
+        self.inputLanguageSelection = .inheritGlobal
         self.translationProcessor = template == .translation ? Self.defaultTranslationProcessor : .llmPrompt
         self.translationTargetLanguage = template == .translation
             ? Self.defaultTranslationTargetLanguage(for: translationProcessor)
@@ -1866,6 +1903,7 @@ private struct WorkflowDraft {
         self.isEnabled = workflow.isEnabled
         self.template = workflow.template
         self.fineTuning = behavior.fineTuning
+        self.inputLanguageSelection = workflow.inputLanguageSelection
         self.translationProcessor = workflow.translationProcessor
         let rawTranslationTargetLanguage = workflow.translationTargetLanguage ?? ""
         if workflow.usesAppleTranslate,
@@ -1918,6 +1956,10 @@ private struct WorkflowDraft {
             self.websitePatterns = []
             self.hotkeys = []
         }
+
+        if self.template == .dictation && self.triggerKind == .manual {
+            self.triggerKind = .hotkey
+        }
     }
 
     var resolvedName: String {
@@ -1929,24 +1971,33 @@ private struct WorkflowDraft {
         template == .translation && translationProcessor == .appleTranslate
     }
 
+    var usesLLMProcessing: Bool {
+        !usesAppleTranslate && template != .dictation
+    }
+
     var reviewText: String {
+        let languageSentence = localizedAppText(
+            " Spoken language: \(workflowInputLanguageSummary(for: inputLanguageSelection)).",
+            de: " Gesprochene Sprache: \(workflowInputLanguageSummary(for: inputLanguageSelection))."
+        )
+
         if triggerKind == .manual {
             return localizedAppText(
-                "\(resolvedName) is available as \(template.definition.name) from the Workflow Palette.",
-                de: "\(resolvedName) ist als \(template.definition.name) über die Workflow-Palette verfügbar."
+                "\(resolvedName) is available as \(template.definition.name) from the Workflow Palette.\(languageSentence)",
+                de: "\(resolvedName) ist als \(template.definition.name) über die Workflow-Palette verfügbar.\(languageSentence)"
             )
         }
 
         if triggerKind == .global {
             return localizedAppText(
-                "\(resolvedName) runs always as \(template.definition.name).",
-                de: "\(resolvedName) läuft immer als \(template.definition.name)."
+                "\(resolvedName) runs always as \(template.definition.name).\(languageSentence)",
+                de: "\(resolvedName) läuft immer als \(template.definition.name).\(languageSentence)"
             )
         }
 
         return localizedAppText(
-            "\(resolvedName) runs as \(template.definition.name) via \(triggerReviewText).",
-            de: "\(resolvedName) läuft als \(template.definition.name) über \(triggerReviewText)."
+            "\(resolvedName) runs as \(template.definition.name) via \(triggerReviewText).\(languageSentence)",
+            de: "\(resolvedName) läuft als \(template.definition.name) über \(triggerReviewText).\(languageSentence)"
         )
     }
 
@@ -1973,6 +2024,16 @@ private struct WorkflowDraft {
         if newTemplate != .custom {
             customInstruction = ""
         }
+
+        if newTemplate == .dictation {
+            fineTuning = ""
+            outputFormat = ""
+            providerId = nil
+            cloudModel = nil
+            if triggerKind == .manual {
+                triggerKind = .hotkey
+            }
+        }
     }
 
     @MainActor
@@ -1982,6 +2043,13 @@ private struct WorkflowDraft {
         profileService: ProfileService,
         existingWorkflowId: UUID?
     ) -> String? {
+        if template == .dictation && triggerKind == .manual {
+            return localizedAppText(
+                "Dictation Only workflows need a recording trigger.",
+                de: "Nur-Diktat-Workflows brauchen einen Aufnahme-Trigger."
+            )
+        }
+
         switch triggerKind {
         case .app:
             if appBundleIdentifiers.isEmpty {
@@ -2103,9 +2171,14 @@ private struct WorkflowDraft {
         settings.removeValue(forKey: "targetLanguage")
         settings.removeValue(forKey: "target")
         settings.removeValue(forKey: WorkflowBehavior.translationProcessorSettingKey)
+        settings.removeValue(forKey: WorkflowBehavior.inputLanguageSettingKey)
         settings.removeValue(forKey: "instruction")
         settings.removeValue(forKey: "goal")
         settings.removeValue(forKey: "prompt")
+
+        if let storedInputLanguage = inputLanguageSelection.storedValue(nilBehavior: .inheritGlobal) {
+            settings[WorkflowBehavior.inputLanguageSettingKey] = storedInputLanguage
+        }
 
         let trimmedTargetLanguage = translationTargetLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
         if template == .translation && !trimmedTargetLanguage.isEmpty {
@@ -2123,9 +2196,9 @@ private struct WorkflowDraft {
 
         return WorkflowBehavior(
             settings: settings,
-            fineTuning: fineTuning.trimmingCharacters(in: .whitespacesAndNewlines),
-            providerId: trimmedProviderId?.isEmpty == false ? trimmedProviderId : nil,
-            cloudModel: trimmedCloudModel?.isEmpty == false ? trimmedCloudModel : nil,
+            fineTuning: usesLLMProcessing ? fineTuning.trimmingCharacters(in: .whitespacesAndNewlines) : "",
+            providerId: usesLLMProcessing && trimmedProviderId?.isEmpty == false ? trimmedProviderId : nil,
+            cloudModel: usesLLMProcessing && trimmedCloudModel?.isEmpty == false ? trimmedCloudModel : nil,
             temperatureModeRaw: temperatureModeRaw,
             temperatureValue: temperatureValue
         )
@@ -2134,9 +2207,9 @@ private struct WorkflowDraft {
     func resolvedOutput() -> WorkflowOutput {
         let trimmedFormat = outputFormat.trimmingCharacters(in: .whitespacesAndNewlines)
         return WorkflowOutput(
-            format: trimmedFormat.isEmpty ? nil : trimmedFormat,
+            format: usesLLMProcessing && !trimmedFormat.isEmpty ? trimmedFormat : nil,
             autoEnter: autoEnter,
-            targetActionPluginId: targetActionPluginId
+            targetActionPluginId: template == .dictation ? nil : targetActionPluginId
         )
     }
 
@@ -2253,6 +2326,47 @@ private func workflowSummaryText(for workflow: Workflow) -> String {
     }
 }
 
+private func workflowInputLanguageSummary(for selection: LanguageSelection) -> String {
+    switch selection {
+    case .inheritGlobal:
+        return localizedAppText("Global Setting", de: "Globale Einstellung")
+    case .auto:
+        return localizedAppText("Auto-detect", de: "Automatische Erkennung")
+    case .exact(let code):
+        return localizedAppLanguageName(for: code)
+    case .hints(let codes):
+        let normalizedCodes = LanguageSelection.hints(codes).selectedCodes
+        guard !normalizedCodes.isEmpty else {
+            return localizedAppText("Auto-detect", de: "Automatische Erkennung")
+        }
+        return localizedAppText(
+            "Auto-detect between \(workflowLanguageNameList(normalizedCodes))",
+            de: "Automatische Erkennung zwischen \(workflowLanguageNameList(normalizedCodes))"
+        )
+    }
+}
+
+private func workflowLanguageNameList(_ codes: [String]) -> String {
+    let names = localizedAppLanguageNames(for: codes)
+    switch names.count {
+    case 0:
+        return ""
+    case 1:
+        return names[0]
+    case 2:
+        return localizedAppText(
+            "\(names[0]) and \(names[1])",
+            de: "\(names[0]) und \(names[1])"
+        )
+    default:
+        let allButLast = names.dropLast().joined(separator: ", ")
+        return localizedAppText(
+            "\(allButLast), and \(names[names.count - 1])",
+            de: "\(allButLast) und \(names[names.count - 1])"
+        )
+    }
+}
+
 private func workflowTriggerSummary(for workflow: Workflow) -> String {
     guard let trigger = workflow.trigger else {
         return localizedAppText("No Trigger", de: "Kein Trigger")
@@ -2299,31 +2413,35 @@ private func workflowReviewText(for workflow: Workflow) -> String {
     let summary = workflowSummaryText(for: workflow)
     let triggerSummary = workflowTriggerSummary(for: workflow)
     let triggerDetail = workflowTriggerDetail(for: workflow)
+    let languageSentence = localizedAppText(
+        ". Spoken language: \(workflowInputLanguageSummary(for: workflow.inputLanguageSelection))",
+        de: ". Gesprochene Sprache: \(workflowInputLanguageSummary(for: workflow.inputLanguageSelection))"
+    )
 
     if workflow.trigger?.kind == .global {
         return localizedAppText(
-            "\(summary) runs always",
-            de: "\(summary) läuft immer"
+            "\(summary) runs always\(languageSentence)",
+            de: "\(summary) läuft immer\(languageSentence)"
         )
     }
 
     if workflow.trigger?.kind == .manual {
         return localizedAppText(
-            "\(summary) is available from the Workflow Palette",
-            de: "\(summary) ist über die Workflow-Palette verfügbar"
+            "\(summary) is available from the Workflow Palette\(languageSentence)",
+            de: "\(summary) ist über die Workflow-Palette verfügbar\(languageSentence)"
         )
     }
 
     if triggerDetail.isEmpty {
         return localizedAppText(
-            "\(summary) via \(triggerSummary)",
-            de: "\(summary) über \(triggerSummary)"
+            "\(summary) via \(triggerSummary)\(languageSentence)",
+            de: "\(summary) über \(triggerSummary)\(languageSentence)"
         )
     }
 
     return localizedAppText(
-        "\(summary) via \(triggerSummary): \(triggerDetail)",
-        de: "\(summary) über \(triggerSummary): \(triggerDetail)"
+        "\(summary) via \(triggerSummary): \(triggerDetail)\(languageSentence)",
+        de: "\(summary) über \(triggerSummary): \(triggerDetail)\(languageSentence)"
     )
 }
 

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -156,7 +156,7 @@ final class WorkflowServiceTests: XCTestCase {
     func testTemplateCatalogMatchesApprovedInitialOrder() {
         XCTAssertEqual(
             WorkflowTemplate.catalog.map(\.template),
-            [.cleanedText, .translation, .emailReply, .meetingNotes, .checklist, .json, .summary, .custom]
+            [.cleanedText, .translation, .emailReply, .meetingNotes, .checklist, .json, .summary, .dictation, .custom]
         )
     }
 
@@ -304,6 +304,55 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(workflow.translationProcessor, .appleTranslate)
         XCTAssertEqual(workflow.translationTargetLanguage, "en")
         XCTAssertTrue(workflow.usesAppleTranslate)
+    }
+
+    func testWorkflowServicePersistsExactInputLanguageSelection() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        service.addWorkflow(
+            name: "German Dictation",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 5, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(settings: [
+                WorkflowBehavior.inputLanguageSettingKey: "de",
+            ])
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(workflow.inputLanguageSelection, .exact("de"))
+        XCTAssertEqual(workflow.behavior.settings[WorkflowBehavior.inputLanguageSettingKey], "de")
+    }
+
+    func testWorkflowServicePersistsInputLanguageHintSelection() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = Workflow(
+            name: "German English Dictation",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 6, modifierFlags: 0, isFn: false))
+        )
+        workflow.inputLanguageSelection = .hints(["de", "en"])
+        service.addWorkflow(
+            name: workflow.name,
+            template: workflow.template,
+            trigger: try XCTUnwrap(workflow.trigger),
+            behavior: workflow.behavior
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let persistedWorkflow = try XCTUnwrap(reloaded.workflows.first)
+
+        XCTAssertEqual(persistedWorkflow.inputLanguageSelection, .hints(["de", "en"]))
+        XCTAssertEqual(
+            persistedWorkflow.behavior.settings[WorkflowBehavior.inputLanguageSettingKey],
+            #"["de","en"]"#
+        )
     }
 
     func testWorkflowTextProcessingServiceUsesAppleTranslatorWithNormalizedLanguages() async throws {
@@ -454,6 +503,31 @@ final class WorkflowServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(result, "Bonjour")
+    }
+
+    func testDictationOnlyWorkflowReturnsOriginalTextWithoutLLM() async throws {
+        let workflow = Workflow(
+            name: "Dictation Only",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 7, modifierFlags: 0, isFn: false))
+        )
+
+        let service = WorkflowTextProcessingService(
+            promptProcessor: { _, _, _, _, _ in
+                XCTFail("Dictation-only workflows must not use the LLM prompt processor")
+                return ""
+            },
+            appleTranslator: { _, _, _ in
+                XCTFail("Dictation-only workflows must not use Apple Translate")
+                return ""
+            }
+        )
+
+        let result = try await service.process(workflow: workflow, text: "Raw transcript")
+
+        XCTAssertEqual(result, "Raw transcript")
+        XCTAssertNil(workflow.systemPrompt())
+        XCTAssertFalse(workflow.isManuallyRunnable)
     }
 
     func testMatchWorkflowSupportsMultipleAppsAndWebsitesPerWorkflow() throws {
@@ -899,5 +973,82 @@ final class WatchFolderExportTests: XCTestCase {
                 TranscriptionSegment(text: "world", start: 1.5, end: 2.75)
             ]
         )
+    }
+}
+
+@MainActor
+final class DictationLanguageResolverTests: XCTestCase {
+    func testWorkflowLanguageOverridesProfileAndGlobalLanguage() {
+        let workflow = Workflow(
+            name: "German Workflow",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 5, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(settings: [
+                WorkflowBehavior.inputLanguageSettingKey: "de",
+            ])
+        )
+        let profile = Profile(name: "English Rule", inputLanguage: "en")
+
+        let resolved = DictationLanguageResolver.resolve(
+            workflow: workflow,
+            profile: profile,
+            globalLanguageSelection: .hints(["fr", "nl"])
+        )
+
+        XCTAssertEqual(resolved, .exact("de"))
+    }
+
+    func testWorkflowInheritFallsBackToProfileBeforeGlobalLanguage() {
+        let workflow = Workflow(
+            name: "Inherit Workflow",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 6, modifierFlags: 0, isFn: false))
+        )
+        let profile = Profile(name: "Hint Rule", inputLanguage: #"["de","en"]"#)
+
+        let resolved = DictationLanguageResolver.resolve(
+            workflow: workflow,
+            profile: profile,
+            globalLanguageSelection: .exact("fr")
+        )
+
+        XCTAssertEqual(resolved, .hints(["de", "en"]))
+    }
+
+    func testWorkflowInheritFallsBackToGlobalWhenProfileAlsoInherits() {
+        let workflow = Workflow(
+            name: "Inherit Workflow",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 7, modifierFlags: 0, isFn: false))
+        )
+        let profile = Profile(name: "Global Rule")
+
+        let resolved = DictationLanguageResolver.resolve(
+            workflow: workflow,
+            profile: profile,
+            globalLanguageSelection: .exact("fr")
+        )
+
+        XCTAssertEqual(resolved, .exact("fr"))
+    }
+
+    func testWorkflowAutoOverridesProfileAndGlobalLanguage() {
+        let workflow = Workflow(
+            name: "Auto Workflow",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 8, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(settings: [
+                WorkflowBehavior.inputLanguageSettingKey: "auto",
+            ])
+        )
+        let profile = Profile(name: "German Rule", inputLanguage: "de")
+
+        let resolved = DictationLanguageResolver.resolve(
+            workflow: workflow,
+            profile: profile,
+            globalLanguageSelection: .exact("fr")
+        )
+
+        XCTAssertEqual(resolved, .auto)
     }
 }


### PR DESCRIPTION
## Summary

Issue #442 asks for language-specific workflow hotkeys without forcing LLM post-processing. This PR adds a per-workflow spoken language setting, a no-LLM `Dictation Only` workflow template, and resolver precedence so workflow language wins over legacy profile/rule and global language settings.

Closes #442

## Changes

- Added the `Dictation Only` workflow template for recording, transcription, and insertion without an LLM prompt.
- Persisted workflow spoken language in `WorkflowBehavior.settings["inputLanguage"]`, reusing the existing `LanguageSelection` encoding for inherit, auto, exact language, and hint lists.
- Updated dictation language resolution to prioritize workflow language, then legacy profile language, then global language.
- Added the Spoken Language editor to workflow behavior settings. `Dictation Only` shows it directly; other workflows show it under Advanced.
- Hid LLM-only fields for `Dictation Only` while keeping Auto Enter available, and blocked Manual/Palette-only dictation-only workflows.
- Added compact language summaries to workflow rows and review text.

## Test Coverage

All new model/service/resolver code paths have XCTest coverage:

- Exact workflow language persistence.
- Workflow language hint-list persistence.
- Dictation-only text processing returns the original transcript without calling LLM or Apple Translate.
- Language resolver precedence: workflow over profile/global, inherit fallback, and explicit auto override.
- Template catalog ordering with `Dictation Only` placed later in the template list.

## Pre-Landing Review

No issues found.

## Design Review

TypeWhisper SwiftUI diff reviewed at code level. The web design checklist is not applicable to this macOS settings UI. No issues found.

## Eval Results

No prompt-eval lane applies to this TypeWhisper app change.

## Scope Drift

Scope Check: CLEAN

Intent: implement Issue #442, language-specific workflow hotkeys and no-LLM dictation-only workflow.

Delivered: workflow language settings, dictation-only workflow behavior/UI, resolver precedence, list/review language summaries, and focused regression tests.

## Plan Completion

No external plan file detected. The issue plan items in the workspace request are addressed.

## Verification Results

- PASS: `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/DictationLanguageResolverTests`
  - 37 tests, 0 failures.
- PASS: `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
  - `** BUILD SUCCEEDED **`
- PASS: `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - 518 tests, 0 failures.
  - Follow-up repro checks for the earlier transient AVAudioEngine interruption also passed:
    - `-only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests/testPreviewRecoveryEngineSwap_replacesStoredEngineInstance`
    - `-only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests`

## Test plan

- [x] Focused Issue #442 workflow/resolver XCTest command passes.
- [x] Fresh TypeWhisper dev build passes after the final code commit.
- [x] Full app XCTest matrix passes.
