### PR TITLE
Clarify GPL and commercial licensing copy

### DIFF
--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -3,12 +3,14 @@
 TypeWhisper is available under a dual-licensing model:
 
 - Open-source usage is licensed under the GNU General Public License v3.0 or later (GPL-3.0-or-later).
-- Commercial/proprietary usage requires a separate commercial license from the copyright holder.
+- Commercial licensing is available when you need rights or terms beyond the GPLv3 license.
 
-If you want to use TypeWhisper in a proprietary product, closed-source distribution, or any use case that is not compliant with GPLv3 obligations, you must obtain a commercial license.
+You do not need a commercial license merely to install and run an unmodified GPL copy of TypeWhisper, including for internal professional or commercial work.
+
+You do need a commercial license if you want to use TypeWhisper in a proprietary product, closed-source distribution, rebranded distribution, or any other use case that is not compliant with GPLv3 obligations. A commercial license can also be used for procurement, invoicing, priority support, or other institutional requirements.
 
 License inquiries:
 
 - Email: licensing@typewhisper.com
 
-If you are contributing to, forking, or redistributing the project as open source in compliance with GPLv3, no separate commercial license is required.
+If you are using, contributing to, forking, or redistributing the project in compliance with GPLv3, no separate commercial license is required.

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -3196,13 +3196,13 @@
         }
       }
     },
-    "If you need a commercial license for proprietary or otherwise non-GPL-compliant use, purchase it on Polar.sh and enter the key below." : {
+    "If you need non-GPL terms, procurement, support, or proprietary redistribution rights, purchase a commercial license on Polar.sh and enter the key below." : {
       "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wenn du eine kommerzielle Lizenz für proprietären oder nicht GPL-konformen Gebrauch brauchst, kaufe sie auf Polar.sh und gib den Key unten ein."
+            "value" : "Wenn du Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilungsrechte brauchst, kaufe eine kommerzielle Lizenz auf Polar.sh und gib den Key unten ein."
           }
         }
       }
@@ -4961,12 +4961,12 @@
         }
       }
     },
-    "Personal use and GPL-compliant open-source use are free. Proprietary or otherwise non-GPL-compliant use requires a commercial license." : {
+    "The GPL version is free to install and run as-is, including internal use. Non-GPL terms, procurement, support, or proprietary redistribution require a commercial license." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Privater und GPL-konformer Open-Source-Gebrauch sind kostenlos. Proprietärer oder nicht GPL-konformer Gebrauch erfordert eine kommerzielle Lizenz."
+            "value" : "Die GPL-Version darf kostenlos unverändert installiert und ausgeführt werden, auch intern. Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung erfordern eine kommerzielle Lizenz."
           }
         }
       }
@@ -7915,22 +7915,22 @@
         }
       }
     },
-    "TypeWhisper is free for personal use. If you'd like to support development, grab a supporter license for a Discord role and an in-app badge." : {
+    "TypeWhisper is open source under GPLv3. If you'd like to support development, grab a supporter license for a Discord role and an in-app badge." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "TypeWhisper ist für den privaten Gebrauch kostenlos. Wenn du die Entwicklung unterstützen möchtest, hol dir eine Supporter-Lizenz für eine Discord-Rolle und ein In-App-Badge."
+            "value" : "TypeWhisper ist Open Source unter GPLv3. Wenn du die Entwicklung unterstützen möchtest, hol dir eine Supporter-Lizenz für eine Discord-Rolle und ein In-App-Badge."
           }
         }
       }
     },
