### PR TITLE
Fix Parakeet onboarding completion

### DIFF
--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -191,6 +191,7 @@ final class PluginManager: ObservableObject {
 
     @Published var loadedPlugins: [LoadedPlugin] = []
     @Published private(set) var incompatibleExternalBundles: [String: IncompatibleExternalBundle] = [:]
+    @Published private(set) var readinessRevision = 0
 
     let pluginsDirectory: URL
     private var ruleNamesProvider: @MainActor () -> [String] = { [] }
@@ -643,7 +644,7 @@ final class PluginManager: ObservableObject {
 
     /// Notify observers that plugin state changed (e.g. a model was loaded/unloaded)
     func notifyPluginStateChanged() {
-        objectWillChange.send()
+        readinessRevision += 1
     }
 
     // MARK: - Dynamic Plugin Management

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -1103,14 +1103,26 @@ struct SetupWizardView: View {
                     .buttonStyle(.bordered)
                 }
 
-                Button(String(localized: "Next")) {
-                    withAnimation { currentStep += 1 }
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!canProceed)
+                nextButton
             }
         }
         .padding()
+    }
+
+    @ViewBuilder
+    private var nextButton: some View {
+        if canProceed {
+            Button(String(localized: "Next")) {
+                withAnimation { currentStep += 1 }
+            }
+            .buttonStyle(.borderedProminent)
+            .frame(minWidth: 72)
+        } else {
+            Button(String(localized: "Next")) {}
+                .buttonStyle(.bordered)
+                .disabled(true)
+                .frame(minWidth: 72)
+        }
     }
 
     // MARK: - Helpers
@@ -1126,7 +1138,8 @@ struct SetupWizardView: View {
     }
 
     private var hasAnyEngineReady: Bool {
-        pluginManager.transcriptionEngines.contains { $0.isConfigured }
+        _ = pluginManager.readinessRevision
+        return pluginManager.transcriptionEngines.contains { $0.isConfigured }
     }
 
     private var hasAnyHotkeySet: Bool {

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings
@@ -31,6 +31,16 @@
         }
       }
     },
