### PR TITLE
fix: remove legacy profile runtime rules

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -155,7 +155,7 @@ final class ServiceContainer: ObservableObject {
             audioFileService: audioFileService,
             translationService: translationService,
             historyService: historyService,
-            profileService: profileService,
+            workflowService: workflowService,
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel
         )
@@ -230,19 +230,7 @@ final class ServiceContainer: ObservableObject {
         }
 
         pluginManager.setRuleNamesProvider { [weak self] in
-            guard let self else { return [] }
-            var names: [String] = []
-            for workflow in self.workflowService.workflows {
-                if !names.contains(workflow.name) {
-                    names.append(workflow.name)
-                }
-            }
-            for profile in self.profileService.profiles {
-                if !names.contains(profile.name) {
-                    names.append(profile.name)
-                }
-            }
-            return names
+            self?.workflowService.availableRuleNames ?? []
         }
         pluginManager.setWorkflowProvider { [weak self] in
             self?.workflowService.workflows.map(\.pluginWorkflowInfo) ?? []
@@ -273,15 +261,5 @@ final class ServiceContainer: ObservableObject {
             }
         }
 
-        // Migrate stale cloudModelOverride in profiles
-        for profile in profileService.profiles {
-            guard let modelOverride = profile.cloudModelOverride,
-                  let engineOverride = profile.engineOverride,
-                  let plugin = PluginManager.shared.transcriptionEngine(for: engineOverride) else { continue }
-            let validIds = plugin.transcriptionModels.map(\.id)
-            if !validIds.contains(modelOverride) {
-                profile.cloudModelOverride = nil
-            }
-        }
     }
 }

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -8,7 +8,7 @@ final class APIHandlers: @unchecked Sendable {
     private let audioFileService: AudioFileService
     private let translationService: AnyObject? // TranslationService (macOS 15+)
     private let historyService: HistoryService
-    private let profileService: ProfileService
+    private let workflowService: WorkflowService
     private let dictionaryService: DictionaryService
     private let dictationViewModel: DictationViewModel
 
@@ -17,7 +17,7 @@ final class APIHandlers: @unchecked Sendable {
         audioFileService: AudioFileService,
         translationService: AnyObject?,
         historyService: HistoryService,
-        profileService: ProfileService,
+        workflowService: WorkflowService,
         dictionaryService: DictionaryService,
         dictationViewModel: DictationViewModel
     ) {
@@ -25,7 +25,7 @@ final class APIHandlers: @unchecked Sendable {
         self.audioFileService = audioFileService
         self.translationService = translationService
         self.historyService = historyService
-        self.profileService = profileService
+        self.workflowService = workflowService
         self.dictionaryService = dictionaryService
         self.dictationViewModel = dictationViewModel
     }
@@ -734,7 +734,7 @@ final class APIHandlers: @unchecked Sendable {
     // MARK: - GET /v1/rules
 
     private func handleGetRules(_ request: HTTPRequest) async -> HTTPResponse {
-        let profileService = self.profileService
+        let workflowService = self.workflowService
         return await MainActor.run {
             struct RuleEntry: Encodable {
                 let id: String
@@ -754,8 +754,8 @@ final class APIHandlers: @unchecked Sendable {
                 let profiles: [RuleEntry]
             }
 
-            let entries = profileService.profiles.map { profile in
-                let selection = profile.inputLanguageSelection
+            let entries = workflowService.workflows.map { workflow in
+                let selection = workflow.inputLanguageSelection
                 let legacyInputLanguage: String?
                 switch selection {
                 case .auto:
@@ -767,16 +767,16 @@ final class APIHandlers: @unchecked Sendable {
                 }
 
                 return RuleEntry(
-                    id: profile.id.uuidString,
-                    name: profile.name,
-                    is_enabled: profile.isEnabled,
-                    priority: profile.priority,
-                    bundle_identifiers: profile.bundleIdentifiers,
-                    url_patterns: profile.urlPatterns,
+                    id: workflow.id.uuidString,
+                    name: workflow.name,
+                    is_enabled: workflow.isEnabled,
+                    priority: workflow.sortOrder,
+                    bundle_identifiers: workflow.trigger?.appBundleIdentifiers ?? [],
+                    url_patterns: workflow.trigger?.websitePatterns ?? [],
                     input_language: legacyInputLanguage,
                     language_mode: selection.mode.rawValue,
                     language_hints: selection.selectedCodes,
-                    translation_target_language: profile.translationTargetLanguage
+                    translation_target_language: workflow.translationTargetLanguage
                 )
             }
 
@@ -792,13 +792,13 @@ final class APIHandlers: @unchecked Sendable {
             return .error(status: 400, message: "Missing or invalid 'id' query parameter")
         }
 
-        let profileService = self.profileService
+        let workflowService = self.workflowService
         return await MainActor.run {
-            guard let profile = profileService.profiles.first(where: { $0.id == uuid }) else {
+            guard let workflow = workflowService.workflows.first(where: { $0.id == uuid }) else {
                 return .error(status: 404, message: "Rule not found")
             }
 
-            profileService.toggleProfile(profile)
+            workflowService.toggleWorkflow(workflow)
 
             struct ToggleResponse: Encodable {
                 let id: String
@@ -809,11 +809,11 @@ final class APIHandlers: @unchecked Sendable {
             }
 
             return .json(ToggleResponse(
-                id: profile.id.uuidString,
-                name: profile.name,
-                rule_name: profile.name,
-                profile_name: profile.name,
-                is_enabled: profile.isEnabled
+                id: workflow.id.uuidString,
+                name: workflow.name,
+                rule_name: workflow.name,
+                profile_name: workflow.name,
+                is_enabled: workflow.isEnabled
             ))
         }
     }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -340,11 +340,8 @@ final class HotkeyService: ObservableObject {
 
     // MARK: - Profile Hotkeys
 
-    func registerProfileHotkeys(_ entries: [(id: UUID, hotkey: UnifiedHotkey)]) {
+    func registerProfileHotkeys(_: [(id: UUID, hotkey: UnifiedHotkey)]) {
         profileSlots.removeAll()
-        for entry in entries {
-            profileSlots[entry.id] = ProfileHotkeyState(profileId: entry.id, hotkey: entry.hotkey)
-        }
         tearDownMonitor()
         setupMonitor()
     }
@@ -360,12 +357,7 @@ final class HotkeyService: ObservableObject {
         setupMonitor()
     }
 
-    func isHotkeyAssignedToProfile(_ hotkey: UnifiedHotkey, excludingProfileId: UUID?) -> UUID? {
-        for (id, state) in profileSlots where id != excludingProfileId {
-            if state.hotkey.conflicts(with: hotkey) {
-                return id
-            }
-        }
+    func isHotkeyAssignedToProfile(_: UnifiedHotkey, excludingProfileId _: UUID?) -> UUID? {
         return nil
     }
 

--- a/TypeWhisper/Services/MemoryService.swift
+++ b/TypeWhisper/Services/MemoryService.swift
@@ -83,10 +83,11 @@ Return ONLY the JSON array, nothing else.
     private func handleTranscription(_ payload: TranscriptionCompletedPayload) {
         guard isEnabled, payload.finalText.count >= minimumTextLength else { return }
 
-        // Per-rule gate
+        // Per-workflow gate. Legacy profiles may still exist on disk, but they
+        // are no longer a runtime source in 1.4.
         if let ruleName = payload.ruleName,
-           let profile = ServiceContainer.shared.profileService.profiles.first(where: { $0.name == ruleName }) {
-            guard profile.memoryEnabled else { return }
+           ServiceContainer.shared.workflowService.workflows.contains(where: { $0.name == ruleName }) {
+            // Continue only for known workflow-backed rule names.
         } else {
             return
         }

--- a/TypeWhisper/Services/WorkflowService.swift
+++ b/TypeWhisper/Services/WorkflowService.swift
@@ -130,6 +130,14 @@ final class WorkflowService: ObservableObject {
         (workflows.map(\.sortOrder).max() ?? -1) + 1
     }
 
+    var availableRuleNames: [String] {
+        var names: [String] = []
+        for workflow in workflows where !names.contains(workflow.name) {
+            names.append(workflow.name)
+        }
+        return names
+    }
+
     func updateWorkflow(_ workflow: Workflow) {
         workflow.updatedAt = Date()
         save()

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -73,7 +73,6 @@ final class DictationSettingsHandler {
     }
 
     func registerInitialTriggerHotkeys() {
-        syncProfileHotkeys(profileService.profiles)
         syncWorkflowHotkeys(workflowService.workflows)
     }
 
@@ -82,14 +81,8 @@ final class DictationSettingsHandler {
         registerInitialTriggerHotkeys()
     }
 
-    func syncProfileHotkeys(_ profiles: [Profile]) {
-        let entries = profiles
-            .filter { $0.isEnabled }
-            .compactMap { profile -> (id: UUID, hotkey: UnifiedHotkey)? in
-                guard let hotkey = profile.hotkey else { return nil }
-                return (id: profile.id, hotkey: hotkey)
-            }
-        hotkeyService.registerProfileHotkeys(entries)
+    func syncProfileHotkeys(_: [Profile]) {
+        hotkeyService.registerProfileHotkeys([])
     }
 
     func syncWorkflowHotkeys(_ workflows: [Workflow]) {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -39,20 +39,12 @@ struct DictationSessionSnapshot: Sendable, Equatable {
 enum DictationLanguageResolver {
     static func resolve(
         workflow: Workflow?,
-        profile: Profile?,
         globalLanguageSelection: LanguageSelection
     ) -> LanguageSelection {
         if let workflow {
             let workflowSelection = workflow.inputLanguageSelection
             if workflowSelection != .inheritGlobal {
                 return workflowSelection
-            }
-        }
-
-        if let profile {
-            let profileSelection = profile.inputLanguageSelection
-            if profileSelection != .inheritGlobal {
-                return profileSelection
             }
         }
 
@@ -192,9 +184,6 @@ final class DictationViewModel: ObservableObject {
     private let postProcessingPipeline: PostProcessingPipeline
     private var matchedWorkflow: Workflow?
     private var activeWorkflowMatch: WorkflowMatchResult?
-    private var matchedProfile: Profile?
-    private var activeRuleMatch: RuleMatchResult?
-    private var forcedProfileId: UUID?
     private var forcedWorkflowId: UUID?
     private var capturedActiveApp: (name: String?, bundleId: String?, url: String?)?
     private var capturedSelectedText: String?
@@ -612,10 +601,6 @@ final class DictationViewModel: ObservableObject {
             self?.stopDictation()
         }
 
-        hotkeyService.onProfileDictationStart = { [weak self] profileId, requestTimestamp in
-            self?.startRecording(forcedProfileId: profileId, requestUptimeNanoseconds: requestTimestamp)
-        }
-
         hotkeyService.onWorkflowDictationStart = { [weak self] workflowId, requestTimestamp in
             self?.startRecording(forcedWorkflowId: workflowId, requestUptimeNanoseconds: requestTimestamp)
         }
@@ -631,16 +616,6 @@ final class DictationViewModel: ObservableObject {
         hotkeyService.onPushToTalkInterruption = { [weak self] in
             self?.handlePushToTalkInterruption()
         }
-
-        // Sync profile hotkeys whenever profiles change
-        // dropFirst: avoid early monitor setup during ServiceContainer.init() before app is ready
-        profileService.$profiles
-            .dropFirst()
-            .sink { [weak self] profiles in
-                guard let self else { return }
-                self.settingsHandler.syncProfileHotkeys(profiles)
-            }
-            .store(in: &cancellables)
 
         workflowService.$workflows
             .dropFirst()
@@ -743,7 +718,6 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func startRecording(
-        forcedProfileId: UUID? = nil,
         forcedWorkflowId: UUID? = nil,
         sessionID: UUID = UUID(),
         requestUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
@@ -765,7 +739,6 @@ final class DictationViewModel: ObservableObject {
         urlResolutionTask?.cancel()
         urlResolutionTask = nil
 
-        self.forcedProfileId = forcedProfileId
         self.forcedWorkflowId = forcedWorkflowId
         beginDictationSession(id: sessionID)
 
@@ -833,13 +806,10 @@ final class DictationViewModel: ObservableObject {
             if let forcedWorkflowId,
                let forcedWorkflow = workflowService.workflows.first(where: { $0.id == forcedWorkflowId && $0.isEnabled }) {
                 applyWorkflowMatch(workflowService.forcedWorkflowMatch(for: forcedWorkflow), activeApp: activeApp)
-            } else if let forcedProfileId,
-               let forcedProfile = profileService.profiles.first(where: { $0.id == forcedProfileId && $0.isEnabled }) {
-                applyRuleMatch(profileService.forcedRuleMatch(for: forcedProfile), activeApp: activeApp)
             } else if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: activeApp.bundleId, url: nil) {
                 applyWorkflowMatch(workflowMatch, activeApp: activeApp)
             } else {
-                applyRuleMatch(profileService.matchRule(bundleIdentifier: activeApp.bundleId, url: nil), activeApp: activeApp)
+                clearActiveRuleState()
             }
             let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
 
@@ -850,7 +820,6 @@ final class DictationViewModel: ObservableObject {
             )))
             scheduleDeferredRecordingMetadataCapture(
                 activeApp: activeApp,
-                forcedProfileId: forcedProfileId,
                 forcedWorkflowId: forcedWorkflowId
             )
 
@@ -881,7 +850,6 @@ final class DictationViewModel: ObservableObject {
 
     private func scheduleDeferredRecordingMetadataCapture(
         activeApp: (name: String?, bundleId: String?, url: String?),
-        forcedProfileId: UUID?,
         forcedWorkflowId: UUID?
     ) {
         let metadataStartTimestamp = CFAbsoluteTimeGetCurrent()
@@ -908,9 +876,9 @@ final class DictationViewModel: ObservableObject {
         }
 
         // Resolve browser URL asynchronously after recording has already started.
-        // If a more specific URL rule matches, update the active rule on the fly.
-        // Skip URL resolution when a forced rule is set (manual rule shortcut overrides app matching).
-        guard forcedProfileId == nil, forcedWorkflowId == nil, let bundleId = activeApp.bundleId else { return }
+        // If a more specific URL workflow matches, update the active rule on the fly.
+        // Skip URL resolution when a forced workflow is set (manual shortcut overrides app matching).
+        guard forcedWorkflowId == nil, let bundleId = activeApp.bundleId else { return }
         urlResolutionTask = Task { [weak self] in
             guard let self else { return }
             logger.info("URL resolution: starting for bundleId=\(bundleId)")
@@ -939,25 +907,13 @@ final class DictationViewModel: ObservableObject {
                 return
             }
 
-            guard matchedWorkflow == nil else {
-                logger.info("URL resolution: keeping existing workflow match")
-                return
-            }
-            guard let refinedRule = profileService.matchRule(bundleIdentifier: bundleId, url: resolvedURL) else {
-                logger.info("URL resolution: no profile rule matched for URL \(resolvedURL)")
-                return
-            }
-
-            logger.info("URL resolution: matched profile rule '\(refinedRule.profile.name)'")
-            applyRuleMatch(refinedRule, activeApp: capturedActiveApp)
-            refreshLiveStreamingIfParamsChanged()
+            logger.info("URL resolution: no workflow matched for URL \(resolvedURL)")
         }
     }
 
     private var effectiveLanguageSelection: LanguageSelection {
         DictationLanguageResolver.resolve(
             workflow: matchedWorkflow,
-            profile: matchedProfile,
             globalLanguageSelection: settingsViewModel.languageSelection
         )
     }
@@ -967,23 +923,10 @@ final class DictationViewModel: ObservableObject {
     }
 
     private var effectiveTask: TranscriptionTask {
-        if let profileTask = matchedProfile?.selectedTask,
-           let task = TranscriptionTask(rawValue: profileTask) {
-            return task
-        }
         return settingsViewModel.selectedTask
     }
 
     private var effectiveTranslationTarget: String? {
-        // Per-profile translation override
-        if let profileEnabled = matchedProfile?.translationEnabled {
-            if !profileEnabled { return nil }
-            return matchedProfile?.translationTargetLanguage ?? settingsViewModel.translationTargetLanguage
-        }
-        // Existing behavior: profile target language override, then global setting
-        if let profileTarget = matchedProfile?.translationTargetLanguage {
-            return profileTarget
-        }
         if settingsViewModel.translationEnabled {
             return settingsViewModel.translationTargetLanguage
         }
@@ -991,37 +934,30 @@ final class DictationViewModel: ObservableObject {
     }
 
     private var effectiveEngineOverrideId: String? {
-        matchedProfile?.engineOverride
+        nil
     }
 
     private var effectiveCloudModelOverride: String? {
-        matchedProfile?.cloudModelOverride
+        nil
     }
 
     private var effectiveRuleName: String? {
-        matchedWorkflow?.name ?? matchedProfile?.name
-    }
-
-    private var effectivePromptAction: PromptAction? {
-        if let actionId = matchedProfile?.promptActionId {
-            return promptActionService.action(byId: actionId)
-        }
-        return nil
+        matchedWorkflow?.name
     }
 
     private var effectiveOutputFormat: String? {
-        matchedWorkflow?.output.format ?? matchedProfile?.outputFormat
+        matchedWorkflow?.output.format
     }
 
     private var effectiveActionPluginId: String? {
-        matchedWorkflow?.output.targetActionPluginId ?? effectivePromptAction?.targetActionPluginId
+        matchedWorkflow?.output.targetActionPluginId
     }
 
     private var effectiveAutoEnterEnabled: Bool {
         if let matchedWorkflow {
             return matchedWorkflow.output.autoEnter
         }
-        return matchedProfile?.autoEnterEnabled == true
+        return false
     }
 
     private func stopDictation() {
@@ -1189,7 +1125,7 @@ final class DictationViewModel: ObservableObject {
                     if self.matchedWorkflow != nil {
                         "Workflow"
                     } else {
-                        (self.effectivePromptAction != nil || self.matchedProfile?.inlineCommandsEnabled == true) ? "Prompt" : "Translation"
+                        "Translation"
                     }
                 } else {
                     nil
@@ -1394,29 +1330,12 @@ final class DictationViewModel: ObservableObject {
     ) {
         activeWorkflowMatch = match
         matchedWorkflow = match?.workflow
-        matchedProfile = nil
-        activeRuleMatch = nil
-        forcedProfileId = nil
         activeRuleName = match?.workflow.name
         activeRuleReasonLabel = match?.kind.label
         activeRuleExplanation = match.map { workflowExplanation(for: $0, activeApp: activeApp) }
     }
 
-    private func applyRuleMatch(
-        _ match: RuleMatchResult?,
-        activeApp: (name: String?, bundleId: String?, url: String?)?
-    ) {
-        activeWorkflowMatch = nil
-        matchedWorkflow = nil
-        forcedWorkflowId = nil
-        activeRuleMatch = match
-        matchedProfile = match?.profile
-        activeRuleName = match?.profile.name
-        activeRuleReasonLabel = match?.kind.label
-        activeRuleExplanation = match.map { ruleExplanation(for: $0, activeApp: activeApp) }
-    }
-
-    /// Starts the live streaming handler with the currently effective profile params
+    /// Starts the live streaming handler with the currently effective workflow/global params
     /// and records a snapshot for later change detection (release review K3).
     private func startLiveStreaming(allowLiveTranscription: Bool) {
         let params = StreamingParamsSnapshot(
@@ -1465,9 +1384,6 @@ final class DictationViewModel: ObservableObject {
     private func clearActiveRuleState() {
         matchedWorkflow = nil
         activeWorkflowMatch = nil
-        matchedProfile = nil
-        activeRuleMatch = nil
-        forcedProfileId = nil
         forcedWorkflowId = nil
         activeRuleName = nil
         activeRuleReasonLabel = nil
@@ -1530,66 +1446,10 @@ final class DictationViewModel: ObservableObject {
         )
     }
 
-    private func ruleExplanation(
-        for match: RuleMatchResult,
-        activeApp: (name: String?, bundleId: String?, url: String?)?
-    ) -> String {
-        let appDescriptor = activeApp?.name ?? activeApp?.bundleId ?? "the active app"
-
-        let base: String
-        switch match.kind {
-        case .appAndWebsite:
-            if let domain = match.matchedDomain {
-                base = localizedAppText(
-                    "This rule applies because \(appDescriptor) was detected together with \(domain).",
-                    de: "Diese Regel greift, weil \(appDescriptor) zusammen mit \(domain) erkannt wurde."
-                )
-            } else {
-                base = localizedAppText(
-                    "This rule applies because the app and website were detected together.",
-                    de: "Diese Regel greift, weil App und Website zusammen erkannt wurden."
-                )
-            }
-        case .websiteOnly:
-            if let domain = match.matchedDomain {
-                base = localizedAppText(
-                    "This rule applies because \(domain) was detected.",
-                    de: "Diese Regel greift, weil \(domain) erkannt wurde."
-                )
-            } else {
-                base = localizedAppText(
-                    "This rule applies because the current website was detected.",
-                    de: "Diese Regel greift, weil die aktuelle Website erkannt wurde."
-                )
-            }
-        case .appOnly:
-            base = localizedAppText(
-                "This rule applies because \(appDescriptor) was detected.",
-                de: "Diese Regel greift, weil \(appDescriptor) erkannt wurde."
-            )
-        case .globalFallback:
-            base = localizedAppText(
-                "This rule applies because no more specific rule matched the current context.",
-                de: "Diese Regel greift, weil keine spezifischere Regel zum aktuellen Kontext gepasst hat."
-            )
-        case .manualOverride:
-            base = localizedAppText(
-                "This rule was manually forced via its keyboard shortcut.",
-                de: "Diese Regel wurde manuell über ihre Tastenkombination erzwungen."
-            )
-        }
-
-        guard match.wonByPriority else { return base }
-        return base + localizedAppText(
-            " Among equally specific rules, the higher priority wins here.",
-            de: " Unter gleich spezifischen Regeln gewinnt hier die höhere Priorität."
-        )
-    }
-
     // MARK: - Shared Helpers
 
     /// Builds an LLM handler for the post-processing pipeline.
-    /// Priority: workflow > profile inline/prompt action > translation > nil.
+    /// Priority: workflow > translation > nil.
     private func buildLLMHandler(
         translationTarget: String?,
         detectedLanguage: String?,
@@ -1601,26 +1461,6 @@ final class DictationViewModel: ObservableObject {
             configuredLanguage: configuredLanguage
         ) {
             return workflowHandler
-        }
-
-        // Inline commands compose with profile prompt; otherwise use prompt action directly
-        let inlineEnabled = matchedProfile?.inlineCommandsEnabled == true
-        if inlineEnabled || effectivePromptAction != nil {
-            let pps = promptProcessingService
-            let promptAction = effectivePromptAction
-            let prompt = inlineEnabled
-                ? Self.buildInlineCommandSystemPrompt(baseContext: promptAction?.prompt)
-                : promptAction!.prompt
-            let providerOverride = promptAction?.providerType
-            let modelOverride = promptAction?.cloudModel
-            return { text in
-                try await pps.process(
-                    prompt: prompt, text: text,
-                    providerOverride: providerOverride,
-                    cloudModelOverride: modelOverride,
-                    temperatureDirective: promptAction?.temperatureDirective ?? .inheritProviderSetting
-                )
-            }
         }
 
         #if canImport(Translation)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -515,6 +515,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let modelManager: ModelManagerService
         let historyService: HistoryService
         let profileService: ProfileService
+        let workflowService: WorkflowService
         let dictionaryService: DictionaryService
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
@@ -527,6 +528,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             modelManager: ModelManagerService,
             historyService: HistoryService,
             profileService: ProfileService,
+            workflowService: WorkflowService,
             dictionaryService: DictionaryService,
             dictationViewModel: DictationViewModel,
             audioRecordingService: AudioRecordingService,
@@ -538,6 +540,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.modelManager = modelManager
             self.historyService = historyService
             self.profileService = profileService
+            self.workflowService = workflowService
             self.dictionaryService = dictionaryService
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
@@ -717,10 +720,19 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 engineUsed: "parakeet"
             )
             context.profileService.addProfile(
-                name: "Docs",
+                name: "Legacy Docs",
                 urlPatterns: ["docs.github.com"],
                 inputLanguage: #"["de","en"]"#,
                 priority: 1
+            )
+            _ = context.workflowService.addWorkflow(
+                name: "Docs",
+                template: .summary,
+                trigger: .website("docs.github.com"),
+                behavior: WorkflowBehavior(settings: [
+                    WorkflowBehavior.inputLanguageSettingKey: #"["de","en"]"#
+                ]),
+                sortOrder: 0
             )
             return context
         }
@@ -747,6 +759,18 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["language_hints"] as? [String], ["de", "en"])
         XCTAssertNil((rules["rules"] as? [[String: Any]])?.first?["input_language"] as? String)
         XCTAssertEqual((legacyProfiles["profiles"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
+
+        let workflowId = try XCTUnwrap((rules["rules"] as? [[String: Any]])?.first?["id"] as? String)
+        let toggle = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "PUT", path: "/v1/rules/toggle", queryParams: ["id": workflowId], headers: [:], body: Data()))
+        )
+        XCTAssertEqual(toggle["name"] as? String, "Docs")
+        XCTAssertEqual(toggle["is_enabled"] as? Bool, false)
+
+        let toggledRules = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "GET", path: "/v1/rules", queryParams: [:], headers: [:], body: Data()))
+        )
+        XCTAssertEqual((toggledRules["rules"] as? [[String: Any]])?.first?["is_enabled"] as? Bool, false)
     }
 
     func testDictionaryTermsEndpointsReplaceNormalizeAndClearTerms() async throws {
@@ -1737,7 +1761,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testApiStartRecording_appliesBundleProfileBeforeDeferredMetadataCapture() async throws {
+    func testApiStartRecording_ignoresLegacyBundleProfileBeforeDeferredMetadataCapture() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?
         defer {
@@ -1764,9 +1788,121 @@ final class APIRouterAndHandlersTests: XCTestCase {
         _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(context.dictationViewModel.state, DictationViewModel.State.recording)
-        XCTAssertEqual(context.dictationViewModel.activeRuleName, "Docs")
+        XCTAssertNil(context.dictationViewModel.activeRuleName)
 
         await fulfillment(of: [selectedTextCaptured], timeout: 1.0)
+    }
+
+    @MainActor
+    func testDictationRuntimeIgnoresLegacyProfileLanguageSelection() async throws {
+        let selectedLanguageKey = UserDefaultsKeys.selectedLanguage
+        let originalSelectedLanguage = UserDefaults.standard.object(forKey: selectedLanguageKey)
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            if let originalSelectedLanguage {
+                UserDefaults.standard.set(originalSelectedLanguage, forKey: selectedLanguageKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedLanguageKey)
+            }
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        UserDefaults.standard.set("de", forKey: selectedLanguageKey)
+        MockTranscriptionPlugin.reset()
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.profileService.addProfile(
+            name: "Legacy Notes",
+            bundleIdentifiers: ["com.apple.Notes"],
+            inputLanguage: "en",
+            translationTargetLanguage: "en"
+        )
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Notes", "com.apple.Notes", nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.pasteSimulatorOverride = {}
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertNil(context.dictationViewModel.activeRuleName)
+
+        _ = context.dictationViewModel.apiStopRecording()
+        for _ in 0..<40 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .completed)
+        XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage, "de")
+    }
+
+    @MainActor
+    func testDictationRuntimeUsesWorkflowInsteadOfCompetingLegacyProfile() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.profileService.addProfile(
+            name: "Legacy Notes",
+            bundleIdentifiers: ["com.apple.Notes"],
+            inputLanguage: "en",
+            translationTargetLanguage: "en"
+        )
+        _ = context.workflowService.addWorkflow(
+            name: "Workflow Notes",
+            template: .dictation,
+            trigger: .app("com.apple.Notes"),
+            behavior: WorkflowBehavior(settings: [
+                WorkflowBehavior.inputLanguageSettingKey: "de"
+            ])
+        )
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Notes", "com.apple.Notes", nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.pasteSimulatorOverride = {}
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertEqual(context.dictationViewModel.activeRuleName, "Workflow Notes")
+
+        _ = context.dictationViewModel.apiStopRecording()
+        for _ in 0..<40 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .completed)
+        XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage, "de")
     }
 
     @MainActor
@@ -2579,7 +2715,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             audioFileService: audioFileService,
             translationService: nil,
             historyService: historyService,
-            profileService: profileService,
+            workflowService: workflowService,
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel
         )
@@ -2590,6 +2726,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             modelManager: modelManager,
             historyService: historyService,
             profileService: profileService,
+            workflowService: workflowService,
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel,
             audioRecordingService: audioRecordingService,
@@ -2720,6 +2857,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let historyService: HistoryService
         let recentTranscriptionStore: RecentTranscriptionStore
         let profileService: ProfileService
+        let workflowService: WorkflowService
         let ttsProvider: MockTTSProviderPlugin
         private let retainedObjects: [AnyObject]
 
@@ -2733,6 +2871,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             historyService: HistoryService,
             recentTranscriptionStore: RecentTranscriptionStore,
             profileService: ProfileService,
+            workflowService: WorkflowService,
             ttsProvider: MockTTSProviderPlugin,
             retainedObjects: [AnyObject]
         ) {
@@ -2745,6 +2884,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.historyService = historyService
             self.recentTranscriptionStore = recentTranscriptionStore
             self.profileService = profileService
+            self.workflowService = workflowService
             self.ttsProvider = ttsProvider
             self.retainedObjects = retainedObjects
         }
@@ -2873,6 +3013,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             historyService: historyService,
             recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
+            workflowService: workflowService,
             ttsProvider: ttsProvider,
             retainedObjects: [
                 EventBus.shared,
@@ -5197,6 +5338,24 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
 
         XCTAssertFalse(service.processEventForTesting(extraModifierDown, source: .monitor))
         XCTAssertNil(startedProfileId)
+    }
+
+    @MainActor
+    func testProfileHotkeysAreIgnoredForLegacyRuntime() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let profileId = UUID()
+        service.registerProfileHotkeys([(id: profileId, hotkey: spaceHotkey())])
+
+        var startedProfileId: UUID?
+        service.onProfileDictationStart = { profileId, _ in startedProfileId = profileId }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertNil(startedProfileId)
+        XCTAssertNil(service.currentMode)
     }
 
     @MainActor

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -4,6 +4,27 @@ import XCTest
 
 @MainActor
 final class WorkflowServiceTests: XCTestCase {
+    func testAvailableRuleNamesExposeWorkflowsButNotLegacyProfiles() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+
+        profileService.addProfile(
+            name: "Legacy Notes",
+            bundleIdentifiers: ["com.apple.Notes"]
+        )
+        workflowService.addWorkflow(
+            name: "Notes Workflow",
+            template: .dictation,
+            trigger: .app("com.apple.Notes")
+        )
+
+        XCTAssertEqual(profileService.profiles.map(\.name), ["Legacy Notes"])
+        XCTAssertEqual(workflowService.availableRuleNames, ["Notes Workflow"])
+    }
+
     func testWorkflowExposesPluginSDKSnapshot() throws {
         let workflowId = try XCTUnwrap(UUID(uuidString: "5696C819-F96E-419B-9224-14FF94C65AA8"))
         let createdAt = Date(timeIntervalSince1970: 100)
@@ -1414,7 +1435,7 @@ final class WatchFolderExportTests: XCTestCase {
 
 @MainActor
 final class DictationLanguageResolverTests: XCTestCase {
-    func testWorkflowLanguageOverridesProfileAndGlobalLanguage() {
+    func testWorkflowLanguageOverridesGlobalLanguage() {
         let workflow = Workflow(
             name: "German Workflow",
             template: .dictation,
@@ -1423,52 +1444,46 @@ final class DictationLanguageResolverTests: XCTestCase {
                 WorkflowBehavior.inputLanguageSettingKey: "de",
             ])
         )
-        let profile = Profile(name: "English Rule", inputLanguage: "en")
 
         let resolved = DictationLanguageResolver.resolve(
             workflow: workflow,
-            profile: profile,
             globalLanguageSelection: .hints(["fr", "nl"])
         )
 
         XCTAssertEqual(resolved, .exact("de"))
     }
 
-    func testWorkflowInheritFallsBackToProfileBeforeGlobalLanguage() {
+    func testWorkflowInheritFallsBackToGlobalLanguage() {
         let workflow = Workflow(
             name: "Inherit Workflow",
             template: .dictation,
             trigger: .hotkey(UnifiedHotkey(keyCode: 6, modifierFlags: 0, isFn: false))
         )
-        let profile = Profile(name: "Hint Rule", inputLanguage: #"["de","en"]"#)
 
         let resolved = DictationLanguageResolver.resolve(
             workflow: workflow,
-            profile: profile,
-            globalLanguageSelection: .exact("fr")
+            globalLanguageSelection: .hints(["de", "en"])
         )
 
         XCTAssertEqual(resolved, .hints(["de", "en"]))
     }
 
-    func testWorkflowInheritFallsBackToGlobalWhenProfileAlsoInherits() {
+    func testWorkflowInheritFallsBackToGlobalExactLanguage() {
         let workflow = Workflow(
             name: "Inherit Workflow",
             template: .dictation,
             trigger: .hotkey(UnifiedHotkey(keyCode: 7, modifierFlags: 0, isFn: false))
         )
-        let profile = Profile(name: "Global Rule")
 
         let resolved = DictationLanguageResolver.resolve(
             workflow: workflow,
-            profile: profile,
             globalLanguageSelection: .exact("fr")
         )
 
         XCTAssertEqual(resolved, .exact("fr"))
     }
 
-    func testWorkflowAutoOverridesProfileAndGlobalLanguage() {
+    func testWorkflowAutoOverridesGlobalLanguage() {
         let workflow = Workflow(
             name: "Auto Workflow",
             template: .dictation,
@@ -1477,11 +1492,9 @@ final class DictationLanguageResolverTests: XCTestCase {
                 WorkflowBehavior.inputLanguageSettingKey: "auto",
             ])
         )
-        let profile = Profile(name: "German Rule", inputLanguage: "de")
 
         let resolved = DictationLanguageResolver.resolve(
             workflow: workflow,
-            profile: profile,
             globalLanguageSelection: .exact("fr")
         )
 


### PR DESCRIPTION
## Context
This implements the 1.4 cleanup plan to make workflows the only runtime source for app, website, hotkey, and Always matching. Legacy Profile and PromptAction data remains on disk for compatibility, but is no longer executable at runtime.

## Summary
- Route dictation matching, language resolution, translation behavior, engine/model overrides, output handling, and URL refinement through `WorkflowService` only.
- Disable legacy profile hotkey registration and dispatch while keeping deprecated compatibility APIs as inert stubs.
- Back `/v1/rules`, `/v1/profiles`, and `/v1/rules/toggle` with workflows, including workflow IDs for toggle behavior.
- Expose plugin `availableRuleNames` from workflows only, so legacy profile names are not offered as filterable rules.
- Keep workflow `Always` matching intact as the supported workflow fallback behavior.

## Test Coverage
- Added regressions that a matching legacy Notes profile is ignored and global German/no-translation behavior is used when no workflow matches.
- Added coverage that a matching workflow wins over a competing legacy profile.
- Added coverage that profile hotkeys no longer start dictation and workflow hotkeys still work.
- Added coverage for workflow-backed `/v1/rules`, `/v1/profiles`, toggle behavior, and plugin rule-name exposure.

## Pre-Landing Review
Manual diff review completed. No issues found.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/84d4/typewhisper-mac`
