### PR TITLE
fix: restore indicator visibility across macOS spaces

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -94,24 +94,24 @@ final class IndicatorCoordinator {
         }
     }
 
-    private func refreshActiveScreenPanels() {
+    private func refreshVisibleIndicatorPanels() {
         notchPanel.refreshPlacementForActiveContextChange()
         overlayPanel.refreshPlacementForActiveContextChange()
         minimalPanel.refreshPlacementForActiveContextChange()
     }
 
     private func scheduleActiveScreenRefreshes() {
-        refreshActiveScreenPanels()
+        refreshVisibleIndicatorPanels()
 
         deferredRefreshTask?.cancel()
         deferredRefreshTask = Task { @MainActor [weak self] in
             await Task.yield()
             guard !Task.isCancelled else { return }
-            self?.refreshActiveScreenPanels()
+            self?.refreshVisibleIndicatorPanels()
 
             try? await Task.sleep(for: .milliseconds(120))
             guard !Task.isCancelled else { return }
-            self?.refreshActiveScreenPanels()
+            self?.refreshVisibleIndicatorPanels()
         }
     }
 }

--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -6,9 +6,16 @@ enum FloatingPanelSpacePolicy {
     // without remaining at the shielding level used by system lock overlays.
     static let indicatorWindowLevel = NSWindow.Level.screenSaver
 
-    static let indicatorCollectionBehavior: NSWindow.CollectionBehavior = [
+    private static let activeSpaceIndicatorCollectionBehavior: NSWindow.CollectionBehavior = [
         .moveToActiveSpace,
         .fullScreenNone,
+        .stationary,
+        .ignoresCycle
+    ]
+
+    private static let fixedDisplayIndicatorCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
         .stationary,
         .ignoresCycle
     ]
@@ -18,15 +25,24 @@ enum FloatingPanelSpacePolicy {
         .fullScreenAuxiliary
     ]
 
-    @MainActor
-    static func applyIndicatorPolicy(to panel: NSPanel) {
-        panel.level = indicatorWindowLevel
-        panel.collectionBehavior = indicatorCollectionBehavior
+    static func indicatorCollectionBehavior(for displayMode: NotchIndicatorDisplay) -> NSWindow.CollectionBehavior {
+        switch displayMode {
+        case .activeScreen:
+            activeSpaceIndicatorCollectionBehavior
+        case .primaryScreen, .builtInScreen:
+            fixedDisplayIndicatorCollectionBehavior
+        }
     }
 
     @MainActor
-    static func orderIndicatorFront(_ panel: NSPanel) {
-        applyIndicatorPolicy(to: panel)
+    static func applyIndicatorPolicy(to panel: NSPanel, displayMode: NotchIndicatorDisplay) {
+        panel.level = indicatorWindowLevel
+        panel.collectionBehavior = indicatorCollectionBehavior(for: displayMode)
+    }
+
+    @MainActor
+    static func orderIndicatorFront(_ panel: NSPanel, displayMode: NotchIndicatorDisplay) {
+        applyIndicatorPolicy(to: panel, displayMode: displayMode)
         panel.orderFrontRegardless()
     }
 }

--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -2,12 +2,12 @@ import AppKit
 import CoreGraphics
 
 enum FloatingPanelSpacePolicy {
-    // Passive indicator panels should stay above normal desktop spaces,
-    // but they must not bleed into another app's fullscreen space.
-    static let indicatorWindowLevel = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+    // Passive indicator panels should stay above the menu bar on normal spaces
+    // without remaining at the shielding level used by system lock overlays.
+    static let indicatorWindowLevel = NSWindow.Level.screenSaver
 
     static let indicatorCollectionBehavior: NSWindow.CollectionBehavior = [
-        .canJoinAllSpaces,
+        .moveToActiveSpace,
         .fullScreenNone,
         .stationary,
         .ignoresCycle
@@ -17,4 +17,16 @@ enum FloatingPanelSpacePolicy {
         .canJoinAllSpaces,
         .fullScreenAuxiliary
     ]
+
+    @MainActor
+    static func applyIndicatorPolicy(to panel: NSPanel) {
+        panel.level = indicatorWindowLevel
+        panel.collectionBehavior = indicatorCollectionBehavior
+    }
+
+    @MainActor
+    static func orderIndicatorFront(_ panel: NSPanel) {
+        applyIndicatorPolicy(to: panel)
+        panel.orderFrontRegardless()
+    }
 }

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -28,7 +28,10 @@ class MinimalIndicatorPanel: NSPanel {
         appearance = NSAppearance(named: .darkAqua)
         hidesOnDeactivate = false
         ignoresMouseEvents = true
-        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: self)
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(
+            to: self,
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+        )
 
         let hostingView = NSHostingView(rootView: MinimalIndicatorView())
         hostingView.sizingOptions = []
@@ -114,7 +117,10 @@ class MinimalIndicatorPanel: NSPanel {
         }
 
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        FloatingPanelSpacePolicy.orderIndicatorFront(self)
+        FloatingPanelSpacePolicy.orderIndicatorFront(
+            self,
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+        )
     }
 
     private func resolveScreen() -> NSScreen {

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -25,11 +25,10 @@ class MinimalIndicatorPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
-        level = FloatingPanelSpacePolicy.indicatorWindowLevel
         appearance = NSAppearance(named: .darkAqua)
-        collectionBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
         hidesOnDeactivate = false
         ignoresMouseEvents = true
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: self)
 
         let hostingView = NSHostingView(rootView: MinimalIndicatorView())
         hostingView.sizingOptions = []
@@ -115,7 +114,7 @@ class MinimalIndicatorPanel: NSPanel {
         }
 
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        orderFrontRegardless()
+        FloatingPanelSpacePolicy.orderIndicatorFront(self)
     }
 
     private func resolveScreen() -> NSScreen {
@@ -123,9 +122,10 @@ class MinimalIndicatorPanel: NSPanel {
     }
 
     func refreshPlacementForActiveContextChange() {
-        guard DictationViewModel.shared.notchIndicatorDisplay == .activeScreen else { return }
-        cachedScreen = nil
         guard isVisible else { return }
+        if DictationViewModel.shared.notchIndicatorDisplay == .activeScreen {
+            cachedScreen = nil
+        }
         show()
     }
 

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -60,11 +60,10 @@ class NotchIndicatorPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
-        level = FloatingPanelSpacePolicy.indicatorWindowLevel
         appearance = NSAppearance(named: .darkAqua)
-        collectionBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
         hidesOnDeactivate = false
         ignoresMouseEvents = true
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: self)
 
         let hostingView = FirstMouseHostingView(rootView: NotchIndicatorView(geometry: notchGeometry))
         hostingView.sizingOptions = []
@@ -96,15 +95,6 @@ class NotchIndicatorPanel: NSPanel {
             .sink { [weak self] _ in
                 self?.cachedScreen = nil
                 self?.updateVisibility(state: vm.state, vm: vm)
-            }
-            .store(in: &cancellables)
-
-        NSWorkspace.shared.notificationCenter
-            .publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self, self.isVisible else { return }
-                self.orderFrontRegardless()
             }
             .store(in: &cancellables)
     }