+    "Done" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        }
+      }
+    },
     "Downloading CTC model..." : {
       "localizations" : {
         "de" : {

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -18,7 +18,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     fileprivate var asrManager: AsrManager?
     fileprivate var loadedModelId: String?
     fileprivate var _selectedModelId: String?
-    fileprivate var modelState: ParakeetModelState = .notLoaded
+    var modelState: ParakeetModelState = .notLoaded
     fileprivate var downloadProgress: Double = 0
     fileprivate var selectedVersion: ParakeetVersion = .v3
     fileprivate var _hfToken: String?
@@ -82,6 +82,13 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     var isConfigured: Bool {
         asrManager != nil && loadedModelId != nil
+    }
+
+    var canDismissSettingsAfterSetup: Bool {
+        if case .ready = modelState {
+            return true
+        }
+        return false
     }
 
     var transcriptionModels: [PluginModelInfo] {
@@ -645,6 +652,8 @@ enum CtcModelState: Equatable {
 private struct ParakeetSettingsView: View {
     let plugin: ParakeetPlugin
     private let bundle = Bundle(for: ParakeetPlugin.self)
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.pluginSettingsClose) private var closeSettings
     @State private var selectedVersion: ParakeetVersion = .v3
     @State private var modelState: ParakeetModelState = .notLoaded
     @State private var downloadProgress: Double = 0
@@ -672,163 +681,118 @@ private struct ParakeetSettingsView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Parakeet")
-                .font(.headline)
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Parakeet")
+                    .font(.headline)
 
-            Text(selectedVersion.settingsDescription(bundle: bundle))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Hugging Face Token", bundle: bundle)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-
-                Text("Optional. Increases download rate limits. Free at huggingface.co/settings/tokens", bundle: bundle)
-                    .font(.caption)
+                Text(selectedVersion.settingsDescription(bundle: bundle))
+                    .font(.callout)
                     .foregroundStyle(.secondary)
 
-                HStack {
-                    if showHfToken {
-                        TextField("hf_...", text: $hfTokenInput)
-                            .textFieldStyle(.roundedBorder)
-                    } else {
-                        SecureField("hf_...", text: $hfTokenInput)
-                            .textFieldStyle(.roundedBorder)
-                    }
+                Divider()
 
-                    Button {
-                        showHfToken.toggle()
-                    } label: {
-                        Image(systemName: showHfToken ? "eye.slash" : "eye")
-                    }
-                    .buttonStyle(.borderless)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Hugging Face Token", bundle: bundle)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
 
-                    if hasStoredHfToken {
-                        Button(String(localized: "Remove", bundle: bundle)) {
-                            hfTokenInput = ""
-                            tokenValidationResult = nil
-                            isValidatingToken = false
-                            plugin.clearHuggingFaceToken()
+                    Text("Optional. Increases download rate limits. Free at huggingface.co/settings/tokens", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        if showHfToken {
+                            TextField("hf_...", text: $hfTokenInput)
+                                .textFieldStyle(.roundedBorder)
+                        } else {
+                            SecureField("hf_...", text: $hfTokenInput)
+                                .textFieldStyle(.roundedBorder)
                         }
-                        .buttonStyle(.bordered)
+
+                        Button {
+                            showHfToken.toggle()
+                        } label: {
+                            Image(systemName: showHfToken ? "eye.slash" : "eye")
+                        }
+                        .buttonStyle(.borderless)
+
+                        if hasStoredHfToken {
+                            Button(String(localized: "Remove", bundle: bundle)) {
+                                hfTokenInput = ""
+                                tokenValidationResult = nil
+                                isValidatingToken = false
+                                plugin.clearHuggingFaceToken()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            validateAndSaveHuggingFaceToken()
+                        }
+                        .buttonStyle(.borderedProminent)
                         .controlSize(.small)
+                        .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
                     }
 
-                    Button(String(localized: "Save", bundle: bundle)) {
-                        validateAndSaveHuggingFaceToken()
+                    if isValidatingToken {
+                        HStack(spacing: 4) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Validating token...", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if let tokenValidationResult {
+                        HStack(spacing: 4) {
+                            Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .foregroundStyle(tokenValidationResult ? .green : .red)
+                            Text(
+                                tokenValidationResult
+                                    ? String(localized: "Valid Hugging Face Token", bundle: bundle)
+                                    : String(localized: "Invalid Hugging Face Token", bundle: bundle)
+                            )
+                            .font(.caption)
+                            .foregroundStyle(tokenValidationResult ? .green : .red)
+                        }
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .disabled(trimmedHfTokenInput.isEmpty || isValidatingToken)
                 }
 
-                if isValidatingToken {
-                    HStack(spacing: 4) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Validating token...", bundle: bundle)
+                Divider()
+
+                // Model version picker
+                HStack {
+                    Text("Model Version", bundle: bundle)
+                    Spacer()
+                    Picker("", selection: $selectedVersion) {
+                        ForEach(ParakeetVersion.allCases, id: \.self) { version in
+                            Text(version.modelDef.displayName).tag(version)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .fixedSize()
+                    .disabled(modelState == .downloading)
+                }
+
+                // Model info and action
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(selectedVersion.modelDef.displayName)
+                            .font(.body)
+                        Text("\(selectedVersion.modelDef.sizeDescription) - RAM: \(selectedVersion.modelDef.ramRequirement)")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                } else if let tokenValidationResult {
-                    HStack(spacing: 4) {
-                        Image(systemName: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill")
-                            .foregroundStyle(tokenValidationResult ? .green : .red)
-                        Text(
-                            tokenValidationResult
-                                ? String(localized: "Valid Hugging Face Token", bundle: bundle)
-                                : String(localized: "Invalid Hugging Face Token", bundle: bundle)
-                        )
-                        .font(.caption)
-                        .foregroundStyle(tokenValidationResult ? .green : .red)
-                    }
-                }
-            }
 
-            Divider()
+                    Spacer()
 
-            // Model version picker
-            HStack {
-                Text("Model Version", bundle: bundle)
-                Spacer()
-                Picker("", selection: $selectedVersion) {
-                    ForEach(ParakeetVersion.allCases, id: \.self) { version in
-                        Text(version.modelDef.displayName).tag(version)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.segmented)
-                .fixedSize()
-                .disabled(modelState == .downloading)
-            }
-
-            // Model info and action
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(selectedVersion.modelDef.displayName)
-                        .font(.body)
-                    Text("\(selectedVersion.modelDef.sizeDescription) - RAM: \(selectedVersion.modelDef.ramRequirement)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                switch modelState {
-                case .notLoaded:
-                    Button(String(localized: "Download & Load", bundle: bundle)) {
-                        modelState = .downloading
-                        downloadProgress = 0.05
-                        isPolling = true
-                        Task {
-                            await plugin.loadModel()
-                            isPolling = false
-                            modelState = plugin.modelState
-                            downloadProgress = plugin.downloadProgress
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-
-                case .downloading:
-                    HStack(spacing: 8) {
-                        ProgressView(value: downloadProgress)
-                            .frame(width: 80)
-                        Text("\(Int(downloadProgress * 100))%")
-                            .font(.caption)
-                            .monospacedDigit()
-                    }
-
-                case .ready:
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Button(String(localized: "Unload", bundle: bundle)) {
-                            plugin.unloadModel()
-                            modelState = plugin.modelState
-                            ctcModelState = plugin.ctcModelState
-                            boostingTermCount = 0
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-
-                case .error(let message):
-                    VStack(alignment: .trailing, spacing: 4) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.orange)
-                            Text(message)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-                        Button(String(localized: "Retry", bundle: bundle)) {
+                    switch modelState {
+                    case .notLoaded:
+                        Button(String(localized: "Download & Load", bundle: bundle)) {
                             modelState = .downloading
+                            downloadProgress = 0.05
                             isPolling = true
                             Task {
                                 await plugin.loadModel()
@@ -837,19 +801,83 @@ private struct ParakeetSettingsView: View {
                                 downloadProgress = plugin.downloadProgress
                             }
                         }
-                        .buttonStyle(.bordered)
-                        .controlSize(.mini)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+
+                    case .downloading:
+                        HStack(spacing: 8) {
+                            ProgressView(value: downloadProgress)
+                                .frame(width: 80)
+                            Text("\(Int(downloadProgress * 100))%")
+                                .font(.caption)
+                                .monospacedDigit()
+                        }
+
+                    case .ready:
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Button(String(localized: "Unload", bundle: bundle)) {
+                                plugin.unloadModel()
+                                modelState = plugin.modelState
+                                ctcModelState = plugin.ctcModelState
+                                boostingTermCount = 0
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                    case .error(let message):
+                        VStack(alignment: .trailing, spacing: 4) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.orange)
+                                Text(message)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                            Button(String(localized: "Retry", bundle: bundle)) {
+                                modelState = .downloading
+                                isPolling = true
+                                Task {
+                                    await plugin.loadModel()
+                                    isPolling = false
+                                    modelState = plugin.modelState
+                                    downloadProgress = plugin.downloadProgress
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.mini)
+                        }
                     }
                 }
-            }
-            .padding(.vertical, 4)
+                .padding(.vertical, 4)
 
-            if case .ready = modelState {
+                if case .ready = modelState {
+                    Divider()
+                    vocabularyBoostingSection
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+
+            if plugin.canDismissSettingsAfterSetup {
                 Divider()
-                vocabularyBoostingSection
+
+                HStack {
+                    Spacer()
+
+                    Button(String(localized: "Done", bundle: bundle)) {
+                        finishSetupAndClose()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                }
+                .padding()
+                .background(.bar)
             }
         }
-        .padding()
         .onAppear {
             selectedVersion = plugin.selectedVersion
             modelState = plugin.modelState
@@ -1002,6 +1030,15 @@ private struct ParakeetSettingsView: View {
                     hfTokenInput = trimmedToken
                 }
             }
+        }
+    }
+
+    private func finishSetupAndClose() {
+        plugin.host?.notifyCapabilitiesChanged()
+        if let closeSettings {
+            closeSettings()
+        } else {
+            dismiss()
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -124,6 +124,21 @@ final class ParakeetPluginTests: XCTestCase {
         XCTAssertEqual(enabledPlugin.dictionaryTermsSupport, .supported)
     }
 
+    func testSettingsDismissalRequiresOnlyBaseModelReadiness() throws {
+        let host = try PluginTestHostServices(defaults: ["vocabularyBoostingEnabled": true])
+        let plugin = makePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.canDismissSettingsAfterSetup)
+
+        plugin.ctcModelState = .ready
+        XCTAssertFalse(plugin.canDismissSettingsAfterSetup)
+
+        plugin.modelState = .ready
+        plugin.ctcModelState = .downloading
+        XCTAssertTrue(plugin.canDismissSettingsAfterSetup)
+    }
+
     func testEnablingVocabularyBoostingPersistsAndNotifiesCapabilityChange() throws {
         let host = try PluginTestHostServices()
         let plugin = makePlugin()

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
-    "version": "1.2.4",
+    "version": "1.2.12",
     "minHostVersion": "1.2.1",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
@@ -74,6 +75,26 @@ final class PluginManifestValidationTests: XCTestCase {
             LanguageSelection.hints(["fr", "uk"]).normalizedForSupportedLanguages(Qwen3Plugin.qwenSupportedLanguageCodes),
             .exact("fr")
         )
+    }
+
+    @MainActor
+    func testNotifyPluginStateChangedIncrementsReadinessRevisionAndNotifiesObservers() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let initialRevision = manager.readinessRevision
+        let notification = expectation(description: "plugin manager publishes readiness change")
+
+        let cancellable = manager.objectWillChange.sink {
+            notification.fulfill()
+        }
+
+        manager.notifyPluginStateChanged()
+
+        XCTAssertEqual(manager.readinessRevision, initialRevision + 1)
+        wait(for: [notification], timeout: 1)
+        withExtendedLifetime(cancellable) {}
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a Parakeet settings `Done` action once the base ASR model is ready, notifying host capabilities before closing.
- Publishes a PluginManager readiness revision so onboarding recomputes engine readiness after plugin capability changes.
- Keeps disabled onboarding `Next` visible in inactive windows and bumps Parakeet to `1.2.12`.

## Issue Context
Issue #521 reports that TypeWhisper 1.4 RC3 onboarding can dead-end after Parakeet setup: the settings window has no explicit completion action, closing it does not refresh Step 2 readiness, and the disabled `Next` button can disappear visually when the window is inactive.

Closes #521

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter ParakeetPluginTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginManifestValidationTests`
- Manual dev smoke: rebuilt `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`, installed `/Users/marco/Library/Application Support/TypeWhisper-Dev/Plugins/ParakeetPlugin.bundle`, and verified the Parakeet bundle loads in the dev app.
