### PR TITLE
Refresh Qwen3 ASR plugin for 1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,5 +134,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.2"
+
       - name: Run Plugin SDK Tests
         run: swift test --package-path TypeWhisperPluginSDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.2"
+
       - name: Run Plugin SDK Tests
         run: swift test --package-path TypeWhisperPluginSDK
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 
@@ -167,7 +167,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26.2"
 

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -9,6 +9,11 @@ let package = Package(
         .library(name: "TypeWhisperPluginSDK", type: .dynamic, targets: ["TypeWhisperPluginSDK"]),
         .library(name: "TypeWhisperPluginSDKTesting", targets: ["TypeWhisperPluginSDKTesting"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
+        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
+    ],
     targets: [
         .target(name: "TypeWhisperPluginSDK"),
         .target(
@@ -29,6 +34,22 @@ let package = Package(
             name: "OpenAIPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/OpenAIPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
+            name: "Qwen3Plugin",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
+                .product(name: "MLXAudioSTT", package: "mlx-audio-swift"),
+            ],
+            path: "Plugins/Qwen3Plugin",
             exclude: ["Tests"],
             resources: [
                 .process("Localizable.xcstrings"),
@@ -113,6 +134,15 @@ let package = Package(
                 "OpenAIPlugin",
             ],
             path: "Plugins/OpenAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "Qwen3PluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "Qwen3Plugin",
+            ],
+            path: "Plugins/Qwen3Plugin/Tests"
         ),
         .testTarget(
             name: "FillerWordsPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Localizable.xcstrings
@@ -31,6 +31,176 @@
         }
       }
     },
+    "Quick picks" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnellauswahl"
+          }
+        }
+      }
+    },
+    "8 GB pick" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8-GB-Tipp"
+          }
+        }
+      }
+    },
+    "Recommended" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empfohlen"
+          }
+        }
+      }
+    },
+    "32 GB quality" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "32-GB-Qualität"
+          }
+        }
+      }
+    },
+    "Fast / 8 GB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnell / 8 GB"
+          }
+        }
+      }
+    },
+    "Best default" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beste Vorgabe"
+          }
+        }
+      }
+    },
+    "Quality / 32 GB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualität / 32 GB"
+          }
+        }
+      }
+    },
+    "Smallest download; use when memory matters more than quality." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleinster Download; nutze es, wenn Speicher wichtiger als Qualität ist."
+          }
+        }
+      }
+    },
+    "Slightly more precision than 4-bit with a similar footprint." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etwas mehr Präzision als 4-bit bei ähnlichem Speicherbedarf."
+          }
+        }
+      }
+    },
+    "Fast pick for 8 GB Macs and casual dictation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnelle Wahl für 8-GB-Macs und einfache Diktate."
+          }
+        }
+      }
+    },
+    "Higher-precision small model when 0.6B quality matters." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleines Modell mit höherer Präzision, wenn 0.6B-Qualität wichtiger ist."
+          }
+        }
+      }
+    },
+    "Unquantized small model; useful for comparison or validation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unquantisiertes kleines Modell; nützlich für Vergleich oder Validierung."
+          }
+        }
+      }
+    },
+    "Smallest 1.7B option; use when 6-bit is too heavy." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleinste 1.7B-Option; nutze sie, wenn 6-bit zu schwer ist."
+          }
+        }
+      }
+    },
+    "Middle ground if the default 6-bit model is tight on memory." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittelweg, wenn das 6-bit-Standardmodell knapp im Speicher wird."
+          }
+        }
+      }
+    },
+    "Best default for most 16 GB+ Macs." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beste Vorgabe für die meisten Macs mit 16 GB+."
+          }
+        }
+      }
+    },
+    "Higher-quality pick for 32 GB+ Macs." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualitätswahl für Macs mit 32 GB+."
+          }
+        }
+      }
+    },
+    "Largest unquantized model; use for max-fidelity validation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Größtes unquantisiertes Modell; für Validierung mit maximaler Wiedergabetreue."
+          }
+        }
+      }
+    },
     "HuggingFace Token" : {
       "localizations" : {
         "de" : {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Localizable.xcstrings
@@ -11,12 +11,12 @@
         }
       }
     },
