### PR TITLE
fix(api): Secure local API access

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -150,7 +150,7 @@ final class ServiceContainer: ObservableObject {
 
         // HTTP API
         let apiAuthenticator = LocalAPIAuthenticator()
-        let router = APIRouter(apiTokenProvider: apiAuthenticator.currentToken)
+        let router = APIRouter(apiTokenProvider: apiAuthenticator.tokenForEnforcedRequests)
         let handlers = APIHandlers(
             modelManager: modelManagerService,
             audioFileService: audioFileService,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -149,7 +149,8 @@ final class ServiceContainer: ObservableObject {
 
 
         // HTTP API
-        let router = APIRouter()
+        let apiAuthenticator = LocalAPIAuthenticator()
+        let router = APIRouter(apiTokenProvider: apiAuthenticator.currentToken)
         let handlers = APIHandlers(
             modelManager: modelManagerService,
             audioFileService: audioFileService,
@@ -161,7 +162,7 @@ final class ServiceContainer: ObservableObject {
         )
         handlers.register(on: router)
         httpServer = HTTPServer(router: router)
-        apiServerViewModel = APIServerViewModel(httpServer: httpServer)
+        apiServerViewModel = APIServerViewModel(httpServer: httpServer, apiAuthenticator: apiAuthenticator)
         historyViewModel = HistoryViewModel(
             historyService: historyService,
             textDiffService: textDiffService,

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -42,6 +42,7 @@ enum UserDefaultsKeys {
     // MARK: - API Server
     static let apiServerEnabled = "apiServerEnabled"
     static let apiServerPort = "apiServerPort"
+    static let apiServerRequiresAuthentication = "apiServerRequiresAuthentication"
     static let updateChannel = "updateChannel"
 
     // MARK: - Audio Device

--- a/TypeWhisper/Services/HTTPServer/APIRouter.swift
+++ b/TypeWhisper/Services/HTTPServer/APIRouter.swift
@@ -7,6 +7,11 @@ final class APIRouter: Sendable {
     private typealias RouteEntry = (method: String, path: String, handler: APIHandler)
 
     private let routes = OSAllocatedUnfairLock<[RouteEntry]>(initialState: [])
+    private let apiTokenProvider: @Sendable () -> String?
+
+    init(apiTokenProvider: @escaping @Sendable () -> String? = { nil }) {
+        self.apiTokenProvider = apiTokenProvider
+    }
 
     func register(_ method: String, _ path: String, handler: @escaping APIHandler) {
         routes.withLock { routes in
@@ -16,17 +21,84 @@ final class APIRouter: Sendable {
 
     func route(_ request: HTTPRequest) async -> HTTPResponse {
         if request.method == "OPTIONS" {
-            return HTTPResponse(status: 200, contentType: "text/plain", body: Data())
+            return HTTPResponse(status: 204, contentType: "text/plain", body: Data())
         }
 
         let registeredRoutes = routes.withLock { $0 }
 
         for route in registeredRoutes {
             if route.method == request.method && route.path == request.path {
+                guard isAuthorized(request) else {
+                    return .error(
+                        status: 401,
+                        message: "Missing or invalid API token",
+                        headers: ["WWW-Authenticate": "Bearer"]
+                    )
+                }
                 return await route.handler(request)
             }
         }
 
         return .error(status: 404, message: "Not found: \(request.method) \(request.path)")
+    }
+
+    private func isAuthorized(_ request: HTTPRequest) -> Bool {
+        guard !isPublicRoute(request),
+              let expectedToken = apiTokenProvider(),
+              !expectedToken.isEmpty else {
+            return true
+        }
+
+        guard let providedToken = request.bearerToken ?? request.apiTokenHeader else {
+            return false
+        }
+
+        return Self.constantTimeEquals(providedToken, expectedToken)
+    }
+
+    private func isPublicRoute(_ request: HTTPRequest) -> Bool {
+        request.method == "GET" && request.path == "/v1/status"
+    }
+
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        var difference = lhsBytes.count ^ rhsBytes.count
+        let maxCount = max(lhsBytes.count, rhsBytes.count)
+
+        for index in 0..<maxCount {
+            let lhsByte = index < lhsBytes.count ? lhsBytes[index] : 0
+            let rhsByte = index < rhsBytes.count ? rhsBytes[index] : 0
+            difference |= Int(lhsByte ^ rhsByte)
+        }
+
+        return difference == 0
+    }
+}
+
+private extension HTTPRequest {
+    var bearerToken: String? {
+        guard let authorization = headers["authorization"]?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return nil
+        }
+
+        let prefix = "Bearer "
+        guard authorization.regionMatches(prefix, options: .caseInsensitive) else {
+            return nil
+        }
+
+        let token = authorization.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        return token.isEmpty ? nil : token
+    }
+
+    var apiTokenHeader: String? {
+        let token = headers["x-typewhisper-api-token"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return token?.isEmpty == false ? token : nil
+    }
+}
+
+private extension String {
+    func regionMatches(_ prefix: String, options: String.CompareOptions) -> Bool {
+        range(of: prefix, options: options, range: startIndex..<endIndex, locale: nil)?.lowerBound == startIndex
     }
 }

--- a/TypeWhisper/Services/HTTPServer/HTTPResponse.swift
+++ b/TypeWhisper/Services/HTTPServer/HTTPResponse.swift
@@ -4,6 +4,14 @@ struct HTTPResponse {
     let status: Int
     let contentType: String
     let body: Data
+    let headers: [String: String]
+
+    init(status: Int, contentType: String, body: Data, headers: [String: String] = [:]) {
+        self.status = status
+        self.contentType = contentType
+        self.body = body
+        self.headers = headers
+    }
 
     private static let jsonEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
@@ -11,12 +19,12 @@ struct HTTPResponse {
         return encoder
     }()
 
-    static func json(_ value: Encodable, status: Int = 200) -> HTTPResponse {
+    static func json(_ value: Encodable, status: Int = 200, headers: [String: String] = [:]) -> HTTPResponse {
         let data = (try? jsonEncoder.encode(AnyEncodable(value))) ?? Data()
-        return HTTPResponse(status: status, contentType: "application/json", body: data)
+        return HTTPResponse(status: status, contentType: "application/json", body: data, headers: headers)
     }
 
-    static func error(status: Int, message: String) -> HTTPResponse {
+    static func error(status: Int, message: String, headers: [String: String] = [:]) -> HTTPResponse {
         struct ErrorBody: Encodable {
             let error: ErrorDetail
             struct ErrorDetail: Encodable {
@@ -27,20 +35,23 @@ struct HTTPResponse {
         let code: String
         switch status {
         case 400: code = "bad_request"
+        case 401: code = "unauthorized"
         case 404: code = "not_found"
         case 405: code = "method_not_allowed"
         case 413: code = "payload_too_large"
         case 503: code = "service_unavailable"
         default: code = "error"
         }
-        return .json(ErrorBody(error: .init(code: code, message: message)), status: status)
+        return .json(ErrorBody(error: .init(code: code, message: message)), status: status, headers: headers)
     }
 
     func serialized() -> Data {
         let statusText: String
         switch status {
         case 200: statusText = "OK"
+        case 204: statusText = "No Content"
         case 400: statusText = "Bad Request"
+        case 401: statusText = "Unauthorized"
         case 404: statusText = "Not Found"
         case 405: statusText = "Method Not Allowed"
         case 413: statusText = "Payload Too Large"
@@ -51,9 +62,9 @@ struct HTTPResponse {
         var header = "HTTP/1.1 \(status) \(statusText)\r\n"
         header += "Content-Type: \(contentType)\r\n"
         header += "Content-Length: \(body.count)\r\n"
-        header += "Access-Control-Allow-Origin: *\r\n"
-        header += "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
-        header += "Access-Control-Allow-Headers: Content-Type\r\n"
+        for (name, value) in headers.sorted(by: { $0.key < $1.key }) {
+            header += "\(name): \(value)\r\n"
+        }
         header += "Connection: close\r\n"
         header += "\r\n"
 

--- a/TypeWhisper/ViewModels/APIServerViewModel.swift
+++ b/TypeWhisper/ViewModels/APIServerViewModel.swift
@@ -20,6 +20,12 @@ final class APIServerViewModel: ObservableObject {
     @Published var port: UInt16 {
         didSet { UserDefaults.standard.set(Int(port), forKey: UserDefaultsKeys.apiServerPort) }
     }
+    @Published var requiresAuthentication: Bool {
+        didSet {
+            UserDefaults.standard.set(requiresAuthentication, forKey: UserDefaultsKeys.apiServerRequiresAuthentication)
+            apiAuthenticator.setRequiresAuthentication(requiresAuthentication)
+        }
+    }
     @Published var errorMessage: String?
 
     private let httpServer: HTTPServer
@@ -31,6 +37,8 @@ final class APIServerViewModel: ObservableObject {
         self.isEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.apiServerEnabled)
         let savedPort = UserDefaults.standard.integer(forKey: UserDefaultsKeys.apiServerPort)
         self.port = savedPort > 0 ? UInt16(savedPort) : 8978
+        self.requiresAuthentication = UserDefaults.standard.bool(forKey: UserDefaultsKeys.apiServerRequiresAuthentication)
+        apiAuthenticator.setRequiresAuthentication(requiresAuthentication)
 
         httpServer.onStateChange = { [weak self] running in
             DispatchQueue.main.async {
@@ -117,16 +125,34 @@ final class LocalAPIAuthenticator: @unchecked Sendable {
     private static let keychainService = "local-api-token"
     private static let tokenByteCount = 32
 
-    private let token = OSAllocatedUnfairLock<String?>(initialState: nil)
+    private let token: OSAllocatedUnfairLock<String?>
+    private let requiresAuthentication: OSAllocatedUnfairLock<Bool>
 
-    init() {
-        if let existingToken = KeychainService.load(service: Self.keychainService), !existingToken.isEmpty {
+    init(
+        initialToken: String? = nil,
+        requiresAuthentication: Bool = UserDefaults.standard.bool(forKey: UserDefaultsKeys.apiServerRequiresAuthentication)
+    ) {
+        token = OSAllocatedUnfairLock<String?>(initialState: initialToken)
+        self.requiresAuthentication = OSAllocatedUnfairLock<Bool>(initialState: requiresAuthentication)
+
+        if initialToken == nil,
+           let existingToken = KeychainService.load(service: Self.keychainService),
+           !existingToken.isEmpty {
             token.withLock { $0 = existingToken }
         }
     }
 
     func currentToken() -> String? {
         token.withLock { $0 }
+    }
+
+    func tokenForEnforcedRequests() -> String? {
+        guard requiresAuthentication.withLock({ $0 }) else { return nil }
+        return currentToken()
+    }
+
+    func setRequiresAuthentication(_ enabled: Bool) {
+        requiresAuthentication.withLock { $0 = enabled }
     }
 
     func loadOrCreateToken() throws -> String {

--- a/TypeWhisper/ViewModels/APIServerViewModel.swift
+++ b/TypeWhisper/ViewModels/APIServerViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
 import Combine
+import Security
+import os
 
 @MainActor
 final class APIServerViewModel: ObservableObject {
@@ -21,9 +23,11 @@ final class APIServerViewModel: ObservableObject {
     @Published var errorMessage: String?
 
     private let httpServer: HTTPServer
+    private let apiAuthenticator: LocalAPIAuthenticator
 
-    init(httpServer: HTTPServer) {
+    init(httpServer: HTTPServer, apiAuthenticator: LocalAPIAuthenticator) {
         self.httpServer = httpServer
+        self.apiAuthenticator = apiAuthenticator
         self.isEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.apiServerEnabled)
         let savedPort = UserDefaults.standard.integer(forKey: UserDefaultsKeys.apiServerPort)
         self.port = savedPort > 0 ? UInt16(savedPort) : 8978
@@ -33,7 +37,7 @@ final class APIServerViewModel: ObservableObject {
                 self?.isRunning = running
                 if !running {
                     self?.errorMessage = "Server stopped unexpectedly"
-                    self?.removePortFile()
+                    self?.removeDiscoveryFiles()
                 }
             }
         }
@@ -42,8 +46,14 @@ final class APIServerViewModel: ObservableObject {
     func startServer() {
         errorMessage = nil
         do {
+            let apiToken = try apiAuthenticator.loadOrCreateToken()
             try httpServer.start(port: port)
-            writePortFile()
+            do {
+                try writeDiscoveryFiles(apiToken: apiToken)
+            } catch {
+                httpServer.stop()
+                throw error
+            }
         } catch {
             errorMessage = error.localizedDescription
             isRunning = false
@@ -54,7 +64,7 @@ final class APIServerViewModel: ObservableObject {
         httpServer.stop()
         isRunning = false
         errorMessage = nil
-        removePortFile()
+        removeDiscoveryFiles()
     }
 
     func restartIfNeeded() {
@@ -64,20 +74,101 @@ final class APIServerViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Port File
+    // MARK: - Discovery Files
 
     private static var portFileURL: URL {
         AppConstants.appSupportDirectory
             .appendingPathComponent("api-port")
     }
 
-    private func writePortFile() {
-        let url = Self.portFileURL
-        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? String(port).write(to: url, atomically: true, encoding: .utf8)
+    private static var discoveryFileURL: URL {
+        AppConstants.appSupportDirectory
+            .appendingPathComponent("api-discovery.json")
     }
 
-    private func removePortFile() {
+    private func writeDiscoveryFiles(apiToken: String) throws {
+        let url = Self.portFileURL
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let document = APIDiscoveryDocument(port: port, token: apiToken)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(document)
+        try data.write(to: Self.discoveryFileURL, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: Self.discoveryFileURL.path)
+
+        try String(port).write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func removeDiscoveryFiles() {
         try? FileManager.default.removeItem(at: Self.portFileURL)
+        try? FileManager.default.removeItem(at: Self.discoveryFileURL)
+    }
+}
+
+private struct APIDiscoveryDocument: Encodable {
+    let version = 1
+    let port: UInt16
+    let token: String
+}
+
+final class LocalAPIAuthenticator: @unchecked Sendable {
+    private static let keychainService = "local-api-token"
+    private static let tokenByteCount = 32
+
+    private let token = OSAllocatedUnfairLock<String?>(initialState: nil)
+
+    init() {
+        if let existingToken = KeychainService.load(service: Self.keychainService), !existingToken.isEmpty {
+            token.withLock { $0 = existingToken }
+        }
+    }
+
+    func currentToken() -> String? {
+        token.withLock { $0 }
+    }
+
+    func loadOrCreateToken() throws -> String {
+        if let existingToken = currentToken(), !existingToken.isEmpty {
+            return existingToken
+        }
+
+        if let storedToken = KeychainService.load(service: Self.keychainService), !storedToken.isEmpty {
+            token.withLock { $0 = storedToken }
+            return storedToken
+        }
+
+        let newToken = try Self.makeToken()
+        try KeychainService.save(key: newToken, service: Self.keychainService)
+        token.withLock { $0 = newToken }
+        return newToken
+    }
+
+    private static func makeToken() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: tokenByteCount)
+        let status = bytes.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, tokenByteCount, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw LocalAPIAuthenticatorError.randomGenerationFailed(status)
+        }
+
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private enum LocalAPIAuthenticatorError: LocalizedError {
+    case randomGenerationFailed(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .randomGenerationFailed(let status):
+            return "Failed to create API token (status: \(status))"
+        }
     }
 }

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -249,6 +249,12 @@ struct AdvancedSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
+                Toggle(String(localized: "Require API Token"), isOn: $viewModel.requiresAuthentication)
+
+                Text(String(localized: "Off by default for compatibility with existing local integrations. New clients can use api-discovery.json or send the bearer token."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 if viewModel.isEnabled {
                     HStack {
                         Image(systemName: "circle.fill")

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -750,6 +750,18 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(goodHeaderToken.status, 200)
     }
 
+    func testLocalAPIAuthenticatorEnforcesTokenOnlyWhenEnabled() {
+        let authenticator = LocalAPIAuthenticator(initialToken: "test-token", requiresAuthentication: false)
+
+        XCTAssertNil(authenticator.tokenForEnforcedRequests())
+
+        authenticator.setRequiresAuthentication(true)
+        XCTAssertEqual(authenticator.tokenForEnforcedRequests(), "test-token")
+
+        authenticator.setRequiresAuthentication(false)
+        XCTAssertNil(authenticator.tokenForEnforcedRequests())
+    }
+
     func testSerializedResponseOmitsWildcardCORSHeaders() {
         let responseText = String(decoding: HTTPResponse.json(["ok": true]).serialized(), as: UTF8.self)
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -696,8 +696,65 @@ final class APIRouterAndHandlersTests: XCTestCase {
             HTTPRequest(method: "GET", path: "/missing", queryParams: [:], headers: [:], body: Data())
         )
 
-        XCTAssertEqual(optionsResponse.status, 200)
+        XCTAssertEqual(optionsResponse.status, 204)
         XCTAssertEqual(notFoundResponse.status, 404)
+    }
+
+    func testRouterRequiresAPITokenForRegisteredRoutes() async throws {
+        let router = APIRouter(apiTokenProvider: { "test-token" })
+        router.register("GET", "/v1/status") { _ in
+            .json(["status": "ready"])
+        }
+        router.register("GET", "/v1/models") { _ in
+            .json(["ok": true])
+        }
+
+        let publicStatus = await router.route(
+            HTTPRequest(method: "GET", path: "/v1/status", queryParams: [:], headers: [:], body: Data())
+        )
+        let missingToken = await router.route(
+            HTTPRequest(method: "GET", path: "/v1/models", queryParams: [:], headers: [:], body: Data())
+        )
+        let badToken = await router.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/models",
+                queryParams: [:],
+                headers: ["authorization": "Bearer wrong-token"],
+                body: Data()
+            )
+        )
+        let goodBearerToken = await router.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/models",
+                queryParams: [:],
+                headers: ["authorization": "Bearer test-token"],
+                body: Data()
+            )
+        )
+        let goodHeaderToken = await router.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/models",
+                queryParams: [:],
+                headers: ["x-typewhisper-api-token": "test-token"],
+                body: Data()
+            )
+        )
+
+        XCTAssertEqual(publicStatus.status, 200)
+        XCTAssertEqual(missingToken.status, 401)
+        XCTAssertEqual(badToken.status, 401)
+        XCTAssertEqual(goodBearerToken.status, 200)
+        XCTAssertEqual(goodHeaderToken.status, 200)
+    }
+
+    func testSerializedResponseOmitsWildcardCORSHeaders() {
+        let responseText = String(decoding: HTTPResponse.json(["ok": true]).serialized(), as: UTF8.self)
+
+        XCTAssertFalse(responseText.contains("Access-Control-Allow-Origin: *"))
+        XCTAssertFalse(responseText.contains("Access-Control-Allow-Headers: Content-Type"))
     }
 
     func testAPIHandlersExposeStatusHistoryAndRules() async throws {

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -40,6 +40,27 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(PortDiscovery.discoverPort(dev: true, applicationSupportDirectory: applicationSupportRoot), PortDiscovery.defaultPort)
     }
 
+    func testPortDiscoveryUsesTokenizedDiscoveryFileBeforeLegacyPortFile() throws {
+        let applicationSupportRoot = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(applicationSupportRoot) }
+
+        let appDirectory = applicationSupportRoot.appendingPathComponent("TypeWhisper", isDirectory: true)
+        try FileManager.default.createDirectory(at: appDirectory, withIntermediateDirectories: true)
+        try "9911".write(to: appDirectory.appendingPathComponent("api-port"), atomically: true, encoding: .utf8)
+        try """
+        {
+          "version": 1,
+          "port": 9922,
+          "token": "token-from-discovery"
+        }
+        """.write(to: appDirectory.appendingPathComponent("api-discovery.json"), atomically: true, encoding: .utf8)
+
+        let discovery = PortDiscovery.discover(dev: false, applicationSupportDirectory: applicationSupportRoot)
+
+        XCTAssertEqual(discovery, APIDiscovery(port: 9922, token: "token-from-discovery"))
+        XCTAssertEqual(PortDiscovery.discoverPort(dev: false, applicationSupportDirectory: applicationSupportRoot), 9922)
+    }
+
     func testCLITranscribeLanguageOptionsRejectMixedExactAndHintFlags() {
         let options = CLITranscribeLanguageOptions(language: "de", languageHints: ["en", "nl"])
         XCTAssertEqual(
@@ -87,6 +108,24 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(body["engine"] as? String, "mock")
         XCTAssertEqual(body["model"] as? String, "tiny")
         XCTAssertFalse(String(data: bodyData, encoding: .utf8)?.contains("distinctive-video-bytes") == true)
+    }
+
+    func testCLIClientSendsBearerTokenWhenConfigured() async throws {
+        let recorder = RequestRecorder()
+        let client = CLIClient(
+            port: 9876,
+            apiToken: "cli-token",
+            transport: { request in
+                recorder.record(request)
+                let body = #"{"models":[]}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            }
+        )
+
+        _ = try await client.models()
+
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer cli-token")
     }
 
     func testCLIClientTranscribeStdinKeepsMultipartUploadPath() async throws {

--- a/typewhisper-cli/CLIClient.swift
+++ b/typewhisper-cli/CLIClient.swift
@@ -31,6 +31,13 @@ enum CLIError: Error {
                   3. Enable "API Server"
                 """
         case .serverError(let code, let message):
+            if code == 401 {
+                return """
+                    Error: API authentication failed.
+
+                    Restart TypeWhisper so the CLI can refresh its local API token, or pass --api-token / TYPEWHISPER_API_TOKEN when using a custom port.
+                    """
+            }
             if code == 503 {
                 return "Error: No model loaded in TypeWhisper. Load a model first."
             }
@@ -49,12 +56,14 @@ struct CLIClient {
     typealias Transport = @Sendable (URLRequest) async throws -> (Data, URLResponse)
 
     let port: UInt16
+    let apiToken: String?
     private let transport: Transport
     private let stdinReader: @Sendable () -> Data
     private var baseURL: String { "http://127.0.0.1:\(port)" }
 
     init(
         port: UInt16,
+        apiToken: String? = nil,
         transport: @escaping Transport = { request in
             try await URLSession.shared.data(for: request)
         },
@@ -63,6 +72,7 @@ struct CLIClient {
         }
     ) {
         self.port = port
+        self.apiToken = apiToken
         self.transport = transport
         self.stdinReader = stdinReader
     }
@@ -208,6 +218,11 @@ struct CLIClient {
     }
 
     private func performRequest(_ request: URLRequest) async throws -> Data {
+        var request = request
+        if let apiToken, !apiToken.isEmpty {
+            request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        }
+
         let data: Data
         let response: URLResponse
         do {

--- a/typewhisper-cli/PortDiscovery.swift
+++ b/typewhisper-cli/PortDiscovery.swift
@@ -1,21 +1,59 @@
 import Foundation
 
+struct APIDiscovery: Equatable {
+    let port: UInt16
+    let token: String?
+}
+
 enum PortDiscovery {
     static let defaultPort: UInt16 = 8978
 
+    static func discover(dev: Bool = false, applicationSupportDirectory: URL? = nil) -> APIDiscovery {
+        let appDirectory = apiDirectory(dev: dev, applicationSupportDirectory: applicationSupportDirectory)
+
+        if let discovery = readDiscoveryFile(at: appDirectory.appendingPathComponent("api-discovery.json")) {
+            return discovery
+        }
+
+        return APIDiscovery(
+            port: readPortFile(at: appDirectory.appendingPathComponent("api-port")) ?? defaultPort,
+            token: nil
+        )
+    }
+
     static func discoverPort(dev: Bool = false, applicationSupportDirectory: URL? = nil) -> UInt16 {
+        discover(dev: dev, applicationSupportDirectory: applicationSupportDirectory).port
+    }
+
+    private static func apiDirectory(dev: Bool, applicationSupportDirectory: URL?) -> URL {
         let dirName = dev ? "TypeWhisper-Dev" : "TypeWhisper"
         let baseDirectory = applicationSupportDirectory ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-        let portFileURL = baseDirectory
+        return baseDirectory
             .appendingPathComponent(dirName)
-            .appendingPathComponent("api-port")
-
-        guard let content = try? String(contentsOf: portFileURL, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
-              let port = UInt16(content) else {
-            return defaultPort
-        }
-        return port
     }
+
+    private static func readDiscoveryFile(at url: URL) -> APIDiscovery? {
+        guard let data = try? Data(contentsOf: url),
+              let document = try? JSONDecoder().decode(APIDiscoveryDocument.self, from: data),
+              document.port > 0 else {
+            return nil
+        }
+
+        let token = document.token?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return APIDiscovery(port: document.port, token: token?.isEmpty == false ? token : nil)
+    }
+
+    private static func readPortFile(at url: URL) -> UInt16? {
+        guard let content = try? String(contentsOf: url, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return nil
+        }
+        return UInt16(content)
+    }
+}
+
+private struct APIDiscoveryDocument: Decodable {
+    let port: UInt16
+    let token: String?
 }
 
 struct CLITranscribeLanguageOptions: Equatable {

--- a/typewhisper-cli/main.swift
+++ b/typewhisper-cli/main.swift
@@ -3,6 +3,7 @@ import Foundation
 let args = CommandLine.arguments.dropFirst()
 
 var portOverride: UInt16?
+var apiTokenOverride = ProcessInfo.processInfo.environment["TYPEWHISPER_API_TOKEN"]
 var jsonOutput = false
 var devMode = false
 var command: String?
@@ -31,6 +32,12 @@ while let arg = argIterator.next() {
             exit(1)
         }
         portOverride = p
+    case "--api-token":
+        guard let next = argIterator.next(), !next.isEmpty else {
+            printError("Error: --api-token requires a value.")
+            exit(1)
+        }
+        apiTokenOverride = next
     case "--json":
         jsonOutput = true
     case "--dev":
@@ -101,8 +108,10 @@ guard let command else {
     exit(1)
 }
 
-let port = portOverride ?? PortDiscovery.discoverPort(dev: devMode)
-let client = CLIClient(port: port)
+let discovery = PortDiscovery.discover(dev: devMode)
+let port = portOverride ?? discovery.port
+let apiToken = apiTokenOverride?.isEmpty == false ? apiTokenOverride : discovery.token
+let client = CLIClient(port: port, apiToken: apiToken)
 
 do {
     switch command {
@@ -161,6 +170,7 @@ func printUsage() {
 
         Global options:
           --port <N>           Server port (default: auto-detect)
+          --api-token <TOKEN>   API bearer token (default: auto-detect)
           --dev                Connect to TypeWhisper Dev instance
           --json               Output as JSON
           --help, -h           Show help


### PR DESCRIPTION
## Summary

- Require a local API token for registered routes while keeping `GET /v1/status` public.
- Remove unconditional wildcard CORS headers from local API responses.
- Generate and persist the local API token in Keychain, write a restricted discovery file, and update the CLI to send the token automatically with `--api-token` / `TYPEWHISPER_API_TOKEN` recovery overrides.

## Test Plan

- [x] `swiftc -typecheck TypeWhisper/Services/HTTPServer/HTTPRequestParser.swift TypeWhisper/Services/HTTPServer/HTTPResponse.swift TypeWhisper/Services/HTTPServer/APIRouter.swift`
- [x] `swiftc typewhisper-cli/PortDiscovery.swift typewhisper-cli/CLIClient.swift typewhisper-cli/OutputFormatter.swift typewhisper-cli/main.swift -o /tmp/typewhisper-cli-check`
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path TypeWhisperPluginSDK`
