### PR TITLE
Cleanup legacy plugin registry compatibility

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -120,14 +120,12 @@ jobs:
 
       - name: Patch manifest version
         run: |
-          # Find the manifest.json for this plugin target
-          MANIFEST=$(find TypeWhisperPluginSDK/Plugins -name manifest.json -path "*${TARGET}*" 2>/dev/null | head -1)
-          if [ -z "$MANIFEST" ]; then
-            # Fallback: search by plugin name
-            MANIFEST=$(find TypeWhisperPluginSDK/Plugins -name manifest.json | head -1)
+          MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "Missing manifest for ${TARGET}: $MANIFEST"
+            exit 1
           fi
-          if [ -n "$MANIFEST" ]; then
-            python3 -c "
+          python3 -c "
           import json
           with open('$MANIFEST', 'r') as f:
               m = json.load(f)
@@ -136,11 +134,8 @@ jobs:
               json.dump(m, f, indent=4)
               f.write('\n')
           "
-            echo "Patched $MANIFEST to version $PLUGIN_VERSION"
-            cat "$MANIFEST"
-          else
-            echo "Warning: No manifest.json found"
-          fi
+          echo "Patched $MANIFEST to version $PLUGIN_VERSION"
+          cat "$MANIFEST"
 
       - name: Build Plugin
         run: |
@@ -227,31 +222,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DOWNLOAD_URL="https://github.com/TypeWhisper/typewhisper-mac/releases/download/${TAG}/${TARGET}.zip"
-          MANIFEST_PATH=$(find TypeWhisperPluginSDK/Plugins -name manifest.json -path "*${TARGET}*" 2>/dev/null | head -1)
+          MANIFEST_PATH="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
+          if [ ! -f "$MANIFEST_PATH" ]; then
+            echo "Missing manifest for ${TARGET}: $MANIFEST_PATH"
+            exit 1
+          fi
           TARGET_REGISTRY=$(python3 << PYEOF
           import json, os
 
           manifest_path = "$MANIFEST_PATH"
           src_manifest = os.path.join("$GITHUB_WORKSPACE", manifest_path) if manifest_path else ""
-          if not src_manifest or not os.path.exists(src_manifest):
-              print("")
-          else:
-              with open(src_manifest) as mf:
-                  manifest = json.load(mf)
-              sdk_compat = manifest.get("sdkCompatibilityVersion")
-              print(f"plugins-{sdk_compat}.json" if sdk_compat else "plugins.json")
+          with open(src_manifest) as mf:
+              manifest = json.load(mf)
+          sdk_compat = manifest.get("sdkCompatibilityVersion")
+          if not sdk_compat:
+              raise SystemExit("manifest.json is missing sdkCompatibilityVersion")
+          print(f"plugins-{sdk_compat}.json")
           PYEOF
           )
 
-          if [ -z "$TARGET_REGISTRY" ]; then
-            echo "Warning: No manifest found for ${TARGET}; skipping registry update"
-            exit 0
-          fi
-
           export TARGET_REGISTRY
           TARGET_REGISTRIES="$TARGET_REGISTRY"
-          if [ "$TARGET_REGISTRY" = "plugins-v1.json" ]; then
-            TARGET_REGISTRIES="$TARGET_REGISTRIES plugins-community-v1.json"
+          if [[ "$TARGET_REGISTRY" =~ ^plugins-(v[0-9]+)\.json$ ]]; then
+            TARGET_REGISTRIES="$TARGET_REGISTRIES plugins-community-${BASH_REMATCH[1]}.json"
           fi
           export TARGET_REGISTRIES
           echo "Updating registry file(s): $TARGET_REGISTRIES"
@@ -276,8 +269,7 @@ jobs:
           src_manifest = os.path.join("$GITHUB_WORKSPACE", manifest_path) if manifest_path else ""
 
           if not src_manifest or not os.path.exists(src_manifest):
-              print(f"Warning: No manifest found at {src_manifest}")
-              sys.exit(0)
+              raise SystemExit(f"Missing manifest at {src_manifest}")
 
           with open(src_manifest) as mf:
               manifest = json.load(mf)
@@ -330,46 +322,6 @@ jobs:
                       release[field] = manifest[field]
               return release
 
