### PR TITLE
Add speaker diarization SDK path with AssemblyAI reference

### DIFF
--- a/TypeWhisper/Models/TranscriptionResult.swift
+++ b/TypeWhisper/Models/TranscriptionResult.swift
@@ -4,6 +4,22 @@ struct TranscriptionSegment {
     let text: String
     let start: TimeInterval
     let end: TimeInterval
+    let speakerLabel: String?
+    let speakerConfidence: Double?
+
+    init(
+        text: String,
+        start: TimeInterval,
+        end: TimeInterval,
+        speakerLabel: String? = nil,
+        speakerConfidence: Double? = nil
+    ) {
+        self.text = text
+        self.start = start
+        self.end = end
+        self.speakerLabel = speakerLabel
+        self.speakerConfidence = speakerConfidence
+    }
 }
 
 struct TranscriptionResult {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -346,6 +346,25 @@ final class APIHandlers: @unchecked Sendable {
                     let start: Double
                     let end: Double
                     let text: String
+                    let speaker: String?
+                    let speakerConfidence: Double?
+
+                    enum CodingKeys: String, CodingKey {
+                        case start
+                        case end
+                        case text
+                        case speaker
+                        case speakerConfidence = "speaker_confidence"
+                    }
+
+                    func encode(to encoder: Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try container.encode(start, forKey: .start)
+                        try container.encode(end, forKey: .end)
+                        try container.encode(text, forKey: .text)
+                        try container.encodeIfPresent(speaker, forKey: .speaker)
+                        try container.encodeIfPresent(speakerConfidence, forKey: .speakerConfidence)
+                    }
                 }
 
                 struct VerboseResponse: Encodable {
@@ -359,7 +378,13 @@ final class APIHandlers: @unchecked Sendable {
                 }
 
                 let segments = result.segments.map {
-                    SegmentEntry(start: $0.start, end: $0.end, text: $0.text)
+                    SegmentEntry(
+                        start: $0.start,
+                        end: $0.end,
+                        text: $0.text,
+                        speaker: $0.speakerLabel,
+                        speakerConfidence: $0.speakerConfidence
+                    )
                 }
 
                 return .json(VerboseResponse(

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -316,7 +316,7 @@ final class ModelManagerService: ObservableObject {
             duration: bufferedDuration,
             processingTime: processingTime,
             engineUsed: handle.providerId,
-            segments: result.segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }
+            segments: Self.transcriptionSegments(from: result.segments)
         )
     }
 
@@ -383,7 +383,7 @@ final class ModelManagerService: ObservableObject {
             duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
-            segments: result.segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }
+            segments: Self.transcriptionSegments(from: result.segments)
         )
     }
 
@@ -454,7 +454,7 @@ final class ModelManagerService: ObservableObject {
             duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
-            segments: result.segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }
+            segments: Self.transcriptionSegments(from: result.segments)
         )
     }
 
