### PR TITLE
docs: prepare 1.3.1 release

### DIFF
--- a/docs/release-notes/1.3.1.md
+++ b/docs/release-notes/1.3.1.md
@@ -1,0 +1,30 @@
+TypeWhisper `1.3.1` is a stable maintenance release for the `1.3` line. It brings the workflow improvements from the `1.3.1` release candidates to stable users, adds direct workflow text hotkeys and a spoken-language dictation template, improves plugin metadata, and includes reliability fixes for Deepgram code-switching, Bluetooth audio, indicators, local LLM cleanup, and large automation requests.
+
+## New Features
+
+- Added an Apple Translate workflow processor for local translation workflows on supported macOS configurations.
+- Added a manual workflow trigger so workflows can stay out of automatic dictation matching and run from the Workflow Palette instead.
+- Added a recorder toggle in the menu bar for faster access to app audio recording.
+- Added packaging support for the bundled Filler Words plugin.
+- Added a workflow dictation template for spoken-language transformations.
+- Added direct workflow text hotkeys so workflows can run on selected or supplied text without starting a dictation.
+
+## Bug Fixes
+
+- Exposed Deepgram multilingual code-switching support so mixed-language dictation can use the provider capability correctly.
+- Reduced workflow post-processing latency so prompt and processor workflows return results faster after transcription.
+- Wrapped Apple Intelligence workflow input so dictated text is treated as source content instead of executable instructions.
+- Stabilized Bluetooth dictation capture and guarded AirPods output volume during audio routing changes.
+- Opted indicators out of fullscreen spaces to avoid unexpected overlay behavior when apps use fullscreen mode.
+- Disabled automatic Live Transcript opening by default.
+- Auto-unloaded local LLM post-processing resources after use to reduce background memory pressure.
+- Supported large CLI transcriptions without truncating or failing oversized requests.
+- Kept the language list available before transcription plugins finish loading.
+- Fixed a Parakeet live preview fallback race.
+
+## Other Changes
+
+- Classified plugin hosting explicitly so local and cloud plugins appear with clearer metadata in plugin listings.
+- Documented plugin hosting metadata in the SDK manifest guidance.
+- Updated Parakeet vocabulary boosting capability detection for current local-model behavior.
+- Expanded automated coverage for workflow text hotkeys, spoken-language workflow templates, plugin hosting compatibility, and Deepgram multilingual code-switching.


### PR DESCRIPTION
## Summary
- Add curated stable release notes for TypeWhisper v1.3.1.
- Fold the 1.3.1 RC line and the Deepgram multilingual code-switching fix into the stable release notes.
- Prepare the repo so the tag-triggered release workflow can publish v1.3.1 with curated notes.

## Issue context
No GitHub issue is closed by this release-preparation PR. The stable release includes the already-merged Deepgram fix from #451.

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee test.log`\n- `bash scripts/check_first_party_warnings.sh test.log`\n- `swift test --package-path TypeWhisperPluginSDK`\n- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath verify-build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee verify-build.log`\n- `bash scripts/check_first_party_warnings.sh verify-build.log`