### PR TITLE
Fix selected USB mic capture with mismatched output clocks

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreAudio
 import AudioToolbox
+import AudioUnit
 @preconcurrency import AVFoundation
 import Combine
 import os
@@ -101,6 +102,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private let transportResolver: AudioDeviceTransportResolving
     private let bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing
     private let selectionEngineValidator: AudioInputSelectionEngineValidating
+    private let inputCaptureFactory: AudioInputCaptureFactory
 
     var selectedDeviceID: AudioDeviceID? {
         guard let uid = selectedDeviceUID else { return nil }
@@ -120,6 +122,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     private var listenerBlock: AudioObjectPropertyListenerBlock?
     private var previewEngine: AVAudioEngine?
+    private var previewInputCaptureSession: AudioInputCaptureSession?
     private var previewConfigChangeObserver: NSObjectProtocol?
     private let deviceChangeSubject = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
@@ -176,12 +179,14 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         transportResolver: AudioDeviceTransportResolving = CoreAudioDeviceTransportResolver(),
         bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
         selectionEngineValidator: AudioInputSelectionEngineValidating = AVAudioInputSelectionEngineValidator(),
+        inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory(),
         inputActivationGuard: AudioInputDeviceActivating = AudioInputDeviceActivationGuard()
     ) {
         self.outputVolumeGuard = outputVolumeGuard
         self.transportResolver = transportResolver
         self.bluetoothInputRouteStabilizer = bluetoothInputRouteStabilizer
         self.selectionEngineValidator = selectionEngineValidator
+        self.inputCaptureFactory = inputCaptureFactory
         self.inputActivationGuard = inputActivationGuard
         previewNotificationQueue.underlyingQueue = previewRecoveryQueue
         isInitializingSelection = true
@@ -228,7 +233,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
 
         let usesBluetoothPreviewInput = previewInputUsesBluetoothTransport(preferredDeviceID)
-        let enginePreferredDeviceID = AudioEngineInputRoute.preferredDeviceIDForEngine(
+        let captureRoute = AudioInputCaptureRoute.selectedRoute(
             selectedDeviceID: preferredDeviceID,
             usesBluetoothTransport: usesBluetoothPreviewInput
         )
@@ -262,7 +267,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         if let startPreviewOverride {
             do {
-                try startPreviewOverride(enginePreferredDeviceID)
+                try startPreviewOverride(captureRoute.avAudioEnginePreferredDeviceID)
                 outputVolumeGuard.restoreIfRaised(reason: "preview-start-override")
                 outputVolumeGuard.clear()
                 isPreviewActive = true
@@ -286,9 +291,38 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             return
         }
 
+        if case .inputOnlyDevice(let inputOnlyDeviceID) = captureRoute {
+            do {
+                try startInputOnlyPreviewCapture(deviceID: inputOnlyDeviceID, label: "preview")
+                if selectedDeviceUID != nil {
+                    markSelectedDeviceCompatibility(.compatible)
+                }
+                outputVolumeGuard.restoreIfRaised(reason: "preview-start")
+                outputVolumeGuard.clear()
+                isPreviewActive = true
+            } catch let error as SelectedInputDeviceError {
+                if case .incompatible(let issue) = error {
+                    markSelectedDeviceCompatibility(.incompatible(issue))
+                }
+                previewError = error
+                cleanupAfterFailedInputOnlyPreviewStart()
+            } catch {
+                logger.error("Failed to start input-only preview capture: \(error.localizedDescription)")
+                if selectedDeviceUID != nil {
+                    markSelectedDeviceCompatibility(.incompatible(.engineStartFailed))
+                    previewError = .incompatible(.engineStartFailed)
+                }
+                cleanupAfterFailedInputOnlyPreviewStart()
+            }
+            return
+        }
+
+        let enginePreferredDeviceID = captureRoute.avAudioEnginePreferredDeviceID
+
         let engine = AVAudioEngine()
         previewLock.withLock {
             previewEngine = engine
+            previewInputCaptureSession = nil
             activePreviewDeviceID = enginePreferredDeviceID
             activePreviewUsesBluetoothTransport = usesBluetoothPreviewInput
             bluetoothPreviewConfigurationChangeIgnoreUntil = nil
@@ -344,10 +378,20 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             bluetoothPreviewConfigurationChangeIgnoreUntil = nil
             return engine
         }
+        let inputCaptureSession: AudioInputCaptureSession? = previewLock.withLock {
+            let session = previewInputCaptureSession
+            previewInputCaptureSession = nil
+            return session
+        }
         if let engine {
             outputVolumeGuard.captureBaseline()
             teardownPreviewEngine(engine)
             previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
+            outputVolumeGuard.restoreIfRaised(reason: "preview-stop")
+        }
+        if let inputCaptureSession {
+            outputVolumeGuard.captureBaseline()
+            inputCaptureSession.stop()
             outputVolumeGuard.restoreIfRaised(reason: "preview-stop")
         }
         outputVolumeGuard.clear()
@@ -367,8 +411,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     }
 
     private func processPreviewBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard let channelData = buffer.floatChannelData?[0] else { return }
-        let frames = Int(buffer.frameLength)
+        guard let monoBuffer = AudioInputBufferNormalizer.monoFloatBuffer(from: buffer),
+              let channelData = monoBuffer.floatChannelData?[0] else { return }
+        let frames = Int(monoBuffer.frameLength)
         var sum: Float = 0
         for i in 0..<frames {
             let sample = channelData[i]
@@ -380,6 +425,26 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             guard let self, self.isPreviewActive else { return }
             self.previewAudioLevel = level
             self.previewRawLevel = rms
+        }
+    }
+
+    private func startInputOnlyPreviewCapture(deviceID: AudioDeviceID, label: String) throws {
+        let session = try inputCaptureFactory.startInputOnlyCapture(
+            deviceID: deviceID,
+            label: label,
+            bufferSize: 1024
+        ) { [weak self] buffer in
+            self?.processPreviewBuffer(buffer)
+        }
+
+        previewRecoveryCoordinator.transitionToIdle()
+        removePreviewConfigurationObserver()
+        previewLock.withLock {
+            previewEngine = nil
+            previewInputCaptureSession = session
+            activePreviewDeviceID = deviceID
+            activePreviewUsesBluetoothTransport = false
+            bluetoothPreviewConfigurationChangeIgnoreUntil = nil
         }
     }
 
@@ -413,7 +478,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         let (engine, preferredDeviceID): (AVAudioEngine?, AudioDeviceID?) = previewLock.withLock {
             (previewEngine, activePreviewDeviceID)
         }
-        guard isPreviewActive, let engine else { return }
+        let hasInputOnlyCapture = previewLock.withLock { previewInputCaptureSession != nil }
+        guard isPreviewActive, !hasInputOnlyCapture, let engine else { return }
 
         logger.warning("Preview audio engine configuration changed, restarting engine")
 
@@ -447,10 +513,16 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             bluetoothPreviewConfigurationChangeIgnoreUntil = nil
             return engine
         }