@@ -535,7 +535,9 @@ final class ModelManagerService: ObservableObject {
     }
 
     private func pluginSupportsLanguageHints(_ plugin: TranscriptionEnginePlugin) -> Bool {
-        plugin is LanguageHintTranscriptionEnginePlugin || plugin is LiveLanguageHintTranscriptionCapablePlugin
+        plugin is LanguageHintTranscriptionEnginePlugin
+            || plugin is StructuredLanguageHintTranscriptionEnginePlugin
+            || plugin is LiveLanguageHintTranscriptionCapablePlugin
     }
 
     private func transcribeWithResolvedLanguageSelection(
@@ -544,10 +546,10 @@ final class ModelManagerService: ObservableObject {
         languageSelection: PluginLanguageSelection,
         task: TranscriptionTask,
         prompt: String?
-    ) async throws -> PluginTranscriptionResult {
+    ) async throws -> PluginStructuredTranscriptionResult {
         if !languageSelection.languageHints.isEmpty,
-           let hintPlugin = plugin as? LanguageHintTranscriptionEnginePlugin {
-            return try await hintPlugin.transcribe(
+           let structuredHintPlugin = plugin as? StructuredLanguageHintTranscriptionEnginePlugin {
+            return try await structuredHintPlugin.transcribeStructured(
                 audio: audio,
                 languageSelection: languageSelection,
                 translate: task == .translate,
@@ -555,12 +557,31 @@ final class ModelManagerService: ObservableObject {
             )
         }
 
-        return try await plugin.transcribe(
+        if !languageSelection.languageHints.isEmpty,
+           let hintPlugin = plugin as? LanguageHintTranscriptionEnginePlugin {
+            return Self.structuredResult(from: try await hintPlugin.transcribe(
+                audio: audio,
+                languageSelection: languageSelection,
+                translate: task == .translate,
+                prompt: prompt
+            ))
+        }
+
+        if let structuredPlugin = plugin as? StructuredTranscriptionEnginePlugin {
+            return try await structuredPlugin.transcribeStructured(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                translate: task == .translate,
+                prompt: prompt
+            )
+        }
+
+        return Self.structuredResult(from: try await plugin.transcribe(
             audio: audio,
             language: languageSelection.requestedLanguage,
             translate: task == .translate,
             prompt: prompt
-        )
+        ))
     }
 
     private func transcribeWithResolvedLanguageSelection(
@@ -570,26 +591,50 @@ final class ModelManagerService: ObservableObject {
         task: TranscriptionTask,
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
-    ) async throws -> PluginTranscriptionResult {
+    ) async throws -> PluginStructuredTranscriptionResult {
+        if !languageSelection.languageHints.isEmpty,
+           let structuredHintPlugin = plugin as? StructuredLanguageHintTranscriptionEnginePlugin,
+           !plugin.supportsStreaming {
+            let result = try await structuredHintPlugin.transcribeStructured(
+                audio: audio,
+                languageSelection: languageSelection,
+                translate: task == .translate,
+                prompt: prompt
+            )
+            let _ = onProgress(result.text)
+            return result
+        }
+
         if !languageSelection.languageHints.isEmpty,
            let hintPlugin = plugin as? LanguageHintTranscriptionEnginePlugin {
-            return try await hintPlugin.transcribe(
+            return Self.structuredResult(from: try await hintPlugin.transcribe(
                 audio: audio,
                 languageSelection: languageSelection,
                 translate: task == .translate,
                 prompt: prompt,
                 onProgress: onProgress
-            )
+            ))
         }
 
         if plugin.supportsStreaming {
-            return try await plugin.transcribe(
+            return Self.structuredResult(from: try await plugin.transcribe(
                 audio: audio,
                 language: languageSelection.requestedLanguage,
                 translate: task == .translate,
                 prompt: prompt,
                 onProgress: onProgress
+            ))
+        }
+
+        if let structuredPlugin = plugin as? StructuredTranscriptionEnginePlugin {
+            let result = try await structuredPlugin.transcribeStructured(
+                audio: audio,
+                language: languageSelection.requestedLanguage,
+                translate: task == .translate,
+                prompt: prompt
             )
+            let _ = onProgress(result.text)
+            return result
         }
 
         let result = try await plugin.transcribe(
@@ -599,7 +644,39 @@ final class ModelManagerService: ObservableObject {
             prompt: prompt
         )
         let _ = onProgress(result.text)
-        return result
+        return Self.structuredResult(from: result)
+    }
+
+    nonisolated private static func structuredResult(
+        from result: PluginTranscriptionResult
+    ) -> PluginStructuredTranscriptionResult {
+        PluginStructuredTranscriptionResult(
+            text: result.text,
+            detectedLanguage: result.detectedLanguage,
+            segments: result.segments.map {
+                PluginStructuredTranscriptionSegment(text: $0.text, start: $0.start, end: $0.end)
+            }
+        )
+    }
+
+    nonisolated private static func transcriptionSegments(
+        from segments: [PluginStructuredTranscriptionSegment]
+    ) -> [TranscriptionSegment] {
+        segments.map {
+            TranscriptionSegment(
+                text: $0.text,
+                start: $0.start,
+                end: $0.end,
+                speakerLabel: $0.speakerLabel,
+                speakerConfidence: $0.speakerConfidence
+            )
+        }
+    }
+
+    nonisolated private static func transcriptionSegments(
+        from segments: [PluginTranscriptionSegment]
+    ) -> [TranscriptionSegment] {
+        segments.map { TranscriptionSegment(text: $0.text, start: $0.start, end: $0.end) }
     }
 
     /// Trigger model restore via ObjC dispatch (avoids Swift protocol witness table issues

--- a/TypeWhisper/Services/SubtitleExporter.swift
+++ b/TypeWhisper/Services/SubtitleExporter.swift
@@ -21,7 +21,7 @@ enum SubtitleExporter {
         segments.enumerated().map { index, segment in
             let start = formatSRTTime(segment.start)
             let end = formatSRTTime(segment.end)
-            return "\(index + 1)\n\(start) --> \(end)\n\(segment.text)"
+            return "\(index + 1)\n\(start) --> \(end)\n\(displayText(for: segment))"
         }.joined(separator: "\n\n")
     }
 
@@ -32,7 +32,7 @@ enum SubtitleExporter {
             let end = formatVTTTime(segment.end)
             lines.append("\(index + 1)")
             lines.append("\(start) --> \(end)")
-            lines.append(segment.text)
+            lines.append(displayText(for: segment))
             lines.append("")
         }
         return lines.joined(separator: "\n")
@@ -51,6 +51,19 @@ enum SubtitleExporter {
     }
 
     // MARK: - Time Formatting
+
+    private static func displayText(for segment: TranscriptionSegment) -> String {
+        guard let speakerLabel = segment.speakerLabel?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !speakerLabel.isEmpty else {
+            return segment.text
+        }
+
+        let trimmedText = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedText.hasPrefix("\(speakerLabel):") {
+            return segment.text
+        }
+        return "\(speakerLabel): \(segment.text)"
+    }
 
     private static func formatSRTTime(_ time: TimeInterval) -> String {
         let hours = Int(time) / 3600

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -72,6 +72,16 @@ let package = Package(
                 .process("manifest.json"),
             ]
         ),
+        .target(
+            name: "AssemblyAIPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/AssemblyAIPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
         .testTarget(
             name: "TypeWhisperPluginSDKTests",
             dependencies: ["TypeWhisperPluginSDK"]
@@ -129,6 +139,15 @@ let package = Package(
                 "LiveTranscriptPlugin",
             ],
             path: "Plugins/LiveTranscriptPlugin/Tests"
+        ),
+        .testTarget(
+            name: "AssemblyAIPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "AssemblyAIPlugin",
+            ],
+            path: "Plugins/AssemblyAIPlugin/Tests"
         ),
     ]
 )

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -37,13 +37,15 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(AssemblyAIPlugin)
-final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
+final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.assemblyai"
     static let pluginName = "AssemblyAI"
+    static let speakerDiarizationEnabledKey = "speakerDiarizationEnabled"
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedModelId: String?
+    fileprivate var _speakerDiarizationEnabled = false
 
     private let logger = Logger(subsystem: "com.typewhisper.assemblyai", category: "Plugin")
 
@@ -56,6 +58,7 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         _apiKey = host.loadSecret(key: "api-key")
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? transcriptionModels.first?.id
+        _speakerDiarizationEnabled = host.userDefault(forKey: Self.speakerDiarizationEnabledKey) as? Bool ?? false
     }
 
     func deactivate() {
@@ -90,6 +93,7 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
     var supportsStreaming: Bool { true }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
     var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryTermsBudget(for: _selectedModelId) }
+    var isSpeakerDiarizationEnabled: Bool { _speakerDiarizationEnabled }
 
     var supportedLanguages: [String] {
         if _selectedModelId == "universal-2" {
@@ -107,6 +111,20 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
     // MARK: - Transcription (REST Fallback)
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        try await Self.legacyResult(from: transcribeStructured(
+            audio: audio,
+            language: language,
+            translate: translate,
+            prompt: prompt
+        ))
+    }
+
+    func transcribeStructured(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginStructuredTranscriptionResult {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -119,7 +137,8 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             language: language,
             modelId: modelId,
             apiKey: apiKey,
-            prompt: prompt
+            prompt: prompt,
+            speakerDiarizationEnabled: _speakerDiarizationEnabled
         )
     }
 
@@ -147,13 +166,14 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             )
         } catch {
             logger.warning("WebSocket streaming failed, falling back to REST: \(error.localizedDescription)")
-            return try await transcribeREST(
+            return try await Self.legacyResult(from: transcribeREST(
                 audio: audio,
                 language: language,
                 modelId: modelId,
                 apiKey: apiKey,
-                prompt: prompt
-            )
+                prompt: prompt,
+                speakerDiarizationEnabled: _speakerDiarizationEnabled
+            ))
         }
     }
 
@@ -164,15 +184,17 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         language: String?,
         modelId: String,
         apiKey: String,
-        prompt: String?
-    ) async throws -> PluginTranscriptionResult {
+        prompt: String?,
+        speakerDiarizationEnabled: Bool
+    ) async throws -> PluginStructuredTranscriptionResult {
         let uploadURL = try await uploadAudio(wavData: audio.wavData, apiKey: apiKey)
         let transcriptId = try await submitTranscription(
             audioURL: uploadURL,
             modelId: modelId,
             language: language,
             apiKey: apiKey,
-            prompt: prompt
+            prompt: prompt,
+            speakerDiarizationEnabled: speakerDiarizationEnabled
         )
         return try await pollTranscription(transcriptId: transcriptId, apiKey: apiKey)
     }
@@ -216,23 +238,20 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         modelId: String,
         language: String?,
         apiKey: String,
-        prompt: String?
+        prompt: String?,
+        speakerDiarizationEnabled: Bool
     ) async throws -> String {
         guard let url = URL(string: "https://api.assemblyai.com/v2/transcript") else {
             throw PluginTranscriptionError.apiError("Invalid transcript URL")
         }
 
-        var body: [String: Any] = [
-            "audio_url": audioURL,
-            "speech_models": [modelId],
-        ]
-
-        if let lang = language, !lang.isEmpty {
-            body["language_code"] = lang
-        } else {
-            body["language_detection"] = true
-        }
-        Self.applyDictionaryTerms(prompt: prompt, modelId: modelId, to: &body)
+        let body = Self.makeSubmitTranscriptionBody(
+            audioURL: audioURL,
+            modelId: modelId,
+            language: language,
+            prompt: prompt,
+            speakerDiarizationEnabled: speakerDiarizationEnabled
+        )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -271,7 +290,33 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         return DictionaryTermsBudget(maxTerms: 100, maxCharsPerTerm: 50)
     }
 
