### PR TITLE
Fix Gemma cache recovery after failed downloads

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -409,6 +409,16 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         try? FileManager.default.removeItem(at: repoDir)
     }
 
+    func resetCachedModel(_ modelDef: Gemma4ModelDef) {
+        modelContainer = nil
+        loadedModelId = nil
+        downloadProgress = 0
+        modelState = .notLoaded
+        host?.setUserDefault(nil, forKey: "loadedModel")
+        deleteModelFiles(modelDef)
+        host?.notifyCapabilitiesChanged()
+    }
+
     func restoreLoadedModel(allowDownloads: Bool = true) async {
         guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
               let modelDef = Self.modelDefinition(for: savedId) else {
@@ -524,12 +534,33 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         }
 
         let rawMessage = String(describing: error).lowercased()
+        if isRecoverableCacheError(rawMessage) {
+            let bundle = Bundle(for: Gemma4Plugin.self)
+            return String(
+                localized: "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again.",
+                bundle: bundle
+            )
+        }
+
         if rawMessage.contains("unsupported model type")
             || rawMessage.contains("model type gemma4 not supported") {
             return unsupportedModelMessage(for: modelDef)
         }
 
         return error.localizedDescription
+    }
+
+    private static func isRecoverableCacheError(_ rawMessage: String) -> Bool {
+        (rawMessage.contains("key ") && rawMessage.contains(" not found"))
+            || rawMessage.contains("missing key")
+            || rawMessage.contains("missing weight")
+            || rawMessage.contains("shape mismatch")
+            || rawMessage.contains("size mismatch")
+            || (rawMessage.contains("checkpoint")
+                && (rawMessage.contains("not found")
+                    || rawMessage.contains("missing")
+                    || rawMessage.contains("shape")
+                    || rawMessage.contains("mismatch")))
     }
 
     static func promptPrefillStepSize(for modelId: String?) -> Int {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -242,13 +242,17 @@ struct Gemma4SettingsView: View {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                     Button(String(localized: "Unload", bundle: bundle)) {
-                        plugin.unloadModel()
-                        plugin.deleteModelFiles(modelDef)
-                        modelState = plugin.modelState
+                        resetCachedModel(modelDef)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                 }
+            } else if isRecoverableCachedModelError(for: modelDef) {
+                Button(String(localized: "Delete cached model", bundle: bundle)) {
+                    resetCachedModel(modelDef)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             } else if let experimentalWarning = modelDef.experimentalWarning {
                 VStack(alignment: .trailing, spacing: 6) {
                     Text("Experimental", bundle: bundle)
@@ -278,6 +282,24 @@ struct Gemma4SettingsView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func isRecoverableCachedModelError(for modelDef: Gemma4ModelDef) -> Bool {
+        if case .error = modelState,
+           selectedModelId == modelDef.id,
+           plugin.isModelDownloaded(modelDef) {
+            return true
+        }
+        return false
+    }
+
+    private func resetCachedModel(_ modelDef: Gemma4ModelDef) {
+        loadTask?.cancel()
+        loadTask = nil
+        isPolling = false
+        plugin.resetCachedModel(modelDef)
+        modelState = plugin.modelState
+        downloadProgress = plugin.currentDownloadProgress
     }
 
     private func startLoading(_ modelDef: Gemma4ModelDef) {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings
@@ -21,12 +21,32 @@
         }
       }
     },
+    "Delete cached model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeichertes Modell löschen"
+          }
+        }
+      }
+    },
     "Download timed out while fetching Gemma 4 from Hugging Face. Please retry. Adding an optional HuggingFace token in this plugin can also increase download rate limits." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Der Download von Gemma 4 von Hugging Face hat zu lange gedauert. Bitte erneut versuchen. Ein optionaler HuggingFace-Token in diesem Plugin kann die Download-Rate-Limits erhoehen."
+          }
+        }
+      }
+    },
+    "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der heruntergeladene Gemma-Modellcache scheint unvollständig oder inkompatibel zu sein. Lösche das zwischengespeicherte Modell und lade es erneut herunter."
           }
         }
       }

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -202,6 +202,69 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         )
     }
 
+    func testGemma4MissingWeightErrorsUseCacheRecoveryMessage() throws {
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let error = NSError(
+            domain: "Test",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Key embed_vision.embedding_projection.weight not found in Gemma4MultiModalEmbedder.Linear"
+            ]
+        )
+
+        let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)
+
+        XCTAssertEqual(
+            message,
+            "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again."
+        )
+    }
+
+    func testGemma4CheckpointShapeErrorsUseCacheRecoveryMessage() throws {
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e4b-it-4bit"))
+        let error = NSError(
+            domain: "Test",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Checkpoint tensor shape mismatch for language_model.layers.0.self_attn.q_proj.weight"
+            ]
+        )
+
+        let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)
+
+        XCTAssertEqual(
+            message,
+            "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again."
+        )
+    }
+
+    func testGemma4ResetCachedModelDeletesCacheAndClearsLoadedState() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let modelDirectory = appSupportDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(model.repoId, isDirectory: true)
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+
+        plugin.activate(host: host)
+        try await Task.sleep(nanoseconds: 10_000_000)
+        host.setUserDefault(model.id, forKey: "loadedModel")
+        plugin.beginModelLoad(for: model, isAlreadyDownloaded: true)
+
+        plugin.resetCachedModel(model)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+        XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 2)
+    }
+
     func testGemma4ValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
         let plugin = Gemma4Plugin()
         let requestRecorder = RequestRecorder()


### PR DESCRIPTION
## Summary
- Add a Gemma 4 cache reset path that unloads the model, deletes the local repo directory, clears persisted loaded-model state, resets progress/state, and notifies capabilities.
- Show `Delete cached model` in Gemma settings when the selected model is in an error state and a local cache directory exists.
- Map missing checkpoint keys and checkpoint shape/size mismatch loader errors to a friendly recovery message, with English and German localizations.

## Issue Context
Issue #483 reports that a failed Hugging Face/network download can leave a corrupt Gemma 4 MLX cache behind. Subsequent retries can hit raw loader errors such as `Key embed_vision.embedding_projection.weight not found in Gemma4MultiModalEmbedder.Linear`, while the settings UI only exposed cache deletion after a model reached `ready`. This PR keeps cache presence detection conservative by using the existing local repo directory signal, but gives users a clear reset path from the `.error` state.

Closes #483

## Test Plan
- [x] `jq empty TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings`
- [x] `git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild build -project TypeWhisper.xcodeproj -scheme Gemma4Plugin -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
