### PR TITLE
Add watch folder file-job automation

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -62,6 +62,7 @@ jobs:
             assemblyai) TARGET="AssemblyAIPlugin" ;;
             obsidian) TARGET="ObsidianPlugin" ;;
             script) TARGET="ScriptPlugin" ;;
+            file-job-script) TARGET="FileJobScriptPlugin" ;;
             livetranscript) TARGET="LiveTranscriptPlugin" ;;
             granite) TARGET="GranitePlugin" ;;
             cloudflare-asr) TARGET="CloudflareASRPlugin" ;;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		F18A00000000000000000001 /* FillerWordsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000010 /* FillerWordsPlugin.swift */; };
 		F18A00000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000011 /* manifest.json */; };
 		F18A00000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F18A00000000000000000037 /* TypeWhisperPluginSDK */; };
+		F48400000000000000000001 /* FileJobScriptPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48400000000000000000010 /* FileJobScriptPlugin.swift */; };
+		F48400000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = F48400000000000000000011 /* manifest.json */; };
+		F48400000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F48400000000000000000037 /* TypeWhisperPluginSDK */; };
 		F18A00000000000000000006 /* FillerWordsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A00000000000000000010 /* FillerWordsPlugin.swift */; };
 		AA00000000000000000001 /* TypeWhisperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000001 /* TypeWhisperApp.swift */; };
 		AA00000000000000000002 /* ServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000002 /* ServiceContainer.swift */; };
@@ -650,6 +653,9 @@
 		BB00000000000000000213 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000214 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000215 /* ScriptPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScriptPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		F48400000000000000000010 /* FileJobScriptPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileJobScriptPlugin.swift; sourceTree = "<group>"; };
+		F48400000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		F48400000000000000000012 /* FileJobScriptPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FileJobScriptPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000216 /* LiveTranscriptPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTranscriptPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000217 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000218 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -953,6 +959,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F48400000000000000000032 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F48400000000000000000003 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F18A00000000000000000032 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1152,6 +1166,7 @@
 				CC00000000000000000030 /* ObsidianPlugin */,
 				CC00000000000000000031 /* ScriptPlugin */,
 				F18A00000000000000000020 /* FillerWordsPlugin */,
+				F48400000000000000000020 /* FileJobScriptPlugin */,
 				CC00000000000000000032 /* LiveTranscriptPlugin */,
 				CC00000000000000000033 /* GranitePlugin */,
 				CC00000000000000000034 /* CloudflareASRPlugin */,
@@ -1614,6 +1629,16 @@
 			path = TypeWhisperPluginSDK/Plugins/ScriptPlugin;
 			sourceTree = "<group>";
 		};
+		F48400000000000000000020 /* FileJobScriptPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				F48400000000000000000010 /* FileJobScriptPlugin.swift */,
+				F48400000000000000000011 /* manifest.json */,
+			);
+			name = FileJobScriptPlugin;
+			path = TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin;
+			sourceTree = "<group>";
+		};
 		F18A00000000000000000020 /* FillerWordsPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -1839,6 +1864,7 @@
 				BB00000000000000000211 /* ObsidianPlugin.bundle */,
 				BB00000000000000000215 /* ScriptPlugin.bundle */,
 				F18A00000000000000000012 /* FillerWordsPlugin.bundle */,
+				F48400000000000000000012 /* FileJobScriptPlugin.bundle */,
 				BB00000000000000000219 /* LiveTranscriptPlugin.bundle */,
 				BB00000000000000000224 /* GranitePlugin.bundle */,
 				BB00000000000000000227 /* CloudflareASRPlugin.bundle */,
@@ -2304,6 +2330,26 @@
 			productReference = BB00000000000000000215 /* ScriptPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		F48400000000000000000030 /* FileJobScriptPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F48400000000000000000036 /* Build configuration list for PBXNativeTarget "FileJobScriptPlugin" */;
