### PR TITLE
Fix onboarding welcome layout

### DIFF
--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -114,57 +114,21 @@ struct SetupWizardView: View {
     // MARK: - Step 0: Welcome
 
     private var welcomeStep: some View {
-        VStack(spacing: 24) {
-            Spacer()
-
-            Image(nsImage: NSApplication.shared.applicationIconImage)
-                .resizable()
-                .frame(width: 96, height: 96)
-
-            Text(String(localized: "Welcome to TypeWhisper"))
-                .font(.largeTitle.weight(.bold))
-
-            Text(String(localized: "Voice-powered typing for your Mac"))
-                .font(.title3)
-                .foregroundStyle(.secondary)
-
-            VStack(alignment: .leading, spacing: 16) {
-                featureHighlight(
-                    icon: "waveform",
-                    title: String(localized: "Speak"),
-                    description: String(localized: "Press a hotkey and talk naturally in any app.")
-                )
-                featureHighlight(
-                    icon: "text.cursor",
-                    title: String(localized: "Type"),
-                    description: String(localized: "Your words appear as text instantly.")
-                )
-                featureHighlight(
-                    icon: "wand.and.stars",
-                    title: String(localized: "Enhance"),
-                    description: String(localized: "AI prompts can rewrite, translate, or summarize.")
-                )
-            }
-            .frame(maxWidth: 380)
-
-            VStack(alignment: .leading, spacing: 10) {
-                Text(String(localized: "What kind of writing do you do most?"))
-                    .font(.headline)
-
-                ForEach(IndustryPreset.allCases) { preset in
-                    industryOption(preset)
+        VStack(spacing: 0) {
+            GeometryReader { proxy in
+                ScrollView {
+                    welcomeContent(twoColumn: proxy.size.width >= 640)
+                        .padding(.horizontal, proxy.size.width >= 520 ? 14 : 28)
+                        .padding(.top, 24)
+                        .padding(.bottom, 14)
+                        .frame(maxWidth: .infinity, minHeight: proxy.size.height, alignment: .top)
                 }
-
-                Text(String(localized: "Industry term packs are prepared during setup and activated automatically when a commercial license is active."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(maxWidth: 420)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            Spacer()
+            Divider()
 
-            VStack(spacing: 12) {
+            VStack(spacing: 8) {
                 Button(String(localized: "Get Started")) {
                     applyIndustrySelection()
                     withAnimation { currentStep = 1 }
@@ -179,30 +143,116 @@ struct SetupWizardView: View {
                 .foregroundStyle(.secondary)
                 .font(.callout)
             }
-            .padding(.bottom, 24)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 12)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func welcomeContent(twoColumn: Bool) -> some View {
+        if twoColumn {
+            VStack(spacing: 16) {
+                welcomeHeader
+
+                HStack(alignment: .top, spacing: 24) {
+                    welcomeFeatureColumn
+                        .frame(width: 230, alignment: .leading)
+                    industryPresetColumn
+                        .frame(width: 360, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+        } else {
+            VStack(spacing: 16) {
+                welcomeHeader
+                welcomeFeatureColumn
+                industryPresetColumn
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var welcomeHeader: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: NSApplication.shared.applicationIconImage)
+                .resizable()
+                .frame(width: 68, height: 68)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Welcome to TypeWhisper"))
+                    .font(.title.weight(.bold))
+                    .lineLimit(1)
+
+                Text(String(localized: "Voice-powered typing for your Mac"))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private var welcomeFeatureColumn: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            featureHighlight(
+                icon: "waveform",
+                title: String(localized: "Speak"),
+                description: String(localized: "Press a hotkey and talk naturally in any app.")
+            )
+            featureHighlight(
+                icon: "text.cursor",
+                title: String(localized: "Type"),
+                description: String(localized: "Your words appear as text instantly.")
+            )
+            featureHighlight(
+                icon: "wand.and.stars",
+                title: String(localized: "Enhance"),
+                description: String(localized: "AI prompts can rewrite, translate, or summarize.")
+            )
+        }
+        .frame(maxWidth: 230, alignment: .leading)
+    }
+
+    private var industryPresetColumn: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: "What kind of writing do you do most?"))
+                .font(.title3.weight(.semibold))
+
+            ForEach(IndustryPreset.allCases) { preset in
+                industryOption(preset)
+            }
+
+            Text(String(localized: "Industry term packs are prepared during setup and activated automatically when a commercial license is active."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: 360, alignment: .leading)
     }
 
     private func industryOption(_ preset: IndustryPreset) -> some View {
         let isSelected = selectedIndustryPreset == preset
 
-        return HStack(spacing: 12) {
+        return HStack(spacing: 10) {
             Image(systemName: isSelected ? "largecircle.fill.circle" : preset.systemImage)
+                .font(.callout)
                 .foregroundStyle(isSelected ? Color.accentColor : .secondary)
-                .frame(width: 24)
+                .frame(width: 22)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 1) {
                 Text(preset.displayName)
-                    .font(.body.weight(.medium))
+                    .font(.headline)
                 Text(preset.description)
-                    .font(.caption)
+                    .font(.callout)
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
 
             Spacer()
         }
-        .padding(10)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
         .background(RoundedRectangle(cornerRadius: 8).fill(isSelected ? Color.accentColor.opacity(0.08) : Color.secondary.opacity(0.08)))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(isSelected ? Color.accentColor.opacity(0.35) : Color.clear, lineWidth: 1))
         .contentShape(Rectangle())
@@ -216,19 +266,20 @@ struct SetupWizardView: View {
     }
 
     private func featureHighlight(icon: String, title: String, description: String) -> some View {
-        HStack(spacing: 14) {
+        HStack(alignment: .top, spacing: 10) {
             Image(systemName: icon)
-                .font(.title2)
+                .font(.title3)
                 .foregroundStyle(.blue)
-                .frame(width: 36, height: 36)
+                .frame(width: 24)
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 1) {
                 Text(title)
                     .font(.headline)
                 Text(description)
                     .font(.callout)
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -47,11 +47,7 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
 
     private func makeTranscriptionHelper() -> PluginOpenAITranscriptionHelper? {
         guard let baseURL = _baseURL, !baseURL.isEmpty else { return nil }
-        return PluginOpenAITranscriptionHelper(
-            baseURL: baseURL,
-            responseFormat: "json",
-            requestTimeout: Self.transcriptionRequestTimeout
-        )
+        return PluginOpenAITranscriptionHelper(baseURL: baseURL, responseFormat: "json")
     }
 
     private func makeChatHelper() -> PluginOpenAIChatHelper? {
@@ -117,7 +113,8 @@ final class OpenAICompatiblePlugin: NSObject, TranscriptionEnginePlugin, Diction
             modelName: modelId,
             language: language,
             translate: translate,
-            prompt: prompt
+            prompt: prompt,
+            requestTimeout: Self.transcriptionRequestTimeout
         )
     }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -259,14 +259,13 @@ public enum PluginTranscriptionError: LocalizedError, Sendable {
 public struct PluginOpenAITranscriptionHelper: Sendable {
     public let baseURL: String
     public let responseFormat: String
-    private let requestTimeout: TimeInterval
+    private static let defaultRequestTimeout: TimeInterval = 30
     static let minimumUploadDuration: TimeInterval = 1.0
     static let uploadSampleRate = 16000
 
-    public init(baseURL: String, responseFormat: String = "verbose_json", requestTimeout: TimeInterval = 30) {
+    public init(baseURL: String, responseFormat: String = "verbose_json") {
         self.baseURL = baseURL
         self.responseFormat = responseFormat
-        self.requestTimeout = requestTimeout
     }
 
     func normalizedAudioForUpload(_ audio: AudioData) -> AudioData {
@@ -294,6 +293,50 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         translate: Bool,
         prompt: String?,
         responseFormat: String? = nil
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            requestTimeout: Self.defaultRequestTimeout
+        )
+    }
+
+    public func transcribe(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            requestTimeout: requestTimeout
+        )
+    }
+
+    private func performTranscribe(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        responseFormat: String?,
+        requestTimeout: TimeInterval
     ) async throws -> PluginTranscriptionResult {
         let endpoint: String
         if translate {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -1,7 +1,18 @@
+import Foundation
 import XCTest
-@testable import TypeWhisperPluginSDK
+@_spi(Testing) @testable import TypeWhisperPluginSDK
 
 final class OpenAITranscriptionHelperTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClient.resetTestingHooks()
+        super.tearDown()
+    }
+
+    func testHelperInstanceLayoutStaysBinaryCompatibleWithExistingPluginBundles() {
+        XCTAssertEqual(MemoryLayout<PluginOpenAITranscriptionHelper>.size, MemoryLayout<String>.size * 2)
+        XCTAssertEqual(MemoryLayout<PluginOpenAITranscriptionHelper>.stride, MemoryLayout<String>.stride * 2)
+    }
+
     func testPluginAudioUtilsPadsShortSamplesToMinimumDuration() {
         let samples = [Float](repeating: 0.1, count: 6_400)
 
@@ -85,4 +96,66 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         XCTAssertEqual(normalized.duration, audio.duration, accuracy: 0.0001)
         XCTAssertEqual(normalized.wavData, wavData)
     }
+
+    func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession()
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let result = try await helper.transcribe(
+            audio: audio,
+            apiKey: "test-key",
+            modelName: "whisper-1",
+            language: "en",
+            translate: false,
+            prompt: nil,
+            requestTimeout: 600
+        )
+
+        XCTAssertEqual(result.text, "ok")
+        XCTAssertEqual(store.sessions.first?.requestedRequests.first?.timeoutInterval, 600)
+    }
+}
+
+private final class OpenAITranscriptionMockSessionStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var sessions: [OpenAITranscriptionMockSession] = []
+
+    func makeSession() -> OpenAITranscriptionMockSession {
+        let session = OpenAITranscriptionMockSession()
+        lock.withLock {
+            sessions.append(session)
+        }
+        return session
+    }
+}
+
+private final class OpenAITranscriptionMockSession: PluginHTTPClientSession, @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var requestedRequests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lock.withLock {
+            requestedRequests.append(request)
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (Data(#"{"text":"ok","language":"en"}"#.utf8), response)
+    }
+
+    func finishTasksAndInvalidate() {}
 }


### PR DESCRIPTION
## Summary
- Fixes the fresh-start onboarding welcome step so `Get Started` and `Skip Setup` stay visible in a fixed footer while the welcome content scrolls above it.
- Reworks the welcome content into a compact two-column layout at normal Settings width, with the logo/title header above the columns and a one-column fallback for narrow widths.
- Keeps existing onboarding actions, localization strings, industry preset behavior, and Settings window sizing unchanged.
- Preserves `PluginOpenAITranscriptionHelper` instance layout compatibility and moves custom transcription timeout handling to a method overload, preventing existing plugin bundles from crashing after the SDK timeout change noticed during local wizard testing.

Closes #520

## Test plan
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAITranscriptionHelperTests`
- `swift test --package-path TypeWhisperPluginSDK --filter PluginHTTPClientTests`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`
- `defaults write com.typewhisper.mac.dev setupWizardCompleted -bool false`
- `defaults delete com.typewhisper.mac.dev setupWizardCurrentStep || true`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7844/typewhisper-mac`
- Visual local check: onboarding opens on the welcome step, the footer actions remain visible at the default Settings window size, the welcome content uses the two-column layout, the upper content scrolls when needed, and `Get Started` advances to the next step.
