### PR TITLE
Recover failed dictation audio

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -78,6 +78,9 @@
 			3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
 			533A00000000000000000002 /* DictationRecoveryAudioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */; };
 			533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A00000000000000000003 /* DictationRecoveryAudioStore.swift */; };
+			533B00000000000000000002 /* FileTranscriptionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533B00000000000000000001 /* FileTranscriptionViewModelTests.swift */; };
+			533C00000000000000000002 /* DictationRecoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C00000000000000000001 /* DictationRecoveryViewModel.swift */; };
+			533C00000000000000000004 /* DictationRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C00000000000000000003 /* DictationRecoveryView.swift */; };
 			6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
 		A91F00000000000000000001 /* SelectionPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000001 /* SelectionPalettePanel.swift */; };
 		A91F00000000000000000002 /* RecentTranscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000002 /* RecentTranscriptionStore.swift */; };
@@ -457,6 +460,7 @@
 			3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
 			533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStoreTests.swift; sourceTree = "<group>"; };
 			533A00000000000000000003 /* DictationRecoveryAudioStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStore.swift; sourceTree = "<group>"; };
+			533B00000000000000000001 /* FileTranscriptionViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FileTranscriptionViewModelTests.swift; sourceTree = "<group>"; };
 			3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
 		B91F00000000000000000001 /* SelectionPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPalettePanel.swift; sourceTree = "<group>"; };
 		B91F00000000000000000002 /* RecentTranscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionStore.swift; sourceTree = "<group>"; };
@@ -485,9 +489,11 @@
 		BB00000000000000000009 /* ModelManagerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerService.swift; sourceTree = "<group>"; };
 		BB00000000000000000010 /* AudioFileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFileService.swift; sourceTree = "<group>"; };
 		BB00000000000000000012 /* FileTranscriptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTranscriptionViewModel.swift; sourceTree = "<group>"; };
+		533C00000000000000000001 /* DictationRecoveryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationRecoveryViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000013 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000014 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		BB00000000000000000016 /* FileTranscriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTranscriptionView.swift; sourceTree = "<group>"; };
+		533C00000000000000000003 /* DictationRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationRecoveryView.swift; sourceTree = "<group>"; };
 		BB00000000000000000017 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000018 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BB00000000000000000019 /* TypeWhisper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TypeWhisper.entitlements; sourceTree = "<group>"; };
@@ -1335,6 +1341,7 @@
 			isa = PBXGroup;
 			children = (
 				BB00000000000000000012 /* FileTranscriptionViewModel.swift */,
+				533C00000000000000000001 /* DictationRecoveryViewModel.swift */,
 				BB00000000000000000013 /* SettingsViewModel.swift */,
 				BB00000000000000000033 /* DictationViewModel.swift */,
 				BB00000000000000000045 /* APIServerViewModel.swift */,
@@ -1367,6 +1374,7 @@
 				BB00000000000000000197 /* SharedIndicatorComponents.swift */,
 				BB00000000000000000014 /* MenuBarView.swift */,
 				BB00000000000000000016 /* FileTranscriptionView.swift */,
+				533C00000000000000000003 /* DictationRecoveryView.swift */,
 				BB00000000000000000017 /* SettingsView.swift */,
 				BB00000000000000000359 /* WorkflowsSettingsView.swift */,
 				BB00000000000000000046 /* AdvancedSettingsView.swift */,
@@ -1948,6 +1956,7 @@
 					6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
 					E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
 					533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */,
+					533B00000000000000000001 /* FileTranscriptionViewModelTests.swift */,
 					AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
 				D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */,
 				A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */,
@@ -3263,6 +3272,7 @@
 					E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,
 					3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,
 					533A00000000000000000002 /* DictationRecoveryAudioStoreTests.swift in Sources */,
+					533B00000000000000000002 /* FileTranscriptionViewModelTests.swift in Sources */,
 					BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,
 				B4CC04DF94001FF7220789BC /* DictionaryServiceTests.swift in Sources */,
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
@@ -3340,9 +3350,11 @@
 				AA00000000000000000009 /* ModelManagerService.swift in Sources */,
 				AA00000000000000000010 /* AudioFileService.swift in Sources */,
 				AA00000000000000000012 /* FileTranscriptionViewModel.swift in Sources */,
+				533C00000000000000000002 /* DictationRecoveryViewModel.swift in Sources */,
 				AA00000000000000000013 /* SettingsViewModel.swift in Sources */,
 				AA00000000000000000014 /* MenuBarView.swift in Sources */,
 				AA00000000000000000016 /* FileTranscriptionView.swift in Sources */,
+				533C00000000000000000004 /* DictationRecoveryView.swift in Sources */,
 				AA00000000000000000017 /* SettingsView.swift in Sources */,
 				AA00000000000000000030 /* AudioRecordingService.swift in Sources */,
 				533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */,

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -74,9 +74,11 @@
 		9A584149706C7567496E0203 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 9A584149706C7567496E0260 /* TypeWhisperPluginSDK */; };
 		9A584149706C7567496E0204 /* XAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A584149706C7567496E0210 /* XAIPlugin.swift */; };
 		E5A1B2C3D4F5061728394A5B /* NotchIndicatorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5C /* NotchIndicatorLayout.swift */; };
-		E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */; };
-		3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
-		6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
+			E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */; };
+			3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
+			533A00000000000000000002 /* DictationRecoveryAudioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */; };
+			533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A00000000000000000003 /* DictationRecoveryAudioStore.swift */; };
+			6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
 		A91F00000000000000000001 /* SelectionPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000001 /* SelectionPalettePanel.swift */; };
 		A91F00000000000000000002 /* RecentTranscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000002 /* RecentTranscriptionStore.swift */; };
 		A91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */; };
@@ -452,8 +454,10 @@
 
 /* Begin PBXFileReference section */
 		05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDiffServiceTests.swift; sourceTree = "<group>"; };
-		3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
-		3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
+			3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
+			533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStoreTests.swift; sourceTree = "<group>"; };
+			533A00000000000000000003 /* DictationRecoveryAudioStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStore.swift; sourceTree = "<group>"; };
+			3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
 		B91F00000000000000000001 /* SelectionPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPalettePanel.swift; sourceTree = "<group>"; };
 		B91F00000000000000000002 /* RecentTranscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionStore.swift; sourceTree = "<group>"; };
 		B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionPaletteHandler.swift; sourceTree = "<group>"; };
@@ -1275,6 +1279,7 @@
 				BB00000000000000000009 /* ModelManagerService.swift */,
 				BB00000000000000000010 /* AudioFileService.swift */,
 				BB00000000000000000030 /* AudioRecordingService.swift */,
+				533A00000000000000000003 /* DictationRecoveryAudioStore.swift */,
 				BB00000000000000000350 /* ObjCExceptionCatcher.h */,
 				BB00000000000000000351 /* ObjCExceptionCatcher.m */,
 				BB00000000000000000220 /* AudioPlaybackService.swift */,
@@ -1940,9 +1945,10 @@
 				CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */,
 				FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
-				6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
-				E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
-				AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
+					6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
+					E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
+					533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */,
+					AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
 				D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */,
 				A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */,
 				8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */,
@@ -3253,10 +3259,11 @@
 				7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */,
 				A40500000000000000000101 /* CLIClient.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */,
-				7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */,
-				E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,
-				3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,
-				BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,
+					7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */,
+					E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,
+					3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,
+					533A00000000000000000002 /* DictationRecoveryAudioStoreTests.swift in Sources */,
+					BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,
 				B4CC04DF94001FF7220789BC /* DictionaryServiceTests.swift in Sources */,
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
@@ -3338,6 +3345,7 @@
 				AA00000000000000000016 /* FileTranscriptionView.swift in Sources */,
 				AA00000000000000000017 /* SettingsView.swift in Sources */,
 				AA00000000000000000030 /* AudioRecordingService.swift in Sources */,
