### PR TITLE
Remove workflow label background

### DIFF
--- a/TypeWhisper/Views/IndicatorPreviewView.swift
+++ b/TypeWhisper/Views/IndicatorPreviewView.swift
@@ -246,7 +246,6 @@ struct IndicatorPreviewView: View {
                 .padding(.horizontal, 5)
                 .padding(.vertical, 2)
                 .frame(maxWidth: NotchIndicatorLayout.profileChipMaxWidth, alignment: .leading)
-                .background(.white.opacity(0.2), in: Capsule())
         case .none:
             Color.clear.frame(width: 0)
         }

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -185,7 +185,6 @@ struct IndicatorRecordingContent: View {
                     .padding(.horizontal, sizing.profilePaddingH)
                     .padding(.vertical, sizing.profilePaddingV)
                     .frame(maxWidth: NotchIndicatorLayout.profileChipMaxWidth, alignment: .leading)
-                    .background(.white.opacity(0.2), in: Capsule())
                     .accessibilityLabel(localizedAppText("Active workflow", de: "Aktiver Workflow"))
                     .accessibilityValue(name)
             } else {


### PR DESCRIPTION
## Summary
- Remove the gray capsule background from the active workflow label in the runtime indicator component.
- Match the Settings indicator preview to the same backgroundless workflow label styling.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7dde/typewhisper-mac`
