### PR TITLE
Allow USB input selection without preflight capture

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -1121,6 +1121,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             reason: "selection-validation"
         )
 
+        // Non-Bluetooth inputs use input-only HAL capture during preview and recording.
+        // Keep selection non-blocking so device-specific HAL start failures surface
+        // when the user actually tests or records with that input.
+        guard usesBluetoothInput else { return }
+
         try validateSelectionEngineRoute(preferredDeviceID: engineDeviceID)
     }
 

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -504,7 +504,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(service.selectedDeviceCompatibility, .compatible)
     }
 
-    func testSelectingUSBDeviceValidatesWithInputOnlyCaptureInsteadOfAVAudioEngineProbe() {
+    func testSelectingUSBDeviceSkipsInputOnlyProbeAndAllowsSelection() {
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         let usbDeviceID = AudioDeviceID(712)
         let inputCaptureFactory = FakeAudioInputCaptureFactory()
@@ -530,9 +530,38 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
 
         XCTAssertEqual(service.selectedDeviceUID, "wave-xlr")
         XCTAssertNil(service.previewError)
-        XCTAssertEqual(inputCaptureFactory.validateCalls, [
-            .init(deviceID: usbDeviceID, label: "selection")
-        ])
+        XCTAssertTrue(inputCaptureFactory.validateCalls.isEmpty)
+        XCTAssertEqual(service.selectedDeviceCompatibility, .compatible)
+    }
+
+    func testSelectingUSBDeviceAllowsSelectionWhenInputOnlyValidationFails() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let usbDeviceID = AudioDeviceID(713)
+        let inputCaptureFactory = FakeAudioInputCaptureFactory()
+        inputCaptureFactory.validateError = SelectedInputDeviceError.incompatible(.engineStartFailed)
+        let transportResolver = FakeAudioDeviceTransportResolver(
+            transports: [usbDeviceID: kAudioDeviceTransportTypeUSB]
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: usbDeviceID, name: "Babyface Pro", uid: "babyface-pro")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: transportResolver,
+            selectionEngineValidator: AVAudioInputSelectionEngineValidator(inputCaptureFactory: inputCaptureFactory),
+            inputCaptureFactory: inputCaptureFactory
+        )
+
+        service.audioDeviceIDResolverOverride = { uid in
+            uid == "babyface-pro" ? usbDeviceID : nil
+        }
+
+        service.selectedDeviceUID = "babyface-pro"
+
+        XCTAssertEqual(service.selectedDeviceUID, "babyface-pro")
+        XCTAssertNil(service.previewError)
+        XCTAssertTrue(inputCaptureFactory.validateCalls.isEmpty)
         XCTAssertEqual(service.selectedDeviceCompatibility, .compatible)
     }
 


### PR DESCRIPTION
## Context

TypeWhisper 1.3.2 still marks an RME Babyface Pro as `(Not compatible)` in Recording settings before preview or recording can start. The 1.3.2 hotfix moved explicit non-Bluetooth capture to the input-only HAL path, but device selection still performed a speculative input-only HAL validation and reverted the selection if that preflight failed.

This keeps Bluetooth selection validation intact, but makes non-Bluetooth input selection non-blocking. Preview and recording still use the input-only HAL path and will surface actual capture errors when the user tests or records with the selected device.

## Changes

- Skip speculative selection-time HAL capture validation for non-Bluetooth input devices.
- Preserve Bluetooth route activation/stabilization and aggregate-route validation.
- Add regression coverage for USB selection remaining selected even when the old input-only validation would fail.

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests`\n- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests`