### PR TITLE
Fix Supertonic plugin release build

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -2516,7 +2516,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D20500000000000000000003 /* Build configuration list for PBXNativeTarget "SupertonicPlugin" */;
 			buildPhases = (
-				D20400000000000000000004 /* Copy ONNX Runtime Module Map */,
 				D20400000000000000000002 /* Sources */,
 				D20400000000000000000003 /* Frameworks */,
 				D20400000000000000000001 /* Resources */,
@@ -3239,29 +3238,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		D20400000000000000000004 /* Copy ONNX Runtime Module Map */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Copy ONNX Runtime Module Map";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(BUILD_DIR)/GeneratedModuleMaps/OnnxRuntimeBindings.modulemap",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\nDEST=\"${BUILD_DIR}/GeneratedModuleMaps\"\nmkdir -p \"$DEST\"\nSEARCH_ROOTS=\"${DERIVED_DATA_DIR:-} ${HOME}/Library/Developer/Xcode/DerivedData\"\nMODULEMAP=\"\"\nfor ROOT in $SEARCH_ROOTS; do\n  if [ -n \"$ROOT\" ] && [ -d \"$ROOT\" ]; then\n    MODULEMAP=$(find \"$ROOT\" -path '*/SourcePackages/checkouts/onnxruntime-swift-package-manager/build/GeneratedModuleMaps/OnnxRuntimeBindings.modulemap' -print -quit)\n    if [ -n \"$MODULEMAP\" ]; then\n      break\n    fi\n  fi\ndone\nif [ -z \"$MODULEMAP\" ]; then\n  echo \"Missing OnnxRuntimeBindings.modulemap\" >&2\n  exit 1\nfi\ncp \"$MODULEMAP\" \"$DEST/OnnxRuntimeBindings.modulemap\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		D7199BC8CB6EE00511EFCC10 /* Sources */ = {


### PR DESCRIPTION
## Summary
- Removes the redundant Supertonic module map copy script from the Xcode target.
- Lets the ONNX Runtime SwiftPM target remain the only producer of `GeneratedModuleMaps/OnnxRuntimeBindings.modulemap`.
- Unblocks the `plugin-release.yml` workflow for `supertonic` v1.0.0 on Xcode 26.3.

## Test Plan
- `plutil -lint TypeWhisper.xcodeproj/project.pbxproj`
- `xcodebuild -project TypeWhisper.xcodeproj -target SupertonicPlugin -configuration Release SYMROOT="/Users/marco/.codex/worktrees/7874/typewhisper-mac/build-release-check" CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.0.0`