### PR TITLE
fix: disambiguate German recorder settings label

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -6753,7 +6753,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aufnahme"
+            "value" : "Recorder"
           }
         },
         "en" : {


### PR DESCRIPTION
## Summary
- Rename the German Recorder settings tab from `Aufnahme` to `Recorder`.
- Keep the normal Recording settings label translated as `Aufnahme`, so the two settings entries no longer collide in German.

## Issue Context
A German UI issue was reported where both the Recording settings and the Recorder tab appeared as `Aufnahme`, making the settings sidebar ambiguous.

## Review
Pre-Landing Review: No issues found.

## Test Plan
- `jq empty TypeWhisper/Resources/Localizable.xcstrings`
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`