+				533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */,
 				AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */,
 				AA00000000000000000230 /* AudioPlaybackService.swift in Sources */,
 				AA00000000000000000031 /* HotkeyService.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -49,6 +49,7 @@ final class ServiceContainer: ObservableObject {
 
     // ViewModels
     let fileTranscriptionViewModel: FileTranscriptionViewModel
+    let dictationRecoveryViewModel: DictationRecoveryViewModel
     let settingsViewModel: SettingsViewModel
     let dictationViewModel: DictationViewModel
     let historyViewModel: HistoryViewModel
@@ -117,6 +118,12 @@ final class ServiceContainer: ObservableObject {
         // ViewModels (created before HTTP API so DictationViewModel is available)
         fileTranscriptionViewModel = FileTranscriptionViewModel(
             modelManager: modelManagerService,
+            audioFileService: audioFileService
+        )
+        dictationRecoveryViewModel = DictationRecoveryViewModel(
+            audioRecordingService: audioRecordingService,
+            modelManager: modelManagerService,
+            historyService: historyService,
             audioFileService: audioFileService
         )
         settingsViewModel = SettingsViewModel(modelManager: modelManagerService)
@@ -194,6 +201,7 @@ final class ServiceContainer: ObservableObject {
 
         // Set shared references
         FileTranscriptionViewModel._shared = fileTranscriptionViewModel
+        DictationRecoveryViewModel._shared = dictationRecoveryViewModel
         SettingsViewModel._shared = settingsViewModel
         DictationViewModel._shared = dictationViewModel
         APIServerViewModel._shared = apiServerViewModel
@@ -218,6 +226,8 @@ final class ServiceContainer: ObservableObject {
 
         modelManagerService.observePluginManager()
         promptProcessingService.observePluginManager()
+        fileTranscriptionViewModel.observePluginManager()
+        dictationRecoveryViewModel.observePluginManager()
         settingsViewModel.observePluginManager()
         watchFolderViewModel.observePluginManager()
     }

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -102,6 +102,16 @@ enum UserDefaultsKeys {
     static let recorderMicDuckingMode = "recorderMicDuckingMode"
     static let recorderTrackMode = "recorderTrackMode"
 
+    // MARK: - File Transcription
+    static let fileTranscriptionEngine = "fileTranscriptionEngine"
+    static let fileTranscriptionModel = "fileTranscriptionModel"
+    static let fileTranscriptionLanguage = "fileTranscriptionLanguage"
+
+    // MARK: - Dictation Recovery
+    static let dictationRecoveryEngine = "dictationRecoveryEngine"
+    static let dictationRecoveryModel = "dictationRecoveryModel"
+    static let dictationRecoveryLanguage = "dictationRecoveryLanguage"
+
     // MARK: - Watch Folder
     static let watchFolderBookmark = "watchFolderBookmark"
     static let watchFolderOutputBookmark = "watchFolderOutputBookmark"

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -88,6 +88,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     /// tears down the session, and resumes any paused media / restores ducking.
     /// Reset to nil at the start of each `startRecording`.
     @Published private(set) var recoveryError: AudioRecordingError?
+    @Published private(set) var recoverableRecordingURLs: [URL]
     @Published private(set) var recoverableRecordingURL: URL?
     var hasMicrophonePermissionOverride: Bool?
     var inputAvailabilityOverride: ((AudioDeviceID?) -> Bool)?
@@ -170,7 +171,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         self.inputReadinessChecker = inputReadinessChecker
         self.inputCaptureFactory = inputCaptureFactory
         self.recoveryAudioStore = recoveryAudioStore
-        self.recoverableRecordingURL = recoveryAudioStore.latestRecoveryURL
+        let recoveryURLs = recoveryAudioStore.recoveryURLs
+        self.recoverableRecordingURLs = recoveryURLs
+        self.recoverableRecordingURL = recoveryURLs.first
         recoveryNotificationQueue.underlyingQueue = recoveryQueue
     }
 
@@ -275,7 +278,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         try validateRecordingInputAvailability()
         clearRecordingBuffer(requestUptimeNanoseconds: requestUptimeNanoseconds)
         recoveryAudioStore.startNewRecording()
-        publishRecoverableRecordingURL(recoveryAudioStore.latestRecoveryURL)
+        publishRecoverableRecordingURLs(recoveryAudioStore.recoveryURLs)
 
         let routeActivationRequest = selectedRouteActivationRequest
         outputVolumeGuard.captureBaseline()
@@ -565,6 +568,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         inputActivationGuard.restore(reason: "recording-recovery-failure")
         processingQueue.sync { }
         let recoveryURL = preserveActiveRecoveryRecording()
+        let recoveryURLs = recoveryRecordingURLs
         clearRecordingBuffer()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -572,6 +576,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             self.isRecording = false
             self.audioLevel = 0
             self.rawAudioLevel = 0
+            self.recoverableRecordingURLs = recoveryURLs
             self.recoverableRecordingURL = recoveryURL
         }
     }
@@ -1071,28 +1076,45 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         recoveryAudioStore.latestRecoveryURL
     }
 
+    var recoveryRecordingURLs: [URL] {
+        recoveryAudioStore.recoveryURLs
+    }
+
     @discardableResult
     func preserveActiveRecoveryRecording() -> URL? {
         let url = recoveryAudioStore.preserveActiveRecording()
-        publishRecoverableRecordingURL(url)
+        publishRecoverableRecordingURLs(recoveryAudioStore.recoveryURLs)
         return url
     }
 
     func discardActiveRecoveryRecording() {
-        discardActiveRecoveryRecording(keepingLatest: false)
+        discardActiveRecoveryRecording(keepingLatest: true)
+    }
+
+    func discardRecoveryRecording(at url: URL) {
+        recoveryAudioStore.discardRecovery(at: url)
+        publishRecoverableRecordingURLs(recoveryAudioStore.recoveryURLs)
+    }
+
+    func discardAllRecoveryRecordings() {
+        recoveryAudioStore.discardAllRecoveries()
+        publishRecoverableRecordingURLs([])
     }
 
     private func discardActiveRecoveryRecording(keepingLatest: Bool) {
         recoveryAudioStore.discardActiveRecording(keepingLatest: keepingLatest)
-        publishRecoverableRecordingURL(recoveryAudioStore.latestRecoveryURL)
+        publishRecoverableRecordingURLs(recoveryAudioStore.recoveryURLs)
     }
 
-    private func publishRecoverableRecordingURL(_ url: URL?) {
+    private func publishRecoverableRecordingURLs(_ urls: [URL]) {
+        let latestURL = urls.first
         if Thread.isMainThread {
-            recoverableRecordingURL = url
+            recoverableRecordingURLs = urls
+            recoverableRecordingURL = latestURL
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.recoverableRecordingURL = url
+                self?.recoverableRecordingURLs = urls
+                self?.recoverableRecordingURL = latestURL
             }
         }
     }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -88,6 +88,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     /// tears down the session, and resumes any paused media / restores ducking.
     /// Reset to nil at the start of each `startRecording`.
     @Published private(set) var recoveryError: AudioRecordingError?
+    @Published private(set) var recoverableRecordingURL: URL?
     var hasMicrophonePermissionOverride: Bool?
     var inputAvailabilityOverride: ((AudioDeviceID?) -> Bool)?
     var startRecordingOverride: (() throws -> Void)?
@@ -140,6 +141,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let recoveryQueue = DispatchQueue(label: "com.typewhisper.audio-recovery", qos: .userInitiated)
     private let engineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.audio-engine-teardown")
     private let recoveryCoordinator = AudioEngineRecoveryCoordinator()
+    private let recoveryAudioStore: DictationRecoveryAudioStore
     private let outputVolumeGuard: AudioOutputVolumeGuard
     private let inputActivationGuard: AudioInputDeviceActivating
     private let bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing
@@ -159,13 +161,16 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         inputActivationGuard: AudioInputDeviceActivating = AudioInputDeviceActivationGuard(),
         bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
         inputReadinessChecker: AudioInputReadinessChecking = BluetoothInputReadinessChecker(),
-        inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory()
+        inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory(),
+        recoveryAudioStore: DictationRecoveryAudioStore = DictationRecoveryAudioStore()
     ) {
         self.outputVolumeGuard = outputVolumeGuard
         self.inputActivationGuard = inputActivationGuard
         self.bluetoothInputRouteStabilizer = bluetoothInputRouteStabilizer
         self.inputReadinessChecker = inputReadinessChecker
         self.inputCaptureFactory = inputCaptureFactory
+        self.recoveryAudioStore = recoveryAudioStore
+        self.recoverableRecordingURL = recoveryAudioStore.latestRecoveryURL
         recoveryNotificationQueue.underlyingQueue = recoveryQueue
     }
 
@@ -269,6 +274,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         try validateRecordingInputAvailability()
         clearRecordingBuffer(requestUptimeNanoseconds: requestUptimeNanoseconds)
+        recoveryAudioStore.startNewRecording()
+        publishRecoverableRecordingURL(recoveryAudioStore.latestRecoveryURL)
 
         let routeActivationRequest = selectedRouteActivationRequest
         outputVolumeGuard.captureBaseline()
@@ -280,6 +287,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         ) else {
             outputVolumeGuard.restoreIfRaised(reason: "recording-start-input-activation-failed")
             outputVolumeGuard.clear()
+            discardActiveRecoveryRecording(keepingLatest: true)
             throw AudioRecordingError.audioRoutingConflict
         }
 
@@ -293,6 +301,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             outputVolumeGuard.restoreIfRaised(reason: "recording-start-route-stabilization-failed")
             outputVolumeGuard.clear()
             inputActivationGuard.restore(reason: "recording-start-route-stabilization-failed")
+            discardActiveRecoveryRecording(keepingLatest: true)
             throw error
         }
 
@@ -310,6 +319,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                 outputVolumeGuard.restoreIfRaised(reason: "recording-start-override-failed")
                 outputVolumeGuard.clear()
                 inputActivationGuard.restore(reason: "recording-start-override-failed")
+                discardActiveRecoveryRecording(keepingLatest: true)
                 throw error
             }
             return
@@ -323,6 +333,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                 isRecording = true
             } catch {
                 cleanupAfterFailedInputOnlyStart()
+                discardActiveRecoveryRecording(keepingLatest: true)
                 throw error
             }
             return
@@ -359,6 +370,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         } catch {
             let failedEngine = engineLock.withLock { audioEngine } ?? engine
             cleanupAfterFailedStart(failedEngine)
+            discardActiveRecoveryRecording(keepingLatest: true)
             throw error
         }
     }
@@ -551,6 +563,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         outputVolumeGuard.restoreIfRaised(reason: "recording-recovery-failure")
         outputVolumeGuard.clear()
         inputActivationGuard.restore(reason: "recording-recovery-failure")
+        processingQueue.sync { }
+        let recoveryURL = preserveActiveRecoveryRecording()
         clearRecordingBuffer()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -558,6 +572,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             self.isRecording = false
             self.audioLevel = 0
             self.rawAudioLevel = 0
+            self.recoverableRecordingURL = recoveryURL
         }
     }
 
@@ -996,6 +1011,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             )
         }
         bufferLock.unlock()
+        recoveryAudioStore.append(samples)
 
         if let requestToFirstBufferMs {
             logger.info(
@@ -1049,6 +1065,36 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     /// unwound so the @Published value doesn't linger for later bindings.
     func clearRecoveryError() {
         recoveryError = nil
+    }
+
+    var latestRecoveryRecordingURL: URL? {
+        recoveryAudioStore.latestRecoveryURL
+    }
+
+    @discardableResult
+    func preserveActiveRecoveryRecording() -> URL? {
+        let url = recoveryAudioStore.preserveActiveRecording()
+        publishRecoverableRecordingURL(url)
+        return url
+    }
+
+    func discardActiveRecoveryRecording() {
+        discardActiveRecoveryRecording(keepingLatest: false)
+    }
+
+    private func discardActiveRecoveryRecording(keepingLatest: Bool) {
+        recoveryAudioStore.discardActiveRecording(keepingLatest: keepingLatest)
+        publishRecoverableRecordingURL(recoveryAudioStore.latestRecoveryURL)
+    }
+
+    private func publishRecoverableRecordingURL(_ url: URL?) {
+        if Thread.isMainThread {
+            recoverableRecordingURL = url
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.recoverableRecordingURL = url
+            }
+        }
     }
 
     private func mapSelectedInputDeviceError(_ error: SelectedInputDeviceError) -> AudioRecordingError {
@@ -1213,6 +1259,14 @@ extension AudioRecordingService {
 
     func testingMarkInitialInputTapSeen(_ buffer: AVAudioPCMBuffer) {
         markInitialInputTapSeenIfNeeded(buffer)
+    }
+
+    func testingProcessConvertedSamples(_ samples: [Float]) {
+        processConvertedSamples(samples)
+    }
+
+    func testingFailActiveRecordingDueToRecovery(_ error: AudioRecordingError) {
+        failActiveRecordingDueToRecovery(error)
     }
 }
 #endif

--- a/TypeWhisper/Services/DictationRecoveryAudioStore.swift
+++ b/TypeWhisper/Services/DictationRecoveryAudioStore.swift
@@ -10,33 +10,42 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
         static let bytesPerSample = 2
         static let wavHeaderByteCount = 44
         static let activeFileName = "active-dictation-recovery.wav"
-        static let latestFileName = "last-dictation-recovery.wav"
+        static let legacyLatestFileName = "last-dictation-recovery.wav"
+        static let recoveryFilePrefix = "dictation-recovery-"
+        static let recoveryFileExtension = "wav"
     }
 
     private let directory: URL
     private let activeFileURL: URL
-    private let latestFileURL: URL
     private let fileManager: FileManager
     private let queue = DispatchQueue(label: "com.typewhisper.dictation-recovery-audio", qos: .utility)
 
     private var activeHandle: FileHandle?
     private var activeSampleCount = 0
     private var hasActiveRecording = false
+    private var recoverySerialNumber: UInt64 = 0
 
     init(
         directory: URL = AppConstants.appSupportDirectory
             .appendingPathComponent("dictation-recovery", isDirectory: true),
         fileManager: FileManager = .default
     ) {
-        self.directory = directory
-        self.activeFileURL = directory.appendingPathComponent(Constants.activeFileName)
-        self.latestFileURL = directory.appendingPathComponent(Constants.latestFileName)
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let standardizedDirectory = directory.resolvingSymlinksInPath().standardizedFileURL
+        self.directory = standardizedDirectory
+        self.activeFileURL = standardizedDirectory.appendingPathComponent(Constants.activeFileName)
         self.fileManager = fileManager
+    }
+
+    var recoveryURLs: [URL] {
+        queue.sync {
+            storedRecoveryURLs()
+        }
     }
 
     var latestRecoveryURL: URL? {
         queue.sync {
-            fileManager.fileExists(atPath: latestFileURL.path) ? latestFileURL : nil
+            storedRecoveryURLs().first
         }
     }
 
@@ -80,7 +89,7 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
     func preserveActiveRecording() -> URL? {
         queue.sync {
             guard hasActiveRecording else {
-                return fileManager.fileExists(atPath: latestFileURL.path) ? latestFileURL : nil
+                return storedRecoveryURLs().first
             }
 
             closeActiveHandle()
@@ -89,40 +98,118 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
             guard activeSampleCount > 0 else {
                 activeSampleCount = 0
                 removeItemIfExists(at: activeFileURL)
-                removeItemIfExists(at: latestFileURL)
-                return nil
+                return storedRecoveryURLs().first
             }
 
             finalizeActiveWavHeader(sampleCount: activeSampleCount)
-            removeItemIfExists(at: latestFileURL)
+            let recoveryURL = makeUniqueRecoveryFileURL()
 
             do {
-                try fileManager.moveItem(at: activeFileURL, to: latestFileURL)
+                try fileManager.moveItem(at: activeFileURL, to: recoveryURL)
                 activeSampleCount = 0
-                return latestFileURL
+                return canonicalFileURL(recoveryURL)
             } catch {
                 activeSampleCount = 0
                 removeItemIfExists(at: activeFileURL)
-                return fileManager.fileExists(atPath: latestFileURL.path) ? latestFileURL : nil
+                return storedRecoveryURLs().first
             }
         }
     }
 
-    func discardActiveRecording(keepingLatest: Bool = false) {
+    func discardActiveRecording(keepingLatest: Bool = true) {
         queue.sync {
             closeActiveHandle()
             activeSampleCount = 0
             hasActiveRecording = false
             removeItemIfExists(at: activeFileURL)
             if !keepingLatest {
-                removeItemIfExists(at: latestFileURL)
+                removeStoredRecoveries()
             }
         }
     }
 
     func discardLatestRecovery() {
         queue.sync {
-            removeItemIfExists(at: latestFileURL)
+            guard let latestRecoveryURL = storedRecoveryURLs().first else { return }
+            removeItemIfExists(at: latestRecoveryURL)
+        }
+    }
+
+    func discardRecovery(at url: URL) {
+        queue.sync {
+            guard isStoredRecoveryFile(url) else { return }
+            removeItemIfExists(at: url)
+        }
+    }
+
+    func discardAllRecoveries() {
+        queue.sync {
+            removeStoredRecoveries()
+        }
+    }
+
+    private func storedRecoveryURLs() -> [URL] {
+        guard fileManager.fileExists(atPath: directory.path),
+              let urls = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+              )
+        else {
+            return []
+        }
+
+        return urls
+            .filter(isStoredRecoveryFile)
+            .map { directory.appendingPathComponent($0.lastPathComponent) }
+            .sorted { lhs, rhs in
+                let lhsDate = contentModificationDate(for: lhs)
+                let rhsDate = contentModificationDate(for: rhs)
+                if lhsDate != rhsDate {
+                    return lhsDate > rhsDate
+                }
+                return lhs.lastPathComponent > rhs.lastPathComponent
+            }
+    }
+
+    private func isStoredRecoveryFile(_ url: URL) -> Bool {
+        let canonicalURL = canonicalFileURL(url)
+        guard canonicalURL.deletingLastPathComponent() == directory else { return false }
+        guard url.pathExtension.lowercased() == Constants.recoveryFileExtension else { return false }
+        let fileName = url.lastPathComponent
+        return fileName == Constants.legacyLatestFileName || fileName.hasPrefix(Constants.recoveryFilePrefix)
+    }
+
+    private func contentModificationDate(for url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+    }
+
+    private func canonicalFileURL(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private func makeUniqueRecoveryFileURL() -> URL {
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        recoverySerialNumber += 1
+        let baseName = "\(Constants.recoveryFilePrefix)\(Self.recoveryTimestamp(from: Date()))-\(String(format: "%04llu", recoverySerialNumber))"
+        var candidate = directory
+            .appendingPathComponent(baseName)
+            .appendingPathExtension(Constants.recoveryFileExtension)
+        var collisionIndex = 2
+
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = directory
+                .appendingPathComponent("\(baseName)-\(collisionIndex)")
+                .appendingPathExtension(Constants.recoveryFileExtension)
+            collisionIndex += 1
+        }
+
+        return candidate
+    }
+
+    private func removeStoredRecoveries() {
+        for url in storedRecoveryURLs() {
+            removeItemIfExists(at: url)
         }
     }
 
@@ -185,6 +272,13 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
         data.appendASCII("data")
         data.appendLittleEndian(dataByteCount)
         return data
+    }
+
+    private static func recoveryTimestamp(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
+        return formatter.string(from: date)
     }
 }
 

--- a/TypeWhisper/Services/DictationRecoveryAudioStore.swift
+++ b/TypeWhisper/Services/DictationRecoveryAudioStore.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+/// Persists the active dictation as a temporary 16 kHz mono PCM WAV so the
+/// audio can be recovered if transcription fails after recording has stopped.
+final class DictationRecoveryAudioStore: @unchecked Sendable {
+    private enum Constants {
+        static let sampleRate: UInt32 = 16_000
+        static let bitsPerSample: UInt16 = 16
+        static let channelCount: UInt16 = 1
+        static let bytesPerSample = 2
+        static let wavHeaderByteCount = 44
+        static let activeFileName = "active-dictation-recovery.wav"
+        static let latestFileName = "last-dictation-recovery.wav"
+    }
+
+    private let directory: URL
+    private let activeFileURL: URL
+    private let latestFileURL: URL
+    private let fileManager: FileManager
+    private let queue = DispatchQueue(label: "com.typewhisper.dictation-recovery-audio", qos: .utility)
+
+    private var activeHandle: FileHandle?
+    private var activeSampleCount = 0
+    private var hasActiveRecording = false
+
+    init(
+        directory: URL = AppConstants.appSupportDirectory
+            .appendingPathComponent("dictation-recovery", isDirectory: true),
+        fileManager: FileManager = .default
+    ) {
+        self.directory = directory
+        self.activeFileURL = directory.appendingPathComponent(Constants.activeFileName)
+        self.latestFileURL = directory.appendingPathComponent(Constants.latestFileName)
+        self.fileManager = fileManager
+    }
+
+    var latestRecoveryURL: URL? {
+        queue.sync {
+            fileManager.fileExists(atPath: latestFileURL.path) ? latestFileURL : nil
+        }
+    }
+
+    func startNewRecording() {
+        queue.sync {
+            closeActiveHandle()
+            removeItemIfExists(at: activeFileURL)
+            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            fileManager.createFile(
+                atPath: activeFileURL.path,
+                contents: Self.wavHeader(sampleCount: 0),
+                attributes: nil
+            )
+            activeHandle = try? FileHandle(forWritingTo: activeFileURL)
+            _ = try? activeHandle?.seekToEnd()
+            activeSampleCount = 0
+            hasActiveRecording = activeHandle != nil
+        }
+    }
+
+    func append(_ samples: [Float]) {
+        guard !samples.isEmpty else { return }
+        let data = Self.pcm16Data(from: samples)
+
+        queue.async { [weak self] in
+            guard let self, self.hasActiveRecording, let activeHandle = self.activeHandle else { return }
+            do {
+                try activeHandle.write(contentsOf: data)
+                self.activeSampleCount += samples.count
+            } catch {
+                self.closeActiveHandle()
+                self.removeItemIfExists(at: self.activeFileURL)
+                self.hasActiveRecording = false
+                self.activeSampleCount = 0
+            }
+        }
+    }
+
+    @discardableResult
+    func preserveActiveRecording() -> URL? {
+        queue.sync {
+            guard hasActiveRecording else {
+                return fileManager.fileExists(atPath: latestFileURL.path) ? latestFileURL : nil
+            }
+
+            closeActiveHandle()
+            hasActiveRecording = false
+
+            guard activeSampleCount > 0 else {
+                activeSampleCount = 0
+                removeItemIfExists(at: activeFileURL)
+                removeItemIfExists(at: latestFileURL)
+                return nil
+            }
+
+            finalizeActiveWavHeader(sampleCount: activeSampleCount)
+            removeItemIfExists(at: latestFileURL)
+
+            do {
+                try fileManager.moveItem(at: activeFileURL, to: latestFileURL)
+                activeSampleCount = 0
+                return latestFileURL
+            } catch {
+                activeSampleCount = 0
+                removeItemIfExists(at: activeFileURL)
+                return fileManager.fileExists(atPath: latestFileURL.path) ? latestFileURL : nil
+            }
+        }
+    }
+
+    func discardActiveRecording(keepingLatest: Bool = false) {
+        queue.sync {
+            closeActiveHandle()
+            activeSampleCount = 0
+            hasActiveRecording = false
+            removeItemIfExists(at: activeFileURL)
+            if !keepingLatest {
+                removeItemIfExists(at: latestFileURL)
+            }
+        }
+    }
+
+    func discardLatestRecovery() {
+        queue.sync {
+            removeItemIfExists(at: latestFileURL)
+        }
+    }
+
+    private func finalizeActiveWavHeader(sampleCount: Int) {
+        guard let handle = try? FileHandle(forWritingTo: activeFileURL) else { return }
+        defer { try? handle.close() }
+
+        do {
+            try handle.seek(toOffset: 0)
+            try handle.write(contentsOf: Self.wavHeader(sampleCount: sampleCount))
+        } catch {
+            removeItemIfExists(at: activeFileURL)
+        }
+    }
+
+    private func closeActiveHandle() {
+        try? activeHandle?.synchronize()
+        try? activeHandle?.close()
+        activeHandle = nil
+    }
+
+    private func removeItemIfExists(at url: URL) {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try? fileManager.removeItem(at: url)
+    }
+
+    private static func pcm16Data(from samples: [Float]) -> Data {
+        var data = Data()
+        data.reserveCapacity(samples.count * Constants.bytesPerSample)
+
+        for sample in samples {
+            let clamped = max(-1, min(1, sample))
+            let scaled = Int16(clamped * Float(Int16.max))
+            var littleEndian = scaled.littleEndian
+            withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+        }
+
+        return data
+    }
+
+    private static func wavHeader(sampleCount: Int) -> Data {
+        let dataByteCount = UInt32(sampleCount * Constants.bytesPerSample)
+        let fileByteCount = UInt32(Constants.wavHeaderByteCount - 8) + dataByteCount
+        let byteRate = Constants.sampleRate * UInt32(Constants.channelCount) * UInt32(Constants.bytesPerSample)
+        let blockAlign = Constants.channelCount * Constants.bitsPerSample / 8
+
+        var data = Data()
+        data.reserveCapacity(Constants.wavHeaderByteCount)
+        data.appendASCII("RIFF")
+        data.appendLittleEndian(fileByteCount)
+        data.appendASCII("WAVE")
+        data.appendASCII("fmt ")
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(Constants.channelCount)
+        data.appendLittleEndian(Constants.sampleRate)
+        data.appendLittleEndian(byteRate)
+        data.appendLittleEndian(blockAlign)
+        data.appendLittleEndian(Constants.bitsPerSample)
+        data.appendASCII("data")
+        data.appendLittleEndian(dataByteCount)
+        return data
+    }
+}
+
+private extension Data {
+    mutating func appendASCII(_ string: String) {
+        append(contentsOf: string.utf8)
+    }
+
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
+    }
+}

--- a/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
@@ -1,0 +1,337 @@
+import Combine
+import Foundation
+import TypeWhisperPluginSDK
+
+@MainActor
+final class DictationRecoveryViewModel: ObservableObject {
+    typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
+    typealias TranscriptionRunner = @MainActor (
+        [Float],
+        LanguageSelection,
+        TranscriptionTask,
+        String?,
+        String?
+    ) async throws -> TranscriptionResult
+    typealias EngineReadinessChecker = @MainActor (String?) -> Bool
+
+    nonisolated(unsafe) static var _shared: DictationRecoveryViewModel?
+    static var shared: DictationRecoveryViewModel {
+        guard let instance = _shared else {
+            fatalError("DictationRecoveryViewModel not initialized")
+        }
+        return instance
+    }
+
+    enum RecoveryState: Equatable {
+        case idle
+        case loading
+        case transcribing
+        case error
+    }
+
+    struct RecoveryItem: Identifiable {
+        let url: URL
+        var state: RecoveryState = .idle
+        var errorMessage: String?
+
+        var id: String { url.path }
+        var fileName: String { url.lastPathComponent }
+
+        var isProcessing: Bool {
+            state == .loading || state == .transcribing
+        }
+    }
+
+    @Published private(set) var recoveries: [RecoveryItem]
+    @Published var selectedRecoveryID: RecoveryItem.ID?
+    @Published private(set) var lastSavedRecoveryFileName: String?
+    @Published private(set) var lastSavedHistoryRecordID: UUID?
+    @Published var languageSelection: LanguageSelection = .auto {
+        didSet {
+            defaults.set(
+                languageSelection.storedValue(nilBehavior: .auto),
+                forKey: UserDefaultsKeys.dictationRecoveryLanguage
+            )
+        }
+    }
+    @Published var selectedTask: TranscriptionTask = .transcribe
+    @Published var selectedEngine: String? {
+        didSet {
+            defaults.set(selectedEngine, forKey: UserDefaultsKeys.dictationRecoveryEngine)
+            guard isInitialized, oldValue != selectedEngine else { return }
+            selectedModel = nil
+            normalizeLanguageSelectionForResolvedEngine()
+        }
+    }
+    @Published var selectedModel: String? {
+        didSet { defaults.set(selectedModel, forKey: UserDefaultsKeys.dictationRecoveryModel) }
+    }
+
+    private let audioRecordingService: AudioRecordingService
+    private let modelManager: ModelManagerService
+    private let historyService: HistoryService
+    private let audioSamplesLoader: AudioSamplesLoader
+    private let transcriptionRunner: TranscriptionRunner
+    private let engineReadinessChecker: EngineReadinessChecker?
+    private let defaults: UserDefaults
+    private var cancellables = Set<AnyCancellable>()
+    private var isInitialized = false
+
+    init(
+        audioRecordingService: AudioRecordingService,
+        modelManager: ModelManagerService,
+        historyService: HistoryService,
+        audioFileService: AudioFileService,
+        defaults: UserDefaults = .standard,
+        audioSamplesLoader: AudioSamplesLoader? = nil,
+        transcriptionRunner: TranscriptionRunner? = nil,
+        engineReadinessChecker: EngineReadinessChecker? = nil
+    ) {
+        self.audioRecordingService = audioRecordingService
+        self.modelManager = modelManager
+        self.historyService = historyService
+        self.defaults = defaults
+        self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
+            try await audioFileService.loadAudioSamples(from: url)
+        }
+        self.transcriptionRunner = transcriptionRunner ?? { [modelManager] samples, languageSelection, task, engineOverrideId, cloudModelOverride in
+            try await modelManager.transcribe(
+                audioSamples: samples,
+                languageSelection: languageSelection,
+                task: task,
+                engineOverrideId: engineOverrideId,
+                cloudModelOverride: cloudModelOverride
+            )
+        }
+        self.engineReadinessChecker = engineReadinessChecker
+        let initialRecoveryURLs = audioRecordingService.recoveryRecordingURLs
+        self.recoveries = initialRecoveryURLs.map { RecoveryItem(url: $0) }
+        self.selectedRecoveryID = initialRecoveryURLs.first?.path
+        self.languageSelection = LanguageSelection(
+            storedValue: defaults.string(forKey: UserDefaultsKeys.dictationRecoveryLanguage),
+            nilBehavior: .auto
+        )
+        self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryEngine)
+        self.selectedModel = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryModel)
+        self.isInitialized = true
+
+        audioRecordingService.$recoverableRecordingURLs
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] urls in
+                self?.updateRecoveryURLs(urls)
+            }
+            .store(in: &cancellables)
+
+        reconcileSelectionWithAvailablePlugins()
+    }
+
+    var hasRecovery: Bool {
+        !recoveries.isEmpty
+    }
+
+    var hasRecoveryContent: Bool {
+        hasRecovery || lastSavedHistoryRecordID != nil
+    }
+
+    var selectedRecovery: RecoveryItem? {
+        if let selectedRecoveryID,
+           let selectedRecovery = recoveries.first(where: { $0.id == selectedRecoveryID }) {
+            return selectedRecovery
+        }
+        return recoveries.first
+    }
+
+    var recoveryURL: URL? {
+        selectedRecovery?.url
+    }
+
+    var state: RecoveryState {
+        selectedRecovery?.state ?? .idle
+    }
+
+    var errorMessage: String? {
+        selectedRecovery?.errorMessage
+    }
+
+    var fileName: String {
+        selectedRecovery?.fileName ?? localizedAppText("No recording", de: "Keine Aufnahme")
+    }
+
+    var isProcessing: Bool {
+        recoveries.contains { $0.isProcessing }
+    }
+
+    var canTranscribe: Bool {
+        selectedRecovery != nil && selectedEngineIsReady && !isProcessing
+    }
+
+    var supportsTranslation: Bool {
+        resolvedEngine?.supportsTranslation ?? false
+    }
+
+    var availableEngines: [TranscriptionEnginePlugin] {
+        guard let pluginManager = PluginManager.shared else { return [] }
+        return pluginManager.transcriptionEngines
+    }
+
+    var resolvedEngine: TranscriptionEnginePlugin? {
+        let engineId = selectedEngine ?? modelManager.selectedProviderId
+        guard let engineId else { return nil }
+        guard let pluginManager = PluginManager.shared else { return nil }
+        return pluginManager.transcriptionEngine(for: engineId)
+    }
+
+    var selectedEngineSupportedLanguages: [String] {
+        resolvedEngine?.supportedLanguages.sorted() ?? []
+    }
+
+    func observePluginManager() {
+        guard let pluginManager = PluginManager.shared else { return }
+        pluginManager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reconcileSelectionWithAvailablePlugins()
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    func canUseForTranscription(_ engine: TranscriptionEnginePlugin) -> Bool {
+        modelManager.canUseForTranscription(engine)
+    }
+
+    func transcribe() {
+        guard canTranscribe, let recovery = selectedRecovery else { return }
+
+        let recoveryID = recovery.id
+        let url = recovery.url
+        updateRecovery(id: recoveryID) { item in
+            item.state = .loading
+            item.errorMessage = nil
+        }
+
+        Task {
+            do {
+                let samples = try await audioSamplesLoader(url)
+                updateRecovery(id: recoveryID) { item in
+                    item.state = .transcribing
+                }
+                let result = try await transcriptionRunner(
+                    samples,
+                    languageSelection,
+                    selectedTask,
+                    selectedEngine,
+                    selectedModel
+                )
+
+                let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else {
+                    updateRecovery(id: recoveryID) { item in
+                        item.state = .error
+                        item.errorMessage = localizedAppText("No speech recognized", de: "Keine Sprache erkannt")
+                    }
+                    return
+                }
+
+                let historyID = UUID()
+                historyService.addRecord(
+                    id: historyID,
+                    rawText: result.text,
+                    finalText: text,
+                    appName: localizedAppText("Dictation Recovery", de: "Dictation-Recovery"),
+                    appBundleIdentifier: Bundle.main.bundleIdentifier,
+                    durationSeconds: result.duration,
+                    language: result.detectedLanguage ?? languageSelection.requestedLanguage,
+                    engineUsed: result.engineUsed,
+                    modelUsed: historyModelDisplayName(result: result),
+                    audioSamples: samples,
+                    pipelineSteps: [localizedAppText("Recovered recording", de: "Wiederhergestellte Aufnahme")]
+                )
+                lastSavedRecoveryFileName = url.lastPathComponent
+                lastSavedHistoryRecordID = historyID
+                audioRecordingService.discardRecoveryRecording(at: url)
+                updateRecoveryURLs(audioRecordingService.recoveryRecordingURLs)
+            } catch {
+                updateRecovery(id: recoveryID) { item in
+                    item.state = .error
+                    item.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func discardRecovery() {
+        discardSelectedRecovery()
+    }
+
+    func discardSelectedRecovery() {
+        guard let recovery = selectedRecovery else { return }
+        discardRecovery(recovery)
+    }
+
+    func discardRecovery(_ recovery: RecoveryItem) {
+        audioRecordingService.discardRecoveryRecording(at: recovery.url)
+        updateRecoveryURLs(audioRecordingService.recoveryRecordingURLs)
+    }
+
+    private func updateRecoveryURLs(_ urls: [URL]) {
+        let previousRecoveries = Dictionary(uniqueKeysWithValues: recoveries.map { ($0.id, $0) })
+        let updatedRecoveries = urls.map { url in
+            previousRecoveries[url.path] ?? RecoveryItem(url: url)
+        }
+        let selectedID = selectedRecoveryID
+
+        recoveries = updatedRecoveries
+
+        if let selectedID,
+           recoveries.contains(where: { $0.id == selectedID }) {
+            selectedRecoveryID = selectedID
+        } else {
+            selectedRecoveryID = recoveries.first?.id
+        }
+    }
+
+    private func updateRecovery(id: RecoveryItem.ID, _ update: (inout RecoveryItem) -> Void) {
+        guard let index = recoveries.firstIndex(where: { $0.id == id }) else { return }
+        update(&recoveries[index])
+    }
+
+    private func historyModelDisplayName(result: TranscriptionResult) -> String {
+        guard PluginManager.shared != nil else {
+            return selectedModel ?? selectedEngine ?? result.engineUsed
+        }
+
+        return modelManager.resolvedModelDisplayName(
+            engineOverrideId: selectedEngine,
+            cloudModelOverride: selectedModel
+        ) ?? selectedModel ?? selectedEngine ?? result.engineUsed
+    }
+
+    private var selectedEngineIsReady: Bool {
+        if let engineReadinessChecker {
+            return engineReadinessChecker(selectedEngine)
+        }
+
+        guard let engine = resolvedEngine else { return false }
+        guard modelManager.canUseForTranscription(engine) else { return false }
+        return engine.isConfigured
+    }
+
+    private func reconcileSelectionWithAvailablePlugins() {
+        guard let pluginManager = PluginManager.shared else { return }
+        if let selectedEngine,
+           pluginManager.transcriptionEngine(for: selectedEngine) == nil {
+            self.selectedEngine = nil
+            selectedModel = nil
+        }
+        normalizeLanguageSelectionForResolvedEngine()
+    }
+
+    private func normalizeLanguageSelectionForResolvedEngine() {
+        guard let engine = resolvedEngine else { return }
+        let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
+        if normalized != languageSelection {
+            languageSelection = normalized
+        }
+    }
+}

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1629,11 +1629,10 @@ final class DictationViewModel: ObservableObject {
     }
 
     func recoverLastRecording(openSettingsWindow: Bool = true) {
-        guard let url = audioRecordingService.latestRecoveryRecordingURL else { return }
+        guard audioRecordingService.latestRecoveryRecordingURL != nil else { return }
 
-        FileTranscriptionViewModel.shared.addFiles([url])
         if let navigationCoordinator = SettingsNavigationCoordinator.shared {
-            navigationCoordinator.navigate(to: .fileTranscription)
+            navigationCoordinator.navigate(to: .dictationRecovery)
         }
         if openSettingsWindow {
             ManagedAppWindowOpener.shared.open(id: "settings")

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -587,13 +587,18 @@ final class DictationViewModel: ObservableObject {
         lastStreamingParams = nil
     }
 
-    private func abortActiveRecordingImmediately(sessionMessage: String) {
+    private func abortActiveRecordingImmediately(sessionMessage: String, preserveRecoveryAudio: Bool = false) {
         clearDeferredRecordingContext()
         restoreRecordingSideEffects()
         streamingHandler.stop()
         stopRecordingTimer()
         Task {
             _ = await audioRecordingService.stopRecording(policy: .immediate)
+            if preserveRecoveryAudio {
+                audioRecordingService.preserveActiveRecoveryRecording()
+            } else {
+                audioRecordingService.discardActiveRecoveryRecording()
+            }
         }
         cancelActiveDictationSessionIfNeeded(message: sessionMessage)
         hotkeyService.cancelDictation()
@@ -666,7 +671,7 @@ final class DictationViewModel: ObservableObject {
                 defer { self.audioRecordingService.clearRecoveryError() }
                 guard self.state == .recording, !self.isStopInFlight else { return }
                 let errorMessage = error.localizedDescription
-                self.abortActiveRecordingImmediately(sessionMessage: errorMessage)
+                self.abortActiveRecordingImmediately(sessionMessage: errorMessage, preserveRecoveryAudio: true)
                 self.accessibilityAnnouncementService.announceError(errorMessage)
                 self.showError(errorMessage, category: "recording")
             }
@@ -729,6 +734,7 @@ final class DictationViewModel: ObservableObject {
             cancelActiveDictationSessionIfNeeded(message: cancelledMessage)
             transcriptionTask?.cancel()
             transcriptionTask = nil
+            audioRecordingService.discardActiveRecoveryRecording()
             showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
         default:
             break
@@ -997,6 +1003,7 @@ final class DictationViewModel: ObservableObject {
             lastStreamingParams = nil
             stopRecordingTimer()
             _ = await audioRecordingService.stopRecording(policy: .immediate)
+            audioRecordingService.discardActiveRecoveryRecording()
             if let sessionID {
                 failDictationSession(id: sessionID, error: discardMessage)
             }
@@ -1042,6 +1049,7 @@ final class DictationViewModel: ObservableObject {
 
         switch decision {
         case .discardTooShort:
+            audioRecordingService.discardActiveRecoveryRecording()
             let errorMessage = String(localized: "Too short, hold the hotkey a bit longer")
             if let sessionID {
                 failDictationSession(id: sessionID, error: errorMessage)
@@ -1053,6 +1061,7 @@ final class DictationViewModel: ObservableObject {
             )
             return
         case .discardNoSpeech:
+            audioRecordingService.discardActiveRecoveryRecording()
             logger.info("Peak level too low (\(String(format: "%.4f", peakLevel))) - no speech detected")
             let errorMessage = String(localized: "No speech detected")
             if let sessionID {
@@ -1117,6 +1126,7 @@ final class DictationViewModel: ObservableObject {
                 var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else {
                     logger.info("Transcription returned empty text (duration: \(String(format: "%.2f", result.duration))s, engine: \(result.engineUsed))")
+                    audioRecordingService.preserveActiveRecoveryRecording()
                     let errorMessage = String(localized: "No speech recognized")
                     if let sessionID {
                         failDictationSession(id: sessionID, error: errorMessage)
@@ -1241,6 +1251,7 @@ final class DictationViewModel: ObservableObject {
                     ruleName: self.effectiveRuleName
                 )))
 
+                audioRecordingService.discardActiveRecoveryRecording()
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                 let wordCount = text.split(separator: " ").count
                 let detectedLang = result.detectedLanguage ?? language
@@ -1275,6 +1286,7 @@ final class DictationViewModel: ObservableObject {
                 }
             } catch {
                 guard !Task.isCancelled else { return }
+                audioRecordingService.preserveActiveRecoveryRecording()
                 EventBus.shared.emit(.transcriptionFailed(TranscriptionFailedPayload(
                     error: error.localizedDescription,
                     appName: capturedActiveApp?.name,
@@ -1610,6 +1622,22 @@ final class DictationViewModel: ObservableObject {
     func readBackLastTranscription() {
         guard let text = lastTranscribedText else { return }
         speechFeedbackService.readBack(text: text, language: lastTranscriptionLanguage)
+    }
+
+    var canRecoverLastRecording: Bool {
+        audioRecordingService.latestRecoveryRecordingURL != nil
+    }
+
+    func recoverLastRecording(openSettingsWindow: Bool = true) {
+        guard let url = audioRecordingService.latestRecoveryRecordingURL else { return }
+
+        FileTranscriptionViewModel.shared.addFiles([url])
+        if let navigationCoordinator = SettingsNavigationCoordinator.shared {
+            navigationCoordinator.navigate(to: .fileTranscription)
+        }
+        if openSettingsWindow {
+            ManagedAppWindowOpener.shared.open(id: "settings")
+        }
     }
 
     func triggerWorkflowPalette() {

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -2,9 +2,20 @@ import Foundation
 import Combine
 import AppKit
 import UniformTypeIdentifiers
+import TypeWhisperPluginSDK
 
 @MainActor
 final class FileTranscriptionViewModel: ObservableObject {
+    typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
+    typealias TranscriptionRunner = @MainActor (
+        [Float],
+        LanguageSelection,
+        TranscriptionTask,
+        String?,
+        String?
+    ) async throws -> TranscriptionResult
+    typealias EngineReadinessChecker = @MainActor (String?) -> Bool
+
     nonisolated(unsafe) static var _shared: FileTranscriptionViewModel?
     static var shared: FileTranscriptionViewModel {
         guard let instance = _shared else {
@@ -41,28 +52,97 @@ final class FileTranscriptionViewModel: ObservableObject {
     @Published var showFilePickerFromMenu = false
     @Published var batchState: BatchState = .idle
     @Published var currentIndex: Int = 0
-    @Published var languageSelection: LanguageSelection = .auto
+    @Published var languageSelection: LanguageSelection = .auto {
+        didSet {
+            defaults.set(
+                languageSelection.storedValue(nilBehavior: .auto),
+                forKey: UserDefaultsKeys.fileTranscriptionLanguage
+            )
+        }
+    }
     @Published var selectedTask: TranscriptionTask = .transcribe
+    @Published var selectedEngine: String? {
+        didSet {
+            defaults.set(selectedEngine, forKey: UserDefaultsKeys.fileTranscriptionEngine)
+            guard isInitialized, oldValue != selectedEngine else { return }
+            selectedModel = nil
+            normalizeLanguageSelectionForResolvedEngine()
+        }
+    }
+    @Published var selectedModel: String? {
+        didSet { defaults.set(selectedModel, forKey: UserDefaultsKeys.fileTranscriptionModel) }
+    }
 
     private let modelManager: ModelManagerService
     private let audioFileService: AudioFileService
+    private let defaults: UserDefaults
+    private let audioSamplesLoader: AudioSamplesLoader
+    private let transcriptionRunner: TranscriptionRunner
+    private let engineReadinessChecker: EngineReadinessChecker?
+    private var cancellables = Set<AnyCancellable>()
+    private var isInitialized = false
 
     static let allowedContentTypes: [UTType] = [
         .wav, .mp3, .mpeg4Audio, .aiff, .audio,
         .mpeg4Movie, .quickTimeMovie, .avi, .movie
     ]
 
-    init(modelManager: ModelManagerService, audioFileService: AudioFileService) {
+    init(
+        modelManager: ModelManagerService,
+        audioFileService: AudioFileService,
+        defaults: UserDefaults = .standard,
+        audioSamplesLoader: AudioSamplesLoader? = nil,
+        transcriptionRunner: TranscriptionRunner? = nil,
+        engineReadinessChecker: EngineReadinessChecker? = nil
+    ) {
         self.modelManager = modelManager
         self.audioFileService = audioFileService
+        self.defaults = defaults
+        self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
+            try await audioFileService.loadAudioSamples(from: url)
+        }
+        self.transcriptionRunner = transcriptionRunner ?? { [modelManager] samples, languageSelection, task, engineOverrideId, cloudModelOverride in
+            try await modelManager.transcribe(
+                audioSamples: samples,
+                languageSelection: languageSelection,
+                task: task,
+                engineOverrideId: engineOverrideId,
+                cloudModelOverride: cloudModelOverride
+            )
+        }
+        self.engineReadinessChecker = engineReadinessChecker
+        self.languageSelection = LanguageSelection(
+            storedValue: defaults.string(forKey: UserDefaultsKeys.fileTranscriptionLanguage),
+            nilBehavior: .auto
+        )
+        self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.fileTranscriptionEngine)
+        self.selectedModel = defaults.string(forKey: UserDefaultsKeys.fileTranscriptionModel)
+        self.isInitialized = true
+        reconcileSelectionWithAvailablePlugins()
     }
 
     var canTranscribe: Bool {
-        !files.isEmpty && modelManager.isModelReady && batchState != .processing
+        !files.isEmpty && selectedEngineIsReady && batchState != .processing
     }
 
     var supportsTranslation: Bool {
-        modelManager.supportsTranslation
+        resolvedEngine?.supportsTranslation ?? false
+    }
+
+    var availableEngines: [TranscriptionEnginePlugin] {
+        guard let pluginManager = PluginManager.shared else { return [] }
+        return pluginManager.transcriptionEngines
+    }
+
+    var resolvedEngine: TranscriptionEnginePlugin? {
+        let engineId = selectedEngine ?? modelManager.selectedProviderId
+        guard let engineId else { return nil }
+        guard let pluginManager = PluginManager.shared else { return nil }
+        return pluginManager.transcriptionEngine(for: engineId)
+    }
+
+    var selectedEngineSupportedLanguages: [String] {
+        resolvedEngine?.supportedLanguages.sorted() ?? []
     }
 
     var hasResults: Bool {
@@ -73,6 +153,21 @@ final class FileTranscriptionViewModel: ObservableObject {
 
     var completedFiles: Int {
         files.filter { $0.state == .done }.count
+    }
+
+    func observePluginManager() {
+        guard let pluginManager = PluginManager.shared else { return }
+        pluginManager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reconcileSelectionWithAvailablePlugins()
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    func canUseForTranscription(_ engine: TranscriptionEnginePlugin) -> Bool {
+        modelManager.canUseForTranscription(engine)
     }
 
     func addFiles(_ urls: [URL]) {
@@ -125,16 +220,16 @@ final class FileTranscriptionViewModel: ObservableObject {
         files[index].state = .loading
 
         do {
-            let samples = try await audioFileService.loadAudioSamples(from: files[index].url)
+            let samples = try await audioSamplesLoader(files[index].url)
 
             files[index].state = .transcribing
 
-            let result = try await modelManager.transcribe(
-                audioSamples: samples,
-                languageSelection: languageSelection,
-                task: selectedTask,
-                engineOverrideId: nil,
-                cloudModelOverride: nil
+            let result = try await transcriptionRunner(
+                samples,
+                languageSelection,
+                selectedTask,
+                selectedEngine,
+                selectedModel
             )
 
             files[index].result = result
@@ -212,5 +307,33 @@ final class FileTranscriptionViewModel: ObservableObject {
         files = []
         batchState = .idle
         currentIndex = 0
+    }
+
+    private var selectedEngineIsReady: Bool {
+        if let engineReadinessChecker {
+            return engineReadinessChecker(selectedEngine)
+        }
+
+        guard let engine = resolvedEngine else { return false }
+        guard modelManager.canUseForTranscription(engine) else { return false }
+        return engine.isConfigured
+    }
+
+    private func reconcileSelectionWithAvailablePlugins() {
+        guard let pluginManager = PluginManager.shared else { return }
+        if let selectedEngine,
+           pluginManager.transcriptionEngine(for: selectedEngine) == nil {
+            self.selectedEngine = nil
+            selectedModel = nil
+        }
+        normalizeLanguageSelectionForResolvedEngine()
+    }
+
+    private func normalizeLanguageSelectionForResolvedEngine() {
+        guard let engine = resolvedEngine else { return }
+        let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
+        if normalized != languageSelection {
+            languageSelection = normalized
+        }
     }
 }

--- a/TypeWhisper/Views/DictationRecoveryView.swift
+++ b/TypeWhisper/Views/DictationRecoveryView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+import TypeWhisperPluginSDK
+
+struct DictationRecoveryView: View {
+    @ObservedObject private var viewModel = DictationRecoveryViewModel.shared
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Group {
+            if viewModel.hasRecoveryContent {
+                recoveryForm
+            } else {
+                ContentUnavailableView {
+                    Label(
+                        localizedAppText("No Recording to Recover", de: "Keine Aufnahme zur Wiederherstellung"),
+                        systemImage: "waveform"
+                    )
+                }
+            }
+        }
+        .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private var recoveryForm: some View {
+        Form {
+            if let lastSavedRecoveryFileName = viewModel.lastSavedRecoveryFileName {
+                Section(String(localized: "History")) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .accessibilityHidden(true)
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(localizedAppText("Saved to History", de: "In Verlauf gespeichert"))
+                                .font(.body.weight(.medium))
+                            Text(lastSavedRecoveryFileName)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Button {
+                            openWindow(id: "history")
+                        } label: {
+                            Label(String(localized: "History"), systemImage: "clock.arrow.circlepath")
+                        }
+                        .disabled(viewModel.isProcessing)
+                    }
+                }
+            }
+
+            if viewModel.hasRecovery {
+                Section(String(localized: "Recordings")) {
+                    if viewModel.recoveries.count > 1 {
+                        Picker(
+                            localizedAppText("Recording", de: "Aufnahme"),
+                            selection: $viewModel.selectedRecoveryID
+                        ) {
+                            ForEach(viewModel.recoveries) { recovery in
+                                Text(recovery.fileName).tag(recovery.id as String?)
+                            }
+                        }
+                        .disabled(viewModel.isProcessing)
+                    }
+
+                    if let recovery = viewModel.selectedRecovery {
+                        recoveryRow(recovery)
+                    }
+                }
+
+                Section(String(localized: "Transcription")) {
+                    Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
+                        Text(String(localized: "Default Engine")).tag(nil as String?)
+                        Divider()
+                        ForEach(viewModel.availableEngines, id: \.providerId) { engine in
+                            enginePickerLabel(for: engine)
+                                .tag(engine.providerId as String?)
+                                .disabled(!viewModel.canUseForTranscription(engine))
+                        }
+                    }
+                    .disabled(viewModel.isProcessing)
+
+                    if let engine = viewModel.resolvedEngine {
+                        let models = engine.transcriptionModels
+                        if models.count > 1 {
+                            Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
+                                Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
+                                Divider()
+                                ForEach(models, id: \.id) { model in
+                                    Text(model.displayName).tag(model.id as String?)
+                                }
+                            }
+                            .disabled(viewModel.isProcessing)
+                        }
+                    }
+
+                    if viewModel.supportsTranslation {
+                        Picker(String(localized: "Task"), selection: $viewModel.selectedTask) {
+                            ForEach(TranscriptionTask.allCases) { task in
+                                Text(task.displayName).tag(task)
+                            }
+                        }
+                        .disabled(viewModel.isProcessing)
+                    }
+
+                    LanguageSelectionEditor(
+                        selection: $viewModel.languageSelection,
+                        availableLanguages: recoveryLanguageOptions
+                    )
+                    .disabled(viewModel.isProcessing)
+                }
+
+                Section {
+                    HStack {
+                        Spacer()
+
+                        if viewModel.isProcessing {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+
+                        Button {
+                            viewModel.transcribe()
+                        } label: {
+                            Label(String(localized: "Transcribe"), systemImage: "waveform")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!viewModel.canTranscribe)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func recoveryRow(_ recovery: DictationRecoveryViewModel.RecoveryItem) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: statusSystemImage(for: recovery.state))
+                .foregroundStyle(statusColor(for: recovery.state))
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(recovery.fileName)
+                    .font(.body.weight(.medium))
+                    .lineLimit(1)
+
+                if let errorMessage = recovery.errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer()
+
+            Button(role: .destructive) {
+                viewModel.discardRecovery(recovery)
+            } label: {
+                Label(localizedAppText("Discard", de: "Verwerfen"), systemImage: "trash")
+            }
+            .disabled(viewModel.isProcessing)
+        }
+    }
+
+    private var recoveryLanguageOptions: [(code: String, name: String)] {
+        let supportedLanguages = viewModel.selectedEngineSupportedLanguages
+        guard !supportedLanguages.isEmpty else {
+            return SettingsViewModel.shared.availableLanguages
+        }
+        return localizedAppLanguageOptions(for: supportedLanguages)
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .map { (code: $0.code, name: $0.name) }
+    }
+
+    private func statusSystemImage(for state: DictationRecoveryViewModel.RecoveryState) -> String {
+        switch state {
+        case .idle:
+            "waveform"
+        case .loading, .transcribing:
+            "waveform"
+        case .error:
+            "exclamationmark.circle.fill"
+        }
+    }
+
+    private func statusColor(for state: DictationRecoveryViewModel.RecoveryState) -> Color {
+        switch state {
+        case .idle, .loading, .transcribing:
+            .secondary
+        case .error:
+            .red
+        }
+    }
+
+    @ViewBuilder
+    private func enginePickerLabel(for engine: TranscriptionEnginePlugin) -> some View {
+        HStack {
+            Text(engine.providerDisplayName)
+            if !viewModel.canUseForTranscription(engine) {
+                Text("(\(String(localized: "not ready")))")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import TypeWhisperPluginSDK
 
 struct FileTranscriptionView: View {
     @ObservedObject private var viewModel = FileTranscriptionViewModel.shared
@@ -82,7 +83,7 @@ struct FileTranscriptionView: View {
                     }
                 }
 
-                Section(String(localized: "fileTranscription.transcription")) {
+                Section(localizedAppText("Watch Folder Transcription", de: "Ordner-Transkription")) {
                     Picker(String(localized: "watchFolder.engine"), selection: $watchFolder.selectedEngine) {
                         Text(String(localized: "watchFolder.engine.default")).tag(nil as String?)
                         Divider()
@@ -389,9 +390,11 @@ struct FileTranscriptionView: View {
     @ViewBuilder
     private var controls: some View {
         VStack(alignment: .leading, spacing: 12) {
+            fileTranscriptionSettings
+
             LanguageSelectionEditor(
                 selection: $viewModel.languageSelection,
-                availableLanguages: SettingsViewModel.shared.availableLanguages
+                availableLanguages: fileTranscriptionLanguageOptions
             )
 
             HStack {
@@ -453,6 +456,59 @@ struct FileTranscriptionView: View {
                 .disabled(viewModel.batchState == .processing)
                 .help(String(localized: "Clear All"))
                 .accessibilityLabel(String(localized: "Clear All"))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var fileTranscriptionSettings: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
+                Text(String(localized: "Default Engine")).tag(nil as String?)
+                Divider()
+                ForEach(viewModel.availableEngines, id: \.providerId) { engine in
+                    enginePickerLabel(for: engine)
+                        .tag(engine.providerId as String?)
+                        .disabled(!viewModel.canUseForTranscription(engine))
+                }
+            }
+            .controlSize(.small)
+            .disabled(viewModel.batchState == .processing)
+
+            if let engine = viewModel.resolvedEngine {
+                let models = engine.transcriptionModels
+                if models.count > 1 {
+                    Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
+                        Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
+                        Divider()
+                        ForEach(models, id: \.id) { model in
+                            Text(model.displayName).tag(model.id as String?)
+                        }
+                    }
+                    .controlSize(.small)
+                    .disabled(viewModel.batchState == .processing)
+                }
+            }
+        }
+    }
+
+    private var fileTranscriptionLanguageOptions: [(code: String, name: String)] {
+        let supportedLanguages = viewModel.selectedEngineSupportedLanguages
+        guard !supportedLanguages.isEmpty else {
+            return SettingsViewModel.shared.availableLanguages
+        }
+        return localizedAppLanguageOptions(for: supportedLanguages)
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .map { (code: $0.code, name: $0.name) }
+    }
+
+    @ViewBuilder
+    private func enginePickerLabel(for engine: TranscriptionEnginePlugin) -> some View {
+        HStack {
+            Text(engine.providerDisplayName)
+            if !viewModel.canUseForTranscription(engine) {
+                Text("(\(String(localized: "not ready")))")
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -203,13 +203,19 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
     }
 
     var items: [MenuBarMenuItem] {
+        items(hasRecoverableRecording: true)
+    }
+
+    func items(hasRecoverableRecording: Bool) -> [MenuBarMenuItem] {
         switch self {
         case .general:
             [.settings, .history, .errorLog]
         case .recorder:
             [.toggleRecorder]
         case .transcription:
-            [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+            hasRecoverableRecording
+                ? [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+                : [.transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         case .updates:
             [.checkForUpdates]
         }
@@ -230,7 +236,7 @@ struct MenuBarView: View {
 
             ForEach(MenuBarMenuSection.allCases, id: \.self) { section in
                 Section(String(localized: section.titleResource)) {
-                    ForEach(section.items, id: \.self) { item in
+                    ForEach(section.items(hasRecoverableRecording: status.hasRecoverableRecording), id: \.self) { item in
                         menuItem(for: item)
                     }
                 }
@@ -304,7 +310,6 @@ struct MenuBarView: View {
             } label: {
                 Label(String(localized: "Recover Last Recording"), systemImage: "waveform")
             }
-            .disabled(!status.hasRecoverableRecording)
 
         case .recentTranscriptions:
             Button {

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -10,6 +10,7 @@ private final class MenuBarState: ObservableObject {
     @Published var isModelReady: Bool
     @Published var hasRecentTranscriptions: Bool
     @Published var canCopyLastTranscription: Bool
+    @Published var hasRecoverableRecording: Bool
     @Published var recorderState: AudioRecorderViewModel.RecorderState
     @Published var canToggleRecorder: Bool
     @Published var recentTranscriptionsMenuShortcut: HotkeyService.MenuShortcutDescriptor?
@@ -21,6 +22,7 @@ private final class MenuBarState: ObservableObject {
     init() {
         let dictation = DictationViewModel.shared
         let modelManager = ServiceContainer.shared.modelManagerService
+        let audioRecordingService = ServiceContainer.shared.audioRecordingService
         let historyService = ServiceContainer.shared.historyService
         let recentTranscriptionStore = ServiceContainer.shared.recentTranscriptionStore
         let recorder = AudioRecorderViewModel.shared
@@ -30,6 +32,7 @@ private final class MenuBarState: ObservableObject {
         let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
         self.hasRecentTranscriptions = hasRecentTranscriptions
         self.canCopyLastTranscription = hasRecentTranscriptions
+        self.hasRecoverableRecording = audioRecordingService.latestRecoveryRecordingURL != nil
         self.recorderState = recorder.state
         self.canToggleRecorder = recorder.canToggleRecording
         self.recentTranscriptionsMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recentTranscriptions)
@@ -73,6 +76,13 @@ private final class MenuBarState: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshCopyAvailability()
+            }
+            .store(in: &cancellables)
+
+        audioRecordingService.$recoverableRecordingURL
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] url in
+                self?.hasRecoverableRecording = url != nil
             }
             .store(in: &cancellables)
 
@@ -162,6 +172,7 @@ enum MenuBarMenuItem: Hashable {
     case errorLog
     case toggleRecorder
     case transcribeFile
+    case recoverLastRecording
     case recentTranscriptions
     case copyLastTranscription
     case readBackLastTranscription
@@ -198,7 +209,7 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
         case .recorder:
             [.toggleRecorder]
         case .transcription:
-            [.transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+            [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         case .updates:
             [.checkForUpdates]
         }
@@ -286,6 +297,14 @@ struct MenuBarView: View {
                 Label(String(localized: "Transcribe File..."), systemImage: "doc.text")
             }
             .disabled(!status.isModelReady)
+
+        case .recoverLastRecording:
+            Button {
+                DictationViewModel.shared.recoverLastRecording()
+            } label: {
+                Label(String(localized: "Recover Last Recording"), systemImage: "waveform")
+            }
+            .disabled(!status.hasRecoverableRecording)
 
         case .recentTranscriptions:
             Button {

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -4,7 +4,7 @@ import TypeWhisperPluginSDK
 
 enum SettingsTab: Hashable {
     case home, general, recording, hotkeys, recorder
-    case fileTranscription, history, dictionary, snippets, workflows, profiles, prompts, integrations, advanced, license, about
+    case dictationRecovery, fileTranscription, history, dictionary, snippets, workflows, profiles, prompts, integrations, advanced, license, about
 }
 
 private struct SettingsDestination: Identifiable, Hashable {
@@ -24,6 +24,7 @@ private struct SettingsDestinationSection: Identifiable {
 struct SettingsView: View {
     @State private var selectedTab: SettingsTab = .home
     @ObservedObject private var fileTranscription = FileTranscriptionViewModel.shared
+    @ObservedObject private var dictationRecovery = DictationRecoveryViewModel.shared
     @ObservedObject private var registryService = PluginRegistryService.shared
     @ObservedObject private var homeViewModel = HomeViewModel.shared
     @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
@@ -41,6 +42,14 @@ struct SettingsView: View {
                 systemImage: "waveform.circle",
                 badge: nil
             ),
+            dictationRecovery.hasRecoveryContent
+                ? SettingsDestination(
+                    tab: .dictationRecovery,
+                    title: localizedAppText("Recovery", de: "Wiederherstellung"),
+                    systemImage: "waveform",
+                    badge: nil
+                )
+                : nil,
             SettingsDestination(tab: .fileTranscription, title: String(localized: "File Transcription"), systemImage: "doc.text", badge: nil),
             SettingsDestination(tab: .history, title: String(localized: "History"), systemImage: "clock.arrow.circlepath", badge: nil),
             SettingsDestination(tab: .dictionary, title: String(localized: "Dictionary"), systemImage: "book.closed", badge: nil),
@@ -60,7 +69,7 @@ struct SettingsView: View {
             SettingsDestination(tab: .advanced, title: String(localized: "Advanced"), systemImage: "gearshape.2", badge: nil),
             SettingsDestination(tab: .license, title: String(localized: "License"), systemImage: "key", badge: nil),
             SettingsDestination(tab: .about, title: String(localized: "About"), systemImage: "info.circle", badge: nil)
-        ]
+        ].compactMap { $0 }
     }
 
     private var destinationSections: [SettingsDestinationSection] {
@@ -84,9 +93,18 @@ struct SettingsView: View {
             }
         }
         .frame(minWidth: 950, idealWidth: 1050, minHeight: 550, idealHeight: 600)
-        .onAppear { navigateToFileTranscriptionIfNeeded() }
+        .onAppear {
+            navigateToFileTranscriptionIfNeeded()
+            navigateAwayFromMissingRecoveryIfNeeded()
+        }
         .onChange(of: fileTranscription.showFilePickerFromMenu) { _, _ in
             navigateToFileTranscriptionIfNeeded()
+        }
+        .onChange(of: dictationRecovery.hasRecovery) { _, _ in
+            navigateAwayFromMissingRecoveryIfNeeded()
+        }
+        .onChange(of: dictationRecovery.lastSavedHistoryRecordID) { _, _ in
+            navigateAwayFromMissingRecoveryIfNeeded()
         }
         .onChange(of: homeViewModel.navigateToHistory) { _, navigate in
             if navigate {
@@ -106,15 +124,23 @@ struct SettingsView: View {
                 selectedTab = .workflows
                 WorkflowsNavigationCoordinator.shared.showMine()
             default:
-                selectedTab = request.tab
+                selectedTab = Self.availableTab(request.tab, hasRecoveryContent: dictationRecovery.hasRecoveryContent)
             }
         }
+    }
+
+    static func availableTab(_ tab: SettingsTab, hasRecoveryContent: Bool) -> SettingsTab {
+        tab == .dictationRecovery && !hasRecoveryContent ? .recording : tab
     }
 
     private func navigateToFileTranscriptionIfNeeded() {
         if fileTranscription.showFilePickerFromMenu {
             selectedTab = .fileTranscription
         }
+    }
+
+    private func navigateAwayFromMissingRecoveryIfNeeded() {
+        selectedTab = Self.availableTab(selectedTab, hasRecoveryContent: dictationRecovery.hasRecoveryContent)
     }
 
     @ViewBuilder
@@ -130,6 +156,8 @@ struct SettingsView: View {
             HotkeySettingsView()
         case .recorder:
             AudioRecorderView(viewModel: AudioRecorderViewModel.shared)
+        case .dictationRecovery:
+            DictationRecoveryView()
         case .fileTranscription:
             FileTranscriptionView()
         case .history:
@@ -210,6 +238,10 @@ private func settingsDestination(_ destinations: [SettingsDestination], _ tab: S
     destinations.first(where: { $0.tab == tab })!
 }
 
+private func settingsDestinationIfAvailable(_ destinations: [SettingsDestination], _ tab: SettingsTab) -> SettingsDestination? {
+    destinations.first(where: { $0.tab == tab })
+}
+
 private func settingsTitle(_ destinations: [SettingsDestination], _ tab: SettingsTab) -> String {
     settingsDestination(destinations, tab).title
 }
@@ -223,6 +255,19 @@ private func settingsBadge(_ destinations: [SettingsDestination], _ tab: Setting
 }
 
 private func settingsDestinationSections(_ destinations: [SettingsDestination]) -> [SettingsDestinationSection] {
+    var coreDestinations = [
+        settingsDestination(destinations, .general),
+        settingsDestination(destinations, .recording)
+    ]
+    if let recoveryDestination = settingsDestinationIfAvailable(destinations, .dictationRecovery) {
+        coreDestinations.append(recoveryDestination)
+    }
+    coreDestinations.append(contentsOf: [
+        settingsDestination(destinations, .hotkeys),
+        settingsDestination(destinations, .fileTranscription),
+        settingsDestination(destinations, .recorder)
+    ])
+
     var workspaceDestinations = [
         settingsDestination(destinations, .history),
         settingsDestination(destinations, .dictionary),
@@ -239,13 +284,7 @@ private func settingsDestinationSections(_ destinations: [SettingsDestination]) 
         ),
         SettingsDestinationSection(
             id: "core",
-            destinations: [
-                settingsDestination(destinations, .general),
-                settingsDestination(destinations, .recording),
-                settingsDestination(destinations, .hotkeys),
-                settingsDestination(destinations, .fileTranscription),
-                settingsDestination(destinations, .recorder)
-            ]
+            destinations: coreDestinations
         ),
         SettingsDestinationSection(
             id: "workspace",

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -395,6 +395,29 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertTrue(try recoveryFileNames(in: directory).isEmpty)
     }
 
+    func testRecordingSuccessDiscardKeepsPreviousStoredRecoveryAudio() async throws {
+        let directory = makeRecoveryTestDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+        store.startNewRecording()
+        store.append([0.5])
+        let existingRecovery = try XCTUnwrap(store.preserveActiveRecording())
+
+        let service = AudioRecordingService(recoveryAudioStore: store)
+        service.hasMicrophonePermissionOverride = true
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in service.getCurrentBuffer() }
+
+        try service.startRecording()
+        service.testingProcessConvertedSamples([0.25, -0.25])
+        _ = await service.stopRecording(policy: .immediate)
+        service.discardActiveRecoveryRecording()
+
+        XCTAssertEqual(service.recoveryRecordingURLs, [existingRecovery])
+        XCTAssertEqual(service.latestRecoveryRecordingURL, existingRecovery)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: existingRecovery.path))
+        XCTAssertEqual(try recoveryFileNames(in: directory), [existingRecovery.lastPathComponent])
+    }
+
     func testTranscriptionFailureCanPreserveStoppedRecoveryAudio() async throws {
         let directory = makeRecoveryTestDirectory()
         let store = DictationRecoveryAudioStore(directory: directory)

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -377,6 +377,92 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertTrue(error.localizedDescription.contains("expected 48000.0 Hz/1 ch"))
         XCTAssertTrue(error.localizedDescription.contains("got 0.0 Hz/0 ch"))
     }
+
+    func testRecordingSuccessDiscardDeletesRecoveryAudio() async throws {
+        let directory = makeRecoveryTestDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+        let service = AudioRecordingService(recoveryAudioStore: store)
+        service.hasMicrophonePermissionOverride = true
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in service.getCurrentBuffer() }
+
+        try service.startRecording()
+        service.testingProcessConvertedSamples([0.25, -0.25])
+        _ = await service.stopRecording(policy: .immediate)
+        service.discardActiveRecoveryRecording()
+
+        XCTAssertNil(service.latestRecoveryRecordingURL)
+        XCTAssertTrue(try recoveryFileNames(in: directory).isEmpty)
+    }
+
+    func testTranscriptionFailureCanPreserveStoppedRecoveryAudio() async throws {
+        let directory = makeRecoveryTestDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+        let service = AudioRecordingService(recoveryAudioStore: store)
+        service.hasMicrophonePermissionOverride = true
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in service.getCurrentBuffer() }
+
+        try service.startRecording()
+        service.testingProcessConvertedSamples([0.25, -0.25, 0.5])
+        _ = await service.stopRecording(policy: .immediate)
+        let url = try XCTUnwrap(service.preserveActiveRecoveryRecording())
+
+        let data = try Data(contentsOf: url)
+        XCTAssertEqual(readRecoveryUInt32(data, at: 40), UInt32(3 * 2))
+        XCTAssertEqual(service.latestRecoveryRecordingURL, url)
+    }
+
+    func testRecoveryCircuitBreakerPreservesBufferedRecoveryAudio() throws {
+        let directory = makeRecoveryTestDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+        let service = AudioRecordingService(recoveryAudioStore: store)
+        service.hasMicrophonePermissionOverride = true
+        service.startRecordingOverride = {}
+
+        try service.startRecording()
+        service.testingProcessConvertedSamples([0.25, -0.25, 0.5])
+        service.testingFailActiveRecordingDueToRecovery(.engineStartFailed("test circuit breaker"))
+
+        let url = try XCTUnwrap(service.latestRecoveryRecordingURL)
+        let data = try Data(contentsOf: url)
+        XCTAssertEqual(readRecoveryUInt32(data, at: 40), UInt32(3 * 2))
+    }
+
+    func testRecordingCancelDiscardDeletesRecoveryAudio() async throws {
+        let directory = makeRecoveryTestDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+        let service = AudioRecordingService(recoveryAudioStore: store)
+        service.hasMicrophonePermissionOverride = true
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in service.getCurrentBuffer() }
+
+        try service.startRecording()
+        service.testingProcessConvertedSamples([0.1, 0.2])
+        _ = await service.stopRecording(policy: .immediate)
+        service.discardActiveRecoveryRecording()
+
+        XCTAssertNil(service.latestRecoveryRecordingURL)
+        XCTAssertTrue(try recoveryFileNames(in: directory).isEmpty)
+    }
+
+    private func makeRecoveryTestDirectory() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioEngineRecoverySupportTests-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    private func recoveryFileNames(in directory: URL) throws -> [String] {
+        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
+        return try FileManager.default.contentsOfDirectory(atPath: directory.path)
+    }
+
+    private func readRecoveryUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        data[offset..<(offset + 4)].reversed().reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+    }
 }
 
 final class AudioDeviceServiceCompatibilityTests: XCTestCase {

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -22,44 +22,115 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         XCTAssertEqual(readInt16(data, at: 46), 16_383)
         XCTAssertEqual(readInt16(data, at: 48), -16_383)
         XCTAssertEqual(store.latestRecoveryURL, url)
+        XCTAssertEqual(store.recoveryURLs, [url])
     }
 
-    func testPreserveDeletesEmptyRecording() throws {
-        let directory = makeTemporaryDirectory()
-        let store = DictationRecoveryAudioStore(directory: directory)
-
-        store.startNewRecording()
-
-        XCTAssertNil(store.preserveActiveRecording())
-        XCTAssertNil(store.latestRecoveryURL)
-        XCTAssertTrue(try fileNames(in: directory).isEmpty)
-    }
-
-    func testDiscardDeletesActiveAndLatestRecovery() throws {
+    func testPreserveKeepsMultipleTimestampedRecoveries() throws {
         let directory = makeTemporaryDirectory()
         let store = DictationRecoveryAudioStore(directory: directory)
 
         store.startNewRecording()
         store.append([0.1])
-        let preserved = try XCTUnwrap(store.preserveActiveRecording())
-        XCTAssertTrue(FileManager.default.fileExists(atPath: preserved.path))
+        let first = try XCTUnwrap(store.preserveActiveRecording())
+
+        store.startNewRecording()
+        store.append([0.2])
+        let second = try XCTUnwrap(store.preserveActiveRecording())
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(first.lastPathComponent.hasPrefix("dictation-recovery-"))
+        XCTAssertTrue(second.lastPathComponent.hasPrefix("dictation-recovery-"))
+        XCTAssertEqual(Set(store.recoveryURLs), Set([first, second]))
+        XCTAssertEqual(store.latestRecoveryURL, second)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.path))
+    }
+
+    func testPreserveDeletesEmptyRecordingWithoutDeletingExistingRecoveries() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.startNewRecording()
+        store.append([0.1])
+        let existingRecovery = try XCTUnwrap(store.preserveActiveRecording())
+
+        store.startNewRecording()
+
+        XCTAssertEqual(store.preserveActiveRecording(), existingRecovery)
+        XCTAssertEqual(store.latestRecoveryURL, existingRecovery)
+        XCTAssertEqual(store.recoveryURLs, [existingRecovery])
+        XCTAssertTrue(try fileNames(in: directory).contains(existingRecovery.lastPathComponent))
+    }
+
+    func testDiscardActiveKeepsStoredRecoveriesAndDiscardRecoveryDeletesSelectedFile() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.startNewRecording()
+        store.append([0.1])
+        let first = try XCTUnwrap(store.preserveActiveRecording())
 
         store.startNewRecording()
         store.append([0.2])
         store.discardActiveRecording()
 
+        XCTAssertEqual(store.recoveryURLs, [first])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.path))
+
+        store.startNewRecording()
+        store.append([0.3])
+        let second = try XCTUnwrap(store.preserveActiveRecording())
+        XCTAssertEqual(Set(store.recoveryURLs), Set([first, second]))
+
+        store.discardRecovery(at: second)
+
+        XCTAssertEqual(store.recoveryURLs, [first])
+        XCTAssertEqual(store.latestRecoveryURL, first)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: second.path))
+    }
+
+    func testDiscardAllRecoveriesDeletesStoredFiles() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.startNewRecording()
+        store.append([0.1])
+        _ = try XCTUnwrap(store.preserveActiveRecording())
+        store.startNewRecording()
+        store.append([0.2])
+        _ = try XCTUnwrap(store.preserveActiveRecording())
+
+        store.discardAllRecoveries()
+
         XCTAssertNil(store.latestRecoveryURL)
+        XCTAssertTrue(store.recoveryURLs.isEmpty)
         XCTAssertTrue(try fileNames(in: directory).isEmpty)
     }
 
+    func testDiscardRecoveryIgnoresMatchingFileOutsideRecoveryDirectory() throws {
+        let directory = makeTemporaryDirectory()
+        let outsideDirectory = makeTemporaryDirectory()
+        let outsideURL = outsideDirectory
+            .appendingPathComponent("dictation-recovery-outside")
+            .appendingPathExtension("wav")
+        FileManager.default.createFile(atPath: outsideURL.path, contents: Data([1, 2, 3]))
+
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.discardRecovery(at: outsideURL)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outsideURL.path))
+    }
+
     @MainActor
-    func testRecoverLastRecordingQueuesWavAndNavigatesWithoutPicker() throws {
+    func testRecoverLastRecordingNavigatesToRecoveryWithoutQueueOrPicker() throws {
         let appSupportDirectory = makeTemporaryDirectory()
         let recoveryDirectory = appSupportDirectory.appendingPathComponent("dictation-recovery", isDirectory: true)
         let store = DictationRecoveryAudioStore(directory: recoveryDirectory)
         store.startNewRecording()
         store.append([0.1, -0.1])
-        let recoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        _ = try XCTUnwrap(store.preserveActiveRecording())
 
         let previousFileTranscriptionViewModel = FileTranscriptionViewModel._shared
         let previousSettingsNavigationCoordinator = SettingsNavigationCoordinator.shared
@@ -85,14 +156,15 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
 
         dictationViewModel.recoverLastRecording(openSettingsWindow: false)
 
-        XCTAssertEqual(fileTranscriptionViewModel.files.map(\.url), [recoveryURL])
-        XCTAssertEqual(navigationCoordinator.request?.tab, .fileTranscription)
+        XCTAssertTrue(fileTranscriptionViewModel.files.isEmpty)
+        XCTAssertEqual(navigationCoordinator.request?.tab, .dictationRecovery)
         XCTAssertFalse(fileTranscriptionViewModel.showFilePickerFromMenu)
     }
 
     private func makeTemporaryDirectory() -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("DictationRecoveryAudioStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         addTeardownBlock {
             try? FileManager.default.removeItem(at: directory)
         }

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import XCTest
+@testable import TypeWhisper
+
+final class DictationRecoveryAudioStoreTests: XCTestCase {
+    func testPreserveWritesWavWithExpectedHeaderAndSamples() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+        let samples: [Float] = [0, 0.5, -0.5]
+
+        store.startNewRecording()
+        store.append(samples)
+        let url = try XCTUnwrap(store.preserveActiveRecording())
+
+        let data = try Data(contentsOf: url)
+        XCTAssertEqual(String(data: data[0..<4], encoding: .ascii), "RIFF")
+        XCTAssertEqual(String(data: data[8..<12], encoding: .ascii), "WAVE")
+        XCTAssertEqual(String(data: data[36..<40], encoding: .ascii), "data")
+        XCTAssertEqual(readUInt32(data, at: 4), UInt32(36 + samples.count * 2))
+        XCTAssertEqual(readUInt32(data, at: 40), UInt32(samples.count * 2))
+        XCTAssertEqual(readInt16(data, at: 44), 0)
+        XCTAssertEqual(readInt16(data, at: 46), 16_383)
+        XCTAssertEqual(readInt16(data, at: 48), -16_383)
+        XCTAssertEqual(store.latestRecoveryURL, url)
+    }
+
+    func testPreserveDeletesEmptyRecording() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.startNewRecording()
+
+        XCTAssertNil(store.preserveActiveRecording())
+        XCTAssertNil(store.latestRecoveryURL)
+        XCTAssertTrue(try fileNames(in: directory).isEmpty)
+    }
+
+    func testDiscardDeletesActiveAndLatestRecovery() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.startNewRecording()
+        store.append([0.1])
+        let preserved = try XCTUnwrap(store.preserveActiveRecording())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: preserved.path))
+
+        store.startNewRecording()
+        store.append([0.2])
+        store.discardActiveRecording()
+
+        XCTAssertNil(store.latestRecoveryURL)
+        XCTAssertTrue(try fileNames(in: directory).isEmpty)
+    }
+
+    @MainActor
+    func testRecoverLastRecordingQueuesWavAndNavigatesWithoutPicker() throws {
+        let appSupportDirectory = makeTemporaryDirectory()
+        let recoveryDirectory = appSupportDirectory.appendingPathComponent("dictation-recovery", isDirectory: true)
+        let store = DictationRecoveryAudioStore(directory: recoveryDirectory)
+        store.startNewRecording()
+        store.append([0.1, -0.1])
+        let recoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+
+        let previousFileTranscriptionViewModel = FileTranscriptionViewModel._shared
+        let previousSettingsNavigationCoordinator = SettingsNavigationCoordinator.shared
+        addTeardownBlock {
+            FileTranscriptionViewModel._shared = previousFileTranscriptionViewModel
+            SettingsNavigationCoordinator.shared = previousSettingsNavigationCoordinator
+        }
+
+        let modelManager = ModelManagerService()
+        let fileTranscriptionViewModel = FileTranscriptionViewModel(
+            modelManager: modelManager,
+            audioFileService: AudioFileService()
+        )
+        FileTranscriptionViewModel._shared = fileTranscriptionViewModel
+        let navigationCoordinator = SettingsNavigationCoordinator()
+        SettingsNavigationCoordinator.shared = navigationCoordinator
+
+        let dictationViewModel = makeDictationViewModel(
+            appSupportDirectory: appSupportDirectory,
+            modelManager: modelManager,
+            audioRecordingService: AudioRecordingService(recoveryAudioStore: store)
+        )
+
+        dictationViewModel.recoverLastRecording(openSettingsWindow: false)
+
+        XCTAssertEqual(fileTranscriptionViewModel.files.map(\.url), [recoveryURL])
+        XCTAssertEqual(navigationCoordinator.request?.tab, .fileTranscription)
+        XCTAssertFalse(fileTranscriptionViewModel.showFilePickerFromMenu)
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DictationRecoveryAudioStoreTests-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    private func fileNames(in directory: URL) throws -> [String] {
+        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
+        return try FileManager.default.contentsOfDirectory(atPath: directory.path)
+    }
+
+    private func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        data[offset..<(offset + 4)].reversed().reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+    }
+
+    private func readInt16(_ data: Data, at offset: Int) -> Int16 {
+        let value = data[offset..<(offset + 2)].reversed().reduce(UInt16(0)) { ($0 << 8) | UInt16($1) }
+        return Int16(bitPattern: value)
+    }
+
+    @MainActor
+    private func makeDictationViewModel(
+        appSupportDirectory: URL,
+        modelManager: ModelManagerService,
+        audioRecordingService: AudioRecordingService
+    ) -> DictationViewModel {
+        let textInsertionService = TextInsertionService()
+        let hotkeyService = HotkeyService()
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let recentTranscriptionStore = RecentTranscriptionStore()
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let promptProcessingService = PromptProcessingService()
+        let punctuationProfileStore = DictationPunctuationProfileStore(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!,
+            storageKey: UUID().uuidString
+        )
+        let punctuationRulesLoader = PunctuationRulesLoader()
+
+        return DictationViewModel(
+            audioRecordingService: audioRecordingService,
+            textInsertionService: textInsertionService,
+            hotkeyService: hotkeyService,
+            modelManager: modelManager,
+            settingsViewModel: SettingsViewModel(modelManager: modelManager),
+            historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
+            profileService: profileService,
+            workflowService: workflowService,
+            translationService: nil,
+            audioDuckingService: AudioDuckingService(),
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            soundService: SoundService(),
+            audioDeviceService: AudioDeviceService(
+                initialInputDevices: [],
+                monitorDeviceChanges: false,
+                probeCompatibilities: false
+            ),
+            promptActionService: promptActionService,
+            promptProcessingService: promptProcessingService,
+            appFormatterService: AppFormatterService(),
+            punctuationStrategyResolver: PunctuationStrategyResolver(profileStore: punctuationProfileStore),
+            speechPunctuationService: SpeechPunctuationService(rulesLoader: punctuationRulesLoader),
+            speechFeedbackService: SpeechFeedbackService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            errorLogService: ErrorLogService(appSupportDirectory: appSupportDirectory),
+            mediaPlaybackService: MediaPlaybackService(startListening: false)
+        )
+    }
+}

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -280,7 +280,7 @@ final class MenuBarGroupingTests: XCTestCase {
         )
         XCTAssertEqual(
             MenuBarMenuSection.transcription.items,
-            [.transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+            [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         )
         XCTAssertEqual(
             MenuBarMenuSection.updates.items,

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -279,8 +279,12 @@ final class MenuBarGroupingTests: XCTestCase {
             [.toggleRecorder]
         )
         XCTAssertEqual(
-            MenuBarMenuSection.transcription.items,
+            MenuBarMenuSection.transcription.items(hasRecoverableRecording: true),
             [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+        )
+        XCTAssertEqual(
+            MenuBarMenuSection.transcription.items(hasRecoverableRecording: false),
+            [.transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         )
         XCTAssertEqual(
             MenuBarMenuSection.updates.items,

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+final class FileTranscriptionViewModelTests: XCTestCase {
+    func testTranscribeAllUsesFileTranscriptionEngineAndModelOverrides() async throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "last-dictation-recovery.wav")
+        var capturedLanguageSelection: LanguageSelection?
+        var capturedTask: TranscriptionTask?
+        var capturedEngineOverrideId: String?
+        var capturedModelOverrideId: String?
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { url in
+                XCTAssertEqual(url, fileURL)
+                return [0.1, -0.1]
+            },
+            transcriptionRunner: { samples, languageSelection, task, engineOverrideId, cloudModelOverride in
+                XCTAssertEqual(samples, [0.1, -0.1])
+                capturedLanguageSelection = languageSelection
+                capturedTask = task
+                capturedEngineOverrideId = engineOverrideId
+                capturedModelOverrideId = cloudModelOverride
+                return TranscriptionResult(
+                    text: "Recovered text",
+                    detectedLanguage: "de",
+                    duration: 1,
+                    processingTime: 0.1,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { engineId in
+                engineId == "parakeet"
+            }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.selectedEngine = "parakeet"
+        viewModel.selectedModel = "parakeet-large"
+        viewModel.languageSelection = .hints(["de", "en"])
+        viewModel.selectedTask = .translate
+
+        viewModel.transcribeAll()
+        try await waitForBatchToFinish(viewModel)
+
+        XCTAssertEqual(capturedLanguageSelection, .hints(["de", "en"]))
+        XCTAssertEqual(capturedTask, .translate)
+        XCTAssertEqual(capturedEngineOverrideId, "parakeet")
+        XCTAssertEqual(capturedModelOverrideId, "parakeet-large")
+        XCTAssertEqual(viewModel.files.first?.state, .done)
+        XCTAssertEqual(viewModel.files.first?.result?.text, "Recovered text")
+    }
+
+    func testRecoveryTranscribeUsesRecoveryEngineAndModelOverrides() async throws {
+        let defaults = try makeDefaults()
+        let directory = makeTemporaryDirectory()
+        let historyService = HistoryService(appSupportDirectory: makeTemporaryDirectory())
+        let store = DictationRecoveryAudioStore(directory: directory)
+        store.startNewRecording()
+        store.append([0.1])
+        let olderRecoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        store.startNewRecording()
+        store.append([0.2, -0.2])
+        let selectedRecoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        let audioRecordingService = AudioRecordingService(recoveryAudioStore: store)
+        var capturedLanguageSelection: LanguageSelection?
+        var capturedTask: TranscriptionTask?
+        var capturedEngineOverrideId: String?
+        var capturedModelOverrideId: String?
+
+        let viewModel = DictationRecoveryViewModel(
+            audioRecordingService: audioRecordingService,
+            modelManager: ModelManagerService(),
+            historyService: historyService,
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { url in
+                XCTAssertEqual(url, selectedRecoveryURL)
+                return [0.2, -0.2]
+            },
+            transcriptionRunner: { samples, languageSelection, task, engineOverrideId, cloudModelOverride in
+                XCTAssertEqual(samples, [0.2, -0.2])
+                capturedLanguageSelection = languageSelection
+                capturedTask = task
+                capturedEngineOverrideId = engineOverrideId
+                capturedModelOverrideId = cloudModelOverride
+                return TranscriptionResult(
+                    text: "Recovered dictation",
+                    detectedLanguage: "de",
+                    duration: 2,
+                    processingTime: 0.2,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { engineId in
+                engineId == "parakeet"
+            }
+        )
+
+        viewModel.selectedEngine = "parakeet"
+        viewModel.selectedModel = "parakeet-large"
+        viewModel.languageSelection = .hints(["de", "en"])
+        viewModel.selectedTask = .translate
+        viewModel.selectedRecoveryID = selectedRecoveryURL.path
+
+        XCTAssertEqual(Set(viewModel.recoveries.map(\.url)), Set([olderRecoveryURL, selectedRecoveryURL]))
+        viewModel.transcribe()
+        try await waitForRecoveryToSave(viewModel, historyService: historyService)
+
+        XCTAssertEqual(capturedLanguageSelection, .hints(["de", "en"]))
+        XCTAssertEqual(capturedTask, .translate)
+        XCTAssertEqual(capturedEngineOverrideId, "parakeet")
+        XCTAssertEqual(capturedModelOverrideId, "parakeet-large")
+        let historyRecord = try XCTUnwrap(historyService.records.first)
+        XCTAssertEqual(historyRecord.rawText, "Recovered dictation")
+        XCTAssertEqual(historyRecord.finalText, "Recovered dictation")
+        XCTAssertEqual(historyRecord.language, "de")
+        XCTAssertEqual(historyRecord.engineUsed, "parakeet")
+        XCTAssertNotNil(historyService.audioFileURL(for: historyRecord))
+        XCTAssertEqual(viewModel.recoveries.map(\.url), [olderRecoveryURL])
+        XCTAssertEqual(audioRecordingService.latestRecoveryRecordingURL, olderRecoveryURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: selectedRecoveryURL.path))
+    }
+
+    func testRecoveryDiscardDeletesOnlySelectedRecoveryFile() throws {
+        let defaults = try makeDefaults()
+        let directory = makeTemporaryDirectory()
+        let historyService = HistoryService(appSupportDirectory: makeTemporaryDirectory())
+        let store = DictationRecoveryAudioStore(directory: directory)
+        store.startNewRecording()
+        store.append([0.1])
+        let olderRecoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        store.startNewRecording()
+        store.append([0.2])
+        let newerRecoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        let audioRecordingService = AudioRecordingService(recoveryAudioStore: store)
+        let viewModel = DictationRecoveryViewModel(
+            audioRecordingService: audioRecordingService,
+            modelManager: ModelManagerService(),
+            historyService: historyService,
+            audioFileService: AudioFileService(),
+            defaults: defaults
+        )
+
+        viewModel.selectedRecoveryID = olderRecoveryURL.path
+        viewModel.discardSelectedRecovery()
+
+        XCTAssertEqual(viewModel.recoveries.map(\.url), [newerRecoveryURL])
+        XCTAssertEqual(viewModel.recoveryURL, newerRecoveryURL)
+        XCTAssertEqual(audioRecordingService.recoveryRecordingURLs, [newerRecoveryURL])
+        XCTAssertEqual(audioRecordingService.latestRecoveryRecordingURL, newerRecoveryURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: olderRecoveryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: newerRecoveryURL.path))
+    }
+
+    func testRecoverySettingsTabFallsBackWhenRecoveryIsUnavailable() {
+        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: false), .recording)
+        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: true), .dictationRecovery)
+        XCTAssertEqual(SettingsView.availableTab(.fileTranscription, hasRecoveryContent: false), .fileTranscription)
+    }
+
+    private func makeDefaults() throws -> UserDefaults {
+        let name = "FileTranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: name)
+        }
+        return defaults
+    }
+
+    private func makeTemporaryFile(named name: String) -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileTranscriptionViewModelTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(name)
+        FileManager.default.createFile(atPath: url.path, contents: Data())
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return url
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileTranscriptionViewModelTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    private func waitForBatchToFinish(_ viewModel: FileTranscriptionViewModel) async throws {
+        for _ in 0..<50 {
+            if viewModel.batchState == .done {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("File transcription batch did not finish")
+    }
+
+    private func waitForRecoveryToSave(
+        _ viewModel: DictationRecoveryViewModel,
+        historyService: HistoryService
+    ) async throws {
+        for _ in 0..<50 {
+            if viewModel.lastSavedHistoryRecordID != nil, !historyService.records.isEmpty {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("Recovery transcription was not saved to history")
+    }
+}


### PR DESCRIPTION
## Summary
- Add a serial dictation recovery WAV store that writes 16 kHz mono PCM during recording, finalizes failed recordings as WAV files, and keeps multiple timestamped recovery files instead of only one latest file.
- Preserve recovery audio for unexpected recording/transcription failures, empty transcription output, and audio recovery circuit-breaker failures; discard the active recovery file on success, cancel, push-to-talk discard, too-short clips, and no-speech clips without deleting older failed recoveries.
- Replace the disabled recovery menu item with a hidden-when-unavailable `Recover Last Recording` action that opens a dedicated Recovery settings tab.
- Add a Recovery settings workflow where users can choose a recovery file, select engine/model/language, transcribe it, and save successful recovery output into History with its audio file.
- Add engine/model overrides to File Transcription so recovered files and manually added files can be retried with a different transcription backend.

## Issue Context
Issue #533 reported that dictation audio can be lost when recording succeeds but transcription fails, returns empty text, or the audio recovery circuit breaker aborts before the in-memory buffer can be reused. This PR persists recording audio to disk during capture and exposes the preserved WAV files through a recovery flow, so users can retry failed dictations with another model and keep successful recoveries in History.

Closes #533

## Test Coverage
- Recovery store tests cover WAV headers/data sizes, sample append, empty recordings, multiple timestamped recoveries, selected/all discard behavior, and guard against deleting lookalike files outside the recovery directory.
- Audio engine flow tests cover successful discard, transcription failure preservation, circuit-breaker preservation, user cancel discard, and preserving older failed recoveries after a later successful recording.
- View model tests cover recovery transcription with engine/model/language overrides, successful History persistence with audio, selected recovery deletion, remaining recovery retention, and settings-tab fallback behavior.
- File transcription tests cover engine/model/language override plumbing for normal file batches.

## Pre-Landing Review
- Auto-fixed: `DictationRecoveryAudioStore.discardRecovery(at:)` now verifies the target file is inside the recovery directory before deleting it.
- No remaining blocking findings.

## Verification Results
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Passed: 614 tests, 0 failures.
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationRecoveryAudioStoreTests`
  - Passed: 7 tests, 0 failures.
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`

Note: Xcode reported the local CoreSimulator framework as out of date, but macOS tests and builds completed successfully.

## Test plan
- [x] Primary app XCTest suite passes.
- [x] Focused recovery-store regression tests pass.
- [x] Debug build passes.
- [x] Local TypeWhisper dev app build script passes.
