### PR TITLE
Add dictation workflow engine overrides

### DIFF
--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -289,6 +289,8 @@ struct WorkflowBehavior: Codable, Equatable, Sendable {
     var fineTuning: String
     var providerId: String?
     var cloudModel: String?
+    var transcriptionEngineId: String?
+    var transcriptionModelId: String?
     var temperatureModeRaw: String?
     var temperatureValue: Double?
 
@@ -297,6 +299,8 @@ struct WorkflowBehavior: Codable, Equatable, Sendable {
         fineTuning: String = "",
         providerId: String? = nil,
         cloudModel: String? = nil,
+        transcriptionEngineId: String? = nil,
+        transcriptionModelId: String? = nil,
         temperatureModeRaw: String? = nil,
         temperatureValue: Double? = nil
     ) {
@@ -304,6 +308,8 @@ struct WorkflowBehavior: Codable, Equatable, Sendable {
         self.fineTuning = fineTuning
         self.providerId = providerId
         self.cloudModel = cloudModel
+        self.transcriptionEngineId = transcriptionEngineId
+        self.transcriptionModelId = transcriptionModelId
         self.temperatureModeRaw = temperatureModeRaw
         self.temperatureValue = temperatureValue
     }
@@ -717,6 +723,8 @@ private extension WorkflowBehavior {
             fineTuning: fineTuning,
             providerId: providerId,
             cloudModel: cloudModel,
+            transcriptionEngineId: transcriptionEngineId,
+            transcriptionModelId: transcriptionModelId,
             temperatureMode: temperatureMode,
             temperatureValue: temperatureValue
         )

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -52,6 +52,24 @@ enum DictationLanguageResolver {
     }
 }
 
+@MainActor
+enum DictationTranscriptionOverrideResolver {
+    static func engineId(for workflow: Workflow?) -> String? {
+        guard workflow?.template == .dictation else { return nil }
+        return trimmed(workflow?.behavior.transcriptionEngineId)
+    }
+
+    static func modelId(for workflow: Workflow?) -> String? {
+        guard engineId(for: workflow) != nil else { return nil }
+        return trimmed(workflow?.behavior.transcriptionModelId)
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}
+
 /// Orchestrates the dictation flow: recording → transcription → text insertion.
 @MainActor
 final class DictationViewModel: ObservableObject {
@@ -934,11 +952,11 @@ final class DictationViewModel: ObservableObject {
     }
 
     private var effectiveEngineOverrideId: String? {
-        nil
+        DictationTranscriptionOverrideResolver.engineId(for: matchedWorkflow)
     }
 
     private var effectiveCloudModelOverride: String? {
-        nil
+        DictationTranscriptionOverrideResolver.modelId(for: matchedWorkflow)
     }
 
     private var effectiveRuleName: String? {

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import TypeWhisperPluginSDK
 
 enum WorkflowRoute: Equatable {
     case create
@@ -686,6 +687,7 @@ private struct WorkflowEditorPage: View {
     @ObservedObject private var historyService = ServiceContainer.shared.historyService
     @ObservedObject private var promptProcessingService = ServiceContainer.shared.promptProcessingService
     @ObservedObject private var settingsViewModel = SettingsViewModel.shared
+    @ObservedObject private var pluginManager = PluginManager.shared
     @ObservedObject private var navigation = WorkflowsNavigationCoordinator.shared
 
     @State private var draft: WorkflowDraft
@@ -807,6 +809,7 @@ private struct WorkflowEditorPage: View {
 
                 if draft.template == .dictation {
                     workflowInputLanguageEditor
+                    workflowTranscriptionEngineSection
                 }
 
                 if draft.template == .translation {
@@ -897,6 +900,78 @@ private struct WorkflowEditorPage: View {
                             Toggle(localizedAppText("Press Enter after inserting", de: "Nach dem Einfügen Enter drücken"), isOn: $draft.autoEnter)
                         }
                         .padding(.top, 4)
+                    }
+                }
+            }
+        }
+    }
+
+    private var workflowTranscriptionEngineSection: some View {
+        let engines = pluginManager.transcriptionEngines.sorted {
+            $0.providerDisplayName.localizedCaseInsensitiveCompare($1.providerDisplayName) == .orderedAscending
+        }
+
+        return VStack(alignment: .leading, spacing: 10) {
+            Text(localizedAppText("Transcription Engine", de: "Transkriptions-Engine"))
+                .font(.subheadline.weight(.semibold))
+
+            if engines.isEmpty {
+                Text(
+                    localizedAppText(
+                        "Install a transcription engine in Integrations before using workflow engine overrides.",
+                        de: "Installiere zuerst eine Transkriptions-Engine in Integrationen, bevor du Workflow-Engine-Overrides nutzt."
+                    )
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } else {
+                Picker(
+                    localizedAppText("Engine", de: "Engine"),
+                    selection: workflowTranscriptionEngineBinding
+                ) {
+                    Text(localizedAppText("Use Global Engine", de: "Globale Engine verwenden"))
+                        .tag(nil as String?)
+                    ForEach(engines, id: \.providerId) { engine in
+                        Text(engine.providerDisplayName).tag(engine.providerId as String?)
+                    }
+                }
+
+                Text(
+                    draft.transcriptionEngineId == nil
+                        ? localizedAppText(
+                            "This workflow follows the global transcription engine setting.",
+                            de: "Dieser Workflow folgt der globalen Transkriptions-Engine-Einstellung."
+                        )
+                        : localizedAppText(
+                            "This workflow starts dictation with its own transcription engine.",
+                            de: "Dieser Workflow startet das Diktat mit einer eigenen Transkriptions-Engine."
+                        )
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                if let engineId = draft.transcriptionEngineId {
+                    let models = transcriptionModels(for: engineId)
+                    if !models.isEmpty {
+                        Picker(
+                            localizedAppText("Model", de: "Modell"),
+                            selection: workflowTranscriptionModelBinding
+                        ) {
+                            Text(localizedAppText("Engine Default", de: "Engine-Standard"))
+                                .tag(nil as String?)
+                            ForEach(models, id: \.id) { model in
+                                Text(model.displayName).tag(model.id as String?)
+                            }
+                        }
+
+                        Text(
+                            localizedAppText(
+                                "Leave the model on Engine Default to follow the engine's selected model.",
+                                de: "Lass das Modell auf Engine-Standard, um dem ausgewählten Modell der Engine zu folgen."
+                            )
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -1387,6 +1462,7 @@ private struct WorkflowEditorPage: View {
         if let validationError = draft.validationError(
             hotkeyService: hotkeyService,
             workflowService: workflowService,
+            pluginManager: pluginManager,
             existingWorkflowId: workflow?.id
         ) {
             validationMessage = validationError
@@ -1474,6 +1550,11 @@ private struct WorkflowEditorPage: View {
         validationMessage = nil
     }
 
+    private func transcriptionModels(for engineId: String) -> [PluginModelInfo] {
+        guard let engine = pluginManager.transcriptionEngine(for: engineId) else { return [] }
+        return engine.modelCatalog
+    }
+
     private func selectedTemplateCard(definition: WorkflowTemplateDefinition) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: definition.systemImage)
@@ -1524,6 +1605,34 @@ private struct WorkflowEditorPage: View {
             get: { draft.cloudModel },
             set: { modelId in
                 draft.cloudModel = modelId
+            }
+        )
+    }
+
+    private var workflowTranscriptionEngineBinding: Binding<String?> {
+        Binding(
+            get: { draft.transcriptionEngineId },
+            set: { engineId in
+                draft.transcriptionEngineId = engineId
+                if engineId == nil {
+                    draft.transcriptionModelId = nil
+                    return
+                }
+
+                if let transcriptionModelId = draft.transcriptionModelId,
+                   let engineId,
+                   !transcriptionModels(for: engineId).contains(where: { $0.id == transcriptionModelId }) {
+                    draft.transcriptionModelId = nil
+                }
+            }
+        )
+    }
+
+    private var workflowTranscriptionModelBinding: Binding<String?> {
+        Binding(
+            get: { draft.transcriptionModelId },
+            set: { modelId in
+                draft.transcriptionModelId = modelId
             }
         )
     }
@@ -1870,6 +1979,8 @@ struct WorkflowDraft {
     var customInstruction: String
     var outputFormat: String
     var autoEnter: Bool
+    var transcriptionEngineId: String?
+    var transcriptionModelId: String?
 
     private var preservedBehaviorSettings: [String: String]
     var providerId: String?
@@ -1899,6 +2010,8 @@ struct WorkflowDraft {
         self.customInstruction = ""
         self.outputFormat = ""
         self.autoEnter = false
+        self.transcriptionEngineId = nil
+        self.transcriptionModelId = nil
         self.preservedBehaviorSettings = [:]
         self.providerId = nil
         self.cloudModel = nil
@@ -1927,6 +2040,8 @@ struct WorkflowDraft {
         self.customInstruction = behavior.settings["instruction"] ?? behavior.settings["goal"] ?? behavior.settings["prompt"] ?? ""
         self.outputFormat = output.format ?? ""
         self.autoEnter = output.autoEnter
+        self.transcriptionEngineId = workflow.template == .dictation ? behavior.transcriptionEngineId : nil
+        self.transcriptionModelId = workflow.template == .dictation ? behavior.transcriptionModelId : nil
         self.hotkeyBehavior = .startDictation
         self.preservedBehaviorSettings = behavior.settings
         self.providerId = behavior.providerId
@@ -2050,6 +2165,9 @@ struct WorkflowDraft {
             if !hasEnabledAutomaticTriggerComponent {
                 isHotkeyTriggerEnabled = true
             }
+        } else {
+            transcriptionEngineId = nil
+            transcriptionModelId = nil
         }
     }
 
@@ -2057,6 +2175,7 @@ struct WorkflowDraft {
     func validationError(
         hotkeyService: HotkeyService,
         workflowService: WorkflowService,
+        pluginManager: PluginManager,
         existingWorkflowId: UUID?
     ) -> String? {
         if template == .dictation && triggerMode == .manual {
@@ -2064,6 +2183,26 @@ struct WorkflowDraft {
                 "Dictation Only workflows need a recording trigger.",
                 de: "Nur-Diktat-Workflows brauchen einen Aufnahme-Trigger."
             )
+        }
+
+        if template == .dictation,
+           let transcriptionEngineId,
+           !transcriptionEngineId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            guard let engine = pluginManager.transcriptionEngine(for: transcriptionEngineId) else {
+                return localizedAppText(
+                    "The selected transcription engine is not installed.",
+                    de: "Die ausgewählte Transkriptions-Engine ist nicht installiert."
+                )
+            }
+
+            if let transcriptionModelId,
+               !transcriptionModelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               !engine.modelCatalog.contains(where: { $0.id == transcriptionModelId }) {
+                return localizedAppText(
+                    "The selected transcription model is not available for this engine.",
+                    de: "Das ausgewählte Transkriptionsmodell ist für diese Engine nicht verfügbar."
+                )
+            }
         }
 
         switch triggerMode {
@@ -2225,12 +2364,15 @@ struct WorkflowDraft {
 
         let trimmedProviderId = providerId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedCloudModel = cloudModel?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTranscriptionEngineId = template == .dictation ? Self.trimmedOptional(transcriptionEngineId) : nil
 
         return WorkflowBehavior(
             settings: settings,
             fineTuning: usesLLMProcessing ? fineTuning.trimmingCharacters(in: .whitespacesAndNewlines) : "",
             providerId: usesLLMProcessing && trimmedProviderId?.isEmpty == false ? trimmedProviderId : nil,
             cloudModel: usesLLMProcessing && trimmedCloudModel?.isEmpty == false ? trimmedCloudModel : nil,
+            transcriptionEngineId: trimmedTranscriptionEngineId,
+            transcriptionModelId: trimmedTranscriptionEngineId != nil ? Self.trimmedOptional(transcriptionModelId) : nil,
             temperatureModeRaw: temperatureModeRaw,
             temperatureValue: temperatureValue
         )
@@ -2357,6 +2499,11 @@ struct WorkflowDraft {
         case .llmPrompt:
             "English"
         }
+    }
+
+    private static func trimmedOptional(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
     }
 }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginWorkflowInfo.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginWorkflowInfo.swift
@@ -77,6 +77,8 @@ public struct PluginWorkflowBehavior: Codable, Sendable, Equatable {
     public let fineTuning: String
     public let providerId: String?
     public let cloudModel: String?
+    public let transcriptionEngineId: String?
+    public let transcriptionModelId: String?
     public let temperatureMode: PluginLLMTemperatureMode
     public let temperatureValue: Double?
 
@@ -85,6 +87,8 @@ public struct PluginWorkflowBehavior: Codable, Sendable, Equatable {
         fineTuning: String = "",
         providerId: String? = nil,
         cloudModel: String? = nil,
+        transcriptionEngineId: String? = nil,
+        transcriptionModelId: String? = nil,
         temperatureMode: PluginLLMTemperatureMode = .inheritProviderSetting,
         temperatureValue: Double? = nil
     ) {
@@ -92,6 +96,8 @@ public struct PluginWorkflowBehavior: Codable, Sendable, Equatable {
         self.fineTuning = fineTuning
         self.providerId = providerId
         self.cloudModel = cloudModel
+        self.transcriptionEngineId = transcriptionEngineId
+        self.transcriptionModelId = transcriptionModelId
         self.temperatureMode = temperatureMode
         self.temperatureValue = temperatureValue
     }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -302,6 +302,8 @@ final class ProtocolContractTests: XCTestCase {
                 fineTuning: "Keep speaker intent.",
                 providerId: "openai",
                 cloudModel: "gpt-5.4",
+                transcriptionEngineId: "whisperkit",
+                transcriptionModelId: "large-v3",
                 temperatureMode: .custom,
                 temperatureValue: 0.2
             ),
@@ -322,7 +324,28 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertEqual(host.availableWorkflows, [workflow])
         XCTAssertEqual(host.availableWorkflows.first?.trigger.websitePatterns, ["example.com"])
         XCTAssertEqual(host.availableWorkflows.first?.behavior.settings["triggerWord"], "cleanup")
+        XCTAssertEqual(host.availableWorkflows.first?.behavior.transcriptionEngineId, "whisperkit")
+        XCTAssertEqual(host.availableWorkflows.first?.behavior.transcriptionModelId, "large-v3")
         XCTAssertEqual(host.availableWorkflows.first?.output.targetActionPluginId, "com.example.action")
+    }
+
+    func testWorkflowBehaviorDecodesLegacyPayloadWithoutTranscriptionOverrides() throws {
+        let payload: [String: Any] = [
+            "settings": ["triggerWord": "cleanup"],
+            "fineTuning": "Keep speaker intent.",
+            "providerId": "openai",
+            "cloudModel": "gpt-5.4",
+            "temperatureMode": "custom",
+            "temperatureValue": 0.2
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+
+        let behavior = try JSONDecoder().decode(PluginWorkflowBehavior.self, from: data)
+
+        XCTAssertEqual(behavior.providerId, "openai")
+        XCTAssertEqual(behavior.cloudModel, "gpt-5.4")
+        XCTAssertNil(behavior.transcriptionEngineId)
+        XCTAssertNil(behavior.transcriptionModelId)
     }
 
     func testTranscriptionPluginUsesDefaultStreamingFallback() async throws {

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -48,6 +48,8 @@ final class WorkflowServiceTests: XCTestCase {
                 fineTuning: "Keep speaker intent.",
                 providerId: "openai",
                 cloudModel: "gpt-5.4",
+                transcriptionEngineId: "whisperkit",
+                transcriptionModelId: "large-v3",
                 temperatureModeRaw: "custom",
                 temperatureValue: 0.2
             ),
@@ -70,6 +72,8 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.trigger.hotkeys.first?.keyCode, 15)
         XCTAssertEqual(snapshot.trigger.hotkeys.first?.modifierKeyCodes, [55])
         XCTAssertEqual(snapshot.behavior.settings["triggerWord"], "cleanup")
+        XCTAssertEqual(snapshot.behavior.transcriptionEngineId, "whisperkit")
+        XCTAssertEqual(snapshot.behavior.transcriptionModelId, "large-v3")
         XCTAssertEqual(snapshot.behavior.temperatureMode, .custom)
         XCTAssertEqual(snapshot.output.targetActionPluginId, "com.example.action")
         XCTAssertEqual(snapshot.createdAt, createdAt)
@@ -93,6 +97,8 @@ final class WorkflowServiceTests: XCTestCase {
                 fineTuning: "Keep it concise.",
                 providerId: "Groq",
                 cloudModel: "llama-3.3",
+                transcriptionEngineId: "whisperkit",
+                transcriptionModelId: "large-v3",
                 temperatureModeRaw: "custom",
                 temperatureValue: 0.2
             ),
@@ -116,6 +122,8 @@ final class WorkflowServiceTests: XCTestCase {
                 fineTuning: "Keep it concise.",
                 providerId: "Groq",
                 cloudModel: "llama-3.3",
+                transcriptionEngineId: "whisperkit",
+                transcriptionModelId: "large-v3",
                 temperatureModeRaw: "custom",
                 temperatureValue: 0.2
             )
@@ -170,6 +178,23 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(workflow.trigger?.hotkeyBehavior, .processSelectedText)
     }
 
+    func testStoredWorkflowBehaviorWithoutTranscriptionOverridesDefaultsToNil() throws {
+        let payload: [String: Any] = [
+            "settings": ["inputLanguage": "en"],
+            "fineTuning": "",
+            "providerId": "Groq",
+            "cloudModel": "llama-3.3"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+
+        let behavior = try JSONDecoder().decode(WorkflowBehavior.self, from: data)
+
+        XCTAssertEqual(behavior.providerId, "Groq")
+        XCTAssertEqual(behavior.cloudModel, "llama-3.3")
+        XCTAssertNil(behavior.transcriptionEngineId)
+        XCTAssertNil(behavior.transcriptionModelId)
+    }
+
     func testWorkflowServicePersistsCombinedTriggerArrays() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WorkflowServiceTests")
         defer { TestSupport.remove(appSupportDirectory) }
@@ -220,6 +245,51 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(trigger.websitePatterns, ["claude.ai"])
         XCTAssertEqual(trigger.hotkeys, [hotkey])
         XCTAssertEqual(trigger.hotkeyBehavior, .processSelectedText)
+    }
+
+    func testWorkflowDraftPreservesDictationTranscriptionOverridesWhenSaving() throws {
+        let hotkey = UnifiedHotkey(keyCode: 15, modifierFlags: NSEvent.ModifierFlags.command.rawValue, isFn: false)
+        let workflow = Workflow(
+            name: "Norwegian Whisper",
+            template: .dictation,
+            trigger: .hotkeys([hotkey]),
+            behavior: WorkflowBehavior(
+                settings: [WorkflowBehavior.inputLanguageSettingKey: "no"],
+                transcriptionEngineId: "local-whisper",
+                transcriptionModelId: "large-v3-turbo"
+            )
+        )
+
+        let draft = WorkflowDraft(workflow)
+        let behavior = draft.resolvedBehavior()
+
+        XCTAssertEqual(draft.transcriptionEngineId, "local-whisper")
+        XCTAssertEqual(draft.transcriptionModelId, "large-v3-turbo")
+        XCTAssertEqual(behavior.transcriptionEngineId, "local-whisper")
+        XCTAssertEqual(behavior.transcriptionModelId, "large-v3-turbo")
+    }
+
+    func testWorkflowDraftDropsTranscriptionOverridesForNonDictationTemplates() throws {
+        var draft = WorkflowDraft(template: .dictation)
+        draft.transcriptionEngineId = "whisperkit"
+        draft.transcriptionModelId = "large-v3"
+
+        draft.selectTemplate(.summary)
+
+        XCTAssertNil(draft.transcriptionEngineId)
+        XCTAssertNil(draft.transcriptionModelId)
+        XCTAssertNil(draft.resolvedBehavior().transcriptionEngineId)
+        XCTAssertNil(draft.resolvedBehavior().transcriptionModelId)
+    }
+
+    func testWorkflowDraftDropsTranscriptionModelWithoutEngineOverride() throws {
+        var draft = WorkflowDraft(template: .dictation)
+        draft.transcriptionModelId = "large-v3"
+
+        let behavior = draft.resolvedBehavior()
+
+        XCTAssertNil(behavior.transcriptionEngineId)
+        XCTAssertNil(behavior.transcriptionModelId)
     }
 
     func testWorkflowServicePersistsDefaultLLMProviderAndModel() throws {
@@ -1499,5 +1569,56 @@ final class DictationLanguageResolverTests: XCTestCase {
         )
 
         XCTAssertEqual(resolved, .auto)
+    }
+}
+
+@MainActor
+final class DictationTranscriptionOverrideResolverTests: XCTestCase {
+    func testDictationWorkflowResolvesEngineAndModelOverrides() {
+        let workflow = Workflow(
+            name: "Norwegian Whisper",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 8, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(
+                transcriptionEngineId: "local-whisper",
+                transcriptionModelId: "large-v3-turbo"
+            )
+        )
+
+        XCTAssertEqual(
+            DictationTranscriptionOverrideResolver.engineId(for: workflow),
+            "local-whisper"
+        )
+        XCTAssertEqual(
+            DictationTranscriptionOverrideResolver.modelId(for: workflow),
+            "large-v3-turbo"
+        )
+    }
+
+    func testModelOverrideRequiresEngineOverride() {
+        let workflow = Workflow(
+            name: "Incomplete Override",
+            template: .dictation,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 8, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(transcriptionModelId: "large-v3")
+        )
+
+        XCTAssertNil(DictationTranscriptionOverrideResolver.engineId(for: workflow))
+        XCTAssertNil(DictationTranscriptionOverrideResolver.modelId(for: workflow))
+    }
+
+    func testNonDictationWorkflowIgnoresTranscriptionOverrides() {
+        let workflow = Workflow(
+            name: "Prompt Cleanup",
+            template: .summary,
+            trigger: .hotkey(UnifiedHotkey(keyCode: 8, modifierFlags: 0, isFn: false)),
+            behavior: WorkflowBehavior(
+                transcriptionEngineId: "local-whisper",
+                transcriptionModelId: "large-v3"
+            )
+        )
+
+        XCTAssertNil(DictationTranscriptionOverrideResolver.engineId(for: workflow))
+        XCTAssertNil(DictationTranscriptionOverrideResolver.modelId(for: workflow))
     }
 }


### PR DESCRIPTION
## Issue context

Issue #506 asks for a small workflow-based way to use different transcription engines without introducing a separate profile system. This PR keeps the change scoped to Dictation Only workflows so users can create multiple dictation hotkeys with their own spoken language, transcription engine, and optional model.

Closes #506

## Summary

- Add optional workflow behavior fields for `transcriptionEngineId` and `transcriptionModelId`, including the plugin SDK contract.
- Show a Transcription Engine section only for Dictation Only workflows, with Use Global Engine, installed engines, and model selection where available.
- Resolve workflow engine/model overrides during dictation without mutating the global selected engine.
- Keep the fields backward compatible and drop them when a draft switches away from Dictation Only.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WorkflowServiceTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationTranscriptionOverrideResolverTests`
- `cd TypeWhisperPluginSDK && swift test --filter ProtocolContractTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`

The dev app was built and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.
