### PR TITLE
Add experimental Supertonic TTS plugin

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -79,6 +79,7 @@ jobs:
             cohere) TARGET="CoherePlugin" ;;
             speechmatics) TARGET="SpeechmaticsPlugin" ;;
             system-tts) TARGET="SystemTTSPlugin" ;;
+            supertonic) TARGET="SupertonicPlugin" ;;
             filler-words) TARGET="FillerWordsPlugin" ;;
             xai) TARGET="XAIPlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 - **Workflows** - Build reusable transformations for translation, rewriting, extraction, formatting, and app-specific automation. Workflows can run automatically by app, website, or app + website combinations, from a dedicated hotkey, as a global fallback, or manually from the Workflow Palette. Hotkey workflows can either start dictation or process the current selection/clipboard directly.
 - **LLM providers** - Apple Intelligence (macOS 26+), Groq, OpenAI / ChatGPT, xAI/Grok, Gemini, and OpenAI Compatible with per-prompt provider and model override
-- **Speech providers** - System voices and xAI/Grok TTS can provide spoken feedback and readback
+- **Speech providers** - System voices, xAI/Grok TTS, and experimental local Supertonic TTS can provide spoken feedback and readback
 - **Local prompt processing** - Gemma 4 via MLX runs on-device on Apple Silicon, with the current verified release path limited to the E2B/E4B 4-bit models
 - **Translation** - Translate transcriptions on-device using Apple Translate
 
@@ -85,8 +85,8 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 ### Integration & Extensibility
 
-- **Plugin system** - Extend TypeWhisper with custom LLM providers, transcription engines, TTS providers, post-processors, and action plugins. Granite, Groq, OpenAI / ChatGPT, OpenAI Compatible, xAI/Grok, Gemini, Linear, Qwen3, Voxtral, and Webhook ship as bundled plugins, alongside the local engine plugins. Linear plugin enables voice-to-issue creation. See [TypeWhisperPluginSDK/Plugins/README.md](TypeWhisperPluginSDK/Plugins/README.md)
-- **MLX download controls** - Bundled Qwen3, Granite, and Voxtral plugins support an optional HuggingFace token for higher rate limits and clearer download errors
+- **Plugin system** - Extend TypeWhisper with custom LLM providers, transcription engines, TTS providers, post-processors, and action plugins. Granite, Groq, OpenAI / ChatGPT, OpenAI Compatible, xAI/Grok, Gemini, Linear, Qwen3, Supertonic, Voxtral, and Webhook ship as bundled plugins, alongside the local engine plugins. Linear plugin enables voice-to-issue creation. See [TypeWhisperPluginSDK/Plugins/README.md](TypeWhisperPluginSDK/Plugins/README.md)
+- **Local model download controls** - Bundled Qwen3, Granite, Voxtral, and Supertonic plugins support an optional HuggingFace token for higher rate limits and clearer download errors. Supertonic requires explicit OpenRAIL-M model-license acceptance before model assets download.
 - **HTTP API** - Local REST API for integration with external tools and scripts
 - **CLI tool** - Shell-friendly transcription via the command line
 - **Discord claim service** - Optional external service for Polar supporter and GitHub Sponsors Discord role claims
@@ -394,7 +394,7 @@ Multiple engines can be loaded simultaneously for instant switching between work
 
 TypeWhisper supports plugins for adding custom LLM providers, transcription engines, TTS providers, post-processors, and action plugins. Plugins are macOS `.bundle` files placed in `~/Library/Application Support/TypeWhisper/Plugins/`.
 
-All 13 engines and integrations (WhisperKit, Parakeet, SpeechAnalyzer, Granite, Qwen3, Voxtral, Groq, OpenAI, xAI/Grok, OpenAI Compatible, Gemini, Linear, Webhook) are implemented as bundled plugins and serve as reference implementations.
+Bundled engines and integrations (WhisperKit, Parakeet, SpeechAnalyzer, Granite, Qwen3, Voxtral, Supertonic, Groq, OpenAI, xAI/Grok, OpenAI Compatible, Gemini, Linear, Webhook, and more) are implemented as plugins and serve as reference implementations.
 
 See [TypeWhisperPluginSDK/Plugins/README.md](TypeWhisperPluginSDK/Plugins/README.md) for the full plugin development guide, including the event bus, host services API, and manifest format.
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -28,6 +28,13 @@
 		A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000001 /* SystemTTSPlugin.swift */; };
 		A10000000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000002 /* manifest.json */; };
 		A10000000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000044 /* TypeWhisperPluginSDK */; };
+		D20000000000000000000001 /* SupertonicPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000001 /* SupertonicPlugin.swift */; };
+		D20000000000000000000002 /* SupertonicModelAssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000002 /* SupertonicModelAssetManager.swift */; };
+		D20000000000000000000003 /* SupertonicPlaybackSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000003 /* SupertonicPlaybackSession.swift */; };
+		D20000000000000000000004 /* SupertonicRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000004 /* SupertonicRuntime.swift */; };
+		D20000000000000000000005 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000005 /* manifest.json */; };
+		D20000000000000000000006 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = D20700000000000000000001 /* TypeWhisperPluginSDK */; };
+		D20000000000000000000007 /* onnxruntime in Frameworks */ = {isa = PBXBuildFile; productRef = D20700000000000000000002 /* onnxruntime */; };
 		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
 		A10000000000000000000006 /* WorkflowServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000005 /* WorkflowServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
@@ -677,6 +684,12 @@
 		B10000000000000000000001 /* SystemTTSPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTTSPlugin.swift; sourceTree = "<group>"; };
 		B10000000000000000000002 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		B10000000000000000000003 /* SystemTTSPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SystemTTSPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		D20100000000000000000001 /* SupertonicPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicPlugin.swift; sourceTree = "<group>"; };
+		D20100000000000000000002 /* SupertonicModelAssetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicModelAssetManager.swift; sourceTree = "<group>"; };
+		D20100000000000000000003 /* SupertonicPlaybackSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicPlaybackSession.swift; sourceTree = "<group>"; };
+		D20100000000000000000004 /* SupertonicRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicRuntime.swift; sourceTree = "<group>"; };
+		D20100000000000000000005 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		D20100000000000000000006 /* SupertonicPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SupertonicPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000232 /* OpenAIVectorMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIVectorMemoryPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000233 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenAIVectorMemoryPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1019,6 +1032,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D20400000000000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D20000000000000000000006 /* TypeWhisperPluginSDK in Frameworks */,
+				D20000000000000000000007 /* onnxruntime in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000120 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1174,6 +1196,7 @@
 				CC00000000000000000034 /* CloudflareASRPlugin */,
 				CC00000000000000000035 /* FileMemoryPlugin */,
 				C10000000000000000000001 /* SystemTTSPlugin */,
+				D20200000000000000000001 /* SupertonicPlugin */,
 				CC00000000000000000036 /* OpenAIVectorMemoryPlugin */,
 				CC00000000000000000037 /* FireworksPlugin */,
 				CC00000000000000000038 /* CerebrasPlugin */,
@@ -1703,6 +1726,19 @@
 			path = TypeWhisperPluginSDK/Plugins/SystemTTSPlugin;
 			sourceTree = "<group>";
 		};
+		D20200000000000000000001 /* SupertonicPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				D20100000000000000000001 /* SupertonicPlugin.swift */,
+				D20100000000000000000002 /* SupertonicModelAssetManager.swift */,
+				D20100000000000000000003 /* SupertonicPlaybackSession.swift */,
+				D20100000000000000000004 /* SupertonicRuntime.swift */,
+				D20100000000000000000005 /* manifest.json */,
+			);
+			name = SupertonicPlugin;
+			path = TypeWhisperPluginSDK/Plugins/SupertonicPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000036 /* OpenAIVectorMemoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -1872,6 +1908,7 @@
 				BB00000000000000000227 /* CloudflareASRPlugin.bundle */,
 				BB00000000000000000231 /* FileMemoryPlugin.bundle */,
 				B10000000000000000000003 /* SystemTTSPlugin.bundle */,
+				D20100000000000000000006 /* SupertonicPlugin.bundle */,
 				BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */,
 				BB00000000000000000254 /* FireworksPlugin.bundle */,
 				BB00000000000000000257 /* CerebrasPlugin.bundle */,
@@ -2475,6 +2512,28 @@
 			productReference = B10000000000000000000003 /* SystemTTSPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		D20300000000000000000001 /* SupertonicPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D20500000000000000000003 /* Build configuration list for PBXNativeTarget "SupertonicPlugin" */;
+			buildPhases = (
+				D20400000000000000000004 /* Copy ONNX Runtime Module Map */,
+				D20400000000000000000002 /* Sources */,
+				D20400000000000000000003 /* Frameworks */,
+				D20400000000000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SupertonicPlugin;
+			packageProductDependencies = (
+				D20700000000000000000001 /* TypeWhisperPluginSDK */,
+				D20700000000000000000002 /* onnxruntime */,
+			);
+			productName = SupertonicPlugin;
+			productReference = D20100000000000000000006 /* SupertonicPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000024 /* OpenAIVectorMemoryPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000122 /* Build configuration list for PBXNativeTarget "OpenAIVectorMemoryPlugin" */;
@@ -2781,6 +2840,7 @@
 				RR00000000000000000007 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */,
 				RR00000000000000000008 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				RR00000000000000000009 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+				D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */,
 			);
 			productRefGroup = CC00000000000000000090 /* Products */;
 			projectDirPath = "";