-          def migrate_legacy_release(plugin):
-              if plugin.get("releases"):
-                  return plugin["releases"]
-
-              version_value = plugin.get("version")
-              min_host = plugin.get("minHostVersion")
-              sdk_compat = plugin.get("sdkCompatibilityVersion")
-              size_value = plugin.get("size")
-              download_value = plugin.get("downloadURL")
-              if not all([version_value, min_host, size_value, download_value]):
-                  return []
-
-              legacy = {
-                  "version": version_value,
-                  "minHostVersion": min_host,
-                  "sdkCompatibilityVersion": sdk_compat,
-                  "size": size_value,
-                  "downloadURL": download_value,
-              }
-              for field in ["minOSVersion", "supportedArchitectures"]:
-                  if field in plugin and plugin[field] is not None:
-                      legacy[field] = plugin[field]
-              return [legacy]
-
-          def sync_legacy_fields(plugin, release):
-              plugin["version"] = release["version"]
-              plugin["minHostVersion"] = release["minHostVersion"]
-              if release.get("sdkCompatibilityVersion") is not None:
-                  plugin["sdkCompatibilityVersion"] = release["sdkCompatibilityVersion"]
-              else:
-                  plugin.pop("sdkCompatibilityVersion", None)
-              plugin["size"] = release["size"]
-              plugin["downloadURL"] = release["downloadURL"]
-
-              for field in ["minOSVersion", "supportedArchitectures"]:
-                  if field in release and release[field] is not None:
-                      plugin[field] = release[field]
-                  else:
-                      plugin.pop(field, None)
-
           def update_registry_file(target_registry):
               target_path = os.path.join("/tmp/gh-pages", target_registry)
               if os.path.exists(target_path):
@@ -387,12 +339,11 @@ jobs:
               updated = False
               for plugin in registry["plugins"]:
                   if plugin["id"] == manifest["id"]:
-                      releases = migrate_legacy_release(plugin)
                       sync_plugin_metadata(plugin)
+                      releases = plugin.get("releases", [])
                       releases = [release for release in releases if release.get("version") != version]
                       releases.append(build_release())
                       plugin["releases"] = sorted(releases, key=lambda release: version_key(release["version"]), reverse=True)
-                      sync_legacy_fields(plugin, plugin["releases"][0])
                       updated = True
                       print(f"{target_registry}: updated {plugin['id']} release set with v{version}")
                       break
@@ -401,7 +352,6 @@ jobs:
                   new_entry = {}
                   sync_plugin_metadata(new_entry)
                   new_entry["releases"] = [build_release()]
-                  sync_legacy_fields(new_entry, new_entry["releases"][0])
                   registry["plugins"].append(new_entry)
                   print(f"{target_registry}: added new plugin {manifest['id']} v{version}")
 

--- a/.github/workflows/update-plugin-downloads.yml
+++ b/.github/workflows/update-plugin-downloads.yml
@@ -51,7 +51,10 @@ jobs:
                   counts[plugin_name] = counts.get(plugin_name, 0) + asset.get("download_count", 0)
 
           changed = False
-          registry_paths = sorted(glob.glob("/tmp/gh-pages/plugins*.json"))
+          registry_paths = sorted(set(
+              glob.glob("/tmp/gh-pages/plugins-v*.json")
+              + glob.glob("/tmp/gh-pages/plugins-community-v*.json")
+          ))
 
           for target_path in registry_paths:
               with open(target_path) as f:
@@ -105,7 +108,7 @@ jobs:
               print("No changes needed")
           PYEOF
 
-            for registry_file in plugins*.json; do
+            for registry_file in plugins-v*.json plugins-community-v*.json; do
               if [ -f "$registry_file" ]; then
                 git add "$registry_file"
               fi

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -146,17 +146,6 @@ struct RegistryPluginRelease: Decodable, Equatable {
     }
 }
 