@@ -151,7 +141,7 @@ class NotchIndicatorPanel: NSPanel {
 
         let wasVisible = isVisible
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        orderFrontRegardless()
+        FloatingPanelSpacePolicy.orderIndicatorFront(self)
 
         guard !wasVisible else {
             if !notchGeometry.isPresented {
@@ -178,9 +168,10 @@ class NotchIndicatorPanel: NSPanel {
     }
 
     func refreshPlacementForActiveContextChange() {
-        guard DictationViewModel.shared.notchIndicatorDisplay == .activeScreen else { return }
-        cachedScreen = nil
         guard isVisible else { return }
+        if DictationViewModel.shared.notchIndicatorDisplay == .activeScreen {
+            cachedScreen = nil
+        }
         show()
     }
 

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -63,7 +63,10 @@ class NotchIndicatorPanel: NSPanel {
         appearance = NSAppearance(named: .darkAqua)
         hidesOnDeactivate = false
         ignoresMouseEvents = true
-        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: self)
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(
+            to: self,
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+        )
 
         let hostingView = FirstMouseHostingView(rootView: NotchIndicatorView(geometry: notchGeometry))
         hostingView.sizingOptions = []
@@ -141,7 +144,10 @@ class NotchIndicatorPanel: NSPanel {
 
         let wasVisible = isVisible
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        FloatingPanelSpacePolicy.orderIndicatorFront(self)
+        FloatingPanelSpacePolicy.orderIndicatorFront(
+            self,
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+        )
 
         guard !wasVisible else {
             if !notchGeometry.isPresented {

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -28,7 +28,10 @@ class OverlayIndicatorPanel: NSPanel {
         appearance = NSAppearance(named: .darkAqua)
         hidesOnDeactivate = false
         ignoresMouseEvents = true
-        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: self)
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(
+            to: self,
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+        )
 
         let hostingView = NSHostingView(rootView: OverlayIndicatorView())
         hostingView.sizingOptions = []
@@ -115,7 +118,10 @@ class OverlayIndicatorPanel: NSPanel {
         }
 
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        FloatingPanelSpacePolicy.orderIndicatorFront(self)
+        FloatingPanelSpacePolicy.orderIndicatorFront(
+            self,
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+        )
     }
 
     private func resolveScreen() -> NSScreen {

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -25,11 +25,10 @@ class OverlayIndicatorPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
-        level = FloatingPanelSpacePolicy.indicatorWindowLevel
         appearance = NSAppearance(named: .darkAqua)
-        collectionBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
         hidesOnDeactivate = false
         ignoresMouseEvents = true
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: self)
 
         let hostingView = NSHostingView(rootView: OverlayIndicatorView())
         hostingView.sizingOptions = []
@@ -116,7 +115,7 @@ class OverlayIndicatorPanel: NSPanel {
         }
 
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        orderFrontRegardless()
+        FloatingPanelSpacePolicy.orderIndicatorFront(self)
     }
 
     private func resolveScreen() -> NSScreen {
@@ -124,9 +123,10 @@ class OverlayIndicatorPanel: NSPanel {
     }
 
     func refreshPlacementForActiveContextChange() {
-        guard DictationViewModel.shared.notchIndicatorDisplay == .activeScreen else { return }
-        cachedScreen = nil
         guard isVisible else { return }
+        if DictationViewModel.shared.notchIndicatorDisplay == .activeScreen {
+            cachedScreen = nil
+        }
         show()
     }
 

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -3,8 +3,8 @@ import XCTest
 @testable import TypeWhisper
 
 final class FloatingPanelSpacePolicyTests: XCTestCase {
-    func testIndicatorPolicyTargetsOnlyTheActiveNormalSpace() {
-        let behavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
+    func testActiveScreenIndicatorPolicyTargetsOnlyTheActiveNormalSpace() {
+        let behavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .activeScreen)
 
         XCTAssertTrue(behavior.contains(.moveToActiveSpace))
         XCTAssertTrue(behavior.contains(.stationary))
@@ -12,12 +12,23 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
         XCTAssertFalse(behavior.contains(.canJoinAllSpaces))
     }
 
-    func testIndicatorPolicyDoesNotJoinForeignFullscreenSpaces() {
+    func testFixedDisplayIndicatorPolicyStaysOnConfiguredDisplayAcrossSpaces() {
+        let primaryBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .primaryScreen)
+        let builtInBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .builtInScreen)
+
+        XCTAssertTrue(primaryBehavior.contains(.canJoinAllSpaces))
+        XCTAssertFalse(primaryBehavior.contains(.moveToActiveSpace))
+        XCTAssertTrue(primaryBehavior.contains(.fullScreenAuxiliary))
+        XCTAssertFalse(primaryBehavior.contains(.fullScreenNone))
+        XCTAssertEqual(primaryBehavior, builtInBehavior)
+    }
+
+    func testActiveScreenIndicatorPolicyDoesNotJoinForeignFullscreenSpaces() {
         XCTAssertFalse(
-            FloatingPanelSpacePolicy.indicatorCollectionBehavior.contains(.fullScreenAuxiliary)
+            FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .activeScreen).contains(.fullScreenAuxiliary)
         )
         XCTAssertTrue(
-            FloatingPanelSpacePolicy.indicatorCollectionBehavior.contains(.fullScreenNone)
+            FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .activeScreen).contains(.fullScreenNone)
         )
     }
 

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -3,12 +3,13 @@ import XCTest
 @testable import TypeWhisper
 
 final class FloatingPanelSpacePolicyTests: XCTestCase {
-    func testIndicatorPolicyKeepsNormalDesktopSpaceBehavior() {
+    func testIndicatorPolicyTargetsOnlyTheActiveNormalSpace() {
         let behavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior
 
-        XCTAssertTrue(behavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(behavior.contains(.moveToActiveSpace))
         XCTAssertTrue(behavior.contains(.stationary))
         XCTAssertTrue(behavior.contains(.ignoresCycle))
+        XCTAssertFalse(behavior.contains(.canJoinAllSpaces))
     }
 
     func testIndicatorPolicyDoesNotJoinForeignFullscreenSpaces() {
@@ -22,14 +23,18 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
 
     func testSelectionPaletteStillSupportsFullscreenUsage() {
         XCTAssertTrue(
+            FloatingPanelSpacePolicy.selectionPaletteCollectionBehavior.contains(.canJoinAllSpaces)
+        )
+        XCTAssertTrue(
             FloatingPanelSpacePolicy.selectionPaletteCollectionBehavior.contains(.fullScreenAuxiliary)
         )
     }
 
-    func testIndicatorPolicyKeepsShieldingWindowLevel() {
-        XCTAssertEqual(
-            FloatingPanelSpacePolicy.indicatorWindowLevel,
-            NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
-        )
+    func testIndicatorPolicyUsesScreenSaverLevelAboveStatusBarButBelowShielding() {
+        let level = FloatingPanelSpacePolicy.indicatorWindowLevel
+
+        XCTAssertEqual(level, .screenSaver)
+        XCTAssertGreaterThan(level.rawValue, NSWindow.Level.statusBar.rawValue)
+        XCTAssertLessThan(level.rawValue, Int(CGShieldingWindowLevel()))
     }
 }

--- a/docs/release-notes/1.3.1-rc2.md
+++ b/docs/release-notes/1.3.1-rc2.md
@@ -8,6 +8,7 @@ TypeWhisper `1.3.1-rc2` is planned as the final release candidate before `1.3.1`
 ## Bug Fixes
 
 - Classified plugin hosting explicitly so local and cloud plugins appear with clearer metadata in plugin listings.
+- Restored indicator visibility across normal macOS desktop spaces without letting indicators bleed into foreign fullscreen spaces.
 
 ## Other Changes
 


### PR DESCRIPTION
## Summary

- restore indicator visibility for notch, overlay, and minimal indicators across normal macOS desktop spaces
- move indicator panels from `canJoinAllSpaces` and shielding-level behavior to active-space reattachment at `NSWindow.Level.screenSaver`
- keep the fullscreen protection from #373 while preserving the multi-space behavior originally introduced for #165

## Issue Context

Issue #454 reports that indicator notifications only appear on Desktop 1 again in TypeWhisper 1.3.0. The earlier fix for #165 relied on panels staying visible across normal spaces, while the later fullscreen fix for #373 changed the shared panel policy to avoid bleeding into another app's fullscreen space. This update makes the shared indicator policy explicitly reattach to the active normal space instead of staying on every space at shielding level.

Closes #454

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/3174/typewhisper-mac`
- Manually verify notch, overlay, and minimal indicators on Desktop 1 and Desktop 2 with `Only during activity`
- Manually verify `Always visible` reattaches after switching spaces
- Manually verify indicators do not appear inside another app's fullscreen space or notch strip