+        let inputCaptureSession: AudioInputCaptureSession? = previewLock.withLock {
+            let session = previewInputCaptureSession
+            previewInputCaptureSession = nil
+            return session
+        }
         if let engine {
             teardownPreviewEngine(engine)
             previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
         }
+        inputCaptureSession?.stop()
         outputVolumeGuard.restoreIfRaised(reason: "preview-recovery-failure")
         outputVolumeGuard.clear()
         inputActivationGuard.restore(reason: "preview-recovery-failure")
@@ -652,6 +724,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         previewLock.withLock {
             if previewEngine === engine {
                 previewEngine = nil
+                previewInputCaptureSession = nil
                 activePreviewDeviceID = nil
                 activePreviewUsesBluetoothTransport = false
                 bluetoothPreviewConfigurationChangeIgnoreUntil = nil
@@ -659,6 +732,27 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
         teardownPreviewEngine(engine)
         previewEngineTeardownRetainer.retain(engine, for: Self.previewEngineTeardownRetentionInterval)
+        outputVolumeGuard.restoreIfRaised(reason: "preview-start-failed")
+        outputVolumeGuard.clear()
+        inputActivationGuard.restore(reason: "preview-start-failed")
+        isPreviewActive = false
+        previewAudioLevel = 0
+        previewRawLevel = 0
+    }
+
+    private func cleanupAfterFailedInputOnlyPreviewStart() {
+        previewRecoveryCoordinator.transitionToIdle()
+        removePreviewConfigurationObserver()
+        let session: AudioInputCaptureSession? = previewLock.withLock {
+            let session = previewInputCaptureSession
+            previewInputCaptureSession = nil
+            previewEngine = nil
+            activePreviewDeviceID = nil
+            activePreviewUsesBluetoothTransport = false
+            bluetoothPreviewConfigurationChangeIgnoreUntil = nil
+            return session
+        }
+        session?.stop()
         outputVolumeGuard.restoreIfRaised(reason: "preview-start-failed")
         outputVolumeGuard.clear()
         inputActivationGuard.restore(reason: "preview-start-failed")
@@ -1055,7 +1149,18 @@ protocol AudioInputSelectionEngineValidating: AnyObject {
 }
 
 final class AVAudioInputSelectionEngineValidator: AudioInputSelectionEngineValidating {
+    private let inputCaptureFactory: AudioInputCaptureFactory
+
+    init(inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory()) {
+        self.inputCaptureFactory = inputCaptureFactory
+    }
+
     func validate(preferredDeviceID: AudioDeviceID?) throws {
+        if let preferredDeviceID {
+            try inputCaptureFactory.validateInputOnlyDevice(deviceID: preferredDeviceID, label: "selection")
+            return
+        }
+
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
 
@@ -1183,6 +1288,459 @@ enum AudioEngineInputRoute {
     ) -> AudioDeviceID? {
         guard let selectedDeviceID else { return nil }
         return usesBluetoothTransport ? nil : selectedDeviceID
+    }
+}
+
+enum AudioInputCaptureRoute: Equatable {
+    case avAudioEngine(preferredDeviceID: AudioDeviceID?)
+    case inputOnlyDevice(AudioDeviceID)
+
+    var avAudioEnginePreferredDeviceID: AudioDeviceID? {
+        switch self {
+        case .avAudioEngine(let preferredDeviceID):
+            return preferredDeviceID
+        case .inputOnlyDevice:
+            return nil
+        }
+    }
+
+    static func selectedRoute(
+        selectedDeviceID: AudioDeviceID?,
+        usesBluetoothTransport: Bool
+    ) -> AudioInputCaptureRoute {
+        guard let selectedDeviceID else {
+            return .avAudioEngine(preferredDeviceID: nil)
+        }
+        guard !usesBluetoothTransport else {
+            return .avAudioEngine(preferredDeviceID: nil)
+        }
+        return .inputOnlyDevice(selectedDeviceID)
+    }
+}
+
+protocol AudioInputCaptureSession: AnyObject {
+    func stop()
+}
+
+protocol AudioInputCaptureFactory: AnyObject {
+    func inputOnlyCaptureFormat(deviceID: AudioDeviceID) throws -> AVAudioFormat
+    func validateInputOnlyDevice(deviceID: AudioDeviceID, label: String) throws
+    func startInputOnlyCapture(
+        deviceID: AudioDeviceID,
+        label: String,
+        bufferSize: AVAudioFrameCount,
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void
+    ) throws -> AudioInputCaptureSession
+}
+
+final class CoreAudioHALInputCaptureFactory: AudioInputCaptureFactory {
+    private let operations: CoreAudioHALInputOperating
+
+    init(operations: CoreAudioHALInputOperating = CoreAudioHALInputOperations()) {
+        self.operations = operations
+    }
+
+    func inputOnlyCaptureFormat(deviceID: AudioDeviceID) throws -> AVAudioFormat {
+        try CoreAudioHALInputCaptureSession.captureFormat(for: deviceID)
+    }
+
+    func validateInputOnlyDevice(deviceID: AudioDeviceID, label: String) throws {
+        let session = try startInputOnlyCapture(
+            deviceID: deviceID,
+            label: label,
+            bufferSize: 128,
+            onBuffer: { _ in }
+        )
+        session.stop()
+    }
+
+    func startInputOnlyCapture(
+        deviceID: AudioDeviceID,
+        label: String,
+        bufferSize: AVAudioFrameCount,
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void
+    ) throws -> AudioInputCaptureSession {
+        let format = try inputOnlyCaptureFormat(deviceID: deviceID)
+        do {
+            return try CoreAudioHALInputCaptureSession(
+                deviceID: deviceID,
+                format: format,
+                bufferSize: bufferSize,
+                label: label,
+                operations: operations,
+                onBuffer: onBuffer
+            )
+        } catch let error as SelectedInputDeviceError {
+            throw error
+        } catch {
+            throw SelectedInputDeviceError.incompatible(.engineStartFailed)
+        }
+    }
+}
+
+protocol CoreAudioHALInputOperating: AnyObject {
+    func makeInputUnit() throws -> AudioUnit
+    func setEnableIO(
+        _ enabled: UInt32,
+        scope: AudioUnitScope,
+        element: AudioUnitElement,
+        audioUnit: AudioUnit,
+        label: String
+    ) throws
+    func setCurrentDevice(_ deviceID: AudioDeviceID, audioUnit: AudioUnit, label: String) throws
+    func setStreamFormat(_ streamDescription: inout AudioStreamBasicDescription, audioUnit: AudioUnit, label: String) throws
+    func setInputCallback(_ callback: inout AURenderCallbackStruct, audioUnit: AudioUnit, label: String) throws
+    func initialize(_ audioUnit: AudioUnit, label: String) throws
+    func start(_ audioUnit: AudioUnit, label: String) throws
+    func stop(_ audioUnit: AudioUnit)
+    func uninitialize(_ audioUnit: AudioUnit)
+    func dispose(_ audioUnit: AudioUnit)
+    func render(
+        audioUnit: AudioUnit,
+        actionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+        timestamp: UnsafePointer<AudioTimeStamp>,
+        busNumber: UInt32,
+        frameCount: UInt32,
+        data: UnsafeMutablePointer<AudioBufferList>
+    ) -> OSStatus
+}
+
+private struct CoreAudioHALInputOperationError: Error {
+    let operation: String
+    let status: OSStatus
+}
+
+final class CoreAudioHALInputOperations: CoreAudioHALInputOperating {
+    func makeInputUnit() throws -> AudioUnit {
+        var description = AudioComponentDescription(
+            componentType: kAudioUnitType_Output,
+            componentSubType: kAudioUnitSubType_HALOutput,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0
+        )
+
+        guard let component = AudioComponentFindNext(nil, &description) else {
+            throw CoreAudioHALInputOperationError(operation: "find HAL output component", status: -1)
+        }
+
+        var audioUnit: AudioUnit?
+        let status = AudioComponentInstanceNew(component, &audioUnit)
+        guard status == noErr, let audioUnit else {
+            throw CoreAudioHALInputOperationError(operation: "create HAL input unit", status: status)
+        }
+        return audioUnit
+    }
+
+    func setEnableIO(
+        _ enabled: UInt32,
+        scope: AudioUnitScope,
+        element: AudioUnitElement,
+        audioUnit: AudioUnit,
+        label: String
+    ) throws {
+        var enabled = enabled
+        try setProperty(
+            kAudioOutputUnitProperty_EnableIO,
+            scope: scope,
+            element: element,
+            audioUnit: audioUnit,
+            valueSize: UInt32(MemoryLayout<UInt32>.size),
+            value: &enabled,
+            operation: "\(label) set EnableIO scope=\(scope) element=\(element)"
+        )
+    }
+
+    func setCurrentDevice(_ deviceID: AudioDeviceID, audioUnit: AudioUnit, label: String) throws {
+        var deviceID = deviceID
+        do {
+            try setProperty(
+                kAudioOutputUnitProperty_CurrentDevice,
+                scope: kAudioUnitScope_Global,
+                element: 0,
+                audioUnit: audioUnit,
+                valueSize: UInt32(MemoryLayout<AudioDeviceID>.size),
+                value: &deviceID,
+                operation: "\(label) set current input device"
+            )
+        } catch let error as CoreAudioHALInputOperationError {
+            deviceHelperLogger.error("[\(label)] Could not set HAL input device \(deviceID): status=\(error.status)")
+            throw SelectedInputDeviceError.incompatible(.cannotSetDevice)
+        }
+    }
+
+    func setStreamFormat(_ streamDescription: inout AudioStreamBasicDescription, audioUnit: AudioUnit, label: String) throws {
+        try setProperty(
+            kAudioUnitProperty_StreamFormat,
+            scope: kAudioUnitScope_Output,
+            element: 1,
+            audioUnit: audioUnit,
+            valueSize: UInt32(MemoryLayout<AudioStreamBasicDescription>.size),
+            value: &streamDescription,
+            operation: "\(label) set HAL input stream format"
+        )
+    }
+
+    func setInputCallback(_ callback: inout AURenderCallbackStruct, audioUnit: AudioUnit, label: String) throws {
+        try setProperty(
+            kAudioOutputUnitProperty_SetInputCallback,
+            scope: kAudioUnitScope_Global,
+            element: 0,
+            audioUnit: audioUnit,
+            valueSize: UInt32(MemoryLayout<AURenderCallbackStruct>.size),
+            value: &callback,
+            operation: "\(label) set HAL input callback"
+        )
+    }
+
+    func initialize(_ audioUnit: AudioUnit, label: String) throws {
+        let status = AudioUnitInitialize(audioUnit)
+        guard status == noErr else {
+            throw CoreAudioHALInputOperationError(operation: "\(label) initialize HAL input unit", status: status)
+        }
+    }
+
+    func start(_ audioUnit: AudioUnit, label: String) throws {
+        let status = AudioOutputUnitStart(audioUnit)
+        guard status == noErr else {
+            throw CoreAudioHALInputOperationError(operation: "\(label) start HAL input unit", status: status)
+        }
+    }
+
+    func stop(_ audioUnit: AudioUnit) {
+        AudioOutputUnitStop(audioUnit)
+    }
+
+    func uninitialize(_ audioUnit: AudioUnit) {
+        AudioUnitUninitialize(audioUnit)
+    }
+
+    func dispose(_ audioUnit: AudioUnit) {
+        AudioComponentInstanceDispose(audioUnit)
+    }
+
+    func render(
+        audioUnit: AudioUnit,
+        actionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+        timestamp: UnsafePointer<AudioTimeStamp>,
+        busNumber: UInt32,
+        frameCount: UInt32,
+        data: UnsafeMutablePointer<AudioBufferList>
+    ) -> OSStatus {
+        AudioUnitRender(audioUnit, actionFlags, timestamp, busNumber, frameCount, data)
+    }
+
+    private func setProperty<T>(
+        _ propertyID: AudioUnitPropertyID,
+        scope: AudioUnitScope,
+        element: AudioUnitElement,
+        audioUnit: AudioUnit,
+        valueSize: UInt32,
+        value: inout T,
+        operation: String
+    ) throws {
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            propertyID,
+            scope,
+            element,
+            &value,
+            valueSize
+        )
+        guard status == noErr else {
+            throw CoreAudioHALInputOperationError(operation: operation, status: status)
+        }
+    }
+}
+
+final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecked Sendable {
+    final class RenderState: @unchecked Sendable {
+        let audioUnit: AudioUnit
+        let operations: CoreAudioHALInputOperating
+        let format: AVAudioFormat
+        let onBuffer: (AVAudioPCMBuffer) -> Void
+
+        init(
+            audioUnit: AudioUnit,
+            operations: CoreAudioHALInputOperating,
+            format: AVAudioFormat,
+            onBuffer: @escaping (AVAudioPCMBuffer) -> Void
+        ) {
+            self.audioUnit = audioUnit
+            self.operations = operations
+            self.format = format
+            self.onBuffer = onBuffer
+        }
+    }
+
+    private let audioUnit: AudioUnit
+    private let operations: CoreAudioHALInputOperating
+    private let renderState: RenderState
+    private let lock = NSLock()
+    private var isStopped = false
+
+    init(
+        deviceID: AudioDeviceID,
+        format: AVAudioFormat,
+        bufferSize: AVAudioFrameCount,
+        label: String,
+        operations: CoreAudioHALInputOperating,
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void
+    ) throws {
+        self.operations = operations
+
+        let audioUnit = try operations.makeInputUnit()
+        self.audioUnit = audioUnit
+
+        do {
+            var disabled: UInt32 = 0
+            var enabled: UInt32 = 1
+            try operations.setEnableIO(disabled, scope: kAudioUnitScope_Output, element: 0, audioUnit: audioUnit, label: label)
+            try operations.setEnableIO(enabled, scope: kAudioUnitScope_Input, element: 1, audioUnit: audioUnit, label: label)
+            try operations.setCurrentDevice(deviceID, audioUnit: audioUnit, label: label)
+
+            var streamDescription = try Self.streamDescription(for: format)
+            try operations.setStreamFormat(&streamDescription, audioUnit: audioUnit, label: label)
+
+            let renderState = RenderState(
+                audioUnit: audioUnit,
+                operations: operations,
+                format: format,
+                onBuffer: onBuffer
+            )
+            self.renderState = renderState
+            var callback = AURenderCallbackStruct(
+                inputProc: coreAudioHALInputRenderCallback,
+                inputProcRefCon: Unmanaged.passUnretained(renderState).toOpaque()
+            )
+            try operations.setInputCallback(&callback, audioUnit: audioUnit, label: label)
+            try operations.initialize(audioUnit, label: label)
+            try operations.start(audioUnit, label: label)
+
+            deviceHelperLogger.info("[\(label)] Started input-only HAL capture for device \(deviceID), sampleRate=\(format.sampleRate), channels=\(format.channelCount), bufferSize=\(bufferSize)")
+        } catch {
+            operations.stop(audioUnit)
+            operations.uninitialize(audioUnit)
+            operations.dispose(audioUnit)
+            throw error
+        }
+    }
+
+    static func captureFormat(for deviceID: AudioDeviceID) throws -> AVAudioFormat {
+        guard let hardwareFormat = AudioInputFormatStabilizer.expectedHardwareFormat(for: deviceID),
+              let format = AVAudioFormat(
+                  commonFormat: .pcmFormatFloat32,
+                  sampleRate: hardwareFormat.sampleRate,
+                  channels: hardwareFormat.channelCount,
+                  interleaved: false
+              ) else {
+            throw SelectedInputDeviceError.incompatible(.invalidInputFormat)
+        }
+        return format
+    }
+
+    func stop() {
+        let shouldStop = lock.withLock { () -> Bool in
+            guard !isStopped else { return false }
+            isStopped = true
+            return true
+        }
+        guard shouldStop else { return }
+        operations.stop(audioUnit)
+        operations.uninitialize(audioUnit)
+        operations.dispose(audioUnit)
+    }
+
+    private static func streamDescription(for format: AVAudioFormat) throws -> AudioStreamBasicDescription {
+        let streamDescription = format.streamDescription.pointee
+        guard streamDescription.mFormatID == kAudioFormatLinearPCM,
+              streamDescription.mChannelsPerFrame > 0,
+              streamDescription.mSampleRate > 0 else {
+            throw SelectedInputDeviceError.incompatible(.invalidInputFormat)
+        }
+        return streamDescription
+    }
+}
+
+private func coreAudioHALInputRenderCallback(
+    inRefCon: UnsafeMutableRawPointer,
+    ioActionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+    inTimeStamp: UnsafePointer<AudioTimeStamp>,
+    inBusNumber: UInt32,
+    inNumberFrames: UInt32,
+    ioData: UnsafeMutablePointer<AudioBufferList>?
+) -> OSStatus {
+    let renderState = Unmanaged<CoreAudioHALInputCaptureSession.RenderState>
+        .fromOpaque(inRefCon)
+        .takeUnretainedValue()
+
+    guard let buffer = AVAudioPCMBuffer(
+        pcmFormat: renderState.format,
+        frameCapacity: AVAudioFrameCount(inNumberFrames)
+    ) else {
+        return kAudioUnitErr_InvalidPropertyValue
+    }
+    buffer.frameLength = AVAudioFrameCount(inNumberFrames)
+
+    let status = renderState.operations.render(
+        audioUnit: renderState.audioUnit,
+        actionFlags: ioActionFlags,
+        timestamp: inTimeStamp,
+        busNumber: 1,
+        frameCount: inNumberFrames,
+        data: buffer.mutableAudioBufferList
+    )
+    guard status == noErr else { return status }
+
+    renderState.onBuffer(buffer)
+    return noErr
+}
+
+enum AudioInputBufferNormalizer {
+    static func monoFloatFormat(for format: AVAudioFormat) -> AVAudioFormat? {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: format.sampleRate,
+            channels: 1,
+            interleaved: false
+        )
+    }
+
+    static func monoFloatBuffer(from buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard buffer.frameLength > 0,
+              buffer.format.sampleRate > 0,
+              let sourceChannels = buffer.floatChannelData else {
+            return nil
+        }
+
+        let frameCount = Int(buffer.frameLength)
+        let channelCount = Int(buffer.format.channelCount)
+        guard channelCount > 0 else { return nil }
+
+        if channelCount == 1,
+           buffer.format.commonFormat == .pcmFormatFloat32,
+           !buffer.format.isInterleaved {
+            return buffer
+        }
+
+        guard let monoFormat = monoFloatFormat(for: buffer.format),
+              let monoBuffer = AVAudioPCMBuffer(
+                  pcmFormat: monoFormat,
+                  frameCapacity: buffer.frameLength
+              ),
+              let monoChannel = monoBuffer.floatChannelData?[0] else {
+            return nil
+        }
+
+        monoBuffer.frameLength = buffer.frameLength
+        for frameIndex in 0..<frameCount {
+            var sum: Float = 0
+            for channelIndex in 0..<channelCount {
+                sum += sourceChannels[channelIndex][frameIndex]
+            }
+            monoChannel[frameIndex] = sum / Float(channelCount)
+        }
+        return monoBuffer
     }
 }
 

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -1440,12 +1440,11 @@ final class CoreAudioHALInputOperations: CoreAudioHALInputOperating {
         label: String
     ) throws {
         var enabled = enabled
-        try setProperty(
+        try setUInt32Property(
             kAudioOutputUnitProperty_EnableIO,
             scope: scope,
             element: element,
             audioUnit: audioUnit,
-            valueSize: UInt32(MemoryLayout<UInt32>.size),
             value: &enabled,
             operation: "\(label) set EnableIO scope=\(scope) element=\(element)"
         )
@@ -1454,12 +1453,11 @@ final class CoreAudioHALInputOperations: CoreAudioHALInputOperating {
     func setCurrentDevice(_ deviceID: AudioDeviceID, audioUnit: AudioUnit, label: String) throws {
         var deviceID = deviceID
         do {
-            try setProperty(
+            try setUInt32Property(
                 kAudioOutputUnitProperty_CurrentDevice,
                 scope: kAudioUnitScope_Global,
                 element: 0,
                 audioUnit: audioUnit,
-                valueSize: UInt32(MemoryLayout<AudioDeviceID>.size),
                 value: &deviceID,
                 operation: "\(label) set current input device"
             )
@@ -1470,24 +1468,22 @@ final class CoreAudioHALInputOperations: CoreAudioHALInputOperating {
     }
 
     func setStreamFormat(_ streamDescription: inout AudioStreamBasicDescription, audioUnit: AudioUnit, label: String) throws {
-        try setProperty(
+        try setStreamDescriptionProperty(
             kAudioUnitProperty_StreamFormat,
             scope: kAudioUnitScope_Output,
             element: 1,
             audioUnit: audioUnit,
-            valueSize: UInt32(MemoryLayout<AudioStreamBasicDescription>.size),
             value: &streamDescription,
             operation: "\(label) set HAL input stream format"
         )
     }
 
     func setInputCallback(_ callback: inout AURenderCallbackStruct, audioUnit: AudioUnit, label: String) throws {
-        try setProperty(
+        try setInputCallbackProperty(
             kAudioOutputUnitProperty_SetInputCallback,
             scope: kAudioUnitScope_Global,
             element: 0,
             audioUnit: audioUnit,
-            valueSize: UInt32(MemoryLayout<AURenderCallbackStruct>.size),
             value: &callback,
             operation: "\(label) set HAL input callback"
         )
@@ -1530,23 +1526,70 @@ final class CoreAudioHALInputOperations: CoreAudioHALInputOperating {
         AudioUnitRender(audioUnit, actionFlags, timestamp, busNumber, frameCount, data)
     }
 
-    private func setProperty<T>(
+    private func setUInt32Property(
         _ propertyID: AudioUnitPropertyID,
         scope: AudioUnitScope,
         element: AudioUnitElement,
         audioUnit: AudioUnit,
-        valueSize: UInt32,
-        value: inout T,
+        value: inout UInt32,
         operation: String
     ) throws {
-        let status = AudioUnitSetProperty(
-            audioUnit,
-            propertyID,
-            scope,
-            element,
-            &value,
-            valueSize
-        )
+        let status = withUnsafePointer(to: &value) { pointer in
+            AudioUnitSetProperty(
+                audioUnit,
+                propertyID,
+                scope,
+                element,
+                pointer,
+                UInt32(MemoryLayout<UInt32>.size)
+            )
+        }
+        try checkPropertyStatus(status, operation: operation)
+    }
+
+    private func setStreamDescriptionProperty(
+        _ propertyID: AudioUnitPropertyID,
+        scope: AudioUnitScope,
+        element: AudioUnitElement,
+        audioUnit: AudioUnit,
+        value: inout AudioStreamBasicDescription,
+        operation: String
+    ) throws {
+        let status = withUnsafePointer(to: &value) { pointer in
+            AudioUnitSetProperty(
+                audioUnit,
+                propertyID,
+                scope,
+                element,
+                pointer,
+                UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+            )
+        }
+        try checkPropertyStatus(status, operation: operation)
+    }
+
+    private func setInputCallbackProperty(
+        _ propertyID: AudioUnitPropertyID,
+        scope: AudioUnitScope,
+        element: AudioUnitElement,
+        audioUnit: AudioUnit,
+        value: inout AURenderCallbackStruct,
+        operation: String
+    ) throws {
+        let status = withUnsafePointer(to: &value) { pointer in
+            AudioUnitSetProperty(
+                audioUnit,
+                propertyID,
+                scope,
+                element,
+                pointer,
+                UInt32(MemoryLayout<AURenderCallbackStruct>.size)
+            )
+        }
+        try checkPropertyStatus(status, operation: operation)
+    }
+
+    private func checkPropertyStatus(_ status: OSStatus, operation: String) throws {
         guard status == noErr else {
             throw CoreAudioHALInputOperationError(operation: operation, status: status)
         }
@@ -1593,8 +1636,8 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
         self.audioUnit = audioUnit
 
         do {
-            var disabled: UInt32 = 0
-            var enabled: UInt32 = 1
+            let disabled: UInt32 = 0
+            let enabled: UInt32 = 1
             try operations.setEnableIO(disabled, scope: kAudioUnitScope_Output, element: 0, audioUnit: audioUnit, label: label)
             try operations.setEnableIO(enabled, scope: kAudioUnitScope_Input, element: 1, audioUnit: audioUnit, label: label)
             try operations.setCurrentDevice(deviceID, audioUnit: audioUnit, label: label)

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -127,6 +127,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private var audioEngine: AVAudioEngine?
+    private var inputCaptureSession: AudioInputCaptureSession?
     private var startupConfigurationChangeGuard: StartupConfigurationChangeGuard?
     private var configChangeObserver: NSObjectProtocol?
     private var sampleBuffer: [Float] = []
@@ -143,6 +144,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let inputActivationGuard: AudioInputDeviceActivating
     private let bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing
     private let inputReadinessChecker: AudioInputReadinessChecking
+    private let inputCaptureFactory: AudioInputCaptureFactory
     private let initialInputTapSeenLock = OSAllocatedUnfairLock(initialState: false)
     private var _lastStopGraceCaptureApplied = false
 
@@ -154,12 +156,14 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         outputVolumeGuard: AudioOutputVolumeGuard = AudioOutputVolumeGuard(),
         inputActivationGuard: AudioInputDeviceActivating = AudioInputDeviceActivationGuard(),
         bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
-        inputReadinessChecker: AudioInputReadinessChecking = BluetoothInputReadinessChecker()
+        inputReadinessChecker: AudioInputReadinessChecking = BluetoothInputReadinessChecker(),
+        inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory()
     ) {
         self.outputVolumeGuard = outputVolumeGuard
         self.inputActivationGuard = inputActivationGuard
         self.bluetoothInputRouteStabilizer = bluetoothInputRouteStabilizer
         self.inputReadinessChecker = inputReadinessChecker
+        self.inputCaptureFactory = inputCaptureFactory
         recoveryNotificationQueue.underlyingQueue = recoveryQueue
     }
 
@@ -309,9 +313,23 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             return
         }
 
+        if case .inputOnlyDevice(let inputOnlyDeviceID) = selectedCaptureRoute {
+            do {
+                try startInputOnlyRecording(deviceID: inputOnlyDeviceID, label: "recording")
+                outputVolumeGuard.restoreIfRaised(reason: "recording-start")
+                outputVolumeGuard.clear()
+                isRecording = true
+            } catch {
+                cleanupAfterFailedInputOnlyStart()
+                throw error
+            }
+            return
+        }
+
         let engine = AVAudioEngine()
         engineLock.withLock {
             audioEngine = engine
+            inputCaptureSession = nil
             startupConfigurationChangeGuard = nil
         }
         recoveryCoordinator.beginStarting()
@@ -372,13 +390,48 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         // Atomically claim the engine - only the first concurrent caller proceeds
-        let engine: AVAudioEngine? = engineLock.withLock {
-            let e = audioEngine
+        let capture: (engine: AVAudioEngine?, inputCaptureSession: AudioInputCaptureSession?) = engineLock.withLock {
+            let capture = (engine: audioEngine, inputCaptureSession: inputCaptureSession)
             audioEngine = nil
+            inputCaptureSession = nil
             startupConfigurationChangeGuard = nil
-            return e
+            return capture
         }
-        guard let engine else {
+        if let inputCaptureSession = capture.inputCaptureSession {
+            let bufferedDuration = totalBufferDuration
+            var graceApplied = false
+
+            if policy.shouldApplyGracePeriod(bufferedDuration: bufferedDuration),
+               case .finalizeShortSpeech(_, let maxExtraCapture, let pollInterval) = policy {
+                let deadline = Date().addingTimeInterval(maxExtraCapture)
+                graceApplied = true
+
+                while Date() < deadline, policy.shouldApplyGracePeriod(bufferedDuration: totalBufferDuration) {
+                    try? await Task.sleep(for: .seconds(pollInterval))
+                }
+            }
+
+            setLastStopGraceCaptureApplied(graceApplied)
+            recoveryCoordinator.transitionToIdle()
+            removeConfigurationObserver()
+            outputVolumeGuard.captureBaseline()
+            inputCaptureSession.stop()
+            outputVolumeGuard.restoreIfRaised(reason: "recording-stop")
+            outputVolumeGuard.clear()
+            inputActivationGuard.restore(reason: "recording-stop")
+            processingQueue.sync { }
+
+            let samples = drainSampleBuffer()
+
+            DispatchQueue.main.async { [weak self] in
+                self?.isRecording = false
+                self?.audioLevel = 0
+            }
+
+            return samples
+        }
+
+        guard let engine = capture.engine else {
             outputVolumeGuard.clear()
             return []
         }
@@ -699,6 +752,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private var selectedCaptureRoute: AudioInputCaptureRoute {
+        configLock.withLock {
+            AudioInputCaptureRoute.selectedRoute(
+                selectedDeviceID: _hasExplicitDeviceSelection ? _selectedDeviceID : nil,
+                usesBluetoothTransport: _hasExplicitDeviceSelection && _selectedInputDeviceUsesBluetoothTransport
+            )
+        }
+    }
+
     private var hasCapturedInitialInput: Bool {
         initialInputTapSeenLock.withLock { $0 }
     }
@@ -744,6 +806,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let didReplace = engineLock.withLock { () -> Bool in
             guard audioEngine === engine else { return false }
             audioEngine = replacementEngine
+            inputCaptureSession = nil
             startupConfigurationChangeGuard = nil
             return true
         }
@@ -757,6 +820,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             if audioEngine === engine {
                 audioEngine = nil
             }
+            inputCaptureSession = nil
             if startupConfigurationChangeGuard?.engineID == ObjectIdentifier(engine) {
                 startupConfigurationChangeGuard = nil
             }
@@ -850,6 +914,70 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         processingQueue.async { [weak self] in
             self?.processConvertedSamples(samples)
+        }
+    }
+
+    private func startInputOnlyRecording(deviceID: AudioDeviceID, label: String) throws {
+        do {
+            let inputFormat = try inputCaptureFactory.inputOnlyCaptureFormat(deviceID: deviceID)
+            guard let monoFormat = AudioInputBufferNormalizer.monoFloatFormat(for: inputFormat),
+                  let targetFormat = AVAudioFormat(
+                      commonFormat: .pcmFormatFloat32,
+                      sampleRate: Self.targetSampleRate,
+                      channels: 1,
+                      interleaved: false
+                  ),
+                  let converter = AVAudioConverter(from: monoFormat, to: targetFormat) else {
+                throw AudioRecordingError.engineStartFailed("Cannot create input-only audio converter")
+            }
+
+            let session = try inputCaptureFactory.startInputOnlyCapture(
+                deviceID: deviceID,
+                label: label,
+                bufferSize: Self.captureTapFrames
+            ) { [weak self] buffer in
+                guard let self,
+                      let monoBuffer = AudioInputBufferNormalizer.monoFloatBuffer(from: buffer) else {
+                    return
+                }
+                self.markInitialInputTapSeenIfNeeded(monoBuffer)
+                self.processAudioBuffer(monoBuffer, converter: converter, targetFormat: targetFormat)
+            }
+
+            recoveryCoordinator.transitionToIdle()
+            removeConfigurationObserver()
+            engineLock.withLock {
+                audioEngine = nil
+                inputCaptureSession = session
+                startupConfigurationChangeGuard = nil
+            }
+        } catch let error as SelectedInputDeviceError {
+            throw mapSelectedInputDeviceError(error)
+        } catch let error as AudioRecordingError {
+            throw error
+        } catch {
+            throw AudioRecordingError.engineStartFailed(error.localizedDescription)
+        }
+    }
+
+    private func cleanupAfterFailedInputOnlyStart() {
+        recoveryCoordinator.transitionToIdle()
+        removeConfigurationObserver()
+        let session: AudioInputCaptureSession? = engineLock.withLock {
+            let session = inputCaptureSession
+            inputCaptureSession = nil
+            audioEngine = nil
+            startupConfigurationChangeGuard = nil
+            return session
+        }
+        session?.stop()
+        outputVolumeGuard.restoreIfRaised(reason: "recording-start-failed")
+        outputVolumeGuard.clear()
+        inputActivationGuard.restore(reason: "recording-start-failed")
+        DispatchQueue.main.async { [weak self] in
+            self?.isRecording = false
+            self?.audioLevel = 0
+            self?.rawAudioLevel = 0
         }
     }
 
@@ -1032,6 +1160,7 @@ extension AudioRecordingService {
     func testingSetAudioEngine(_ engine: AVAudioEngine?) {
         engineLock.withLock {
             audioEngine = engine
+            inputCaptureSession = nil
         }
     }
 

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1,4 +1,5 @@
 import AudioToolbox
+import AudioUnit
 import AVFoundation
 import XCTest
 @testable import TypeWhisper
@@ -100,6 +101,62 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
             ),
             AudioDeviceID(410)
         )
+    }
+
+    func testCaptureRouteUsesInputOnlyHALForExplicitNonBluetoothSelection() {
+        XCTAssertEqual(
+            AudioInputCaptureRoute.selectedRoute(
+                selectedDeviceID: AudioDeviceID(410),
+                usesBluetoothTransport: false
+            ),
+            .inputOnlyDevice(AudioDeviceID(410))
+        )
+    }
+
+    func testCaptureRouteKeepsAVAudioEngineForDefaultAndBluetoothSelection() {
+        XCTAssertEqual(
+            AudioInputCaptureRoute.selectedRoute(
+                selectedDeviceID: nil,
+                usesBluetoothTransport: false
+            ),
+            .avAudioEngine(preferredDeviceID: nil)
+        )
+        XCTAssertEqual(
+            AudioInputCaptureRoute.selectedRoute(
+                selectedDeviceID: AudioDeviceID(112),
+                usesBluetoothTransport: true
+            ),
+            .avAudioEngine(preferredDeviceID: nil)
+        )
+    }
+
+    func testAudioInputBufferNormalizerDownmixesMultiChannelFloatBuffers() throws {
+        let stereoFormat = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 96_000,
+            channels: 2,
+            interleaved: false
+        ))
+        let stereoBuffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: stereoFormat,
+            frameCapacity: 3
+        ))
+        stereoBuffer.frameLength = 3
+        stereoBuffer.floatChannelData?[0][0] = 1
+        stereoBuffer.floatChannelData?[0][1] = 0.5
+        stereoBuffer.floatChannelData?[0][2] = -1
+        stereoBuffer.floatChannelData?[1][0] = -1
+        stereoBuffer.floatChannelData?[1][1] = 0.5
+        stereoBuffer.floatChannelData?[1][2] = 1
+
+        let monoBuffer = try XCTUnwrap(AudioInputBufferNormalizer.monoFloatBuffer(from: stereoBuffer))
+
+        XCTAssertEqual(monoBuffer.format.sampleRate, 96_000)
+        XCTAssertEqual(monoBuffer.format.channelCount, 1)
+        let monoChannel = try XCTUnwrap(monoBuffer.floatChannelData?[0])
+        XCTAssertEqual(monoChannel[0], 0, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[1], 0.5, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[2], 0, accuracy: Float(0.0001))
     }
 
     func testInputFormatStabilizerRejectsStaleDefaultFormatAfterBluetoothDeviceSwitch() {
@@ -447,6 +504,38 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(service.selectedDeviceCompatibility, .compatible)
     }
 
+    func testSelectingUSBDeviceValidatesWithInputOnlyCaptureInsteadOfAVAudioEngineProbe() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let usbDeviceID = AudioDeviceID(712)
+        let inputCaptureFactory = FakeAudioInputCaptureFactory()
+        let transportResolver = FakeAudioDeviceTransportResolver(
+            transports: [usbDeviceID: kAudioDeviceTransportTypeUSB]
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: usbDeviceID, name: "Elgato Wave XLR", uid: "wave-xlr")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: transportResolver,
+            selectionEngineValidator: AVAudioInputSelectionEngineValidator(inputCaptureFactory: inputCaptureFactory),
+            inputCaptureFactory: inputCaptureFactory
+        )
+
+        service.audioDeviceIDResolverOverride = { uid in
+            uid == "wave-xlr" ? usbDeviceID : nil
+        }
+
+        service.selectedDeviceUID = "wave-xlr"
+
+        XCTAssertEqual(service.selectedDeviceUID, "wave-xlr")
+        XCTAssertNil(service.previewError)
+        XCTAssertEqual(inputCaptureFactory.validateCalls, [
+            .init(deviceID: usbDeviceID, label: "selection")
+        ])
+        XCTAssertEqual(service.selectedDeviceCompatibility, .compatible)
+    }
+
     func testDisplayName_marksIncompatibleDevicesWithoutRemovingThem() {
         let device = AudioInputDevice(
             deviceID: AudioDeviceID(42),
@@ -603,9 +692,10 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testStartPreviewKeepsExplicitEngineRouteForUSBInput() {
+    func testStartPreviewUsesInputOnlyCaptureForUSBInput() {
         let usbDeviceID = AudioDeviceID(711)
         let inputActivationGuard = FakeAudioInputDeviceActivator()
+        let inputCaptureFactory = FakeAudioInputCaptureFactory()
         let transportResolver = FakeAudioDeviceTransportResolver(
             transports: [usbDeviceID: kAudioDeviceTransportTypeUSB]
         ) { deviceID in
@@ -618,6 +708,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             monitorDeviceChanges: false,
             probeCompatibilities: false,
             transportResolver: transportResolver,
+            inputCaptureFactory: inputCaptureFactory,
             inputActivationGuard: inputActivationGuard
         )
 
@@ -627,16 +718,18 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             uid == "usb-input" ? usbDeviceID : nil
         }
         service.selectedDeviceUID = "usb-input"
-        service.startPreviewOverride = { preferredDeviceID in
-            XCTAssertEqual(preferredDeviceID, usbDeviceID)
-        }
 
         service.startPreview()
 
         XCTAssertTrue(inputActivationGuard.activateCalls.isEmpty)
+        XCTAssertEqual(inputCaptureFactory.startCalls, [
+            .init(deviceID: usbDeviceID, label: "preview", bufferSize: 1024)
+        ])
         XCTAssertTrue(service.isPreviewActive)
 
         service.stopPreview()
+
+        XCTAssertEqual(inputCaptureFactory.createdSessions.first?.stopCalls, 1)
     }
 }
 
@@ -962,6 +1055,32 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertTrue(inputActivationGuard.activateCalls.isEmpty)
     }
 
+    func testStartRecordingUsesInputOnlyCaptureForExplicitUSBInput() async throws {
+        let usbDeviceID = AudioDeviceID(730)
+        let inputCaptureFactory = FakeAudioInputCaptureFactory()
+        let service = AudioRecordingService(inputCaptureFactory: inputCaptureFactory)
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = true
+        service.selectedDeviceID = usbDeviceID
+        service.selectedInputDeviceUsesBluetoothTransport = false
+        service.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertEqual(selectedDeviceID, usbDeviceID)
+            return true
+        }
+
+        try service.startRecording()
+
+        XCTAssertTrue(service.isRecording)
+        XCTAssertEqual(inputCaptureFactory.startCalls, [
+            .init(deviceID: usbDeviceID, label: "recording", bufferSize: 1024)
+        ])
+
+        let samples = await service.stopRecording(policy: .immediate)
+
+        XCTAssertTrue(samples.isEmpty)
+        XCTAssertEqual(inputCaptureFactory.createdSessions.first?.stopCalls, 1)
+    }
+
     func testRecoveryEngineSwap_replacesStoredEngineInstance() {
         let service = AudioRecordingService()
         let originalEngine = AVAudioEngine()
@@ -1027,6 +1146,89 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
 
         XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: mismatchedFormat))
         XCTAssertFalse(service.testingConsumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: expectedFormat))
+    }
+}
+
+final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
+    func testSessionConfiguresInputOnlyHALUnitAndPullsInputFromRenderCallback() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 96_000,
+            channels: 2,
+            interleaved: false
+        ))
+        var receivedBuffers: [AVAudioPCMBuffer] = []
+
+        let session = try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(900),
+            format: format,
+            bufferSize: 256,
+            label: "test-hal",
+            operations: operations
+        ) { buffer in
+            receivedBuffers.append(buffer)
+        }
+
+        XCTAssertEqual(operations.enableIOCalls, [
+            .init(enabled: 0, scope: kAudioUnitScope_Output, element: 0),
+            .init(enabled: 1, scope: kAudioUnitScope_Input, element: 1)
+        ])
+        XCTAssertEqual(operations.currentDeviceCalls, [AudioDeviceID(900)])
+        XCTAssertEqual(operations.streamFormatCalls.first?.mSampleRate, 96_000)
+        XCTAssertEqual(operations.streamFormatCalls.first?.mChannelsPerFrame, 2)
+        XCTAssertEqual(operations.initializeCalls, 1)
+        XCTAssertEqual(operations.startCalls, 1)
+        XCTAssertNotNil(operations.inputCallback)
+
+        var flags = AudioUnitRenderActionFlags()
+        var timestamp = AudioTimeStamp()
+        let callback = try XCTUnwrap(operations.inputCallback)
+        let callbackStatus = try XCTUnwrap(callback.inputProc)(
+            try XCTUnwrap(callback.inputProcRefCon),
+            &flags,
+            &timestamp,
+            1,
+            64,
+            nil
+        )
+
+        XCTAssertEqual(callbackStatus, noErr)
+        XCTAssertEqual(operations.renderCalls, [
+            .init(busNumber: 1, frameCount: 64)
+        ])
+        XCTAssertEqual(receivedBuffers.count, 1)
+        XCTAssertEqual(receivedBuffers.first?.format.sampleRate, 96_000)
+        XCTAssertEqual(receivedBuffers.first?.format.channelCount, 2)
+
+        session.stop()
+
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testSessionMapsCurrentDeviceFailureToSelectedInputCompatibilityError() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        operations.currentDeviceError = SelectedInputDeviceError.incompatible(.cannotSetDevice)
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+
+        XCTAssertThrowsError(try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(901),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )) { error in
+            XCTAssertEqual(error as? SelectedInputDeviceError, .incompatible(.cannotSetDevice))
+        }
+        XCTAssertEqual(operations.disposeCalls, 1)
     }
 }
 
