### PR TITLE
Fix memory extraction for normal dictations

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */; };
 		7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */; };
 		86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BD305007A3A158038C75C /* ProfileServiceTests.swift */; };
+		C50700000000000000000001 /* MemoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50700000000000000000002 /* MemoryServiceTests.swift */; };
 		928A1F1B7A0D4C62A2B90761 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000034 /* TypeWhisperPluginSDK */; };
 		A47BC06842DCB0BB47A2D938 /* SnippetServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */; };
 		F18A00000000000000000001 /* FillerWordsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000010 /* FillerWordsPlugin.swift */; };
@@ -527,6 +528,7 @@
 		BB00000000000000000084 /* SnippetsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000085 /* SnippetsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsSettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000086 /* SoundService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundService.swift; sourceTree = "<group>"; };
+		C50700000000000000000002 /* MemoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryServiceTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000087 /* recording_start.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = recording_start.wav; sourceTree = "<group>"; };
 		BB00000000000000000088 /* transcription_success.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = transcription_success.wav; sourceTree = "<group>"; };
 		BB00000000000000000089 /* error.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = error.wav; sourceTree = "<group>"; };
@@ -1884,6 +1886,7 @@
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
 				B91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift */,
 				B91F00000000000000000004 /* RecentTranscriptionStoreTests.swift */,
+				C50700000000000000000002 /* MemoryServiceTests.swift */,
 				A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
@@ -3162,6 +3165,7 @@
 				1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */,
 				1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */,
 				86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */,
+				C50700000000000000000001 /* MemoryServiceTests.swift in Sources */,
 				A10000000000000000000006 /* WorkflowServiceTests.swift in Sources */,
 				A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */,
 				6C1F7A8B9D2E4F5061728394 /* SoundServiceTests.swift in Sources */,

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -80,6 +80,7 @@ enum UserDefaultsKeys {
     static let memoryExtractionModel = "memoryExtractionModel"
     static let memoryMinTextLength = "memoryMinTextLength"
     static let memoryExtractionPrompt = "memoryExtractionPrompt"
+    static let memoryCaptureScope = "memoryCaptureScope"
 
     // MARK: - Formatting
     static let appFormattingEnabled = "appFormattingEnabled"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -928,6 +928,16 @@
         }
       }
     },
+    "All dictations" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Diktate"
+          }
+        }
+      }
+    },
     "All imported" : {
       "localizations" : {
         "de" : {
@@ -1418,6 +1428,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abgebrochen"
+          }
+        }
+      }
+    },
+    "Capture From" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erfassen aus"
           }
         }
       }
@@ -3917,6 +3937,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Memory"
+          }
+        }
+      }
+    },
+    "Memory extraction runs for every eligible transcription after the minimum text length and cooldown checks." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory-Extraktion läuft für jede geeignete Transkription nach Mindestlänge und Cooldown."
+          }
+        }
+      }
+    },
+    "Memory extraction runs only when the transcription was produced by a known workflow." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory-Extraktion läuft nur, wenn die Transkription von einem bekannten Workflow erzeugt wurde."
           }
         }
       }
@@ -8792,6 +8832,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wörter"
+          }
+        }
+      }
+    },
+    "Workflow dictations only" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur Workflow-Diktate"
           }
         }
       }

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -75,6 +75,7 @@ private struct DiagnosticsReport: Encodable {
         let historyRetentionDays: Int
         let saveAudioWithHistory: Bool
         let memoryEnabled: Bool
+        let memoryCaptureScope: String
         let appFormattingEnabled: Bool
         let soundFeedbackEnabled: Bool
         let spokenFeedbackEnabled: Bool
@@ -228,6 +229,7 @@ final class ErrorLogService: ObservableObject {
                 historyRetentionDays: defaults.integer(forKey: UserDefaultsKeys.historyRetentionDays),
                 saveAudioWithHistory: defaults.bool(forKey: UserDefaultsKeys.saveAudioWithHistory),
                 memoryEnabled: defaults.bool(forKey: UserDefaultsKeys.memoryEnabled),
+                memoryCaptureScope: MemoryCaptureScope.load(from: defaults).rawValue,
                 appFormattingEnabled: defaults.bool(forKey: UserDefaultsKeys.appFormattingEnabled),
                 soundFeedbackEnabled: defaults.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true,
                 spokenFeedbackEnabled: defaults.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled),

--- a/TypeWhisper/Services/MemoryService.swift
+++ b/TypeWhisper/Services/MemoryService.swift
@@ -4,8 +4,45 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "MemoryService")
 
