### PR TITLE
Reduce hotkey recording start latency

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -776,31 +776,14 @@ final class DictationViewModel: ObservableObject {
             return
         }
 
-        // Match rule: forced manual override or app-based matching
-        let activeApp = textInsertionService.captureActiveApp()
-        capturedActiveApp = activeApp
-        capturedSelectedText = nil
-        activeAppIcon = nil
-
-        if let forcedWorkflowId,
-           let forcedWorkflow = workflowService.workflows.first(where: { $0.id == forcedWorkflowId && $0.isEnabled }) {
-            applyWorkflowMatch(workflowService.forcedWorkflowMatch(for: forcedWorkflow), activeApp: activeApp)
-        } else if let forcedProfileId,
-           let forcedProfile = profileService.profiles.first(where: { $0.id == forcedProfileId && $0.isEnabled }) {
-            applyRuleMatch(profileService.forcedRuleMatch(for: forcedProfile), activeApp: activeApp)
-        } else if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: activeApp.bundleId, url: nil) {
-            applyWorkflowMatch(workflowMatch, activeApp: activeApp)
-        } else {
-            applyRuleMatch(profileService.matchRule(bundleIdentifier: activeApp.bundleId, url: nil), activeApp: activeApp)
-        }
-        let immediateContextMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
-
         do {
             audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
             audioRecordingService.hasExplicitDeviceSelection = audioDeviceService.selectedDeviceUID != nil
             let selectedInputUsesBluetooth = audioDeviceService.selectedDeviceUsesBluetoothTransport
             audioRecordingService.selectedInputDeviceUsesBluetoothTransport = selectedInputUsesBluetooth
+            let audioStartTimestamp = CFAbsoluteTimeGetCurrent()
             try audioRecordingService.startRecording()
+            let audioStartMs = (CFAbsoluteTimeGetCurrent() - audioStartTimestamp) * 1000
             if selectedInputUsesBluetooth {
                 logger.info("Skipping recording start sound for Bluetooth input device")
             } else {
@@ -820,6 +803,28 @@ final class DictationViewModel: ObservableObject {
             isStopInFlight = false
             recordingStartTime = Date()
             startRecordingTimer()
+
+            let contextStartTimestamp = CFAbsoluteTimeGetCurrent()
+            // Match rule after the audio engine is live so app/context lookup does
+            // not delay capture of the user's first spoken words.
+            let activeApp = textInsertionService.captureActiveApp()
+            capturedActiveApp = activeApp
+            capturedSelectedText = nil
+            activeAppIcon = nil
+
+            if let forcedWorkflowId,
+               let forcedWorkflow = workflowService.workflows.first(where: { $0.id == forcedWorkflowId && $0.isEnabled }) {
+                applyWorkflowMatch(workflowService.forcedWorkflowMatch(for: forcedWorkflow), activeApp: activeApp)
+            } else if let forcedProfileId,
+               let forcedProfile = profileService.profiles.first(where: { $0.id == forcedProfileId && $0.isEnabled }) {
+                applyRuleMatch(profileService.forcedRuleMatch(for: forcedProfile), activeApp: activeApp)
+            } else if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: activeApp.bundleId, url: nil) {
+                applyWorkflowMatch(workflowMatch, activeApp: activeApp)
+            } else {
+                applyRuleMatch(profileService.matchRule(bundleIdentifier: activeApp.bundleId, url: nil), activeApp: activeApp)
+            }
+            let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
+
             startLiveStreaming(allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0)
             EventBus.shared.emit(.recordingStarted(RecordingStartedPayload(
                 appName: capturedActiveApp?.name,
@@ -833,7 +838,7 @@ final class DictationViewModel: ObservableObject {
 
             let totalStartMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
             logger.info(
-                "Recording started: immediateContextMs=\(String(format: "%.1f", immediateContextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
+                "Recording started: audioStartMs=\(String(format: "%.1f", audioStartMs), privacy: .public), contextMs=\(String(format: "%.1f", contextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
             )
         } catch {
             clearDeferredRecordingContext()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1651,7 +1651,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testApiStartRecording_startsAudioBeforeDeferredSelectedTextCapture() async throws {
+    func testApiStartRecording_startsAudioBeforeContextAndDeferredSelectedTextCapture() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?
         defer {
@@ -1683,10 +1683,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
         _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
-        XCTAssertEqual(events, ["capture_app", "start_audio"])
+        XCTAssertEqual(events, ["start_audio", "capture_app"])
 
         await fulfillment(of: [selectedTextCaptured], timeout: 1.0)
-        XCTAssertEqual(Array(events.prefix(3)), ["capture_app", "start_audio", "selected_text"])
+        XCTAssertEqual(Array(events.prefix(3)), ["start_audio", "capture_app", "selected_text"])
     }
 
     @MainActor
@@ -1801,7 +1801,56 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         _ = context.dictationViewModel.apiStartRecording()
 
-        XCTAssertEqual(Array(events.prefix(3)), ["capture_app", "start_audio", "pause_media"])
+        XCTAssertEqual(Array(events.prefix(3)), ["start_audio", "pause_media", "capture_app"])
+    }
+
+    @MainActor
+    func testApiStartRecordingFailureSkipsPostAudioStartSideEffects() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var events: [String] = []
+        let mediaPlaybackService = MockMediaPlaybackService {
+            events.append("pause_media")
+        }
+        let soundService = MockSoundService { event, enabled in
+            guard event == .recordingStarted, enabled else { return }
+            events.append("start_sound")
+        }
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            mediaPlaybackService: mediaPlaybackService,
+            soundService: soundService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.mediaPauseEnabled = true
+        context.dictationViewModel.soundFeedbackEnabled = true
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.textInsertionService.captureActiveAppOverride = {
+            events.append("capture_app")
+            return ("Notes", "com.apple.Notes", nil)
+        }
+        context.audioRecordingService.startRecordingOverride = {
+            events.append("start_audio")
+            throw NSError(
+                domain: "TypeWhisperTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Audio start failed"]
+            )
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, "Audio start failed")
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.error, "Audio start failed")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Starts the dictation audio engine before app/workflow/profile context lookup so hotkey capture begins as early as possible.
- Keeps workflow/profile matching, live preview setup, metadata capture, sounds, media pause, and ducking after the audio engine is live.
- Adds regression coverage for audio-before-context ordering and failed audio-start cleanup.

## Issue Context
Issue #490 reports that Push-to-Talk recording can start slightly late, cutting off words spoken immediately after pressing the hotkey. This keeps microphone capture first in the hotkey start path and leaves always-on/pre-roll behavior out of scope.

Closes #490

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_startsAudioBeforeContextAndDeferredSelectedTextCapture -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_pausesMediaAfterAudioStart -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecordingFailureSkipsPostAudioStartSideEffects`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests`