### PR TITLE
Add Parakeet live transcription session

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -1,13 +1,54 @@
+@preconcurrency import AVFoundation
 import Foundation
 import OSLog
 import SwiftUI
 import FluidAudio
 import TypeWhisperPluginSDK
 
+private let parakeetLiveSampleRate: Double = 16_000
+
+private func makeParakeetLiveAudioBuffer(from samples: [Float]) throws -> AVAudioPCMBuffer {
+    guard let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: parakeetLiveSampleRate,
+        channels: 1,
+        interleaved: false
+    ) else {
+        throw PluginTranscriptionError.apiError("Unable to create Parakeet live audio format")
+    }
+
+    guard let buffer = AVAudioPCMBuffer(
+        pcmFormat: format,
+        frameCapacity: AVAudioFrameCount(samples.count)
+    ) else {
+        throw PluginTranscriptionError.apiError("Unable to create Parakeet live audio buffer")
+    }
+
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    guard let destination = buffer.floatChannelData?.pointee else {
+        throw PluginTranscriptionError.apiError("Unable to access Parakeet live audio buffer")
+    }
+
+    samples.withUnsafeBufferPointer { source in
+        if let baseAddress = source.baseAddress {
+            destination.update(from: baseAddress, count: samples.count)
+        }
+    }
+
+    return buffer
+}
+
+private func combinedParakeetLiveTranscript(confirmed: String, volatile: String) -> String {
+    [confirmed, volatile]
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+}
+
 // MARK: - Plugin Entry Point
 
 @objc(ParakeetPlugin)
-final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
     private static let logger = Logger(subsystem: "com.typewhisper.plugin.parakeet", category: "Transcription")
@@ -16,6 +57,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     fileprivate var host: HostServices?
     fileprivate var asrManager: AsrManager?
+    fileprivate var loadedAsrModels: AsrModels?
     fileprivate var loadedModelId: String?
     fileprivate var _selectedModelId: String?
     var modelState: ParakeetModelState = .notLoaded