+enum MemoryCaptureScope: String, CaseIterable, Identifiable, Hashable {
+    case allDictations
+    case workflowDictationsOnly
+
+    static let defaultScope: MemoryCaptureScope = .allDictations
+
+    var id: String { rawValue }
+
+    var localizedTitle: String {
+        switch self {
+        case .allDictations:
+            return String(localized: "All dictations")
+        case .workflowDictationsOnly:
+            return String(localized: "Workflow dictations only")
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .allDictations:
+            return String(localized: "Memory extraction runs for every eligible transcription after the minimum text length and cooldown checks.")
+        case .workflowDictationsOnly:
+            return String(localized: "Memory extraction runs only when the transcription was produced by a known workflow.")
+        }
+    }
+
+    static func load(from defaults: UserDefaults = .standard) -> MemoryCaptureScope {
+        guard let rawValue = defaults.string(forKey: UserDefaultsKeys.memoryCaptureScope),
+              let scope = MemoryCaptureScope(rawValue: rawValue) else {
+            return defaultScope
+        }
+        return scope
+    }
+}
+
 @MainActor
 final class MemoryService: ObservableObject, MemoryRetrieving {
+    nonisolated static let rawMemoryTypeMetadataKey = "rawMemoryType"
+
     @Published var isEnabled: Bool {
         didSet { UserDefaults.standard.set(isEnabled, forKey: UserDefaultsKeys.memoryEnabled) }
     }
@@ -20,6 +57,9 @@ final class MemoryService: ObservableObject, MemoryRetrieving {
     }
     @Published var extractionPrompt: String {
         didSet { UserDefaults.standard.set(extractionPrompt, forKey: UserDefaultsKeys.memoryExtractionPrompt) }
+    }
+    @Published var captureScope: MemoryCaptureScope {
+        didSet { UserDefaults.standard.set(captureScope.rawValue, forKey: UserDefaultsKeys.memoryCaptureScope) }
     }
 
     static let defaultExtractionPrompt = """
@@ -45,18 +85,26 @@ Return ONLY the JSON array, nothing else.
 """
 
     private let promptProcessingService: PromptProcessingService
+    private let workflowNameProvider: @MainActor () -> [String]
     private var eventSubscriptionId: UUID?
     private var lastExtractionTime: Date = .distantPast
     private let extractionCooldown: TimeInterval = 30
 
-    init(promptProcessingService: PromptProcessingService) {
+    init(
+        promptProcessingService: PromptProcessingService,
+        workflowNameProvider: @escaping @MainActor () -> [String] = {
+            ServiceContainer.shared.workflowService.workflows.map(\.name)
+        }
+    ) {
         self.promptProcessingService = promptProcessingService
+        self.workflowNameProvider = workflowNameProvider
         self.isEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.memoryEnabled)
         self.extractionProviderId = UserDefaults.standard.string(forKey: UserDefaultsKeys.memoryExtractionProvider) ?? ""
         self.extractionModel = UserDefaults.standard.string(forKey: UserDefaultsKeys.memoryExtractionModel) ?? ""
         self.minimumTextLength = UserDefaults.standard.object(forKey: UserDefaultsKeys.memoryMinTextLength) as? Int ?? 50
         let saved = UserDefaults.standard.string(forKey: UserDefaultsKeys.memoryExtractionPrompt) ?? ""
         self.extractionPrompt = saved.isEmpty ? Self.defaultExtractionPrompt : saved
+        self.captureScope = MemoryCaptureScope.load()
     }
 
     // MARK: - Lifecycle
@@ -80,25 +128,41 @@ Return ONLY the JSON array, nothing else.
 
     // MARK: - Extraction
 
-    private func handleTranscription(_ payload: TranscriptionCompletedPayload) {
-        guard isEnabled, payload.finalText.count >= minimumTextLength else { return }
+    nonisolated static func shouldAttemptExtraction(
+        payload: TranscriptionCompletedPayload,
+        isEnabled: Bool,
+        minimumTextLength: Int,
+        captureScope: MemoryCaptureScope,
+        knownWorkflowNames: [String]
+    ) -> Bool {
+        guard isEnabled, payload.finalText.count >= minimumTextLength else { return false }
 
-        // Per-workflow gate. Legacy profiles may still exist on disk, but they
-        // are no longer a runtime source in 1.4.
-        if let ruleName = payload.ruleName,
-           ServiceContainer.shared.workflowService.workflows.contains(where: { $0.name == ruleName }) {
-            // Continue only for known workflow-backed rule names.
-        } else {
-            return
+        switch captureScope {
+        case .allDictations:
+            return true
+        case .workflowDictationsOnly:
+            guard let ruleName = payload.ruleName else { return false }
+            return knownWorkflowNames.contains(ruleName)
         }
+    }
+
+    private func handleTranscription(_ payload: TranscriptionCompletedPayload) {
+        let knownWorkflowNames = captureScope == .workflowDictationsOnly ? workflowNameProvider() : []
+        guard Self.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: isEnabled,
+            minimumTextLength: minimumTextLength,
+            captureScope: captureScope,
+            knownWorkflowNames: knownWorkflowNames
+        ) else { return }
+
+        let providerId = extractionProviderId
+        guard !providerId.isEmpty else { return }
 
         // Cooldown
         let now = Date()
         guard now.timeIntervalSince(lastExtractionTime) >= extractionCooldown else { return }
         lastExtractionTime = now
-
-        let providerId = extractionProviderId
-        guard !providerId.isEmpty else { return }
 
         // Capture all MainActor properties before detaching
         let prompt = extractionPrompt
@@ -129,18 +193,42 @@ Return ONLY the JSON array, nothing else.
             ruleName: payload.ruleName,
             timestamp: payload.timestamp
         ))
-        guard !entries.isEmpty else { return }
+        guard !entries.isEmpty else {
+            logger.info("Memory extraction produced no storable entries")
+            return
+        }
 
         let plugins = PluginManager.shared.memoryStoragePlugins
-        guard !plugins.isEmpty else { return }
+        guard !plugins.isEmpty else {
+            logger.warning("Memory extraction produced entries, but no memory storage plugins are loaded")
+            return
+        }
 
         let deduped = await deduplicate(entries: entries, using: plugins)
-        guard !deduped.isEmpty else { return }
-
-        for plugin in plugins where plugin.isReady {
-            try? await plugin.store(deduped)
-            logger.info("Stored \(deduped.count) memories in \(plugin.storageName)")
+        guard !deduped.isEmpty else {
+            logger.info("Memory extraction produced only duplicate entries")
+            return
         }
+
+        var storedInReadyPlugin = false
+        for plugin in plugins where plugin.isReady {
+            do {
+                try await plugin.store(deduped)
+                storedInReadyPlugin = true
+                logger.info("Stored \(deduped.count) memories in \(plugin.storageName)")
+            } catch {
+                logger.error("Failed to store memories in \(plugin.storageName): \(error.localizedDescription)")
+            }
+        }
+
+        if !storedInReadyPlugin {
+            logger.warning("Memory extraction produced entries, but no ready memory storage plugin accepted them")
+        }
+    }
+
+    nonisolated static func memoryType(for rawValue: String) -> MemoryType {
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return MemoryType(rawValue: normalized) ?? .context
     }
 
     private func parseExtractedMemories(_ json: String, source: MemorySource) -> [MemoryEntry] {
@@ -156,13 +244,22 @@ Return ONLY the JSON array, nothing else.
         }
 
         guard let data = cleaned.data(using: .utf8),
-              let raw = try? JSONDecoder().decode([RawMemory].self, from: data) else { return [] }
+              let raw = try? JSONDecoder().decode([RawMemory].self, from: data) else {
+            logger.info("Memory extraction response was not a JSON array of memory entries")
+            return []
+        }
 
         return raw.compactMap { item in
-            guard let type = MemoryType(rawValue: item.type) else { return nil }
+            let type = Self.memoryType(for: item.type)
+            let normalizedType = item.type.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            var metadata: [String: String] = [:]
+            if MemoryType(rawValue: normalizedType) == nil {
+                logger.info("Memory extraction returned unknown type '\(item.type, privacy: .public)'; storing it as context")
+                metadata[Self.rawMemoryTypeMetadataKey] = normalizedType
+            }
             let conf = item.confidence ?? 0.8
             guard conf >= 0.8 else { return nil }
-            return MemoryEntry(content: item.content, type: type, source: source, confidence: conf)
+            return MemoryEntry(content: item.content, type: type, source: source, metadata: metadata, confidence: conf)
         }
     }
 
