### PR TITLE
Fix system audio recorder sample handling

### DIFF
--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -6,6 +6,370 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioRecorderService")
 
+struct SystemAudioSampleProcessingResult {
+    let pcmBuffer: AVAudioPCMBuffer
+    let frameCount: Int
+    let rms: Float
+    let level: Float
+    let transcriptionSamples: [Float]
+}
+
+enum SystemAudioSampleProcessingError: LocalizedError {
+    case invalidSampleBuffer
+    case missingAudioFormat
+    case unsupportedAudioFormat
+    case emptyAudioBufferList
+    case emptyAudioData
+    case bufferListExtractionFailed(OSStatus)
+    case cannotCreateOutputFormat
+    case cannotCreatePCMBuffer
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidSampleBuffer:
+            "Invalid system audio sample buffer."
+        case .missingAudioFormat:
+            "System audio sample buffer is missing its audio format."
+        case .unsupportedAudioFormat:
+            "Unsupported system audio sample format."
+        case .emptyAudioBufferList:
+            "System audio sample buffer did not contain audio buffers."
+        case .emptyAudioData:
+            "System audio sample buffer did not contain audio data."
+        case .bufferListExtractionFailed(let status):
+            "Could not read system audio buffer list: \(status)."
+        case .cannotCreateOutputFormat:
+            "Could not create system audio output format."
+        case .cannotCreatePCMBuffer:
+            "Could not create system audio PCM buffer."
+        }
+    }
+}
+
+struct SystemAudioSampleProcessor {
+    static func process(
+        _ sampleBuffer: CMSampleBuffer,
+        transcriptionSampleRate: Double = AudioRecorderService.transcriptionSampleRate
+    ) throws -> SystemAudioSampleProcessingResult {
+        guard sampleBuffer.isValid else {
+            throw SystemAudioSampleProcessingError.invalidSampleBuffer
+        }
+        guard let formatDescription = sampleBuffer.formatDescription,
+              let asbdPointer = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription) else {
+            throw SystemAudioSampleProcessingError.missingAudioFormat
+        }
+
+        var bufferListSizeNeeded = 0
+        var status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: &bufferListSizeNeeded,
+            bufferListOut: nil,
+            bufferListSize: 0,
+            blockBufferAllocator: nil,
+            blockBufferMemoryAllocator: nil,
+            flags: kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
+            blockBufferOut: nil
+        )
+        guard status == noErr, bufferListSizeNeeded > 0 else {
+            throw SystemAudioSampleProcessingError.bufferListExtractionFailed(status)
+        }
+
+        let rawPointer = UnsafeMutableRawPointer.allocate(
+            byteCount: bufferListSizeNeeded,
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { rawPointer.deallocate() }
+        rawPointer.initializeMemory(as: UInt8.self, repeating: 0, count: bufferListSizeNeeded)
+
+        var retainedBlockBuffer: CMBlockBuffer?
+        status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: nil,
+            bufferListOut: rawPointer.assumingMemoryBound(to: AudioBufferList.self),
+            bufferListSize: bufferListSizeNeeded,
+            blockBufferAllocator: kCFAllocatorDefault,
+            blockBufferMemoryAllocator: kCFAllocatorDefault,
+            flags: kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
+            blockBufferOut: &retainedBlockBuffer
+        )
+        guard status == noErr else {
+            throw SystemAudioSampleProcessingError.bufferListExtractionFailed(status)
+        }
+
+        let audioBufferList = UnsafeMutableAudioBufferListPointer(rawPointer.assumingMemoryBound(to: AudioBufferList.self))
+        return try process(
+            audioBufferList: audioBufferList,
+            asbd: asbdPointer.pointee,
+            transcriptionSampleRate: transcriptionSampleRate
+        )
+    }
+
+    static func process(
+        audioBufferList: UnsafeMutableAudioBufferListPointer,
+        asbd: AudioStreamBasicDescription,
+        transcriptionSampleRate: Double
+    ) throws -> SystemAudioSampleProcessingResult {
+        guard asbd.mFormatID == kAudioFormatLinearPCM,
+              asbd.mSampleRate > 0,
+              asbd.mChannelsPerFrame > 0,
+              asbd.mBitsPerChannel > 0 else {
+            throw SystemAudioSampleProcessingError.unsupportedAudioFormat
+        }
+        guard !audioBufferList.isEmpty else {
+            throw SystemAudioSampleProcessingError.emptyAudioBufferList
+        }
+
+        let bytesPerSample = Int(asbd.mBitsPerChannel / 8)
+        let isFloat = asbd.mFormatFlags & kAudioFormatFlagIsFloat != 0
+        let isSignedInteger = asbd.mFormatFlags & kAudioFormatFlagIsSignedInteger != 0
+        let isNonInterleaved = asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved != 0
+        guard (isFloat && bytesPerSample == MemoryLayout<Float>.size)
+            || (isSignedInteger && bytesPerSample == MemoryLayout<Int16>.size) else {
+            throw SystemAudioSampleProcessingError.unsupportedAudioFormat
+        }
+
+        let channelCount = Int(asbd.mChannelsPerFrame)
+        let frameCount = frameCount(
+            in: audioBufferList,
+            bytesPerSample: bytesPerSample,
+            channelCount: channelCount,
+            isNonInterleaved: isNonInterleaved
+        )
+        guard frameCount > 0 else {
+            throw SystemAudioSampleProcessingError.emptyAudioData
+        }
+
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: asbd.mSampleRate,
+            channels: AVAudioChannelCount(channelCount),
+            interleaved: false
+        ) else {
+            throw SystemAudioSampleProcessingError.cannotCreateOutputFormat
+        }
+        guard let pcmBuffer = AVAudioPCMBuffer(
+            pcmFormat: outputFormat,
+            frameCapacity: AVAudioFrameCount(frameCount)
+        ) else {
+            throw SystemAudioSampleProcessingError.cannotCreatePCMBuffer
+        }
+        pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+        guard let outputChannels = pcmBuffer.floatChannelData else {
+            throw SystemAudioSampleProcessingError.cannotCreatePCMBuffer
+        }
+        clear(outputChannels: outputChannels, channelCount: channelCount, frameCount: frameCount)
+
+        if isNonInterleaved {
+            copyNonInterleaved(
+                audioBufferList,
+                outputChannels: outputChannels,
+                channelCount: channelCount,
+                frameCount: frameCount,
+                isFloat: isFloat
+            )
+        } else {
+            try copyInterleaved(
+                audioBufferList,
+                outputChannels: outputChannels,
+                channelCount: channelCount,
+                frameCount: frameCount,
+                isFloat: isFloat
+            )
+        }
+
+        let rms = rms(outputChannels: outputChannels, channelCount: channelCount, frameCount: frameCount)
+        return SystemAudioSampleProcessingResult(
+            pcmBuffer: pcmBuffer,
+            frameCount: frameCount,
+            rms: rms,
+            level: min(1, rms * 5),
+            transcriptionSamples: transcriptionSamples(
+                outputChannels: outputChannels,
+                channelCount: channelCount,
+                frameCount: frameCount,
+                sampleRate: asbd.mSampleRate,
+                targetSampleRate: transcriptionSampleRate
+            )
+        )
+    }
+
+    private static func frameCount(
+        in audioBufferList: UnsafeMutableAudioBufferListPointer,
+        bytesPerSample: Int,
+        channelCount: Int,
+        isNonInterleaved: Bool
+    ) -> Int {
+        if isNonInterleaved {
+            let counts = audioBufferList.compactMap { buffer -> Int? in
+                guard buffer.mData != nil else { return nil }
+                let channels = max(1, Int(buffer.mNumberChannels))
+                return Int(buffer.mDataByteSize) / max(1, bytesPerSample * channels)
+            }
+            return counts.min() ?? 0
+        }
+
+        let firstBuffer = audioBufferList[0]
+        guard firstBuffer.mData != nil else { return 0 }
+        let channels = max(1, Int(firstBuffer.mNumberChannels), channelCount)
+        return Int(firstBuffer.mDataByteSize) / max(1, bytesPerSample * channels)
+    }
+
+    private static func clear(
+        outputChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        channelCount: Int,
+        frameCount: Int
+    ) {
+        for channel in 0..<channelCount {
+            outputChannels[channel].update(repeating: 0, count: frameCount)
+        }
+    }
+
+    private static func copyInterleaved(
+        _ audioBufferList: UnsafeMutableAudioBufferListPointer,
+        outputChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        channelCount: Int,
+        frameCount: Int,
+        isFloat: Bool
+    ) throws {
+        let inputBuffer = audioBufferList[0]
+        guard let data = inputBuffer.mData else {
+            throw SystemAudioSampleProcessingError.emptyAudioData
+        }
+        let inputChannels = max(1, Int(inputBuffer.mNumberChannels), channelCount)
+
+        if isFloat {
+            let input = data.assumingMemoryBound(to: Float.self)
+            for frame in 0..<frameCount {
+                for channel in 0..<channelCount {
+                    outputChannels[channel][frame] = input[frame * inputChannels + channel]
+                }
+            }
+        } else {
+            let input = data.assumingMemoryBound(to: Int16.self)
+            for frame in 0..<frameCount {
+                for channel in 0..<channelCount {
+                    outputChannels[channel][frame] = Float(input[frame * inputChannels + channel]) / Float(Int16.max)
+                }
+            }
+        }
+    }
+
+    private static func copyNonInterleaved(
+        _ audioBufferList: UnsafeMutableAudioBufferListPointer,
+        outputChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        channelCount: Int,
+        frameCount: Int,
+        isFloat: Bool
+    ) {
+        var outputChannelIndex = 0
+        for inputBuffer in audioBufferList {
+            guard outputChannelIndex < channelCount, let data = inputBuffer.mData else { continue }
+            let channelsInBuffer = max(1, Int(inputBuffer.mNumberChannels))
+            if isFloat {
+                let input = data.assumingMemoryBound(to: Float.self)
+                for localChannel in 0..<channelsInBuffer where outputChannelIndex + localChannel < channelCount {
+                    for frame in 0..<frameCount {
+                        outputChannels[outputChannelIndex + localChannel][frame] = input[frame * channelsInBuffer + localChannel]
+                    }
+                }
+            } else {
+                let input = data.assumingMemoryBound(to: Int16.self)
+                for localChannel in 0..<channelsInBuffer where outputChannelIndex + localChannel < channelCount {
+                    for frame in 0..<frameCount {
+                        outputChannels[outputChannelIndex + localChannel][frame] =
+                            Float(input[frame * channelsInBuffer + localChannel]) / Float(Int16.max)
+                    }
+                }
+            }
+            outputChannelIndex += channelsInBuffer
+        }
+    }
+
+    private static func rms(
+        outputChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        channelCount: Int,
+        frameCount: Int
+    ) -> Float {
+        var sum: Float = 0
+        for channel in 0..<channelCount {
+            for frame in 0..<frameCount {
+                let sample = outputChannels[channel][frame]
+                sum += sample * sample
+            }
+        }
+        return sqrt(sum / Float(frameCount * channelCount))
+    }
+
+    private static func transcriptionSamples(
+        outputChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        channelCount: Int,
+        frameCount: Int,
+        sampleRate: Double,
+        targetSampleRate: Double
+    ) -> [Float] {
+        guard frameCount > 0, channelCount > 0, sampleRate > 0, targetSampleRate > 0 else { return [] }
+        let decimationFactor = max(1, Int(sampleRate / targetSampleRate))
+        var samples: [Float] = []
+        samples.reserveCapacity(frameCount / decimationFactor)
+
+        for frame in stride(from: 0, to: frameCount, by: decimationFactor) {
+            var sample: Float = 0
+            for channel in 0..<channelCount {
+                sample += outputChannels[channel][frame]
+            }
+            samples.append(sample / Float(channelCount))
+        }
+
+        return samples
+    }
+}
+
+struct SystemAudioCaptureDiagnostics {
+    private(set) var buffersReceived = 0
+    private(set) var framesReceived = 0
+    private(set) var lastErrorDescription: String?
+    private(set) var lastNonSilentRMS: Float = 0
+    private(set) var lastRMS: Float = 0
+    private var sessionStartedAt: Date?
+    private var isActive = false
+
+    mutating func beginSession(startedAt: Date = Date()) {
+        buffersReceived = 0
+        framesReceived = 0
+        lastErrorDescription = nil
+        lastNonSilentRMS = 0
+        lastRMS = 0
+        sessionStartedAt = startedAt
+        isActive = true
+    }
+
+    mutating func endSession() {
+        isActive = false
+    }
+
+    mutating func recordProcessedBuffer(frameCount: Int, rms: Float, nonSilentThreshold: Float) {
+        buffersReceived += 1
+        framesReceived += frameCount
+        lastErrorDescription = nil
+        lastRMS = rms
+        if rms >= nonSilentThreshold {
+            lastNonSilentRMS = rms
+        }
+    }
+
+    mutating func recordError(_ error: Error) {
+        lastErrorDescription = error.localizedDescription
+    }
+
+    func noAudioWarningIfNeeded(now: Date, gracePeriod: TimeInterval) -> String? {
+        guard isActive, let sessionStartedAt else { return nil }
+        guard now.timeIntervalSince(sessionStartedAt) >= gracePeriod else { return nil }
+        guard lastNonSilentRMS <= 0 else { return nil }
+        return AudioRecorderService.noSystemAudioDetectedWarning
+    }
+}
+
 /// Records audio from microphone and/or system audio to file.
 /// Uses AVAudioEngine for mic and ScreenCaptureKit for system audio.
 final class AudioRecorderService: ObservableObject, @unchecked Sendable {
@@ -89,6 +453,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     @Published private(set) var duration: TimeInterval = 0
     @Published private(set) var micLevel: Float = 0
     @Published private(set) var systemLevel: Float = 0
+    @Published private(set) var systemAudioWarningMessage: String?
 
     private var audioEngine: AVAudioEngine?
     private let micFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
@@ -97,6 +462,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     private let sysFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
     private var durationTimer: Timer?
     private var startTime: Date?
+    private let systemAudioDiagnosticsLock = OSAllocatedUnfairLock(initialState: SystemAudioCaptureDiagnostics())
 
     private var micTempURL: URL?
     private var systemTempURL: URL?
@@ -109,7 +475,15 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     // 16kHz mono buffer for streaming transcription
     private let transcriptionBufferLock = OSAllocatedUnfairLock<RecorderTranscriptionBuffer>(initialState: RecorderTranscriptionBuffer())
-    private static let transcriptionSampleRate: Double = 16000
+    static let transcriptionSampleRate: Double = 16000
+    static var noSystemAudioDetectedWarning: String {
+        localizedAppText(
+            "No system audio was detected. If the other app is playing audio, macOS may be blocking that source from ScreenCaptureKit.",
+            de: "Es wurde kein Systemaudio erkannt. Wenn die andere App Audio abspielt, blockiert macOS diese Quelle möglicherweise für ScreenCaptureKit."
+        )
+    }
+    private static let systemAudioDetectionGracePeriod: TimeInterval = 2
+    private static let systemAudioNonSilentThreshold: Float = 0.0001
 
     static let recordingsDirectoryName = "TypeWhisper Recordings"
 
@@ -201,6 +575,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         self.micEnabled = micEnabled
         self.systemAudioEnabled = systemAudioEnabled
         self.outputFormat = format
+        resetSystemAudioMonitoring(systemAudioEnabled: systemAudioEnabled)
 
         // Clear transcription buffer
         transcriptionBufferLock.withLock { $0.reset() }
@@ -266,6 +641,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         // Stop timer
         durationTimer?.invalidate()
         durationTimer = nil
+        endSystemAudioMonitoring()
 
         // Stop mic
         if micEnabled {
@@ -499,7 +875,6 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         sysFileLock.withLock { $0 = audioFile }
 
         let output = SystemAudioStreamOutput()
-        output.audioFile = audioFile
         output.fileLock = sysFileLock
         let levelSetter = SystemLevelSetter(service: self)
         output.levelCallback = { level in
@@ -507,6 +882,12 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         }
         output.transcriptionBufferCallback = { [weak self] samples in
             self?.appendSystemTranscriptionSamples(samples)
+        }
+        output.processingResultCallback = { [weak self] result in
+            self?.recordSystemAudioProcessingResult(result)
+        }
+        output.processingErrorCallback = { [weak self] error in
+            self?.recordSystemAudioProcessingError(error)
         }
 
         streamOutput = output
@@ -516,6 +897,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
         try await stream.startCapture()
         scStream = stream
+        scheduleSystemAudioDetectionCheck()
     }
 
     // MARK: - Audio Mixing
@@ -711,6 +1093,85 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         systemLevel = level
     }
 