@@ -2810,6 +2870,7 @@
 				DD00000000000000000022 /* CloudflareASRPlugin */,
 				DD00000000000000000023 /* FileMemoryPlugin */,
 				D10000000000000000000001 /* SystemTTSPlugin */,
+				D20300000000000000000001 /* SupertonicPlugin */,
 				DD00000000000000000024 /* OpenAIVectorMemoryPlugin */,
 				DD00000000000000000025 /* FireworksPlugin */,
 				DD00000000000000000026 /* CerebrasPlugin */,
@@ -3054,6 +3115,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D20400000000000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D20000000000000000000005 /* manifest.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000121 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3172,6 +3241,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		D20400000000000000000004 /* Copy ONNX Runtime Module Map */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy ONNX Runtime Module Map";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILD_DIR)/GeneratedModuleMaps/OnnxRuntimeBindings.modulemap",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nDEST=\"${BUILD_DIR}/GeneratedModuleMaps\"\nmkdir -p \"$DEST\"\nSEARCH_ROOTS=\"${DERIVED_DATA_DIR:-} ${HOME}/Library/Developer/Xcode/DerivedData\"\nMODULEMAP=\"\"\nfor ROOT in $SEARCH_ROOTS; do\n  if [ -n \"$ROOT\" ] && [ -d \"$ROOT\" ]; then\n    MODULEMAP=$(find \"$ROOT\" -path '*/SourcePackages/checkouts/onnxruntime-swift-package-manager/build/GeneratedModuleMaps/OnnxRuntimeBindings.modulemap' -print -quit)\n    if [ -n \"$MODULEMAP\" ]; then\n      break\n    fi\n  fi\ndone\nif [ -z \"$MODULEMAP\" ]; then\n  echo \"Missing OnnxRuntimeBindings.modulemap\" >&2\n  exit 1\nfi\ncp \"$MODULEMAP\" \"$DEST/OnnxRuntimeBindings.modulemap\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -3242,6 +3331,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D20400000000000000000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D20000000000000000000001 /* SupertonicPlugin.swift in Sources */,
+				D20000000000000000000002 /* SupertonicModelAssetManager.swift in Sources */,
+				D20000000000000000000003 /* SupertonicPlaybackSession.swift in Sources */,
+				D20000000000000000000004 /* SupertonicRuntime.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3964,13 +4064,13 @@
 			};
 			name = Release;
 		};
-		XX00000000000000000013 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
+			XX00000000000000000013 /* Debug */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
+					CODE_SIGN_STYLE = Automatic;
+					COMBINE_HIDPI_IMAGES = YES;
+					CURRENT_PROJECT_VERSION = 1;
+					DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5084,6 +5184,76 @@
 			};
 			name = Release;
 		};
+			D20500000000000000000001 /* Debug */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
+					ARCHS = arm64;
+					CODE_SIGN_STYLE = Automatic;
+					COMBINE_HIDPI_IMAGES = YES;
+					CURRENT_PROJECT_VERSION = 1;
+					DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+				);
+					GENERATE_INFOPLIST_FILE = YES;
+					INFOPLIST_KEY_CFBundleDisplayName = "Supertonic (Experimental)";
+					INFOPLIST_KEY_NSHumanReadableCopyright = "";
+					INFOPLIST_KEY_NSPrincipalClass = SupertonicPlugin;
+					INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+					LD_RUNPATH_SEARCH_PATHS = (
+						"$(inherited)",
+						"@loader_path/../Frameworks",
+						"@executable_path/../Frameworks",
+					);
+					MACOSX_DEPLOYMENT_TARGET = 14.0;
+					MARKETING_VERSION = 1.0;
+					PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.tts.supertonic;
+					PRODUCT_NAME = SupertonicPlugin;
+					SDKROOT = macosx;
+					SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)";
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+			};
+			D20500000000000000000002 /* Release */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
+					ARCHS = arm64;
+					CODE_SIGN_STYLE = Automatic;
+					COMBINE_HIDPI_IMAGES = YES;
+					CURRENT_PROJECT_VERSION = 1;
+					DEAD_CODE_STRIPPING = YES;
+					FRAMEWORK_SEARCH_PATHS = (
+						"$(inherited)",
+						"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+				);
+					GENERATE_INFOPLIST_FILE = YES;
+					INFOPLIST_KEY_CFBundleDisplayName = "Supertonic (Experimental)";
+					INFOPLIST_KEY_NSHumanReadableCopyright = "";
+					INFOPLIST_KEY_NSPrincipalClass = SupertonicPlugin;
+					INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+					LD_RUNPATH_SEARCH_PATHS = (
+						"$(inherited)",
+						"@loader_path/../Frameworks",
+						"@executable_path/../Frameworks",
+					);
+					MACOSX_DEPLOYMENT_TARGET = 14.0;
+					MARKETING_VERSION = 1.0;
+					PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.tts.supertonic;
+					PRODUCT_NAME = SupertonicPlugin;
+					SDKROOT = macosx;
+					SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)";
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		XX00000000000000000097 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5915,6 +6085,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		D20500000000000000000003 /* Build configuration list for PBXNativeTarget "SupertonicPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D20500000000000000000001 /* Debug */,
+				D20500000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000122 /* Build configuration list for PBXNativeTarget "OpenAIVectorMemoryPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6087,6 +6266,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.1.6;
+			};
+		};
+		D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/microsoft/onnxruntime-swift-package-manager.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.24.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -6303,6 +6490,15 @@
 		PP00000000000000000046 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
+		};
+		D20700000000000000000001 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		D20700000000000000000002 /* onnxruntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */;
+			productName = onnxruntime;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "16e1d8333637e2f35585a0446add22dac52bb3aaba40cfbfda0069ca7df2d27c",
+  "originHash" : "7c66048b411ed2317343aef0981b2f3eb75034329630d9ce205815131e0176cd",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
         "version" : "3.31.3"
