### PR TITLE
fix(webhook): Store sensitive headers in secrets

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -136,6 +136,16 @@ let package = Package(
                 .process("manifest.json"),
             ]
         ),
+        .target(
+            name: "WebhookPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/WebhookPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
         .testTarget(
             name: "TypeWhisperPluginSDKTests",
             dependencies: ["TypeWhisperPluginSDK"]
@@ -237,6 +247,15 @@ let package = Package(
                 "AssemblyAIPlugin",
             ],
             path: "Plugins/AssemblyAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "WebhookPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "WebhookPlugin",
+            ],
+            path: "Plugins/WebhookPlugin/Tests"
         ),
     ]
 )

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
@@ -84,6 +84,66 @@ final class WebhookPluginTests: XCTestCase {
         XCTAssertEqual(persisted.secretHeaderNames, ["Authorization"])
     }
 
+    func testBlankSensitiveHeaderClearsSecretAndDoesNotReloadOrSend() async throws {
+        let host = try PluginTestHostServices()
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        let webhook = ExampleWebhookConfig(
+            name: "Rotated Hook",
+            url: "https://example.com/hook",
+            headers: [
+                "Authorization": "Bearer old-token",
+                "Content-Type": "application/json",
+            ]
+        )
+        let storageKey = ExampleWebhookService.secretStorageKey(
+            webhookID: webhook.id,
+            headerName: "Authorization"
+        )
+
+        service.addWebhook(webhook)
+        XCTAssertEqual(host.loadSecret(key: storageKey), "Bearer old-token")
+
+        var updated = try XCTUnwrap(service.webhooks.first)
+        updated.headers["Authorization"] = ""
+        service.updateWebhook(updated)
+
+        XCTAssertEqual(host.loadSecret(key: storageKey), "")
+
+        let storedData = try Data(contentsOf: configURL(for: host))
+        let storedRaw = String(decoding: storedData, as: UTF8.self)
+        XCTAssertFalse(storedRaw.contains("Bearer old-token"))
+
+        let persisted = try XCTUnwrap(try JSONDecoder().decode([ExampleWebhookConfig].self, from: storedData).first)
+        XCTAssertNil(persisted.headers["Authorization"])
+        XCTAssertFalse(persisted.secretHeaderNames.contains("Authorization"))
+
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: URL(string: "https://example.com/hook")!,
+            statusCode: 204,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let sessionStore = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            sessionStore.makeSession(outcomes: [.success(Data(), response)])
+        }
+
+        let reloadedService = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        XCTAssertNil(reloadedService.webhooks.first?.headers["Authorization"])
+
+        await reloadedService.sendWebhooks(for: TranscriptionCompletedPayload(
+            rawText: "raw",
+            finalText: "final",
+            engineUsed: "test",
+            durationSeconds: 1,
+            ruleName: nil
+        ))
+
+        let request = try XCTUnwrap(sessionStore.sessions.first?.requestedRequests.first)
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
     func testSendUsesRestoredSensitiveHeaders() async throws {
         let host = try PluginTestHostServices()
         let webhook = ExampleWebhookConfig(

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import XCTest
+@_spi(Testing) import TypeWhisperPluginSDK
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import WebhookPlugin
+
+final class WebhookPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testSaveMovesSensitiveHeadersToSecrets() throws {
+        let host = try PluginTestHostServices()
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        let webhook = ExampleWebhookConfig(
+            name: "Secure Hook",
+            url: "https://example.com/hook",
+            headers: [
+                "Authorization": "Bearer local-token",
+                "Content-Type": "application/json",
+                "X-API-Key": "api-key-value",
+            ]
+        )
+
+        service.addWebhook(webhook)
+
+        let storedData = try Data(contentsOf: configURL(for: host))
+        let storedRaw = String(decoding: storedData, as: UTF8.self)
+        XCTAssertFalse(storedRaw.contains("Bearer local-token"))
+        XCTAssertFalse(storedRaw.contains("api-key-value"))
+
+        let persisted = try XCTUnwrap(try JSONDecoder().decode([ExampleWebhookConfig].self, from: storedData).first)
+        XCTAssertEqual(persisted.headers["Authorization"], ExampleWebhookConfig.secretHeaderPlaceholder)
+        XCTAssertEqual(persisted.headers["X-API-Key"], ExampleWebhookConfig.secretHeaderPlaceholder)
+        XCTAssertEqual(persisted.headers["Content-Type"], "application/json")
+        XCTAssertEqual(Set(persisted.secretHeaderNames), ["Authorization", "X-API-Key"])
+        XCTAssertEqual(
+            host.loadSecret(key: ExampleWebhookService.secretStorageKey(
+                webhookID: webhook.id,
+                headerName: "Authorization"
+            )),
+            "Bearer local-token"
+        )
+        XCTAssertEqual(
+            host.loadSecret(key: ExampleWebhookService.secretStorageKey(
+                webhookID: webhook.id,
+                headerName: "X-API-Key"
+            )),
+            "api-key-value"
+        )
+    }
+
+    func testLoadMigratesLegacyPlaintextSensitiveHeaders() throws {
+        let host = try PluginTestHostServices()
+        let legacyWebhook = ExampleWebhookConfig(
+            name: "Legacy Hook",
+            url: "https://example.com/hook",
+            headers: [
+                "Authorization": "Bearer legacy-token",
+                "Content-Type": "application/json",
+            ]
+        )
+        let configData = try JSONEncoder().encode([legacyWebhook])
+        try configData.write(to: configURL(for: host), options: .atomic)
+
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+
+        XCTAssertEqual(service.webhooks.first?.headers["Authorization"], "Bearer legacy-token")
+        XCTAssertEqual(
+            host.loadSecret(key: ExampleWebhookService.secretStorageKey(
+                webhookID: legacyWebhook.id,
+                headerName: "Authorization"
+            )),
+            "Bearer legacy-token"
+        )
+
+        let storedData = try Data(contentsOf: configURL(for: host))
+        let storedRaw = String(decoding: storedData, as: UTF8.self)
+        XCTAssertFalse(storedRaw.contains("Bearer legacy-token"))
+
+        let persisted = try XCTUnwrap(try JSONDecoder().decode([ExampleWebhookConfig].self, from: storedData).first)
+        XCTAssertEqual(persisted.headers["Authorization"], ExampleWebhookConfig.secretHeaderPlaceholder)
+        XCTAssertEqual(persisted.secretHeaderNames, ["Authorization"])
+    }
+
+    func testSendUsesRestoredSensitiveHeaders() async throws {
+        let host = try PluginTestHostServices()
+        let webhook = ExampleWebhookConfig(
+            name: "Restored Hook",
+            url: "https://example.com/hook",
+            headers: [
+                "Authorization": ExampleWebhookConfig.secretHeaderPlaceholder,
+                "Content-Type": "application/json",
+            ],
+            secretHeaderNames: ["Authorization"]
+        )
+        try host.storeSecret(
+            key: ExampleWebhookService.secretStorageKey(
+                webhookID: webhook.id,
+                headerName: "Authorization"
+            ),
+            value: "Bearer restored-token"
+        )
+        let configData = try JSONEncoder().encode([webhook])
+        try configData.write(to: configURL(for: host), options: .atomic)
+
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: URL(string: "https://example.com/hook")!,
+            statusCode: 204,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let sessionStore = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            sessionStore.makeSession(outcomes: [.success(Data(), response)])
+        }
+
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        await service.sendWebhooks(for: TranscriptionCompletedPayload(
+            rawText: "raw",
+            finalText: "final",
+            engineUsed: "test",
+            durationSeconds: 1,
+            ruleName: nil
+        ))
+
+        let request = try XCTUnwrap(sessionStore.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer restored-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    private func configURL(for host: PluginTestHostServices) -> URL {
+        host.pluginDataDirectory.appendingPathComponent("webhooks.json")
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -182,7 +182,7 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
         guard let data = try? Data(contentsOf: configURL),
               let config = try? JSONDecoder().decode([ExampleWebhookConfig].self, from: data) else { return }
         webhooks = config.map(resolveSecretHeaders)
-        if config.contains(where: containsPlaintextSecretHeader) {
+        if config.contains(where: containsPlaintextSecretHeader) || config.contains(where: containsEmptySensitiveHeader) {
             saveConfig()
         }
     }
@@ -194,7 +194,7 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
     }
 
     func addWebhook(_ webhook: ExampleWebhookConfig) {
-        webhooks.append(webhook)
+        webhooks.append(configRemovingEmptySensitiveHeaders(from: webhook))
         saveConfig()
     }
 
@@ -208,8 +208,9 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
 
     func updateWebhook(_ webhook: ExampleWebhookConfig) {
         guard let index = webhooks.firstIndex(where: { $0.id == webhook.id }) else { return }
-        clearSecretsRemoved(from: webhooks[index], next: webhook)
-        webhooks[index] = webhook
+        let nextWebhook = configRemovingEmptySensitiveHeaders(from: webhook)
+        clearSecretsRemoved(from: webhooks[index], next: nextWebhook)
+        webhooks[index] = nextWebhook
         saveConfig()
     }
 
@@ -242,9 +243,16 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private func containsEmptySensitiveHeader(_ webhook: ExampleWebhookConfig) -> Bool {
+        webhook.headers.contains { headerName, value in
+            Self.isSensitiveHeader(headerName) && value.isEmpty
+        }
+    }
+
     private func resolveSecretHeaders(_ webhook: ExampleWebhookConfig) -> ExampleWebhookConfig {
-        var resolved = webhook
-        let secretHeaderNames = persistedSecretHeaderNames(for: webhook)
+        clearEmptySensitiveHeaderSecrets(in: webhook)
+        var resolved = configRemovingEmptySensitiveHeaders(from: webhook)
+        let secretHeaderNames = persistedSecretHeaderNames(for: resolved)
 
         for headerName in secretHeaderNames {
             let storageKey = Self.secretStorageKey(webhookID: webhook.id, headerName: headerName)
@@ -260,8 +268,9 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
     }
 
     private func configForPersistence(_ webhook: ExampleWebhookConfig) -> ExampleWebhookConfig {
-        var persisted = webhook
-        let secretHeaderNames = persistedSecretHeaderNames(for: webhook)
+        clearEmptySensitiveHeaderSecrets(in: webhook)
+        var persisted = configRemovingEmptySensitiveHeaders(from: webhook)
+        let secretHeaderNames = persistedSecretHeaderNames(for: persisted)
 
         for headerName in secretHeaderNames {
             guard let value = webhook.headers[headerName], !value.isEmpty else { continue }
@@ -274,6 +283,31 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
 
         persisted.secretHeaderNames = secretHeaderNames
         return persisted
+    }
+
+    private func configRemovingEmptySensitiveHeaders(from webhook: ExampleWebhookConfig) -> ExampleWebhookConfig {
+        let emptySensitiveHeaderNames = Set(webhook.headers.compactMap { headerName, value in
+            Self.isSensitiveHeader(headerName) && value.isEmpty ? Self.normalizeHeaderName(headerName) : nil
+        })
+        guard !emptySensitiveHeaderNames.isEmpty else { return webhook }
+
+        var sanitized = webhook
+        sanitized.headers = webhook.headers.filter { headerName, _ in
+            !emptySensitiveHeaderNames.contains(Self.normalizeHeaderName(headerName))
+        }
+        sanitized.secretHeaderNames = webhook.secretHeaderNames.filter { headerName in
+            !emptySensitiveHeaderNames.contains(Self.normalizeHeaderName(headerName))
+        }
+        return sanitized
+    }
+
+    private func clearEmptySensitiveHeaderSecrets(in webhook: ExampleWebhookConfig) {
+        for (headerName, value) in webhook.headers where Self.isSensitiveHeader(headerName) && value.isEmpty {
+            try? host.storeSecret(
+                key: Self.secretStorageKey(webhookID: webhook.id, headerName: headerName),
+                value: ""
+            )
+        }
     }
 
     private func persistedSecretHeaderNames(for webhook: ExampleWebhookConfig) -> [String] {

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -68,24 +68,64 @@ final class WebhookPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendable {
 // MARK: - Webhook Config Model
 
 struct ExampleWebhookConfig: Codable, Identifiable {
+    static let secretHeaderPlaceholder = "__typewhisper_keychain_secret__"
+
     var id: UUID
     var name: String
     var url: String
     var httpMethod: String
     var headers: [String: String]
+    var secretHeaderNames: [String]
     var isEnabled: Bool
     var profileFilter: [String]  // Empty = all rules
 
     init(name: String = "", url: String = "", httpMethod: String = "POST",
          headers: [String: String] = ["Content-Type": "application/json"],
+         secretHeaderNames: [String] = [],
          isEnabled: Bool = true, profileFilter: [String] = []) {
         self.id = UUID()
         self.name = name
         self.url = url
         self.httpMethod = httpMethod
         self.headers = headers
+        self.secretHeaderNames = secretHeaderNames
         self.isEnabled = isEnabled
         self.profileFilter = profileFilter
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case url
+        case httpMethod
+        case headers
+        case secretHeaderNames
+        case isEnabled
+        case profileFilter
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        url = try container.decode(String.self, forKey: .url)
+        httpMethod = try container.decode(String.self, forKey: .httpMethod)
+        headers = try container.decode([String: String].self, forKey: .headers)
+        secretHeaderNames = try container.decodeIfPresent([String].self, forKey: .secretHeaderNames) ?? []
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        profileFilter = try container.decode([String].self, forKey: .profileFilter)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(url, forKey: .url)
+        try container.encode(httpMethod, forKey: .httpMethod)
+        try container.encode(headers, forKey: .headers)
+        try container.encode(secretHeaderNames, forKey: .secretHeaderNames)
+        try container.encode(isEnabled, forKey: .isEnabled)
+        try container.encode(profileFilter, forKey: .profileFilter)
     }
 }
 
@@ -110,6 +150,23 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
     private let configURL: URL
     private let maxLogEntries = 20
     let host: HostServices
+    private static let sensitiveHeaderNames: Set<String> = [
+        "authorization",
+        "proxy-authorization",
+        "api-key",
+        "x-api-key",
+        "x-auth-token",
+        "x-access-token",
+        "x-webhook-secret",
+        "webhook-secret",
+        "x-hub-signature",
+        "x-hub-signature-256",
+        "x-signature",
+        "signature",
+        "x-signing-secret",
+        "private-token",
+        "token",
+    ]
 
     init(dataDirectory: URL, host: HostServices) {
         self.host = host
@@ -124,11 +181,15 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
     private func loadConfig() {
         guard let data = try? Data(contentsOf: configURL),
               let config = try? JSONDecoder().decode([ExampleWebhookConfig].self, from: data) else { return }
-        webhooks = config
+        webhooks = config.map(resolveSecretHeaders)
+        if config.contains(where: containsPlaintextSecretHeader) {
+            saveConfig()
+        }
     }
 
     func saveConfig() {
-        guard let data = try? JSONEncoder().encode(webhooks) else { return }
+        let persistedWebhooks = webhooks.map(configForPersistence)
+        guard let data = try? JSONEncoder().encode(persistedWebhooks) else { return }
         try? data.write(to: configURL, options: .atomic)
     }
 
@@ -138,14 +199,114 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
     }
 
     func removeWebhook(id: UUID) {
+        if let webhook = webhooks.first(where: { $0.id == id }) {
+            clearStoredSecrets(for: webhook)
+        }
         webhooks.removeAll { $0.id == id }
         saveConfig()
     }
 
     func updateWebhook(_ webhook: ExampleWebhookConfig) {
         guard let index = webhooks.firstIndex(where: { $0.id == webhook.id }) else { return }
+        clearSecretsRemoved(from: webhooks[index], next: webhook)
         webhooks[index] = webhook
         saveConfig()
+    }
+
+    static func secretStorageKey(webhookID: UUID, headerName: String) -> String {
+        let keyComponent = Data(normalizeHeaderName(headerName).utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "webhook.\(webhookID.uuidString).header.\(keyComponent)"
+    }
+
+    static func isSensitiveHeader(_ headerName: String) -> Bool {
+        let normalized = normalizeHeaderName(headerName)
+        return sensitiveHeaderNames.contains(normalized)
+            || normalized.hasSuffix("-token")
+            || normalized.hasSuffix("-secret")
+            || normalized.hasSuffix("-api-key")
+    }
+
+    private static func normalizeHeaderName(_ headerName: String) -> String {
+        headerName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func containsPlaintextSecretHeader(_ webhook: ExampleWebhookConfig) -> Bool {
+        webhook.headers.contains { headerName, value in
+            Self.isSensitiveHeader(headerName)
+                && value != ExampleWebhookConfig.secretHeaderPlaceholder
+                && !value.isEmpty
+        }
+    }
+
+    private func resolveSecretHeaders(_ webhook: ExampleWebhookConfig) -> ExampleWebhookConfig {
+        var resolved = webhook
+        let secretHeaderNames = persistedSecretHeaderNames(for: webhook)
+
+        for headerName in secretHeaderNames {
+            let storageKey = Self.secretStorageKey(webhookID: webhook.id, headerName: headerName)
+            if let secret = host.loadSecret(key: storageKey), !secret.isEmpty {
+                resolved.headers[headerName] = secret
+            } else if resolved.headers[headerName] == ExampleWebhookConfig.secretHeaderPlaceholder {
+                resolved.headers.removeValue(forKey: headerName)
+            }
+        }
+
+        resolved.secretHeaderNames = secretHeaderNames
+        return resolved
+    }
+
+    private func configForPersistence(_ webhook: ExampleWebhookConfig) -> ExampleWebhookConfig {
+        var persisted = webhook
+        let secretHeaderNames = persistedSecretHeaderNames(for: webhook)
+
+        for headerName in secretHeaderNames {
+            guard let value = webhook.headers[headerName], !value.isEmpty else { continue }
+            if value != ExampleWebhookConfig.secretHeaderPlaceholder {
+                let storageKey = Self.secretStorageKey(webhookID: webhook.id, headerName: headerName)
+                try? host.storeSecret(key: storageKey, value: value)
+            }
+            persisted.headers[headerName] = ExampleWebhookConfig.secretHeaderPlaceholder
+        }
+
+        persisted.secretHeaderNames = secretHeaderNames
+        return persisted
+    }
+
+    private func persistedSecretHeaderNames(for webhook: ExampleWebhookConfig) -> [String] {
+        var namesByNormalizedHeader: [String: String] = [:]
+        for headerName in webhook.secretHeaderNames {
+            namesByNormalizedHeader[Self.normalizeHeaderName(headerName)] = headerName
+        }
+        for headerName in webhook.headers.keys where Self.isSensitiveHeader(headerName) {
+            namesByNormalizedHeader[Self.normalizeHeaderName(headerName)] = headerName
+        }
+        return namesByNormalizedHeader.values.sorted {
+            Self.normalizeHeaderName($0) < Self.normalizeHeaderName($1)
+        }
+    }
+
+    private func clearStoredSecrets(for webhook: ExampleWebhookConfig) {
+        for headerName in persistedSecretHeaderNames(for: webhook) {
+            try? host.storeSecret(
+                key: Self.secretStorageKey(webhookID: webhook.id, headerName: headerName),
+                value: ""
+            )
+        }
+    }
+
+    private func clearSecretsRemoved(from previous: ExampleWebhookConfig, next: ExampleWebhookConfig) {
+        let nextNames = Set(persistedSecretHeaderNames(for: next).map(Self.normalizeHeaderName))
+        for headerName in persistedSecretHeaderNames(for: previous)
+            where !nextNames.contains(Self.normalizeHeaderName(headerName)) {
+            try? host.storeSecret(
+                key: Self.secretStorageKey(webhookID: previous.id, headerName: headerName),
+                value: ""
+            )
+        }
     }
 
     // MARK: - Sending


### PR DESCRIPTION
## Summary

- Move sensitive Webhook plugin header values, such as `Authorization` and API token headers, out of `webhooks.json` and into plugin-scoped host secrets.
- Restore secret header values at runtime before sending webhook requests so existing behavior is preserved.
- Migrate legacy plaintext webhook configs on load and add SwiftPM coverage for the Webhook plugin.

## Test Plan

- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path TypeWhisperPluginSDK --filter WebhookPluginTests`
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path TypeWhisperPluginSDK`
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
