### PR TITLE
docs: update 1.3.1 release notes

### DIFF
--- a/docs/release-notes/1.3.1.md
+++ b/docs/release-notes/1.3.1.md
@@ -16,6 +16,7 @@ TypeWhisper `1.3.1` is a stable maintenance release for the `1.3` line. It bring
 - Wrapped Apple Intelligence workflow input so dictated text is treated as source content instead of executable instructions.
 - Stabilized Bluetooth dictation capture and guarded AirPods output volume during audio routing changes.
 - Opted indicators out of fullscreen spaces to avoid unexpected overlay behavior when apps use fullscreen mode.
+- Restored indicator visibility across macOS spaces.
 - Disabled automatic Live Transcript opening by default.
 - Auto-unloaded local LLM post-processing resources after use to reduce background memory pressure.
 - Supported large CLI transcriptions without truncating or failing oversized requests.


### PR DESCRIPTION
## Summary
- Add the newly merged #456 indicator spaces fix to the curated v1.3.1 stable release notes.
- Keep the release notes aligned with the exact commit that will receive the v1.3.1 stable tag.

## Issue context
No GitHub issue is closed by this docs-only follow-up. It reflects the already-merged PR #456 in the v1.3.1 release notes.

## Test Plan
- `git diff --check origin/main...HEAD -- docs/release-notes/1.3.1.md`