### PR TITLE
Add licensed industry term packs

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -173,7 +173,11 @@ final class ServiceContainer: ObservableObject {
             settingsViewModel: settingsViewModel,
             textInsertionService: textInsertionService
         )
-        dictionaryViewModel = DictionaryViewModel(dictionaryService: dictionaryService)
+        dictionaryViewModel = DictionaryViewModel(
+            dictionaryService: dictionaryService,
+            licenseService: licenseService,
+            termPackRegistryService: termPackRegistryService
+        )
         snippetsViewModel = SnippetsViewModel(snippetService: snippetService)
         homeViewModel = HomeViewModel(historyService: historyService)
         promptActionsViewModel = PromptActionsViewModel(

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -55,6 +55,7 @@ enum UserDefaultsKeys {
     static let activatedTermPacks = "activatedTermPacks" // Legacy - kept for migration cleanup
     static let activatedTermPackStates = "activatedTermPackStates"
     static let termPackRegistryLastUpdateCheck = "termPackRegistryLastUpdateCheck"
+    static let selectedIndustryPreset = "selectedIndustryPreset"
 
     // MARK: - History
     static let historyEnabled = "historyEnabled"

--- a/TypeWhisper/Models/TermPack.swift
+++ b/TypeWhisper/Models/TermPack.swift
@@ -24,6 +24,7 @@ struct TermPack: Identifiable {
     let source: Source
     let version: String?
     let author: String?
+    let requiresCommercialLicense: Bool
 
     let defaultName: String
     let defaultDescription: String
@@ -56,7 +57,7 @@ struct TermPack: Identifiable {
     }
 
     /// Built-in convenience init - same signature as the old memberwise init
-    init(id: String, nameKey: String, descriptionKey: String, icon: String, terms: [String]) {
+    init(id: String, nameKey: String, descriptionKey: String, icon: String, terms: [String], requiresCommercialLicense: Bool = false) {
         self.id = id
         self.defaultName = nameKey
         self.defaultDescription = descriptionKey
@@ -66,6 +67,7 @@ struct TermPack: Identifiable {
         self.source = .builtIn
         self.version = nil
         self.author = nil
+        self.requiresCommercialLicense = requiresCommercialLicense
         self.localizedNames = nil
         self.localizedDescriptions = nil
     }
@@ -74,7 +76,8 @@ struct TermPack: Identifiable {
     init(id: String, name: String, description: String, icon: String,
          terms: [String], corrections: [TermPackCorrection],
          version: String, author: String,
-         localizedNames: [String: String]?, localizedDescriptions: [String: String]?) {
+         localizedNames: [String: String]?, localizedDescriptions: [String: String]?,
+         requiresCommercialLicense: Bool = false) {
         self.id = id
         self.defaultName = name
         self.defaultDescription = description
@@ -84,6 +87,7 @@ struct TermPack: Identifiable {
         self.source = .community
         self.version = version
         self.author = author
+        self.requiresCommercialLicense = requiresCommercialLicense
         self.localizedNames = localizedNames
         self.localizedDescriptions = localizedDescriptions
     }
@@ -177,4 +181,65 @@ struct TermPack: Identifiable {
             ]
         )
     ]
+}
+
+enum IndustryPreset: String, CaseIterable, Identifiable {
+    case general
+    case realEstate = "real-estate"
+    case architecture
+    case legal
+
+    var id: String { rawValue }
+
+    var termPackID: String? {
+        switch self {
+        case .general:
+            nil
+        case .realEstate, .architecture, .legal:
+            rawValue
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .general:
+            String(localized: "General writing")
+        case .realEstate:
+            String(localized: "Real Estate")
+        case .architecture:
+            String(localized: "Architecture")
+        case .legal:
+            String(localized: "Legal")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .general:
+            String(localized: "Start with TypeWhisper defaults. You can add term packs later.")
+        case .realEstate:
+            String(localized: "Prepare property, viewing, and client vocabulary.")
+        case .architecture:
+            String(localized: "Prepare planning, construction, and defect vocabulary.")
+        case .legal:
+            String(localized: "Prepare legal dictation vocabulary for drafts and notes.")
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: "text.alignleft"
+        case .realEstate: "house"
+        case .architecture: "ruler"
+        case .legal: "scale.3d"
+        }
+    }
+
+    static func selected(defaults: UserDefaults = .standard) -> IndustryPreset {
+        guard let raw = defaults.string(forKey: UserDefaultsKeys.selectedIndustryPreset),
+              let preset = IndustryPreset(rawValue: raw) else {
+            return .general
+        }
+        return preset
+    }
 }

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -199,6 +199,7 @@ final class LicenseService: ObservableObject {
     }
 
     var isSupporter: Bool { supporterStatus == .active && supporterTier != nil }
+    var hasCommercialLicense: Bool { licenseStatus == .active }
     var supporterClaimProof: SupporterClaimProof? {
         guard supporterStatus == .active,
               let supporterTier,

--- a/TypeWhisper/Services/TermPackRegistryService.swift
+++ b/TypeWhisper/Services/TermPackRegistryService.swift
@@ -21,6 +21,7 @@ struct RemoteTermPack: Codable {
     let corrections: [TermPackCorrection]?
     let names: [String: String]?
     let descriptions: [String: String]?
+    let requiresCommercialLicense: Bool?
 
     func toTermPack() -> TermPack {
         TermPack(
@@ -33,7 +34,8 @@ struct RemoteTermPack: Codable {
             version: version,
             author: author,
             localizedNames: names,
-            localizedDescriptions: descriptions
+            localizedDescriptions: descriptions,
+            requiresCommercialLicense: requiresCommercialLicense ?? false
         )
     }
 }
@@ -61,7 +63,7 @@ final class TermPackRegistryService: ObservableObject {
     }
 
     init(
-        registryURL: URL = URL(string: "https://typewhisper.github.io/typewhisper-mac/termpacks.json")!,
+        registryURL: URL = URL(string: "https://typewhisper.github.io/typewhisper-termpacks/termpacks.json")!,
         cacheDuration: TimeInterval = 300,
         userDefaults: UserDefaults = .standard,
         fetchData: @escaping (URLRequest) async throws -> (Data, URLResponse) = { request in

--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -11,6 +11,7 @@ struct ActivatedTermPackState: Codable {
     let installedVersion: String?
     let installedTerms: [String]
     let installedCorrections: [TermPackCorrection]
+    let requiresCommercialLicense: Bool?
 }
 
 // MARK: - Dictionary ViewModel
@@ -47,6 +48,8 @@ class DictionaryViewModel: ObservableObject {
     @Published var activatedPackStates: [String: ActivatedTermPackState] = [:]
 
     private let dictionaryService: DictionaryService
+    private let licenseService: LicenseService?
+    private let termPackRegistryService: TermPackRegistryService?
     private var cancellables = Set<AnyCancellable>()
     private var selectedEntry: DictionaryEntry?
 
@@ -67,12 +70,28 @@ class DictionaryViewModel: ObservableObject {
     var correctionsCount: Int { dictionaryService.correctionsCount }
     var enabledTermsCount: Int { dictionaryService.enabledTermsCount }
     var enabledCorrectionsCount: Int { dictionaryService.enabledCorrectionsCount }
+    var hasCommercialLicense: Bool { licenseService?.hasCommercialLicense ?? false }
+    var visibleBuiltInPacks: [TermPack] {
+        TermPack.allPacks.filter { !$0.requiresCommercialLicense || hasCommercialLicense }
+    }
+    var visibleCommunityPacks: [TermPack] {
+        (termPackRegistryService ?? TermPackRegistryService.shared)?
+            .communityPacks
+            .filter(canUsePack) ?? []
+    }
 
-    init(dictionaryService: DictionaryService) {
+    init(
+        dictionaryService: DictionaryService,
+        licenseService: LicenseService? = nil,
+        termPackRegistryService: TermPackRegistryService? = nil
+    ) {
         self.dictionaryService = dictionaryService
+        self.licenseService = licenseService
+        self.termPackRegistryService = termPackRegistryService
         self.entries = dictionaryService.entries
         migrateLegacyActivatedPacks()
         loadActivatedPackStates()
+        reconcileCommercialPackAccess()
         setupBindings()
     }
 
@@ -84,6 +103,31 @@ class DictionaryViewModel: ObservableObject {
                 self?.entries = entries
             }
             .store(in: &cancellables)
+
+        licenseService?.$licenseStatus
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reconcileCommercialPackAccess()
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        if let registryService = termPackRegistryService ?? TermPackRegistryService.shared {
+            registryService.$communityPacks
+                .dropFirst()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    guard let self else { return }
+                    if self.hasCommercialLicense {
+                        self.applyIndustryPreset(IndustryPreset.selected())
+                    } else {
+                        self.reconcileCommercialPackAccess()
+                    }
+                    self.objectWillChange.send()
+                }
+                .store(in: &cancellables)
+        }
     }
 
     // MARK: - Editor Actions
@@ -202,6 +246,11 @@ class DictionaryViewModel: ObservableObject {
     }
 
     func togglePack(_ pack: TermPack) {
+        guard canUsePack(pack) else {
+            error = String(localized: "This industry term pack requires an active commercial license.")
+            return
+        }
+
         if isPackActivated(pack) {
             deactivatePack(pack)
         } else {
@@ -210,6 +259,11 @@ class DictionaryViewModel: ObservableObject {
     }
 
     func activatePack(_ pack: TermPack) {
+        guard canUsePack(pack) else {
+            error = String(localized: "This industry term pack requires an active commercial license.")
+            return
+        }
+
         var nextStates = activatedPackStates
         nextStates[pack.id] = makeActivatedState(for: pack)
         reconcileActivatedPacks(from: activatedPackStates, to: nextStates)
@@ -235,12 +289,46 @@ class DictionaryViewModel: ObservableObject {
         return TermPackRegistryService.compareVersions(packVersion, installedVersion) == .orderedDescending
     }
 
+    func applyIndustryPreset(_ preset: IndustryPreset) {
+        UserDefaults.standard.set(preset.rawValue, forKey: UserDefaultsKeys.selectedIndustryPreset)
+
+        guard let packID = preset.termPackID,
+              hasCommercialLicense,
+              let pack = resolvePack(id: packID),
+              !isPackActivated(pack) else {
+            return
+        }
+
+        activatePack(pack)
+    }
+
+    func canUsePack(_ pack: TermPack) -> Bool {
+        !pack.requiresCommercialLicense || hasCommercialLicense
+    }
+
+    private func reconcileCommercialPackAccess() {
+        if hasCommercialLicense {
+            applyIndustryPreset(IndustryPreset.selected())
+            return
+        }
+
+        let industryPackIDs = Set(IndustryPreset.allCases.compactMap(\.termPackID))
+        let allowedStates = activatedPackStates.filter { packID, state in
+            state.requiresCommercialLicense != true && !industryPackIDs.contains(packID)
+        }
+
+        guard allowedStates.count != activatedPackStates.count else { return }
+        reconcileActivatedPacks(from: activatedPackStates, to: allowedStates)
+    }
+
     /// Resolves a pack by ID from built-in + community packs
     func resolvePack(id: String) -> TermPack? {
         if let builtIn = TermPack.allPacks.first(where: { $0.id == id }) {
             return builtIn
         }
-        return TermPackRegistryService.shared?.communityPacks.first(where: { $0.id == id })
+        return (termPackRegistryService ?? TermPackRegistryService.shared)?
+            .communityPacks
+            .first(where: { $0.id == id })
     }
 
     // MARK: - Reconciliation
@@ -252,7 +340,8 @@ class DictionaryViewModel: ObservableObject {
             source: pack.source.rawValue,
             installedVersion: pack.version,
             installedTerms: pack.terms,
-            installedCorrections: pack.corrections
+            installedCorrections: pack.corrections,
+            requiresCommercialLicense: pack.requiresCommercialLicense
         )
     }
 
@@ -281,7 +370,8 @@ class DictionaryViewModel: ObservableObject {
                 source: state.source,
                 installedVersion: state.installedVersion,
                 installedTerms: actuallyAddedTerms,
-                installedCorrections: actuallyAddedCorrections
+                installedCorrections: actuallyAddedCorrections,
+                requiresCommercialLicense: state.requiresCommercialLicense
             )
         }
 

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -176,7 +176,7 @@ struct DictionarySettingsView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 10) {
                 // Built-in Packs
-                ForEach(TermPack.allPacks) { pack in
+                ForEach(viewModel.visibleBuiltInPacks) { pack in
                     TermPackCardView(pack: pack, viewModel: viewModel)
                 }
 
@@ -224,7 +224,7 @@ struct DictionarySettingsView: View {
                 .padding(.vertical, 12)
 
             case .loaded:
-                if termPackRegistryService.communityPacks.isEmpty {
+                if viewModel.visibleCommunityPacks.isEmpty {
                     HStack {
                         Spacer()
                         Text(String(localized: "No community packs available yet."))
@@ -234,7 +234,7 @@ struct DictionarySettingsView: View {
                     }
                     .padding(.vertical, 12)
                 } else {
-                    ForEach(termPackRegistryService.communityPacks) { pack in
+                    ForEach(viewModel.visibleCommunityPacks) { pack in
                         TermPackCardView(pack: pack, viewModel: viewModel)
                     }
                 }

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -8,11 +8,13 @@ struct SetupWizardView: View {
     @ObservedObject private var audioDevice = ServiceContainer.shared.audioDeviceService
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
     @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
+    @ObservedObject private var dictionaryViewModel = DictionaryViewModel.shared
     @ObservedObject private var promptProcessingService: PromptProcessingService
 
     @State private var currentStep: Int
     @State private var selectedProvider: String?
     @State private var selectedHotkeyMode: HotkeySlotType
+    @State private var selectedIndustryPreset: IndustryPreset
     @State private var trialSuccess = false
     @State private var trialText = ""
     @FocusState private var isTrialFieldFocused: Bool
@@ -22,6 +24,7 @@ struct SetupWizardView: View {
     init() {
         let saved = UserDefaults.standard.integer(forKey: UserDefaultsKeys.setupWizardCurrentStep)
         _currentStep = State(initialValue: min(saved, 5))
+        _selectedIndustryPreset = State(initialValue: IndustryPreset.selected())
         _promptProcessingService = ObservedObject(wrappedValue: PromptActionsViewModel.shared.promptProcessingService)
 
         if UserDefaults.standard.data(forKey: UserDefaultsKeys.hybridHotkey) != nil {
@@ -144,10 +147,26 @@ struct SetupWizardView: View {
             }
             .frame(maxWidth: 380)
 
+            VStack(alignment: .leading, spacing: 10) {
+                Text(String(localized: "What kind of writing do you do most?"))
+                    .font(.headline)
+
+                ForEach(IndustryPreset.allCases) { preset in
+                    industryOption(preset)
+                }
+
+                Text(String(localized: "Industry term packs are prepared during setup and activated automatically when a commercial license is active."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: 420)
+
             Spacer()
 
             VStack(spacing: 12) {
                 Button(String(localized: "Get Started")) {
+                    applyIndustrySelection()
                     withAnimation { currentStep = 1 }
                 }
                 .buttonStyle(.borderedProminent)
@@ -163,6 +182,37 @@ struct SetupWizardView: View {
             .padding(.bottom, 24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func industryOption(_ preset: IndustryPreset) -> some View {
+        let isSelected = selectedIndustryPreset == preset
+
+        return HStack(spacing: 12) {
+            Image(systemName: isSelected ? "largecircle.fill.circle" : preset.systemImage)
+                .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(preset.displayName)
+                    .font(.body.weight(.medium))
+                Text(preset.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(isSelected ? Color.accentColor.opacity(0.08) : Color.secondary.opacity(0.08)))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(isSelected ? Color.accentColor.opacity(0.35) : Color.clear, lineWidth: 1))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedIndustryPreset = preset
+        }
+    }
+
+    private func applyIndustrySelection() {
+        dictionaryViewModel.applyIndustryPreset(selectedIndustryPreset)
     }
 
     private func featureHighlight(icon: String, title: String, description: String) -> some View {

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -55,11 +55,13 @@ final class DictionaryServiceTests: XCTestCase {
         super.setUp()
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activatedTermPacks)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activatedTermPackStates)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedIndustryPreset)
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activatedTermPacks)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activatedTermPackStates)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedIndustryPreset)
         PluginManager.shared = nil
         super.tearDown()
     }
@@ -273,6 +275,97 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testCommercialIndustryPacksAreHiddenWithoutCommercialLicense() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let license = LicenseService(defaults: UserDefaults(suiteName: #function)!)
+        let registry = TermPackRegistryService()
+        registry.communityPacks = [
+            makeCommercialIndustryPack(id: "real-estate", terms: ["Exposé"]),
+            makeCommercialIndustryPack(id: "architecture", terms: ["HOAI"]),
+            makeCommercialIndustryPack(id: "legal", terms: ["Mandat"])
+        ]
+        let viewModel = DictionaryViewModel(
+            dictionaryService: service,
+            licenseService: license,
+            termPackRegistryService: registry
+        )
+
+        XCTAssertFalse(viewModel.visibleBuiltInPacks.contains { $0.id == "real-estate" })
+        XCTAssertFalse(viewModel.visibleBuiltInPacks.contains { $0.id == "architecture" })
+        XCTAssertFalse(viewModel.visibleBuiltInPacks.contains { $0.id == "legal" })
+        XCTAssertFalse(viewModel.visibleCommunityPacks.contains { $0.id == "real-estate" })
+        XCTAssertFalse(viewModel.visibleCommunityPacks.contains { $0.id == "architecture" })
+        XCTAssertFalse(viewModel.visibleCommunityPacks.contains { $0.id == "legal" })
+    }
+
+    @MainActor
+    func testCommercialIndustryPresetActivatesMatchingPackWhenLicensed() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let defaults = UserDefaults(suiteName: #function)!
+        let license = LicenseService(defaults: defaults)
+        license.licenseStatus = .active
+        license.licenseTier = .team
+        let registry = TermPackRegistryService()
+        let realEstatePack = makeCommercialIndustryPack(id: "real-estate", terms: ["Exposé", "Grundbuch"])
+        registry.communityPacks = [realEstatePack]
+        let viewModel = DictionaryViewModel(
+            dictionaryService: service,
+            licenseService: license,
+            termPackRegistryService: registry
+        )
+
+        viewModel.applyIndustryPreset(.realEstate)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedIndustryPreset), IndustryPreset.realEstate.rawValue)
+        XCTAssertTrue(viewModel.isPackActivated(realEstatePack))
+        XCTAssertTrue(service.entries.contains { $0.original == "Exposé" })
+    }
+
+    @MainActor
+    func testIndustryPresetStoresSelectionWithoutActivatingPackWhenUnlicensed() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let license = LicenseService(defaults: UserDefaults(suiteName: #function)!)
+        let registry = TermPackRegistryService()
+        registry.communityPacks = [makeCommercialIndustryPack(id: "architecture", terms: ["HOAI"])]
+        let viewModel = DictionaryViewModel(
+            dictionaryService: service,
+            licenseService: license,
+            termPackRegistryService: registry
+        )
+
+        viewModel.applyIndustryPreset(.architecture)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedIndustryPreset), IndustryPreset.architecture.rawValue)
+        XCTAssertFalse(viewModel.activatedPackStates.keys.contains("architecture"))
+        XCTAssertFalse(service.entries.contains { $0.original == "HOAI" })
+    }
+
+    private func makeCommercialIndustryPack(id: String, terms: [String]) -> TermPack {
+        TermPack(
+            id: id,
+            name: id,
+            description: "Industry test pack",
+            icon: "shippingbox",
+            terms: terms,
+            corrections: [],
+            version: "1.0.0",
+            author: "Tests",
+            localizedNames: nil,
+            localizedDescriptions: nil,
+            requiresCommercialLicense: true
+        )
+    }
+
+    @MainActor
     private func installPlugins(_ plugins: [any TranscriptionEnginePlugin], appSupportDirectory: URL) {
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
         PluginManager.shared.loadedPlugins = plugins.enumerated().map { index, plugin in
@@ -341,6 +434,7 @@ final class TermPackRegistryServiceTests: XCTestCase {
               "icon": "shippingbox",
               "version": "1.0.0",
               "author": "Tests",
+              "requiresCommercialLicense": true,
               "terms": ["Tokio"]
             }
           ]
@@ -371,5 +465,6 @@ final class TermPackRegistryServiceTests: XCTestCase {
 
         XCTAssertGreaterThan(defaults.double(forKey: UserDefaultsKeys.termPackRegistryLastUpdateCheck), 0)
         XCTAssertEqual(service.communityPacks.map(\.id), ["community-rust"])
+        XCTAssertEqual(service.communityPacks.first?.requiresCommercialLicense, true)
     }
 }


### PR DESCRIPTION
## Summary
- Add industry preset selection in setup and dictionary licensing gates for real estate, architecture, and legal term packs.
- Move industry packs to the shared remote term pack registry and preserve activation only for active commercial licenses.
- Decode and persist commercial pack state so license loss removes paid packs cleanly.

## Test Plan
- [x] xcodebuild test -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictionaryServiceTests
- [x] xcodebuild test -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' -only-testing:TypeWhisperTests/TermPackRegistryServiceTests