+    // MARK: - System Audio Diagnostics
+
+    private func resetSystemAudioMonitoring(systemAudioEnabled: Bool) {
+        systemAudioDiagnosticsLock.withLock { diagnostics in
+            if systemAudioEnabled {
+                diagnostics.beginSession()
+            } else {
+                diagnostics.endSession()
+            }
+        }
+        setSystemAudioWarningMessage(nil)
+    }
+
+    private func endSystemAudioMonitoring() {
+        systemAudioDiagnosticsLock.withLock { diagnostics in
+            diagnostics.endSession()
+        }
+    }
+
+    private func scheduleSystemAudioDetectionCheck() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.systemAudioDetectionGracePeriod) { [weak self] in
+            self?.publishSystemAudioWarningIfNeeded()
+        }
+    }
+
+    private func recordSystemAudioProcessingResult(_ result: SystemAudioSampleProcessingResult) {
+        let shouldClearWarning = result.rms >= Self.systemAudioNonSilentThreshold
+        let warning = systemAudioDiagnosticsLock.withLock { diagnostics in
+            diagnostics.recordProcessedBuffer(
+                frameCount: result.frameCount,
+                rms: result.rms,
+                nonSilentThreshold: Self.systemAudioNonSilentThreshold
+            )
+            return diagnostics.noAudioWarningIfNeeded(
+                now: Date(),
+                gracePeriod: Self.systemAudioDetectionGracePeriod
+            )
+        }
+
+        if shouldClearWarning {
+            setSystemAudioWarningMessage(nil)
+        } else if let warning {
+            setSystemAudioWarningMessage(warning)
+        }
+    }
+
+    private func recordSystemAudioProcessingError(_ error: Error) {
+        let warning = systemAudioDiagnosticsLock.withLock { diagnostics in
+            diagnostics.recordError(error)
+            return diagnostics.noAudioWarningIfNeeded(
+                now: Date(),
+                gracePeriod: Self.systemAudioDetectionGracePeriod
+            )
+        }
+
+        if let warning {
+            setSystemAudioWarningMessage(warning)
+        }
+    }
+
+    private func publishSystemAudioWarningIfNeeded() {
+        let warning = systemAudioDiagnosticsLock.withLock { diagnostics in
+            diagnostics.noAudioWarningIfNeeded(
+                now: Date(),
+                gracePeriod: Self.systemAudioDetectionGracePeriod
+            )
+        }
+
+        if let warning {
+            setSystemAudioWarningMessage(warning)
+        }
+    }
+
+    private func setSystemAudioWarningMessage(_ message: String?) {
+        DispatchQueue.main.async { [weak self] in
+            self?.systemAudioWarningMessage = message
+        }
+    }
+
     // MARK: - Helpers
 
     private func copyOrConvert(from sourceURL: URL, to destinationURL: URL) throws {
@@ -900,6 +1361,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         durationTimer?.invalidate()
         durationTimer = nil
         startTime = nil
+        endSystemAudioMonitoring()
 
         if let stream = scStream {
             try? await stream.stopCapture()
@@ -948,118 +1410,40 @@ private final class SystemLevelSetter: @unchecked Sendable {
 // MARK: - SCStream Output Handler
 
 private final class SystemAudioStreamOutput: NSObject, SCStreamOutput, SCStreamDelegate, @unchecked Sendable {
-    var audioFile: AVAudioFile?
     var fileLock: OSAllocatedUnfairLock<AVAudioFile?>?
     var levelCallback: ((Float) -> Void)?
     var transcriptionBufferCallback: (([Float]) -> Void)?
+    var processingResultCallback: ((SystemAudioSampleProcessingResult) -> Void)?
+    var processingErrorCallback: ((Error) -> Void)?
 
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .audio else { return }
-        guard sampleBuffer.isValid else { return }
+        do {
+            let result = try SystemAudioSampleProcessor.process(sampleBuffer)
+            processingResultCallback?(result)
+            levelCallback?(result.level)
 
-        guard let formatDesc = sampleBuffer.formatDescription,
-              let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc) else { return }
-
-        guard let blockBuffer = sampleBuffer.dataBuffer else { return }
-        let length = CMBlockBufferGetDataLength(blockBuffer)
-        guard length > 0 else { return }
-
-        var dataPointer: UnsafeMutablePointer<Int8>?
-        let status = CMBlockBufferGetDataPointer(blockBuffer, atOffset: 0, lengthAtOffsetOut: nil, totalLengthOut: nil, dataPointerOut: &dataPointer)
-        guard status == kCMBlockBufferNoErr, let dataPointer else { return }
-
-        // Calculate level from raw samples
-        let bytesPerSample = Int(asbd.pointee.mBitsPerChannel / 8)
-        let channelCount = Int(asbd.pointee.mChannelsPerFrame)
-        guard bytesPerSample > 0, channelCount > 0 else { return }
-        let sampleCount = length / (bytesPerSample * channelCount)
-        guard sampleCount > 0 else { return }
-
-        if asbd.pointee.mFormatFlags & kAudioFormatFlagIsFloat != 0 && bytesPerSample == 4 {
-            let floatPointer = UnsafeRawPointer(dataPointer).bindMemory(to: Float.self, capacity: sampleCount * channelCount)
-            var sum: Float = 0
-            for i in 0..<(sampleCount * channelCount) {
-                let sample = floatPointer[i]
-                sum += sample * sample
-            }
-            let rms = sqrt(sum / Float(sampleCount * channelCount))
-            let level = min(1.0, rms * 5)
-            levelCallback?(level)
-        } else if bytesPerSample == 2 {
-            let int16Pointer = UnsafeRawPointer(dataPointer).bindMemory(to: Int16.self, capacity: sampleCount * channelCount)
-            var sum: Float = 0
-            for i in 0..<(sampleCount * channelCount) {
-                let sample = Float(int16Pointer[i]) / Float(Int16.max)
-                sum += sample * sample
-            }
-            let rms = sqrt(sum / Float(sampleCount * channelCount))
-            let level = min(1.0, rms * 5)
-            levelCallback?(level)
-        }
-
-        // Convert CMSampleBuffer to AVAudioPCMBuffer and write
-        let isFloat = asbd.pointee.mFormatFlags & kAudioFormatFlagIsFloat != 0
-        let isNonInterleaved = asbd.pointee.mFormatFlags & kAudioFormatFlagIsNonInterleaved != 0
-        guard let format = AVAudioFormat(
-            commonFormat: isFloat && bytesPerSample == 4 ? .pcmFormatFloat32 : .pcmFormatInt16,
-            sampleRate: asbd.pointee.mSampleRate,
-            channels: AVAudioChannelCount(channelCount),
-            interleaved: !isNonInterleaved
-        ) else { return }
-
-        let frameCount = AVAudioFrameCount(sampleCount)
-        guard let pcmBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
-        pcmBuffer.frameLength = frameCount
-
-        // Copy data into buffer
-        if let bufferData = pcmBuffer.audioBufferList.pointee.mBuffers.mData {
-            memcpy(bufferData, dataPointer, length)
-        }
-
-        fileLock?.withLock { file in
-            guard let file else { return }
-            do {
-                try file.write(from: pcmBuffer)
-            } catch {
-                logger.error("Failed to write system audio: \(error.localizedDescription)")
-            }
-        }
-
-        // Downsample to 16kHz mono for transcription buffer
-        if let callback = transcriptionBufferCallback {
-            let sampleRate = asbd.pointee.mSampleRate
-            let decimationFactor = Int(sampleRate / 16000)
-            guard decimationFactor > 0 else { return }
-
-            if isFloat && bytesPerSample == 4 {
-                let floatPtr = UnsafeRawPointer(dataPointer).bindMemory(to: Float.self, capacity: sampleCount * channelCount)
-                var mono16k: [Float] = []
-                mono16k.reserveCapacity(sampleCount / decimationFactor)
-                for i in stride(from: 0, to: sampleCount, by: decimationFactor) {
-                    var sample: Float = 0
-                    for ch in 0..<channelCount {
-                        sample += floatPtr[i * channelCount + ch]
-                    }
-                    mono16k.append(sample / Float(channelCount))
+            fileLock?.withLock { file in
+                guard let file else { return }
+                do {
+                    try file.write(from: result.pcmBuffer)
+                } catch {
+                    processingErrorCallback?(error)
+                    logger.error("Failed to write system audio: \(error.localizedDescription)")
                 }
-                callback(mono16k)
-            } else if bytesPerSample == 2 {
-                let int16Ptr = UnsafeRawPointer(dataPointer).bindMemory(to: Int16.self, capacity: sampleCount * channelCount)
-                var mono16k: [Float] = []
-                mono16k.reserveCapacity(sampleCount / decimationFactor)
-                for i in stride(from: 0, to: sampleCount, by: decimationFactor) {
-                    var sample: Float = 0
-                    for ch in 0..<channelCount {
-                        sample += Float(int16Ptr[i * channelCount + ch]) / Float(Int16.max)
-                    }
-                    mono16k.append(sample / Float(channelCount))
-                }
-                callback(mono16k)
             }
+
+            if !result.transcriptionSamples.isEmpty {
+                transcriptionBufferCallback?(result.transcriptionSamples)
+            }
+        } catch {
+            processingErrorCallback?(error)
+            logger.error("Failed to process system audio: \(error.localizedDescription)")
         }
     }
 
     func stream(_ stream: SCStream, didStopWithError error: any Error) {
+        processingErrorCallback?(error)
         logger.error("SCStream stopped with error: \(error.localizedDescription)")
     }
 }

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -74,6 +74,7 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var selectedTask: TranscriptionTask = .transcribe
     @Published var recordings: [RecordingItem] = []
     @Published var errorMessage: String?
+    @Published var systemAudioWarningMessage: String?
     @Published var partialText: String = ""
     @Published var isTranscribing: Bool = false
 
@@ -187,6 +188,11 @@ final class AudioRecorderViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in self?.systemLevel = value }
             .store(in: &cancellables)
+
+        recorderService.$systemAudioWarningMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in self?.systemAudioWarningMessage = value }
+            .store(in: &cancellables)
     }
 
     nonisolated static func canToggleRecording(
@@ -220,6 +226,7 @@ final class AudioRecorderViewModel: ObservableObject {
     func startRecording() {
         guard state == .idle else { return }
         errorMessage = nil
+        systemAudioWarningMessage = nil
         partialText = ""
         Task {
             do {

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -67,6 +67,12 @@ struct AudioRecorderView: View {
                         .foregroundStyle(.red)
                         .font(.callout)
                 }
+
+                if let warning = viewModel.systemAudioWarningMessage {
+                    Label(warning, systemImage: "speaker.slash")
+                        .foregroundStyle(.orange)
+                        .font(.callout)
+                }
             }
 
             // Transcribing indicator after stop

--- a/TypeWhisperTests/RecorderTranscriptionBufferTests.swift
+++ b/TypeWhisperTests/RecorderTranscriptionBufferTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 @testable import TypeWhisper
 
@@ -83,5 +84,252 @@ final class RecorderTranscriptionBufferTests: XCTestCase {
 
         XCTAssertEqual(delta.nextOffset, 4)
         XCTAssertEqual(delta.samples, [22, 3, 4])
+    }
+}
+
+final class SystemAudioSampleProcessorTests: XCTestCase {
+    func testProcessesStereoInterleavedFloat32Buffers() throws {
+        var samples: [Float] = [
+            0.2, 0.4,
+            -0.2, 0.2,
+            0, 0,
+            0.6, -0.6,
+            0.3, 0.3,
+            -0.3, 0.1,
+        ]
+        let asbd = makeAudioDescription(
+            sampleRate: 48_000,
+            channels: 2,
+            bitsPerChannel: 32,
+            flags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            bytesPerFrame: 8
+        )
+
+        let result = try samples.withUnsafeMutableBytes { bytes in
+            try withAudioBufferList([
+                .init(channels: 2, byteSize: UInt32(bytes.count), data: bytes.baseAddress)
+            ]) { bufferList in
+                try SystemAudioSampleProcessor.process(
+                    audioBufferList: bufferList,
+                    asbd: asbd,
+                    transcriptionSampleRate: 16_000
+                )
+            }
+        }
+
+        XCTAssertEqual(result.frameCount, 6)
+        XCTAssertEqual(result.pcmBuffer.format.channelCount, 2)
+        XCTAssertEqual(result.pcmBuffer.frameLength, 6)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![0], count: 6)), [0.2, -0.2, 0, 0.6, 0.3, -0.3])
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![1], count: 6)), [0.4, 0.2, 0, -0.6, 0.3, 0.1])
+        XCTAssertEqual(result.rms, rms(samples), accuracy: 0.0001)
+        XCTAssertEqual(result.level, min(1, rms(samples) * 5), accuracy: 0.0001)
+        XCTAssertFloats(result.transcriptionSamples, [0.3, 0])
+    }
+
+    func testProcessesStereoNonInterleavedFloat32Buffers() throws {
+        var left: [Float] = [0.1, -0.2, 0.4, 0.8]
+        var right: [Float] = [0.3, 0.2, -0.4, 0]
+        let asbd = makeAudioDescription(
+            sampleRate: 16_000,
+            channels: 2,
+            bitsPerChannel: 32,
+            flags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved,
+            bytesPerFrame: 4
+        )
+
+        let result = try left.withUnsafeMutableBytes { leftBytes in
+            try right.withUnsafeMutableBytes { rightBytes in
+                try withAudioBufferList([
+                    .init(channels: 1, byteSize: UInt32(leftBytes.count), data: leftBytes.baseAddress),
+                    .init(channels: 1, byteSize: UInt32(rightBytes.count), data: rightBytes.baseAddress),
+                ]) { bufferList in
+                    try SystemAudioSampleProcessor.process(
+                        audioBufferList: bufferList,
+                        asbd: asbd,
+                        transcriptionSampleRate: 16_000
+                    )
+                }
+            }
+        }
+
+        XCTAssertEqual(result.frameCount, 4)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![0], count: 4)), left)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![1], count: 4)), right)
+        XCTAssertFloats(result.transcriptionSamples, [0.2, 0, 0, 0.4])
+    }
+
+    func testProcessesStereoInterleavedInt16Buffers() throws {
+        var samples: [Int16] = [
+            16_384, -16_384,
+            32_767, 0,
+            -32_767, 32_767,
+            0, 0,
+        ]
+        let asbd = makeAudioDescription(
+            sampleRate: 16_000,
+            channels: 2,
+            bitsPerChannel: 16,
+            flags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            bytesPerFrame: 4
+        )
+        let expectedLeft = [Float(16_384) / Float(Int16.max), 1, -1, 0]
+        let expectedRight = [Float(-16_384) / Float(Int16.max), 0, 1, 0]
+
+        let result = try samples.withUnsafeMutableBytes { bytes in
+            try withAudioBufferList([
+                .init(channels: 2, byteSize: UInt32(bytes.count), data: bytes.baseAddress)
+            ]) { bufferList in
+                try SystemAudioSampleProcessor.process(
+                    audioBufferList: bufferList,
+                    asbd: asbd,
+                    transcriptionSampleRate: 16_000
+                )
+            }
+        }
+
+        XCTAssertEqual(result.frameCount, 4)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![0], count: 4)), expectedLeft)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![1], count: 4)), expectedRight)
+        XCTAssertFloats(result.transcriptionSamples, [
+            (expectedLeft[0] + expectedRight[0]) * 0.5,
+            0.5,
+            0,
+            0,
+        ])
+    }
+
+    func testProcessesStereoNonInterleavedInt16Buffers() throws {
+        var left: [Int16] = [16_384, -16_384, 0, 32_767]
+        var right: [Int16] = [0, 16_384, -32_767, -16_384]
+        let asbd = makeAudioDescription(
+            sampleRate: 16_000,
+            channels: 2,
+            bitsPerChannel: 16,
+            flags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved,
+            bytesPerFrame: 2
+        )
+        let expectedLeft = left.map { Float($0) / Float(Int16.max) }
+        let expectedRight = right.map { Float($0) / Float(Int16.max) }
+
+        let result = try left.withUnsafeMutableBytes { leftBytes in
+            try right.withUnsafeMutableBytes { rightBytes in
+                try withAudioBufferList([
+                    .init(channels: 1, byteSize: UInt32(leftBytes.count), data: leftBytes.baseAddress),
+                    .init(channels: 1, byteSize: UInt32(rightBytes.count), data: rightBytes.baseAddress),
+                ]) { bufferList in
+                    try SystemAudioSampleProcessor.process(
+                        audioBufferList: bufferList,
+                        asbd: asbd,
+                        transcriptionSampleRate: 16_000
+                    )
+                }
+            }
+        }
+
+        XCTAssertEqual(result.frameCount, 4)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![0], count: 4)), expectedLeft)
+        XCTAssertFloats(Array(UnsafeBufferPointer(start: result.pcmBuffer.floatChannelData![1], count: 4)), expectedRight)
+        XCTAssertFloats(result.transcriptionSamples, [
+            (expectedLeft[0] + expectedRight[0]) * 0.5,
+            0,
+            -0.5,
+            (expectedLeft[3] + expectedRight[3]) * 0.5,
+        ])
+    }
+
+    func testSystemAudioDiagnosticsWarnsWhenNoUsableAudioArrivesAfterGracePeriod() {
+        var diagnostics = SystemAudioCaptureDiagnostics()
+        let startedAt = Date(timeIntervalSince1970: 10)
+        diagnostics.beginSession(startedAt: startedAt)
+
+        XCTAssertNil(diagnostics.noAudioWarningIfNeeded(now: startedAt.addingTimeInterval(1), gracePeriod: 2))
+        XCTAssertEqual(
+            diagnostics.noAudioWarningIfNeeded(now: startedAt.addingTimeInterval(3), gracePeriod: 2),
+            AudioRecorderService.noSystemAudioDetectedWarning
+        )
+
+        diagnostics.recordProcessedBuffer(frameCount: 256, rms: 0.000001, nonSilentThreshold: 0.0001)
+        XCTAssertEqual(
+            diagnostics.noAudioWarningIfNeeded(now: startedAt.addingTimeInterval(4), gracePeriod: 2),
+            AudioRecorderService.noSystemAudioDetectedWarning
+        )
+
+        diagnostics.recordProcessedBuffer(frameCount: 256, rms: 0.01, nonSilentThreshold: 0.0001)
+        XCTAssertNil(diagnostics.noAudioWarningIfNeeded(now: startedAt.addingTimeInterval(5), gracePeriod: 2))
+    }
+}
+
+private struct TestAudioBuffer {
+    let channels: UInt32
+    let byteSize: UInt32
+    let data: UnsafeMutableRawPointer?
+}
+
+private func withAudioBufferList<T>(
+    _ buffers: [TestAudioBuffer],
+    _ body: (UnsafeMutableAudioBufferListPointer) throws -> T
+) rethrows -> T {
+    let byteCount = MemoryLayout<AudioBufferList>.size
+        + max(0, buffers.count - 1) * MemoryLayout<AudioBuffer>.size
+    let rawPointer = UnsafeMutableRawPointer.allocate(
+        byteCount: byteCount,
+        alignment: MemoryLayout<AudioBufferList>.alignment
+    )
+    defer { rawPointer.deallocate() }
+    rawPointer.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+
+    let audioBufferList = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
+    audioBufferList.pointee.mNumberBuffers = UInt32(buffers.count)
+    let mutableList = UnsafeMutableAudioBufferListPointer(audioBufferList)
+    for index in buffers.indices {
+        mutableList[index] = AudioBuffer(
+            mNumberChannels: buffers[index].channels,
+            mDataByteSize: buffers[index].byteSize,
+            mData: buffers[index].data
+        )
+    }
+
+    return try body(mutableList)
+}
+
+private func makeAudioDescription(
+    sampleRate: Double,
+    channels: UInt32,
+    bitsPerChannel: UInt32,
+    flags: AudioFormatFlags,
+    bytesPerFrame: UInt32
+) -> AudioStreamBasicDescription {
+    AudioStreamBasicDescription(
+        mSampleRate: sampleRate,
+        mFormatID: kAudioFormatLinearPCM,
+        mFormatFlags: flags,
+        mBytesPerPacket: bytesPerFrame,
+        mFramesPerPacket: 1,
+        mBytesPerFrame: bytesPerFrame,
+        mChannelsPerFrame: channels,
+        mBitsPerChannel: bitsPerChannel,
+        mReserved: 0
+    )
+}
+
+private func rms<T: BinaryFloatingPoint>(_ values: [T]) -> Float {
+    let sum = values.reduce(Float(0)) { partial, value in
+        let sample = Float(value)
+        return partial + sample * sample
+    }
+    return sqrt(sum / Float(values.count))
+}
+
+private func XCTAssertFloats(
+    _ actual: [Float],
+    _ expected: [Float],
+    accuracy: Float = 0.0001,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    XCTAssertEqual(actual.count, expected.count, file: file, line: line)
+    for (actual, expected) in zip(actual, expected) {
+        XCTAssertEqual(actual, expected, accuracy: accuracy, file: file, line: line)
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the ScreenCaptureKit system-audio `dataBuffer` path with AudioBufferList extraction via `CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer`.
- Converts interleaved and non-interleaved Float32/Int16 system-audio buffers into PCM file buffers, level metering, and 16 kHz mono transcription samples.
- Adds non-fatal recorder diagnostics and a visible warning when system audio capture starts but no usable non-silent system audio is detected.

## Issue context
FaceTime or other call-style sources could produce apparently successful recordings with silent system-audio tracks. This hardens the native ScreenCaptureKit path without introducing BlackHole or any virtual audio driver dependency. If Browser audio records but FaceTime still stays silent, the app now surfaces that no system audio was detected instead of silently producing a misleading capture.

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/SystemAudioSampleProcessorTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper`
- Built and launched the dev app with `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/45db/typewhisper-mac`

## Manual testing still recommended
- With System Audio enabled, record Browser audio and confirm `systemLevel` moves and the saved recording contains browser playback.
- With System Audio enabled and no playback, confirm the warning appears.
- With FaceTime, confirm whether the remote participant is captured or classified by the warning as no detectable system audio.