-private struct LegacyRegistryRelease: Decodable {
-    let version: String?
-    let minHostVersion: String?
-    let sdkCompatibilityVersion: String?
-    let minOSVersion: String?
-    let supportedArchitectures: [String]?
-    let size: Int64?
-    let downloadURL: String?
-    let downloadCount: Int?
-}
-
 struct RegistryPluginEntry: Decodable {
     let id: String
     let source: PluginDistributionSource
@@ -216,35 +205,7 @@ struct RegistryPluginEntry: Decodable {
         downloadCount = try container.decodeIfPresent(Int.self, forKey: .downloadCount)
 
         let decodedReleases = try container.decodeIfPresent([RegistryPluginRelease].self, forKey: .releases) ?? []
-        if !decodedReleases.isEmpty {
-            releases = decodedReleases
-            return
-        }
-
-        let legacy = try LegacyRegistryRelease(from: decoder)
-        guard
-            let version = legacy.version,
-            let minHostVersion = legacy.minHostVersion,
-            let size = legacy.size,
-            let downloadURL = legacy.downloadURL
-        else {
-            releases = []
-            return
-        }
-
-            releases = [
-            RegistryPluginRelease(
-                version: version,
-                minHostVersion: minHostVersion,
-                sdkCompatibilityVersion: legacy.sdkCompatibilityVersion,
-                minOSVersion: legacy.minOSVersion,
-                supportedArchitectures: legacy.supportedArchitectures,
-                size: size,
-                downloadURL: downloadURL,
-                publishedAt: nil,
-                downloadCount: legacy.downloadCount
-            )
-        ]
+        releases = decodedReleases
     }
 
     func resolvedPlugin(
@@ -308,7 +269,7 @@ struct PluginRegistryResponse: Decodable {
 
     /// Decodes the registry tolerantly: a single malformed plugin entry is
     /// logged and skipped instead of aborting the entire fetch. Without this,
-    /// one bad entry on the gh-pages `plugins.json` would empty the marketplace
+    /// one bad entry in a published registry feed would empty the marketplace
     /// for every installed app until a fix is deployed (release review K4).
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -376,7 +337,6 @@ final class PluginRegistryService: ObservableObject {
     nonisolated(unsafe) static var shared: PluginRegistryService!
 
     enum RegistryFeed: String, Equatable {
-        case legacy = "plugins.json"
         case v1 = "plugins-v1.json"
         case communityV1 = "plugins-community-v1.json"
 
@@ -431,9 +391,6 @@ final class PluginRegistryService: ObservableObject {
         releaseChannel: AppConstants.ReleaseChannel
     ) -> RegistryFeed {
         _ = releaseChannel
-        if compareVersions(appVersion, "1.3.0") == .orderedAscending {
-            return .legacy
-        }
         if compareVersions(appVersion, "1.4.0") != .orderedAscending {
             return .communityV1
         }

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -5,7 +5,7 @@ import TypeWhisperPluginSDK
 final class PluginRegistryServiceTests: XCTestCase {
     private let sdkCompatibilityVersion = "v1"
 
-    func testLegacyRegistryEntryDoesNotResolveWithoutSDKCompatibilityVersion() throws {
+    func testFlatRegistryEntryWithoutReleasesDoesNotResolve() throws {
         let data = Data(
             """
             {
@@ -17,7 +17,7 @@ final class PluginRegistryServiceTests: XCTestCase {
                   "version": "1.0.5",
                   "minHostVersion": "1.2.0",
                   "author": "TypeWhisper",
-                  "description": "Legacy entry",
+                  "description": "Legacy flat entry",
                   "category": "utility",
                   "size": 42,
                   "downloadURL": "https://example.com/legacy.zip"
@@ -336,13 +336,10 @@ final class PluginRegistryServiceTests: XCTestCase {
                 {
                   "id": "com.typewhisper.ok",
                   "name": "Good Plugin",
-                  "version": "1.0.0",
-                  "minHostVersion": "1.0.0",
                   "author": "TypeWhisper",
-                  "description": "Legacy good entry",
+                  "description": "Entry without releases",
                   "category": "utility",
-                  "size": 10,
-                  "downloadURL": "https://example.com/ok.zip"
+                  "size": 10
                 }
               ]
             }
@@ -359,34 +356,28 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertTrue(plugins.isEmpty)
     }
 
-    func testRegistryFeedUsesLegacyForStableBuildBefore130() {
+    func testRegistryFeedUsesV1ForPre14Builds() {
         XCTAssertEqual(
             PluginRegistryService.registryFeed(
                 appVersion: "1.2.2",
                 releaseChannel: .stable
             ),
-            .legacy
+            .v1
         )
-    }
-
-    func testRegistryFeedKeepsLegacyForPre130PreviewBuilds() {
         XCTAssertEqual(
             PluginRegistryService.registryFeed(
                 appVersion: "1.2.2",
                 releaseChannel: .releaseCandidate
             ),
-            .legacy
+            .v1
         )
         XCTAssertEqual(
             PluginRegistryService.registryFeed(
                 appVersion: "1.2.2",
                 releaseChannel: .daily
             ),
-            .legacy
+            .v1
         )
-    }
-
-    func testRegistryFeedUsesV1ForReleaseCandidateBuild() {
         XCTAssertEqual(
             PluginRegistryService.registryFeed(
                 appVersion: "1.3.0",
@@ -394,9 +385,6 @@ final class PluginRegistryServiceTests: XCTestCase {
             ),
             .v1
         )
-    }
-
-    func testRegistryFeedUsesV1ForDailyBuild() {
         XCTAssertEqual(
             PluginRegistryService.registryFeed(
                 appVersion: "1.3.0",
@@ -404,9 +392,6 @@ final class PluginRegistryServiceTests: XCTestCase {
             ),
             .v1
         )
-    }
-
-    func testRegistryFeedUsesV1ForStable13xBuilds() {
         XCTAssertEqual(
             PluginRegistryService.registryFeed(
                 appVersion: "1.3.0",


### PR DESCRIPTION
## Summary
- remove `plugins.json` and flat registry entry compatibility from `PluginRegistryService`
- make `plugin-release.yml` resolve plugin manifests by exact SDK path and fail fast when compatibility metadata is missing
- limit registry update workflows to versioned feeds and publish release metadata only under `releases[]`

## Context
- stacked on top of #464
- finishes the plugin registry/workflow cleanup after moving first-party plugin sources into `TypeWhisperPluginSDK/Plugins`

## Test plan
- `swift test --package-path /Users/marco/.codex/worktrees/ca06/typewhisper-mac/TypeWhisperPluginSDK`
- `xcodebuild test -project /Users/marco/.codex/worktrees/ca06/typewhisper-mac/TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`