### PR TITLE
fix(deepgram): expose multilingual code-switching

### DIFF
--- a/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -364,9 +364,9 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         [
             "bg", "ca", "cs", "da", "de", "de-CH", "el", "en", "en-AU", "en-GB",
             "en-IN", "en-NZ", "en-US", "es", "es-419", "et", "fi", "fr", "fr-CA",
-            "hi", "hu", "id", "it", "ja", "ko", "lt", "lv", "ms", "nl", "nl-BE",
-            "no", "pl", "pt", "pt-BR", "ro", "ru", "sk", "sv", "th", "tr",
-            "uk", "vi", "zh", "zh-CN", "zh-TW",
+            "hi", "hu", "id", "it", "ja", "ko", "lt", "lv", "multi", "ms", "nl",
+            "nl-BE", "no", "pl", "pt", "pt-BR", "ro", "ru", "sk", "sv", "th",
+            "tr", "uk", "vi", "zh", "zh-CN", "zh-TW",
         ]
     }
 

--- a/TypeWhisper/ViewModels/ProfilesViewModel.swift
+++ b/TypeWhisper/ViewModels/ProfilesViewModel.swift
@@ -22,6 +22,9 @@ func localizedAppLanguageName(for code: String) -> String {
     guard code != "auto" else {
         return localizedAppText("Auto-Detect", de: "Automatisch erkennen")
     }
+    guard code != "multi" else {
+        return localizedAppText("Multilingual", de: "Mehrsprachig")
+    }
 
     let locale = Locale(identifier: preferredAppLanguageCode())
     return locale.localizedString(forIdentifier: code) ?? code
@@ -61,6 +64,10 @@ func localizedAppLanguageSearchTerms(for code: String, preferredDisplayName: Str
 
     appendLanguageSearchTerm(code, to: &terms)
     appendLanguageSearchTerm(localizedAppLanguageName(for: code), to: &terms)
+    if code == "multi" {
+        appendLanguageSearchTerm("Multilingual", to: &terms)
+        appendLanguageSearchTerm("Mehrsprachig", to: &terms)
+    }
 
     let locales = [
         Locale.current,

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -380,6 +380,24 @@ final class LanguageLocalizationTests: XCTestCase {
         XCTAssertTrue(searchTerms.contains(where: { $0.localizedCaseInsensitiveContains("englisch") }))
     }
 
+    func testLocalizedAppLanguageNameDisplaysDeepgramMultilingualCode() {
+        UserDefaults.standard.set("en", forKey: UserDefaultsKeys.preferredAppLanguage)
+        XCTAssertEqual(localizedAppLanguageName(for: "multi"), "Multilingual")
+
+        UserDefaults.standard.set("de", forKey: UserDefaultsKeys.preferredAppLanguage)
+        XCTAssertEqual(localizedAppLanguageName(for: "multi"), "Mehrsprachig")
+    }
+
+    func testLanguageSearchTermsIncludeDeepgramMultilingualAliases() {
+        UserDefaults.standard.set("de", forKey: UserDefaultsKeys.preferredAppLanguage)
+
+        let searchTerms = localizedAppLanguageSearchTerms(for: "multi")
+
+        XCTAssertTrue(searchTerms.contains(where: { $0.caseInsensitiveCompare("multi") == .orderedSame }))
+        XCTAssertTrue(searchTerms.contains(where: { $0.caseInsensitiveCompare("Multilingual") == .orderedSame }))
+        XCTAssertTrue(searchTerms.contains(where: { $0.caseInsensitiveCompare("Mehrsprachig") == .orderedSame }))
+    }
+
     @MainActor
     func testSettingsLanguageOptionsDoNotGoEmptyBeforePluginsLoad() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "LanguageFallbackTests")

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -627,6 +627,10 @@ final class PluginDictionaryGuardTests: XCTestCase {
         )
     }
 
+    func testDeepgramSupportedLanguagesIncludeMultilingualCodeSwitchingMode() {
+        XCTAssertTrue(DeepgramPlugin().supportedLanguages.contains("multi"))
+    }
+
     func testDeepgramDictionaryQueryItemsLimitDictionaryTermsTo100AndPreserveOrder() {
         let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 150, length: 10), maxLength: 10_000)
         let queryItems = DeepgramPlugin.dictionaryQueryItems(prompt: prompt, modelId: "nova-2")


### PR DESCRIPTION
## Summary
- Add Deepgram `multi` to the plugin supported-language allowlist so host normalization preserves `LanguageSelection.exact("multi")` and forwards `language=multi`.
- Display `multi` as `Multilingual` / `Mehrsprachig` in language pickers and include the relevant search aliases.
- Add regression coverage for the Deepgram allowlist and localized picker/search labels.

## Issue Context
Deepgram Nova multilingual/code-switching mode requires `language=multi`. Before this change, TypeWhisper did not list `multi` as a supported Deepgram language, so exact-language normalization could drop the value before request construction.

Closes #450.

## Test Coverage
All new code paths are covered by regression tests:
- `DeepgramPlugin().supportedLanguages` includes `multi`.
- `localizedAppLanguageName(for: "multi")` returns `Multilingual` / `Mehrsprachig` for English and German app preferences.
- language search terms include `multi`, `Multilingual`, and `Mehrsprachig`.

## Pre-Landing Review
No issues found.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginDictionaryGuardTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/LanguageLocalizationTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh DeepgramPlugin "$(pwd)"`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
- [x] `git diff --check`
