### PR TITLE
Fix fixed-display indicators in fullscreen spaces

### DIFF
--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -15,7 +15,7 @@ enum FloatingPanelSpacePolicy {
 
     private static let fixedDisplayIndicatorCollectionBehavior: NSWindow.CollectionBehavior = [
         .canJoinAllSpaces,
-        .fullScreenAuxiliary,
+        .fullScreenNone,
         .stationary,
         .ignoresCycle
     ]

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -12,14 +12,14 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
         XCTAssertFalse(behavior.contains(.canJoinAllSpaces))
     }
 
-    func testFixedDisplayIndicatorPolicyStaysOnConfiguredDisplayAcrossSpaces() {
+    func testFixedDisplayIndicatorPolicyStaysOnConfiguredDisplayAcrossNormalSpaces() {
         let primaryBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .primaryScreen)
         let builtInBehavior = FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .builtInScreen)
 
         XCTAssertTrue(primaryBehavior.contains(.canJoinAllSpaces))
         XCTAssertFalse(primaryBehavior.contains(.moveToActiveSpace))
-        XCTAssertTrue(primaryBehavior.contains(.fullScreenAuxiliary))
-        XCTAssertFalse(primaryBehavior.contains(.fullScreenNone))
+        XCTAssertFalse(primaryBehavior.contains(.fullScreenAuxiliary))
+        XCTAssertTrue(primaryBehavior.contains(.fullScreenNone))
         XCTAssertEqual(primaryBehavior, builtInBehavior)
     }
 


### PR DESCRIPTION
## Summary

Fixes a regression from issue #373 where passive indicator panels configured for a fixed display could still appear in another app's fullscreen Space, including the built-in display notch strip.

The fixed-display modes (`Primary Screen` and `Built-in Display`) were still using `.fullScreenAuxiliary`, while `Active Screen` had already opted out with `.fullScreenNone`. Fixed-display should choose placement, not join other apps' fullscreen Spaces.

Closes #373

## Changes

- Updates fixed-display indicator collection behavior to use `.canJoinAllSpaces` with `.fullScreenNone`.
- Keeps `Active Screen` behavior unchanged: `.moveToActiveSpace` plus `.fullScreenNone`.
- Keeps selection palette behavior unchanged because those panels remain interactive and still need fullscreen support.
- Updates `FloatingPanelSpacePolicyTests` to assert the fixed-display policy joins normal Spaces without using `.fullScreenAuxiliary` or `.moveToActiveSpace`.

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/f4cd/typewhisper-mac`
- Manual verification on the dev app:
  - Set `indicatorStyle=notch`, `notchIndicatorVisibility=always`, `notchIndicatorDisplay=builtInScreen` and confirmed the notch indicator is visible on the normal built-in Desktop but absent from a separate fullscreen AppKit test app on the built-in display.
  - Set `indicatorStyle=overlay`, `notchIndicatorVisibility=always`, `notchIndicatorDisplay=builtInScreen` and confirmed the overlay indicator is visible on the normal built-in Desktop but absent from the fullscreen AppKit test app.
  - Restored dev defaults to `indicatorStyle=overlay`, `notchIndicatorVisibility=duringActivity`, `notchIndicatorDisplay=activeScreen` after testing.