-    "TypeWhisper is open source.\nPersonal use and GPL-compliant open-source use are free.\nProprietary or otherwise non-GPL-compliant use requires a commercial license." : {
+    "TypeWhisper is open source under GPLv3.\nYou can install and run the GPL version as-is.\nUse a commercial license for non-GPL terms, procurement, support, or proprietary redistribution." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "TypeWhisper ist Open Source.\nDie private Nutzung und die GPL-konforme Open-Source-Nutzung sind kostenlos.\nFür proprietäre oder anderweitig nicht GPL-konforme Nutzung ist eine kommerzielle Lizenz erforderlich."
+            "value" : "TypeWhisper ist Open Source unter GPLv3.\nDu darfst die GPL-Version unverändert installieren und ausführen.\nNutze eine kommerzielle Lizenz für Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung."
           }
         }
       }

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -102,11 +102,11 @@ struct HomeSettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(localizedAppText("Using TypeWhisper at work?", de: "Nutzt du TypeWhisper beruflich?"))
+                    Text(localizedAppText("Need commercial license terms?", de: "Brauchst du kommerzielle Lizenzbedingungen?"))
                         .font(.headline)
                     Text(localizedAppText(
-                        "Commercial pricing, lifetime options, and the team story are clearer on the website.",
-                        de: "Kommerzielle Preise, Lifetime-Optionen und die Team-Story sind auf der Website klarer erklärt."
+                        "Pricing, lifetime options, procurement, and support are clearer on the website.",
+                        de: "Preise, Lifetime-Optionen, Beschaffung und Support sind auf der Website klarer erklärt."
                     ))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -127,7 +127,7 @@ struct HomeSettingsView: View {
                 Button {
                     NSWorkspace.shared.open(AppConstants.Website.pricingURL)
                 } label: {
-                    Label(localizedAppText("See pricing on the website", de: "Preise auf der Website ansehen"), systemImage: "globe")
+                    Label(localizedAppText("See licensing on the website", de: "Lizenzierung auf der Website ansehen"), systemImage: "globe")
                 }
                 .buttonStyle(.borderedProminent)
 

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -78,11 +78,11 @@ struct LicenseSettingsView: View {
 
             LazyVGrid(columns: planColumns, spacing: 12) {
                 planSelectionButton(
-                    title: localizedAppText("Private & OSS", de: "Privat & OSS"),
+                    title: localizedAppText("GPLv3 / OSS", de: "GPLv3 / OSS"),
                     price: localizedAppText("Free", de: "Kostenlos"),
                     description: localizedAppText(
-                        "For personal use and GPL-compatible open-source work.",
-                        de: "Für private Nutzung und GPL-kompatible Open-Source-Arbeit."
+                        "Install and run the GPL version as-is, including personal or internal use.",
+                        de: "Installiere und nutze die GPL-Version unverändert, auch privat oder intern."
                     ),
                     systemImage: "checkmark.circle",
                     selected: license.usageIntent == .personalOSS && license.licenseTier != .enterprise,
@@ -95,8 +95,8 @@ struct LicenseSettingsView: View {
                     title: localizedAppText("Individual", de: "Einzelnutzer"),
                     price: localizedAppText("from 5 EUR/mo", de: "ab 5 EUR/Monat"),
                     description: localizedAppText(
-                        "One person using TypeWhisper professionally on up to 2 devices.",
-                        de: "Eine Person nutzt TypeWhisper beruflich auf bis zu 2 Geräten."
+                        "Non-GPL terms, procurement, support, or proprietary distribution for one person.",
+                        de: "Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung für eine Person."
                     ),
                     systemImage: "briefcase",
                     selected: license.usageIntent == .workSolo && license.licenseTier != .enterprise,
@@ -109,8 +109,8 @@ struct LicenseSettingsView: View {
                     title: "Team",
                     price: localizedAppText("from 19 EUR/mo", de: "ab 19 EUR/Monat"),
                     description: localizedAppText(
-                        "Small teams, up to 10 devices, and the clearest future path for sync and sharing.",
-                        de: "Kleine Teams, bis zu 10 Geräte und der klarste spätere Pfad für Sync und Sharing."
+                        "Procurement, support, managed seats, and up to 10 devices.",
+                        de: "Beschaffung, Support, verwaltete Plätze und bis zu 10 Geräte."
                     ),
                     systemImage: "person.3",
                     selected: license.usageIntent == .team && license.licenseTier != .enterprise,
@@ -395,8 +395,8 @@ struct LicenseSettingsView: View {
 
     private var supporterDescriptionText: String {
         localizedAppText(
-            "Supporter status is personal and optional. It can exist alongside Private & OSS, Individual, Team, or Enterprise, but it never replaces a commercial license.",
-            de: "Supporter-Status ist persönlich und optional. Er kann neben Privat & OSS, Einzelnutzer, Team oder Unternehmensplan bestehen, ersetzt aber nie eine kommerzielle Lizenz."
+            "Supporter status is personal and optional. It can exist alongside GPLv3 / OSS, Individual, Team, or Enterprise, but it never grants commercial license terms.",
+            de: "Supporter-Status ist persönlich und optional. Er kann neben GPLv3 / OSS, Einzelnutzer, Team oder Unternehmensplan bestehen, gewährt aber nie kommerzielle Lizenzbedingungen."
         )
     }
 
@@ -637,13 +637,13 @@ struct LicenseSettingsView: View {
             return ""
         case .workSolo:
             return localizedAppText(
-                "Professional solo usage needs a commercial license. Individual covers one person on up to 2 devices.",
-                de: "Berufliche Einzel-Nutzung braucht eine kommerzielle Lizenz. Der Einzelnutzer-Plan deckt eine Person auf bis zu 2 Geräten ab."
+                "Individual covers one person who needs non-GPL terms, procurement, support, or proprietary distribution on up to 2 devices.",
+                de: "Der Einzelnutzer-Plan deckt eine Person ab, die Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung auf bis zu 2 Geräten braucht."
             )
         case .team:
             return localizedAppText(
-                "Team usage needs Team or Enterprise. Team covers up to 10 devices under one commercial plan.",
-                de: "Team-Nutzung braucht den Team- oder Unternehmensplan. Team deckt bis zu 10 Geräte unter einer kommerziellen Lizenz ab."
+                "Team covers procurement-friendly licensing, support, managed seats, and up to 10 devices.",
+                de: "Team deckt beschaffungsfreundliche Lizenzierung, Support, verwaltete Plätze und bis zu 10 Geräte ab."
             )
         case .enterprise:
             return localizedAppText(
@@ -680,8 +680,8 @@ struct LicenseSettingsView: View {
             switch tier {
             case .individual:
                 return localizedAppText(
-                    "This Mac is covered for professional single-seat usage on up to 2 devices.",
-                    de: "Dieser Mac ist für berufliche Einzel-Nutzung auf bis zu 2 Geräten abgedeckt."
+                    "This Mac is covered by Individual commercial license terms on up to 2 devices.",
+                    de: "Dieser Mac ist durch kommerzielle Einzelnutzer-Bedingungen auf bis zu 2 Geräten abgedeckt."
                 )
             case .team:
                 return localizedAppText(
@@ -706,8 +706,8 @@ struct LicenseSettingsView: View {
         switch tier {
         case .individual:
             return localizedAppText(
-                "Professional single-seat access for up to 2 devices with recurring billing.",
-                de: "Beruflicher Einzelzugang für bis zu 2 Geräte mit wiederkehrender Abrechnung."
+                "Individual commercial license terms for up to 2 devices with recurring billing.",
+                de: "Kommerzielle Einzelnutzer-Bedingungen für bis zu 2 Geräte mit wiederkehrender Abrechnung."
             )
         case .team:
             return localizedAppText(

--- a/TypeWhisper/Views/PostUpdateLicensePromptView.swift
+++ b/TypeWhisper/Views/PostUpdateLicensePromptView.swift
@@ -28,12 +28,12 @@ struct PostUpdateLicensePromptView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Text(localizedAppText("Using TypeWhisper professionally?", de: "Nutzt du TypeWhisper beruflich?"))
+                Text(localizedAppText("Need commercial license terms?", de: "Brauchst du kommerzielle Lizenzbedingungen?"))
                     .font(.title2.weight(.semibold))
 
                 Text(localizedAppText(
-                    "Private and GPL-compatible open-source use stays free. If you use TypeWhisper for work, please get a license.",
-                    de: "Private Nutzung und GPL-kompatible Open-Source-Arbeit bleiben kostenlos. Wenn du TypeWhisper beruflich nutzt, hole dir bitte eine Lizenz."
+                    "You can keep using the GPL version as-is. Choose a commercial license if you need non-GPL terms, procurement, support, or proprietary redistribution.",
+                    de: "Du kannst die GPL-Version unverändert weiter nutzen. Wähle eine kommerzielle Lizenz, wenn du Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung brauchst."
                 ))
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -41,10 +41,10 @@ struct PostUpdateLicensePromptView: View {
 
             VStack(spacing: 12) {
                 actionCard(
-                    title: localizedAppText("Private / OSS", de: "Privat / OSS"),
+                    title: localizedAppText("GPLv3 / OSS", de: "GPLv3 / OSS"),
                     description: localizedAppText(
-                        "Keep using it for personal work and compliant open source.",
-                        de: "Nutze es weiter privat oder für kompatible Open-Source-Arbeit."
+                        "Keep using the GPL version as-is.",
+                        de: "Nutze die GPL-Version unverändert weiter."
                     ),
                     systemImage: "person",
                     emphasized: false,
@@ -52,10 +52,10 @@ struct PostUpdateLicensePromptView: View {
                 )
 
                 actionCard(
-                    title: localizedAppText("I use it for work", de: "Ich nutze es beruflich"),
+                    title: localizedAppText("Show commercial options", de: "Kommerzielle Optionen anzeigen"),
                     description: localizedAppText(
-                        "Open the licensing options and keep this reminder active until a license is in place.",
-                        de: "Öffne die Lizenzoptionen und behalte diese Erinnerung aktiv, bis eine Lizenz hinterlegt ist."
+                        "Open licensing for non-GPL terms, procurement, support, or proprietary redistribution.",
+                        de: "Öffne Lizenzen für Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung."
                     ),
                     systemImage: "briefcase.fill",
                     emphasized: true,

--- a/TypeWhisper/Views/WelcomeSheet.swift
+++ b/TypeWhisper/Views/WelcomeSheet.swift
@@ -23,20 +23,20 @@ struct WelcomeSheet: View {
             VStack(spacing: 12) {
                 welcomeChoiceButton(
                     intent: .personalOSS,
-                    title: localizedAppText("Private & OSS", de: "Privat & OSS"),
+                    title: localizedAppText("GPLv3 / OSS", de: "GPLv3 / OSS"),
                     description: localizedAppText(
-                        "Personal use and GPL-compatible open-source work stay free.",
-                        de: "Private Nutzung und GPL-kompatible Open-Source-Arbeit bleiben kostenlos."
+                        "Install and run the GPL version as-is, including personal or internal use.",
+                        de: "Installiere und nutze die GPL-Version unverändert, auch privat oder intern."
                     ),
                     systemImage: "person"
                 )
 
                 welcomeChoiceButton(
                     intent: .workSolo,
-                    title: localizedAppText("At work, solo", de: "Beruflich allein"),
+                    title: localizedAppText("Commercial license", de: "Kommerzielle Lizenz"),
                     description: localizedAppText(
-                        "Freelance work, day job usage, or closed-source projects for one person.",
-                        de: "Freelance-Arbeit, Nutzung im Job oder Closed-Source-Projekte für eine Person."
+                        "Non-GPL terms, procurement, support, or proprietary distribution for one person.",
+                        de: "Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung für eine Person."
                     ),
                     systemImage: "briefcase"
                 )
@@ -45,8 +45,8 @@ struct WelcomeSheet: View {
                     intent: .team,
                     title: localizedAppText("With a team", de: "Mit Team"),
                     description: localizedAppText(
-                        "Shared rollout, multiple devices, and team-wide usage.",
-                        de: "Gemeinsamer Rollout, mehrere Geräte und Team-Nutzung."
+                        "Procurement, support, managed seats, and multi-device rollout.",
+                        de: "Beschaffung, Support, verwaltete Plätze und Rollout auf mehreren Geräten."
                     ),
                     systemImage: "person.3"
                 )


### PR DESCRIPTION
## Summary
- clarify LICENSE-COMMERCIAL.md so running an unmodified GPL copy does not imply a commercial-license requirement
- update welcome, license, post-update, and home licensing copy around non-GPL terms, procurement, support, and proprietary redistribution
- refresh related localized strings

## Tests
- xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -only-testing:TypeWhisperTests/PostUpdatePromptCoordinatorTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO