### PR TITLE
fix: support combined workflow triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 ## What's New in 1.3
 
 - **Unified Workflows** - Prompt actions and matching rules now live in one dedicated workflow surface with a native editor and guided creation flow
-- **Always fallback trigger** - Create a global workflow that runs when no more specific app, website, or hotkey workflow matches
+- **Always fallback trigger** - Create a global workflow that runs when no more specific app or website workflow matches
 - **Manual workflow palette** - Keep workflows out of automatic dictation matching and run them from one global Workflow Palette shortcut
 - **Safer prompt boundaries** - Workflow prompts treat dictated text as source content to transform, not instructions to execute
 - **Focus-safe local processing** - On-device workflows keep focus in the original target app instead of foregrounding TypeWhisper unexpectedly
@@ -69,7 +69,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 ### AI Processing
 
-- **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app or website, from a dedicated hotkey, as a global fallback, or manually from the Workflow Palette. Hotkey workflows can either start dictation or process the current selection/clipboard directly.
+- **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app, website, or app + website combinations, from a dedicated hotkey, as a global fallback, or manually from the Workflow Palette. Hotkey workflows can either start dictation or process the current selection/clipboard directly.
 - **LLM providers** - Apple Intelligence (macOS 26+), Groq, OpenAI / ChatGPT, xAI/Grok, Gemini, and OpenAI Compatible with per-prompt provider and model override
 - **Speech providers** - System voices and xAI/Grok TTS can provide spoken feedback and readback
 - **Local prompt processing** - Gemma 4 via MLX runs on-device on Apple Silicon, with the current verified release path limited to the E2B/E4B 4-bit models
@@ -77,7 +77,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 ### Personalization
 
-- **Workflow triggers** - Per-app, per-website, hotkey, global fallback, and manual palette-only triggers for language, task, engine, prompt, and auto-submit behavior. Website matching supports subdomains
+- **Workflow triggers** - Per-app, per-website, combined app + website, hotkey, global fallback, and manual palette-only triggers for language, task, engine, prompt, and auto-submit behavior. Website matching supports subdomains
 - **Dictionary** - Terms improve cloud recognition accuracy. Corrections fix common transcription mistakes automatically. Auto-learns from manual corrections. Includes importable term packs
 - **Localized term packs** - Built-in term pack names and descriptions are localized in English and German
 - **Snippets** - Text shortcuts with trigger/replacement. Supports placeholders like `{{DATE}}`, `{{TIME}}`, and `{{CLIPBOARD}}`
@@ -368,7 +368,7 @@ Local file paths are handed to the running TypeWhisper app directly, so large fi
 
 ## Workflows
 
-Workflows let you configure transcription, transformation, and automation behavior per application, website, hotkey, global fallback, or manual palette-only workflow. For example:
+Workflows let you configure transcription, transformation, and automation behavior per application, website, combined app + website context, hotkey, global fallback, or manual palette-only workflow. For example:
 
 - **Mail** - German language, Whisper Large v3
 - **Slack** - English language, Parakeet TDT v3
@@ -376,7 +376,7 @@ Workflows let you configure transcription, transformation, and automation behavi
 - **github.com** - English cleanup workflow that matches in any browser
 - **docs.google.com** - German dictation workflow that translates to English
 
