### PR TITLE
Press enter after inserting

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -249,6 +249,10 @@ final class TextInsertionService {
         let selectedText: String?
         let selectedRange: NSRange?
 
+        var hasObservableTextState: Bool {
+            value != nil || selectedText != nil || selectedRange != nil
+        }
+
         static func == (lhs: FocusedTextState, rhs: FocusedTextState) -> Bool {
             lhs.element == rhs.element &&
             lhs.value == rhs.value &&
@@ -261,6 +265,12 @@ final class TextInsertionService {
         let element: AXUIElement?
         let bundleId: String?
         let shouldPressReturn: Bool
+    }
+
+    private enum PasteCompletion {
+        case verified
+        case unavailable
+        case timedOut
     }
 
     func getSelectedText() -> String? {
@@ -294,7 +304,7 @@ final class TextInsertionService {
     }
 
     /// Returns the focused text element (even without selection), for later insertion.
-    func getFocusedTextElement() -> AXUIElement? {
+    func getFocusedElement() -> AXUIElement? {
         if let focusedTextElementOverride {
             return focusedTextElementOverride()
         }
@@ -306,7 +316,16 @@ final class TextInsertionService {
             return nil
         }
 
-        let element = focusedElement as! AXUIElement
+        return (focusedElement as! AXUIElement)
+    }
+
+    /// Returns the focused text element (even without selection), for later insertion.
+    func getFocusedTextElement() -> AXUIElement? {
+        if let focusedTextElementOverride {
+            return focusedTextElementOverride()
+        }
+
+        guard let element = getFocusedElement() else { return nil }
         var roleValue: AnyObject?
         guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleValue) == .success,
               let role = roleValue as? String else { return nil }
@@ -376,6 +395,18 @@ final class TextInsertionService {
         PasteVerificationState(focusedTextState: captureFocusedTextState())
     }
 
+    private func capturePasteVerificationState(for preferredElement: AXUIElement?) -> PasteVerificationState? {
+        let focusedTextState: FocusedTextState?
+        if let preferredElement {
+            focusedTextState = captureFocusedTextState(for: preferredElement)
+        } else {
+            focusedTextState = captureFocusedTextState()
+        }
+
+        guard let focusedTextState, focusedTextState.hasObservableTextState else { return nil }
+        return PasteVerificationState(focusedTextState: focusedTextState)
+    }
+
     func canRestoreClipboard(afterPasteUsing state: PasteVerificationState) -> Bool {
         guard let initialState = state.focusedTextState,
               let currentState = captureFocusedTextState(for: initialState.element) else {
@@ -395,6 +426,35 @@ final class TextInsertionService {
         )
     }
 
+    private func waitForPasteCompletion(using state: PasteVerificationState?) async -> PasteCompletion {
+        guard let state, let initialState = state.focusedTextState else {
+            try? await Task.sleep(for: .milliseconds(120))
+            return .unavailable
+        }
+
+        let deadline = Date().addingTimeInterval(0.6)
+        repeat {
+            if let currentState = captureFocusedTextState(for: initialState.element),
+               Self.focusedTextDidChange(
+                   from: (
+                       value: initialState.value,
+                       selectedText: initialState.selectedText,
+                       selectedRange: initialState.selectedRange
+                   ),
+                   to: (
+                       value: currentState.value,
+                       selectedText: currentState.selectedText,
+                       selectedRange: currentState.selectedRange
+                   )
+               ) {
+                return .verified
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        } while Date() < deadline
+
+        return .timedOut
+    }
+
     func insertText(
         _ text: String,
         preserveClipboard: Bool = false,
@@ -407,11 +467,11 @@ final class TextInsertionService {
             throw TextInsertionError.accessibilityNotGranted
         }
 
-        let currentFocusedElement = autoEnter ? getFocusedTextElement() : nil
+        let currentFocusedElement = autoEnter ? getFocusedElement() : nil
         let autoEnterTarget = autoEnter ? AutoEnterTarget(
             element: autoEnterTargetElement ?? currentFocusedElement,
             bundleId: autoEnterTargetBundleId ?? captureActiveApp().bundleId,
-            shouldPressReturn: autoEnterTargetElement != nil || currentFocusedElement != nil || hasFocusedTextField()
+            shouldPressReturn: true
         ) : nil
         let formattedClipboardPayload = ClipboardContentFormatter.payload(for: text, outputFormat: outputFormat)
         let requiresPasteboardInsertion = ClipboardContentFormatter.requiresPasteboardInsertion(
@@ -429,6 +489,10 @@ final class TextInsertionService {
 
         let pasteboard = pasteboardProvider()
         let savedItems = preserveClipboard ? saveClipboard(from: pasteboard) : []
+        if let autoEnterTarget {
+            await restoreAutoEnterTarget(autoEnterTarget)
+        }
+        let pasteVerificationState = autoEnterTarget.flatMap { capturePasteVerificationState(for: $0.element) }
 
         // Set transcribed text on clipboard and simulate Cmd+V.
         // Text stays on clipboard as fallback if no text field is focused.
@@ -440,13 +504,19 @@ final class TextInsertionService {
         }
         simulatePaste()
 
+        let pasteCompletion = await waitForPasteCompletion(using: pasteVerificationState)
+
         if preserveClipboard {
-            try? await Task.sleep(for: .milliseconds(200))
             restoreClipboard(savedItems, to: pasteboard)
         }
 
         if let autoEnterTarget, autoEnterTarget.shouldPressReturn {
-            await performAutoEnter(using: autoEnterTarget)
+            switch pasteCompletion {
+            case .verified, .unavailable:
+                await performAutoEnter(using: autoEnterTarget)
+            case .timedOut:
+                logger.warning("Auto Enter skipped because paste completion could not be verified")
+            }
         }
 
         return .pasted
@@ -529,16 +599,15 @@ final class TextInsertionService {
             return
         }
         let returnKeyCode: CGKeyCode = 0x24
-        let source = CGEventSource(stateID: .hidSystemState)
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: returnKeyCode, keyDown: true)
+        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true)
         keyDown?.flags = []
-        keyDown?.post(tap: .cghidEventTap)
+        keyDown?.post(tap: .cgSessionEventTap)
 
-        try? await Task.sleep(for: .milliseconds(10))
+        try? await Task.sleep(for: .milliseconds(5))
 
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: returnKeyCode, keyDown: false)
+        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
         keyUp?.flags = []
-        keyUp?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cgSessionEventTap)
     }
 
     private func simulatePaste() {
@@ -580,10 +649,53 @@ final class TextInsertionService {
             )
             if result != .success {
                 logger.debug("Auto Enter could not refocus captured element: \(result.rawValue)")
+                if let fallbackElement = focusedElementForApp(bundleId: target.bundleId) {
+                    let fallbackResult = AXUIElementSetAttributeValue(
+                        fallbackElement,
+                        kAXFocusedAttribute as CFString,
+                        kCFBooleanTrue
+                    )
+                    logger.debug("Auto Enter fallback focus result: \(fallbackResult.rawValue)")
+                    if fallbackResult == .success {
+                        try? await Task.sleep(for: .milliseconds(30))
+                    }
+                }
             } else {
                 try? await Task.sleep(for: .milliseconds(30))
             }
+        } else if let fallbackElement = focusedElementForApp(bundleId: target.bundleId) {
+            let fallbackResult = AXUIElementSetAttributeValue(
+                fallbackElement,
+                kAXFocusedAttribute as CFString,
+                kCFBooleanTrue
+            )
+            logger.debug("Auto Enter focused fallback app element: \(fallbackResult.rawValue)")
+            if fallbackResult == .success {
+                try? await Task.sleep(for: .milliseconds(30))
+            }
         }
+    }
+
+    private func focusedElementForApp(bundleId: String?) -> AXUIElement? {
+        guard let bundleId,
+              let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first else {
+            return nil
+        }
+
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        var focusedElement: AnyObject?
+        if AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedElement) == .success,
+           let focusedElement {
+            return (focusedElement as! AXUIElement)
+        }
+
+        var focusedWindow: AnyObject?
+        if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &focusedWindow) == .success,
+           let focusedWindow {
+            return (focusedWindow as! AXUIElement)
+        }
+
+        return nil
     }
 
     private func simulateCopy() {

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -257,6 +257,12 @@ final class TextInsertionService {
         }
     }
 
+    private struct AutoEnterTarget {
+        let element: AXUIElement?
+        let bundleId: String?
+        let shouldPressReturn: Bool
+    }
+
     func getSelectedText() -> String? {
         if let selectedTextOverride {
             return selectedTextOverride()
@@ -393,13 +399,20 @@ final class TextInsertionService {
         _ text: String,
         preserveClipboard: Bool = false,
         autoEnter: Bool = false,
-        outputFormat: String? = nil
+        outputFormat: String? = nil,
+        autoEnterTargetElement: AXUIElement? = nil,
+        autoEnterTargetBundleId: String? = nil
     ) async throws -> InsertionResult {
         guard isAccessibilityGranted else {
             throw TextInsertionError.accessibilityNotGranted
         }
 
-        let hadFocusedTextField = autoEnter && hasFocusedTextField()
+        let currentFocusedElement = autoEnter ? getFocusedTextElement() : nil
+        let autoEnterTarget = autoEnter ? AutoEnterTarget(
+            element: autoEnterTargetElement ?? currentFocusedElement,
+            bundleId: autoEnterTargetBundleId ?? captureActiveApp().bundleId,
+            shouldPressReturn: autoEnterTargetElement != nil || currentFocusedElement != nil || hasFocusedTextField()
+        ) : nil
         let formattedClipboardPayload = ClipboardContentFormatter.payload(for: text, outputFormat: outputFormat)
         let requiresPasteboardInsertion = ClipboardContentFormatter.requiresPasteboardInsertion(
             outputFormat: outputFormat
@@ -408,9 +421,8 @@ final class TextInsertionService {
         if preserveClipboard, !requiresPasteboardInsertion,
            let focusedElement = getFocusedTextElement(),
            insertTextAtAndVerifyChange(element: focusedElement, text: text) {
-            if hadFocusedTextField {
-                try? await Task.sleep(for: .milliseconds(50))
-                simulateReturn()
+            if let autoEnterTarget, autoEnterTarget.shouldPressReturn {
+                await performAutoEnter(using: autoEnterTarget)
             }
             return .pasted
         }
@@ -433,9 +445,8 @@ final class TextInsertionService {
             restoreClipboard(savedItems, to: pasteboard)
         }
 
-        if hadFocusedTextField {
-            try? await Task.sleep(for: .milliseconds(50))
-            simulateReturn()
+        if let autoEnterTarget, autoEnterTarget.shouldPressReturn {
+            await performAutoEnter(using: autoEnterTarget)
         }
 
         return .pasted
@@ -512,19 +523,22 @@ final class TextInsertionService {
         return point
     }
 
-    func simulateReturn() {
+    func simulateReturn() async {
         if let returnSimulatorOverride {
             returnSimulatorOverride()
             return
         }
         let returnKeyCode: CGKeyCode = 0x24
-        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true)
+        let source = CGEventSource(stateID: .hidSystemState)
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: returnKeyCode, keyDown: true)
         keyDown?.flags = []
-        keyDown?.post(tap: .cgSessionEventTap)
+        keyDown?.post(tap: .cghidEventTap)
 
-        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
+        try? await Task.sleep(for: .milliseconds(10))
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: returnKeyCode, keyDown: false)
         keyUp?.flags = []
-        keyUp?.post(tap: .cgSessionEventTap)
+        keyUp?.post(tap: .cghidEventTap)
     }
 
     private func simulatePaste() {
@@ -541,6 +555,35 @@ final class TextInsertionService {
         let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: vKeyCode, keyDown: false)
         keyUp?.flags = .maskCommand
         keyUp?.post(tap: .cgSessionEventTap)
+    }
+
+    private func performAutoEnter(using target: AutoEnterTarget) async {
+        await restoreAutoEnterTarget(target)
+        try? await Task.sleep(for: .milliseconds(80))
+        await simulateReturn()
+    }
+
+    private func restoreAutoEnterTarget(_ target: AutoEnterTarget) async {
+        if let bundleId = target.bundleId,
+           NSWorkspace.shared.frontmostApplication?.bundleIdentifier != bundleId,
+           let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first {
+            let activated = app.activate(from: NSRunningApplication.current)
+            logger.info("Auto Enter reactivated target app \(bundleId, privacy: .public): \(activated)")
+            try? await Task.sleep(for: .milliseconds(120))
+        }
+
+        if let element = target.element {
+            let result = AXUIElementSetAttributeValue(
+                element,
+                kAXFocusedAttribute as CFString,
+                kCFBooleanTrue
+            )
+            if result != .success {
+                logger.debug("Auto Enter could not refocus captured element: \(result.rawValue)")
+            } else {
+                try? await Task.sleep(for: .milliseconds(30))
+            }
+        }
     }
 
     private func simulateCopy() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -828,7 +828,7 @@ final class DictationViewModel: ObservableObject {
             // not delay capture of the user's first spoken words.
             let activeApp = textInsertionService.captureActiveApp()
             capturedActiveApp = activeApp
-            capturedFocusedTextElement = textInsertionService.getFocusedTextElement()
+            capturedFocusedTextElement = textInsertionService.getFocusedElement()
             capturedSelectedText = nil
             activeAppIcon = nil
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -197,6 +197,7 @@ final class DictationViewModel: ObservableObject {
     private var forcedProfileId: UUID?
     private var forcedWorkflowId: UUID?
     private var capturedActiveApp: (name: String?, bundleId: String?, url: String?)?
+    private var capturedFocusedTextElement: AXUIElement?
     private var capturedSelectedText: String?
 
     private var cancellables = Set<AnyCancellable>()
@@ -827,6 +828,7 @@ final class DictationViewModel: ObservableObject {
             // not delay capture of the user's first spoken words.
             let activeApp = textInsertionService.captureActiveApp()
             capturedActiveApp = activeApp
+            capturedFocusedTextElement = textInsertionService.getFocusedTextElement()
             capturedSelectedText = nil
             activeAppIcon = nil
 
@@ -1243,7 +1245,9 @@ final class DictationViewModel: ObservableObject {
                         text,
                         preserveClipboard: preserveClipboard,
                         autoEnter: self.effectiveAutoEnterEnabled,
-                        outputFormat: self.effectiveOutputFormat
+                        outputFormat: self.effectiveOutputFormat,
+                        autoEnterTargetElement: self.capturedFocusedTextElement,
+                        autoEnterTargetBundleId: activeApp.bundleId
                     )
                     EventBus.shared.emit(.textInserted(TextInsertedPayload(
                         text: text,
@@ -1374,6 +1378,7 @@ final class DictationViewModel: ObservableObject {
         recordingStartTime = nil
         clearActiveRuleState()
         capturedActiveApp = nil
+        capturedFocusedTextElement = nil
         capturedSelectedText = nil
         activeAppIcon = nil
         processingPhase = nil

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -283,7 +283,7 @@ final class PromptPaletteHandler {
 
                 if workflow.output.autoEnter, insertionOutcome != .failed {
                     try? await Task.sleep(for: .milliseconds(50))
-                    textInsertionService.simulateReturn()
+                    await textInsertionService.simulateReturn()
                 }
 
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1418,11 +1418,12 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testAutoEnterSkipsReturnWithoutFocusedTextField() async throws {
+    func testAutoEnterTriggersReturnWithoutFocusedTextFieldWhenRequested() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { nil }
         service.focusedTextFieldOverride = { false }
 
         var didSimulatePaste = false
@@ -1438,8 +1439,44 @@ final class APIRouterAndHandlersTests: XCTestCase {
         _ = try await service.insertText("Hello", autoEnter: true)
 
         XCTAssertTrue(didSimulatePaste)
-        XCTAssertFalse(didSimulateReturn)
+        XCTAssertTrue(didSimulateReturn)
         XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+    }
+
+    @MainActor
+    func testAutoEnterWaitsForVerifiedPasteBeforeReturn() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let targetElement = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { targetElement }
+        service.focusedTextFieldOverride = { true }
+        service.captureActiveAppOverride = { (nil, nil, nil) }
+
+        var pasteHasCompleted = false
+        service.focusedTextStateOverride = { _ in
+            pasteHasCompleted
+                ? (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+                : (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+        }
+
+        var events: [String] = []
+        service.pasteSimulatorOverride = {
+            events.append("paste")
+            pasteHasCompleted = true
+        }
+        service.returnSimulatorOverride = {
+            events.append("return")
+        }
+
+        _ = try await service.insertText(
+            "Hello",
+            autoEnter: true,
+            autoEnterTargetElement: targetElement
+        )
+
+        XCTAssertEqual(events, ["paste", "return"])
     }
 
     @MainActor

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1463,6 +1463,33 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testAutoEnterTriggersReturnWithCapturedTargetElement() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let targetElement = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { nil }
+        service.focusedTextFieldOverride = { false }
+        service.captureActiveAppOverride = { (nil, nil, nil) }
+        service.pasteSimulatorOverride = {}
+
+        var didSimulateReturn = false
+        service.returnSimulatorOverride = {
+            didSimulateReturn = true
+        }
+
+        _ = try await service.insertText(
+            "Hello",
+            autoEnter: true,
+            autoEnterTargetElement: targetElement
+        )
+
+        XCTAssertTrue(didSimulateReturn)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+    }
+
+    @MainActor
     func testPreserveClipboardAvoidsPasteboardWhenVerifiedAccessibilityInsertionSucceeds() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()


### PR DESCRIPTION
## Summary

Fixes Auto Enter reliability after TypeWhisper inserts dictated text.

The previous flow could send Return against the wrong focus target, or send it before the paste had completed, especially in apps that change focus or process paste asynchronously. This was unreliable in apps such as Codex and Chrome even though it worked consistently in others.

## Changes

- Capture the originally focused accessibility element and active app at recording start.
- Pass that captured target into text insertion so Auto Enter can restore focus before submitting.
- Reactivate/refocus the target app/element before paste and before Return.
- Wait for paste completion when observable accessibility text state is available.
- Avoid sending Return if paste completion can be observed but does not complete in time.
- Keep clipboard preservation compatible with the new paste-completion flow.
- Make Return simulation async and use `Task.sleep(for:)` for the key-down/key-up dwell, matching the project’s async timing style.
- Update prompt palette Auto Enter handling for the async Return API.

## Files

- `TypeWhisper/Services/TextInsertionService.swift`
- `TypeWhisper/ViewModels/DictationViewModel.swift`
- `TypeWhisper/ViewModels/PromptPaletteHandler.swift`
- `TypeWhisperTests/APIRouterAndHandlersTests.swift`

## Test plan

- [x] Focused insertion/API test suite passes
- [x] Plugin SDK test suite passes
- [x] Local signed Debug app builds successfully
- [x] Manual: Auto Enter submits dictated text after insertion in Codex
- [x] Manual: Auto Enter still submits normally in Telegram
- [x] Manual: Auto Enter submits normally in Slack
- [x] Manual: Auto Enter submits normally in Signal
- [x] Manual: Auto Enter submits normally in Zoom
- [ ] Manual: Auto Enter submits normally in  Claude Code
- [ ] Manual: Auto Enter remains reliable in Chrome
- [ ] Manual: Auto Enter submits normally in TickTick