@@ -1287,6 +1489,155 @@ private final class FakeAudioInputSelectionEngineValidator: AudioInputSelectionE
 
     func validate(preferredDeviceID: AudioDeviceID?) throws {
         try handler(preferredDeviceID)
+    }
+}
+
+private final class FakeAudioInputCaptureSession: AudioInputCaptureSession {
+    private(set) var stopCalls = 0
+
+    func stop() {
+        stopCalls += 1
+    }
+}
+
+private final class FakeAudioInputCaptureFactory: AudioInputCaptureFactory {
+    struct ValidateCall: Equatable {
+        let deviceID: AudioDeviceID
+        let label: String
+    }
+
+    struct StartCall: Equatable {
+        let deviceID: AudioDeviceID
+        let label: String
+        let bufferSize: AVAudioFrameCount
+    }
+
+    private let format: AVAudioFormat
+    var inputFormatError: Error?
+    var validateError: Error?
+    var startError: Error?
+    private(set) var inputFormatCalls: [AudioDeviceID] = []
+    private(set) var validateCalls: [ValidateCall] = []
+    private(set) var startCalls: [StartCall] = []
+    private(set) var createdSessions: [FakeAudioInputCaptureSession] = []
+
+    init(format: AVAudioFormat? = nil) {
+        self.format = format ?? AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 96_000,
+            channels: 2,
+            interleaved: false
+        )!
+    }
+
+    func inputOnlyCaptureFormat(deviceID: AudioDeviceID) throws -> AVAudioFormat {
+        inputFormatCalls.append(deviceID)
+        if let inputFormatError { throw inputFormatError }
+        return format
+    }
+
+    func validateInputOnlyDevice(deviceID: AudioDeviceID, label: String) throws {
+        validateCalls.append(.init(deviceID: deviceID, label: label))
+        if let validateError { throw validateError }
+    }
+
+    func startInputOnlyCapture(
+        deviceID: AudioDeviceID,
+        label: String,
+        bufferSize: AVAudioFrameCount,
+        onBuffer: @escaping (AVAudioPCMBuffer) -> Void
+    ) throws -> AudioInputCaptureSession {
+        startCalls.append(.init(deviceID: deviceID, label: label, bufferSize: bufferSize))
+        if let startError { throw startError }
+        let session = FakeAudioInputCaptureSession()
+        createdSessions.append(session)
+        return session
+    }
+}
+
+private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating {
+    struct EnableIOCall: Equatable {
+        let enabled: UInt32
+        let scope: AudioUnitScope
+        let element: AudioUnitElement
+    }
+
+    struct RenderCall: Equatable {
+        let busNumber: UInt32
+        let frameCount: UInt32
+    }
+
+    let audioUnit: AudioUnit = AudioUnit(bitPattern: 0x1)!
+    var currentDeviceError: Error?
+    var renderStatus: OSStatus = noErr
+    private(set) var enableIOCalls: [EnableIOCall] = []
+    private(set) var currentDeviceCalls: [AudioDeviceID] = []
+    private(set) var streamFormatCalls: [AudioStreamBasicDescription] = []
+    private(set) var inputCallback: AURenderCallbackStruct?
+    private(set) var initializeCalls = 0
+    private(set) var startCalls = 0
+    private(set) var stopCalls = 0
+    private(set) var uninitializeCalls = 0
+    private(set) var disposeCalls = 0
+    private(set) var renderCalls: [RenderCall] = []
+
+    func makeInputUnit() throws -> AudioUnit {
+        audioUnit
+    }
+
+    func setEnableIO(
+        _ enabled: UInt32,
+        scope: AudioUnitScope,
+        element: AudioUnitElement,
+        audioUnit: AudioUnit,
+        label: String
+    ) throws {
+        enableIOCalls.append(.init(enabled: enabled, scope: scope, element: element))
+    }
+
+    func setCurrentDevice(_ deviceID: AudioDeviceID, audioUnit: AudioUnit, label: String) throws {
+        if let currentDeviceError { throw currentDeviceError }
+        currentDeviceCalls.append(deviceID)
+    }
+
+    func setStreamFormat(_ streamDescription: inout AudioStreamBasicDescription, audioUnit: AudioUnit, label: String) throws {
+        streamFormatCalls.append(streamDescription)
+    }
+
+    func setInputCallback(_ callback: inout AURenderCallbackStruct, audioUnit: AudioUnit, label: String) throws {
+        inputCallback = callback
+    }
+
+    func initialize(_ audioUnit: AudioUnit, label: String) throws {
+        initializeCalls += 1
+    }
+
+    func start(_ audioUnit: AudioUnit, label: String) throws {
+        startCalls += 1
+    }
+
+    func stop(_ audioUnit: AudioUnit) {
+        stopCalls += 1
+    }
+
+    func uninitialize(_ audioUnit: AudioUnit) {
+        uninitializeCalls += 1
+    }
+
+    func dispose(_ audioUnit: AudioUnit) {
+        disposeCalls += 1
+    }
+
+    func render(
+        audioUnit: AudioUnit,
+        actionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+        timestamp: UnsafePointer<AudioTimeStamp>,
+        busNumber: UInt32,
+        frameCount: UInt32,
+        data: UnsafeMutablePointer<AudioBufferList>
+    ) -> OSStatus {
+        renderCalls.append(.init(busNumber: busNumber, frameCount: frameCount))
+        return renderStatus
     }
 }
 


### PR DESCRIPTION
## Issue Context

Issue #473 reports that selecting an Elgato Wave XLR USB microphone can mark the device as `(Not compatible)` when the selected input and current default output run on different clocks, for example Wave XLR input at 96 kHz with an LG TV default output at 44.1 kHz. The affected route repeatedly logs CoreAudio `-10877` (`kAudioUnitErr_InvalidElement`) through the AVAudioEngine/AUHAL full-duplex path.

## Changes

- Add an internal input-only CoreAudio HAL capture path for explicit non-Bluetooth input devices.
- Keep AVAudioEngine routing for default input and Bluetooth selections, preserving existing route activation, stabilization, and recovery behavior.
- Route selected-device validation, preview, and dictation recording through the capture abstraction so USB interfaces avoid stale AVAudioEngine input-node formats.
- Downmix Float32 multi-channel input buffers to mono before the existing 16 kHz conversion path.
- Add regression tests for capture route selection, HAL setup wiring, selected-device validation, preview, and dictation recording.

Closes #473

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/a470/typewhisper-mac`

## Manual Validation

Automated tests and the dev build passed locally. Hardware-specific Wave XLR validation with a separate default output clock is still pending because the affected hardware setup is not available in this environment.