-Create workflows in Settings > Workflows. Choose a template, assign an app, website, hotkey, Always, or Manual trigger, then configure language/task/engine overrides, prompt processing, auto-submit behavior, and priority. Hotkey workflows choose whether the shortcut starts dictation or processes the current selection/clipboard through the same insertion path as the Workflow Palette. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. Website patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`.
+Create workflows in Settings > Workflows. Choose a template, then use Automatic to enable app, website, hotkey, or any combination of those trigger components. Always stays the global fallback, and Manual keeps the workflow palette-only. Hotkey workflows choose whether the shortcut starts dictation or processes the current selection/clipboard through the same insertion path as the Workflow Palette. Spoken language can be left on full auto-detect, fixed to one exact language, or restricted to a shortlist of likely languages for better detection accuracy. Website patterns support subdomain matching - e.g. `google.com` also matches `docs.google.com`.
 
 When you start dictating, TypeWhisper matches the active app and browser URL against enabled workflows with the following priority:
 1. **App + URL match** - highest specificity (e.g. Chrome + github.com)
@@ -384,7 +384,7 @@ When you start dictating, TypeWhisper matches the active app and browser URL aga
 3. **App-only match** - generic app workflows (e.g. all of Chrome)
 4. **Always fallback** - global workflow when no more specific workflow matches
 
-Manual workflows are excluded from automatic dictation matching. They appear only in the Workflow Palette and use the existing Workflow Palette hotkey.
+Hotkeys are direct workflow shortcuts, not context conditions in the app/URL matching order. Manual workflows are excluded from automatic dictation matching. They appear only in the Workflow Palette and use the existing Workflow Palette hotkey.
 
 The active workflow name is shown as a badge in the indicator, together with a short explanation of why it matched.
 

--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -272,12 +272,8 @@ struct WorkflowTrigger: Codable, Equatable, Sendable {
 
     var hasValues: Bool {
         switch kind {
-        case .app:
-            !appBundleIdentifiers.isEmpty
-        case .website:
-            !websitePatterns.isEmpty
-        case .hotkey:
-            !hotkeys.isEmpty
+        case .app, .website, .hotkey:
+            !appBundleIdentifiers.isEmpty || !websitePatterns.isEmpty || !hotkeys.isEmpty
         case .global, .manual:
             true
         }

--- a/TypeWhisper/Services/WorkflowService.swift
+++ b/TypeWhisper/Services/WorkflowService.swift
@@ -9,6 +9,7 @@ private let workflowLogger = Logger(
 )
 
 enum WorkflowMatchKind: String, Sendable {
+    case appAndWebsite
     case website
     case app
     case globalFallback
@@ -16,6 +17,8 @@ enum WorkflowMatchKind: String, Sendable {
 
     var label: String {
         switch self {
+        case .appAndWebsite:
+            localizedAppText("App + Website", de: "App + Website")
         case .website:
             localizedAppText("Website", de: "Website")
         case .app:
@@ -193,9 +196,30 @@ final class WorkflowService: ObservableObject {
         let domain = extractDomain(from: url)
         let enabled = workflows.filter(\.isEnabled)
 
+        if !bundleId.isEmpty, let domain {
+            let matches = enabled.filter { workflow in
+                guard let trigger = workflow.trigger,
+                      !trigger.appBundleIdentifiers.isEmpty,
+                      !trigger.websitePatterns.isEmpty,
+                      trigger.appBundleIdentifiers.contains(bundleId) else {
+                    return false
+                }
+                return trigger.websitePatterns.contains { pattern in
+                    !pattern.isEmpty && domainMatches(domain, pattern: pattern)
+                }
+            }
+            if let result = bestMatch(from: matches, kind: .appAndWebsite, matchedDomain: domain) {
+                return result
+            }
+        }
+
         if let domain {
             let matches = enabled.filter { workflow in
-                guard let trigger = workflow.trigger, trigger.kind == .website else { return false }
+                guard let trigger = workflow.trigger,
+                      trigger.appBundleIdentifiers.isEmpty,
+                      !trigger.websitePatterns.isEmpty else {
+                    return false
+                }
                 return trigger.websitePatterns.contains { pattern in
                     !pattern.isEmpty && domainMatches(domain, pattern: pattern)
                 }
@@ -207,7 +231,10 @@ final class WorkflowService: ObservableObject {
 
         if !bundleId.isEmpty {
             let matches = enabled.filter { workflow in
-                guard let trigger = workflow.trigger, trigger.kind == .app else { return false }
+                guard let trigger = workflow.trigger,
+                      trigger.websitePatterns.isEmpty else {
+                    return false
+                }
                 return trigger.appBundleIdentifiers.contains(bundleId)
             }
             if let result = bestMatch(from: matches, kind: .app, matchedDomain: nil) {

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -96,7 +96,7 @@ final class DictationSettingsHandler {
         let entries = workflows
             .filter(\.isEnabled)
             .flatMap { workflow -> [(id: UUID, hotkey: UnifiedHotkey, behavior: WorkflowHotkeyBehavior)] in
-                guard let trigger = workflow.trigger, trigger.kind == .hotkey else {
+                guard let trigger = workflow.trigger, !trigger.hotkeys.isEmpty else {
                     return []
                 }
                 return trigger.hotkeys.map { hotkey in

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1446,6 +1446,18 @@ final class DictationViewModel: ObservableObject {
 
         let base: String
         switch match.kind {
+        case .appAndWebsite:
+            if let domain = match.matchedDomain {
+                base = localizedAppText(
+                    "This workflow applies because \(appDescriptor) was detected together with \(domain).",
+                    de: "Dieser Workflow greift, weil \(appDescriptor) zusammen mit \(domain) erkannt wurde."
+                )
+            } else {
+                base = localizedAppText(
+                    "This workflow applies because the app and website were detected together.",
+                    de: "Dieser Workflow greift, weil App und Website zusammen erkannt wurden."
+                )
+            }
         case .website:
             if let domain = match.matchedDomain {
                 base = localizedAppText(

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -60,15 +60,10 @@ final class PromptPaletteController: PromptPaletteControlling {
 
         let triggerSummary: String
         switch trigger.kind {
-        case .app:
-            let appNames = trigger.appBundleIdentifiers.map(resolveAppDisplayName(for:))
-            triggerSummary = "\(trigger.kind.paletteLabel): \(appNames.joined(separator: ", "))"
-        case .website:
-            triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.websitePatterns.joined(separator: ", "))"
-        case .hotkey:
-            triggerSummary = "\(trigger.kind.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", ")) · \(trigger.hotkeyBehavior.shortcutSubtitle)"
         case .global, .manual:
             triggerSummary = trigger.kind.paletteLabel
+        case .app, .website, .hotkey:
+            triggerSummary = workflowPaletteTriggerComponents(for: trigger).joined(separator: " + ")
         }
 
         if workflow.name.localizedCaseInsensitiveCompare(workflow.definition.name) == .orderedSame {
@@ -81,6 +76,7 @@ final class PromptPaletteController: PromptPaletteControlling {
         var tokens = [workflow.name, workflow.definition.name]
         if let trigger = workflow.trigger {
             tokens.append(trigger.kind.paletteLabel)
+            tokens.append(contentsOf: workflowPaletteTriggerLabels(for: trigger))
             tokens.append(contentsOf: trigger.appBundleIdentifiers.map(resolveAppDisplayName(for:)))
             tokens.append(contentsOf: trigger.appBundleIdentifiers)
             tokens.append(contentsOf: trigger.websitePatterns)
@@ -88,6 +84,35 @@ final class PromptPaletteController: PromptPaletteControlling {
             tokens.append(trigger.hotkeyBehavior.shortcutSubtitle)
         }
         return tokens
+    }
+
+    private func workflowPaletteTriggerComponents(for trigger: WorkflowTrigger) -> [String] {
+        var components: [String] = []
+        if !trigger.appBundleIdentifiers.isEmpty {
+            let appNames = trigger.appBundleIdentifiers.map(resolveAppDisplayName(for:))
+            components.append("\(WorkflowTriggerKind.app.paletteLabel): \(appNames.joined(separator: ", "))")
+        }
+        if !trigger.websitePatterns.isEmpty {
+            components.append("\(WorkflowTriggerKind.website.paletteLabel): \(trigger.websitePatterns.joined(separator: ", "))")
+        }
+        if !trigger.hotkeys.isEmpty {
+            components.append("\(WorkflowTriggerKind.hotkey.paletteLabel): \(trigger.hotkeys.map(HotkeyService.displayName(for:)).joined(separator: ", ")) · \(trigger.hotkeyBehavior.shortcutSubtitle)")
+        }
+        return components.isEmpty ? [trigger.kind.paletteLabel] : components
+    }
+
+    private func workflowPaletteTriggerLabels(for trigger: WorkflowTrigger) -> [String] {
+        var labels: [String] = []
+        if !trigger.appBundleIdentifiers.isEmpty {
+            labels.append(WorkflowTriggerKind.app.paletteLabel)
+        }
+        if !trigger.websitePatterns.isEmpty {
+            labels.append(WorkflowTriggerKind.website.paletteLabel)
+        }
+        if !trigger.hotkeys.isEmpty {
+            labels.append(WorkflowTriggerKind.hotkey.paletteLabel)
+        }
+        return labels
     }
 
     private func resolveAppDisplayName(for bundleIdentifier: String) -> String {

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -575,8 +575,8 @@ private struct WorkflowEditorPage: View {
                     }
 
                     templateSection
-                    behaviorSection
                     triggerSection
+                    behaviorSection
                     reviewSection
                 }
                 .padding(16)
@@ -619,7 +619,7 @@ private struct WorkflowEditorPage: View {
                 Text(
                     isEditing
                         ? localizedAppText("Adjust the current workflow without changing its template.", de: "Passe den aktuellen Workflow an, ohne seine Vorlage zu ändern.")
-                        : localizedAppText("Pick a concrete outcome first, then add behavior and one trigger category.", de: "Wähle zuerst ein konkretes Ergebnis und ergänze dann Verhalten und eine Trigger-Kategorie.")
+                        : localizedAppText("Pick a concrete outcome first, then add behavior and one or more triggers.", de: "Wähle zuerst ein konkretes Ergebnis und ergänze dann Verhalten und einen oder mehrere Trigger.")
                 )
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -933,31 +933,25 @@ private struct WorkflowEditorPage: View {
         WorkflowSectionCard(
             title: localizedAppText("Trigger", de: "Trigger"),
             description: localizedAppText(
-                "Choose how this workflow starts. Manual workflows are available from the Workflow Palette only.",
-                de: "Wähle, wie dieser Workflow startet. Manuelle Workflows sind nur über die Workflow-Palette verfügbar."
+                "Choose how this workflow starts. Automatic can use app, website, hotkey, or combinations.",
+                de: "Wähle, wie dieser Workflow startet. Automatisch kann App, Website, Hotkey oder Kombinationen nutzen."
             )
         ) {
             VStack(alignment: .leading, spacing: 14) {
-                Picker(localizedAppText("Trigger", de: "Trigger"), selection: $draft.triggerKind) {
+                Picker(localizedAppText("Trigger", de: "Trigger"), selection: $draft.triggerMode) {
+                    Text(localizedAppText("Automatic", de: "Automatisch")).tag(WorkflowTriggerMode.automatic)
                     if draft.template != .dictation {
-                        Text(localizedAppText("Manual", de: "Manuell")).tag(WorkflowTriggerKind.manual)
+                        Text(localizedAppText("Manual", de: "Manuell")).tag(WorkflowTriggerMode.manual)
                     }
-                    Text(localizedAppText("App", de: "App")).tag(WorkflowTriggerKind.app)
-                    Text(localizedAppText("Website", de: "Website")).tag(WorkflowTriggerKind.website)
-                    Text(localizedAppText("Hotkey", de: "Hotkey")).tag(WorkflowTriggerKind.hotkey)
-                    Text(localizedAppText("Always", de: "Immer")).tag(WorkflowTriggerKind.global)
+                    Text(localizedAppText("Always", de: "Immer")).tag(WorkflowTriggerMode.global)
                 }
                 .pickerStyle(.segmented)
 
-                switch draft.triggerKind {
+                switch draft.triggerMode {
                 case .manual:
                     manualTriggerEditor
-                case .app:
-                    appTriggerEditor
-                case .website:
-                    websiteTriggerEditor
-                case .hotkey:
-                    hotkeyTriggerEditor
+                case .automatic:
+                    automaticTriggerEditor
                 case .global:
                     alwaysTriggerEditor
                 }
@@ -1008,6 +1002,57 @@ private struct WorkflowEditorPage: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(workflowsGroupedSurface(cornerRadius: 12))
+    }
+
+    private var automaticTriggerEditor: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            triggerComponentEditor(
+                title: localizedAppText("App", de: "App"),
+                isOn: $draft.isAppTriggerEnabled
+            ) {
+                appTriggerEditor
+            }
+
+            Divider()
+
+            triggerComponentEditor(
+                title: localizedAppText("Website", de: "Website"),
+                isOn: $draft.isWebsiteTriggerEnabled
+            ) {
+                websiteTriggerEditor
+            }
+
+            Divider()
+
+            triggerComponentEditor(
+                title: localizedAppText("Hotkey", de: "Hotkey"),
+                isOn: $draft.isHotkeyTriggerEnabled
+            ) {
+                hotkeyTriggerEditor
+            }
+        }
+        .background(workflowsGroupedSurface(cornerRadius: 12))
+    }
+
+    private func triggerComponentEditor<Content: View>(
+        title: String,
+        isOn: Binding<Bool>,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(isOn: isOn) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .toggleStyle(.checkbox)
+
+            if isOn.wrappedValue {
+                content()
+                    .padding(.leading, 28)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 12)
     }
 
     private var appTriggerEditor: some View {
@@ -1078,14 +1123,22 @@ private struct WorkflowEditorPage: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
 
-                    ForEach(websiteSuggestions, id: \.self) { domain in
-                        Button(domain) {
-                            draft.addWebsitePattern(domain)
-                            websiteInput = ""
-                            validationMessage = nil
+                    FlowLayout(spacing: 6) {
+                        ForEach(websiteSuggestions, id: \.self) { domain in
+                            Button(domain) {
+                                draft.addWebsitePattern(domain)
+                                websiteInput = ""
+                                validationMessage = nil
+                            }
+                            .buttonStyle(.plain)
+                            .font(.caption)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background {
+                                Capsule(style: .continuous)
+                                    .fill(Color.secondary.opacity(0.12))
+                            }
                         }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.primary)
                     }
                 }
             }
@@ -1112,6 +1165,7 @@ private struct WorkflowEditorPage: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .labelsHidden()
 
                 Text(draft.hotkeyBehavior.editorDescription)
                     .font(.caption)
@@ -1140,7 +1194,7 @@ private struct WorkflowEditorPage: View {
             HotkeyRecorderView(
                 label: "",
                 title: localizedAppText("Add Shortcut", de: "Shortcut hinzufügen"),
-                subtitle: localizedAppText("You can attach more than one shortcut to the same workflow.", de: "Du kannst mehrere Shortcuts mit demselben Workflow verbinden."),
+                subtitle: nil,
                 onRecord: { hotkey in
                     addRecordedHotkey(hotkey)
                 },
@@ -1161,8 +1215,8 @@ private struct WorkflowEditorPage: View {
 
                 Text(
                     localizedAppText(
-                        "Runs when no app, website, or hotkey workflow matches.",
-                        de: "Läuft, wenn kein App-, Website- oder Hotkey-Workflow passt."
+                        "Runs when no app or website workflow matches. Hotkeys stay direct triggers.",
+                        de: "Läuft, wenn kein App- oder Website-Workflow passt. Hotkeys bleiben direkte Trigger."
                     )
                 )
                 .font(.caption)
@@ -1652,11 +1706,20 @@ private struct MissingWorkflowPage: View {
     }
 }
 
-private struct WorkflowDraft {
+enum WorkflowTriggerMode: String, CaseIterable, Hashable {
+    case manual
+    case automatic
+    case global
+}
+
+struct WorkflowDraft {
     var name: String
     var isEnabled: Bool
     var template: WorkflowTemplate
-    var triggerKind: WorkflowTriggerKind
+    var triggerMode: WorkflowTriggerMode
+    var isAppTriggerEnabled: Bool
+    var isWebsiteTriggerEnabled: Bool
+    var isHotkeyTriggerEnabled: Bool
     var appBundleIdentifiers: [String]
     var websitePatterns: [String]
     var hotkeys: [UnifiedHotkey]
@@ -1680,7 +1743,10 @@ private struct WorkflowDraft {
         self.name = template.definition.name
         self.isEnabled = true
         self.template = template
-        self.triggerKind = template == .dictation ? .hotkey : .manual
+        self.triggerMode = template == .dictation ? .automatic : .manual
+        self.isAppTriggerEnabled = false
+        self.isWebsiteTriggerEnabled = false
+        self.isHotkeyTriggerEnabled = template == .dictation
         self.appBundleIdentifiers = []
         self.websitePatterns = []
         self.hotkeys = []
@@ -1731,43 +1797,43 @@ private struct WorkflowDraft {
         self.targetActionPluginId = output.targetActionPluginId
 
         if let trigger = workflow.trigger {
+            self.appBundleIdentifiers = trigger.appBundleIdentifiers
+            self.websitePatterns = trigger.websitePatterns
+            self.hotkeys = trigger.hotkeys
+            self.hotkeyBehavior = trigger.hotkeyBehavior
+
             switch trigger.kind {
-            case .app:
-                self.triggerKind = .app
-                self.appBundleIdentifiers = trigger.appBundleIdentifiers
-                self.websitePatterns = []
-                self.hotkeys = []
-            case .website:
-                self.triggerKind = .website
-                self.appBundleIdentifiers = []
-                self.websitePatterns = trigger.websitePatterns
-                self.hotkeys = []
-            case .hotkey:
-                self.triggerKind = .hotkey
-                self.appBundleIdentifiers = []
-                self.websitePatterns = []
-                self.hotkeys = trigger.hotkeys
-                self.hotkeyBehavior = trigger.hotkeyBehavior
             case .global:
-                self.triggerKind = .global
-                self.appBundleIdentifiers = []
-                self.websitePatterns = []
-                self.hotkeys = []
+                self.triggerMode = .global
+                self.isAppTriggerEnabled = false
+                self.isWebsiteTriggerEnabled = false
+                self.isHotkeyTriggerEnabled = false
             case .manual:
-                self.triggerKind = .manual
-                self.appBundleIdentifiers = []
-                self.websitePatterns = []
-                self.hotkeys = []
+                self.triggerMode = .manual
+                self.isAppTriggerEnabled = false
+                self.isWebsiteTriggerEnabled = false
+                self.isHotkeyTriggerEnabled = false
+            case .app, .website, .hotkey:
+                self.triggerMode = .automatic
+                self.isAppTriggerEnabled = !trigger.appBundleIdentifiers.isEmpty
+                self.isWebsiteTriggerEnabled = !trigger.websitePatterns.isEmpty
+                self.isHotkeyTriggerEnabled = !trigger.hotkeys.isEmpty
             }
         } else {
-            self.triggerKind = .manual
+            self.triggerMode = .manual
+            self.isAppTriggerEnabled = false
+            self.isWebsiteTriggerEnabled = false
+            self.isHotkeyTriggerEnabled = false
             self.appBundleIdentifiers = []
             self.websitePatterns = []
             self.hotkeys = []
         }
 
-        if self.template == .dictation && self.triggerKind == .manual {
-            self.triggerKind = .hotkey
+        if self.template == .dictation && self.triggerMode == .manual {
+            self.triggerMode = .automatic
+            if !hasEnabledAutomaticTriggerComponent {
+                self.isHotkeyTriggerEnabled = true
+            }
         }
     }
 
@@ -1790,14 +1856,14 @@ private struct WorkflowDraft {
             de: " Gesprochene Sprache: \(workflowInputLanguageSummary(for: inputLanguageSelection))."
         )
 
-        if triggerKind == .manual {
+        if triggerMode == .manual {
             return localizedAppText(
                 "\(resolvedName) is available as \(template.definition.name) from the Workflow Palette.\(languageSentence)",
                 de: "\(resolvedName) ist als \(template.definition.name) über die Workflow-Palette verfügbar.\(languageSentence)"
             )
         }
 
-        if triggerKind == .global {
+        if triggerMode == .global {
             return localizedAppText(
                 "\(resolvedName) runs always as \(template.definition.name).\(languageSentence)",
                 de: "\(resolvedName) läuft immer als \(template.definition.name).\(languageSentence)"
@@ -1839,8 +1905,11 @@ private struct WorkflowDraft {
             outputFormat = ""
             providerId = nil
             cloudModel = nil
-            if triggerKind == .manual {
-                triggerKind = .hotkey
+            if triggerMode == .manual {
+                triggerMode = .automatic
+            }
+            if !hasEnabledAutomaticTriggerComponent {
+                isHotkeyTriggerEnabled = true
             }
         }
     }
@@ -1851,59 +1920,68 @@ private struct WorkflowDraft {
         workflowService: WorkflowService,
         existingWorkflowId: UUID?
     ) -> String? {
-        if template == .dictation && triggerKind == .manual {
+        if template == .dictation && triggerMode == .manual {
             return localizedAppText(
                 "Dictation Only workflows need a recording trigger.",
                 de: "Nur-Diktat-Workflows brauchen einen Aufnahme-Trigger."
             )
         }
 
-        switch triggerKind {
-        case .app:
-            if appBundleIdentifiers.isEmpty {
+        switch triggerMode {
+        case .automatic:
+            if !hasEnabledAutomaticTriggerComponent {
+                return localizedAppText(
+                    "Please enable at least one automatic trigger.",
+                    de: "Bitte aktiviere mindestens einen automatischen Trigger."
+                )
+            }
+
+            if isAppTriggerEnabled && appBundleIdentifiers.isEmpty {
                 return localizedAppText(
                     "Please select at least one app.",
                     de: "Bitte wähle mindestens eine App aus."
                 )
             }
-        case .website:
-            if websitePatterns.isEmpty {
+
+            if isWebsiteTriggerEnabled && websitePatterns.isEmpty {
                 return localizedAppText(
                     "Please add at least one website or domain.",
                     de: "Bitte füge mindestens eine Website oder Domain hinzu."
                 )
             }
-        case .hotkey:
-            guard !hotkeys.isEmpty else {
-                return localizedAppText(
-                    "Please record at least one workflow shortcut.",
-                    de: "Bitte nimm mindestens einen Workflow-Shortcut auf."
-                )
-            }
 
-            for hotkey in hotkeys {
-                if hotkeys.contains(where: { candidate in
-                    candidate != hotkey && workflowHotkeysConflict(candidate, hotkey)
-                }) {
+            if isHotkeyTriggerEnabled {
+                guard !hotkeys.isEmpty else {
                     return localizedAppText(
-                        "The workflow contains duplicate shortcuts.",
-                        de: "Der Workflow enthält doppelte Shortcuts."
+                        "Please record at least one workflow shortcut.",
+                        de: "Bitte nimm mindestens einen Workflow-Shortcut auf."
                     )
                 }
 
-                if let conflictWorkflowId = hotkeyService.isHotkeyAssignedToWorkflow(hotkey, excludingWorkflowId: existingWorkflowId),
-                   let conflictWorkflow = workflowService.workflow(id: conflictWorkflowId) {
-                    return localizedAppText(
-                        "This hotkey is already used by workflow “\(conflictWorkflow.name)”.",
-                        de: "Dieser Hotkey wird bereits vom Workflow „\(conflictWorkflow.name)“ verwendet."
-                    )
-                }
+                for hotkey in hotkeys {
+                    if hotkeys.contains(where: { candidate in
+                        candidate != hotkey && workflowHotkeysConflict(candidate, hotkey)
+                    }) {
+                        return localizedAppText(
+                            "The workflow contains duplicate shortcuts.",
+                            de: "Der Workflow enthält doppelte Shortcuts."
+                        )
+                    }
 
-                if let conflictSlot = hotkeyService.isHotkeyAssignedToGlobalSlot(hotkey) {
-                    return localizedAppText(
-                        "This hotkey is already used by the global slot “\(conflictSlot.rawValue)”.",
-                        de: "Dieser Hotkey wird bereits vom globalen Slot „\(conflictSlot.rawValue)“ verwendet."
-                    )
+                    if let conflictWorkflowId = hotkeyService.isHotkeyAssignedToWorkflow(hotkey, excludingWorkflowId: existingWorkflowId),
+                       let conflictWorkflow = workflowService.workflow(id: conflictWorkflowId) {
+                        return localizedAppText(
+                            "This hotkey is already used by workflow “\(conflictWorkflow.name)”.",
+                            de: "Dieser Hotkey wird bereits vom Workflow „\(conflictWorkflow.name)“ verwendet."
+                        )
+                    }
+
+                    if let conflictSlot = hotkeyService.isHotkeyAssignedToGlobalSlot(hotkey) {
+                        return localizedAppText(
+                            "This hotkey is already used by the global slot “\(conflictSlot.rawValue)”.",
+                            de: "Dieser Hotkey wird bereits vom globalen Slot „\(conflictSlot.rawValue)“ verwendet."
+                        )
+                    }
                 }
             }
         case .global, .manual:
@@ -1949,16 +2027,31 @@ private struct WorkflowDraft {
     }
 
     func resolvedTrigger() -> WorkflowTrigger? {
-        switch triggerKind {
-        case .app:
-            guard !appBundleIdentifiers.isEmpty else { return nil }
-            return .apps(appBundleIdentifiers)
-        case .website:
-            guard !websitePatterns.isEmpty else { return nil }
-            return .websites(websitePatterns)
-        case .hotkey:
-            guard !hotkeys.isEmpty else { return nil }
-            return .hotkeys(hotkeys, behavior: hotkeyBehavior)
+        switch triggerMode {
+        case .automatic:
+            let resolvedApps = isAppTriggerEnabled ? appBundleIdentifiers : []
+            let resolvedWebsites = isWebsiteTriggerEnabled ? websitePatterns : []
+            let resolvedHotkeys = isHotkeyTriggerEnabled ? hotkeys : []
+            guard !resolvedApps.isEmpty || !resolvedWebsites.isEmpty || !resolvedHotkeys.isEmpty else {
+                return nil
+            }
+
+            let kind: WorkflowTriggerKind
+            if !resolvedApps.isEmpty {
+                kind = .app
+            } else if !resolvedWebsites.isEmpty {
+                kind = .website
+            } else {
+                kind = .hotkey
+            }
+
+            return WorkflowTrigger(
+                kind: kind,
+                appBundleIdentifiers: resolvedApps,
+                websitePatterns: resolvedWebsites,
+                hotkeys: resolvedHotkeys,
+                hotkeyBehavior: hotkeyBehavior
+            )
         case .global:
             return .global()
         case .manual:
@@ -2014,48 +2107,69 @@ private struct WorkflowDraft {
     }
 
     private var triggerReviewText: String {
-        switch triggerKind {
-        case .app:
-            if appBundleIdentifiers.isEmpty {
-                return localizedAppText("an app trigger", de: "einen App-Trigger")
+        switch triggerMode {
+        case .automatic:
+            var parts: [String] = []
+
+            if isAppTriggerEnabled {
+                if appBundleIdentifiers.isEmpty {
+                    parts.append(localizedAppText("an app trigger", de: "einen App-Trigger"))
+                } else {
+                    parts.append(localizedAppText(
+                        "the apps \(workflowCompactList(appBundleIdentifiers.map(workflowAppDisplayName(for:)), conjunction: localizedAppText("and", de: "und")))",
+                        de: "die Apps \(workflowCompactList(appBundleIdentifiers.map(workflowAppDisplayName(for:)), conjunction: "und"))"
+                    ))
+                }
             }
-            return localizedAppText(
-                "the apps \(workflowCompactList(appBundleIdentifiers.map(workflowAppDisplayName(for:)), conjunction: localizedAppText("and", de: "und")))",
-                de: "die Apps \(workflowCompactList(appBundleIdentifiers.map(workflowAppDisplayName(for:)), conjunction: "und"))"
-            )
-        case .website:
-            if websitePatterns.isEmpty {
-                return localizedAppText("a website trigger", de: "einen Website-Trigger")
+
+            if isWebsiteTriggerEnabled {
+                if websitePatterns.isEmpty {
+                    parts.append(localizedAppText("a website trigger", de: "einen Website-Trigger"))
+                } else {
+                    parts.append(localizedAppText(
+                        "the websites \(workflowCompactList(websitePatterns, conjunction: localizedAppText("and", de: "und")))",
+                        de: "die Websites \(workflowCompactList(websitePatterns, conjunction: "und"))"
+                    ))
+                }
             }
-            return localizedAppText(
-                "the websites \(workflowCompactList(websitePatterns, conjunction: localizedAppText("and", de: "und")))",
-                de: "die Websites \(workflowCompactList(websitePatterns, conjunction: "und"))"
-            )
-        case .hotkey:
-            if !hotkeys.isEmpty {
+
+            if isHotkeyTriggerEnabled {
                 let shortcuts = workflowCompactList(
                     hotkeys.map(HotkeyService.displayName(for:)),
                     conjunction: localizedAppText("and", de: "und")
                 )
-                switch hotkeyBehavior {
-                case .startDictation:
-                    return localizedAppText(
-                        "the shortcuts \(shortcuts) to start dictation",
-                        de: "die Shortcuts \(shortcuts) zum Starten des Diktats"
-                    )
-                case .processSelectedText:
-                    return localizedAppText(
-                        "the shortcuts \(shortcuts) to process selected text",
-                        de: "die Shortcuts \(shortcuts) zum Verarbeiten markierten Texts"
-                    )
+                if shortcuts.isEmpty {
+                    parts.append(localizedAppText("a hotkey", de: "einen Hotkey"))
+                } else {
+                    switch hotkeyBehavior {
+                    case .startDictation:
+                        parts.append(localizedAppText(
+                            "the shortcuts \(shortcuts) to start dictation",
+                            de: "die Shortcuts \(shortcuts) zum Starten des Diktats"
+                        ))
+                    case .processSelectedText:
+                        parts.append(localizedAppText(
+                            "the shortcuts \(shortcuts) to process selected text",
+                            de: "die Shortcuts \(shortcuts) zum Verarbeiten markierten Texts"
+                        ))
+                    }
                 }
             }
-            return localizedAppText("a hotkey", de: "einen Hotkey")
+
+            if parts.isEmpty {
+                return localizedAppText("an automatic trigger", de: "einen automatischen Trigger")
+            }
+
+            return workflowCompactList(parts, conjunction: localizedAppText("and", de: "und"))
         case .global:
             return localizedAppText("always", de: "immer")
         case .manual:
             return localizedAppText("the Workflow Palette", de: "die Workflow-Palette")
         }
+    }
+
+    private var hasEnabledAutomaticTriggerComponent: Bool {
+        isAppTriggerEnabled || isWebsiteTriggerEnabled || isHotkeyTriggerEnabled
     }
 
     mutating func addWebsitePattern(_ value: String) {
@@ -2187,20 +2301,11 @@ private func workflowTriggerSummary(for workflow: Workflow) -> String {
     switch trigger.kind {
     case .manual:
         return localizedAppText("Manual", de: "Manuell")
-    case .app:
-        return trigger.appBundleIdentifiers.count == 1
-            ? localizedAppText("App", de: "App")
-            : localizedAppText("Apps", de: "Apps")
-    case .website:
-        return trigger.websitePatterns.count == 1
-            ? localizedAppText("Website", de: "Website")
-            : localizedAppText("Websites", de: "Websites")
-    case .hotkey:
-        return trigger.hotkeys.count == 1
-            ? localizedAppText("Hotkey", de: "Hotkey")
-            : localizedAppText("Hotkeys", de: "Hotkeys")
     case .global:
         return localizedAppText("Always", de: "Immer")
+    case .app, .website, .hotkey:
+        let parts = workflowTriggerSummaryParts(for: trigger)
+        return parts.isEmpty ? trigger.kind.paletteLabel : parts.joined(separator: " + ")
     }
 }
 
@@ -2210,17 +2315,46 @@ private func workflowTriggerDetail(for workflow: Workflow) -> String {
     switch trigger.kind {
     case .manual:
         return localizedAppText("Workflow Palette", de: "Workflow-Palette")
-    case .app:
-        return workflowCompactList(trigger.appBundleIdentifiers.map(workflowAppDisplayName(for:)))
-    case .website:
-        return workflowCompactList(trigger.websitePatterns)
-    case .hotkey:
-        let shortcuts = workflowCompactList(trigger.hotkeys.map(HotkeyService.displayName(for:)))
-        guard !shortcuts.isEmpty else { return trigger.hotkeyBehavior.shortcutSubtitle }
-        return "\(shortcuts) · \(trigger.hotkeyBehavior.shortcutSubtitle)"
     case .global:
         return ""
+    case .app, .website, .hotkey:
+        return workflowTriggerDetailParts(for: trigger).joined(separator: " · ")
     }
+}
+
+private func workflowTriggerSummaryParts(for trigger: WorkflowTrigger) -> [String] {
+    var parts: [String] = []
+    if !trigger.appBundleIdentifiers.isEmpty {
+        parts.append(trigger.appBundleIdentifiers.count == 1
+            ? localizedAppText("App", de: "App")
+            : localizedAppText("Apps", de: "Apps"))
+    }
+    if !trigger.websitePatterns.isEmpty {
+        parts.append(trigger.websitePatterns.count == 1
+            ? localizedAppText("Website", de: "Website")
+            : localizedAppText("Websites", de: "Websites"))
+    }
+    if !trigger.hotkeys.isEmpty {
+        parts.append(trigger.hotkeys.count == 1
+            ? localizedAppText("Hotkey", de: "Hotkey")
+            : localizedAppText("Hotkeys", de: "Hotkeys"))
+    }
+    return parts
+}
+
+private func workflowTriggerDetailParts(for trigger: WorkflowTrigger) -> [String] {
+    var parts: [String] = []
+    if !trigger.appBundleIdentifiers.isEmpty {
+        parts.append(workflowCompactList(trigger.appBundleIdentifiers.map(workflowAppDisplayName(for:))))
+    }
+    if !trigger.websitePatterns.isEmpty {
+        parts.append(workflowCompactList(trigger.websitePatterns))
+    }
+    if !trigger.hotkeys.isEmpty {
+        let shortcuts = workflowCompactList(trigger.hotkeys.map(HotkeyService.displayName(for:)))
+        parts.append(shortcuts.isEmpty ? trigger.hotkeyBehavior.shortcutSubtitle : "\(shortcuts) · \(trigger.hotkeyBehavior.shortcutSubtitle)")
+    }
+    return parts
 }
 
 private func workflowReviewText(for workflow: Workflow) -> String {

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -149,6 +149,58 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(workflow.trigger?.hotkeyBehavior, .processSelectedText)
     }
 
+    func testWorkflowServicePersistsCombinedTriggerArrays() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let hotkey = UnifiedHotkey(keyCode: 15, modifierFlags: NSEvent.ModifierFlags.command.rawValue, isFn: false)
+
+        service.addWorkflow(
+            name: "Claude Cleanup",
+            template: .summary,
+            trigger: WorkflowTrigger(
+                kind: .app,
+                appBundleIdentifiers: ["ai.anthropic.Claude"],
+                websitePatterns: ["claude.ai"],
+                hotkeys: [hotkey],
+                hotkeyBehavior: .processSelectedText
+            )
+        )
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let trigger = try XCTUnwrap(reloaded.workflows.first?.trigger)
+
+        XCTAssertEqual(trigger.kind, .app)
+        XCTAssertEqual(trigger.appBundleIdentifiers, ["ai.anthropic.Claude"])
+        XCTAssertEqual(trigger.websitePatterns, ["claude.ai"])
+        XCTAssertEqual(trigger.hotkeys, [hotkey])
+        XCTAssertEqual(trigger.hotkeyBehavior, .processSelectedText)
+    }
+
+    func testWorkflowDraftPreservesCombinedTriggerArraysWhenSaving() throws {
+        let hotkey = UnifiedHotkey(keyCode: 15, modifierFlags: NSEvent.ModifierFlags.command.rawValue, isFn: false)
+        let workflow = Workflow(
+            name: "Claude Cleanup",
+            template: .summary,
+            trigger: WorkflowTrigger(
+                kind: .app,
+                appBundleIdentifiers: ["ai.anthropic.Claude"],
+                websitePatterns: ["claude.ai"],
+                hotkeys: [hotkey],
+                hotkeyBehavior: .processSelectedText
+            )
+        )
+
+        let trigger = try XCTUnwrap(WorkflowDraft(workflow).resolvedTrigger())
+
+        XCTAssertEqual(trigger.kind, .app)
+        XCTAssertEqual(trigger.appBundleIdentifiers, ["ai.anthropic.Claude"])
+        XCTAssertEqual(trigger.websitePatterns, ["claude.ai"])
+        XCTAssertEqual(trigger.hotkeys, [hotkey])
+        XCTAssertEqual(trigger.hotkeyBehavior, .processSelectedText)
+    }
+
     func testWorkflowServicePersistsDefaultLLMProviderAndModel() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }
@@ -713,6 +765,71 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertTrue(match.wonBySortOrder)
     }
 
+    func testMatchWorkflowPrefersAppAndWebsiteBeforeWebsiteAndAppOnly() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Claude Website Cleanup",
+            template: .summary,
+            trigger: .website("claude.ai"),
+            sortOrder: 0
+        )
+        _ = service.addWorkflow(
+            name: "Claude App Cleanup",
+            template: .cleanedText,
+            trigger: .app("ai.anthropic.Claude"),
+            sortOrder: 1
+        )
+        _ = service.addWorkflow(
+            name: "Claude App Website Cleanup",
+            template: .checklist,
+            trigger: WorkflowTrigger(
+                kind: .app,
+                appBundleIdentifiers: ["ai.anthropic.Claude"],
+                websitePatterns: ["claude.ai"]
+            ),
+            sortOrder: 2
+        )
+
+        let match = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "ai.anthropic.Claude",
+            url: "https://claude.ai/chat"
+        ))
+
+        XCTAssertEqual(match.workflow.name, "Claude App Website Cleanup")
+        XCTAssertEqual(match.kind, .appAndWebsite)
+        XCTAssertEqual(match.matchedDomain, "claude.ai")
+        XCTAssertEqual(match.competingWorkflowCount, 0)
+        XCTAssertFalse(match.wonBySortOrder)
+    }
+
+    func testCombinedWorkflowRequiresBothAppAndWebsiteForAutomaticMatch() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "Claude App Website Cleanup",
+            template: .checklist,
+            trigger: WorkflowTrigger(
+                kind: .app,
+                appBundleIdentifiers: ["ai.anthropic.Claude"],
+                websitePatterns: ["claude.ai"]
+            )
+        )
+
+        XCTAssertNil(service.matchWorkflow(
+            bundleIdentifier: "com.apple.Safari",
+            url: "https://claude.ai/chat"
+        ))
+        XCTAssertNil(service.matchWorkflow(
+            bundleIdentifier: "ai.anthropic.Claude",
+            url: "https://example.com"
+        ))
+    }
+
     func testMatchWorkflowIgnoresDisabledAndHotkeyOnlyEntries() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }
@@ -731,6 +848,45 @@ final class WorkflowServiceTests: XCTestCase {
         )
 
         XCTAssertNil(service.matchWorkflow(bundleIdentifier: "com.apple.mail", url: "https://mail.google.com"))
+    }
+
+    func testSyncWorkflowHotkeysRegistersCombinedTriggerHotkeys() throws {
+        let profileDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowProfileTests")
+        let workflowDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer {
+            TestSupport.remove(profileDirectory)
+            TestSupport.remove(workflowDirectory)
+        }
+
+        let hotkeyService = HotkeyService()
+        let workflowService = WorkflowService(appSupportDirectory: workflowDirectory)
+        let profileService = ProfileService(appSupportDirectory: profileDirectory)
+        let handler = DictationSettingsHandler(
+            hotkeyService: hotkeyService,
+            audioRecordingService: AudioRecordingService(),
+            textInsertionService: TextInsertionService(),
+            profileService: profileService,
+            workflowService: workflowService
+        )
+        let hotkey = UnifiedHotkey(keyCode: 15, modifierFlags: NSEvent.ModifierFlags.command.rawValue, isFn: false)
+        let workflow = try XCTUnwrap(workflowService.addWorkflow(
+            name: "Claude Cleanup",
+            template: .summary,
+            trigger: WorkflowTrigger(
+                kind: .app,
+                appBundleIdentifiers: ["ai.anthropic.Claude"],
+                websitePatterns: ["claude.ai"],
+                hotkeys: [hotkey],
+                hotkeyBehavior: .processSelectedText
+            )
+        ))
+
+        handler.syncWorkflowHotkeys(workflowService.workflows)
+
+        XCTAssertEqual(
+            hotkeyService.isHotkeyAssignedToWorkflow(hotkey, excludingWorkflowId: nil),
+            workflow.id
+        )
     }
 
     func testForcedWorkflowMatchUsesManualOverrideKind() throws {

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -39,8 +39,8 @@
 - Workflow setup step (cross-tab navigation)
 - History edit/export
 - Post-processing transparency in history and indicators
-- Workflow matching for app, URL, hotkey, and fallback triggers
-- Global fallback workflow when no app-, URL-, or hotkey-specific workflow matches
+- Workflow matching for app + URL, URL-only, app-only, direct hotkey, and fallback triggers
+- Global fallback workflow when no app- or URL-specific workflow matches
 - Notch, Overlay, and Minimal indicator styles
 - Transcript preview toggle for Notch and Overlay
 - Plugin enable/disable

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -16,7 +16,7 @@ TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac Ap
 - System-wide dictation with a global hotkey and text insertion
 - File transcription, including batch processing and export
 - Workflow processing with bundled prompt presets and custom actions
-- Workflows for app-, URL-, hotkey-, and global fallback control, with legacy prompt/profile compatibility
+- Workflows for app, URL, combined app + URL, direct hotkey, and global fallback control, with legacy prompt/profile compatibility
 - History, Dictionary, and Snippets
 - Bundled default integrations and bundled plugins
 
@@ -95,7 +95,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Workflow setup flow across tabs
 - History edit/export
 - History entry shows both STT and AI-processed text where applicable
-- Workflow matching for app, URL, hotkey, and global fallback triggers
+- Workflow matching for app + URL, URL-only, app-only, direct hotkey, and global fallback triggers
 - Auto-submit workflow behavior and legacy Auto Enter profile compatibility
 - Plugin enable/disable
 - Community term pack download and apply


### PR DESCRIPTION
## Summary
Issue #459 reports that the workflow editor's exclusive trigger picker could drop existing App, Website, or Hotkey arrays when saving a workflow. This PR makes the existing trigger arrays the source of truth while keeping `kind` as the legacy primary classification.

Closes #459

- Preserve App, Website, and Hotkey trigger arrays together through `WorkflowDraft` loading and saving.
- Match workflows in the documented order: App + Website before Website-only, App-only, and Always fallback.
- Keep workflow hotkeys as direct triggers independent of context matching, even when App or Website arrays are also set.
- Update workflow trigger summaries, review text, and palette labels/search tokens to derive labels from the populated arrays.
- Clean up the Workflow editor trigger UI around Automatic, Manual, and Always modes, with Automatic first and App/Website/Hotkey as combinable components.
- Add regression tests for draft round-tripping, persistence reloads, matching priority, negative combined matches, and combined hotkey registration.
- Sync README and release smoke-check docs with combined trigger behavior and the hotkey/direct-trigger distinction.

## Test Coverage
All new backend/state paths have regression coverage.

Tests: 34 Swift test files before this PR; `WorkflowServiceTests` now includes combined trigger persistence, draft round-trip, matching order, negative matching, and hotkey sync coverage.

## Pre-Landing Review
No issues found.

## Design Review
Web design review skipped. This is SwiftUI/macOS UI work; the trigger editor was manually visually checked during implementation.

## Eval Results
No prompt-related eval lane applies to this TypeWhisper macOS app change.

## Plan Completion
No plan file detected. The implementation follows the issue plan provided in the conversation.

## Verification Results
TypeWhisper macOS app tests and dev build passed after the code changes. A docs-only commit was added afterward to keep product/release documentation aligned.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/.codex/worktrees/5192/typewhisper-mac`
