### PR TITLE
Reduce hotkey cold-start latency

### DIFF
--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -147,9 +147,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let inputCaptureFactory: AudioInputCaptureFactory
     private let initialInputTapSeenLock = OSAllocatedUnfairLock(initialState: false)
     private var _lastStopGraceCaptureApplied = false
+    private var recordingRequestUptimeNanoseconds: UInt64?
+    private var hasLoggedFirstConvertedSample = false
 
     static let targetSampleRate: Double = 16000
-    private static let captureTapFrames: AVAudioFrameCount = 1024
+    private static let captureTapFrames: AVAudioFrameCount = 256
     private static let engineTeardownRetentionInterval: TimeInterval = 0.3
 
     init(
@@ -256,7 +258,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         return inputFormat
     }
 
-    func startRecording() throws {
+    func startRecording(requestUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds) throws {
         guard hasMicrophonePermission else {
             throw AudioRecordingError.microphonePermissionDenied
         }
@@ -266,7 +268,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         recoveryError = nil
 
         try validateRecordingInputAvailability()
-        clearRecordingBuffer()
+        clearRecordingBuffer(requestUptimeNanoseconds: requestUptimeNanoseconds)
 
         let routeActivationRequest = selectedRouteActivationRequest
         outputVolumeGuard.captureBaseline()
@@ -838,14 +840,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func validateRecordingInputAvailability() throws {
-        if let inputAvailabilityOverride {
-            guard inputAvailabilityOverride(selectedDeviceID) else {
-                throw AudioRecordingError.noMicrophoneDetected
-            }
-            return
-        }
-
         if hasExplicitDeviceSelection {
+            if let inputAvailabilityOverride {
+                guard inputAvailabilityOverride(selectedDeviceID) else {
+                    throw AudioRecordingError.noMicrophoneDetected
+                }
+                return
+            }
             guard let selectedDeviceID else {
                 throw AudioRecordingError.selectedInputDeviceUnavailable
             }
@@ -854,16 +855,14 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             }
             return
         }
-
-        guard AudioDeviceService.hasAvailableInputDevice() else {
-            throw AudioRecordingError.noMicrophoneDetected
-        }
     }
 
-    private func clearRecordingBuffer() {
+    private func clearRecordingBuffer(requestUptimeNanoseconds: UInt64? = nil) {
         bufferLock.lock()
         sampleBuffer.removeAll()
         _peakRawAudioLevel = 0
+        recordingRequestUptimeNanoseconds = requestUptimeNanoseconds
+        hasLoggedFirstConvertedSample = false
         bufferLock.unlock()
         initialInputTapSeenLock.withLock { $0 = false }
     }
@@ -984,11 +983,25 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func processConvertedSamples(_ samples: [Float]) {
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(samples.count))
         let normalizedLevel = AudioLevelMeter.normalizedLevel(rms: rms)
+        var requestToFirstBufferMs: Double?
 
         bufferLock.lock()
         sampleBuffer.append(contentsOf: samples)
         if rms > _peakRawAudioLevel { _peakRawAudioLevel = rms }
+        if !hasLoggedFirstConvertedSample {
+            hasLoggedFirstConvertedSample = true
+            requestToFirstBufferMs = Self.elapsedMilliseconds(
+                from: recordingRequestUptimeNanoseconds,
+                to: DispatchTime.now().uptimeNanoseconds
+            )
+        }
         bufferLock.unlock()
+
+        if let requestToFirstBufferMs {
+            logger.info(
+                "First recording audio buffer appended: requestToFirstBufferMs=\(Self.formatMilliseconds(requestToFirstBufferMs), privacy: .public), sampleCount=\(samples.count, privacy: .public)"
+            )
+        }
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -1009,6 +1022,16 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let samples = sampleBuffer
         sampleBuffer.removeAll()
         return samples
+    }
+
+    private static func elapsedMilliseconds(from start: UInt64?, to end: UInt64) -> Double? {
+        guard let start, end >= start else { return nil }
+        return Double(end - start) / 1_000_000
+    }
+
+    private static func formatMilliseconds(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return String(format: "%.1f", value)
     }
 
     private func validateRecordingInputFormat(_ format: AVAudioFormat, preferredDeviceID: AudioDeviceID?) throws {

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -154,14 +154,14 @@ final class HotkeyService: ObservableObject {
 
     @Published private(set) var currentMode: HotkeyMode?
 
-    var onDictationStart: (() -> Void)?
+    var onDictationStart: ((UInt64) -> Void)?
     var onDictationStop: (() -> Void)?
     var onPromptPaletteToggle: (() -> Void)?
     var onRecentTranscriptionsToggle: (() -> Void)?
     var onCopyLastTranscription: (() -> Void)?
     var onRecorderToggle: (() -> Void)?
-    var onProfileDictationStart: ((UUID) -> Void)?
-    var onWorkflowDictationStart: ((UUID) -> Void)?
+    var onProfileDictationStart: ((UUID, UInt64) -> Void)?
+    var onWorkflowDictationStart: ((UUID, UInt64) -> Void)?
     var onWorkflowTextProcessing: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
     var onPushToTalkInterruption: (() -> Void)?
@@ -179,6 +179,10 @@ final class HotkeyService: ObservableObject {
     private static let monitorDedupWindow: TimeInterval = 0.12
     private static let capsLockKeyCode: UInt16 = 0x39
     private static let capsLockSuppressionWindow: TimeInterval = 0.25
+
+    nonisolated static func requestTimestamp() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
 
     // MARK: - Per-Slot State
 
@@ -1139,6 +1143,7 @@ final class HotkeyService: ObservableObject {
             pushToTalkInterruptionSignaled = false
             onDictationStop?()
         } else {
+            let requestTimestamp = Self.requestTimestamp()
             activeSlotType = slotType
             activeProfileId = nil
             activeWorkflowId = nil
@@ -1146,7 +1151,7 @@ final class HotkeyService: ObservableObject {
             isActive = true
             pushToTalkInterruptionSignaled = false
             currentMode = slotType == .toggle ? .toggle : .pushToTalk
-            onDictationStart?()
+            onDictationStart?(requestTimestamp)
         }
     }
 
@@ -1200,6 +1205,7 @@ final class HotkeyService: ObservableObject {
             pushToTalkInterruptionSignaled = false
             onDictationStop?()
         } else {
+            let requestTimestamp = Self.requestTimestamp()
             activeProfileId = profileId
             activeWorkflowId = nil
             activeSlotType = nil
@@ -1207,7 +1213,7 @@ final class HotkeyService: ObservableObject {
             isActive = true
             pushToTalkInterruptionSignaled = false
             currentMode = .pushToTalk // hybrid behavior
-            onProfileDictationStart?(profileId)
+            onProfileDictationStart?(profileId, requestTimestamp)
         }
     }
 
@@ -1248,6 +1254,7 @@ final class HotkeyService: ObservableObject {
             pushToTalkInterruptionSignaled = false
             onDictationStop?()
         } else {
+            let requestTimestamp = Self.requestTimestamp()
             activeProfileId = nil
             activeWorkflowId = workflowId
             activeSlotType = nil
@@ -1255,7 +1262,7 @@ final class HotkeyService: ObservableObject {
             isActive = true
             pushToTalkInterruptionSignaled = false
             currentMode = .pushToTalk
-            onWorkflowDictationStart?(workflowId)
+            onWorkflowDictationStart?(workflowId, requestTimestamp)
         }
     }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -472,6 +472,16 @@ final class DictationViewModel: ObservableObject {
         min(max(offset, 0), 8)
     }
 
+    nonisolated private static func elapsedMilliseconds(from start: UInt64, to end: UInt64) -> Double? {
+        guard end >= start else { return nil }
+        return Double(end - start) / 1_000_000
+    }
+
+    nonisolated private static func formatMilliseconds(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return String(format: "%.1f", value)
+    }
+
     var needsMicPermission: Bool {
         !audioRecordingService.hasMicrophonePermission
     }
@@ -488,7 +498,10 @@ final class DictationViewModel: ObservableObject {
 
     func apiStartRecording() -> UUID {
         let sessionID = UUID()
-        startRecording(sessionID: sessionID)
+        startRecording(
+            sessionID: sessionID,
+            requestUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds
+        )
         return sessionID
     }
 
@@ -591,20 +604,20 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func setupBindings() {
-        hotkeyService.onDictationStart = { [weak self] in
-            self?.startRecording()
+        hotkeyService.onDictationStart = { [weak self] requestTimestamp in
+            self?.startRecording(requestUptimeNanoseconds: requestTimestamp)
         }
 
         hotkeyService.onDictationStop = { [weak self] in
             self?.stopDictation()
         }
 
-        hotkeyService.onProfileDictationStart = { [weak self] profileId in
-            self?.startRecording(forcedProfileId: profileId)
+        hotkeyService.onProfileDictationStart = { [weak self] profileId, requestTimestamp in
+            self?.startRecording(forcedProfileId: profileId, requestUptimeNanoseconds: requestTimestamp)
         }
 
-        hotkeyService.onWorkflowDictationStart = { [weak self] workflowId in
-            self?.startRecording(forcedWorkflowId: workflowId)
+        hotkeyService.onWorkflowDictationStart = { [weak self] workflowId, requestTimestamp in
+            self?.startRecording(forcedWorkflowId: workflowId, requestUptimeNanoseconds: requestTimestamp)
         }
 
         hotkeyService.onWorkflowTextProcessing = { [weak self] workflowId in
@@ -732,16 +745,10 @@ final class DictationViewModel: ObservableObject {
     private func startRecording(
         forcedProfileId: UUID? = nil,
         forcedWorkflowId: UUID? = nil,
-        sessionID: UUID = UUID()
+        sessionID: UUID = UUID(),
+        requestUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
     ) {
         let startTimestamp = CFAbsoluteTimeGetCurrent()
-
-        // Dismiss prompt palette if active
-        promptPaletteHandler.hide()
-        recentTranscriptionPaletteHandler.hide()
-
-        // Cancel auto-unload timer to prevent unloading during recording
-        modelManager.cancelAutoUnloadTimer()
 
         // Cancel any pending transcription from a previous recording
         if transcriptionTask != nil {
@@ -781,9 +788,20 @@ final class DictationViewModel: ObservableObject {
             audioRecordingService.hasExplicitDeviceSelection = audioDeviceService.selectedDeviceUID != nil
             let selectedInputUsesBluetooth = audioDeviceService.selectedDeviceUsesBluetoothTransport
             audioRecordingService.selectedInputDeviceUsesBluetoothTransport = selectedInputUsesBluetooth
-            let audioStartTimestamp = CFAbsoluteTimeGetCurrent()
-            try audioRecordingService.startRecording()
-            let audioStartMs = (CFAbsoluteTimeGetCurrent() - audioStartTimestamp) * 1000
+            let audioStartTimestamp = DispatchTime.now().uptimeNanoseconds
+            try audioRecordingService.startRecording(requestUptimeNanoseconds: requestUptimeNanoseconds)
+            let audioStartCompletedTimestamp = DispatchTime.now().uptimeNanoseconds
+            let audioStartMs = Self.elapsedMilliseconds(
+                from: audioStartTimestamp,
+                to: audioStartCompletedTimestamp
+            )
+            let requestToAudioStartMs = Self.elapsedMilliseconds(
+                from: requestUptimeNanoseconds,
+                to: audioStartCompletedTimestamp
+            )
+            promptPaletteHandler.hide()
+            recentTranscriptionPaletteHandler.hide()
+            modelManager.cancelAutoUnloadTimer()
             if selectedInputUsesBluetooth {
                 logger.info("Skipping recording start sound for Bluetooth input device")
             } else {
@@ -838,7 +856,7 @@ final class DictationViewModel: ObservableObject {
 
             let totalStartMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
             logger.info(
-                "Recording started: audioStartMs=\(String(format: "%.1f", audioStartMs), privacy: .public), contextMs=\(String(format: "%.1f", contextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
+                "Recording started: requestToAudioStartMs=\(Self.formatMilliseconds(requestToAudioStartMs), privacy: .public), audioStartMs=\(Self.formatMilliseconds(audioStartMs), privacy: .public), contextMs=\(String(format: "%.1f", contextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
             )
         } catch {
             clearDeferredRecordingContext()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2210,18 +2210,43 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testApiStartRecording_showsNoMicDetectedErrorWhenNoInputAvailable() async throws {
+    func testApiStartRecording_showsNoMicDetectedErrorWhenSelectedInputUnavailable() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let deviceID = AudioDeviceID(42)
+        let transportResolver = FakeAudioDeviceTransportResolver(
+            transports: [deviceID: kAudioDeviceTransportTypeUSB]
+        ) { requestedDeviceID in
+            XCTAssertEqual(requestedDeviceID, deviceID)
+        }
+        let selectionEngineValidator = FakeAudioInputSelectionEngineValidator { preferredDeviceID in
+            XCTAssertEqual(preferredDeviceID, deviceID)
+        }
         var dictationContext: DictationContext?
         defer {
             dictationContext = nil
             TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
         }
 
-        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDeviceTransportResolver: transportResolver,
+            audioDeviceSelectionEngineValidator: selectionEngineValidator
+        )
         let context = try XCTUnwrap(dictationContext)
+        context.audioDeviceService.inputDevices = [
+            AudioInputDevice(deviceID: deviceID, name: "USB Mic", uid: "usb-input")
+        ]
+        context.audioDeviceService.audioDeviceIDResolverOverride = { uid in
+            uid == "usb-input" ? deviceID : nil
+        }
+        context.audioDeviceService.selectedDeviceUID = "usb-input"
         context.audioRecordingService.hasMicrophonePermissionOverride = true
-        context.audioRecordingService.inputAvailabilityOverride = { _ in false }
+        context.audioRecordingService.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertEqual(selectedDeviceID, deviceID)
+            return false
+        }
 
         _ = context.dictationViewModel.apiStartRecording()
 
@@ -4313,6 +4338,7 @@ final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {
 
         service.hasMicrophonePermissionOverride = true
         service.selectedDeviceID = AudioDeviceID(42)
+        service.hasExplicitDeviceSelection = true
         service.inputAvailabilityOverride = { selectedDeviceID in
             XCTAssertEqual(selectedDeviceID, AudioDeviceID(42))
             return false
@@ -4355,7 +4381,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4372,7 +4398,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4386,6 +4412,28 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testPushToTalkStartCallbackIncludesRequestTimestamp() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .pushToTalk)
+
+        let before = DispatchTime.now().uptimeNanoseconds
+        var requestTimestamp: UInt64?
+        service.onDictationStart = { timestamp in
+            requestTimestamp = timestamp
+        }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+
+        let timestamp = try XCTUnwrap(requestTimestamp)
+        XCTAssertGreaterThanOrEqual(timestamp, before)
+        XCTAssertLessThanOrEqual(timestamp, DispatchTime.now().uptimeNanoseconds)
+    }
+
+    @MainActor
     func testMonitorFallbackStopsPushToTalkOnKeyUp() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -4394,7 +4442,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
         service.onDictationStop = {
@@ -4419,7 +4467,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
 
         let comboDown = try makeFlagsChangedEvent(keyCode: 0x3D, modifierFlags: [.command, .option])
@@ -4451,7 +4499,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
 
         let rightCommandDown = try makeFlagsChangedEvent(keyCode: 0x36, modifierFlags: [.command])
@@ -4486,7 +4534,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(try rightCommandRightOptionComboHotkey(), for: .pushToTalk)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let leftCommandDown = try makeFlagsChangedEvent(
             keyCode: 0x37,
@@ -4511,7 +4559,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
 
         let rightCommandDown = try makeFlagsChangedEvent(
@@ -4540,7 +4588,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(try rightCommandRightOptionComboHotkey(), for: .pushToTalk)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let rightCommandDown = try makeFlagsChangedEvent(
             keyCode: 0x36,
@@ -4564,7 +4612,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(controlShiftComboHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let comboDown = try makeFlagsChangedEvent(keyCode: 0x38, modifierFlags: [.control, .shift])
 
@@ -4580,7 +4628,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(controlShiftComboHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let commandControlShift = try makeFlagsChangedEvent(
             keyCode: 0x38,
@@ -4609,7 +4657,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(try rightCommandRightOptionComboHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let rightComboWithExtraLeftCommand = try makeFlagsChangedEvent(
             keyCode: 0x37,
@@ -4627,7 +4675,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         leftService.setHotkeyForTesting(try legacyCommandOptionComboHotkey(), for: .toggle)
 
         var leftStartCount = 0
-        leftService.onDictationStart = { leftStartCount += 1 }
+        leftService.onDictationStart = { _ in leftStartCount += 1 }
 
         let leftOptionDown = try makeFlagsChangedEvent(
             keyCode: 0x3A,
@@ -4641,7 +4689,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         rightService.setHotkeyForTesting(try legacyCommandOptionComboHotkey(), for: .toggle)
 
         var rightStartCount = 0
-        rightService.onDictationStart = { rightStartCount += 1 }
+        rightService.onDictationStart = { _ in rightStartCount += 1 }
 
         let rightOptionDown = try makeFlagsChangedEvent(
             keyCode: 0x3D,
@@ -4704,7 +4752,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var startCount = 0
         var stopCount = 0
         var interruptionCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
         service.onPushToTalkInterruption = { interruptionCount += 1 }
 
@@ -4756,7 +4804,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4776,7 +4824,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(commandOptionAHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4798,7 +4846,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(commandOptionComboHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4816,7 +4864,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(commandOptionAHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4834,7 +4882,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(bareSpaceHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = {
+        service.onDictationStart = { _ in
             startCount += 1
         }
 
@@ -4855,7 +4903,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
 
         let keyDown = try makeFnEvent(isDown: true)
@@ -4879,7 +4927,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
 
         let keyDown = try makeFnEvent(isDown: true)
@@ -4904,7 +4952,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         var startCount = 0
         var stopCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
 
         let keyDown = try makeFnEvent(isDown: true)
@@ -4929,7 +4977,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(fnHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let keyDown = try makeFnEvent(isDown: true)
         let keyUp = try makeFnEvent(isDown: false)
@@ -4951,7 +4999,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var callbackCount = 0
         var startCount = 0
         service.onRecentTranscriptionsToggle = { callbackCount += 1 }
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
 
@@ -4972,7 +5020,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var startCount = 0
         var stopCount = 0
         var callbackCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
         service.onRecentTranscriptionsToggle = { callbackCount += 1 }
 
@@ -4998,7 +5046,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var callbackCount = 0
         var startCount = 0
         service.onCopyLastTranscription = { callbackCount += 1 }
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let keyDown = try makeKeyboardEvent(keyCode: 0x08, keyDown: true, flags: [.maskCommand, .maskShift])
 
@@ -5019,7 +5067,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var startCount = 0
         var stopCount = 0
         var callbackCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
         service.onCopyLastTranscription = { callbackCount += 1 }
 
@@ -5045,7 +5093,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var callbackCount = 0
         var startCount = 0
         service.onRecorderToggle = { callbackCount += 1 }
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let keyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
 
@@ -5066,7 +5114,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var startCount = 0
         var stopCount = 0
         var callbackCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
         service.onDictationStop = { stopCount += 1 }
         service.onRecorderToggle = { callbackCount += 1 }
 
@@ -5119,7 +5167,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.setHotkeyForTesting(commandOptionAHotkey(), for: .toggle)
 
         var startCount = 0
-        service.onDictationStart = { startCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
 
         let keyDown = try makeKeyboardEvent(
             keyCode: 0x00,
@@ -5140,7 +5188,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.registerProfileHotkeys([(id: profileId, hotkey: controlShiftComboHotkey())])
 
         var startedProfileId: UUID?
-        service.onProfileDictationStart = { startedProfileId = $0 }
+        service.onProfileDictationStart = { profileId, _ in startedProfileId = profileId }
 
         let extraModifierDown = try makeFlagsChangedEvent(
             keyCode: 0x38,
@@ -5160,7 +5208,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey(), behavior: .startDictation)])
 
         var startedWorkflowId: UUID?
-        service.onWorkflowDictationStart = { startedWorkflowId = $0 }
+        service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowId = workflowId }
 
         let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
         let keyUp = try makeKeyboardEvent(keyCode: 0x31, keyDown: false)
@@ -5186,7 +5234,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         var textWorkflowId: UUID?
         var startedWorkflowId: UUID?
         service.onWorkflowTextProcessing = { textWorkflowId = $0 }
-        service.onWorkflowDictationStart = { startedWorkflowId = $0 }
+        service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowId = workflowId }
 
         let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
         let keyUp = try makeKeyboardEvent(keyCode: 0x31, keyDown: false)
@@ -5214,7 +5262,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         ])
 
         var startedWorkflowIds: [UUID] = []
-        service.onWorkflowDictationStart = { startedWorkflowIds.append($0) }
+        service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowIds.append(workflowId) }
 
         let firstDown = try makeKeyboardEvent(
             keyCode: 0x31,
@@ -5244,7 +5292,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         ])
 
         var startedWorkflowId: UUID?
-        service.onWorkflowDictationStart = { startedWorkflowId = $0 }
+        service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowId = workflowId }
 
         let extraModifierDown = try makeFlagsChangedEvent(
             keyCode: 0x38,

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1072,13 +1072,26 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
 
         XCTAssertTrue(service.isRecording)
         XCTAssertEqual(inputCaptureFactory.startCalls, [
-            .init(deviceID: usbDeviceID, label: "recording", bufferSize: 1024)
+            .init(deviceID: usbDeviceID, label: "recording", bufferSize: 256)
         ])
 
         let samples = await service.stopRecording(policy: .immediate)
 
         XCTAssertTrue(samples.isEmpty)
         XCTAssertEqual(inputCaptureFactory.createdSessions.first?.stopCalls, 1)
+    }
+
+    func testDefaultInputRecordingSkipsAvailabilityPreflightFastPath() throws {
+        let service = AudioRecordingService()
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = false
+        service.inputAvailabilityOverride = { _ in
+            XCTFail("default-input fast path should rely on engine startup instead of input availability preflight")
+            return true
+        }
+        service.startRecordingOverride = {}
+
+        XCTAssertNoThrow(try service.startRecording())
     }
 
     func testRecoveryEngineSwap_replacesStoredEngineInstance() {


### PR DESCRIPTION
## Summary
- Pass a monotonic hotkey request timestamp into dictation start and log request-to-audio-start plus request-to-first-buffer timings.
- Move avoidable UI/context work out of the pre-audio start path so audio capture starts before palette/context handling.
- Speed up default microphone recording startup by skipping the default-input availability preflight, keeping explicit selected-device validation, and reducing the recording capture tap buffer to 256 frames.

## Issue Context
Issue #496 reports that `v1.4.0-daily.20260509` still cuts off initial speech when starting immediately after the Push-to-Talk hotkey. That daily already includes #491, so this follow-up treats the report as remaining audio-engine cold-start latency rather than a stale-build report.

This keeps the chosen privacy constraint: no always-on or pre-roll microphone capture. The change reduces avoidable startup delay and adds timing logs for the next daily verification, but it does not claim to recover speech spoken before macOS/AVAudioEngine delivers the first input buffer.

Closes #496

## Manual Cold-Start Verification
After launching the dev build from this branch, I ran immediate-speech Push-to-Talk attempts with the new timing logs enabled.

Run 1:
- `requestToAudioStartMs`: n=9, min=194.1 ms, avg=219.2 ms, max=311.5 ms, median=205.2 ms
- `requestToFirstBufferMs`: n=9, min=300.5 ms, avg=325.6 ms, max=418.0 ms, median=311.5 ms

Run 2:
- `requestToAudioStartMs`: n=11, min=196.7 ms, avg=203.7 ms, max=212.0 ms, median=202.2 ms
- `requestToFirstBufferMs`: n=11, min=303.1 ms, avg=309.9 ms, max=318.3 ms, median=308.4 ms

Interpretation: this PR removes avoidable pre-audio work and makes the remaining delay measurable, but the first processed audio buffer still arrives roughly 300 ms after the hotkey request on the tested default-input path. If the user starts speaking at the exact same time as the hotkey press, the initial phonemes can still be missing or degraded. Under the current privacy constraint, TypeWhisper cannot recover audio spoken before macOS/AVAudioEngine delivers the first input buffer.

Follow-up product choices are therefore explicit:
- keep the privacy-neutral model and cue readiness only after the first input buffer arrives; or
- add a clearly opt-in pre-roll/ring-buffer mode for users who want speech from the exact hotkey instant preserved.

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_showsNoMicDetectedErrorWhenSelectedInputUnavailable -only-testing:TypeWhisperTests/AudioRecordingServiceInputAvailabilityTests/testStartRecording_throwsNoMicrophoneDetectedBeforeStartingOverride -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests/testPushToTalkStartCallbackIncludesRequestTimestamp -only-testing:TypeWhisperTests/AudioRecordingServiceSelectedDeviceTests/testDefaultInputRecordingSkipsAvailabilityPreflightFastPath -only-testing:TypeWhisperTests/AudioRecordingServiceSelectedDeviceTests/testStartRecordingUsesInputOnlyCaptureForExplicitUSBInput`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests -only-testing:TypeWhisperTests/DictationShortSpeechTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests`
