### PR TITLE
Handle multichannel USB input capture formats

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -2089,12 +2089,16 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
               let format = AVAudioFormat(
                   commonFormat: .pcmFormatFloat32,
                   sampleRate: hardwareFormat.sampleRate,
-                  channels: hardwareFormat.channelCount,
+                  channels: inputOnlyCaptureChannelCount(for: hardwareFormat.channelCount),
                   interleaved: false
               ) else {
             throw SelectedInputDeviceError.incompatible(.invalidInputFormat)
         }
         return format
+    }
+
+    private static func inputOnlyCaptureChannelCount(for hardwareChannelCount: AVAudioChannelCount) -> AVAudioChannelCount {
+        min(hardwareChannelCount, 2)
     }
 
     func stop() {
@@ -2636,6 +2640,12 @@ extension AudioDeviceService {
 
     func testingShouldSuppressBluetoothPreviewConfigurationChange(now: TimeInterval) -> Bool {
         shouldSuppressBluetoothPreviewConfigurationChange(now: now)
+    }
+}
+
+extension CoreAudioHALInputCaptureSession {
+    static func testingInputOnlyCaptureChannelCount(for hardwareChannelCount: AVAudioChannelCount) -> AVAudioChannelCount {
+        inputOnlyCaptureChannelCount(for: hardwareChannelCount)
     }
 }
 #endif

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1230,6 +1230,12 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
 }
 
 final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
+    func testInputOnlyCaptureCapsMultichannelHardwareToStereoClientFormat() {
+        XCTAssertEqual(CoreAudioHALInputCaptureSession.testingInputOnlyCaptureChannelCount(for: 1), 1)
+        XCTAssertEqual(CoreAudioHALInputCaptureSession.testingInputOnlyCaptureChannelCount(for: 2), 2)
+        XCTAssertEqual(CoreAudioHALInputCaptureSession.testingInputOnlyCaptureChannelCount(for: 14), 2)
+    }
+
     func testSessionConfiguresInputOnlyHALUnitAndPullsInputFromRenderCallback() throws {
         let operations = FakeCoreAudioHALInputOperations()
         let format = try XCTUnwrap(AVAudioFormat(


### PR DESCRIPTION
## Summary
- cap input-only HAL client capture formats at stereo for multichannel devices
- keep hardware channel counts visible in diagnostics while avoiding invalid `AVAudioFormat` creation for devices like RME Babyface Pro
- add coverage for 14-channel hardware falling back to a 2-channel client format

## Context
Diagnostics from an RME Babyface Pro showed `inputChannels: 14` and `inputOnlyCaptureFormatError: incompatible:invalidInputFormat`. TypeWhisper was trying to create the client capture format with all hardware channels even though dictation normalizes to mono after capture.

## Test plan
- `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -derivedDataPath /tmp/typewhisper-multichannel-input-tests -only-testing:TypeWhisperTests/CoreAudioHALInputCaptureSessionTests -only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests`
- `xcodebuild build -scheme TypeWhisper -destination 'platform=macOS' -derivedDataPath /tmp/typewhisper-multichannel-input-build`