### PR TITLE
Fix echo handling localization labels

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -864,6 +864,16 @@
         }
       }
     },
+    "Aggressive" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggressiv"
+          }
+        }
+      }
+    },
     "AI enhanced" : {
       "localizations" : {
         "de" : {
@@ -4087,6 +4097,16 @@
         }
       }
     },
+    "Medium" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittel"
+          }
+        }
+      }
+    },
     "Model" : {
       "localizations" : {
         "de" : {
@@ -4652,7 +4672,6 @@
       }
     },
     "Off" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -440,11 +440,11 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         var displayName: String {
             switch self {
             case .aggressive:
-                return String(localized: "Aggressiv")
+                return String(localized: "Aggressive")
             case .medium:
-                return String(localized: "Mittel")
+                return String(localized: "Medium")
             case .off:
-                return String(localized: "Aus")
+                return String(localized: "Off")
             }
         }
     }

--- a/TypeWhisperTests/SoundServiceTests.swift
+++ b/TypeWhisperTests/SoundServiceTests.swift
@@ -35,6 +35,26 @@ final class SoundServiceTests: XCTestCase {
         )
     }
 
+    func testRecorderEchoHandlingLabelsUseEnglishSourceStringsWithGermanTranslations() throws {
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(for: "Aggressive", preferredLanguages: ["en-US"]),
+            "Aggressive"
+        )
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Aggressive", language: "de"), "Aggressiv")
+
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(for: "Medium", preferredLanguages: ["en-US"]),
+            "Medium"
+        )
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Medium", language: "de"), "Mittel")
+
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(for: "Off", preferredLanguages: ["en-US"]),
+            "Off"
+        )
+        XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Off", language: "de"), "Aus")
+    }
+
     @MainActor
     func testSoundResolutionCachesImportedCustomSounds() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()


### PR DESCRIPTION
## Summary
- Fix the Recorder settings Echo Handling dropdown so the options use English source labels in English UI.
- Keep the German translations for Aggressive, Medium, and Off in the string catalog.
- Add a regression test that verifies the English fallback labels and German catalog values.

## Issue Context
Issue #528 reports that, with the app UI set to English, the Echo Handling dropdown still showed the German options `Aggressiv`, `Mittel`, and `Aus`.

Closes #528

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/SoundServiceTests/testRecorderEchoHandlingLabelsUseEnglishSourceStringsWithGermanTranslations`
- `jq empty TypeWhisper/Resources/Localizable.xcstrings`
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/SoundServiceTests`