-    private static func applyDictionaryTerms(prompt: String?, modelId: String, to body: inout [String: Any]) {
+    static func makeSubmitTranscriptionBody(
+        audioURL: String,
+        modelId: String,
+        language: String?,
+        prompt: String?,
+        speakerDiarizationEnabled: Bool
+    ) -> [String: Any] {
+        var body: [String: Any] = [
+            "audio_url": audioURL,
+            "speech_models": [modelId],
+        ]
+
+        if let lang = language, !lang.isEmpty {
+            body["language_code"] = lang
+        } else {
+            body["language_detection"] = true
+        }
+
+        if speakerDiarizationEnabled {
+            body["speaker_labels"] = true
+        }
+
+        applyDictionaryTerms(prompt: prompt, modelId: modelId, to: &body)
+        return body
+    }
+
+    static func applyDictionaryTerms(prompt: String?, modelId: String, to body: inout [String: Any]) {
         let terms = PluginDictionaryTerms.clippedTerms(
             from: PluginDictionaryTerms.terms(fromPrompt: prompt),
             budget: dictionaryTermsBudget(for: modelId)
@@ -286,7 +331,7 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         }
     }
 
-    private func pollTranscription(transcriptId: String, apiKey: String) async throws -> PluginTranscriptionResult {
+    private func pollTranscription(transcriptId: String, apiKey: String) async throws -> PluginStructuredTranscriptionResult {
         guard let url = URL(string: "https://api.assemblyai.com/v2/transcript/\(transcriptId)") else {
             throw PluginTranscriptionError.apiError("Invalid poll URL")
         }
@@ -311,9 +356,7 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
 
             switch status {
             case "completed":
-                let text = json["text"] as? String ?? ""
-                let detectedLanguage = json["language_code"] as? String
-                return PluginTranscriptionResult(text: text, detectedLanguage: detectedLanguage)
+                return Self.parseCompletedTranscriptionResponse(json)
             case "error":
                 let errorMsg = json["error"] as? String ?? "Unknown transcription error"
                 throw PluginTranscriptionError.apiError(errorMsg)
@@ -323,6 +366,102 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         }
 
         throw PluginTranscriptionError.apiError("Transcription timed out after 5 minutes")
+    }
+
+    static func parseCompletedTranscriptionResponse(_ json: [String: Any]) -> PluginStructuredTranscriptionResult {
+        let detectedLanguage = json["language_code"] as? String
+        let utterances = json["utterances"] as? [[String: Any]] ?? []
+
+        let segments = utterances.compactMap { utterance -> PluginStructuredTranscriptionSegment? in
+            let text = (utterance["text"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+
+            let start = milliseconds(from: utterance["start"]) ?? 0
+            let end = milliseconds(from: utterance["end"]) ?? start
+            let speakerLabel = normalizedSpeakerLabel(from: utterance["speaker"])
+            let confidence = double(from: utterance["confidence"])
+
+            return PluginStructuredTranscriptionSegment(
+                text: text,
+                start: start,
+                end: end,
+                speakerLabel: speakerLabel,
+                speakerConfidence: confidence
+            )
+        }
+
+        guard !segments.isEmpty else {
+            return PluginStructuredTranscriptionResult(
+                text: json["text"] as? String ?? "",
+                detectedLanguage: detectedLanguage
+            )
+        }
+
+        let text = segments
+            .map { segment in
+                if let speakerLabel = segment.speakerLabel {
+                    return "\(speakerLabel): \(segment.text)"
+                }
+                return segment.text
+            }
+            .joined(separator: "\n")
+
+        return PluginStructuredTranscriptionResult(
+            text: text,
+            detectedLanguage: detectedLanguage,
+            segments: segments
+        )
+    }
+
+    private static func legacyResult(
+        from structuredResult: PluginStructuredTranscriptionResult
+    ) -> PluginTranscriptionResult {
+        PluginTranscriptionResult(
+            text: structuredResult.text,
+            detectedLanguage: structuredResult.detectedLanguage,
+            segments: structuredResult.segments.map {
+                PluginTranscriptionSegment(text: $0.text, start: $0.start, end: $0.end)
+            }
+        )
+    }
+
+    private static func normalizedSpeakerLabel(from rawValue: Any?) -> String? {
+        let raw: String?
+        if let value = rawValue as? String {
+            raw = value
+        } else if let value = rawValue as? Int {
+            raw = "\(value)"
+        } else {
+            raw = nil
+        }
+
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.localizedCaseInsensitiveCompare("unknown") == .orderedSame {
+            return nil
+        }
+        if trimmed.localizedCaseInsensitiveContains("speaker") {
+            return trimmed
+        }
+        return "Speaker \(trimmed)"
+    }
+
+    private static func milliseconds(from value: Any?) -> Double? {
+        double(from: value).map { $0 / 1000.0 }
+    }
+
+    private static func double(from value: Any?) -> Double? {
+        if let value = value as? Double {
+            return value
+        }
+        if let value = value as? Int {
+            return Double(value)
+        }
+        if let value = value as? NSNumber {
+            return value.doubleValue
+        }
+        return nil
     }
 
     // MARK: - WebSocket Implementation (v3 Streaming)
@@ -519,6 +658,13 @@ final class AssemblyAIPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             host.notifyCapabilitiesChanged()
         }
     }
+
+    func setSpeakerDiarizationEnabled(_ enabled: Bool) {
+        guard _speakerDiarizationEnabled != enabled else { return }
+        _speakerDiarizationEnabled = enabled
+        host?.setUserDefault(enabled, forKey: Self.speakerDiarizationEnabledKey)
+        host?.notifyCapabilitiesChanged()
+    }
 }
 
 // MARK: - Settings View
@@ -530,6 +676,7 @@ private struct AssemblyAISettingsView: View {
     @State private var validationResult: Bool?
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
+    @State private var speakerDiarizationEnabled = false
     private let bundle = Bundle(for: AssemblyAIPlugin.self)
 
     var body: some View {
@@ -611,6 +758,11 @@ private struct AssemblyAISettingsView: View {
                         plugin.selectModel(selectedModel)
                     }
                 }
+
+                Toggle(String(localized: "Speaker diarization", bundle: bundle), isOn: $speakerDiarizationEnabled)
+                    .onChange(of: speakerDiarizationEnabled) {
+                        plugin.setSpeakerDiarizationEnabled(speakerDiarizationEnabled)
+                    }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -623,6 +775,7 @@ private struct AssemblyAISettingsView: View {
                 apiKeyInput = key
             }
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+            speakerDiarizationEnabled = plugin.isSpeakerDiarizationEnabled
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Localizable.xcstrings
@@ -61,6 +61,16 @@
         }
       }
     },
