### PR TITLE
Add WhisperKit Distil Large v3 Turbo model

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -697,6 +697,12 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
             ramRequirement: "8 GB+"
         ),
         WhisperModelDef(
+            id: "distil-whisper_distil-large-v3_turbo",
+            displayName: "Distil Large v3 Turbo",
+            sizeDescription: "~600 MB",
+            ramRequirement: "8 GB+"
+        ),
+        WhisperModelDef(
             id: "distil-whisper_distil-large-v3",
             displayName: "Distil Large v3",
             sizeDescription: "~594 MB",
@@ -720,7 +726,7 @@ struct WhisperModelDef: Identifiable {
         switch displayName {
         case "Tiny", "Base":
             return gb < 8
-        case "Small", "Medium", "Large v3 Turbo":
+        case "Small", "Medium", "Large v3 Turbo", "Distil Large v3 Turbo":
             return gb >= 8 && gb <= 16
         case "Large v3":
             return gb > 16

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -9,9 +9,9 @@
         "arm64"
     ],
     "author": "TypeWhisper",
-    "description": "Local speech-to-text powered by WhisperKit. 7 model sizes, 99 languages, streaming support.",
+    "description": "Local speech-to-text powered by WhisperKit. 8 model sizes, 99 languages, streaming support.",
     "descriptions": {
-        "de": "Lokale Spracherkennung mit WhisperKit. 7 Modellgroessen, 99 Sprachen, Streaming-Unterstuetzung."
+        "de": "Lokale Spracherkennung mit WhisperKit. 8 Modellgroessen, 99 Sprachen, Streaming-Unterstuetzung."
     },
     "category": "transcription",
     "iconSystemName": "waveform",

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -40,6 +40,16 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         return MockHostServices(pluginDataDirectory: pluginDataDirectory, defaults: defaults)
     }
 
+    func testAvailableModelsIncludeDistilLargeV3Turbo() {
+        let model = WhisperKitPlugin.availableModels.first {
+            $0.id == "distil-whisper_distil-large-v3_turbo"
+        }
+
+        XCTAssertEqual(model?.displayName, "Distil Large v3 Turbo")
+        XCTAssertEqual(model?.sizeDescription, "~600 MB")
+        XCTAssertEqual(model?.ramRequirement, "8 GB+")
+    }
+
     func testActivationPromotesPersistedLoadedModelToSelectedModelWhenSelectionMissing() async throws {
         let host = try makeHost(defaults: ["loadedModel": "openai_whisper-tiny"])
         defer { TestSupport.remove(host.pluginDataDirectory) }


### PR DESCRIPTION
## Summary
- Adds the upstream WhisperKit CoreML `distil-whisper_distil-large-v3_turbo` variant to the bundled WhisperKit model catalog.
- Marks Distil Large v3 Turbo as recommended on 8-16 GB Macs alongside the existing fast local options.
- Updates the WhisperKit plugin manifest copy from 7 to 8 model sizes.

## Discussion context
This follows up on https://github.com/TypeWhisper/typewhisper-mac/discussions/443#discussion-9990678. `distil-large-v3.5` is not currently available in `argmaxinc/whisperkit-coreml`, so this PR ships the available CoreML turbo distil variant without changing the existing WhisperKit download/load path.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
