### PR TITLE
Add SDK auth roles for OpenAI transcription availability

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -72,8 +72,9 @@ final class ModelManagerService: ObservableObject {
     /// True when the selected engine plugin exists. The actual model readiness check
     /// happens in transcribe() which handles restoration via triggerRestoreModel().
     var canTranscribe: Bool {
-        guard let providerId = selectedProviderId else { return false }
-        return PluginManager.shared.transcriptionEngine(for: providerId) != nil
+        guard let providerId = selectedProviderId,
+              let engine = PluginManager.shared.transcriptionEngine(for: providerId) else { return false }
+        return canUseForTranscription(engine)
     }
 
     var activeEngineName: String? {
@@ -112,6 +113,11 @@ final class ModelManagerService: ObservableObject {
     func selectProvider(_ providerId: String) {
         selectedProviderId = providerId
         UserDefaults.standard.set(providerId, forKey: providerKey)
+    }
+
+    func clearProviderSelection() {
+        selectedProviderId = nil
+        UserDefaults.standard.removeObject(forKey: providerKey)
     }
 
     func selectModel(_ providerId: String, modelId: String) {
@@ -166,6 +172,28 @@ final class ModelManagerService: ObservableObject {
         return (plugin as? any TranscriptPreviewFallbackPolicyProviding)?.allowsTranscriptPreviewFallback ?? true
     }
 
+    func transcriptionAuthStatus(for engine: TranscriptionEnginePlugin) -> PluginAuthRoleStatus {
+        // Legacy plugins may use isConfigured for loaded-model state, so absence of the
+        // optional auth-role protocol should not make auto-unloaded local engines unselectable.
+        PluginAuthRoleStatusResolver.status(
+            for: engine,
+            role: .transcription,
+            legacyIsConfigured: true
+        )
+    }
+
+    func transcriptionAuthStatus(for providerId: String?) -> PluginAuthRoleStatus? {
+        guard let providerId,
+              let engine = PluginManager.shared.transcriptionEngine(for: providerId) else {
+            return nil
+        }
+        return transcriptionAuthStatus(for: engine)
+    }
+
+    func canUseForTranscription(_ engine: TranscriptionEnginePlugin) -> Bool {
+        transcriptionAuthStatus(for: engine).isAvailable
+    }
+
     /// Resolve display name for a given engine/model override combination
     func resolvedModelDisplayName(engineOverrideId: String? = nil, cloudModelOverride: String? = nil) -> String? {
         let providerId = engineOverrideId ?? selectedProviderId
@@ -189,17 +217,17 @@ final class ModelManagerService: ObservableObject {
     /// If the selected plugin is missing, fall back to the first available engine.
     func restoreProviderSelection() {
         if let providerId = selectedProviderId,
-           PluginManager.shared.transcriptionEngine(for: providerId) != nil {
+           let engine = PluginManager.shared.transcriptionEngine(for: providerId),
+           canUseForTranscription(engine) {
             return
         }
         // Selected provider doesn't exist - find a fallback
-        if let fallback = PluginManager.shared.transcriptionEngines.first(where: { $0.isConfigured }) {
+        if let fallback = PluginManager.shared.transcriptionEngines.first(where: { $0.isConfigured && canUseForTranscription($0) }) {
             selectProvider(fallback.providerId)
-        } else if let anyEngine = PluginManager.shared.transcriptionEngines.first {
+        } else if let anyEngine = PluginManager.shared.transcriptionEngines.first(where: { canUseForTranscription($0) }) {
             selectProvider(anyEngine.providerId)
         } else {
-            selectedProviderId = nil
-            UserDefaults.standard.removeObject(forKey: providerKey)
+            clearProviderSelection()
         }
     }
 
@@ -277,6 +305,13 @@ final class ModelManagerService: ObservableObject {
         guard let providerId,
               let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
             throw TranscriptionEngineError.modelNotLoaded
+        }
+
+        let authStatus = transcriptionAuthStatus(for: plugin)
+        guard authStatus.isAvailable else {
+            throw TranscriptionEngineError.unsupportedTask(
+                authStatus.unavailableReason ?? "Transcription is not available for this engine."
+            )
         }
 
         if !plugin.isConfigured {
@@ -366,6 +401,13 @@ final class ModelManagerService: ObservableObject {
             throw TranscriptionEngineError.modelNotLoaded
         }
 
+        let authStatus = transcriptionAuthStatus(for: plugin)
+        guard authStatus.isAvailable else {
+            throw TranscriptionEngineError.unsupportedTask(
+                authStatus.unavailableReason ?? "Transcription is not available for this engine."
+            )
+        }
+
         if !plugin.isConfigured {
             await triggerRestoreModel(plugin)
         }
@@ -434,6 +476,13 @@ final class ModelManagerService: ObservableObject {
         guard let providerId,
               let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
             throw TranscriptionEngineError.modelNotLoaded
+        }
+
+        let authStatus = transcriptionAuthStatus(for: plugin)
+        guard authStatus.isAvailable else {
+            throw TranscriptionEngineError.unsupportedTask(
+                authStatus.unavailableReason ?? "Transcription is not available for this engine."
+            )
         }
 
         if !plugin.isConfigured {

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TypeWhisperPluginSDK
 
 struct AudioRecorderView: View {
     @ObservedObject var viewModel: AudioRecorderViewModel
@@ -8,6 +9,28 @@ struct AudioRecorderView: View {
 
     private var isEditingLocked: Bool {
         viewModel.state != .idle
+    }
+
+    private func transcriptionAuthNotice(for engines: [TranscriptionEnginePlugin]) -> String? {
+        engines
+            .map { modelManager.transcriptionAuthStatus(for: $0) }
+            .first { !$0.isAvailable }?
+            .unavailableReason
+    }
+
+    @ViewBuilder
+    private func enginePickerLabel(for engine: TranscriptionEnginePlugin) -> some View {
+        let authStatus = modelManager.transcriptionAuthStatus(for: engine)
+        HStack {
+            Text(engine.providerDisplayName)
+            if !authStatus.isAvailable {
+                Text("(\(String(localized: "unavailable")))")
+                    .foregroundStyle(.secondary)
+            } else if !engine.isConfigured {
+                Text("(\(String(localized: "not ready")))")
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     var body: some View {
@@ -148,13 +171,9 @@ struct AudioRecorderView: View {
                         Text(String(localized: "None")).tag(nil as String?)
                         Divider()
                         ForEach(engines, id: \.providerId) { engine in
-                            HStack {
-                                Text(engine.providerDisplayName)
-                                if !engine.isConfigured {
-                                    Text("(\(String(localized: "not ready")))")
-                                        .foregroundStyle(.secondary)
-                                }
-                            }.tag(engine.providerId as String?)
+                            enginePickerLabel(for: engine)
+                                .tag(engine.providerId as String?)
+                                .disabled(!modelManager.canUseForTranscription(engine))
                         }
                     }
                     .onChange(of: selectedProvider) { _, newValue in
@@ -164,9 +183,16 @@ struct AudioRecorderView: View {
                     }
                     .disabled(isEditingLocked)
 
+                    if let notice = transcriptionAuthNotice(for: engines) {
+                        Label(notice, systemImage: "key")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
                     // Model picker
                     if let providerId = selectedProvider,
-                       let engine = pluginManager.transcriptionEngine(for: providerId) {
+                       let engine = pluginManager.transcriptionEngine(for: providerId),
+                       modelManager.canUseForTranscription(engine) {
                         let models = engine.transcriptionModels
                         if models.count > 1 {
                             Picker(String(localized: "Model"), selection: Binding(
@@ -239,6 +265,7 @@ struct AudioRecorderView: View {
                 }
             }
             .onAppear {
+                modelManager.restoreProviderSelection()
                 selectedProvider = modelManager.selectedProviderId
             }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import TypeWhisperPluginSDK
 
 enum SettingsTab: Hashable {
     case home, general, recording, hotkeys, recorder
@@ -360,6 +361,28 @@ struct RecordingSettingsView: View {
         dictation.needsMicPermission || dictation.needsAccessibilityPermission
     }
 
+    private func transcriptionAuthNotice(for engines: [TranscriptionEnginePlugin]) -> String? {
+        engines
+            .map { modelManager.transcriptionAuthStatus(for: $0) }
+            .first { !$0.isAvailable }?
+            .unavailableReason
+    }
+
+    @ViewBuilder
+    private func enginePickerLabel(for engine: TranscriptionEnginePlugin) -> some View {
+        let authStatus = modelManager.transcriptionAuthStatus(for: engine)
+        HStack {
+            Text(engine.providerDisplayName)
+            if !authStatus.isAvailable {
+                Text("(\(String(localized: "unavailable")))")
+                    .foregroundStyle(.secondary)
+            } else if !engine.isConfigured {
+                Text("(\(String(localized: "not ready")))")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
     var body: some View {
         Form {
             if needsPermissions {
@@ -376,13 +399,9 @@ struct RecordingSettingsView: View {
                         Text(String(localized: "None")).tag(nil as String?)
                         Divider()
                         ForEach(engines, id: \.providerId) { engine in
-                            HStack {
-                                Text(engine.providerDisplayName)
-                                if !engine.isConfigured {
-                                    Text("(\(String(localized: "not ready")))")
-                                        .foregroundStyle(.secondary)
-                                }
-                            }.tag(engine.providerId as String?)
+                            enginePickerLabel(for: engine)
+                                .tag(engine.providerId as String?)
+                                .disabled(!modelManager.canUseForTranscription(engine))
                         }
                     }
                     .onChange(of: selectedProvider) { _, newValue in
@@ -391,8 +410,15 @@ struct RecordingSettingsView: View {
                         }
                     }
 
+                    if let notice = transcriptionAuthNotice(for: engines) {
+                        Label(notice, systemImage: "key")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
                     if let providerId = selectedProvider,
-                       let engine = pluginManager.transcriptionEngine(for: providerId) {
+                       let engine = pluginManager.transcriptionEngine(for: providerId),
+                       modelManager.canUseForTranscription(engine) {
                         let models = engine.transcriptionModels
                         if models.count > 1 {
                             Picker(String(localized: "Model"), selection: Binding(
@@ -585,6 +611,7 @@ struct RecordingSettingsView: View {
         .padding()
         .frame(minWidth: 500, minHeight: 300)
         .onAppear {
+            modelManager.restoreProviderSelection()
             selectedProvider = modelManager.selectedProviderId
             customSounds = SoundChoice.installedCustomSounds()
         }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -1267,6 +1267,7 @@ final class OpenAIPlugin: NSObject,
     LiveTranscriptionCapablePlugin,
     LLMProviderPlugin,
     TTSProviderPlugin,
+    PluginAuthRoleStatusProviding,
     @unchecked Sendable
 {
     static let pluginId = "com.typewhisper.openai"
@@ -1296,6 +1297,13 @@ final class OpenAIPlugin: NSObject,
     )
 
     private let chatHelper = PluginOpenAIChatHelper(baseURL: "https://api.openai.com")
+
+    private static let openAIAPIKeyCredentialLabel = "OpenAI API key"
+    private static let chatGPTLoginCredentialLabel = "ChatGPT Login"
+    private static let apiKeyOrChatGPTCredentialLabel = "OpenAI API key or ChatGPT Login"
+    private static let transcriptionRequiresAPIKeyReason = "ChatGPT Login only enables prompt processing. OpenAI transcription requires an OpenAI API key."
+    private static let ttsRequiresAPIKeyReason = "ChatGPT Login only enables prompt processing. OpenAI text-to-speech requires an OpenAI API key."
+    private static let llmRequiresCredentialsReason = "OpenAI prompt processing requires an OpenAI API key or ChatGPT Login."
 
     private static let storageKeys = (
         apiKey: "api-key",
@@ -1385,6 +1393,47 @@ final class OpenAIPlugin: NSObject,
 
     func deactivate() {
         host = nil
+    }
+
+    // MARK: - PluginAuthRoleStatusProviding
+
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        switch role {
+        case .transcription:
+            guard normalizedAPIKey != nil else {
+                return .unavailable(
+                    reason: _authMode == .chatGPT
+                        ? Self.transcriptionRequiresAPIKeyReason
+                        : "OpenAI transcription requires an OpenAI API key.",
+                    requiredCredentialLabel: Self.openAIAPIKeyCredentialLabel
+                )
+            }
+            return .available
+
+        case .llm:
+            guard isAvailable else {
+                return .unavailable(
+                    reason: _authMode == .chatGPT
+                        ? "ChatGPT Login is not connected."
+                        : Self.llmRequiresCredentialsReason,
+                    requiredCredentialLabel: _authMode == .chatGPT
+                        ? Self.chatGPTLoginCredentialLabel
+                        : Self.apiKeyOrChatGPTCredentialLabel
+                )
+            }
+            return .available
+
+        case .tts:
+            guard normalizedAPIKey != nil else {
+                return .unavailable(
+                    reason: _authMode == .chatGPT
+                        ? Self.ttsRequiresAPIKeyReason
+                        : "OpenAI text-to-speech requires an OpenAI API key.",
+                    requiredCredentialLabel: Self.openAIAPIKeyCredentialLabel
+                )
+            }
+            return .available
+        }
     }
 
     // MARK: - TranscriptionEnginePlugin

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -33,6 +33,49 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.5")
     }
 
+    func testOpenAIChatGPTLoginOnlyMakesLLMAuthRoleAvailable() throws {
+        let host = try PluginTestHostServices(
+            defaults: ["authMode": "chatgpt"],
+            secrets: ["oauth-refresh-token": "refresh-token"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.authStatus(for: .llm).isAvailable)
+
+        let transcriptionStatus = plugin.authStatus(for: .transcription)
+        XCTAssertFalse(transcriptionStatus.isAvailable)
+        XCTAssertEqual(transcriptionStatus.requiredCredentialLabel, "OpenAI API key")
+        XCTAssertEqual(
+            transcriptionStatus.unavailableReason,
+            "ChatGPT Login only enables prompt processing. OpenAI transcription requires an OpenAI API key."
+        )
+
+        let ttsStatus = plugin.authStatus(for: .tts)
+        XCTAssertFalse(ttsStatus.isAvailable)
+        XCTAssertEqual(ttsStatus.requiredCredentialLabel, "OpenAI API key")
+    }
+
+    func testOpenAIAPIKeyMakesLLMTranscriptionAndTTSAuthRolesAvailable() throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk-live"])
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.authStatus(for: .llm).isAvailable)
+        XCTAssertTrue(plugin.authStatus(for: .transcription).isAvailable)
+        XCTAssertTrue(plugin.authStatus(for: .tts).isAvailable)
+    }
+
+    func testOpenAIWithoutCredentialsMakesCloudAuthRolesUnavailable() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.authStatus(for: .llm).isAvailable)
+        XCTAssertFalse(plugin.authStatus(for: .transcription).isAvailable)
+        XCTAssertFalse(plugin.authStatus(for: .tts).isAvailable)
+    }
+
     func testOpenAIUsesResponsesAPIForGPT5ModelsOnly() {
         XCTAssertTrue(OpenAIPlugin.usesResponsesAPI(for: "gpt-5.5"))
         XCTAssertTrue(OpenAIPlugin.usesResponsesAPI(for: "gpt-5.4-mini"))

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -40,6 +40,80 @@ public extension PluginSettingsActivityReporting {
     var currentSettingsActivity: PluginSettingsActivity? { nil }
 }
 
+// MARK: - Auth Role Status
+
+public enum PluginAuthRole: String, CaseIterable, Sendable {
+    case transcription
+    case llm
+    case tts
+}
+
+public struct PluginAuthRoleStatus: Sendable, Equatable {
+    public let isAvailable: Bool
+    public let unavailableReason: String?
+    public let requiredCredentialLabel: String?
+
+    public init(
+        isAvailable: Bool,
+        unavailableReason: String? = nil,
+        requiredCredentialLabel: String? = nil
+    ) {
+        self.isAvailable = isAvailable
+        self.unavailableReason = unavailableReason
+        self.requiredCredentialLabel = requiredCredentialLabel
+    }
+
+    public static let available = PluginAuthRoleStatus(isAvailable: true)
+
+    public static func unavailable(
+        reason: String,
+        requiredCredentialLabel: String? = nil
+    ) -> PluginAuthRoleStatus {
+        PluginAuthRoleStatus(
+            isAvailable: false,
+            unavailableReason: reason,
+            requiredCredentialLabel: requiredCredentialLabel
+        )
+    }
+
+    public static func legacyFallback(
+        isConfigured: Bool,
+        unavailableReason: String = "Plugin is not configured.",
+        requiredCredentialLabel: String? = nil
+    ) -> PluginAuthRoleStatus {
+        isConfigured
+            ? .available
+            : .unavailable(
+                reason: unavailableReason,
+                requiredCredentialLabel: requiredCredentialLabel
+            )
+    }
+}
+
+public protocol PluginAuthRoleStatusProviding: TypeWhisperPlugin {
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus
+}
+
+public enum PluginAuthRoleStatusResolver {
+    public static func status(
+        for plugin: any TypeWhisperPlugin,
+        role: PluginAuthRole,
+        legacyIsConfigured: Bool = true,
+        legacyUnavailableReason: String = "Plugin is not configured.",
+        legacyRequiredCredentialLabel: String? = nil
+    ) -> PluginAuthRoleStatus {
+        if let provider = plugin as? any PluginAuthRoleStatusProviding {
+            return provider.authStatus(for: role)
+        }
+
+        return .legacyFallback(
+            isConfigured: legacyIsConfigured,
+            unavailableReason: legacyUnavailableReason,
+            requiredCredentialLabel: legacyRequiredCredentialLabel
+        )
+    }
+}
+
 // MARK: - Settings Window Environment
 
 private struct PluginSettingsCloseActionKey: EnvironmentKey {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -96,6 +96,27 @@ private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin
     }
 }
 
+@objc(MockAuthRoleStatusPlugin)
+private final class MockAuthRoleStatusPlugin: NSObject, TypeWhisperPlugin, PluginAuthRoleStatusProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.auth-roles"
+    static let pluginName = "Mock Auth Roles"
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        role == .transcription
+            ? PluginAuthRoleStatus(
+                isAvailable: false,
+                unavailableReason: "Transcription needs a key.",
+                requiredCredentialLabel: "API key"
+            )
+            : .available
+    }
+}
+
 @objc(MockDictionaryTermsPlugin)
 private final class MockDictionaryTermsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.dictionary-terms"
@@ -260,6 +281,34 @@ private final class MockTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Senda
 }
 
 final class ProtocolContractTests: XCTestCase {
+    func testPluginAuthRolesExposeStableRawValues() {
+        XCTAssertEqual(PluginAuthRole.transcription.rawValue, "transcription")
+        XCTAssertEqual(PluginAuthRole.llm.rawValue, "llm")
+        XCTAssertEqual(PluginAuthRole.tts.rawValue, "tts")
+    }
+
+    func testPluginAuthRoleStatusResolverUsesProviderOverrideAndLegacyFallback() {
+        let roleAwarePlugin = MockAuthRoleStatusPlugin()
+        let roleStatus = PluginAuthRoleStatusResolver.status(
+            for: roleAwarePlugin,
+            role: .transcription,
+            legacyIsConfigured: true
+        )
+
+        XCTAssertFalse(roleStatus.isAvailable)
+        XCTAssertEqual(roleStatus.unavailableReason, "Transcription needs a key.")
+        XCTAssertEqual(roleStatus.requiredCredentialLabel, "API key")
+
+        let legacyPlugin = MockTranscriptionPlugin()
+        XCTAssertEqual(
+            PluginAuthRoleStatusResolver.status(for: legacyPlugin, role: .transcription, legacyIsConfigured: true),
+            .available
+        )
+        XCTAssertFalse(
+            PluginAuthRoleStatusResolver.status(for: legacyPlugin, role: .transcription, legacyIsConfigured: false).isAvailable
+        )
+    }
+
     func testHostServicesExposeRulesSecretsAndDefaults() throws {
         let host = MockHostServices(eventBus: MockEventBus(), availableRuleNames: ["Work", "Docs"])
 

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -780,6 +780,36 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
         }
     }
 
+    private final class MockRoleGatedTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthRoleStatusProviding, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.role-gated" }
+        static var pluginName: String { "Mock Role Gated" }
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        var providerId: String { "mock-role-gated" }
+        var providerDisplayName: String { "Mock Role Gated" }
+        var isConfigured: Bool { true }
+        var supportsTranslation: Bool { false }
+        var supportedLanguages: [String] { ["en"] }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        func selectModel(_ modelId: String) {}
+
+        func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+            role == .transcription
+                ? PluginAuthRoleStatus(
+                    isAvailable: false,
+                    unavailableReason: "Transcription needs a separate credential.",
+                    requiredCredentialLabel: "API key"
+                )
+                : .available
+        }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "ok", detectedLanguage: language)
+        }
+    }
+
     override func tearDown() {
         RuntimeArchitecture.overrideCurrent = nil
         super.tearDown()
@@ -960,6 +990,55 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
 
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
         PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.compatible",
+                    name: "Mock Compatible",
+                    version: "1.0.0",
+                    principalClass: "MockTranscriptionPlugin"
+                ),
+                instance: MockTranscriptionPlugin(),
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.restoreProviderSelection()
+
+        XCTAssertEqual(modelManager.selectedProviderId, "mock-compatible")
+    }
+
+    func testModelManagerFallsBackWhenStoredProviderCannotUseTranscriptionRole() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.set("mock-role-gated", forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.role-gated",
+                    name: "Mock Role Gated",
+                    version: "1.0.0",
+                    principalClass: "MockRoleGatedTranscriptionPlugin"
+                ),
+                instance: MockRoleGatedTranscriptionPlugin(),
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ),
             LoadedPlugin(
                 manifest: PluginManifest(
                     id: "com.typewhisper.mock.compatible",


### PR DESCRIPTION
## Summary
- Add an optional SDK auth role status model for `transcription`, `llm`, and `tts`.
- Implement OpenAI role-aware auth status so ChatGPT Login enables LLM/prompt processing only, while OpenAI transcription and TTS require an OpenAI API key.
- Update recording engine pickers and selection reconciliation to use the transcription auth role instead of provider-specific OpenAI checks.

## Issue Context
Issue #498 reports that a user can connect OpenAI through ChatGPT/browser login only, then still see OpenAI transcription options as selectable. That state cannot run OpenAI transcription because ChatGPT Login only enables prompt/LLM processing; OpenAI transcription requires an OpenAI API key. This PR disables and blocks transcription engines whose `.transcription` auth role is unavailable and shows the unavailable reason in Recording UI.

Closes #498

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
