### PR TITLE
Prepare 1.3.1-rc2 release

### DIFF
--- a/docs/release-notes/1.3.1-rc1.md
+++ b/docs/release-notes/1.3.1-rc1.md
@@ -2,7 +2,6 @@ TypeWhisper `1.3.1-rc1` starts the `1.3.1` release-candidate line with new workf
 
 ## New Features
 
-- Added the bundled Filler Words plugin for cleaning filler words from dictated text and plugin workflows.
 - Added an Apple Translate workflow processor for local translation workflows on supported macOS configurations.
 - Added a manual workflow trigger so workflows can stay out of automatic dictation matching and run from the Workflow Palette instead.
 - Added a recorder toggle in the menu bar for faster access to app audio recording.
@@ -21,4 +20,4 @@ TypeWhisper `1.3.1-rc1` starts the `1.3.1` release-candidate line with new workf
 ## Other Changes
 
 - Updated Parakeet vocabulary boosting capability detection for current local-model behavior.
-- Added release support for the Filler Words plugin package.
+- Added packaging support for the bundled Filler Words plugin.

--- a/docs/release-notes/1.3.1-rc2.md
+++ b/docs/release-notes/1.3.1-rc2.md
@@ -1,0 +1,15 @@
+TypeWhisper `1.3.1-rc2` is planned as the final release candidate before `1.3.1`. This update rounds out the `1.3.1` line with spoken-language workflow dictation templates, direct text hotkeys for workflows, and clearer plugin hosting metadata before the stable release.
+
+## New Features
+
+- Added a workflow dictation template for spoken-language transformations.
+- Added direct workflow text hotkeys so workflows can run on selected or supplied text without starting a dictation.
+
+## Bug Fixes
+
+- Classified plugin hosting explicitly so local and cloud plugins appear with clearer metadata in plugin listings.
+
+## Other Changes
+
+- Documented plugin hosting metadata in the SDK manifest guidance.
+- Expanded automated coverage for workflow text hotkeys, spoken-language workflow templates, and plugin hosting compatibility.


### PR DESCRIPTION
## Summary
- Add curated release notes for `1.3.1-rc2` as the final release candidate before `1.3.1`.
- Demote the Filler Words plugin mention in the existing `1.3.1-rc1` notes so it no longer appears as a release highlight.
- Keep `1.3.1-rc2` focused on spoken-language workflow templates, direct workflow text hotkeys, and plugin hosting metadata.

## Issue context
Not tied to a GitHub issue.

## Release context
- Tag `v1.3.1-rc2` has been pushed and points at commit `20347d82159b8f31a442621cbcaa26f26b1a6f94`.
- `MARKETING_VERSION` remains `1.3.1`; the RC suffix is carried by the tag and release notes only.

## Test Plan
- `git diff --check`
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`