### PR TITLE
feat(deepgram): expose Nova-3 multilingual code-switching

### DIFF
--- a/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -362,6 +362,7 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     var supportedLanguages: [String] {
         [
+            "multi",
             "bg", "ca", "cs", "da", "de", "de-CH", "el", "en", "en-AU", "en-GB",
             "en-IN", "en-NZ", "en-US", "es", "es-419", "et", "fi", "fr", "fr-CA",
             "hi", "hu", "id", "it", "ja", "ko", "lt", "lv", "ms", "nl", "nl-BE",

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -23,6 +23,10 @@ func localizedAppLanguageName(for code: String) -> String {
         return localizedAppText("Auto-Detect", de: "Automatisch erkennen")
     }
 
+    if code == "multi" {
+        return localizedAppText("Multilingual", de: "Mehrsprachig")
+    }
+
     let locale = Locale(identifier: preferredAppLanguageCode())
     return locale.localizedString(forIdentifier: code) ?? code
 }


### PR DESCRIPTION
## Summary

Add `multi` to the Deepgram plugin's `supportedLanguages` so users can select Nova-3's multilingual (code-switching) mode from the Spoken Language picker.

Without this entry, host normalization in `SettingsViewModel.normalizedForSupportedLanguages` (`SettingsViewModel.swift:147-148`) strips `multi` to `.auto`, which on the Deepgram streaming path falls back to `detect_language=true` — Deepgram's older single-language detector that is heavily English-biased and never engages Nova-3 multilingual. The result is that users who pay for Nova-3 cannot reach its headline feature from TypeWhisper today; non-English short utterances default to English.

Also displays `multi` as "Multilingual" / "Mehrsprachig" in the picker rather than the raw code, matching the existing special-case for `auto`.

Closes #450.

Refs:
- Deepgram docs: https://developers.deepgram.com/docs/multilingual-code-switching
- Deepgram blog (Nova-3 multilingual WER): https://deepgram.com/learn/nova-3-multilingual-major-wer-improvements-across-languages

## Test Plan

- [x] Inspected `DictationViewModel → ModelManagerService → DeepgramPlugin.transcribe` chain to confirm `language` is forwarded as a `language=multi` query param without further validation past the host normalization gate
- [ ] Built and ran locally with Nova-3 + `multi` selected — verified mixed FR/EN audio transcribes both languages
- [ ] Verified picker shows "Multilingual" entry and that selecting it persists across app restart
- [ ] No regressions when selecting a specific language (e.g. `fr`) — same query param behavior as before

I have not built locally yet (no Xcode set up on this machine); flagging the unchecked items for a maintainer or follow-up. The change is small and self-contained — `supportedLanguages` array entry plus a host-side display label for `multi`. Happy to iterate.