-    "Local speech-to-text powered by MLX on Apple Silicon. 30 languages, no API key required." : {
+    "Local Qwen3-ASR speech-to-text powered by MLX on Apple Silicon. 30 languages plus Chinese dialect coverage, no API key required." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lokale Spracherkennung mit MLX auf Apple Silicon. 30 Sprachen, kein API-Schlüssel nötig."
+            "value" : "Lokale Qwen3-ASR-Spracherkennung mit MLX auf Apple Silicon. 30 Sprachen plus chinesische Dialektabdeckung, kein API-Schlüssel nötig."
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3ContextBiasFormatter.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3ContextBiasFormatter.swift
@@ -2,9 +2,11 @@ import Foundation
 import TypeWhisperPluginSDK
 
 enum Qwen3ContextBiasFormatter {
+    static let baseInstruction = "Transcribe only words that are spoken in the audio. Do not append acknowledgements, continuations, or filler words after speech ends."
+
     static func format(prompt: String?) -> String {
         let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
-        guard !terms.isEmpty else { return "" }
-        return "Technical terms: \(terms.joined(separator: ", "))."
+        guard !terms.isEmpty else { return baseInstruction }
+        return "\(baseInstruction)\nTechnical terms: \(terms.joined(separator: ", "))."
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -269,70 +269,83 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             displayName: "Qwen3 0.6B (4-bit)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-4bit",
             sizeDescription: "~0.7 GB",
-            ramRequirement: "8 GB+"
+            ramRequirement: "8 GB+",
+            usageHint: "Smallest download; use when memory matters more than quality."
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-0.6b-5bit",
             displayName: "Qwen3 0.6B (5-bit)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-5bit",
             sizeDescription: "~0.8 GB",
-            ramRequirement: "8 GB+"
+            ramRequirement: "8 GB+",
+            usageHint: "Slightly more precision than 4-bit with a similar footprint."
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-0.6b-6bit",
             displayName: "Qwen3 0.6B (6-bit)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-6bit",
             sizeDescription: "~0.9 GB",
-            ramRequirement: "8 GB+"
+            ramRequirement: "8 GB+",
+            usageHint: "Fast pick for 8 GB Macs and casual dictation.",
+            recommendation: .lowMemory
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-0.6b-8bit",
             displayName: "Qwen3 0.6B (8-bit)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-8bit",
             sizeDescription: "~1.0 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            usageHint: "Higher-precision small model when 0.6B quality matters."
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-0.6b-bf16",
             displayName: "Qwen3 0.6B (BF16)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-bf16",
             sizeDescription: "~1.6 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            usageHint: "Unquantized small model; useful for comparison or validation."
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-4bit",
             displayName: "Qwen3 1.7B (4-bit)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-4bit",
             sizeDescription: "~1.6 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            usageHint: "Smallest 1.7B option; use when 6-bit is too heavy."
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-5bit",
             displayName: "Qwen3 1.7B (5-bit)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-5bit",
             sizeDescription: "~1.8 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            usageHint: "Middle ground if the default 6-bit model is tight on memory."
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-6bit",
             displayName: "Qwen3 1.7B (6-bit)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-6bit",
             sizeDescription: "~2.0 GB",
-            ramRequirement: "16 GB+"
+            ramRequirement: "16 GB+",
+            usageHint: "Best default for most 16 GB+ Macs.",
+            recommendation: .balanced
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-8bit",
             displayName: "Qwen3 1.7B (8-bit)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-8bit",
             sizeDescription: "~2.5 GB",
-            ramRequirement: "32 GB+"
+            ramRequirement: "32 GB+",
+            usageHint: "Higher-quality pick for 32 GB+ Macs.",
+            recommendation: .highQuality
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-bf16",
             displayName: "Qwen3 1.7B (BF16)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-bf16",
             sizeDescription: "~4.1 GB",
-            ramRequirement: "32 GB+"
+            ramRequirement: "32 GB+",
+            usageHint: "Largest unquantized model; use for max-fidelity validation."
         ),
     ]
 
@@ -428,6 +441,32 @@ struct Qwen3ModelDef: Identifiable {
     let repoId: String
     let sizeDescription: String
     let ramRequirement: String
+    let usageHint: String
+    let recommendation: Qwen3ModelRecommendation?
+
+    init(
+        id: String,
+        displayName: String,
+        repoId: String,
+        sizeDescription: String,
+        ramRequirement: String,
+        usageHint: String,
+        recommendation: Qwen3ModelRecommendation? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.repoId = repoId
+        self.sizeDescription = sizeDescription
+        self.ramRequirement = ramRequirement
+        self.usageHint = usageHint
+        self.recommendation = recommendation
+    }
+}
+
+enum Qwen3ModelRecommendation: Equatable {
+    case lowMemory
+    case balanced
+    case highQuality
 }
 
 enum Qwen3ModelState: Equatable {
@@ -609,6 +648,10 @@ private struct Qwen3SettingsView: View {
         !storedHfToken.isEmpty
     }
 
+    private var quickPickModels: [Qwen3ModelDef] {
+        Qwen3Plugin.availableModels.filter { $0.recommendation != nil }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Qwen3 ASR (MLX)")
@@ -695,6 +738,8 @@ private struct Qwen3SettingsView: View {
                     .font(.subheadline)
                     .fontWeight(.medium)
 
+                quickPickGuide
+
                 ForEach(Qwen3Plugin.availableModels) { modelDef in
                     modelRow(modelDef)
                 }
@@ -745,12 +790,54 @@ private struct Qwen3SettingsView: View {
     }
 
     @ViewBuilder
+    private var quickPickGuide: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Quick picks", bundle: bundle)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            ForEach(quickPickModels) { modelDef in
+                if let recommendation = modelDef.recommendation {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Image(systemName: recommendationSystemImage(for: recommendation))
+                            .font(.caption)
+                            .foregroundStyle(recommendationColor(for: recommendation))
+                            .frame(width: 14)
+
+                        Text(recommendationTitle(for: recommendation))
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.primary)
+
+                        Text(modelDef.displayName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
     private func modelRow(_ modelDef: Qwen3ModelDef) -> some View {
         HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(modelDef.displayName)
-                    .font(.body)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(modelDef.displayName)
+                        .font(.body)
+
+                    if let recommendation = modelDef.recommendation {
+                        recommendationBadge(recommendation)
+                    }
+                }
+
                 Text("\(modelDef.sizeDescription) - RAM: \(modelDef.ramRequirement)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(localizedUsageHint(for: modelDef))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -789,6 +876,92 @@ private struct Qwen3SettingsView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func recommendationBadge(_ recommendation: Qwen3ModelRecommendation) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: recommendationSystemImage(for: recommendation))
+                .imageScale(.small)
+            Text(recommendationShortLabel(for: recommendation))
+        }
+        .font(.caption2)
+        .fontWeight(.semibold)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .foregroundStyle(recommendationColor(for: recommendation))
+        .background(recommendationColor(for: recommendation).opacity(0.12), in: Capsule())
+    }
+
+    private func recommendationSystemImage(for recommendation: Qwen3ModelRecommendation) -> String {
+        switch recommendation {
+        case .lowMemory:
+            "bolt.fill"
+        case .balanced:
+            "checkmark.seal.fill"
+        case .highQuality:
+            "star.fill"
+        }
+    }
+
+    private func recommendationColor(for recommendation: Qwen3ModelRecommendation) -> Color {
+        switch recommendation {
+        case .lowMemory:
+            .blue
+        case .balanced:
+            .green
+        case .highQuality:
+            .purple
+        }
+    }
+
+    private func recommendationShortLabel(for recommendation: Qwen3ModelRecommendation) -> String {
+        switch recommendation {
+        case .lowMemory:
+            String(localized: "8 GB pick", bundle: bundle)
+        case .balanced:
+            String(localized: "Recommended", bundle: bundle)
+        case .highQuality:
+            String(localized: "32 GB quality", bundle: bundle)
+        }
+    }
+
+    private func recommendationTitle(for recommendation: Qwen3ModelRecommendation) -> String {
+        switch recommendation {
+        case .lowMemory:
+            String(localized: "Fast / 8 GB", bundle: bundle)
+        case .balanced:
+            String(localized: "Best default", bundle: bundle)
+        case .highQuality:
+            String(localized: "Quality / 32 GB", bundle: bundle)
+        }
+    }
+
+    private func localizedUsageHint(for modelDef: Qwen3ModelDef) -> String {
+        switch modelDef.id {
+        case "qwen3-asr-0.6b-4bit":
+            String(localized: "Smallest download; use when memory matters more than quality.", bundle: bundle)
+        case "qwen3-asr-0.6b-5bit":
+            String(localized: "Slightly more precision than 4-bit with a similar footprint.", bundle: bundle)
+        case "qwen3-asr-0.6b-6bit":
+            String(localized: "Fast pick for 8 GB Macs and casual dictation.", bundle: bundle)
+        case "qwen3-asr-0.6b-8bit":
+            String(localized: "Higher-precision small model when 0.6B quality matters.", bundle: bundle)
+        case "qwen3-asr-0.6b-bf16":
+            String(localized: "Unquantized small model; useful for comparison or validation.", bundle: bundle)
+        case "qwen3-asr-1.7b-4bit":
+            String(localized: "Smallest 1.7B option; use when 6-bit is too heavy.", bundle: bundle)
+        case "qwen3-asr-1.7b-5bit":
+            String(localized: "Middle ground if the default 6-bit model is tight on memory.", bundle: bundle)
+        case "qwen3-asr-1.7b-6bit":
+            String(localized: "Best default for most 16 GB+ Macs.", bundle: bundle)
+        case "qwen3-asr-1.7b-8bit":
+            String(localized: "Higher-quality pick for 32 GB+ Macs.", bundle: bundle)
+        case "qwen3-asr-1.7b-bf16":
+            String(localized: "Largest unquantized model; use for max-fidelity validation.", bundle: bundle)
+        default:
+            modelDef.usageHint
+        }
     }
 
     private func validateAndSaveHuggingFaceToken() {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -24,7 +24,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     private static let primaryParams = STTGenerateParameters(
         maxTokens: 2048,
         temperature: 0.0,
-        language: "English",
+        language: nil,
         chunkDuration: 30.0,
         minChunkDuration: 1.0
     )
@@ -32,7 +32,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     private static let fallbackParams = STTGenerateParameters(
         maxTokens: 1536,
         temperature: 0.0,
-        language: "English",
+        language: nil,
         chunkDuration: 15.0,
         minChunkDuration: 1.0
     )
@@ -85,17 +85,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     }
 
     var supportedLanguages: [String] {
-        [
-            "af", "am", "ar", "az", "be", "bg", "bn", "bs", "ca", "cs",
-            "cy", "da", "de", "el", "en", "es", "et", "fa", "fi", "fr",
-            "gl", "gu", "ha", "he", "hi", "hr", "hu", "hy", "id", "is",
-            "it", "ja", "jw", "ka", "kk", "km", "kn", "ko", "lo", "lt",
-            "lv", "mk", "ml", "mn", "mr", "ms", "my", "ne", "nl", "no",
-            "pa", "pl", "ps", "pt", "ro", "ru", "sd", "si", "sk", "sl",
-            "sn", "so", "sq", "sr", "su", "sv", "sw", "ta", "te", "tg",
-            "th", "tk", "tl", "tr", "tt", "uk", "ur", "uz", "vi", "yo",
-            "yue", "zh",
-        ]
+        Self.qwenSupportedLanguageCodes
     }
 
     var selectedModelId: String? { _selectedModelId }
@@ -132,6 +122,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         )
         let primaryText = Self.normalizeTranscript(primaryOutput.text)
         let text: String
+        let outputLanguageName: String?
 
         if QwenTranscriptGuard.isLikelyLooped(primaryText) {
             let fallbackOutput = Self.generate(
@@ -145,16 +136,27 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
             if fallbackText.isEmpty {
                 text = primaryText
+                outputLanguageName = primaryOutput.language
             } else if QwenTranscriptGuard.isLikelyLooped(fallbackText) {
                 text = QwenTranscriptGuard.preferredTranscript(primary: primaryText, fallback: fallbackText)
+                outputLanguageName = primaryOutput.language ?? fallbackOutput.language
             } else {
                 text = fallbackText
+                outputLanguageName = fallbackOutput.language
             }
         } else {
             text = primaryText
+            outputLanguageName = primaryOutput.language
         }
 
-        return PluginTranscriptionResult(text: text, detectedLanguage: language)
+        let resultLanguageName = outputLanguageName ?? languageName
+        let cleanedText = QwenTranscriptGuard.removingLikelyTrailingArtifact(
+            from: text,
+            languageName: resultLanguageName
+        )
+        let detectedLanguage = Self.languageCode(forQwenLanguageName: resultLanguageName) ?? language
+
+        return PluginTranscriptionResult(text: cleanedText, detectedLanguage: detectedLanguage)
     }
 
     // MARK: - Model Management
@@ -266,36 +268,85 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             id: "qwen3-asr-0.6b-4bit",
             displayName: "Qwen3 0.6B (4-bit)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-4bit",
-            sizeDescription: "~400 MB",
+            sizeDescription: "~0.7 GB",
+            ramRequirement: "8 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-0.6b-5bit",
+            displayName: "Qwen3 0.6B (5-bit)",
+            repoId: "mlx-community/Qwen3-ASR-0.6B-5bit",
+            sizeDescription: "~0.8 GB",
+            ramRequirement: "8 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-0.6b-6bit",
+            displayName: "Qwen3 0.6B (6-bit)",
+            repoId: "mlx-community/Qwen3-ASR-0.6B-6bit",
+            sizeDescription: "~0.9 GB",
             ramRequirement: "8 GB+"
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-0.6b-8bit",
             displayName: "Qwen3 0.6B (8-bit)",
             repoId: "mlx-community/Qwen3-ASR-0.6B-8bit",
-            sizeDescription: "~800 MB",
+            sizeDescription: "~1.0 GB",
+            ramRequirement: "16 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-0.6b-bf16",
+            displayName: "Qwen3 0.6B (BF16)",
+            repoId: "mlx-community/Qwen3-ASR-0.6B-bf16",
+            sizeDescription: "~1.6 GB",
             ramRequirement: "16 GB+"
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-4bit",
             displayName: "Qwen3 1.7B (4-bit)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-4bit",
-            sizeDescription: "~1 GB",
+            sizeDescription: "~1.6 GB",
+            ramRequirement: "16 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-1.7b-5bit",
+            displayName: "Qwen3 1.7B (5-bit)",
+            repoId: "mlx-community/Qwen3-ASR-1.7B-5bit",
+            sizeDescription: "~1.8 GB",
+            ramRequirement: "16 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-1.7b-6bit",
+            displayName: "Qwen3 1.7B (6-bit)",
+            repoId: "mlx-community/Qwen3-ASR-1.7B-6bit",
+            sizeDescription: "~2.0 GB",
             ramRequirement: "16 GB+"
         ),
         Qwen3ModelDef(
             id: "qwen3-asr-1.7b-8bit",
             displayName: "Qwen3 1.7B (8-bit)",
             repoId: "mlx-community/Qwen3-ASR-1.7B-8bit",
-            sizeDescription: "~2 GB",
+            sizeDescription: "~2.5 GB",
+            ramRequirement: "32 GB+"
+        ),
+        Qwen3ModelDef(
+            id: "qwen3-asr-1.7b-bf16",
+            displayName: "Qwen3 1.7B (BF16)",
+            repoId: "mlx-community/Qwen3-ASR-1.7B-bf16",
+            sizeDescription: "~4.1 GB",
             ramRequirement: "32 GB+"
         ),
     ]
 
     // MARK: - Helpers
 
-    // ISO 639-1 code to English language name (used by Qwen3 ASR API)
-    private static let languageNames: [String: String] = [
+    static let qwenSupportedLanguageCodes: [String] = [
+        "zh", "en", "yue", "ar", "de", "fr", "es", "pt", "id", "it",
+        "ko", "ru", "th", "vi", "ja", "tr", "hi", "ms", "nl", "sv",
+        "da", "fi", "pl", "cs", "fil", "tl", "fa", "el", "ro", "hu",
+        "mk",
+    ]
+
+    // Language code to English language name used by the Qwen3 ASR API.
+    private static let languageNamesByCode: [String: String] = [
         "zh": "Chinese", "en": "English", "yue": "Cantonese",
         "ar": "Arabic", "de": "German", "fr": "French",
         "es": "Spanish", "pt": "Portuguese", "id": "Indonesian",
@@ -304,16 +355,43 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         "tr": "Turkish", "hi": "Hindi", "ms": "Malay",
         "nl": "Dutch", "sv": "Swedish", "da": "Danish",
         "fi": "Finnish", "pl": "Polish", "cs": "Czech",
-        "fil": "Filipino", "fa": "Persian", "el": "Greek",
+        "fil": "Filipino", "tl": "Filipino", "fa": "Persian", "el": "Greek",
         "hu": "Hungarian", "mk": "Macedonian", "ro": "Romanian",
     ]
 
-    fileprivate static func resolveLanguageName(_ isoCode: String?) -> String {
-        guard let code = isoCode else { return "English" }
-        return languageNames[code] ?? "English"
+    private static let languageCodesByName: [String: String] = {
+        var result: [String: String] = [:]
+        for (code, name) in languageNamesByCode {
+            if result[name.lowercased()] == nil || code != "tl" {
+                result[name.lowercased()] = code
+            }
+        }
+        return result
+    }()
+
+    static func resolveLanguageName(_ isoCode: String?) -> String? {
+        guard let code = isoCode?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !code.isEmpty else {
+            return nil
+        }
+        return languageNamesByCode[code]
     }
 
-    private static func contextBiasString(from prompt: String?) -> String {
+    static func languageCode(forQwenLanguageName languageName: String?) -> String? {
+        guard let languageName = languageName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !languageName.isEmpty else {
+            return nil
+        }
+
+        let names = languageName
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        guard names.count == 1 else { return nil }
+        return languageCodesByName[names[0]]
+    }
+
+    static func contextBiasString(from prompt: String?) -> String {
         Qwen3ContextBiasFormatter.format(prompt: prompt)
     }
 
@@ -322,7 +400,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         audio: MLXArray,
         params: STTGenerateParameters,
         context: String,
-        language: String
+        language: String?
     ) -> STTOutput {
         model.generate(
             audio: audio,
@@ -372,6 +450,27 @@ enum Qwen3ModelState: Equatable {
 // MARK: - QwenTranscriptGuard (Loop Detection)
 
 enum QwenTranscriptGuard {
+    static func removingLikelyTrailingArtifact(from text: String, languageName: String?) -> String {
+        guard isFrench(languageName) else { return text }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return text }
+
+        let artifactPattern = #"(?i)[.!?;:]\s+oui[.!?]*$"#
+        guard let artifactRange = trimmed.range(of: artifactPattern, options: .regularExpression) else {
+            return text
+        }
+
+        let artifact = String(trimmed[artifactRange])
+        guard let punctuation = artifact.first else { return text }
+
+        let prefix = trimmed[..<artifactRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prefix.isEmpty else { return text }
+
+        return "\(prefix)\(punctuation)"
+    }
+
     static func isLikelyLooped(_ text: String) -> Bool {
         let words = words(in: text)
         guard words.count >= 16 else { return false }
@@ -402,6 +501,18 @@ enum QwenTranscriptGuard {
             .lowercased()
             .split(whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != "'" })
             .map(String.init)
+    }
+
+    private static func isFrench(_ languageName: String?) -> Bool {
+        guard let languageName = languageName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !languageName.isEmpty else {
+            return false
+        }
+
+        return languageName
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .contains("french")
     }
 
     private struct LoopMetrics {
@@ -482,6 +593,10 @@ private struct Qwen3SettingsView: View {
 
     private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
+    nonisolated init(plugin: Qwen3Plugin) {
+        self.plugin = plugin
+    }
+
     private var trimmedHfTokenInput: String {
         hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -499,7 +614,7 @@ private struct Qwen3SettingsView: View {
             Text("Qwen3 ASR (MLX)")
                 .font(.headline)
 
-            Text("Local speech-to-text powered by MLX on Apple Silicon. 30 languages, no API key required.", bundle: bundle)
+            Text("Local Qwen3-ASR speech-to-text powered by MLX on Apple Silicon. 30 languages plus Chinese dialect coverage, no API key required.", bundle: bundle)
                 .font(.callout)
                 .foregroundStyle(.secondary)
 

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -96,4 +96,23 @@ final class Qwen3PluginTests: XCTestCase {
             ]
         )
     }
+
+    func testModelCatalogIncludesRecommendationGuidance() {
+        let modelsById = Dictionary(
+            uniqueKeysWithValues: Qwen3Plugin.availableModels.map { ($0.id, $0) }
+        )
+
+        XCTAssertEqual(modelsById["qwen3-asr-0.6b-6bit"]?.recommendation, .lowMemory)
+        XCTAssertEqual(modelsById["qwen3-asr-1.7b-6bit"]?.recommendation, .balanced)
+        XCTAssertEqual(modelsById["qwen3-asr-1.7b-8bit"]?.recommendation, .highQuality)
+        XCTAssertTrue(Qwen3Plugin.availableModels.allSatisfy { !$0.usageHint.isEmpty })
+        XCTAssertEqual(
+            Qwen3Plugin.availableModels.filter { $0.recommendation != nil }.map(\.id),
+            [
+                "qwen3-asr-0.6b-6bit",
+                "qwen3-asr-1.7b-6bit",
+                "qwen3-asr-1.7b-8bit",
+            ]
+        )
+    }
 }

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import Qwen3Plugin
+
+final class Qwen3PluginTests: XCTestCase {
+    func testAutoDetectDoesNotForceEnglish() {
+        XCTAssertNil(Qwen3Plugin.resolveLanguageName(nil))
+        XCTAssertNil(Qwen3Plugin.resolveLanguageName(""))
+        XCTAssertNil(Qwen3Plugin.resolveLanguageName("   "))
+    }
+
+    func testFrenchLanguageResolvesToQwenLanguageName() {
+        XCTAssertEqual(Qwen3Plugin.resolveLanguageName("fr"), "French")
+        XCTAssertEqual(Qwen3Plugin.languageCode(forQwenLanguageName: "French"), "fr")
+    }
+
+    func testUnsupportedLanguageDoesNotFallbackToEnglish() {
+        XCTAssertNil(Qwen3Plugin.resolveLanguageName("uk"))
+        XCTAssertNil(Qwen3Plugin.languageCode(forQwenLanguageName: "French,English"))
+    }
+
+    func testSupportedLanguagesMatchQwenASRLanguageSetWithTagalogAlias() {
+        XCTAssertEqual(
+            Qwen3Plugin.qwenSupportedLanguageCodes,
+            [
+                "zh", "en", "yue", "ar", "de", "fr", "es", "pt", "id", "it",
+                "ko", "ru", "th", "vi", "ja", "tr", "hi", "ms", "nl", "sv",
+                "da", "fi", "pl", "cs", "fil", "tl", "fa", "el", "ro", "hu",
+                "mk",
+            ]
+        )
+        XCTAssertEqual(Qwen3Plugin.resolveLanguageName("fil"), "Filipino")
+        XCTAssertEqual(Qwen3Plugin.resolveLanguageName("tl"), "Filipino")
+    }
+
+    func testContextFormatterAddsAntiHallucinationInstructionAndDictionaryTerms() {
+        let context = Qwen3Plugin.contextBiasString(from: " TypeWhisper, MLX, TypeWhisper ")
+
+        XCTAssertTrue(context.contains(Qwen3ContextBiasFormatter.baseInstruction))
+        XCTAssertTrue(context.contains("Technical terms: TypeWhisper, MLX."))
+    }
+
+    func testContextFormatterIncludesBaseInstructionWithoutDictionaryTerms() {
+        XCTAssertEqual(
+            Qwen3Plugin.contextBiasString(from: nil),
+            Qwen3ContextBiasFormatter.baseInstruction
+        )
+    }
+
+    func testFrenchTrailingOuiArtifactIsRemovedOnlyAfterSentencePunctuation() {
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(
+                from: "Je vais envoyer le fichier. oui",
+                languageName: "French"
+            ),
+            "Je vais envoyer le fichier."
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(
+                from: "Je vais envoyer le fichier. Oui.",
+                languageName: "French"
+            ),
+            "Je vais envoyer le fichier."
+        )
+    }
+
+    func testFrenchTrailingOuiGuardPreservesRealOuiUsages() {
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "Oui.", languageName: "French"),
+            "Oui."
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "Je pense que oui.", languageName: "French"),
+            "Je pense que oui."
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "I will send it. oui", languageName: "English"),
+            "I will send it. oui"
+        )
+    }
+
+    func testModelCatalogIncludesRefreshedMLXVariants() {
+        XCTAssertEqual(
+            Qwen3Plugin.availableModels.map(\.id),
+            [
+                "qwen3-asr-0.6b-4bit",
+                "qwen3-asr-0.6b-5bit",
+                "qwen3-asr-0.6b-6bit",
+                "qwen3-asr-0.6b-8bit",
+                "qwen3-asr-0.6b-bf16",
+                "qwen3-asr-1.7b-4bit",
+                "qwen3-asr-1.7b-5bit",
+                "qwen3-asr-1.7b-6bit",
+                "qwen3-asr-1.7b-8bit",
+                "qwen3-asr-1.7b-bf16",
+            ]
+        )
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
-    "version": "1.0.16",
+    "version": "1.1.0",
     "minHostVersion": "1.2.1",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
@@ -9,9 +9,9 @@
         "arm64"
     ],
     "author": "TypeWhisper",
-    "description": "Local speech-to-text powered by MLX on Apple Silicon. 30 languages, no API key required.",
+    "description": "Local Qwen3-ASR speech-to-text powered by MLX on Apple Silicon. 30 languages plus Chinese dialect coverage, no API key required.",
     "descriptions": {
-        "de": "Lokale Spracherkennung mit MLX auf Apple Silicon. 30 Sprachen, kein API-Key noetig."
+        "de": "Lokale Qwen3-ASR-Spracherkennung mit MLX auf Apple Silicon. 30 Sprachen plus chinesische Dialektabdeckung, kein API-Key noetig."
     },
     "category": "transcription",
     "iconSystemName": "cpu",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -64,6 +64,17 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.resolvedHosting, .cloud)
         XCTAssertEqual(manifest.resolvedCategoryIdentifiers, ["transcription", "llm", "tts"])
     }
+
+    func testQwen3UnsupportedLanguageSelectionFallsBackToAuto() {
+        XCTAssertEqual(
+            LanguageSelection.exact("uk").normalizedForSupportedLanguages(Qwen3Plugin.qwenSupportedLanguageCodes),
+            .auto
+        )
+        XCTAssertEqual(
+            LanguageSelection.hints(["fr", "uk"]).normalizedForSupportedLanguages(Qwen3Plugin.qwenSupportedLanguageCodes),
+            .exact("fr")
+        )
+    }
 }
 
 @MainActor

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -895,21 +895,24 @@ final class PluginManagerLoadOrderTests: XCTestCase {
 }
 
 final class Qwen3PluginContextFormattingTests: XCTestCase {
-    func testQwen3ContextFormatterReturnsEmptyStringForNilPrompt() throws {
-        XCTAssertEqual(Qwen3ContextBiasFormatter.format(prompt: nil), "")
+    func testQwen3ContextFormatterIncludesBaseInstructionWithoutPrompt() throws {
+        XCTAssertEqual(
+            Qwen3ContextBiasFormatter.format(prompt: nil),
+            Qwen3ContextBiasFormatter.baseInstruction
+        )
     }
 
     func testQwen3ContextFormatterWrapsSingleTerm() throws {
         XCTAssertEqual(
             Qwen3ContextBiasFormatter.format(prompt: "Qwen3"),
-            "Technical terms: Qwen3."
+            "\(Qwen3ContextBiasFormatter.baseInstruction)\nTechnical terms: Qwen3."
         )
     }
 
     func testQwen3ContextFormatterWrapsMultipleTermsAsCommaSeparatedSentence() throws {
         XCTAssertEqual(
             Qwen3ContextBiasFormatter.format(prompt: "Qwen3, MLX, LoRA"),
-            "Technical terms: Qwen3, MLX, LoRA."
+            "\(Qwen3ContextBiasFormatter.baseInstruction)\nTechnical terms: Qwen3, MLX, LoRA."
         )
     }
 
@@ -917,7 +920,7 @@ final class Qwen3PluginContextFormattingTests: XCTestCase {
         let prompt = PluginDictionaryTerms.prompt(from: [" Kubernetes ", "MLX", "mlx", "TypeWhisper"])
         XCTAssertEqual(
             Qwen3ContextBiasFormatter.format(prompt: prompt),
-            "Technical terms: Kubernetes, MLX, TypeWhisper."
+            "\(Qwen3ContextBiasFormatter.baseInstruction)\nTechnical terms: Kubernetes, MLX, TypeWhisper."
         )
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the French Qwen3 ASR trailing `oui` artifact from #489 with a conservative French-only cleanup guard.
- Releases the Qwen3 plugin manifest as `1.1.0` and refreshes Qwen3-ASR copy to 30 languages plus Chinese dialect coverage.
- Stops forcing auto-detect to English so Qwen3 can identify the spoken language itself.
- Adds Qwen3 plugin tests under `TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests` and wires the target through `TypeWhisperPluginSDK/Package.swift` following the OpenAI plugin test pattern.
- Refreshes the MLX Qwen3-ASR model catalog with 0.6B and 1.7B 4-bit, 5-bit, 6-bit, 8-bit, and BF16 variants.
- Adds model recommendation guidance and quick picks for low-memory, balanced default, and higher-quality local choices.

## Issue Context
Issue #489 reports that Qwen3 1.7B 8-bit often appends a random standalone `oui` after French sentences when French is selected manually. This PR keeps real short answers such as `oui`, preserves in-sentence `oui`, and only removes the artifact when it appears as a trailing standalone token after sentence punctuation in French output.

Closes #489

## Recommendation Context
The quick-pick recommendations are based on Qwen's official model-card positioning: 1.7B is the quality/SOTA option, while 0.6B is the accuracy-efficiency trade-off. The MLX-community catalog and Hugging Face model metadata are used for the current 4-bit, 5-bit, 6-bit, 8-bit, and BF16 variant set and size labels.

References:
- https://huggingface.co/Qwen/Qwen3-ASR-1.7B
- https://huggingface.co/Qwen/Qwen3-ASR-0.6B
- https://huggingface.co/collections/mlx-community/qwen3-asr

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/PluginManifestValidationTests CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project TypeWhisper.xcodeproj -target Qwen3Plugin -configuration Release CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `scripts/check_first_party_warnings.sh`

## Local Verification Notes
- Passed: `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests`
- Passed: `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/PluginManifestValidationTests CODE_SIGNING_ALLOWED=NO`
- Passed local dev-plugin smoke: `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run Qwen3Plugin /Users/marco/.codex/worktrees/c6be/typewhisper-mac`
- Passed local arm64 Release scheme build: `xcodebuild -project TypeWhisper.xcodeproj -scheme Qwen3Plugin -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- Passed warning gate against the release build log: `bash scripts/check_first_party_warnings.sh /tmp/qwen3-plugin-release-build.log`
- Local caveat: the exact target-build command above fails in this checkout's local Xcode package build path while resolving transitive external package modules (`Crypto`/`EventSource`). The Qwen3Plugin Release scheme arm64 build succeeds, and the warning gate script is `100644` and requires a log-file argument locally.