+      }
+    },
+    {
+      "identity" : "onnxruntime-swift-package-manager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/onnxruntime-swift-package-manager.git",
+      "state" : {
+        "revision" : "b7fb7f7dea8a2469e6335d95a61b8f36d0dc83b2",
+        "version" : "1.24.2"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
         .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
+        .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
     ],
     targets: [
         .target(name: "TypeWhisperPluginSDK"),
@@ -102,6 +103,18 @@ let package = Package(
             name: "SystemTTSPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/SystemTTSPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
+            name: "SupertonicPlugin",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                .product(name: "onnxruntime", package: "onnxruntime-swift-package-manager"),
+            ],
+            path: "Plugins/SupertonicPlugin",
             exclude: ["Tests"],
             resources: [
                 .process("manifest.json"),
@@ -210,6 +223,15 @@ let package = Package(
                 "SystemTTSPlugin",
             ],
             path: "Plugins/SystemTTSPlugin/Tests"
+        ),
+        .testTarget(
+            name: "SupertonicPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "SupertonicPlugin",
+            ],
+            path: "Plugins/SupertonicPlugin/Tests"
         ),
         .testTarget(
             name: "FileMemoryPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -79,6 +79,8 @@ Each plugin receives a `HostServices` object providing:
 
 Bundled MLX plugins such as Qwen3, Granite, and Voxtral store their optional HuggingFace token via the same plugin-scoped keychain helpers.
 
+Bundled experimental local TTS plugins such as Supertonic store optional HuggingFace tokens the same way, but model weights are not bundled in the plugin ZIP. Supertonic downloads `Supertone/supertonic-3` assets only after the user accepts the OpenRAIL-M model license in plugin settings. That model-license confirmation is scoped to the model download and does not change TypeWhisper app licensing.
+
 Bundled cloud plugins include Groq, OpenAI, OpenAI Compatible, and xAI/Grok. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
 
 ## Example

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicModelAssetManager.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicModelAssetManager.swift
@@ -1,0 +1,261 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+enum SupertonicModelLicense {
+    static let id = "Supertone/supertonic-3"
+    static let revision = "openrail-m-2022-08-18"
+    static let licenseName = "OpenRAIL-M"
+    static let url = URL(string: "https://huggingface.co/Supertone/supertonic-3/blob/main/LICENSE")!
+}
+
+enum SupertonicPluginError: LocalizedError, Equatable {
+    case notConfigured
+    case licenseNotAccepted
+    case incompleteModelAssets
+    case invalidDownloadResponse
+    case playbackUnavailable
+    case emptyText
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Supertonic model assets are not downloaded."
+        case .licenseNotAccepted:
+            return "Accept the Supertonic 3 model license before downloading model assets."
+        case .incompleteModelAssets:
+            return "The downloaded Supertonic model cache is incomplete."
+        case .invalidDownloadResponse:
+            return "Supertonic model download returned an invalid response."
+        case .playbackUnavailable:
+            return "Supertonic audio playback could not be started."
+        case .emptyText:
+            return "TTS text is empty."
+        }
+    }
+}
+
+struct SupertonicLanguageResolver {
+    static let supportedLanguageCodes: Set<String> = [
+        "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es",
+        "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv",
+        "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi",
+    ]
+
+    static func normalizedLanguageCode(for language: String?) -> String {
+        guard let language else { return "en" }
+        let primary = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(whereSeparator: { $0 == "-" || $0 == "_" })
+            .first
+            .map(String.init)
+
+        guard let primary, supportedLanguageCodes.contains(primary) else {
+            return "en"
+        }
+        return primary
+    }
+}
+
+struct SupertonicModelAssetManager: Sendable {
+    static let repositoryId = "Supertone/supertonic-3"
+    static let modelSubdirectory = "models/supertonic-3"
+    static let requiredRelativePaths = [
+        "onnx/tts.json",
+        "onnx/unicode_indexer.json",
+        "onnx/duration_predictor.onnx",
+        "onnx/text_encoder.onnx",
+        "onnx/vector_estimator.onnx",
+        "onnx/vocoder.onnx",
+        "voice_styles/M1.json",
+        "voice_styles/F1.json",
+    ]
+
+    let rootDirectory: URL
+
+    var modelDirectory: URL {
+        rootDirectory.appendingPathComponent(Self.modelSubdirectory, isDirectory: true)
+    }
+
+    var onnxDirectory: URL {
+        modelDirectory.appendingPathComponent("onnx", isDirectory: true)
+    }
+
+    var voiceStylesDirectory: URL {
+        modelDirectory.appendingPathComponent("voice_styles", isDirectory: true)
+    }
+
+    func hasDownloadedModel() -> Bool {
+        Self.requiredRelativePaths.allSatisfy { relativePath in
+            FileManager.default.fileExists(atPath: modelDirectory.appendingPathComponent(relativePath).path)
+        }
+    }
+
+    func availableVoices() -> [PluginVoiceInfo] {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: voiceStylesDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return Self.defaultVoices
+        }
+
+        let voices = contents
+            .filter { $0.pathExtension == "json" }
+            .map { url in
+                let id = url.deletingPathExtension().lastPathComponent
+                return PluginVoiceInfo(id: id, displayName: id)
+            }
+            .sorted { (lhs: PluginVoiceInfo, rhs: PluginVoiceInfo) in
+                lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            }
+
+        return voices.isEmpty ? Self.defaultVoices : voices
+    }
+
+    func install(files: [String: Data], licenseAccepted: Bool) throws {
+        guard licenseAccepted else { throw SupertonicPluginError.licenseNotAccepted }
+        guard Self.requiredRelativePaths.allSatisfy({ files[$0] != nil }) else {
+            throw SupertonicPluginError.incompleteModelAssets
+        }
+
+        try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+        let stagingDirectory = rootDirectory.appendingPathComponent(
+            ".supertonic-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+
+        do {
+            for (relativePath, data) in files {
+                guard Self.isSafeRelativePath(relativePath) else {
+                    throw SupertonicPluginError.invalidDownloadResponse
+                }
+                let destination = stagingDirectory.appendingPathComponent(relativePath)
+                try FileManager.default.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: destination, options: .atomic)
+            }
+
+            guard Self.requiredRelativePaths.allSatisfy({
+                FileManager.default.fileExists(atPath: stagingDirectory.appendingPathComponent($0).path)
+            }) else {
+                throw SupertonicPluginError.incompleteModelAssets
+            }
+
+            try replaceModelDirectory(with: stagingDirectory)
+        } catch {
+            try? FileManager.default.removeItem(at: stagingDirectory)
+            throw error
+        }
+    }
+
+    func download(
+        token: String?,
+        licenseAccepted: Bool,
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        guard licenseAccepted else { throw SupertonicPluginError.licenseNotAccepted }
+        let paths = try await remoteAssetPaths(token: token)
+        guard !paths.isEmpty else { throw SupertonicPluginError.incompleteModelAssets }
+
+        var files: [String: Data] = [:]
+        for (index, path) in paths.enumerated() {
+            files[path] = try await fetchData(path: path, token: token)
+            progress(Double(index + 1) / Double(paths.count))
+        }
+        try install(files: files, licenseAccepted: true)
+    }
+
+    func deleteModelFiles() {
+        try? FileManager.default.removeItem(at: modelDirectory)
+    }
+
+    private func remoteAssetPaths(token: String?) async throws -> [String] {
+        var components = URLComponents(string: "https://huggingface.co/api/models/\(Self.repositoryId)/tree/main")
+        components?.queryItems = [URLQueryItem(name: "recursive", value: "1")]
+        guard let url = components?.url else { throw SupertonicPluginError.invalidDownloadResponse }
+
+        var request = URLRequest(url: url)
+        if let token = PluginHuggingFaceTokenHelper.normalizedToken(token) {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw SupertonicPluginError.invalidDownloadResponse
+        }
+
+        let entries = try JSONDecoder().decode([HuggingFaceTreeEntry].self, from: data)
+        let paths = entries
+            .map(\.path)
+            .filter { $0.hasPrefix("onnx/") || ($0.hasPrefix("voice_styles/") && $0.hasSuffix(".json")) }
+            .filter(Self.isSafeRelativePath)
+            .sorted()
+
+        guard Self.requiredRelativePaths.allSatisfy({ paths.contains($0) }) else {
+            throw SupertonicPluginError.incompleteModelAssets
+        }
+        return paths
+    }
+
+    private func fetchData(path: String, token: String?) async throws -> Data {
+        guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let url = URL(string: "https://huggingface.co/\(Self.repositoryId)/resolve/main/\(encodedPath)") else {
+            throw SupertonicPluginError.invalidDownloadResponse
+        }
+
+        var request = URLRequest(url: url)
+        if let token = PluginHuggingFaceTokenHelper.normalizedToken(token) {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw SupertonicPluginError.invalidDownloadResponse
+        }
+        return data
+    }
+
+    private func replaceModelDirectory(with stagingDirectory: URL) throws {
+        let finalDirectory = modelDirectory
+        let finalParent = finalDirectory.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: finalParent, withIntermediateDirectories: true)
+
+        if FileManager.default.fileExists(atPath: finalDirectory.path) {
+            let backupDirectory = rootDirectory.appendingPathComponent(
+                ".supertonic-backup-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.moveItem(at: finalDirectory, to: backupDirectory)
+            do {
+                try FileManager.default.moveItem(at: stagingDirectory, to: finalDirectory)
+                try? FileManager.default.removeItem(at: backupDirectory)
+            } catch {
+                try? FileManager.default.moveItem(at: backupDirectory, to: finalDirectory)
+                throw error
+            }
+        } else {
+            try FileManager.default.moveItem(at: stagingDirectory, to: finalDirectory)
+        }
+    }
+
+    private static func isSafeRelativePath(_ path: String) -> Bool {
+        !path.isEmpty
+            && !path.hasPrefix("/")
+            && !path.split(separator: "/").contains("..")
+    }
+
+    private static var defaultVoices: [PluginVoiceInfo] {
+        ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+            .map { PluginVoiceInfo(id: $0, displayName: $0) }
+    }
+}
+
+private struct HuggingFaceTreeEntry: Decodable {
+    let path: String
+}

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlaybackSession.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlaybackSession.swift
@@ -1,0 +1,89 @@
+import AVFoundation
+import Foundation
+import TypeWhisperPluginSDK
+import os
+
+final class SupertonicPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    private struct State {
+        var isActive = true
+        var onFinish: (@Sendable () -> Void)?
+    }
+
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var isActive: Bool {
+        state.withLock { $0.isActive }
+    }
+
+    var onFinish: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onFinish } }
+        set {
+            let shouldNotify = state.withLock { state in
+                state.onFinish = newValue
+                return !state.isActive
+            }
+            if shouldNotify {
+                newValue?()
+            }
+        }
+    }
+
+    init(samples: [Float], sampleRate: Int) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw SupertonicPluginError.playbackUnavailable
+        }
+
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+
+        guard !samples.isEmpty,
+              let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(samples.count)
+              ),
+              let channel = buffer.floatChannelData?[0] else {
+            throw SupertonicPluginError.playbackUnavailable
+        }
+
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for index in samples.indices {
+            channel[index] = max(-1, min(1, samples[index]))
+        }
+
+        try engine.start()
+        player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+            self?.finish()
+        }
+        player.play()
+    }
+
+    func stop() {
+        let wasActive = state.withLock { state -> Bool in
+            guard state.isActive else { return false }
+            state.isActive = false
+            return true
+        }
+        guard wasActive else { return }
+
+        player.stop()
+        engine.stop()
+        engine.detach(player)
+        onFinish?()
+    }
+
+    private func finish() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        callback?()
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
@@ -64,6 +64,7 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
 
     private let logger = Logger(subsystem: "com.typewhisper.tts.supertonic", category: "Plugin")
     private var host: HostServices?
+    private let synthesizerLock = NSLock()
     private var synthesizer: (any SupertonicSynthesizing)?
     private var downloadProgress = 0.0
     private(set) var modelState: SupertonicModelState = .notDownloaded
@@ -78,7 +79,7 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
     }
 
     func deactivate() {
-        synthesizer = nil
+        clearSynthesizerCache()
         host = nil
         downloadProgress = 0
         modelState = .notDownloaded
@@ -197,7 +198,7 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
                     self?.host?.notifyCapabilitiesChanged()
                 }
             }
-            synthesizer = nil
+            clearSynthesizerCache()
             downloadProgress = 1
             modelState = .ready
             host?.notifyCapabilitiesChanged()