+    "Speaker diarization" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprechererkennung"
+          }
+        }
+      }
+    },
     "Valid API Key" : {
       "localizations" : {
         "de" : {

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import TypeWhisperPluginSDK
+import TypeWhisperPluginSDKTesting
+@testable import AssemblyAIPlugin
+
+final class AssemblyAIPluginTests: XCTestCase {
+    func testSpeakerDiarizationSettingPersistsAndNotifies() throws {
+        let host = try PluginTestHostServices()
+        let plugin = AssemblyAIPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.isSpeakerDiarizationEnabled)
+
+        plugin.setSpeakerDiarizationEnabled(true)
+
+        XCTAssertTrue(plugin.isSpeakerDiarizationEnabled)
+        XCTAssertEqual(host.userDefault(forKey: AssemblyAIPlugin.speakerDiarizationEnabledKey) as? Bool, true)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    func testSubmitBodyIncludesSpeakerLabelsOnlyWhenEnabled() {
+        var disabledBody = AssemblyAIPlugin.makeSubmitTranscriptionBody(
+            audioURL: "https://example.test/audio.wav",
+            modelId: "universal-3-pro",
+            language: nil,
+            prompt: nil,
+            speakerDiarizationEnabled: false
+        )
+        XCTAssertNil(disabledBody["speaker_labels"])
+
+        var enabledBody = AssemblyAIPlugin.makeSubmitTranscriptionBody(
+            audioURL: "https://example.test/audio.wav",
+            modelId: "universal-3-pro",
+            language: "en",
+            prompt: nil,
+            speakerDiarizationEnabled: true
+        )
+        XCTAssertEqual(enabledBody["speaker_labels"] as? Bool, true)
+        XCTAssertEqual(enabledBody["language_code"] as? String, "en")
+
+        AssemblyAIPlugin.applyDictionaryTerms(prompt: "TypeWhisper", modelId: "universal-3-pro", to: &disabledBody)
+        AssemblyAIPlugin.applyDictionaryTerms(prompt: "TypeWhisper", modelId: "universal-3-pro", to: &enabledBody)
+        XCTAssertEqual(disabledBody["keyterms_prompt"] as? [String], ["TypeWhisper"])
+        XCTAssertEqual(enabledBody["keyterms_prompt"] as? [String], ["TypeWhisper"])
+    }
+
+    func testCompletedResponseBuildsSpeakerLabeledStructuredSegments() {
+        let json: [String: Any] = [
+            "text": "fallback text",
+            "language_code": "en",
+            "utterances": [
+                [
+                    "speaker": "A",
+                    "text": "Hello",
+                    "start": 250,
+                    "end": 1500,
+                    "confidence": 0.93,
+                ],
+                [
+                    "speaker": "B",
+                    "text": "Hi",
+                    "start": 1500,
+                    "end": 2750,
+                ],
+            ],
+        ]
+
+        let result = AssemblyAIPlugin.parseCompletedTranscriptionResponse(json)
+
+        XCTAssertEqual(result.text, "Speaker A: Hello\nSpeaker B: Hi")
+        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.segments[0].text, "Hello")
+        XCTAssertEqual(result.segments[0].start, 0.25)
+        XCTAssertEqual(result.segments[0].end, 1.5)
+        XCTAssertEqual(result.segments[0].speakerLabel, "Speaker A")
+        XCTAssertEqual(result.segments[0].speakerConfidence, 0.93)
+        XCTAssertEqual(result.segments[1].speakerLabel, "Speaker B")
+        XCTAssertNil(result.segments[1].speakerConfidence)
+    }
+
+    func testCompletedResponseFallsBackToPlainTextWithoutUtterances() {
+        let result = AssemblyAIPlugin.parseCompletedTranscriptionResponse([
+            "text": "plain transcript",
+            "language_code": "de",
+        ])
+
+        XCTAssertEqual(result.text, "plain transcript")
+        XCTAssertEqual(result.detectedLanguage, "de")
+        XCTAssertTrue(result.segments.isEmpty)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.assemblyai",
     "name": "AssemblyAI",
     "version": "1.0.4",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -228,6 +228,44 @@ public struct PluginTranscriptionResult: Sendable {
     }
 }
 
+public struct PluginStructuredTranscriptionSegment: Sendable {
+    public let text: String
+    public let start: Double
+    public let end: Double
+    public let speakerLabel: String?
+    public let speakerConfidence: Double?
+
+    public init(
+        text: String,
+        start: Double,
+        end: Double,
+        speakerLabel: String? = nil,
+        speakerConfidence: Double? = nil
+    ) {
+        self.text = text
+        self.start = start
+        self.end = end
+        self.speakerLabel = speakerLabel
+        self.speakerConfidence = speakerConfidence
+    }
+}
+
+public struct PluginStructuredTranscriptionResult: Sendable {
+    public let text: String
+    public let detectedLanguage: String?
+    public let segments: [PluginStructuredTranscriptionSegment]
+
+    public init(
+        text: String,
+        detectedLanguage: String? = nil,
+        segments: [PluginStructuredTranscriptionSegment] = []
+    ) {
+        self.text = text
+        self.detectedLanguage = detectedLanguage
+        self.segments = segments
+    }
+}
+
 public struct PluginLanguageSelection: Sendable, Equatable {
     public let requestedLanguage: String?
     public let languageHints: [String]
@@ -375,6 +413,24 @@ public protocol TranscriptionEnginePlugin: TypeWhisperPlugin {
     var supportedLanguages: [String] { get }
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?,
                     onProgress: @Sendable @escaping (String) -> Bool) async throws -> PluginTranscriptionResult
+}
+
+public protocol StructuredTranscriptionEnginePlugin: TranscriptionEnginePlugin {
+    func transcribeStructured(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginStructuredTranscriptionResult
+}
+
+public protocol StructuredLanguageHintTranscriptionEnginePlugin: StructuredTranscriptionEnginePlugin {
+    func transcribeStructured(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginStructuredTranscriptionResult
 }
 
 public protocol DictionaryTermsBudgetProviding: TranscriptionEnginePlugin {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -175,6 +175,45 @@ private final class MockCatalogTranscriptionPlugin: NSObject, TranscriptionEngin
     }
 }
 
+@objc(MockStructuredTranscriptionPlugin)
+private final class MockStructuredTranscriptionPlugin: NSObject, StructuredTranscriptionEnginePlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.structured"
+    static let pluginName = "Mock Structured"
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    var providerId: String { "mock-structured" }
+    var providerDisplayName: String { "Mock Structured" }
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] { [] }
+    var selectedModelId: String? { nil }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "legacy", detectedLanguage: language)
+    }
+
+    func transcribeStructured(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginStructuredTranscriptionResult {
+        PluginStructuredTranscriptionResult(
+            text: "Speaker A: Hello",
+            detectedLanguage: language,
+            segments: [
+                PluginStructuredTranscriptionSegment(
+                    text: "Hello",
+                    start: 0.25,
+                    end: 1.5,
+                    speakerLabel: "Speaker A",
+                    speakerConfidence: 0.91
+                )
+            ]
+        )
+    }
+}
+
 private final class MockTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
     var isActive = true
     var onFinish: (@Sendable () -> Void)?
@@ -347,6 +386,28 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertFalse(legacyPlugin is any TranscriptionModelCatalogProviding)
         XCTAssertEqual(legacyPlugin.modelCatalog.map(\.id), ["tiny"])
         XCTAssertEqual(catalogPlugin.modelCatalog.map(\.id), ["tiny", "large"])
+    }
+
+    func testStructuredTranscriptionProtocolIsOptionalAndCarriesSpeakerMetadata() async throws {
+        let legacyPlugin = MockTranscriptionPlugin()
+        let structuredPlugin = MockStructuredTranscriptionPlugin()
+        let erasedStructuredPlugin: Any = structuredPlugin
+
+        XCTAssertFalse(legacyPlugin is any StructuredTranscriptionEnginePlugin)
+        XCTAssertTrue(erasedStructuredPlugin is any StructuredTranscriptionEnginePlugin)
+
+        let result = try await structuredPlugin.transcribeStructured(
+            audio: AudioData(samples: [0.1], wavData: Data([0x00]), duration: 1),
+            language: "en",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Speaker A: Hello")
+        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.segments.first?.text, "Hello")
+        XCTAssertEqual(result.segments.first?.speakerLabel, "Speaker A")
+        XCTAssertEqual(result.segments.first?.speakerConfidence, 0.91)
     }
 
     func testTTSPluginCanPersistVoiceAndReceiveSpeakRequest() async throws {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -226,6 +226,87 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterStructuredTranscriptionPlugin)
