### PR TITLE
Clean up plugin registry release metadata

### DIFF
--- a/.github/workflows/community-plugin-registry.yml
+++ b/.github/workflows/community-plugin-registry.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'PluginRegistry/community-v1/**'
       - 'scripts/assemble_community_plugin_registry.py'
+      - 'scripts/plugin_registry_metadata.py'
       - '.github/workflows/community-plugin-registry.yml'
   push:
     branches: [main]
     paths:
       - 'PluginRegistry/community-v1/**'
       - 'scripts/assemble_community_plugin_registry.py'
+      - 'scripts/plugin_registry_metadata.py'
       - '.github/workflows/community-plugin-registry.yml'
 
 permissions:

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -260,6 +260,9 @@ jobs:
             python3 << PYEOF
           import json, os, re, sys, tempfile
 
+          sys.path.insert(0, os.path.join(os.environ["GITHUB_WORKSPACE"], "scripts"))
+          from plugin_registry_metadata import format_findings, normalize_registry_release_metadata
+
           target_registries = os.environ["TARGET_REGISTRIES"].split()
 
           version = "$PLUGIN_VERSION"
@@ -354,6 +357,10 @@ jobs:
                   new_entry["releases"] = [build_release()]
                   registry["plugins"].append(new_entry)
                   print(f"{target_registry}: added new plugin {manifest['id']} v{version}")
+
+              metadata_findings = normalize_registry_release_metadata(registry)
+              for line in format_findings(metadata_findings):
+                  print(f"{target_registry}: removed {line}")
 
               # Atomic write: write to a temp file in the same directory, fsync,
               # then rename into place. Prevents a half-written registry file from

--- a/.github/workflows/update-plugin-downloads.yml
+++ b/.github/workflows/update-plugin-downloads.yml
@@ -30,7 +30,10 @@ jobs:
             git reset --hard origin/gh-pages
 
             python3 << 'PYEOF'
-          import glob, json, os, re, tempfile
+          import glob, json, os, re, sys, tempfile
+
+          sys.path.insert(0, os.path.join(os.environ["GITHUB_WORKSPACE"], "scripts"))
+          from plugin_registry_metadata import format_findings, normalize_registry_release_metadata
 
           with open("/tmp/releases.json") as f:
               releases = json.load(f)
@@ -82,6 +85,12 @@ jobs:
                                   file_changed = True
                                   print(f"{os.path.basename(target_path)} {pid}@{version}: {release_old} -> {release_new}")
                           break
+
+              metadata_findings = normalize_registry_release_metadata(registry)
+              if metadata_findings:
+                  file_changed = True
+                  for line in format_findings(metadata_findings):
+                      print(f"{os.path.basename(target_path)} removed {line}")
 
               if not file_changed:
                   continue

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -548,6 +548,8 @@ Registry entry format:
 
 `source` is registry metadata for the TypeWhisper Integrations UI. Omit it for official marketplace entries; TypeWhisper treats missing values as `official`. Use `"source": "community"` for community-maintained plugins submitted to the `1.4+` community feed. This field is not required in the plugin bundle manifest.
 
+Release metadata belongs only inside `releases[]`. Do not duplicate `version`, `minHostVersion`, `sdkCompatibilityVersion`, `minOSVersion`, `supportedArchitectures`, `size`, or `downloadURL` as top-level registry fields. `category` and `categories` remain plugin-level metadata.
+
 ---
 
 ## Requirements

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -83,6 +83,61 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(plugins.first?.downloadCount, 100)
     }
 
