### PR TITLE
Add Swift CodeQL quality workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,110 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+      - "!v*-daily*"
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "26 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  SCHEME: TypeWhisper
+  PROJECT: TypeWhisper.xcodeproj
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout-minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+            runner: ubuntu-latest
+            timeout-minutes: 10
+          - language: python
+            build-mode: none
+            runner: ubuntu-latest
+            timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  analyze-swift:
+    name: Analyze (swift)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-daily')
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: "26.2"
+
+      - name: Resolve Swift packages
+        run: |
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt of 3"
+            if xcodebuild -resolvePackageDependencies \
+              -project "$PROJECT" \
+              -scheme "$SCHEME"; then
+              exit 0
+            fi
+            echo "Package resolution failed, retrying in 10s..."
+            sleep 10
+          done
+          exit 1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: swift
+          build-mode: manual
+          queries: security-and-quality
+
+      - name: Build Swift for CodeQL
+        run: |
+          set -o pipefail
+          xcodebuild -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -derivedDataPath codeql-build \
+            -destination 'generic/platform=macOS' \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO | tee codeql-swift-build.log
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:swift"


### PR DESCRIPTION
## Summary

- Adds a versioned CodeQL advanced setup workflow for Actions, Python, and Swift.
- Runs `actions` and `python` CodeQL with `security-and-quality` on PRs, `main`, and the weekly schedule.
- Runs Swift CodeQL only on app release tags (`v*`, excluding `v*-daily*`) so RC and stable releases get Swift analysis without blocking normal PRs.
- Pins the third-party Xcode setup action to a commit SHA to satisfy GitHub Advanced Security's unpinned-action review.

## Issue context

No linked issue. This implements the maintainer-approved Swift CodeQL quality checks plan, adjusted after CI showed Swift CodeQL builds are too expensive for every PR.

## Operational note

GitHub-managed CodeQL Default Setup was disabled because GitHub rejects advanced CodeQL uploads while Default Setup remains enabled.

## Test Plan

- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codeql.yml')"`
- [x] `git diff --check`
- [x] PR CodeQL `Analyze (actions)` passed before the release-only Swift adjustment
- [x] PR CodeQL `Analyze (python)` passed before the release-only Swift adjustment
- [x] Verified Swift CodeQL reaches the manual Xcode build path, but the build took over 30 minutes; Swift is now release-tag only by design