+    private final class StructuredTranscriptionPlugin: NSObject, StructuredTranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.structured-transcription" }
+        static var pluginName: String { "Structured Mock Transcription" }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "structured-mock" }
+        var providerDisplayName: String { "Structured Mock" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [PluginModelInfo(id: "structured", displayName: "Structured")] }
+        var selectedModelId: String? { "structured" }
+        func selectModel(_ modelId: String) {}
+        var supportsTranslation: Bool { false }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(
+                text: "legacy text",
+                detectedLanguage: language,
+                segments: [
+                    PluginTranscriptionSegment(text: "legacy text", start: 0, end: 1)
+                ]
+            )
+        }
+
+        func transcribeStructured(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginStructuredTranscriptionResult {
+            PluginStructuredTranscriptionResult(
+                text: "Speaker A: Hello\nSpeaker B: Hi",
+                detectedLanguage: language,
+                segments: [
+                    PluginStructuredTranscriptionSegment(
+                        text: "Hello",
+                        start: 0.0,
+                        end: 1.0,
+                        speakerLabel: "Speaker A",
+                        speakerConfidence: 0.9
+                    ),
+                    PluginStructuredTranscriptionSegment(
+                        text: "Hi",
+                        start: 1.0,
+                        end: 2.0,
+                        speakerLabel: "Speaker B",
+                        speakerConfidence: 0.82
+                    )
+                ]
+            )
+        }
+    }
+
+    @objc(APIRouterLegacySegmentTranscriptionPlugin)
+    private final class LegacySegmentTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.legacy-segment-transcription" }
+        static var pluginName: String { "Legacy Segment Mock Transcription" }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "legacy-segment-mock" }
+        var providerDisplayName: String { "Legacy Segment Mock" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [PluginModelInfo(id: "legacy", displayName: "Legacy")] }
+        var selectedModelId: String? { "legacy" }
+        func selectModel(_ modelId: String) {}
+        var supportsTranslation: Bool { false }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(
+                text: "legacy segment",
+                detectedLanguage: language,
+                segments: [
+                    PluginTranscriptionSegment(text: "legacy segment", start: 0.0, end: 1.0)
+                ]
+            )
+        }
+    }
+
     @objc(APIRouterBudgetedTranscriptionPlugin)
     private final class BudgetedTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsBudgetProviding, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.budgeted-transcription" }