@@ -68,6 +110,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     func deactivate() {
         clearVocabularyBoostingState(resetModelState: true)
         asrManager = nil
+        loadedAsrModels = nil
         loadedModelId = nil
         _selectedModelId = nil
         modelState = .notLoaded
@@ -105,6 +148,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     var selectedModelId: String? { _selectedModelId }
     var allowsTranscriptPreviewFallback: Bool { false }
+    var supportsStreaming: Bool { true }
 
     func selectModel(_ modelId: String) {
         guard let version = ParakeetVersion.from(modelId: modelId) else { return }
@@ -192,6 +236,44 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         }
 
         return PluginTranscriptionResult(text: finalResult.text, detectedLanguage: nil, segments: segments)
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("Parakeet does not support translation")
+        }
+
+        guard let loadedAsrModels else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        if vocabularyBoostingEnabled {
+            await configureBoostingIfNeeded(prompt: prompt)
+        }
+
+        let manager = SlidingWindowAsrManager(config: .streaming)
+        try await manager.loadModels(loadedAsrModels)
+
+        if vocabularyBoostingEnabled,
+           let customVocabulary,
+           let ctcModels {
+            do {
+                try await manager.configureVocabularyBoosting(
+                    vocabulary: customVocabulary,
+                    ctcModels: ctcModels
+                )
+            } catch {
+                Self.logger.warning("Live vocabulary boosting setup failed: \(error.localizedDescription)")
+            }
+        }
+
+        try await manager.startStreaming(source: .microphone)
+        return ParakeetLiveTranscriptionSession(manager: manager, onProgress: onProgress)
     }
 
     private static func fluidAudioLanguage(for language: String?) -> Language? {
@@ -454,6 +536,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
             downloadProgress = 1.0
 
             asrManager = manager
+            loadedAsrModels = models
             loadedModelId = selectedVersion.modelDef.id
             _selectedModelId = selectedVersion.modelDef.id
             modelState = .ready
@@ -481,6 +564,7 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     func unloadModel(clearPersistence: Bool = true) {
         clearVocabularyBoostingState(resetModelState: true)
         asrManager = nil
+        loadedAsrModels = nil
         loadedModelId = nil
         modelState = .notLoaded
         downloadProgress = 0
@@ -562,6 +646,88 @@ final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     func applyHuggingFaceTokenToEnvironment() {
         PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
+    }
+}
+
+// MARK: - Live Transcription
+
+private actor ParakeetLiveTranscriptionSession: LiveTranscriptionSession {
+    private let manager: SlidingWindowAsrManager
+    private var updateTask: Task<Void, Never>?
+    private var isCancelled = false
+
+    init(
+        manager: SlidingWindowAsrManager,
+        onProgress: @escaping @Sendable (String) -> Bool
+    ) {
+        self.manager = manager
+        self.updateTask = Self.startUpdateTask(manager: manager, onProgress: onProgress)
+    }
+
+    func appendAudio(samples: [Float]) async throws {
+        guard !isCancelled, !samples.isEmpty else { return }
+        let buffer = try makeParakeetLiveAudioBuffer(from: samples)
+        await manager.streamAudio(buffer)
+    }
+
+    func finish() async throws -> PluginTranscriptionResult {
+        guard !isCancelled else {
+            return PluginTranscriptionResult(text: "", detectedLanguage: nil, segments: [])
+        }
+
+        do {
+            let finalText = try await manager.finish()
+            await stop()
+            return PluginTranscriptionResult(
+                text: finalText.trimmingCharacters(in: .whitespacesAndNewlines),
+                detectedLanguage: nil,
+                segments: []
+            )
+        } catch {
+            await stop()
+            throw error
+        }
+    }
+
+    func cancel() async {
+        await stop()
+    }
+
+    private func stop() async {
+        guard !isCancelled else { return }
+        isCancelled = true
+        updateTask?.cancel()
+        updateTask = nil
+        await manager.cancel()
+    }
+
+    private static func startUpdateTask(
+        manager: SlidingWindowAsrManager,
+        onProgress: @escaping @Sendable (String) -> Bool
+    ) -> Task<Void, Never> {
+        Task {
+            var lastProgressText = ""
+
+            for await _ in await manager.transcriptionUpdates {
+                guard !Task.isCancelled else { return }
+
+                let confirmed = await manager.confirmedTranscript
+                let volatile = await manager.volatileTranscript
+                let combinedText = combinedParakeetLiveTranscript(
+                    confirmed: confirmed,
+                    volatile: volatile
+                )
+                guard !combinedText.isEmpty, combinedText != lastProgressText else {
+                    continue
+                }
+
+                lastProgressText = combinedText
+                if !onProgress(combinedText) {
+                    await manager.cancel()
+                    return
+                }
+            }
+        }
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -112,6 +112,15 @@ final class ParakeetPluginTests: XCTestCase {
         XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
     }
 
+    func testProvidesLiveTranscriptionSessionCapability() throws {
+        let plugin = ParakeetPlugin()
+        let livePlugin: any LiveTranscriptionCapablePlugin = plugin
+        let fallbackPolicy: any TranscriptPreviewFallbackPolicyProviding = plugin
+
+        XCTAssertTrue(livePlugin.supportsStreaming)
+        XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
+    }
+
     func testDictionaryTermsSupportReflectsStoredBoostingPreference() throws {
         let defaultHost = try PluginTestHostServices()
         let defaultPlugin = makePlugin()


### PR DESCRIPTION
## Summary
- Adds a real `LiveTranscriptionSession` implementation to Parakeet using FluidAudio's `SlidingWindowAsrManager`.
- Retains loaded `AsrModels` for live-session creation and releases them on unload/deactivate.
- Streams 16 kHz mono float samples into FluidAudio as `AVAudioPCMBuffer` chunks and emits deduped cumulative live progress text from confirmed + volatile transcript.
- Keeps `allowsTranscriptPreviewFallback` disabled so Parakeet does not regress to the batch preview path from #433.

## Issue context
Issue #531 reports that after updating to TypeWhisper 1.4.0 (752) RC, Parakeet v3 still produces the overlay/notch UI but no longer renders live transcript text while speaking. This restores live preview by routing Parakeet through a real live transcription session instead of relying on the disabled batch-preview fallback.

Closes #531

## Test plan
- [x] `swift test --package-path TypeWhisperPluginSDK --filter ParakeetPluginTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/StreamingHandlerTests`
  - Local note: the first run exposed a missing Metal Toolchain; after `xcodebuild -downloadComponent MetalToolchain`, the same test command passed.
- [x] `git diff --check`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh ParakeetPlugin "$(pwd)"`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$(pwd)"`
- [ ] Manual acceptance: Parakeet v3 selected, live transcript preview enabled, indicator mode Notch; verify speech updates live text, final dictation inserts text, and preview-disabled final transcription remains unchanged.