### PR TITLE
Make plugin settings windows scrollable

### DIFF
--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -25,7 +25,7 @@ final class PluginSettingsWindowManager {
             defer: false
         )
         let hostingView = NSHostingView(
-            rootView: settingsView
+            rootView: PluginSettingsWindowContent(settingsView: settingsView)
                 .environment(\.pluginSettingsClose, { [weak window] in
                     window?.close()
                 })
@@ -52,6 +52,18 @@ final class PluginSettingsWindowManager {
         window.delegate = delegate
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+private struct PluginSettingsWindowContent: View {
+    let settingsView: AnyView
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            settingsView
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap standalone plugin settings windows in a vertical scroll view at the host level.
- Preserve the existing plugin settings close environment, window sizing, resizability, and frame autosave behavior.
- Fixes long plugin settings views such as Qwen3 ASR where the model list could be clipped in the window.

## Issue Context
Issue #526 reports that the Qwen3 ASR v1.1.0 settings window can exceed the standalone plugin settings window height, hiding lower model controls. The expected behavior is that plugin settings windows support vertical scrolling.

Closes #526

## Test Plan
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' build`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/313a/typewhisper-mac`
- [x] Manual smoke: Settings > Integrations > Qwen3 ASR settings, resize the window smaller, verify the model list scrolls without clipped controls.