@@ -902,6 +983,55 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(response["text"] as? String, "transcribed")
         XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.languageHints, ["de", "en"])
         XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
+    }
+
+    @MainActor
+    func testTranscribeEndpointVerboseJSONIncludesSpeakerWhenStructuredSegmentsAreReturned() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = Self.makeAPIContext(appSupportDirectory: appSupportDirectory)
+        let plugin = StructuredTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins.append(
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.structured-transcription",
+                    name: "Structured Mock Transcription",
+                    version: "1.0.0",
+                    principalClass: "APIRouterStructuredTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        )
+        context?.modelManager.selectProvider(plugin.providerId)
+
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let response = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-response-format": "verbose_json",
+                ],
+                body: wavData
+            )
+        ))
+
+        let segments = try XCTUnwrap(response["segments"] as? [[String: Any]])
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0]["text"] as? String, "Hello")
+        XCTAssertEqual(segments[0]["speaker"] as? String, "Speaker A")
+        XCTAssertEqual(segments[1]["speaker"] as? String, "Speaker B")
     }
 
     func testTranscribeLocalFileEndpointTranscribesTemporaryWavFile() async throws {
@@ -3462,6 +3592,88 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
 
         XCTAssertEqual(plugin.selectedModelId, "alpha", "cloudModelOverride must not persist the plugin's default model")
+    }
+
+    @MainActor
+    func testModelManagerPreservesStructuredSpeakerSegmentsWhenPluginOptsIn() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = StructuredTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.structured-transcription",
+                    name: "Structured Mock Transcription",
+                    version: "1.0.0",
+                    principalClass: "APIRouterStructuredTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            language: "en",
+            task: .transcribe,
+            engineOverrideId: nil,
+            cloudModelOverride: nil,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Speaker A: Hello\nSpeaker B: Hi")
+        XCTAssertEqual(result.segments.map(\.speakerLabel), ["Speaker A", "Speaker B"])
+        XCTAssertEqual(result.segments.first?.speakerConfidence, 0.9)
+    }
+
+    @MainActor
+    func testModelManagerKeepsLegacyTranscriptionSegmentsSpeakerless() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = LegacySegmentTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.legacy-segment-transcription",
+                    name: "Legacy Segment Mock Transcription",
+                    version: "1.0.0",
+                    principalClass: "APIRouterLegacySegmentTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            language: "en",
+            task: .transcribe,
+            engineOverrideId: nil,
+            cloudModelOverride: nil,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.segments.map(\.text), ["legacy segment"])
+        XCTAssertNil(result.segments.first?.speakerLabel)
+        XCTAssertNil(result.segments.first?.speakerConfidence)
     }
 
     @MainActor

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -1193,6 +1193,50 @@ final class WatchFolderExportTests: XCTestCase {
         )
     }
 
