### PR TITLE
Fix scheduled app test CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Resolve Swift packages
         run: |
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Resolve Swift packages
         run: |
@@ -137,7 +137,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Run Plugin SDK Tests
         run: swift test --package-path TypeWhisperPluginSDK

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -83,13 +83,13 @@ jobs:
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin
-          # All plugins use Xcode 26.2 (mlx-audio-swift requires Swift 6.2 for package resolution,
-          # and workspace-state.json v7 from Xcode 26.2 is incompatible with Xcode 16.2)
+          # All plugins use Xcode 26.3 (mlx-audio-swift requires Swift 6.2+ for package resolution,
+          # and workspace-state.json v7 from Xcode 26.x is incompatible with Xcode 16.2)
           # - SpeechAnalyzer: macOS 26 deployment target
           # - Qwen3/Voxtral/Granite/Gemma4: macOS 14 + embed Swift compat libs (MLX uses Swift 6.2 features)
           # - All others: macOS 14, no compat libs needed (simple Foundation/SDK code)
           EMBED_SWIFT_LIBS="NO"
-          XCODE_VERSION="26.2"
+          XCODE_VERSION="26.3"
           if [ "$TARGET" = "SpeechAnalyzerPlugin" ]; then
             DEPLOY_TARGET="26.0"
           elif [ "$TARGET" = "Qwen3Plugin" ] || [ "$TARGET" = "VoxtralPlugin" ] || [ "$TARGET" = "GranitePlugin" ] || [ "$TARGET" = "Gemma4Plugin" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Resolve Swift packages
         run: |
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Resolve Swift packages
         run: |
@@ -145,7 +145,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Run Plugin SDK Tests
         run: swift test --package-path TypeWhisperPluginSDK
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.3"
 
       - name: Resolve Swift packages
         run: |

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -150,8 +150,10 @@ struct LoadedPlugin: Identifiable {
         !(instance is UnloadedPluginPlaceholder)
     }
 
+    @MainActor
     var supportsSettingsWindow: Bool {
-        isRuntimeLoaded && instance.settingsView != nil
+        guard isRuntimeLoaded else { return false }
+        return instance.settingsView != nil
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/Tests/FillerWordsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/Tests/FillerWordsPluginTests.swift
@@ -24,6 +24,7 @@ final class FillerWordsPluginTests: XCTestCase {
         XCTAssertEqual(result, "hello?")
     }
 
+    @MainActor
     func testActivationSeedsPluginScopedDefaultWords() throws {
         let host = try PluginTestHostServices()
         let plugin = FillerWordsPlugin()

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -10,10 +10,11 @@ public protocol TypeWhisperPlugin: AnyObject, Sendable {
     init()
     func activate(host: HostServices)
     func deactivate()
-    var settingsView: AnyView? { get }
+    @MainActor var settingsView: AnyView? { get }
 }
 
 public extension TypeWhisperPlugin {
+    @MainActor
     var settingsView: AnyView? { nil }
 }
 

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -343,7 +343,8 @@ final class ProtocolContractTests: XCTestCase {
 
         XCTAssertEqual(result.text, "transcribed")
         XCTAssertEqual(plugin.host?.availableRuleNames, ["Work"])
-        XCTAssertNil(plugin.settingsView)
+        let hasSettingsView = await MainActor.run { plugin.settingsView != nil }
+        XCTAssertFalse(hasSettingsView)
 
         plugin.deactivate()
         XCTAssertNil(plugin.host)


### PR DESCRIPTION
## Summary
- Move GitHub Actions macOS jobs from Xcode 26.2 to Xcode 26.3, which is available on the current macos-15-arm64 runner image.
- Treat plugin settings views as MainActor UI surfaces and update SDK/app call sites and tests accordingly.
- Clear the first-party Swift concurrency warnings that appeared in the failing app-test log.

## CI context
The scheduled Build and Release `app-tests` job in run 25621923994 restarted after an unexpected exit/crash/timeout during `Gemma4PluginModelPolicyTests.testParakeetEnablingVocabularyBoostingPersistsAndNotifiesCapabilityChange`, then exited 65 after the retry summary showed zero test failures. The same log contained first-party concurrency warnings around plugin `settingsView` construction, which would fail the repo warning gate.

## Test plan
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`\n- `bash scripts/check_first_party_warnings.sh /tmp/typewhisper-app-tests-fixed.log`\n- `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`\n- `bash scripts/check_first_party_warnings.sh /tmp/typewhisper-release-build-fixed.log`