+    func testTopLevelReleaseMetadataDoesNotAffectMultiReleaseMatching() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [
+                {
+                  "id": "com.typewhisper.future",
+                  "name": "Future Plugin",
+                  "author": "TypeWhisper",
+                  "description": "New releases are gated by host version.",
+                  "category": "transcription",
+                  "version": "9.9.9",
+                  "minHostVersion": "1.0.0",
+                  "sdkCompatibilityVersion": "v1",
+                  "size": 1,
+                  "downloadURL": "https://example.com/stale-top-level.zip",
+                  "releases": [
+                    {
+                      "version": "1.2.0",
+                      "minHostVersion": "1.4.0",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 20,
+                      "downloadURL": "https://example.com/requires-1.4.zip"
+                    },
+                    {
+                      "version": "1.1.6",
+                      "minHostVersion": "1.2.2",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 10,
+                      "downloadURL": "https://example.com/compatible-1.3.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let pre14Plugins = response.resolvedPlugins(
+            appVersion: "1.3.3",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
+        let plugins14 = response.resolvedPlugins(
+            appVersion: "1.4.0",
+            sdkCompatibilityVersion: sdkCompatibilityVersion
+        )
+
+        XCTAssertEqual(pre14Plugins.first?.version, "1.1.6")
+        XCTAssertEqual(pre14Plugins.first?.downloadURL, "https://example.com/compatible-1.3.zip")
+        XCTAssertEqual(plugins14.first?.version, "1.2.0")
+        XCTAssertEqual(plugins14.first?.downloadURL, "https://example.com/requires-1.4.zip")
+    }
+
     func testRegistryEntryDecodesMultipleCategoryIdentifiers() throws {
         let data = Data(
             """

--- a/scripts/assemble_community_plugin_registry.py
+++ b/scripts/assemble_community_plugin_registry.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
+from plugin_registry_metadata import remove_top_level_release_metadata
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_COMMUNITY_DIR = REPO_ROOT / "PluginRegistry" / "community-v1"
@@ -345,6 +347,8 @@ def assemble_registry(base_registry: dict, community_entries: list[dict]) -> tup
             continue
         if plugin.get("source", "official") == "community":
             continue
+        plugin = copy.deepcopy(plugin)
+        remove_top_level_release_metadata(plugin)
         plugin_id = plugin.get("id")
         if isinstance(plugin_id, str):
             official_ids.add(plugin_id)

--- a/scripts/plugin_registry_metadata.py
+++ b/scripts/plugin_registry_metadata.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Normalize TypeWhisper plugin registry release metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+TOP_LEVEL_RELEASE_FIELDS = {
+    "version",
+    "minHostVersion",
+    "sdkCompatibilityVersion",
+    "minOSVersion",
+    "supportedArchitectures",
+    "size",
+    "downloadURL",
+}
+
+
+def _release_metadata_finding(plugin: dict[str, Any], index: int) -> dict[str, Any] | None:
+    fields = sorted(field for field in TOP_LEVEL_RELEASE_FIELDS if field in plugin)
+    if not fields:
+        return None
+
+    releases = plugin.get("releases")
+    latest_release = releases[0] if isinstance(releases, list) and releases else None
+    stale_fields = []
+    for field in fields:
+        if not isinstance(latest_release, dict) or plugin.get(field) != latest_release.get(field):
+            stale_fields.append(field)
+
+    return {
+        "id": plugin.get("id", f"<plugin[{index}]>"),
+        "fields": fields,
+        "staleFields": stale_fields,
+    }
+
+
+def find_top_level_release_metadata(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    plugins = registry.get("plugins")
+    if not isinstance(plugins, list):
+        return []
+
+    findings = []
+    for index, plugin in enumerate(plugins):
+        if not isinstance(plugin, dict):
+            continue
+        finding = _release_metadata_finding(plugin, index)
+        if finding is not None:
+            findings.append(finding)
+    return findings
+
+
+def remove_top_level_release_metadata(plugin: dict[str, Any]) -> dict[str, Any] | None:
+    finding = _release_metadata_finding(plugin, -1)
+    if finding is None:
+        return None
+
+    for field in TOP_LEVEL_RELEASE_FIELDS:
+        plugin.pop(field, None)
+    return finding
+
+
+def normalize_registry_release_metadata(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    plugins = registry.get("plugins")
+    if not isinstance(plugins, list):
+        return []
+
+    findings = []
+    for plugin in plugins:
+        if not isinstance(plugin, dict):
+            continue
+        finding = remove_top_level_release_metadata(plugin)
+        if finding is not None:
+            findings.append(finding)
+    return findings
+
+
+def format_findings(findings: list[dict[str, Any]]) -> list[str]:
+    lines = []
+    for finding in findings:
+        fields = ", ".join(finding["fields"])
+        stale_fields = ", ".join(finding["staleFields"])
+        suffix = f"; stale: {stale_fields}" if stale_fields else ""
+        lines.append(f"{finding['id']}: top-level release fields: {fields}{suffix}")
+    return lines
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open() as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _dump_json(path: Path, registry: dict[str, Any]) -> None:
+    path.write_text(json.dumps(registry, indent=2, ensure_ascii=False) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Remove or check top-level release metadata in plugin registry files."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if any top-level release metadata is present.",
+    )
+    parser.add_argument("registry", nargs="+", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    failed = False
+
+    for registry_path in args.registry:
+        registry = _load_json(registry_path)
+        findings = find_top_level_release_metadata(registry)
+
+        if args.check:
+            if findings:
+                failed = True
+                print(f"{registry_path}: top-level release metadata found", file=sys.stderr)
+                for line in format_findings(findings):
+                    print(f"  - {line}", file=sys.stderr)
+            continue
+
+        removed = normalize_registry_release_metadata(registry)
+        if removed:
+            _dump_json(registry_path, registry)
+            print(f"{registry_path}: removed top-level release metadata")
+            for line in format_findings(removed):
+                print(f"  - {line}")
+        else:
+            print(f"{registry_path}: no top-level release metadata found")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_plugin_registry_metadata.py
+++ b/scripts/test_plugin_registry_metadata.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for plugin registry metadata normalization."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+from plugin_registry_metadata import (
+    find_top_level_release_metadata,
+    normalize_registry_release_metadata,
+)
+
+
+class PluginRegistryMetadataTests(unittest.TestCase):
+    def test_normalization_removes_stale_top_level_release_metadata(self) -> None:
+        registry = {
+            "schemaVersion": 1,
+            "plugins": [
+                {
+                    "id": "com.typewhisper.openai",
+                    "name": "OpenAI",
+                    "author": "TypeWhisper",
+                    "description": "Cloud transcription.",
+                    "category": "transcription",
+                    "categories": ["transcription", "llm"],
+                    "downloadCount": 10,
+                    "version": "1.1.6",
+                    "minHostVersion": "1.2.2",
+                    "sdkCompatibilityVersion": "v1",
+                    "size": 100,
+                    "downloadURL": "https://example.com/openai-1.1.6.zip",
+                    "releases": [
+                        {
+                            "version": "1.2.0",
+                            "minHostVersion": "1.4.0",
+                            "sdkCompatibilityVersion": "v1",
+                            "size": 200,
+                            "downloadURL": "https://example.com/openai-1.2.0.zip",
+                        },
+                        {
+                            "version": "1.1.6",
+                            "minHostVersion": "1.2.2",
+                            "sdkCompatibilityVersion": "v1",
+                            "size": 100,
+                            "downloadURL": "https://example.com/openai-1.1.6.zip",
+                        },
+                    ],
+                }
+            ],
+        }
+        original_releases = copy.deepcopy(registry["plugins"][0]["releases"])
+
+        findings = normalize_registry_release_metadata(registry)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["id"], "com.typewhisper.openai")
+        self.assertEqual(
+            findings[0]["staleFields"],
+            ["downloadURL", "minHostVersion", "size", "version"],
+        )
+        plugin = registry["plugins"][0]
+        for field in [
+            "version",
+            "minHostVersion",
+            "sdkCompatibilityVersion",
+            "minOSVersion",
+            "supportedArchitectures",
+            "size",
+            "downloadURL",
+        ]:
+            self.assertNotIn(field, plugin)
+        self.assertEqual(plugin["category"], "transcription")
+        self.assertEqual(plugin["categories"], ["transcription", "llm"])
+        self.assertEqual(plugin["downloadCount"], 10)
+        self.assertEqual(plugin["releases"], original_releases)
+
+    def test_normalization_is_idempotent(self) -> None:
+        registry = {
+            "schemaVersion": 1,
+            "plugins": [
+                {
+                    "id": "com.typewhisper.ready",
+                    "name": "Ready",
+                    "author": "TypeWhisper",
+                    "description": "Already normalized.",
+                    "category": "utility",
+                    "releases": [
+                        {
+                            "version": "1.0.0",
+                            "minHostVersion": "1.4.0",
+                            "sdkCompatibilityVersion": "v1",
+                            "size": 10,
+                            "downloadURL": "https://example.com/ready.zip",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        self.assertEqual(normalize_registry_release_metadata(registry), [])
+        self.assertEqual(find_top_level_release_metadata(registry), [])
+
+    def test_flat_entry_top_level_release_metadata_is_not_preserved(self) -> None:
+        registry = {
+            "schemaVersion": 1,
+            "plugins": [
+                {
+                    "id": "com.typewhisper.legacy-flat",
+                    "name": "Legacy Flat",
+                    "author": "TypeWhisper",
+                    "description": "Flat legacy entry.",
+                    "category": "utility",
+                    "version": "1.0.0",
+                    "minHostVersion": "1.2.0",
+                    "sdkCompatibilityVersion": "v1",
+                    "size": 10,
+                    "downloadURL": "https://example.com/legacy.zip",
+                }
+            ],
+        }
+
+        findings = normalize_registry_release_metadata(registry)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(
+            findings[0]["staleFields"],
+            ["downloadURL", "minHostVersion", "sdkCompatibilityVersion", "size", "version"],
+        )
+        plugin = registry["plugins"][0]
+        self.assertNotIn("version", plugin)
+        self.assertNotIn("downloadURL", plugin)
+        self.assertNotIn("releases", plugin)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes the stale top-level release metadata left in the generated plugin registries after the migration to per-release `releases[]` entries.

Issue #488 called out that official registry entries can contain a new release in `releases[]` while the legacy top-level `version`, `minHostVersion`, `size`, and `downloadURL` still point at an older release. That is confusing during manual inspection and can mislead tooling that has not fully moved to `releases[]`.

Closes #488

## Changes

- Adds a reusable registry metadata normalizer that removes top-level release fields and reports stale fields for diagnostics.
- Applies that normalizer in the official plugin release workflow, the plugin download count updater, and community registry assembly for preserved official entries.
- Documents that release metadata belongs only in `releases[]`; `category` and `categories` stay plugin-level.
- Adds regression coverage for the important host-version behavior: stale top-level metadata does not affect matching, so a `minHostVersion: 1.4.0` release is only selected for 1.4+ while older compatible releases remain available to 1.3.x clients.

## Rollout note

After this lands, manually run the `Update Plugin Download Counts` workflow once. That will normalize the existing `gh-pages` `plugins-v1.json` and `plugins-community-v1.json` feeds without waiting for the next scheduled run.

## Test Plan

- `python3 scripts/test_plugin_registry_metadata.py`
- `python3 scripts/assemble_community_plugin_registry.py`
- `python3 -m py_compile scripts/plugin_registry_metadata.py scripts/test_plugin_registry_metadata.py scripts/assemble_community_plugin_registry.py && git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/PluginRegistryServiceTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`