+    func testWatchFolderSubtitleExportsPrefixSpeakerLabelsWhenPresent() throws {
+        let result = TranscriptionResult(
+            text: "Speaker A: Hello\nSpeaker B: Hi",
+            detectedLanguage: "en",
+            duration: 2,
+            processingTime: 0.3,
+            engineUsed: "assemblyai",
+            segments: [
+                TranscriptionSegment(text: "Hello", start: 0, end: 1, speakerLabel: "Speaker A"),
+                TranscriptionSegment(text: "Hi", start: 1, end: 2, speakerLabel: "Speaker B")
+            ]
+        )
+
+        let srt = try WatchFolderExportBuilder.build(
+            format: .srt,
+            result: result,
+            fileName: "meeting.m4a",
+            engineName: "AssemblyAI",
+            date: .distantPast
+        )
+        XCTAssertEqual(
+            srt.content,
+            """
+            1
+            00:00:00,000 --> 00:00:01,000
+            Speaker A: Hello
+
+            2
+            00:00:01,000 --> 00:00:02,000
+            Speaker B: Hi
+            """
+        )
+
+        let vtt = try WatchFolderExportBuilder.build(
+            format: .vtt,
+            result: result,
+            fileName: "meeting.m4a",
+            engineName: "AssemblyAI",
+            date: .distantPast
+        )
+        XCTAssertTrue(vtt.content.contains("Speaker A: Hello"))
+        XCTAssertTrue(vtt.content.contains("Speaker B: Hi"))
+    }
+
     func testWatchFolderExportBuilderRejectsSubtitleFormatsWithoutSegments() {
         let result = TranscriptionResult(
             text: "Hello world",


### PR DESCRIPTION
## Issue context

Issue #476 asks for speaker diarization so multi-speaker recordings such as meetings, interviews, and conversations can preserve who said what instead of flattening everything into one unlabeled transcript.

Closes #476

## Summary

- Adds an additive structured transcription SDK path with optional speaker label/confidence metadata, without changing the legacy transcription result/segment layout or SDK compatibility version.
- Updates the host to prefer structured transcription plugins when available and map speaker metadata into internal transcription segments while preserving legacy plugin behavior.
- Preserves speaker labels in SRT/VTT cues and includes optional `speaker` / `speaker_confidence` fields in `verbose_json` segments.
- Migrates AssemblyAI as the first reference provider behind a default-off plugin setting, submitting `speaker_labels: true` for REST batch transcriptions and parsing returned utterances into structured speaker segments.
- Sets the AssemblyAI plugin manifest `minHostVersion` to `1.4.0` for this release so TypeWhisper 1.3.x users keep receiving the existing compatible AssemblyAI 1.0.9 release instead of a plugin binary that requires the new SDK symbols.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryServiceTests`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh AssemblyAIPlugin "$(pwd)"`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$(pwd)"`
- [x] Manual local API smoke test with AssemblyAI diarization enabled: `POST /v1/transcribe/local-file` against `/Users/marco/Downloads/job-interview-esl-diarization-test.m4a` returned `verbose_json` with 21 speaker-labeled segments across `Speaker A` and `Speaker B`.