@@ -210,7 +211,7 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
     }
 
     func deleteCachedModel() {
-        synthesizer = nil
+        clearSynthesizerCache()
         modelAssetManager.deleteModelFiles()
         downloadProgress = 0
         modelState = .notDownloaded
@@ -250,12 +251,21 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
     }
 
     private func synthesizerForCurrentModel() throws -> any SupertonicSynthesizing {
+        synthesizerLock.lock()
+        defer { synthesizerLock.unlock() }
+
         if let synthesizer {
             return synthesizer
         }
         let synthesizer = try SupertonicONNXSynthesizer(modelDirectory: modelAssetManager.modelDirectory)
         self.synthesizer = synthesizer
         return synthesizer
+    }
+
+    private func clearSynthesizerCache() {
+        synthesizerLock.lock()
+        synthesizer = nil
+        synthesizerLock.unlock()
     }
 
     private static func clampedSpeed(_ value: Double) -> Double {

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
@@ -1,0 +1,516 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+import os
+
+enum SupertonicDefaultsKey {
+    static let selectedVoiceId = "selectedVoiceId"
+    static let speed = "speed"
+    static let quality = "quality"
+    static let hfToken = "hf-token"
+    static let acceptedModelLicenseId = "acceptedModelLicenseId"
+    static let acceptedModelLicenseRevision = "acceptedModelLicenseRevision"
+    static let acceptedModelLicenseAt = "acceptedModelLicenseAt"
+}
+
+enum SupertonicQuality: String, CaseIterable, Sendable {
+    case fast
+    case balanced
+    case high
+
+    var totalSteps: Int {
+        switch self {
+        case .fast: 2
+        case .balanced: 5
+        case .high: 10
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .fast: "Fast"
+        case .balanced: "Balanced"
+        case .high: "High"
+        }
+    }
+}
+
+enum SupertonicModelState: Equatable, Sendable {
+    case notDownloaded
+    case downloading
+    case ready
+    case error(String)
+}
+
+struct SupertonicSynthesisOutput: Sendable {
+    let samples: [Float]
+    let sampleRate: Int
+}
+
+protocol SupertonicSynthesizing: AnyObject, Sendable {
+    func synthesize(
+        text: String,
+        language: String,
+        voiceId: String,
+        quality: SupertonicQuality,
+        speed: Double
+    ) throws -> SupertonicSynthesisOutput
+}
+
+@objc(SupertonicPlugin)
+final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivityReporting, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.tts.supertonic"
+    static let pluginName = "Supertonic (Experimental)"
+
+    private let logger = Logger(subsystem: "com.typewhisper.tts.supertonic", category: "Plugin")
+    private var host: HostServices?
+    private var synthesizer: (any SupertonicSynthesizing)?
+    private var downloadProgress = 0.0
+    private(set) var modelState: SupertonicModelState = .notDownloaded
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        modelState = modelAssetManager.hasDownloadedModel() ? .ready : .notDownloaded
+    }
+
+    func deactivate() {
+        synthesizer = nil
+        host = nil
+        downloadProgress = 0
+        modelState = .notDownloaded
+    }
+
+    var providerId: String { "supertonic" }
+    var providerDisplayName: String { "Supertonic (Experimental)" }
+    var isConfigured: Bool { modelAssetManager.hasDownloadedModel() }
+    var availableVoices: [PluginVoiceInfo] { modelAssetManager.availableVoices() }
+
+    var selectedVoiceId: String? {
+        (host?.userDefault(forKey: SupertonicDefaultsKey.selectedVoiceId) as? String) ?? "M1"
+    }
+
+    var selectedSpeed: Double {
+        let raw = host?.userDefault(forKey: SupertonicDefaultsKey.speed) as? Double ?? 1.05
+        return Self.clampedSpeed(raw)
+    }
+
+    var selectedQuality: SupertonicQuality {
+        if let raw = host?.userDefault(forKey: SupertonicDefaultsKey.quality) as? String,
+           let quality = SupertonicQuality(rawValue: raw) {
+            return quality
+        }
+        return .balanced
+    }
+
+    var settingsSummary: String? {
+        let voice = selectedVoiceId ?? "M1"
+        return "Voice: \(voice) - Speed: \(String(format: "%.2fx", selectedSpeed)) - \(selectedQuality.displayName)"
+    }
+
+    @MainActor
+    var settingsView: AnyView? {
+        AnyView(SupertonicSettingsView(plugin: self))
+    }
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notDownloaded, .ready:
+            return nil
+        case .downloading:
+            return PluginSettingsActivity(message: "Downloading Supertonic model", progress: downloadProgress)
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
+
+    var hasAcceptedCurrentModelLicense: Bool {
+        guard let host else { return false }
+        return host.userDefault(forKey: SupertonicDefaultsKey.acceptedModelLicenseId) as? String == SupertonicModelLicense.id
+            && host.userDefault(forKey: SupertonicDefaultsKey.acceptedModelLicenseRevision) as? String == SupertonicModelLicense.revision
+    }
+
+    var canDownloadModel: Bool {
+        hasAcceptedCurrentModelLicense
+    }
+
+    var huggingFaceToken: String? {
+        PluginHuggingFaceTokenHelper.loadToken(from: host)
+    }
+
+    var modelDownloadProgress: Double {
+        downloadProgress
+    }
+
+    func selectVoice(_ voiceId: String?) {
+        host?.setUserDefault(voiceId, forKey: SupertonicDefaultsKey.selectedVoiceId)
+    }
+
+    func setSpeed(_ speed: Double) {
+        host?.setUserDefault(Self.clampedSpeed(speed), forKey: SupertonicDefaultsKey.speed)
+    }
+
+    func setQuality(_ quality: SupertonicQuality) {
+        host?.setUserDefault(quality.rawValue, forKey: SupertonicDefaultsKey.quality)
+    }
+
+    func acceptCurrentModelLicense(now: Date = Date()) {
+        host?.setUserDefault(SupertonicModelLicense.id, forKey: SupertonicDefaultsKey.acceptedModelLicenseId)
+        host?.setUserDefault(SupertonicModelLicense.revision, forKey: SupertonicDefaultsKey.acceptedModelLicenseRevision)
+        host?.setUserDefault(Self.isoDateString(from: now), forKey: SupertonicDefaultsKey.acceptedModelLicenseAt)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func saveHuggingFaceToken(_ token: String) {
+        PluginHuggingFaceTokenHelper.saveToken(token, to: host)
+    }
+
+    func clearHuggingFaceToken() {
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = PluginHTTPClient.data
+    ) async -> Bool {
+        await PluginHuggingFaceTokenHelper.validateToken(token, dataFetcher: dataFetcher)
+    }
+
+    func downloadModel() async {
+        guard canDownloadModel else {
+            modelState = .error(SupertonicPluginError.licenseNotAccepted.localizedDescription)
+            host?.notifyCapabilitiesChanged()
+            return
+        }
+
+        downloadProgress = 0
+        modelState = .downloading
+        host?.notifyCapabilitiesChanged()
+
+        do {
+            try await modelAssetManager.download(token: huggingFaceToken, licenseAccepted: true) { [weak self] progress in
+                Task { @MainActor in
+                    self?.downloadProgress = progress
+                    self?.host?.notifyCapabilitiesChanged()
+                }
+            }
+            synthesizer = nil
+            downloadProgress = 1
+            modelState = .ready
+            host?.notifyCapabilitiesChanged()
+        } catch {
+            logger.error("Supertonic model download failed: \(error.localizedDescription)")
+            downloadProgress = 0
+            modelState = .error(error.localizedDescription)
+            host?.notifyCapabilitiesChanged()
+        }
+    }
+
+    func deleteCachedModel() {
+        synthesizer = nil
+        modelAssetManager.deleteModelFiles()
+        downloadProgress = 0
+        modelState = .notDownloaded
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        let text = request.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { throw SupertonicPluginError.emptyText }
+        guard modelAssetManager.hasDownloadedModel() else {
+            throw SupertonicPluginError.notConfigured
+        }
+
+        let voiceId = selectedVoiceId ?? "M1"
+        let language = SupertonicLanguageResolver.normalizedLanguageCode(for: request.language)
+        let quality = selectedQuality
+        let speed = selectedSpeed
+
+        let output = try await Task.detached(priority: .userInitiated) { [self] in
+            try synthesizerForCurrentModel().synthesize(
+                text: text,
+                language: language,
+                voiceId: voiceId,
+                quality: quality,
+                speed: speed
+            )
+        }.value
+
+        return try SupertonicPlaybackSession(samples: output.samples, sampleRate: output.sampleRate)
+    }
+
+    fileprivate var modelAssetManager: SupertonicModelAssetManager {
+        SupertonicModelAssetManager(
+            rootDirectory: host?.pluginDataDirectory
+                ?? FileManager.default.temporaryDirectory.appendingPathComponent("SupertonicPlugin", isDirectory: true)
+        )
+    }
+
+    private func synthesizerForCurrentModel() throws -> any SupertonicSynthesizing {
+        if let synthesizer {
+            return synthesizer
+        }
+        let synthesizer = try SupertonicONNXSynthesizer(modelDirectory: modelAssetManager.modelDirectory)
+        self.synthesizer = synthesizer
+        return synthesizer
+    }
+
+    private static func clampedSpeed(_ value: Double) -> Double {
+        min(max(value, 0.7), 2.0)
+    }
+
+    private static func isoDateString(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+}
+
+private struct SupertonicSettingsView: View {
+    let plugin: SupertonicPlugin
+
+    @State private var acceptedLicense = false
+    @State private var selectedVoiceId = "M1"
+    @State private var speed = 1.05
+    @State private var quality: SupertonicQuality = .balanced
+    @State private var modelState: SupertonicModelState = .notDownloaded
+    @State private var progress = 0.0
+    @State private var hfTokenInput = ""
+    @State private var isValidatingToken = false
+    @State private var tokenValidationResult: Bool?
+    @State private var isDownloading = false
+
+    private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Supertonic (Experimental)")
+                .font(.headline)
+
+            Text("Local text-to-speech powered by Supertonic 3 ONNX models. Model assets are downloaded only after you accept the model license.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            licenseSection
+
+            Divider()
+
+            modelSection
+
+            Divider()
+
+            voiceSection
+
+            Divider()
+
+            tokenSection
+        }
+        .padding()
+        .frame(minWidth: 480)
+        .onAppear {
+            refreshFromPlugin()
+        }
+        .onReceive(pollTimer) { _ in
+            refreshTransientState()
+        }
+    }
+
+    private var licenseSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Model License")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Text("Supertonic 3 model assets are licensed under OpenRAIL-M and include use restrictions. Review the full license before downloading the model.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Link("Open Supertonic 3 OpenRAIL-M license", destination: SupertonicModelLicense.url)
+                .font(.caption)
+
+            Toggle(isOn: $acceptedLicense) {
+                Text("I have read and accept the Supertonic 3 model license terms")
+            }
+            .onChange(of: acceptedLicense) { _, newValue in
+                if newValue {
+                    plugin.acceptCurrentModelLicense()
+                }
+            }
+        }
+    }
+
+    private var modelSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Model")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            switch modelState {
+            case .ready:
+                HStack {
+                    Label("Ready", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Spacer()
+                    Button("Delete cached model") {
+                        plugin.deleteCachedModel()
+                        refreshFromPlugin()
+                    }
+                    .controlSize(.small)
+                }
+            case .downloading:
+                HStack(spacing: 8) {
+                    ProgressView(value: progress)
+                        .frame(width: 160)
+                    Text("\(Int(progress * 100))%")
+                        .font(.caption)
+                        .monospacedDigit()
+                }
+            case .error(let message):
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                downloadButton
+            case .notDownloaded:
+                downloadButton
+            }
+        }
+    }
+
+    private var downloadButton: some View {
+        Button {
+            isDownloading = true
+            Task {
+                await plugin.downloadModel()
+                await MainActor.run {
+                    isDownloading = false
+                    refreshFromPlugin()
+                }
+            }
+        } label: {
+            Label("Download & Load", systemImage: "arrow.down.circle")
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!acceptedLicense || isDownloading || modelState == .downloading)
+    }
+
+    private var voiceSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Voice")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Picker("Voice", selection: $selectedVoiceId) {
+                ForEach(plugin.availableVoices, id: \.id) { voice in
+                    Text(voice.displayName).tag(voice.id)
+                }
+            }
+            .onChange(of: selectedVoiceId) { _, newValue in
+                plugin.selectVoice(newValue)
+            }
+
+            HStack {
+                Text("Speed")
+                Spacer()
+                Text(speed, format: .number.precision(.fractionLength(2)))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .font(.caption)
+
+            Slider(value: $speed, in: 0.7...2.0, step: 0.05)
+                .onChange(of: speed) { _, newValue in
+                    plugin.setSpeed(newValue)
+                }
+
+            Picker("Quality", selection: $quality) {
+                ForEach(SupertonicQuality.allCases, id: \.self) { quality in
+                    Text(quality.displayName).tag(quality)
+                }
+            }
+            .onChange(of: quality) { _, newValue in
+                plugin.setQuality(newValue)
+            }
+        }
+    }
+
+    private var tokenSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Hugging Face Token")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Text("Optional. It can increase download rate limits for the model download.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                SecureField("hf_...", text: $hfTokenInput)
+                    .textFieldStyle(.roundedBorder)
+
+                Button("Save") {
+                    validateAndSaveHuggingFaceToken()
+                }
+                .controlSize(.small)
+                .disabled(hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingToken)
+
+                if plugin.huggingFaceToken != nil {
+                    Button("Remove") {
+                        hfTokenInput = ""
+                        tokenValidationResult = nil
+                        plugin.clearHuggingFaceToken()
+                    }
+                    .controlSize(.small)
+                }
+            }
+
+            if isValidatingToken {
+                ProgressView()
+                    .controlSize(.small)
+            } else if let tokenValidationResult {
+                Label(
+                    tokenValidationResult ? "Valid Hugging Face token" : "Invalid Hugging Face token",
+                    systemImage: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill"
+                )
+                .font(.caption)
+                .foregroundStyle(tokenValidationResult ? .green : .red)
+            }
+        }
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        let trimmed = hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        isValidatingToken = true
+        tokenValidationResult = nil
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(trimmed)
+            await MainActor.run {
+                isValidatingToken = false
+                tokenValidationResult = isValid
+                if isValid {
+                    plugin.saveHuggingFaceToken(trimmed)
+                }
+            }
+        }
+    }
+
+    private func refreshFromPlugin() {
+        acceptedLicense = plugin.hasAcceptedCurrentModelLicense
+        selectedVoiceId = plugin.selectedVoiceId ?? "M1"
+        speed = plugin.selectedSpeed
+        quality = plugin.selectedQuality
+        modelState = plugin.modelState
+        progress = plugin.modelDownloadProgress
+        hfTokenInput = plugin.huggingFaceToken ?? ""
+    }
+
+    private func refreshTransientState() {
+        modelState = plugin.modelState
+        progress = plugin.modelDownloadProgress
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicRuntime.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicRuntime.swift
@@ -1,0 +1,671 @@
+import Foundation
+import OnnxRuntimeBindings
+
+final class SupertonicONNXSynthesizer: SupertonicSynthesizing, @unchecked Sendable {
+    private let textToSpeech: SupertonicTextToSpeech
+    private let voiceStylesDirectory: URL
+    private let inferenceLock = NSLock()
+
+    init(modelDirectory: URL) throws {
+        let onnxDirectory = modelDirectory.appendingPathComponent("onnx", isDirectory: true)
+        let environment = try ORTEnv(loggingLevel: .warning)
+        self.textToSpeech = try SupertonicTextToSpeech.load(onnxDirectory: onnxDirectory, environment: environment)
+        self.voiceStylesDirectory = modelDirectory.appendingPathComponent("voice_styles", isDirectory: true)
+    }
+
+    func synthesize(
+        text: String,
+        language: String,
+        voiceId: String,
+        quality: SupertonicQuality,
+        speed: Double
+    ) throws -> SupertonicSynthesisOutput {
+        let style = try SupertonicStyle.load(
+            from: voiceStylesDirectory.appendingPathComponent("\(voiceId).json")
+        )
+
+        inferenceLock.lock()
+        defer { inferenceLock.unlock() }
+
+        let result = try textToSpeech.call(
+            text,
+            language,
+            style,
+            quality.totalSteps,
+            speed: Float(speed),
+            silenceDuration: 0.3
+        )
+        return SupertonicSynthesisOutput(samples: result.wav, sampleRate: textToSpeech.sampleRate)
+    }
+}
+
+private struct SupertonicConfig: Decodable {
+    struct AEConfig: Decodable {
+        let sampleRate: Int
+        let baseChunkSize: Int
+
+        enum CodingKeys: String, CodingKey {
+            case sampleRate = "sample_rate"
+            case baseChunkSize = "base_chunk_size"
+        }
+    }
+
+    struct TTLConfig: Decodable {
+        let chunkCompressFactor: Int
+        let latentDim: Int
+
+        enum CodingKeys: String, CodingKey {
+            case chunkCompressFactor = "chunk_compress_factor"
+            case latentDim = "latent_dim"
+        }
+    }
+
+    let ae: AEConfig
+    let ttl: TTLConfig
+}
+
+private struct SupertonicVoiceStyleData: Decodable {
+    struct Component: Decodable {
+        let data: [[[Float]]]
+        let dims: [Int]
+    }
+
+    let styleTTL: Component
+    let styleDP: Component
+
+    enum CodingKeys: String, CodingKey {
+        case styleTTL = "style_ttl"
+        case styleDP = "style_dp"
+    }
+}
+
+private final class SupertonicUnicodeProcessor {
+    private let indexer: [Int64]
+
+    init(indexerPath: URL) throws {
+        let data = try Data(contentsOf: indexerPath)
+        self.indexer = try JSONDecoder().decode([Int64].self, from: data)
+    }
+
+    func call(_ textList: [String], _ languageList: [String]) -> (textIds: [[Int64]], textMask: [[[Float]]]) {
+        let processedTexts = textList.enumerated().map { index, text in
+            supertonicPreprocessText(text, language: languageList[index])
+        }
+        let lengths = processedTexts.map { $0.unicodeScalars.count }
+        let maxLength = lengths.max() ?? 0
+
+        let textIds = processedTexts.map { text in
+            var row = Array(repeating: Int64(0), count: maxLength)
+            for (index, value) in text.unicodeScalars.map({ Int($0.value) }).enumerated() {
+                row[index] = value < indexer.count ? indexer[value] : -1
+            }
+            return row
+        }
+
+        return (textIds, supertonicLengthToMask(lengths, maxLength: maxLength))
+    }
+}
+
+private struct SupertonicStyle {
+    let ttl: ORTValue
+    let dp: ORTValue
+
+    static func load(from url: URL) throws -> SupertonicStyle {
+        let data = try Data(contentsOf: url)
+        let styleData = try JSONDecoder().decode(SupertonicVoiceStyleData.self, from: data)
+
+        guard styleData.styleTTL.dims.count == 3,
+              styleData.styleDP.dims.count == 3 else {
+            throw SupertonicPluginError.incompleteModelAssets
+        }
+
+        let ttlDims = styleData.styleTTL.dims
+        let dpDims = styleData.styleDP.dims
+        let ttlFlat = styleData.styleTTL.data.flatMap { $0.flatMap { $0 } }
+        let dpFlat = styleData.styleDP.data.flatMap { $0.flatMap { $0 } }
+
+        let ttlShape: [NSNumber] = ttlDims.map { NSNumber(value: $0) }
+        let dpShape: [NSNumber] = dpDims.map { NSNumber(value: $0) }
+
+        return SupertonicStyle(
+            ttl: try SupertonicORT.tensor(values: ttlFlat, elementType: .float, shape: ttlShape),
+            dp: try SupertonicORT.tensor(values: dpFlat, elementType: .float, shape: dpShape)
+        )
+    }
+}
+
+private final class SupertonicTextToSpeech {
+    let sampleRate: Int
+
+    private let config: SupertonicConfig
+    private let textProcessor: SupertonicUnicodeProcessor
+    private let durationPredictor: ORTSession
+    private let textEncoder: ORTSession
+    private let vectorEstimator: ORTSession
+    private let vocoder: ORTSession
+
+    init(
+        config: SupertonicConfig,
+        textProcessor: SupertonicUnicodeProcessor,
+        durationPredictor: ORTSession,
+        textEncoder: ORTSession,
+        vectorEstimator: ORTSession,
+        vocoder: ORTSession
+    ) {
+        self.config = config
+        self.textProcessor = textProcessor
+        self.durationPredictor = durationPredictor
+        self.textEncoder = textEncoder
+        self.vectorEstimator = vectorEstimator
+        self.vocoder = vocoder
+        self.sampleRate = config.ae.sampleRate
+    }
+
+    static func load(onnxDirectory: URL, environment: ORTEnv) throws -> SupertonicTextToSpeech {
+        let configData = try Data(contentsOf: onnxDirectory.appendingPathComponent("tts.json"))
+        let config = try JSONDecoder().decode(SupertonicConfig.self, from: configData)
+        let sessionOptions = try ORTSessionOptions()
+
+        return try SupertonicTextToSpeech(
+            config: config,
+            textProcessor: SupertonicUnicodeProcessor(
+                indexerPath: onnxDirectory.appendingPathComponent("unicode_indexer.json")
+            ),
+            durationPredictor: ORTSession(
+                env: environment,
+                modelPath: onnxDirectory.appendingPathComponent("duration_predictor.onnx").path,
+                sessionOptions: sessionOptions
+            ),
+            textEncoder: ORTSession(
+                env: environment,
+                modelPath: onnxDirectory.appendingPathComponent("text_encoder.onnx").path,
+                sessionOptions: sessionOptions
+            ),
+            vectorEstimator: ORTSession(
+                env: environment,
+                modelPath: onnxDirectory.appendingPathComponent("vector_estimator.onnx").path,
+                sessionOptions: sessionOptions
+            ),
+            vocoder: ORTSession(
+                env: environment,
+                modelPath: onnxDirectory.appendingPathComponent("vocoder.onnx").path,
+                sessionOptions: sessionOptions
+            )
+        )
+    }
+
+    func call(
+        _ text: String,
+        _ language: String,
+        _ style: SupertonicStyle,
+        _ totalSteps: Int,
+        speed: Float = 1.05,
+        silenceDuration: Float = 0.3
+    ) throws -> (wav: [Float], duration: Float) {
+        let chunkLength = (language == "ko" || language == "ja") ? 120 : 300
+        let chunks = supertonicChunkText(text, maxLength: chunkLength)
+        let languageList = Array(repeating: language, count: chunks.count)
+
+        var combinedWav: [Float] = []
+        var combinedDuration: Float = 0
+
+        for (index, chunk) in chunks.enumerated() {
+            let result = try infer([chunk], [languageList[index]], style, totalSteps, speed: speed)
+            let duration = result.duration[0]
+            let wavLength = min(Int(Float(sampleRate) * duration), result.wav.count)
+            let wavChunk = Array(result.wav.prefix(wavLength))
+
+            if index > 0 {
+                let silenceLength = Int(silenceDuration * Float(sampleRate))
+                combinedWav.append(contentsOf: [Float](repeating: 0, count: silenceLength))
+                combinedDuration += silenceDuration
+            }
+
+            combinedWav.append(contentsOf: wavChunk)
+            combinedDuration += duration
+        }
+
+        return (combinedWav, combinedDuration)
+    }
+
+    private func infer(
+        _ textList: [String],
+        _ languageList: [String],
+        _ style: SupertonicStyle,
+        _ totalSteps: Int,
+        speed: Float
+    ) throws -> (wav: [Float], duration: [Float]) {
+        let batchSize = textList.count
+        let (textIds, textMask) = textProcessor.call(textList, languageList)
+
+        let textIdsFlat = textIds.flatMap { $0 }
+        let textMaskFlat = textMask.flatMap { $0.flatMap { $0 } }
+
+        let textIdsValue = try SupertonicORT.tensor(
+            values: textIdsFlat,
+            elementType: .int64,
+            shape: [NSNumber(value: batchSize), NSNumber(value: textIds[0].count)]
+        )
+        let textMaskValue = try SupertonicORT.tensor(
+            values: textMaskFlat,
+            elementType: .float,
+            shape: [NSNumber(value: batchSize), 1, NSNumber(value: textMask[0][0].count)]
+        )
+
+        let durationOutputs = try durationPredictor.run(
+            withInputs: ["text_ids": textIdsValue, "style_dp": style.dp, "text_mask": textMaskValue],
+            outputNames: ["duration"],
+            runOptions: nil
+        )
+        guard let durationValue = durationOutputs["duration"] else {
+            throw SupertonicPluginError.invalidDownloadResponse
+        }
+        var duration = try SupertonicORT.floatArray(from: durationValue)
+        for index in duration.indices {
+            duration[index] /= speed
+        }
+
+        let textEncoderOutputs = try textEncoder.run(
+            withInputs: ["text_ids": textIdsValue, "style_ttl": style.ttl, "text_mask": textMaskValue],
+            outputNames: ["text_emb"],
+            runOptions: nil
+        )
+        guard let textEmbeddings = textEncoderOutputs["text_emb"] else {
+            throw SupertonicPluginError.invalidDownloadResponse
+        }
+
+        var (noisyLatent, latentMask) = supertonicSampleNoisyLatent(
+            duration: duration,
+            sampleRate: sampleRate,
+            baseChunkSize: config.ae.baseChunkSize,
+            chunkCompress: config.ttl.chunkCompressFactor,
+            latentDim: config.ttl.latentDim
+        )
+
+        let totalStepValue = try SupertonicORT.tensor(
+            values: Array(repeating: Float(totalSteps), count: batchSize),
+            elementType: .float,
+            shape: [NSNumber(value: batchSize)]
+        )
+
+        for step in 0..<totalSteps {
+            let currentStepValue = try SupertonicORT.tensor(
+                values: Array(repeating: Float(step), count: batchSize),
+                elementType: .float,
+                shape: [NSNumber(value: batchSize)]
+            )
+            let latentValue = try SupertonicORT.tensor(
+                values: noisyLatent.flatMap { $0.flatMap { $0 } },
+                elementType: .float,
+                shape: [
+                    NSNumber(value: batchSize),
+                    NSNumber(value: noisyLatent[0].count),
+                    NSNumber(value: noisyLatent[0][0].count),
+                ]
+            )
+            let latentMaskValue = try SupertonicORT.tensor(
+                values: latentMask.flatMap { $0.flatMap { $0 } },
+                elementType: .float,
+                shape: [NSNumber(value: batchSize), 1, NSNumber(value: latentMask[0][0].count)]
+            )
+
+            let vectorOutputs = try vectorEstimator.run(
+                withInputs: [
+                    "noisy_latent": latentValue,
+                    "text_emb": textEmbeddings,
+                    "style_ttl": style.ttl,
+                    "latent_mask": latentMaskValue,
+                    "text_mask": textMaskValue,
+                    "current_step": currentStepValue,
+                    "total_step": totalStepValue,
+                ],
+                outputNames: ["denoised_latent"],
+                runOptions: nil
+            )
+            guard let denoisedValue = vectorOutputs["denoised_latent"] else {
+                throw SupertonicPluginError.invalidDownloadResponse
+            }
+            noisyLatent = SupertonicORT.reshape3D(
+                try SupertonicORT.floatArray(from: denoisedValue),
+                batchSize: batchSize,
+                rows: noisyLatent[0].count,
+                columns: noisyLatent[0][0].count
+            )
+        }
+
+        let finalLatentValue = try SupertonicORT.tensor(
+            values: noisyLatent.flatMap { $0.flatMap { $0 } },
+            elementType: .float,
+            shape: [
+                NSNumber(value: batchSize),
+                NSNumber(value: noisyLatent[0].count),
+                NSNumber(value: noisyLatent[0][0].count),
+            ]
+        )
+        let vocoderOutputs = try vocoder.run(
+            withInputs: ["latent": finalLatentValue],
+            outputNames: ["wav_tts"],
+            runOptions: nil
+        )
+        guard let wavValue = vocoderOutputs["wav_tts"] else {
+            throw SupertonicPluginError.invalidDownloadResponse
+        }
+
+        return (try SupertonicORT.floatArray(from: wavValue), duration)
+    }
+}
+
+private enum SupertonicORT {
+    static func tensor<T>(
+        values: [T],
+        elementType: ORTTensorElementDataType,
+        shape: [NSNumber]
+    ) throws -> ORTValue {
+        var mutableValues = values
+        let data = mutableValues.withUnsafeMutableBytes { bytes in
+            NSMutableData(bytes: bytes.baseAddress, length: bytes.count)
+        }
+        return try ORTValue(tensorData: data, elementType: elementType, shape: shape)
+    }
+
+    static func floatArray(from value: ORTValue) throws -> [Float] {
+        let data = try value.tensorData() as Data
+        return data.withUnsafeBytes { pointer in
+            Array(pointer.bindMemory(to: Float.self))
+        }
+    }
+
+    static func reshape3D(
+        _ values: [Float],
+        batchSize: Int,
+        rows: Int,
+        columns: Int
+    ) -> [[[Float]]] {
+        var result: [[[Float]]] = []
+        var index = 0
+
+        for _ in 0..<batchSize {
+            var batch: [[Float]] = []
+            for _ in 0..<rows {
+                let endIndex = index + columns
+                batch.append(Array(values[index..<endIndex]))
+                index = endIndex
+            }
+            result.append(batch)
+        }
+
+        return result
+    }
+}
+
+private func supertonicPreprocessText(_ text: String, language: String) -> String {
+    var text = text.decomposedStringWithCompatibilityMapping
+
+    text = text.unicodeScalars.filter { scalar in
+        let value = scalar.value
+        return !((value >= 0x1F600 && value <= 0x1F64F)
+            || (value >= 0x1F300 && value <= 0x1F5FF)
+            || (value >= 0x1F680 && value <= 0x1F6FF)
+            || (value >= 0x1F700 && value <= 0x1F77F)
+            || (value >= 0x1F780 && value <= 0x1F7FF)
+            || (value >= 0x1F800 && value <= 0x1F8FF)
+            || (value >= 0x1F900 && value <= 0x1F9FF)
+            || (value >= 0x1FA00 && value <= 0x1FA6F)
+            || (value >= 0x1FA70 && value <= 0x1FAFF)
+            || (value >= 0x2600 && value <= 0x26FF)
+            || (value >= 0x2700 && value <= 0x27BF)
+            || (value >= 0x1F1E6 && value <= 0x1F1FF))
+    }.map { String($0) }.joined()
+
+    let replacements: [String: String] = [
+        "–": "-",
+        "‑": "-",
+        "—": "-",
+        "_": " ",
+        "\u{201C}": "\"",
+        "\u{201D}": "\"",
+        "\u{2018}": "'",
+        "\u{2019}": "'",
+        "´": "'",
+        "`": "'",
+        "[": " ",
+        "]": " ",
+        "|": " ",
+        "/": " ",
+        "#": " ",
+        "→": " ",
+        "←": " ",
+        "♥": "",
+        "☆": "",
+        "♡": "",
+        "©": "",
+        "\\": "",
+        "@": " at ",
+        "e.g.,": "for example, ",
+        "i.e.,": "that is, ",
+    ]
+
+    for (source, replacement) in replacements {
+        text = text.replacingOccurrences(of: source, with: replacement)
+    }
+
+    for (source, replacement) in [
+        " ,": ",",
+        " .": ".",
+        " !": "!",
+        " ?": "?",
+        " ;": ";",
+        " :": ":",
+        " '": "'",
+    ] {
+        text = text.replacingOccurrences(of: source, with: replacement)
+    }
+
+    while text.contains("\"\"") {
+        text = text.replacingOccurrences(of: "\"\"", with: "\"")
+    }
+    while text.contains("''") {
+        text = text.replacingOccurrences(of: "''", with: "'")
+    }
+    while text.contains("``") {
+        text = text.replacingOccurrences(of: "``", with: "`")
+    }
+
+    if let whitespaceRegex = try? NSRegularExpression(pattern: "\\s+") {
+        let range = NSRange(text.startIndex..., in: text)
+        text = whitespaceRegex.stringByReplacingMatches(in: text, range: range, withTemplate: " ")
+    }
+    text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if !text.isEmpty,
+       let punctuationRegex = try? NSRegularExpression(pattern: "[.!?;:,'\"\\u201C\\u201D\\u2018\\u2019)\\]}…。」』】〉》›»]$") {
+        let range = NSRange(text.startIndex..., in: text)
+        if punctuationRegex.firstMatch(in: text, range: range) == nil {
+            text += "."
+        }
+    }
+
+    let safeLanguage = SupertonicLanguageResolver.supportedLanguageCodes.contains(language) ? language : "en"
+    return "<\(safeLanguage)>\(text)</\(safeLanguage)>"
+}
+
+private func supertonicLengthToMask(_ lengths: [Int], maxLength: Int? = nil) -> [[[Float]]] {
+    let resolvedMaxLength = maxLength ?? (lengths.max() ?? 0)
+
+    return lengths.map { length in
+        var row = Array(repeating: Float(0), count: resolvedMaxLength)
+        for index in 0..<min(length, resolvedMaxLength) {
+            row[index] = 1
+        }
+        return [row]
+    }
+}
+
+private func supertonicSampleNoisyLatent(
+    duration: [Float],
+    sampleRate: Int,
+    baseChunkSize: Int,
+    chunkCompress: Int,
+    latentDim: Int
+) -> (noisyLatent: [[[Float]]], latentMask: [[[Float]]]) {
+    let batchSize = duration.count
+    let maxDuration = duration.max() ?? 0
+    let chunkSize = baseChunkSize * chunkCompress
+    let latentLength = (Int(maxDuration * Float(sampleRate)) + chunkSize - 1) / chunkSize
+    let latentDimension = latentDim * chunkCompress
+
+    var noisyLatent: [[[Float]]] = []
+    for _ in 0..<batchSize {
+        var batch: [[Float]] = []
+        for _ in 0..<latentDimension {
+            var row: [Float] = []
+            for _ in 0..<latentLength {
+                let u1 = Float.random(in: 0.0001...1)
+                let u2 = Float.random(in: 0...1)
+                row.append(sqrt(-2 * log(u1)) * cos(2 * Float.pi * u2))
+            }
+            batch.append(row)
+        }
+        noisyLatent.append(batch)
+    }
+
+    let latentLengths = duration.map { (Int($0 * Float(sampleRate)) + chunkSize - 1) / chunkSize }
+    let latentMask = supertonicLengthToMask(latentLengths, maxLength: latentLength)
+
+    for batchIndex in 0..<batchSize {
+        for dimension in 0..<latentDimension {
+            for timeIndex in 0..<latentLength {
+                noisyLatent[batchIndex][dimension][timeIndex] *= latentMask[batchIndex][0][timeIndex]
+            }
+        }
+    }
+
+    return (noisyLatent, latentMask)
+}
+
+private let supertonicMaxChunkLength = 300
+private let supertonicAbbreviations: Set<String> = [
+    "Dr.", "Mr.", "Mrs.", "Ms.", "Prof.", "Sr.", "Jr.",
+    "St.", "Ave.", "Rd.", "Blvd.", "Dept.", "Inc.", "Ltd.",
+    "Co.", "Corp.", "etc.", "vs.", "i.e.", "e.g.", "Ph.D.",
+]
+
+private func supertonicChunkText(_ text: String, maxLength: Int = 0) -> [String] {
+    let resolvedMaxLength = maxLength > 0 ? maxLength : supertonicMaxChunkLength
+    let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !trimmedText.isEmpty else { return [""] }
+
+    let paragraphs = trimmedText
+        .components(separatedBy: "\n\n")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+    var chunks: [String] = []
+    for paragraph in paragraphs.isEmpty ? [trimmedText] : paragraphs {
+        if paragraph.count <= resolvedMaxLength {
+            chunks.append(paragraph)
+            continue
+        }
+
+        let sentences = supertonicSplitSentences(paragraph)
+        var current = ""
+        var currentLength = 0
+
+        for sentence in sentences {
+            let trimmedSentence = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedSentence.isEmpty else { continue }
+
+            if trimmedSentence.count > resolvedMaxLength {
+                if !current.isEmpty {
+                    chunks.append(current.trimmingCharacters(in: .whitespacesAndNewlines))
+                    current = ""
+                    currentLength = 0
+                }
+                chunks.append(contentsOf: supertonicSplitLongText(trimmedSentence, maxLength: resolvedMaxLength))
+                continue
+            }
+
+            if currentLength + trimmedSentence.count + 1 > resolvedMaxLength, !current.isEmpty {
+                chunks.append(current.trimmingCharacters(in: .whitespacesAndNewlines))
+                current = ""
+                currentLength = 0
+            }
+
+            if !current.isEmpty {
+                current += " "
+                currentLength += 1
+            }
+            current += trimmedSentence
+            currentLength += trimmedSentence.count
+        }
+
+        if !current.isEmpty {
+            chunks.append(current.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    return chunks.isEmpty ? [""] : chunks
+}
+
+private func supertonicSplitLongText(_ text: String, maxLength: Int) -> [String] {
+    var chunks: [String] = []
+    var current = ""
+    var currentLength = 0
+
+    for word in text.components(separatedBy: .whitespaces).filter({ !$0.isEmpty }) {
+        if currentLength + word.count + 1 > maxLength, !current.isEmpty {
+            chunks.append(current.trimmingCharacters(in: .whitespacesAndNewlines))
+            current = ""
+            currentLength = 0
+        }
+        if !current.isEmpty {
+            current += " "
+            currentLength += 1
+        }
+        current += word
+        currentLength += word.count
+    }
+
+    if !current.isEmpty {
+        chunks.append(current.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return chunks
+}
+
+private func supertonicSplitSentences(_ text: String) -> [String] {
+    guard let regex = try? NSRegularExpression(pattern: "([.!?])\\s+") else {
+        return [text]
+    }
+
+    let range = NSRange(text.startIndex..., in: text)
+    let matches = regex.matches(in: text, range: range)
+    guard !matches.isEmpty else { return [text] }
+
+    var sentences: [String] = []
+    var lastEnd = text.startIndex
+
+    for match in matches {
+        guard let matchRange = Range(match.range, in: text),
+              let punctuationRange = Range(NSRange(location: match.range.location, length: 1), in: text) else {
+            continue
+        }
+
+        let beforePunctuation = String(text[lastEnd..<matchRange.lowerBound])
+        let punctuation = String(text[punctuationRange])
+        let combined = beforePunctuation.trimmingCharacters(in: .whitespaces) + punctuation
+
+        guard !supertonicAbbreviations.contains(where: { combined.hasSuffix($0) }) else {
+            continue
+        }
+
+        sentences.append(String(text[lastEnd..<matchRange.upperBound]))
+        lastEnd = matchRange.upperBound
+    }
+
+    if lastEnd < text.endIndex {
+        sentences.append(String(text[lastEnd...]))
+    }
+
+    return sentences.isEmpty ? [text] : sentences
+}

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Tests/SupertonicPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Tests/SupertonicPluginTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import TypeWhisperPluginSDK
+import TypeWhisperPluginSDKTesting
+import XCTest
+@testable import SupertonicPlugin
+
+final class SupertonicPluginTests: XCTestCase {
+    func testManifestDeclaresLocalTTSPluginForHost14AndArm64() throws {
+        let manifestURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("manifest.json")
+
+        let manifest = try JSONDecoder().decode(
+            PluginManifest.self,
+            from: try Data(contentsOf: manifestURL)
+        )
+
+        XCTAssertEqual(manifest.id, "com.typewhisper.tts.supertonic")
+        XCTAssertEqual(manifest.name, "Supertonic (Experimental)")
+        XCTAssertEqual(manifest.category, "tts")
+        XCTAssertEqual(manifest.hosting, .local)
+        XCTAssertEqual(manifest.requiresAPIKey, false)
+        XCTAssertEqual(manifest.minHostVersion, "1.4.0")
+        XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
+    }
+
+    func testDownloadRequiresCurrentModelLicenseAcceptance() throws {
+        let host = try PluginTestHostServices()
+        let plugin = SupertonicPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.hasAcceptedCurrentModelLicense)
+        XCTAssertFalse(plugin.canDownloadModel)
+
+        plugin.acceptCurrentModelLicense(now: Date(timeIntervalSince1970: 1_716_000_000))
+
+        XCTAssertTrue(plugin.hasAcceptedCurrentModelLicense)
+        XCTAssertTrue(plugin.canDownloadModel)
+        XCTAssertEqual(host.userDefault(forKey: "acceptedModelLicenseId") as? String, SupertonicModelLicense.id)
+        XCTAssertEqual(host.userDefault(forKey: "acceptedModelLicenseRevision") as? String, SupertonicModelLicense.revision)
+        XCTAssertEqual(host.userDefault(forKey: "acceptedModelLicenseAt") as? String, "2024-05-18T02:40:00Z")
+    }
+
+    func testDownloadWithoutAcceptedLicenseDoesNotStartDownloadFlow() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = SupertonicPlugin()
+        plugin.activate(host: host)
+
+        await plugin.downloadModel()
+
+        XCTAssertEqual(plugin.modelState, .error(SupertonicPluginError.licenseNotAccepted.localizedDescription))
+        let modelDirectory = SupertonicModelAssetManager(rootDirectory: host.pluginDataDirectory).modelDirectory
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+    }
+
+    func testChangedModelLicenseRevisionInvalidatesPriorAcceptance() throws {
+        let host = try PluginTestHostServices(defaults: [
+            "acceptedModelLicenseId": SupertonicModelLicense.id,
+            "acceptedModelLicenseRevision": "old-revision",
+            "acceptedModelLicenseAt": "2024-05-18T08:00:00Z",
+        ])
+        let plugin = SupertonicPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.hasAcceptedCurrentModelLicense)
+        XCTAssertFalse(plugin.canDownloadModel)
+    }
+
+    func testSelectVoiceSpeedAndQualityPersistChoices() throws {
+        let host = try PluginTestHostServices()
+        let plugin = SupertonicPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectVoice("F1")
+        plugin.setSpeed(1.35)
+        plugin.setQuality(.high)
+
+        XCTAssertEqual(plugin.selectedVoiceId, "F1")
+        XCTAssertEqual(plugin.selectedSpeed, 1.35, accuracy: 0.001)
+        XCTAssertEqual(plugin.selectedQuality, .high)
+        XCTAssertEqual(host.userDefault(forKey: "selectedVoiceId") as? String, "F1")
+        XCTAssertEqual(host.userDefault(forKey: "speed") as? Double, 1.35)
+        XCTAssertEqual(host.userDefault(forKey: "quality") as? String, "high")
+    }
+
+    func testLanguageNormalizationFallsBackToEnglish() {
+        XCTAssertEqual(SupertonicLanguageResolver.normalizedLanguageCode(for: "de-DE"), "de")
+        XCTAssertEqual(SupertonicLanguageResolver.normalizedLanguageCode(for: "ja"), "ja")
+        XCTAssertEqual(SupertonicLanguageResolver.normalizedLanguageCode(for: nil), "en")
+        XCTAssertEqual(SupertonicLanguageResolver.normalizedLanguageCode(for: "ga-IE"), "en")
+    }
+
+    func testModelInstallerDoesNotWriteFinalDirectoryWhenRequiredFileIsMissing() throws {
+        let root = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: FileManager.default.temporaryDirectory,
+            create: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let installer = SupertonicModelAssetManager(rootDirectory: root)
+        var files = SupertonicModelAssetManager.requiredRelativePaths.reduce(into: [String: Data]()) { result, path in
+            result[path] = Data("fixture-\(path)".utf8)
+        }
+        files.removeValue(forKey: "onnx/vocoder.onnx")
+
+        XCTAssertThrowsError(try installer.install(files: files, licenseAccepted: true)) { error in
+            XCTAssertEqual((error as? SupertonicPluginError), .incompleteModelAssets)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installer.modelDirectory.path))
+    }
+
+    func testSpeakBeforeModelSetupThrowsNotConfigured() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = SupertonicPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.speak(TTSSpeakRequest(text: "Hello", language: "en", purpose: .manualReadback))
+            XCTFail("Expected speak to fail before model setup")
+        } catch {
+            XCTAssertEqual(error as? SupertonicPluginError, .notConfigured)
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
@@ -1,0 +1,24 @@
+{
+    "id": "com.typewhisper.tts.supertonic",
+    "name": "Supertonic (Experimental)",
+    "version": "1.0.0",
+    "minHostVersion": "1.4.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "supportedArchitectures": [
+        "arm64"
+    ],
+    "author": "TypeWhisper",
+    "description": "Experimental local text-to-speech with Supertonic 3 ONNX models. Requires accepting the OpenRAIL-M model license before downloading model assets.",
+    "descriptions": {
+        "de": "Experimentelles lokales Text-to-Speech mit Supertonic-3-ONNX-Modellen. Vor dem Download der Modellassets muss die OpenRAIL-M-Modelllizenz akzeptiert werden."
+    },
+    "category": "tts",
+    "categories": [
+        "tts"
+    ],
+    "hosting": "local",
+    "iconSystemName": "waveform.circle.fill",
+    "principalClass": "SupertonicPlugin",
+    "requiresAPIKey": false
+}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -44,7 +44,8 @@
 - Notch, Overlay, and Minimal indicator styles
 - Transcript preview toggle for Notch and Overlay
 - Plugin enable/disable
-- MLX plugin settings: save and remove HuggingFace token, then verify download error copy for Qwen3, Granite, and Voxtral
+- Local model plugin settings: save and remove HuggingFace token, then verify download error copy for Qwen3, Granite, Voxtral, and Supertonic
+- Supertonic plugin: verify OpenRAIL-M license checkbox gates the first model download and that changed license revision requires re-acceptance
 - Gemma 4 plugin: verify E2B/E4B 4-bit download and load, and verify E4B 8-bit plus 26B-A4B remain visible but disabled with explanatory copy
 - Community term pack download and apply
 - Built-in term packs render localized metadata in English and German


### PR DESCRIPTION
## Summary
- Adds experimental first-party `Supertonic (Experimental)` local TTS plugin backed by Supertonic 3 ONNX assets.
- Gates model download behind explicit OpenRAIL-M license acceptance for `Supertone/supertonic-3`; model weights are not bundled.
- Adds staged and validated Hugging Face asset download, local playback, settings, tests, Xcode/SPM target wiring, release slug `supertonic`, and docs.

## License Gate
- Shows model name, license name, full license link, restrictions warning, and required checkbox before download.
- Stores plugin-scoped acceptance keys: `acceptedModelLicenseId`, `acceptedModelLicenseRevision`, `acceptedModelLicenseAt`.
- Invalidates acceptance when model id or license revision changes.
- Acceptance applies only to the model download, not TypeWhisper commercial/GPL licensing.

## Review
- Pre-landing review found one concurrency issue in the lazy synthesizer cache; fixed with a lock.
- No remaining findings.

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh SupertonicPlugin /Users/marco/.codex/worktrees/7874/typewhisper-mac`
- `xcodebuild -project TypeWhisper.xcodeproj -target SupertonicPlugin -configuration Release CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`