+			buildPhases = (
+				F48400000000000000000031 /* Sources */,
+				F48400000000000000000032 /* Frameworks */,
+				F48400000000000000000033 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FileJobScriptPlugin;
+			packageProductDependencies = (
+				F48400000000000000000037 /* TypeWhisperPluginSDK */,
+			);
+			productName = FileJobScriptPlugin;
+			productReference = F48400000000000000000012 /* FileJobScriptPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		F18A00000000000000000030 /* FillerWordsPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F18A00000000000000000036 /* Build configuration list for PBXNativeTarget "FillerWordsPlugin" */;
@@ -2755,6 +2801,7 @@
 				DD00000000000000000018 /* ObsidianPlugin */,
 				DD00000000000000000019 /* ScriptPlugin */,
 				F18A00000000000000000030 /* FillerWordsPlugin */,
+				F48400000000000000000030 /* FileJobScriptPlugin */,
 				DD00000000000000000020 /* LiveTranscriptPlugin */,
 				DD00000000000000000021 /* GranitePlugin */,
 				DD00000000000000000022 /* CloudflareASRPlugin */,
@@ -2943,6 +2990,14 @@
 			files = (
 				AA00000000000000000223 /* manifest.json in Resources */,
 				AA00000000000000000224 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F48400000000000000000033 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F48400000000000000000002 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3472,6 +3527,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000222 /* ScriptPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F48400000000000000000031 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F48400000000000000000001 /* FileJobScriptPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4689,6 +4752,52 @@
 			};
 			name = Release;
 		};
+		F48400000000000000000034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "File Job Script";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FileJobScriptPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.file-job-script";
+				PRODUCT_NAME = FileJobScriptPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		F48400000000000000000035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "File Job Script";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = FileJobScriptPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.file-job-script";
+				PRODUCT_NAME = FileJobScriptPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		F18A00000000000000000034 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5748,6 +5857,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		F48400000000000000000036 /* Build configuration list for PBXNativeTarget "FileJobScriptPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F48400000000000000000034 /* Debug */,
+				F48400000000000000000035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000106 /* Build configuration list for PBXNativeTarget "LiveTranscriptPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6078,6 +6196,10 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		F18A00000000000000000037 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		F48400000000000000000037 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -203,6 +203,13 @@ final class PluginManager: ObservableObject {
             .sorted { $0.priority < $1.priority }
     }
 
+    var fileJobAutomations: [FileJobAutomationPlugin] {
+        loadedPlugins
+            .filter { $0.isEnabled }
+            .compactMap { $0.instance as? FileJobAutomationPlugin }
+            .sorted { $0.priority < $1.priority }
+    }
+
     var llmProviders: [LLMProviderPlugin] {
         loadedPlugins
             .filter { $0.isEnabled }

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -28,6 +28,7 @@ enum PluginCategory: String, CaseIterable {
     case tts
     case llm
     case postProcessor = "post-processor"
+    case fileAutomation = "file-automation"
     case action
     case memory
     case utility
@@ -38,6 +39,7 @@ enum PluginCategory: String, CaseIterable {
         case .tts: String(localized: "Text-to-Speech")
         case .llm: String(localized: "LLM Providers")
         case .postProcessor: String(localized: "Post-Processors")
+        case .fileAutomation: String(localized: "File Automations")
         case .action: String(localized: "Actions")
         case .memory: String(localized: "Memory")
         case .utility: String(localized: "Utilities")
@@ -50,6 +52,7 @@ enum PluginCategory: String, CaseIterable {
         case .tts: "speaker.wave.2.fill"
         case .llm: "brain"
         case .postProcessor: "arrow.triangle.2.circlepath"
+        case .fileAutomation: "folder.badge.gearshape"
         case .action: "bolt.fill"
         case .memory: "brain.head.profile"
         case .utility: "wrench"
@@ -62,9 +65,10 @@ enum PluginCategory: String, CaseIterable {
         case .tts: 1
         case .llm: 2
         case .postProcessor: 3
-        case .action: 4
-        case .memory: 5
-        case .utility: 6
+        case .fileAutomation: 4
+        case .action: 5
+        case .memory: 6
+        case .utility: 7
         }
     }
 }

--- a/TypeWhisper/Services/WatchFolderService.swift
+++ b/TypeWhisper/Services/WatchFolderService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import os
 import Combine
+import TypeWhisperPluginSDK
 
 enum WatchFolderOutputFormat: String, CaseIterable {
     case markdown = "md"
@@ -42,6 +43,47 @@ enum WatchFolderOutputFormat: String, CaseIterable {
 struct WatchFolderExportArtifact {
     let fileExtension: String
     let content: String
+}
+
+@MainActor
+struct FileJobAutomationPipeline {
+    private let automationsProvider: @MainActor () -> [any FileJobAutomationPlugin]
+    private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "FileJobAutomation")
+
+    init(automationsProvider: @escaping @MainActor () -> [any FileJobAutomationPlugin] = {
+        PluginManager.shared.fileJobAutomations
+    }) {
+        self.automationsProvider = automationsProvider
+    }
+
+    func process(artifact: FileJobArtifact, context: FileJobContext) async -> FileJobAutomationResult {
+        var currentArtifact = artifact
+        var appliedSteps: [String] = []
+        var outputPathWasWritten = false
+
+        for automation in automationsProvider() {
+            let before = currentArtifact
+            do {
+                let result = try await automation.process(artifact: currentArtifact, context: context)
+                currentArtifact = result.artifact
+                outputPathWasWritten = outputPathWasWritten || result.outputPathWasWritten
+
+                if !result.appliedSteps.isEmpty {
+                    appliedSteps.append(contentsOf: result.appliedSteps)
+                } else if result.artifact != before || result.outputPathWasWritten {
+                    appliedSteps.append(automation.automationName)
+                }
+            } catch {
+                logger.error("File job automation '\(automation.automationName)' failed: \(error.localizedDescription)")
+            }
+        }
+
+        return FileJobAutomationResult(
+            artifact: currentArtifact,
+            appliedSteps: appliedSteps,
+            outputPathWasWritten: outputPathWasWritten
+        )
+    }
 }
 
 enum WatchFolderExportBuilder {
@@ -128,11 +170,17 @@ final class WatchFolderService: ObservableObject {
 
     private let audioFileService: AudioFileService
     private let modelManagerService: ModelManagerService
+    private let fileJobAutomationPipeline: FileJobAutomationPipeline
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "WatchFolder")
 
-    init(audioFileService: AudioFileService, modelManagerService: ModelManagerService) {
+    init(
+        audioFileService: AudioFileService,
+        modelManagerService: ModelManagerService,
+        fileJobAutomationPipeline: FileJobAutomationPipeline = FileJobAutomationPipeline()
+    ) {
         self.audioFileService = audioFileService
         self.modelManagerService = modelManagerService
+        self.fileJobAutomationPipeline = fileJobAutomationPipeline
         loadProcessedFileFingerprints()
         loadProcessedFiles()
     }
@@ -318,7 +366,36 @@ final class WatchFolderService: ObservableObject {
                 .appendingPathComponent(outputName)
                 .appendingPathExtension(artifact.fileExtension)
 
-            try artifact.content.write(to: outputURL, atomically: true, encoding: .utf8)
+            let fileJobContext = FileJobContext(
+                jobKind: .watchFolder,
+                sourceFilePath: url.path,
+                outputDirectoryPath: outputFolder.path,
+                outputFilePath: outputURL.path,
+                outputFormat: artifact.fileExtension,
+                engineId: overrides.engineId ?? modelManagerService.selectedProviderId,
+                engineName: engineName,
+                modelId: modelManagerService.resolvedModelId(
+                    engineOverrideId: overrides.engineId,
+                    cloudModelOverride: overrides.modelId
+                ),
+                transcriptText: result.text,
+                detectedLanguage: result.detectedLanguage,
+                segments: result.segments.map {
+                    FileJobTranscriptSegment(
+                        text: $0.text,
+                        start: $0.start,
+                        end: $0.end,
+                        speakerLabel: $0.speakerLabel,
+                        speakerConfidence: $0.speakerConfidence
+                    )
+                }
+            )
+            let automationResult = await fileJobAutomationPipeline.process(
+                artifact: FileJobArtifact(fileExtension: artifact.fileExtension, content: artifact.content),
+                context: fileJobContext
+            )
+
+            try automationResult.artifact.content.write(to: outputURL, atomically: true, encoding: .utf8)
 
             if deleteSource {
                 try? FileManager.default.removeItem(at: url)

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -318,6 +318,7 @@ struct PluginSettingsView: View {
         if plugin.instance is any TTSProviderPlugin { categories.append(.tts) }
         if plugin.instance is any LLMProviderPlugin { categories.append(.llm) }
         if plugin.instance is any PostProcessorPlugin { categories.append(.postProcessor) }
+        if plugin.instance is any FileJobAutomationPlugin { categories.append(.fileAutomation) }
         if plugin.instance is any ActionPlugin { categories.append(.action) }
         if plugin.instance is any MemoryStoragePlugin { categories.append(.memory) }
         return categories
@@ -883,6 +884,7 @@ private extension PluginCategory {
         case .tts: String(localized: "TTS")
         case .llm: String(localized: "LLM")
         case .postProcessor: String(localized: "Post-processing")
+        case .fileAutomation: String(localized: "File automation")
         case .action: String(localized: "Actions")
         case .memory: String(localized: "Memory")
         case .utility: String(localized: "Utility")

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -80,6 +80,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "FileJobScriptPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/FileJobScriptPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "ObsidianPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/ObsidianPlugin",
@@ -175,6 +184,14 @@ let package = Package(
                 "FillerWordsPlugin",
             ],
             path: "Plugins/FillerWordsPlugin/Tests"
+        ),
+        .testTarget(
+            name: "FileJobScriptPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "FileJobScriptPlugin",
+            ],
+            path: "Plugins/FileJobScriptPlugin/Tests"
         ),
         .testTarget(
             name: "ObsidianPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/FileJobScriptPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/FileJobScriptPlugin.swift
@@ -1,0 +1,542 @@
+import Foundation
+import os
+import SwiftUI
+import TypeWhisperPluginSDK
+
+@objc(FileJobScriptPlugin)
+final class FileJobScriptPlugin: NSObject, FileJobAutomationPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.file-job-script"
+    static let pluginName = "File Job Script"
+
+    let automationName = "File Job Script"
+    let priority = 400
+
+    private var service: FileJobScriptService?
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        service = FileJobScriptService(dataDirectory: host.pluginDataDirectory)
+    }
+
+    func deactivate() {
+        service = nil
+    }
+
+    @MainActor
+    var settingsView: AnyView? {
+        guard let service else { return nil }
+        return AnyView(FileJobScriptSettingsView(service: service))
+    }
+
+    @MainActor
+    func process(artifact: FileJobArtifact, context: FileJobContext) async throws -> FileJobAutomationResult {
+        guard let service else { return FileJobAutomationResult(artifact: artifact) }
+        return await service.process(artifact: artifact, context: context)
+    }
+}
+
+struct FileJobScriptConfig: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var name: String
+    var command: String
+    var isEnabled: Bool
+    var timeoutSeconds: Int
+
+    init(
+        id: UUID = UUID(),
+        name: String = "",
+        command: String,
+        isEnabled: Bool = true,
+        timeoutSeconds: Int = 120
+    ) {
+        self.id = id
+        self.name = name
+        self.command = command
+        self.isEnabled = isEnabled
+        self.timeoutSeconds = timeoutSeconds
+    }
+
+    var effectiveTimeoutSeconds: Int {
+        min(max(timeoutSeconds, 5), 3_600)
+    }
+
+    var displayName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Untitled Script" : trimmed
+    }
+}
+
+struct FileJobScriptExecutionResult: Equatable, Sendable {
+    let artifact: FileJobArtifact
+    let didChangeArtifact: Bool
+    let wroteOutputPath: Bool
+    let errorMessage: String?
+    let durationMs: Int
+}
+
+struct FileJobScriptExecutionLogEntry: Identifiable {
+    let id = UUID()
+    let timestamp = Date()
+    let scriptName: String
+    let success: Bool
+    let durationMs: Int
+    let errorMessage: String?
+}
+
+final class FileJobScriptService: ObservableObject, @unchecked Sendable {
+    @Published var scripts: [FileJobScriptConfig] = []
+    @Published var executionLog: [FileJobScriptExecutionLogEntry] = []
+
+    private let configURL: URL
+    private let runner: FileJobScriptRunner
+    private let maxLogEntries = 20
+
+    init(dataDirectory: URL, runner: FileJobScriptRunner = FileJobScriptRunner()) {
+        self.configURL = dataDirectory.appendingPathComponent("file-job-scripts.json")
+        self.runner = runner
+        loadConfig()
+    }
+
+    func addScript(_ script: FileJobScriptConfig) {
+        scripts.append(script)
+        saveConfig()
+    }
+
+    func removeScript(id: UUID) {
+        scripts.removeAll { $0.id == id }
+        saveConfig()
+    }
+
+    func updateScript(_ script: FileJobScriptConfig) {
+        guard let index = scripts.firstIndex(where: { $0.id == script.id }) else { return }
+        scripts[index] = script
+        saveConfig()
+    }
+
+    func process(artifact: FileJobArtifact, context: FileJobContext) async -> FileJobAutomationResult {
+        var currentArtifact = artifact
+        var appliedSteps: [String] = []
+        var outputPathWasWritten = false
+
+        for script in scripts where script.isEnabled {
+            let result = await runner.execute(script: script, artifact: currentArtifact, context: context)
+            addLog(FileJobScriptExecutionLogEntry(
+                scriptName: script.displayName,
+                success: result.errorMessage == nil,
+                durationMs: result.durationMs,
+                errorMessage: result.errorMessage
+            ))
+
+            guard result.errorMessage == nil, result.didChangeArtifact else { continue }
+            currentArtifact = result.artifact
+            outputPathWasWritten = outputPathWasWritten || result.wroteOutputPath
+            appliedSteps.append(script.displayName)
+        }
+
+        return FileJobAutomationResult(
+            artifact: currentArtifact,
+            appliedSteps: appliedSteps,
+            outputPathWasWritten: outputPathWasWritten
+        )
+    }
+
+    func saveConfig() {
+        guard let data = try? JSONEncoder().encode(scripts) else { return }
+        let directory = configURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? data.write(to: configURL, options: .atomic)
+    }
+
+    private func loadConfig() {
+        guard let data = try? Data(contentsOf: configURL),
+              let config = try? JSONDecoder().decode([FileJobScriptConfig].self, from: data) else { return }
+        scripts = config
+    }
+
+    private func addLog(_ entry: FileJobScriptExecutionLogEntry) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.executionLog.insert(entry, at: 0)
+            if self.executionLog.count > self.maxLogEntries {
+                self.executionLog = Array(self.executionLog.prefix(self.maxLogEntries))
+            }
+        }
+    }
+}
+
+final class FileJobScriptRunner: @unchecked Sendable {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func execute(
+        script: FileJobScriptConfig,
+        artifact: FileJobArtifact,
+        context: FileJobContext
+    ) async -> FileJobScriptExecutionResult {
+        let start = Date()
+
+        do {
+            let sidecarDirectory = try makeSidecarDirectory()
+            defer { try? fileManager.removeItem(at: sidecarDirectory) }
+
+            let sidecars = try FileJobScriptSidecarWriter.write(context: context, to: sidecarDirectory)
+            let outputSnapshot = OutputFileSnapshot.capture(path: context.outputFilePath, fileManager: fileManager)
+            let stdout = try await runProcess(
+                command: script.command,
+                input: artifact.content,
+                context: context,
+                sidecars: sidecars,
+                timeoutSeconds: script.effectiveTimeoutSeconds
+            )
+
+            if !stdout.isEmpty {
+                return FileJobScriptExecutionResult(
+                    artifact: FileJobArtifact(fileExtension: artifact.fileExtension, content: stdout),
+                    didChangeArtifact: stdout != artifact.content,
+                    wroteOutputPath: false,
+                    errorMessage: nil,
+                    durationMs: elapsedMilliseconds(since: start)
+                )
+            }
+
+            if let outputPath = context.outputFilePath,
+               OutputFileSnapshot.pathDidChange(outputPath, comparedTo: outputSnapshot, fileManager: fileManager),
+               let replacement = try? String(contentsOfFile: outputPath, encoding: .utf8) {
+                return FileJobScriptExecutionResult(
+                    artifact: FileJobArtifact(fileExtension: artifact.fileExtension, content: replacement),
+                    didChangeArtifact: replacement != artifact.content,
+                    wroteOutputPath: true,
+                    errorMessage: nil,
+                    durationMs: elapsedMilliseconds(since: start)
+                )
+            }
+
+            return FileJobScriptExecutionResult(
+                artifact: artifact,
+                didChangeArtifact: false,
+                wroteOutputPath: false,
+                errorMessage: FileJobScriptError.emptyOutput.errorDescription,
+                durationMs: elapsedMilliseconds(since: start)
+            )
+        } catch {
+            return FileJobScriptExecutionResult(
+                artifact: artifact,
+                didChangeArtifact: false,
+                wroteOutputPath: false,
+                errorMessage: error.localizedDescription,
+                durationMs: elapsedMilliseconds(since: start)
+            )
+        }
+    }
+
+    private func makeSidecarDirectory() throws -> URL {
+        let url = fileManager.temporaryDirectory
+            .appendingPathComponent("typewhisper-file-job-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func elapsedMilliseconds(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1_000)
+    }
+
+    private func runProcess(
+        command: String,
+        input: String,
+        context: FileJobContext,
+        sidecars: FileJobScriptSidecarPaths,
+        timeoutSeconds: Int
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/bin/sh")
+                process.arguments = ["-c", command]
+                process.environment = FileJobScriptEnvironmentBuilder.environment(
+                    context: context,
+                    sidecars: sidecars
+                )
+
+                let stdinPipe = Pipe()
+                let stdoutPipe = Pipe()
+                let stderrPipe = Pipe()
+                process.standardInput = stdinPipe
+                process.standardOutput = stdoutPipe
+                process.standardError = stderrPipe
+
+                let stdoutData = OSAllocatedUnfairLock(initialState: Data())
+                let stderrData = OSAllocatedUnfairLock(initialState: Data())
+                let didTimeout = OSAllocatedUnfairLock(initialState: false)
+
+                stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                    stdoutData.withLock { $0.append(handle.availableData) }
+                }
+                stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                    stderrData.withLock { $0.append(handle.availableData) }
+                }
+
+                let timeoutWork = DispatchWorkItem { [weak process] in
+                    didTimeout.withLock { $0 = true }
+                    process?.terminate()
+                }
+                DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(timeoutSeconds), execute: timeoutWork)
+
+                do {
+                    try process.run()
+
+                    let inputData = input.data(using: .utf8) ?? Data()
+                    stdinPipe.fileHandleForWriting.write(inputData)
+                    stdinPipe.fileHandleForWriting.closeFile()
+
+                    process.waitUntilExit()
+                    timeoutWork.cancel()
+
+                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                    stderrPipe.fileHandleForReading.readabilityHandler = nil
+
+                    stdoutData.withLock {
+                        $0.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
+                    }
+                    stderrData.withLock {
+                        $0.append(stderrPipe.fileHandleForReading.readDataToEndOfFile())
+                    }
+
+                    if didTimeout.withLock({ $0 }) {
+                        continuation.resume(throwing: FileJobScriptError.timeout(seconds: timeoutSeconds))
+                        return
+                    }
+
+                    guard process.terminationStatus == 0 else {
+                        let stderr = stderrData.withLock {
+                            String(data: $0, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                        }
+                        continuation.resume(throwing: FileJobScriptError.nonZeroExit(
+                            code: process.terminationStatus,
+                            stderr: stderr
+                        ))
+                        return
+                    }
+
+                    let outputData = stdoutData.withLock { $0 }
+                    var output = String(data: outputData, encoding: .utf8) ?? ""
+                    if output.hasSuffix("\n") {
+                        output = String(output.dropLast())
+                    }
+                    output = output.replacingOccurrences(of: "\0", with: "")
+                    continuation.resume(returning: output)
+                } catch {
+                    timeoutWork.cancel()
+                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                    stderrPipe.fileHandleForReading.readabilityHandler = nil
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+struct FileJobScriptSidecarPaths: Sendable {
+    let transcriptJSONPath: String
+    let segmentsJSONPath: String
+}
+
+enum FileJobScriptSidecarWriter {
+    private struct TranscriptPayload: Encodable {
+        let text: String
+        let detected_language: String?
+        let engine_id: String?
+        let engine_name: String?
+        let model_id: String?
+        let segments: [FileJobTranscriptSegment]
+    }
+
+    static func write(context: FileJobContext, to directory: URL) throws -> FileJobScriptSidecarPaths {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let transcriptURL = directory.appendingPathComponent("transcript.json")
+        let segmentsURL = directory.appendingPathComponent("segments.json")
+        let transcriptPayload = TranscriptPayload(
+            text: context.transcriptText,
+            detected_language: context.detectedLanguage,
+            engine_id: context.engineId,
+            engine_name: context.engineName,
+            model_id: context.modelId,
+            segments: context.segments
+        )
+
+        try encoder.encode(transcriptPayload).write(to: transcriptURL, options: .atomic)
+        try encoder.encode(context.segments).write(to: segmentsURL, options: .atomic)
+
+        return FileJobScriptSidecarPaths(
+            transcriptJSONPath: transcriptURL.path,
+            segmentsJSONPath: segmentsURL.path
+        )
+    }
+}
+
+enum FileJobScriptEnvironmentBuilder {
+    static func environment(
+        context: FileJobContext,
+        sidecars: FileJobScriptSidecarPaths,
+        base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var env = base
+        if env["LANG"] == nil && env["LC_ALL"] == nil {
+            env["LANG"] = "en_US.UTF-8"
+        }
+
+        env["TYPEWHISPER_JOB_KIND"] = context.jobKind.rawValue
+        env["TYPEWHISPER_TRANSCRIPT_TEXT"] = context.transcriptText
+        env["TYPEWHISPER_TRANSCRIPT_JSON_PATH"] = sidecars.transcriptJSONPath
+        env["TYPEWHISPER_SEGMENTS_JSON_PATH"] = sidecars.segmentsJSONPath
+
+        setIfPresent(context.sourceFilePath, forKey: "TYPEWHISPER_SOURCE_FILE_PATH", in: &env)
+        setIfPresent(context.sourceFileName, forKey: "TYPEWHISPER_SOURCE_FILE_NAME", in: &env)
+        setIfPresent(context.outputDirectoryPath, forKey: "TYPEWHISPER_OUTPUT_DIR", in: &env)
+        setIfPresent(context.outputFilePath, forKey: "TYPEWHISPER_OUTPUT_PATH", in: &env)
+        setIfPresent(context.outputFormat, forKey: "TYPEWHISPER_OUTPUT_FORMAT", in: &env)
+        setIfPresent(context.engineId, forKey: "TYPEWHISPER_ENGINE_ID", in: &env)
+        setIfPresent(context.engineName, forKey: "TYPEWHISPER_ENGINE_NAME", in: &env)
+        setIfPresent(context.modelId, forKey: "TYPEWHISPER_MODEL_ID", in: &env)
+        setIfPresent(context.detectedLanguage, forKey: "TYPEWHISPER_LANGUAGE", in: &env)
+
+        return env
+    }
+
+    private static func setIfPresent(_ value: String?, forKey key: String, in env: inout [String: String]) {
+        guard let value, !value.isEmpty else { return }
+        env[key] = value
+    }
+}
+
+private struct OutputFileSnapshot: Equatable {
+    let exists: Bool
+    let modificationDate: Date?
+    let fileSize: UInt64?
+
+    static func capture(path: String?, fileManager: FileManager) -> OutputFileSnapshot {
+        guard let path else {
+            return OutputFileSnapshot(exists: false, modificationDate: nil, fileSize: nil)
+        }
+
+        guard let attributes = try? fileManager.attributesOfItem(atPath: path) else {
+            return OutputFileSnapshot(exists: false, modificationDate: nil, fileSize: nil)
+        }
+
+        return OutputFileSnapshot(
+            exists: true,
+            modificationDate: attributes[.modificationDate] as? Date,
+            fileSize: attributes[.size] as? UInt64
+        )
+    }
+
+    static func pathDidChange(_ path: String, comparedTo snapshot: OutputFileSnapshot, fileManager: FileManager) -> Bool {
+        let current = capture(path: path, fileManager: fileManager)
+        guard current.exists else { return false }
+        return current != snapshot
+    }
+}
+
+enum FileJobScriptError: LocalizedError, Equatable {
+    case timeout(seconds: Int)
+    case nonZeroExit(code: Int32, stderr: String)
+    case emptyOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout(let seconds):
+            return "Script timed out after \(seconds) seconds"
+        case .nonZeroExit(let code, let stderr):
+            return "Exit code \(code)\(stderr.isEmpty ? "" : ": \(stderr)")"
+        case .emptyOutput:
+            return "Script produced no output"
+        }
+    }
+}
+
+private struct FileJobScriptSettingsView: View {
+    @ObservedObject var service: FileJobScriptService
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("File Job Script")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    service.addScript(FileJobScriptConfig(
+                        name: "New Script",
+                        command: #"cat > "$TYPEWHISPER_OUTPUT_PATH""#
+                    ))
+                } label: {
+                    Label(String(localized: "Add Script"), systemImage: "plus")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if service.scripts.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "No Scripts"),
+                    systemImage: "terminal",
+                    description: Text(String(localized: "Add a script to customize watch-folder exports."))
+                )
+            } else {
+                List {
+                    ForEach($service.scripts) { $script in
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Toggle(String(localized: "Enabled"), isOn: $script.isEnabled)
+                                Spacer()
+                                Button(role: .destructive) {
+                                    service.removeScript(id: script.id)
+                                } label: {
+                                    Image(systemName: "trash")
+                                }
+                                .buttonStyle(.borderless)
+                            }
+
+                            TextField(String(localized: "Name"), text: $script.name)
+                            TextField(String(localized: "Command"), text: $script.command, axis: .vertical)
+                                .font(.system(.body, design: .monospaced))
+                                .lineLimit(3...8)
+                            Stepper(
+                                String(localized: "Timeout: \(script.effectiveTimeoutSeconds)s"),
+                                value: $script.timeoutSeconds,
+                                in: 5...3_600,
+                                step: 5
+                            )
+                        }
+                        .padding(.vertical, 6)
+                        .onChange(of: script) { _, _ in
+                            service.saveConfig()
+                        }
+                    }
+                }
+                .listStyle(.inset)
+            }
+
+            if !service.executionLog.isEmpty {
+                Divider()
+                Text(String(localized: "Recent Runs"))
+                    .font(.subheadline.weight(.semibold))
+                ForEach(service.executionLog.prefix(5)) { entry in
+                    Label(
+                        entry.errorMessage ?? "\(entry.scriptName) finished in \(entry.durationMs)ms",
+                        systemImage: entry.success ? "checkmark.circle" : "xmark.circle"
+                    )
+                    .foregroundStyle(entry.success ? Color.secondary : Color.red)
+                    .font(.caption)
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 520, minHeight: 360)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/Tests/FileJobScriptPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/Tests/FileJobScriptPluginTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import TypeWhisperPluginSDK
+import XCTest
+@testable import FileJobScriptPlugin
+
+final class FileJobScriptPluginTests: XCTestCase {
+    private var cleanupURLs: [URL] = []
+
+    override func tearDown() {
+        for url in cleanupURLs {
+            try? FileManager.default.removeItem(at: url)
+        }
+        cleanupURLs.removeAll()
+        super.tearDown()
+    }
+
+    func testTimeoutSecondsClampToFileJobBounds() {
+        XCTAssertEqual(FileJobScriptConfig(command: "true", timeoutSeconds: 1).effectiveTimeoutSeconds, 5)
+        XCTAssertEqual(FileJobScriptConfig(command: "true", timeoutSeconds: 120).effectiveTimeoutSeconds, 120)
+        XCTAssertEqual(FileJobScriptConfig(command: "true", timeoutSeconds: 9_000).effectiveTimeoutSeconds, 3_600)
+    }
+
+    func testStdoutReceivesArtifactOnStdinAndReplacesContent() async throws {
+        let outputURL = try makeOutputURL()
+        let context = makeContext(outputPath: outputURL.path)
+        let artifact = FileJobArtifact(fileExtension: "txt", content: "hello")
+        let script = FileJobScriptConfig(name: "Append", command: "cat; printf ' processed'")
+
+        let result = await FileJobScriptRunner().execute(script: script, artifact: artifact, context: context)
+
+        XCTAssertNil(result.errorMessage)
+        XCTAssertTrue(result.didChangeArtifact)
+        XCTAssertFalse(result.wroteOutputPath)
+        XCTAssertEqual(result.artifact.content, "hello processed")
+    }
+
+    func testEnvironmentIncludesWatchFolderContextAndSidecarPaths() async throws {
+        let outputURL = try makeOutputURL(fileExtension: "srt")
+        let context = makeContext(outputPath: outputURL.path)
+        let artifact = FileJobArtifact(fileExtension: "srt", content: "default")
+        let command = #"""
+        printf "%s|%s|%s|%s|%s|%s|%s|%s" \
+          "$TYPEWHISPER_JOB_KIND" \
+          "$TYPEWHISPER_SOURCE_FILE_PATH" \
+          "$TYPEWHISPER_SOURCE_FILE_NAME" \
+          "$TYPEWHISPER_OUTPUT_DIR" \
+          "$TYPEWHISPER_OUTPUT_PATH" \
+          "$TYPEWHISPER_OUTPUT_FORMAT" \
+          "$TYPEWHISPER_ENGINE_ID" \
+          "$TYPEWHISPER_TRANSCRIPT_JSON_PATH"
+        """#
+        let script = FileJobScriptConfig(name: "Env", command: command)
+
+        let result = await FileJobScriptRunner().execute(script: script, artifact: artifact, context: context)
+        let parts = result.artifact.content.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+
+        XCTAssertNil(result.errorMessage)
+        XCTAssertEqual(parts[0], "watch-folder")
+        XCTAssertEqual(parts[1], "/tmp/in/meeting.wav")
+        XCTAssertEqual(parts[2], "meeting.wav")
+        XCTAssertEqual(parts[3], outputURL.deletingLastPathComponent().path)
+        XCTAssertEqual(parts[4], outputURL.path)
+        XCTAssertEqual(parts[5], "srt")
+        XCTAssertEqual(parts[6], "whisperkit")
+        XCTAssertTrue(parts[7].hasSuffix("transcript.json"))
+    }
+
+    func testWritesTranscriptAndSegmentsJSONSidecars() async throws {
+        let outputURL = try makeOutputURL()
+        let context = makeContext(outputPath: outputURL.path)
+        let script = FileJobScriptConfig(
+            name: "Sidecars",
+            command: #"""
+            printf "TRANSCRIPT\n"
+            cat "$TYPEWHISPER_TRANSCRIPT_JSON_PATH"
+            printf "\nSEGMENTS\n"
+            cat "$TYPEWHISPER_SEGMENTS_JSON_PATH"
+            """#
+        )
+
+        let result = await FileJobScriptRunner().execute(
+            script: script,
+            artifact: FileJobArtifact(fileExtension: "md", content: "default"),
+            context: context
+        )
+
+        XCTAssertNil(result.errorMessage)
+        XCTAssertTrue(result.artifact.content.contains(#""text":"Speaker A: Hello""#))
+        XCTAssertTrue(result.artifact.content.contains(#""detected_language":"en""#))
+        XCTAssertTrue(result.artifact.content.contains(#""engine_id":"whisperkit""#))
+        XCTAssertTrue(result.artifact.content.contains(#""speaker":"Speaker A""#))
+        XCTAssertTrue(result.artifact.content.contains(#""speaker_confidence":0.91"#))
+    }
+
+    func testEmptyStdoutUsesScriptWrittenOutputPath() async throws {
+        let outputURL = try makeOutputURL()
+        let context = makeContext(outputPath: outputURL.path)
+        let artifact = FileJobArtifact(fileExtension: "txt", content: "default")
+        let script = FileJobScriptConfig(
+            name: "Write file",
+            command: #"printf 'from file' > "$TYPEWHISPER_OUTPUT_PATH""#
+        )
+
+        let result = await FileJobScriptRunner().execute(script: script, artifact: artifact, context: context)
+
+        XCTAssertNil(result.errorMessage)
+        XCTAssertTrue(result.didChangeArtifact)
+        XCTAssertTrue(result.wroteOutputPath)
+        XCTAssertEqual(result.artifact.content, "from file")
+    }
+
+    func testNonZeroExitFallsBackToInputArtifact() async throws {
+        let outputURL = try makeOutputURL()
+        let context = makeContext(outputPath: outputURL.path)
+        let artifact = FileJobArtifact(fileExtension: "txt", content: "default")
+        let script = FileJobScriptConfig(name: "Broken", command: "printf 'ignored'; exit 2")
+
+        let result = await FileJobScriptRunner().execute(script: script, artifact: artifact, context: context)
+
+        XCTAssertFalse(result.didChangeArtifact)
+        XCTAssertFalse(result.wroteOutputPath)
+        XCTAssertEqual(result.artifact, artifact)
+        XCTAssertEqual(result.errorMessage, "Exit code 2")
+    }
+
+    func testTimeoutFallsBackToInputArtifact() async throws {
+        let outputURL = try makeOutputURL()
+        let context = makeContext(outputPath: outputURL.path)
+        let artifact = FileJobArtifact(fileExtension: "txt", content: "default")
+        let script = FileJobScriptConfig(name: "Slow", command: "sleep 20; printf 'ignored'", timeoutSeconds: 5)
+
+        let result = await FileJobScriptRunner().execute(script: script, artifact: artifact, context: context)
+
+        XCTAssertFalse(result.didChangeArtifact)
+        XCTAssertFalse(result.wroteOutputPath)
+        XCTAssertEqual(result.artifact, artifact)
+        XCTAssertEqual(result.errorMessage, "Script timed out after 5 seconds")
+    }
+
+    private func makeContext(outputPath: String) -> FileJobContext {
+        FileJobContext(
+            jobKind: .watchFolder,
+            sourceFilePath: "/tmp/in/meeting.wav",
+            outputDirectoryPath: URL(fileURLWithPath: outputPath).deletingLastPathComponent().path,
+            outputFilePath: outputPath,
+            outputFormat: URL(fileURLWithPath: outputPath).pathExtension,
+            engineId: "whisperkit",
+            engineName: "WhisperKit",
+            modelId: "large-v3",
+            transcriptText: "Speaker A: Hello",
+            detectedLanguage: "en",
+            segments: [
+                FileJobTranscriptSegment(
+                    text: "Hello",
+                    start: 0.25,
+                    end: 1.5,
+                    speakerLabel: "Speaker A",
+                    speakerConfidence: 0.91
+                )
+            ]
+        )
+    }
+
+    private func makeOutputURL(fileExtension: String = "txt") throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        cleanupURLs.append(directory)
+        return directory.appendingPathComponent("meeting.\(fileExtension)")
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/manifest.json
@@ -1,0 +1,16 @@
+{
+    "id": "com.typewhisper.file-job-script",
+    "name": "File Job Script",
+    "version": "1.0.0",
+    "minHostVersion": "1.4.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Run shell scripts for watch-folder file jobs. Scripts can replace the final exported artifact.",
+    "descriptions": {
+        "de": "Shell-Skripte fuer Watch-Folder-Dateijobs ausfuehren. Skripte koennen das finale Export-Artefakt ersetzen."
+    },
+    "category": "file-automation",
+    "iconSystemName": "folder.badge.gearshape",
+    "principalClass": "FileJobScriptPlugin"
+}

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -136,6 +136,129 @@ public protocol PostProcessorPlugin: TypeWhisperPlugin {
     @MainActor func process(text: String, context: PostProcessingContext) async throws -> String
 }
 
+// MARK: - File Job Automation Plugin
+
+public enum FileJobKind: String, Codable, Sendable {
+    case watchFolder = "watch-folder"
+    case fileTranscription = "file-transcription"
+    case dictation
+}
+
+public struct FileJobTranscriptSegment: Codable, Equatable, Sendable {
+    public let text: String
+    public let start: TimeInterval
+    public let end: TimeInterval
+    public let speakerLabel: String?
+    public let speakerConfidence: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case start
+        case end
+        case speakerLabel = "speaker"
+        case speakerConfidence = "speaker_confidence"
+    }
+
+    public init(
+        text: String,
+        start: TimeInterval,
+        end: TimeInterval,
+        speakerLabel: String? = nil,
+        speakerConfidence: Double? = nil
+    ) {
+        self.text = text
+        self.start = start
+        self.end = end
+        self.speakerLabel = speakerLabel
+        self.speakerConfidence = speakerConfidence
+    }
+}
+
+public struct FileJobContext: Codable, Equatable, Sendable {
+    public let jobKind: FileJobKind
+    public let sourceFilePath: String?
+    public let sourceFileName: String?
+    public let outputDirectoryPath: String?
+    public let outputFilePath: String?
+    public let outputFormat: String?
+    public let engineId: String?
+    public let engineName: String?
+    public let modelId: String?
+    public let transcriptText: String
+    public let detectedLanguage: String?
+    public let segments: [FileJobTranscriptSegment]
+
+    public init(
+        jobKind: FileJobKind,
+        sourceFilePath: String? = nil,
+        sourceFileName: String? = nil,
+        outputDirectoryPath: String? = nil,
+        outputFilePath: String? = nil,
+        outputFormat: String? = nil,
+        engineId: String? = nil,
+        engineName: String? = nil,
+        modelId: String? = nil,
+        transcriptText: String,
+        detectedLanguage: String? = nil,
+        segments: [FileJobTranscriptSegment] = []
+    ) {
+        self.jobKind = jobKind
+        self.sourceFilePath = sourceFilePath
+        if let sourceFileName {
+            self.sourceFileName = sourceFileName
+        } else if let sourceFilePath {
+            self.sourceFileName = URL(fileURLWithPath: sourceFilePath).lastPathComponent
+        } else {
+            self.sourceFileName = nil
+        }
+        self.outputDirectoryPath = outputDirectoryPath
+        self.outputFilePath = outputFilePath
+        self.outputFormat = outputFormat
+        self.engineId = engineId
+        self.engineName = engineName
+        self.modelId = modelId
+        self.transcriptText = transcriptText
+        self.detectedLanguage = detectedLanguage
+        self.segments = segments
+    }
+}
+
+public struct FileJobArtifact: Codable, Equatable, Sendable {
+    public let fileExtension: String
+    public let content: String
+
+    public init(fileExtension: String, content: String) {
+        self.fileExtension = fileExtension
+        self.content = content
+    }
+}
+
+public struct FileJobAutomationResult: Codable, Equatable, Sendable {
+    public let artifact: FileJobArtifact
+    public let appliedSteps: [String]
+    public let outputPathWasWritten: Bool
+
+    public init(
+        artifact: FileJobArtifact,
+        appliedSteps: [String] = [],
+        outputPathWasWritten: Bool = false
+    ) {
+        self.artifact = artifact
+        self.appliedSteps = appliedSteps
+        self.outputPathWasWritten = outputPathWasWritten
+    }
+}
+
+public protocol FileJobAutomationPlugin: TypeWhisperPlugin {
+    var automationName: String { get }
+    var priority: Int { get }
+    @MainActor func process(artifact: FileJobArtifact, context: FileJobContext) async throws -> FileJobAutomationResult
+}
+
+public extension FileJobAutomationPlugin {
+    var priority: Int { 400 }
+}
+
 // MARK: - Transcription Engine Plugin
 
 public struct AudioData: Sendable {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -434,6 +434,47 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertEqual(result.segments.first?.speakerConfidence, 0.91)
     }
 
+    func testFileJobAutomationContextCarriesWatchFolderExportMetadata() throws {
+        let segment = FileJobTranscriptSegment(
+            text: "Hello",
+            start: 0.25,
+            end: 1.5,
+            speakerLabel: "Speaker A",
+            speakerConfidence: 0.91
+        )
+        let context = FileJobContext(
+            jobKind: .watchFolder,
+            sourceFilePath: "/tmp/in/meeting.wav",
+            outputDirectoryPath: "/tmp/out",
+            outputFilePath: "/tmp/out/meeting.srt",
+            outputFormat: "srt",
+            engineId: "whisperkit",
+            engineName: "WhisperKit",
+            modelId: "large-v3",
+            transcriptText: "Speaker A: Hello",
+            detectedLanguage: "en",
+            segments: [segment]
+        )
+        let artifact = FileJobArtifact(fileExtension: "srt", content: "1\n00:00:00,250 --> 00:00:01,500\nHello")
+        let result = FileJobAutomationResult(
+            artifact: artifact,
+            appliedSteps: ["File Job Script"],
+            outputPathWasWritten: true
+        )
+
+        XCTAssertEqual(FileJobKind.watchFolder.rawValue, "watch-folder")
+        XCTAssertEqual(context.sourceFileName, "meeting.wav")
+        XCTAssertEqual(context.outputFormat, "srt")
+        XCTAssertEqual(context.segments, [segment])
+        XCTAssertEqual(result.artifact, artifact)
+        XCTAssertEqual(result.appliedSteps, ["File Job Script"])
+        XCTAssertTrue(result.outputPathWasWritten)
+
+        let encoded = try JSONEncoder().encode(context)
+        let decoded = try JSONDecoder().decode(FileJobContext.self, from: encoded)
+        XCTAssertEqual(decoded, context)
+    }
+
     func testTTSPluginCanPersistVoiceAndReceiveSpeakRequest() async throws {
         let plugin = MockTTSPlugin()
         let host = MockHostServices(eventBus: MockEventBus(), availableRuleNames: ["Work"])

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import TypeWhisperPluginSDK
 import XCTest
 @testable import TypeWhisper
 
@@ -1500,6 +1501,82 @@ final class WatchFolderExportTests: XCTestCase {
                 TranscriptionSegment(text: "world", start: 1.5, end: 2.75)
             ]
         )
+    }
+}
+
+@MainActor
+final class FileJobAutomationPipelineTests: XCTestCase {
+    func testPipelineAppliesFileJobAutomationResult() async throws {
+        let plugin = MockFileJobAutomationPlugin(
+            artifact: FileJobArtifact(fileExtension: "txt", content: "custom export"),
+            appliedSteps: ["Mock File Job"],
+            outputPathWasWritten: true
+        )
+        let pipeline = FileJobAutomationPipeline(automationsProvider: { [plugin] })
+        let context = FileJobContext(
+            jobKind: .watchFolder,
+            sourceFilePath: "/tmp/in/meeting.wav",
+            outputDirectoryPath: "/tmp/out",
+            outputFilePath: "/tmp/out/meeting.txt",
+            outputFormat: "txt",
+            engineId: "whisperkit",
+            engineName: "WhisperKit",
+            modelId: "large-v3",
+            transcriptText: "raw transcript",
+            detectedLanguage: "en"
+        )
+
+        let result = await pipeline.process(
+            artifact: FileJobArtifact(fileExtension: "txt", content: "default export"),
+            context: context
+        )
+
+        XCTAssertEqual(plugin.receivedArtifact?.content, "default export")
+        XCTAssertEqual(plugin.receivedContext?.jobKind, .watchFolder)
+        XCTAssertEqual(result.artifact.content, "custom export")
+        XCTAssertEqual(result.appliedSteps, ["Mock File Job"])
+        XCTAssertTrue(result.outputPathWasWritten)
+    }
+
+    private final class MockFileJobAutomationPlugin: NSObject, FileJobAutomationPlugin, @unchecked Sendable {
+        static let pluginId = "com.typewhisper.test.file-job"
+        static let pluginName = "Mock File Job"
+
+        let automationName = "Mock File Job"
+        let priority = 10
+
+        private let artifact: FileJobArtifact
+        private let appliedSteps: [String]
+        private let outputPathWasWritten: Bool
+        private(set) var receivedArtifact: FileJobArtifact?
+        private(set) var receivedContext: FileJobContext?
+
+        required override init() {
+            self.artifact = FileJobArtifact(fileExtension: "txt", content: "")
+            self.appliedSteps = []
+            self.outputPathWasWritten = false
+            super.init()
+        }
+
+        init(artifact: FileJobArtifact, appliedSteps: [String], outputPathWasWritten: Bool) {
+            self.artifact = artifact
+            self.appliedSteps = appliedSteps
+            self.outputPathWasWritten = outputPathWasWritten
+            super.init()
+        }
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        func process(artifact: FileJobArtifact, context: FileJobContext) async throws -> FileJobAutomationResult {
+            receivedArtifact = artifact
+            receivedContext = context
+            return FileJobAutomationResult(
+                artifact: self.artifact,
+                appliedSteps: appliedSteps,
+                outputPathWasWritten: outputPathWasWritten
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements Issue #484 as a v1 watch-folder-only file-job automation surface. This adds a separate `file-automation` plugin category and bundled `File Job Script` plugin while leaving the existing text-only Script Runner behavior unchanged.

## Issue Context

Issue #484 asks for a scriptable file/watch-folder automation hook so power users can automate advanced file transcription/export workflows, including stereo split -> per-channel transcription -> timestamp merge, without adding a dedicated native dual-channel speaker-labeling UI. The new hook receives the original source file path, output context, transcript text, and structured segment sidecars, and can replace the final watch-folder artifact.

Closes #484

## Changes

- Adds SDK file-job automation contracts: `FileJobKind`, `FileJobContext`, `FileJobArtifact`, `FileJobAutomationResult`, and `FileJobAutomationPlugin`.
- Adds package-owned `FileJobScriptPlugin` with script config, env population, JSON sidecar generation, timeout handling, stdout replacement, output-path replacement, and fallback behavior.
- Adds app-side file-job automation discovery and a watch-folder pipeline that runs after the default export is built and before the artifact is written.
- Registers the new `file-automation` category, bundled Xcode plugin target, and `file-job-script` release workflow alias.
- Adds package tests for the file-job script contract and a thin Xcode integration test for the watch-folder pipeline.

## Test Plan

- `swift test --package-path TypeWhisperPluginSDK --filter TypeWhisperPluginSDKTests`
- `swift test --package-path TypeWhisperPluginSDK --filter FileJobScriptPluginTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
