### PR TITLE
Extend OpenAI Compatible transcription timeout

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -17,6 +17,7 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedModels: [FetchedModel] = []
+    private static let transcriptionRequestTimeout: TimeInterval = 600
 
     required override init() {
         super.init()
@@ -46,7 +47,11 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
 
     private func makeTranscriptionHelper() -> PluginOpenAITranscriptionHelper? {
         guard let baseURL = _baseURL, !baseURL.isEmpty else { return nil }
-        return PluginOpenAITranscriptionHelper(baseURL: baseURL, responseFormat: "json")
+        return PluginOpenAITranscriptionHelper(
+            baseURL: baseURL,
+            responseFormat: "json",
+            requestTimeout: Self.transcriptionRequestTimeout
+        )
     }
 
     private func makeChatHelper() -> PluginOpenAIChatHelper? {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -86,6 +86,34 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(store.sessions[0].requestedPaths, ["/v1/models"])
     }
 
+    func testTranscribeUsesLongTimeoutForLocalCompatibleServers() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedModel": "large-v3",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"hello"}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/audio/transcriptions", statusCode: 200)
+                )
+            ])
+        }
+
+        let audio = AudioData(samples: [0, 0, 0], wavData: Data("wav".utf8), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: nil, translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "hello")
+        XCTAssertEqual(store.sessions[0].requestedPaths, ["/v1/audio/transcriptions"])
+        XCTAssertEqual(store.sessions[0].requestedRequests.first?.timeoutInterval, 600)
+    }
+
     func testProcessFailsWithoutSelectedModel() async throws {
         let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
         let plugin = OpenAICompatiblePlugin()

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -56,6 +56,8 @@ public extension HostServices {
 /// session so fast plugin requests can keep DNS/TLS/HTTP connections warm.
 public enum PluginHTTPClient {
     private static let logger = Logger(subsystem: "com.typewhisper.sdk", category: "HTTP")
+    private static let defaultRequestTimeout: TimeInterval = 30
+    private static let longRunningResourceTimeout: TimeInterval = 600
     private static let lock = NSLock()
     nonisolated(unsafe) private static var sharedSession: (any PluginHTTPClientSession)?
     nonisolated(unsafe) private static var sessionFactory: (URLSessionConfiguration) -> any PluginHTTPClientSession = {
@@ -140,8 +142,8 @@ public enum PluginHTTPClient {
 
     private static func makeConfiguration() -> URLSessionConfiguration {
         let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 90
+        config.timeoutIntervalForRequest = defaultRequestTimeout
+        config.timeoutIntervalForResource = longRunningResourceTimeout
         return config
     }
 
@@ -257,12 +259,14 @@ public enum PluginTranscriptionError: LocalizedError, Sendable {
 public struct PluginOpenAITranscriptionHelper: Sendable {
     public let baseURL: String
     public let responseFormat: String
+    private let requestTimeout: TimeInterval
     static let minimumUploadDuration: TimeInterval = 1.0
     static let uploadSampleRate = 16000
 
-    public init(baseURL: String, responseFormat: String = "verbose_json") {
+    public init(baseURL: String, responseFormat: String = "verbose_json", requestTimeout: TimeInterval = 30) {
         self.baseURL = baseURL
         self.responseFormat = responseFormat
+        self.requestTimeout = requestTimeout
     }
 
     func normalizedAudioForUpload(_ audio: AudioData) -> AudioData {
@@ -307,7 +311,7 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 30
+        request.timeoutInterval = requestTimeout
 
         let uploadAudio = normalizedAudioForUpload(audio)
         var body = Data()

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
@@ -56,6 +56,22 @@ final class PluginHTTPClientTests: XCTestCase {
         XCTAssertEqual(store.sessions[1].requestedPaths, ["/retry"])
     }
 
+    func testHTTPClientResourceTimeoutAllowsLongRunningRequests() async throws {
+        let store = MockHTTPSessionStore()
+        PluginHTTPClient.configureForTesting { configuration in
+            store.makeSession(outcomes: [.success(Self.okResponse())], configuration: configuration)
+        }
+
+        var request = Self.request(path: "/long-running")
+        request.timeoutInterval = 600
+
+        _ = try await PluginHTTPClient.data(for: request)
+
+        XCTAssertEqual(store.configurations.first?.timeoutIntervalForRequest, 30)
+        XCTAssertEqual(store.configurations.first?.timeoutIntervalForResource, 600)
+        XCTAssertEqual(store.sessions.first?.requestedRequests.first?.timeoutInterval, 600)
+    }
+
     private static func request(path: String) -> URLRequest {
         var request = URLRequest(url: URL(string: "https://example.test\(path)")!)
         request.httpMethod = "POST"
@@ -74,11 +90,18 @@ final class PluginHTTPClientTests: XCTestCase {
 private final class MockHTTPSessionStore: @unchecked Sendable {
     private let lock = NSLock()
     private(set) var sessions: [MockHTTPSession] = []
+    private(set) var configurations: [URLSessionConfiguration] = []
 
-    func makeSession(outcomes: [Result<(Data, URLResponse), Error>]) -> MockHTTPSession {
+    func makeSession(
+        outcomes: [Result<(Data, URLResponse), Error>],
+        configuration: URLSessionConfiguration? = nil
+    ) -> MockHTTPSession {
         let session = MockHTTPSession(outcomes: outcomes)
         lock.withLock {
             sessions.append(session)
+            if let configuration {
+                configurations.append(configuration)
+            }
         }
         return session
     }
@@ -88,6 +111,7 @@ private final class MockHTTPSession: PluginHTTPClientSession, @unchecked Sendabl
     private let lock = NSLock()
     private var outcomes: [Result<(Data, URLResponse), Error>]
     private(set) var requestedPaths: [String] = []
+    private(set) var requestedRequests: [URLRequest] = []
     private(set) var didInvalidate = false
 
     init(outcomes: [Result<(Data, URLResponse), Error>]) {
@@ -96,6 +120,7 @@ private final class MockHTTPSession: PluginHTTPClientSession, @unchecked Sendabl
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         let outcome = lock.withLock {
+            requestedRequests.append(request)
             requestedPaths.append(request.url?.path ?? "")
             if outcomes.count > 1 {
                 return outcomes.removeFirst()


### PR DESCRIPTION
## Summary
- Add a request-timeout override to the shared OpenAI-compatible transcription helper while preserving the existing 30s default.
- Use a fixed 600s timeout for OpenAI Compatible plugin transcription requests so local Whisper servers can finish long jobs without adding a user-facing setting.
- Raise the shared plugin HTTP resource timeout to 600s so long-running per-request timeouts are not capped, while `/v1/models` fetch and validation requests keep their explicit 10s timeouts.

## Issue context
Issue #518 reports that local OpenAI-compatible Whisper servers, especially with large files or large-v3 models, can take longer than the previous request window. The product decision here is to support that use case with a built-in longer transcription timeout rather than adding timeout configuration to Settings.

Closes #518

## Related follow-up
Created TypeWhisper/typewhisper.com#65 for the broken website source link reported in the issue comments.

## Test plan
- `swift test --package-path TypeWhisperPluginSDK`