@@ -177,7 +274,11 @@ Return ONLY the JSON array, nothing else.
             for plugin in plugins where plugin.isReady {
                 if let results = try? await plugin.search(query),
                    let best = results.first,
-                   best.relevanceScore > 0.85 {
+                   Self.shouldTreatAsDuplicate(
+                       newEntry: entry,
+                       existingEntry: best.entry,
+                       relevanceScore: best.relevanceScore
+                   ) {
                     var updated = best.entry
                     updated.lastAccessedAt = Date()
                     updated.accessCount += 1
@@ -189,6 +290,22 @@ Return ONLY the JSON array, nothing else.
             if !isDuplicate { unique.append(entry) }
         }
         return unique
+    }
+
+    nonisolated static func shouldTreatAsDuplicate(
+        newEntry: MemoryEntry,
+        existingEntry: MemoryEntry,
+        relevanceScore: Double
+    ) -> Bool {
+        guard relevanceScore > 0.85 else { return false }
+
+        if newEntry.metadata[rawMemoryTypeMetadataKey] != nil || existingEntry.metadata[rawMemoryTypeMetadataKey] != nil {
+            let newContent = newEntry.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            let existingContent = existingEntry.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            return newContent.caseInsensitiveCompare(existingContent) == .orderedSame
+        }
+
+        return true
     }
 
     // MARK: - Retrieval

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -27,6 +27,15 @@ struct AdvancedSettingsView: View {
                     .foregroundStyle(.secondary)
 
                 if memoryService.isEnabled {
+                    Picker(String(localized: "Capture From"), selection: $memoryService.captureScope) {
+                        ForEach(MemoryCaptureScope.allCases) { scope in
+                            Text(scope.localizedTitle).tag(scope)
+                        }
+                    }
+                    Text(memoryService.captureScope.localizedDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
                     Picker(String(localized: "Extraction Provider"), selection: $memoryService.extractionProviderId) {
                         Text(String(localized: "None")).tag("")
                         ForEach(promptProcessingService.availableProviders, id: \.id) { provider in

--- a/TypeWhisperTests/MemoryServiceTests.swift
+++ b/TypeWhisperTests/MemoryServiceTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+final class MemoryServiceTests: XCTestCase {
+    func testAllDictationsScopeAllowsTranscriptionWithoutWorkflowRule() {
+        let payload = makePayload(
+            finalText: "My name is Marco and this transcription is long enough.",
+            ruleName: nil
+        )
+
+        XCTAssertTrue(MemoryService.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: true,
+            minimumTextLength: 10,
+            captureScope: .allDictations,
+            knownWorkflowNames: []
+        ))
+    }
+
+    func testWorkflowOnlyScopeSkipsTranscriptionWithoutWorkflowRule() {
+        let payload = makePayload(
+            finalText: "My name is Marco and this transcription is long enough.",
+            ruleName: nil
+        )
+
+        XCTAssertFalse(MemoryService.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: true,
+            minimumTextLength: 10,
+            captureScope: .workflowDictationsOnly,
+            knownWorkflowNames: ["Notes"]
+        ))
+    }
+
+    func testWorkflowOnlyScopeAllowsKnownWorkflowRule() {
+        let payload = makePayload(
+            finalText: "My name is Marco and this transcription is long enough.",
+            ruleName: "Notes"
+        )
+
+        XCTAssertTrue(MemoryService.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: true,
+            minimumTextLength: 10,
+            captureScope: .workflowDictationsOnly,
+            knownWorkflowNames: ["Notes"]
+        ))
+    }
+
+    func testWorkflowOnlyScopeSkipsUnknownWorkflowRule() {
+        let payload = makePayload(
+            finalText: "My name is Marco and this transcription is long enough.",
+            ruleName: "Legacy Profile"
+        )
+
+        XCTAssertFalse(MemoryService.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: true,
+            minimumTextLength: 10,
+            captureScope: .workflowDictationsOnly,
+            knownWorkflowNames: ["Notes"]
+        ))
+    }
+
+    func testExtractionPolicyRespectsGlobalEnabledFlagAndMinimumLength() {
+        let payload = makePayload(finalText: "Too short", ruleName: nil)
+
+        XCTAssertFalse(MemoryService.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: false,
+            minimumTextLength: 10,
+            captureScope: .allDictations,
+            knownWorkflowNames: []
+        ))
+        XCTAssertFalse(MemoryService.shouldAttemptExtraction(
+            payload: payload,
+            isEnabled: true,
+            minimumTextLength: 10,
+            captureScope: .allDictations,
+            knownWorkflowNames: []
+        ))
+    }
+
+    func testUnknownExtractedMemoryTypeFallsBackToContext() {
+        XCTAssertEqual(MemoryService.memoryType(for: "metric"), .context)
+        XCTAssertEqual(MemoryService.memoryType(for: " FACT "), .fact)
+    }
+
+    func testUnknownMemoryTypesRequireExactContentForDuplicateMatch() {
+        let newMetricEntry = MemoryEntry(
+            content: "words=34, sentences=2, avg_wps=17.0",
+            type: .context,
+            metadata: [MemoryService.rawMemoryTypeMetadataKey: "metric"]
+        )
+        let existingMetricEntry = MemoryEntry(
+            content: "words=11, sentences=1, avg_wps=11.0",
+            type: .context
+        )
+        let existingSameMetricEntry = MemoryEntry(
+            content: "words=34, sentences=2, avg_wps=17.0",
+            type: .context
+        )
+
+        XCTAssertFalse(MemoryService.shouldTreatAsDuplicate(
+            newEntry: newMetricEntry,
+            existingEntry: existingMetricEntry,
+            relevanceScore: 1.0
+        ))
+        XCTAssertTrue(MemoryService.shouldTreatAsDuplicate(
+            newEntry: newMetricEntry,
+            existingEntry: existingSameMetricEntry,
+            relevanceScore: 1.0
+        ))
+    }
+
+    private func makePayload(finalText: String, ruleName: String?) -> TranscriptionCompletedPayload {
+        TranscriptionCompletedPayload(
+            rawText: finalText,
+            finalText: finalText,
+            language: "en",
+            engineUsed: "Test",
+            modelUsed: nil,
+            durationSeconds: 1,
+            appName: "TextEdit",
+            bundleIdentifier: "com.apple.TextEdit",
+            url: nil,
+            ruleName: ruleName
+        )
+    }
+}


### PR DESCRIPTION
## Issue Context

Issue #507 reports that File Memory extraction never creates `memories.json` even after many dictations. Local reproduction showed that normal dictations without a workflow-backed `ruleName` were skipped before extraction, so storage was never reached.

During local repro, the permissive issue prompt also surfaced two follow-up failure modes: unknown extracted memory types such as `metric` were silently dropped, and metric-shaped memories could be over-deduplicated because token search ignores changing numeric values.

Closes #507

## Summary

- Adds a Memory capture scope setting that defaults to all eligible dictations while preserving an explicit workflow-only mode.
- Keeps the existing global Memory toggle, minimum text length, provider/model selection, and cooldown gates.
- Normalizes unknown extracted memory types to `context` with raw-type metadata instead of silently dropping them.
- Tightens duplicate handling for unknown/raw memory types so only exact content matches are treated as duplicates.
- Adds diagnostics/logging and focused `MemoryService` unit coverage for the extraction gate and duplicate policy.

## Test Plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/MemoryServiceTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests`
- [x] `swift test --package-path TypeWhisperPluginSDK --filter FileMemoryPluginTests`
- [x] `git diff --check`
- [x] Manual dev-app repro under `TypeWhisper-Dev`: normal dictation without a workflow writes File Memory entries using the issue prompt.
