### PR TITLE
Add workflow drag reorder

### DIFF
--- a/TypeWhisper/Services/WorkflowService.swift
+++ b/TypeWhisper/Services/WorkflowService.swift
@@ -159,6 +159,28 @@ final class WorkflowService: ObservableObject {
         fetchWorkflows()
     }
 
+    @discardableResult
+    func moveWorkflow(draggedWorkflowId: UUID, droppedOn targetWorkflowId: UUID) -> Bool {
+        guard draggedWorkflowId != targetWorkflowId,
+              let fromIndex = workflows.firstIndex(where: { $0.id == draggedWorkflowId }),
+              let toIndex = workflows.firstIndex(where: { $0.id == targetWorkflowId }) else {
+            return false
+        }
+
+        var reordered = workflows
+        let movedWorkflow = reordered.remove(at: fromIndex)
+        // The original target index inserts before the target when moving up and
+        // after the shifted target when moving down.
+        let insertionIndex = toIndex
+        guard insertionIndex >= reordered.startIndex, insertionIndex <= reordered.endIndex else {
+            return false
+        }
+
+        reordered.insert(movedWorkflow, at: insertionIndex)
+        reorderWorkflows(reordered)
+        return true
+    }
+
     func workflow(id: UUID) -> Workflow? {
         workflows.first(where: { $0.id == id })
     }

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -80,8 +80,16 @@ private struct MyWorkflowsPage: View {
     @State private var searchText = ""
     @State private var pendingDeleteWorkflowId: UUID?
 
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isFilteringWorkflows: Bool {
+        !trimmedSearchText.isEmpty
+    }
+
     private var filteredWorkflows: [Workflow] {
-        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedQuery = trimmedSearchText
         guard !trimmedQuery.isEmpty else { return workflowService.workflows }
 
         return workflowService.workflows.filter { workflow in
@@ -107,6 +115,10 @@ private struct MyWorkflowsPage: View {
                         emptyState
                     } else {
                         searchField
+
+                        if isFilteringWorkflows {
+                            reorderDisabledNotice
+                        }
 
                         if filteredWorkflows.isEmpty {
                             filteredEmptyState
@@ -386,20 +398,62 @@ private struct MyWorkflowsPage: View {
         }
     }
 
+    private var reorderDisabledNotice: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.body)
+                .foregroundStyle(.secondary)
+
+            Text(
+                localizedAppText(
+                    "Reordering is disabled while search is active to keep the global workflow order deterministic.",
+                    de: "Die Sortierung ist während der Suche deaktiviert, damit die globale Workflow-Reihenfolge eindeutig bleibt."
+                )
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            Spacer(minLength: 0)
+
+            Button(localizedAppText("Clear Search", de: "Suche löschen")) {
+                searchText = ""
+            }
+            .buttonStyle(.link)
+            .font(.caption)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        }
+    }
+
     private var workflowsList: some View {
         let orderedIds = workflowService.workflows.map(\.id)
+        let canReorder = !isFilteringWorkflows
 
         return LazyVStack(spacing: 0) {
             ForEach(Array(filteredWorkflows.enumerated()), id: \.element.id) { index, workflow in
                 WorkflowRow(
                     workflow: workflow,
-                    canMoveUp: orderedIds.firstIndex(of: workflow.id).map { $0 > 0 } ?? false,
-                    canMoveDown: orderedIds.firstIndex(of: workflow.id).map { $0 < orderedIds.count - 1 } ?? false,
+                    canMoveUp: canReorder && (orderedIds.firstIndex(of: workflow.id).map { $0 > 0 } ?? false),
+                    canMoveDown: canReorder && (orderedIds.firstIndex(of: workflow.id).map { $0 < orderedIds.count - 1 } ?? false),
+                    isReorderingEnabled: canReorder,
                     onToggle: { workflowService.toggleWorkflow(workflow) },
                     onEdit: { navigation.editWorkflow(id: workflow.id) },
                     onDelete: { pendingDeleteWorkflowId = workflow.id },
                     onMoveUp: { move(workflow: workflow, by: -1) },
-                    onMoveDown: { move(workflow: workflow, by: 1) }
+                    onMoveDown: { move(workflow: workflow, by: 1) },
+                    onDropWorkflow: { droppedId in
+                        guard let draggedWorkflowId = UUID(uuidString: droppedId) else {
+                            return false
+                        }
+                        return workflowService.moveWorkflow(
+                            draggedWorkflowId: draggedWorkflowId,
+                            droppedOn: workflow.id
+                        )
+                    }
                 )
 
                 if index < filteredWorkflows.count - 1 {
@@ -431,11 +485,16 @@ private struct WorkflowRow: View {
     let workflow: Workflow
     let canMoveUp: Bool
     let canMoveDown: Bool
+    let isReorderingEnabled: Bool
     let onToggle: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
     let onMoveUp: () -> Void
     let onMoveDown: () -> Void
+    let onDropWorkflow: (String) -> Bool
+
+    @State private var isDropTargeted = false
+    @State private var isHovered = false
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -531,9 +590,89 @@ private struct WorkflowRow: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+        .background(rowBackgroundColor)
         .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovered = hovering
+        }
         .onTapGesture {
             onEdit()
+        }
+        .workflowReordering(
+            isEnabled: isReorderingEnabled,
+            workflowId: workflow.id.uuidString,
+            isTargeted: $isDropTargeted
+        ) { droppedItems in
+            guard let droppedId = droppedItems.first else {
+                return false
+            }
+            return onDropWorkflow(droppedId)
+        }
+        .help(
+            isReorderingEnabled
+                ? localizedAppText("Drag to reorder workflow", de: "Workflow ziehen, um die Reihenfolge zu ändern")
+                : localizedAppText("Clear search to reorder workflows", de: "Suche löschen, um Workflows zu sortieren")
+        )
+        .accessibilityHint(
+            isReorderingEnabled
+                ? localizedAppText("Drag this row to reorder workflows.", de: "Ziehe diese Zeile, um Workflows zu sortieren.")
+                : localizedAppText("Reordering is disabled while search is active.", de: "Die Sortierung ist während aktiver Suche deaktiviert.")
+        )
+    }
+
+    private var rowBackgroundColor: Color {
+        if isDropTargeted {
+            return Color.accentColor.opacity(0.08)
+        }
+
+        if isHovered, isReorderingEnabled {
+            return Color.primary.opacity(0.035)
+        }
+
+        return Color.clear
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func workflowReordering(
+        isEnabled: Bool,
+        workflowId: String,
+        isTargeted: Binding<Bool>,
+        onDrop: @escaping ([String]) -> Bool
+    ) -> some View {
+        if isEnabled {
+            self
+                .draggable(workflowId)
+                .dropDestination(for: String.self) { droppedItems, _ in
+                    onDrop(droppedItems)
+                } isTargeted: { targeted in
+                    isTargeted.wrappedValue = targeted
+                }
+                .overlay {
+                    OpenHandCursorView()
+                        .allowsHitTesting(false)
+                }
+        } else {
+            self
+        }
+    }
+}
+
+private struct OpenHandCursorView: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        CursorView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class CursorView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+
+        override func resetCursorRects() {
+            addCursorRect(bounds, cursor: .openHand)
         }
     }
 }

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -274,6 +274,127 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(service.nextSortOrder(), 3)
     }
 
+    func testMoveWorkflowDownDropsAfterTargetAndRenumbersFullOrder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let first = try XCTUnwrap(service.addWorkflow(
+            name: "First",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail")
+        ))
+        _ = service.addWorkflow(
+            name: "Second",
+            template: .translation,
+            trigger: .website("docs.github.com")
+        )
+        let third = try XCTUnwrap(service.addWorkflow(
+            name: "Third",
+            template: .summary,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 3, modifierFlags: 0, isFn: false))
+        ))
+        _ = service.addWorkflow(
+            name: "Fourth",
+            template: .checklist,
+            trigger: .manual()
+        )
+
+        let moved = service.moveWorkflow(draggedWorkflowId: first.id, droppedOn: third.id)
+
+        XCTAssertTrue(moved)
+        XCTAssertEqual(service.workflows.map(\.name), ["Second", "Third", "First", "Fourth"])
+        XCTAssertEqual(service.workflows.map(\.sortOrder), [0, 1, 2, 3])
+
+        let reloaded = WorkflowService(appSupportDirectory: appSupportDirectory)
+        XCTAssertEqual(reloaded.workflows.map(\.name), ["Second", "Third", "First", "Fourth"])
+        XCTAssertEqual(reloaded.workflows.map(\.sortOrder), [0, 1, 2, 3])
+    }
+
+    func testMoveWorkflowUpDropsBeforeTargetAndRenumbersFullOrder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = service.addWorkflow(
+            name: "First",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail")
+        )
+        let second = try XCTUnwrap(service.addWorkflow(
+            name: "Second",
+            template: .translation,
+            trigger: .website("docs.github.com")
+        ))
+        let third = try XCTUnwrap(service.addWorkflow(
+            name: "Third",
+            template: .summary,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 3, modifierFlags: 0, isFn: false))
+        ))
+        _ = service.addWorkflow(
+            name: "Fourth",
+            template: .checklist,
+            trigger: .manual()
+        )
+
+        let moved = service.moveWorkflow(draggedWorkflowId: third.id, droppedOn: second.id)
+
+        XCTAssertTrue(moved)
+        XCTAssertEqual(service.workflows.map(\.name), ["First", "Third", "Second", "Fourth"])
+        XCTAssertEqual(service.workflows.map(\.sortOrder), [0, 1, 2, 3])
+    }
+
+    func testMoveWorkflowRejectsSelfAndUnknownDropsWithoutChangingOrder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let first = try XCTUnwrap(service.addWorkflow(
+            name: "First",
+            template: .cleanedText,
+            trigger: .app("com.apple.mail")
+        ))
+        let second = try XCTUnwrap(service.addWorkflow(
+            name: "Second",
+            template: .translation,
+            trigger: .website("docs.github.com")
+        ))
+        let originalNames = service.workflows.map(\.name)
+        let originalSortOrders = service.workflows.map(\.sortOrder)
+
+        XCTAssertFalse(service.moveWorkflow(draggedWorkflowId: first.id, droppedOn: first.id))
+        XCTAssertFalse(service.moveWorkflow(draggedWorkflowId: UUID(), droppedOn: second.id))
+        XCTAssertFalse(service.moveWorkflow(draggedWorkflowId: first.id, droppedOn: UUID()))
+        XCTAssertEqual(service.workflows.map(\.name), originalNames)
+        XCTAssertEqual(service.workflows.map(\.sortOrder), originalSortOrders)
+    }
+
+    func testMovedWorkflowSortOrderControlsMatchingPriority() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let summary = try XCTUnwrap(service.addWorkflow(
+            name: "Docs Summary",
+            template: .summary,
+            trigger: .website("docs.github.com")
+        ))
+        let cleanup = try XCTUnwrap(service.addWorkflow(
+            name: "Docs Cleanup",
+            template: .cleanedText,
+            trigger: .website("docs.github.com")
+        ))
+
+        XCTAssertTrue(service.moveWorkflow(draggedWorkflowId: cleanup.id, droppedOn: summary.id))
+
+        let match = try XCTUnwrap(service.matchWorkflow(
+            bundleIdentifier: "com.apple.Safari",
+            url: "https://docs.github.com/en/actions"
+        ))
+        XCTAssertEqual(match.workflow.name, "Docs Cleanup")
+        XCTAssertTrue(match.wonBySortOrder)
+    }
+
     func testToggleAndDeleteWorkflowUpdatePublishedState() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary
- Add drag-and-drop reordering for workflows using the existing full-list `sortOrder` persistence path.
- Keep up/down controls as an accessibility-friendly fallback and disable all reordering while search is active.
- Use a subtle hover affordance plus open-hand cursor instead of a permanent left-side drag handle.
- Add workflow ordering regression coverage for drag-style moves and matching priority.

## Issue Context
Users with dozens of workflows currently have to move workflows one arrow click at a time. Workflow order is also matching priority, so reorder operations must keep the global `sortOrder` deterministic and avoid ambiguous filtered-list behavior.

Closes #478

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WorkflowServiceTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/1f1d/typewhisper-mac`