### PR TITLE
Support multiple global hotkeys per action

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -17,7 +17,7 @@ enum UserDefaultsKeys {
     static let mediaPauseEnabled = "mediaPauseEnabled"
     static let transcribeShortQuietClipsAggressively = "transcribeShortQuietClipsAggressively"
 
-    // MARK: - Hotkey (JSON-encoded UnifiedHotkey per slot)
+    // MARK: - Hotkey (JSON-encoded UnifiedHotkey per slot, legacy mirror for first binding)
     static let hybridHotkey = "hybridHotkey"
     static let pttHotkey = "pttHotkey"
     static let toggleHotkey = "toggleHotkey"
@@ -25,6 +25,15 @@ enum UserDefaultsKeys {
     static let recentTranscriptionsHotkey = "recentTranscriptionsHotkey"
     static let copyLastTranscriptionHotkey = "copyLastTranscriptionHotkey"
     static let recorderToggleHotkey = "recorderToggleHotkey"
+
+    // MARK: - Hotkeys (JSON-encoded [UnifiedHotkey] per slot)
+    static let hybridHotkeys = "hybridHotkeys"
+    static let pttHotkeys = "pttHotkeys"
+    static let toggleHotkeys = "toggleHotkeys"
+    static let promptPaletteHotkeys = "promptPaletteHotkeys"
+    static let recentTranscriptionsHotkeys = "recentTranscriptionsHotkeys"
+    static let copyLastTranscriptionHotkeys = "copyLastTranscriptionHotkeys"
+    static let recorderToggleHotkeys = "recorderToggleHotkeys"
 
     // MARK: - Model / Engine
     static let selectedEngine = "selectedEngine"

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -111,6 +111,18 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
         case .recorderToggle: return UserDefaultsKeys.recorderToggleHotkey
         }
     }
+
+    var hotkeysDefaultsKey: String {
+        switch self {
+        case .hybrid: return UserDefaultsKeys.hybridHotkeys
+        case .pushToTalk: return UserDefaultsKeys.pttHotkeys
+        case .toggle: return UserDefaultsKeys.toggleHotkeys
+        case .promptPalette: return UserDefaultsKeys.promptPaletteHotkeys
+        case .recentTranscriptions: return UserDefaultsKeys.recentTranscriptionsHotkeys
+        case .copyLastTranscription: return UserDefaultsKeys.copyLastTranscriptionHotkeys
+        case .recorderToggle: return UserDefaultsKeys.recorderToggleHotkeys
+        }
+    }
 }
 
 /// Manages global hotkeys for dictation and standalone app actions.
@@ -170,6 +182,7 @@ final class HotkeyService: ObservableObject {
     private var keyDownTime: Date?
     private var isActive = false
     private var activeSlotType: HotkeySlotType?
+    private var activeGlobalHotkey: UnifiedHotkey?
     private(set) var activeProfileId: UUID?
     private(set) var activeWorkflowId: UUID?
     private var pushToTalkInterruptionSignaled = false
@@ -208,15 +221,9 @@ final class HotkeyService: ObservableObject {
         }
     }
 
-    private var slots: [HotkeySlotType: SlotState] = [
-        .hybrid: SlotState(),
-        .pushToTalk: SlotState(),
-        .toggle: SlotState(),
-        .promptPalette: SlotState(),
-        .recentTranscriptions: SlotState(),
-        .copyLastTranscription: SlotState(),
-        .recorderToggle: SlotState(),
-    ]
+    private var slots: [HotkeySlotType: [SlotState]] = HotkeySlotType.allCases.reduce(into: [:]) { result, slotType in
+        result[slotType] = []
+    }
 
     // MARK: - Per-Profile Hotkey State
 
@@ -296,26 +303,55 @@ final class HotkeyService: ObservableObject {
         setupMonitor()
     }
 
+    func hotkeys(for slotType: HotkeySlotType) -> [UnifiedHotkey] {
+        slots[slotType]?.compactMap(\.hotkey) ?? []
+    }
+
     func updateHotkey(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
-        slots[slotType] = SlotState(hotkey: hotkey)
-        UserDefaults.standard.set(try? JSONEncoder().encode(hotkey), forKey: slotType.defaultsKey)
-        tearDownMonitor()
-        setupMonitor()
+        setHotkeys([hotkey], for: slotType)
+    }
+
+    func appendHotkey(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
+        var existing = hotkeys(for: slotType)
+        guard !existing.contains(where: { $0.conflicts(with: hotkey) }) else { return }
+        existing.append(hotkey)
+        setHotkeys(existing, for: slotType)
+    }
+
+    func replaceHotkey(_ existingHotkey: UnifiedHotkey, with newHotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
+        var existing = hotkeys(for: slotType)
+        guard let index = existing.firstIndex(of: existingHotkey) else {
+            appendHotkey(newHotkey, for: slotType)
+            return
+        }
+
+        existing[index] = newHotkey
+        let updated = existing.enumerated().compactMap { offset, hotkey -> UnifiedHotkey? in
+            if offset == index { return hotkey }
+            return hotkey.conflicts(with: newHotkey) ? nil : hotkey
+        }
+        setHotkeys(updated, for: slotType)
+    }
+
+    func removeHotkey(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
+        let updated = hotkeys(for: slotType).filter { $0 != hotkey }
+        setHotkeys(updated, for: slotType)
+    }
+
+    func removeConflictingHotkey(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
+        let updated = hotkeys(for: slotType).filter { !$0.conflicts(with: hotkey) }
+        setHotkeys(updated, for: slotType)
     }
 
     func clearHotkey(for slotType: HotkeySlotType) {
-        slots[slotType] = SlotState()
-        UserDefaults.standard.removeObject(forKey: slotType.defaultsKey)
-        tearDownMonitor()
-        setupMonitor()
+        setHotkeys([], for: slotType)
     }
 
     /// Returns which slot already has this hotkey assigned, excluding a given slot.
     /// Also detects conflicts between single-tap and double-tap variants of the same key.
     func isHotkeyAssigned(_ hotkey: UnifiedHotkey, excluding: HotkeySlotType) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases where slotType != excluding {
-            guard let existing = slots[slotType]?.hotkey else { continue }
-            if existing.conflicts(with: hotkey) {
+            if hotkeys(for: slotType).contains(where: { $0.conflicts(with: hotkey) }) {
                 return slotType
             }
         }
@@ -331,6 +367,7 @@ final class HotkeyService: ObservableObject {
     func cancelDictation() {
         isActive = false
         activeSlotType = nil
+        activeGlobalHotkey = nil
         activeProfileId = nil
         activeWorkflowId = nil
         currentMode = nil
@@ -374,8 +411,7 @@ final class HotkeyService: ObservableObject {
 
     func isHotkeyAssignedToGlobalSlot(_ hotkey: UnifiedHotkey) -> HotkeySlotType? {
         for slotType in HotkeySlotType.allCases {
-            guard let existing = slots[slotType]?.hotkey else { continue }
-            if existing.conflicts(with: hotkey) {
+            if hotkeys(for: slotType).contains(where: { $0.conflicts(with: hotkey) }) {
                 return slotType
             }
         }
@@ -385,10 +421,54 @@ final class HotkeyService: ObservableObject {
     private func loadHotkeys() {
         let defaults = UserDefaults.standard
         for slotType in HotkeySlotType.allCases {
+            if let data = defaults.data(forKey: slotType.hotkeysDefaultsKey),
+               let hotkeys = try? JSONDecoder().decode([UnifiedHotkey].self, from: data) {
+                let uniqueHotkeys = Self.uniqueHotkeys(hotkeys)
+                slots[slotType] = uniqueHotkeys.map { SlotState(hotkey: $0) }
+                persistHotkeys(uniqueHotkeys, for: slotType)
+                continue
+            }
+
             if let data = defaults.data(forKey: slotType.defaultsKey),
                let hotkey = try? JSONDecoder().decode(UnifiedHotkey.self, from: data) {
-                slots[slotType] = SlotState(hotkey: hotkey)
+                slots[slotType] = [SlotState(hotkey: hotkey)]
+                persistHotkeys([hotkey], for: slotType)
+                continue
             }
+
+            slots[slotType] = []
+        }
+    }
+
+    private func setHotkeys(_ hotkeys: [UnifiedHotkey], for slotType: HotkeySlotType) {
+        let uniqueHotkeys = Self.uniqueHotkeys(hotkeys)
+        slots[slotType] = uniqueHotkeys.map { SlotState(hotkey: $0) }
+        persistHotkeys(uniqueHotkeys, for: slotType)
+        tearDownMonitor()
+        setupMonitor()
+    }
+
+    private func persistHotkeys(_ hotkeys: [UnifiedHotkey], for slotType: HotkeySlotType) {
+        let defaults = UserDefaults.standard
+        guard !hotkeys.isEmpty else {
+            defaults.removeObject(forKey: slotType.hotkeysDefaultsKey)
+            defaults.removeObject(forKey: slotType.defaultsKey)
+            return
+        }
+
+        if let data = try? JSONEncoder().encode(hotkeys) {
+            defaults.set(data, forKey: slotType.hotkeysDefaultsKey)
+        }
+        if let first = hotkeys.first,
+           let data = try? JSONEncoder().encode(first) {
+            defaults.set(data, forKey: slotType.defaultsKey)
+        }
+    }
+
+    private nonisolated static func uniqueHotkeys(_ hotkeys: [UnifiedHotkey]) -> [UnifiedHotkey] {
+        hotkeys.reduce(into: []) { uniqueHotkeys, hotkey in
+            guard !uniqueHotkeys.contains(where: { $0.conflicts(with: hotkey) }) else { return }
+            uniqueHotkeys.append(hotkey)
         }
     }
 
@@ -542,28 +622,33 @@ final class HotkeyService: ObservableObject {
 
         // Global slots
         for slotType in HotkeySlotType.allCases {
-            guard var state = slots[slotType], let hotkey = state.hotkey else { continue }
-            let fnTriggerMode: FnTriggerMode = slotType == .toggle ? .releaseOnly : .pressThenRelease
-            if shouldSuppressForCapsLockOrigin(event, hotkey: hotkey, keyWasDown: state.keyWasDown) {
-                state.resetTransientState()
-                slots[slotType] = state
-                continue
+            guard var states = slots[slotType] else { continue }
+            for index in states.indices {
+                var state = states[index]
+                guard let hotkey = state.hotkey else { continue }
+                let fnTriggerMode: FnTriggerMode = slotType == .toggle ? .releaseOnly : .pressThenRelease
+                if shouldSuppressForCapsLockOrigin(event, hotkey: hotkey, keyWasDown: state.keyWasDown) {
+                    state.resetTransientState()
+                    states[index] = state
+                    continue
+                }
+                let (keyDown, keyUp, isMatch) = processKeyEvent(
+                    event,
+                    hotkey: hotkey,
+                    state: &state,
+                    fnTriggerMode: fnTriggerMode
+                )
+                states[index] = state
+                if isMatch { shouldSuppress = true }
+                dispatchGlobalMatch(
+                    slotType: slotType,
+                    hotkey: hotkey,
+                    keyDown: keyDown,
+                    keyUp: keyUp,
+                    source: source
+                )
             }
-            let (keyDown, keyUp, isMatch) = processKeyEvent(
-                event,
-                hotkey: hotkey,
-                state: &state,
-                fnTriggerMode: fnTriggerMode
-            )
-            slots[slotType] = state
-            if isMatch { shouldSuppress = true }
-            dispatchGlobalMatch(
-                slotType: slotType,
-                hotkey: hotkey,
-                keyDown: keyDown,
-                keyUp: keyUp,
-                source: source
-            )
+            slots[slotType] = states
         }
 
         // Profile slots
@@ -705,7 +790,7 @@ final class HotkeyService: ObservableObject {
             if source != .eventTap {
                 logFallbackMatchIfNeeded(hotkey: hotkey, source: source)
             }
-            handleKeyDown(slotType: slotType)
+            handleKeyDown(slotType: slotType, hotkey: hotkey)
         } else if keyUp, shouldDispatch(
             target: .slot(slotType),
             phase: .up,
@@ -779,7 +864,7 @@ final class HotkeyService: ObservableObject {
               activeProfileId == nil,
               activeWorkflowId == nil,
               event.type == .keyDown,
-              let hotkey = slots[.pushToTalk]?.hotkey,
+              let hotkey = activeGlobalHotkey,
               isExtraKeyDuringActivePushToTalk(event, hotkey: hotkey) else {
             return
         }
@@ -826,7 +911,15 @@ final class HotkeyService: ObservableObject {
 
 #if DEBUG
     func setHotkeyForTesting(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
-        slots[slotType] = SlotState(hotkey: hotkey)
+        slots[slotType] = [SlotState(hotkey: hotkey)]
+    }
+
+    func setHotkeysForTesting(_ hotkeys: [UnifiedHotkey], for slotType: HotkeySlotType) {
+        slots[slotType] = Self.uniqueHotkeys(hotkeys).map { SlotState(hotkey: $0) }
+    }
+
+    func loadHotkeysForTesting() {
+        loadHotkeys()
     }
 
     @discardableResult
@@ -1106,7 +1199,7 @@ final class HotkeyService: ObservableObject {
 
     // MARK: - Key Down / Up (Global Slots)
 
-    private func handleKeyDown(slotType: HotkeySlotType) {
+    private func handleKeyDown(slotType: HotkeySlotType, hotkey: UnifiedHotkey) {
         if slotType == .promptPalette {
             onPromptPaletteToggle?()
             return
@@ -1128,6 +1221,7 @@ final class HotkeyService: ObservableObject {
             // Any hotkey stops active recording
             isActive = false
             activeSlotType = nil
+            activeGlobalHotkey = nil
             activeProfileId = nil
             activeWorkflowId = nil
             currentMode = nil
@@ -1137,6 +1231,7 @@ final class HotkeyService: ObservableObject {
         } else {
             let requestTimestamp = Self.requestTimestamp()
             activeSlotType = slotType
+            activeGlobalHotkey = hotkey
             activeProfileId = nil
             activeWorkflowId = nil
             keyDownTime = Date()
@@ -1158,6 +1253,7 @@ final class HotkeyService: ObservableObject {
             } else {
                 isActive = false
                 activeSlotType = nil
+                activeGlobalHotkey = nil
                 currentMode = nil
                 keyDownTime = nil
                 pushToTalkInterruptionSignaled = false
@@ -1166,6 +1262,7 @@ final class HotkeyService: ObservableObject {
         case .pushToTalk:
             isActive = false
             activeSlotType = nil
+            activeGlobalHotkey = nil
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
@@ -1190,6 +1287,7 @@ final class HotkeyService: ObservableObject {
             // Any hotkey stops active recording
             isActive = false
             activeSlotType = nil
+            activeGlobalHotkey = nil
             activeProfileId = nil
             activeWorkflowId = nil
             currentMode = nil
@@ -1201,6 +1299,7 @@ final class HotkeyService: ObservableObject {
             activeProfileId = profileId
             activeWorkflowId = nil
             activeSlotType = nil
+            activeGlobalHotkey = nil
             keyDownTime = Date()
             isActive = true
             pushToTalkInterruptionSignaled = false
@@ -1219,6 +1318,7 @@ final class HotkeyService: ObservableObject {
         } else {
             isActive = false
             activeSlotType = nil
+            activeGlobalHotkey = nil
             activeProfileId = nil
             activeWorkflowId = nil
             currentMode = nil
@@ -1239,6 +1339,7 @@ final class HotkeyService: ObservableObject {
         if isActive {
             isActive = false
             activeSlotType = nil
+            activeGlobalHotkey = nil
             activeProfileId = nil
             activeWorkflowId = nil
             currentMode = nil
@@ -1250,6 +1351,7 @@ final class HotkeyService: ObservableObject {
             activeProfileId = nil
             activeWorkflowId = workflowId
             activeSlotType = nil
+            activeGlobalHotkey = nil
             keyDownTime = Date()
             isActive = true
             pushToTalkInterruptionSignaled = false
@@ -1268,6 +1370,7 @@ final class HotkeyService: ObservableObject {
         } else {
             isActive = false
             activeSlotType = nil
+            activeGlobalHotkey = nil
             activeProfileId = nil
             activeWorkflowId = nil
             currentMode = nil

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -46,30 +46,66 @@ final class DictationSettingsHandler {
         onHotkeyLabelsChanged?()
     }
 
+    func addHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) {
+        hotkeyService.appendHotkey(hotkey, for: slot)
+        onHotkeyLabelsChanged?()
+    }
+
+    func replaceHotkey(_ existingHotkey: UnifiedHotkey, with newHotkey: UnifiedHotkey, for slot: HotkeySlotType) {
+        hotkeyService.replaceHotkey(existingHotkey, with: newHotkey, for: slot)
+        onHotkeyLabelsChanged?()
+    }
+
+    func removeHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) {
+        hotkeyService.removeHotkey(hotkey, for: slot)
+        onHotkeyLabelsChanged?()
+    }
+
+    func removeConflictingHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) {
+        hotkeyService.removeConflictingHotkey(hotkey, for: slot)
+        onHotkeyLabelsChanged?()
+    }
+
     func clearHotkey(for slot: HotkeySlotType) {
         hotkeyService.clearHotkey(for: slot)
         onHotkeyLabelsChanged?()
+    }
+
+    func hotkeys(for slot: HotkeySlotType) -> [UnifiedHotkey] {
+        hotkeyService.hotkeys(for: slot)
     }
 
     func isHotkeyAssigned(_ hotkey: UnifiedHotkey, excluding: HotkeySlotType) -> HotkeySlotType? {
         hotkeyService.isHotkeyAssigned(hotkey, excluding: excluding)
     }
 
-    static func loadHotkey(for slotType: HotkeySlotType) -> UnifiedHotkey? {
-        guard let data = UserDefaults.standard.data(forKey: slotType.defaultsKey) else {
-            return nil
+    static func loadHotkeys(for slotType: HotkeySlotType) -> [UnifiedHotkey] {
+        if let data = UserDefaults.standard.data(forKey: slotType.hotkeysDefaultsKey),
+           let hotkeys = try? JSONDecoder().decode([UnifiedHotkey].self, from: data) {
+            return hotkeys
         }
-        return try? JSONDecoder().decode(UnifiedHotkey.self, from: data)
+
+        guard let data = UserDefaults.standard.data(forKey: slotType.defaultsKey),
+              let hotkey = try? JSONDecoder().decode(UnifiedHotkey.self, from: data) else {
+            return []
+        }
+        return [hotkey]
+    }
+
+    static func loadHotkey(for slotType: HotkeySlotType) -> UnifiedHotkey? {
+        loadHotkeys(for: slotType).first
+    }
+
+    static func loadHotkeyLabels(for slotType: HotkeySlotType) -> [String] {
+        loadHotkeys(for: slotType).map { HotkeyService.displayName(for: $0) }
     }
 
     static func loadHotkeyLabel(for slotType: HotkeySlotType) -> String {
-        guard let hotkey = loadHotkey(for: slotType) else { return "" }
-        return HotkeyService.displayName(for: hotkey)
+        loadHotkeyLabels(for: slotType).first ?? ""
     }
 
     static func loadMenuShortcutDescriptor(for slotType: HotkeySlotType) -> HotkeyService.MenuShortcutDescriptor? {
-        guard let hotkey = loadHotkey(for: slotType) else { return nil }
-        return HotkeyService.menuShortcutDescriptor(for: hotkey)
+        loadHotkeys(for: slotType).compactMap { HotkeyService.menuShortcutDescriptor(for: $0) }.first
     }
 
     func registerInitialTriggerHotkeys() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1307,7 +1307,12 @@ final class DictationViewModel: ObservableObject {
 
     func requestMicPermission() { settingsHandler.requestMicPermission() }
     func requestAccessibilityPermission() { settingsHandler.requestAccessibilityPermission() }
+    func hotkeys(for slot: HotkeySlotType) -> [UnifiedHotkey] { settingsHandler.hotkeys(for: slot) }
     func setHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) { settingsHandler.setHotkey(hotkey, for: slot) }
+    func addHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) { settingsHandler.addHotkey(hotkey, for: slot) }
+    func replaceHotkey(_ existingHotkey: UnifiedHotkey, with newHotkey: UnifiedHotkey, for slot: HotkeySlotType) { settingsHandler.replaceHotkey(existingHotkey, with: newHotkey, for: slot) }
+    func removeHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) { settingsHandler.removeHotkey(hotkey, for: slot) }
+    func removeConflictingHotkey(_ hotkey: UnifiedHotkey, for slot: HotkeySlotType) { settingsHandler.removeConflictingHotkey(hotkey, for: slot) }
     func clearHotkey(for slot: HotkeySlotType) { settingsHandler.clearHotkey(for: slot) }
     func isHotkeyAssigned(_ hotkey: UnifiedHotkey, excluding: HotkeySlotType) -> HotkeySlotType? { settingsHandler.isHotkeyAssigned(hotkey, excluding: excluding) }
 

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -362,13 +362,13 @@ struct HomeSettingsView: View {
     // MARK: - Getting Started Card
 
     private var primaryHotkeyLabel: String {
-        if UserDefaults.standard.data(forKey: UserDefaultsKeys.hybridHotkey) != nil {
+        if !DictationSettingsHandler.loadHotkeys(for: .hybrid).isEmpty {
             return dictation.hybridHotkeyLabel
         }
-        if UserDefaults.standard.data(forKey: UserDefaultsKeys.pttHotkey) != nil {
+        if !DictationSettingsHandler.loadHotkeys(for: .pushToTalk).isEmpty {
             return dictation.pttHotkeyLabel
         }
-        if UserDefaults.standard.data(forKey: UserDefaultsKeys.toggleHotkey) != nil {
+        if !DictationSettingsHandler.loadHotkeys(for: .toggle).isEmpty {
             return dictation.toggleHotkeyLabel
         }
         return dictation.hybridHotkeyLabel

--- a/TypeWhisper/Views/HotkeyRecorderView.swift
+++ b/TypeWhisper/Views/HotkeyRecorderView.swift
@@ -1,9 +1,17 @@
 import SwiftUI
 
 struct HotkeyRecorderView: View {
+    enum Presentation {
+        case row
+        case iconButton(systemName: String)
+        case compactChip
+    }
+
     let label: String
     var title: String = String(localized: "Dictation shortcut")
     var subtitle: String? = nil
+    var presentation: Presentation = .row
+    var trailingAccessory: AnyView = AnyView(EmptyView())
     let onRecord: (UnifiedHotkey) -> Void
     let onClear: () -> Void
 
@@ -23,6 +31,17 @@ struct HotkeyRecorderView: View {
     @State private var doubleTapTimer: DispatchWorkItem?
 
     var body: some View {
+        switch presentation {
+        case .row:
+            rowBody
+        case .iconButton(let systemName):
+            iconButtonBody(systemName: systemName)
+        case .compactChip:
+            compactChipBody
+        }
+    }
+
+    private var rowBody: some View {
         HStack {
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
@@ -33,55 +52,115 @@ struct HotkeyRecorderView: View {
                 }
             }
             Spacer()
-            if isRecording {
-                Button {
-                    cancelRecording()
-                } label: {
-                    if let displayName = firstTapDisplayName {
-                        Text("\(displayName) - \(String(localized: "tap again for double-tap…"))")
-                            .foregroundStyle(.orange)
-                    } else {
-                        Text(pendingModifierString.isEmpty
-                            ? String(localized: "Press a key or mouse button…")
-                            : pendingModifierString)
-                            .foregroundStyle(.orange)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .accessibilityLabel(String(localized: "Recording shortcut - press a key or Escape to cancel"))
-            } else if label.isEmpty {
-                Button {
-                    startRecording()
-                } label: {
-                    Text(String(localized: "Record Shortcut"))
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .accessibilityLabel(String(localized: "Record shortcut for \(title)"))
-            } else {
-                HStack(spacing: 4) {
-                    Button {
-                        startRecording()
-                    } label: {
-                        Text(label)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(localized: "Current shortcut: \(label). Click to change."))
-                    Button {
-                        onClear()
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(localized: "Clear shortcut"))
-                }
+            recorderControl
+
+            if !isRecording {
+                trailingAccessory
             }
         }
+    }
+
+    @ViewBuilder
+    private func iconButtonBody(systemName: String) -> some View {
+        if isRecording {
+            Button {
+                cancelRecording()
+            } label: {
+                Text(recordingLabel)
+                    .foregroundStyle(.orange)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel(String(localized: "Recording shortcut - press a key or Escape to cancel"))
+        } else {
+            Button {
+                startRecording()
+            } label: {
+                Image(systemName: systemName)
+                    .imageScale(.medium)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help(title)
+            .accessibilityLabel(title)
+        }
+    }
+
+    @ViewBuilder
+    private var compactChipBody: some View {
+        if isRecording {
+            Button {
+                cancelRecording()
+            } label: {
+                Text(recordingLabel)
+                    .foregroundStyle(.orange)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel(String(localized: "Recording shortcut - press a key or Escape to cancel"))
+        } else if !label.isEmpty {
+            recordedShortcutControl
+        }
+    }
+
+    @ViewBuilder
+    private var recorderControl: some View {
+        if isRecording {
+            Button {
+                cancelRecording()
+            } label: {
+                Text(recordingLabel)
+                    .foregroundStyle(.orange)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel(String(localized: "Recording shortcut - press a key or Escape to cancel"))
+        } else if label.isEmpty {
+            Button {
+                startRecording()
+            } label: {
+                Text(String(localized: "Record Shortcut"))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel(String(localized: "Record shortcut for \(title)"))
+        } else {
+            recordedShortcutControl
+        }
+    }
+
+    private var recordedShortcutControl: some View {
+        HStack(spacing: 4) {
+            Button {
+                startRecording()
+            } label: {
+                Text(label)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "Current shortcut: \(label). Click to change."))
+            Button {
+                onClear()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "Clear shortcut"))
+        }
+        .fixedSize()
+    }
+
+    private var recordingLabel: String {
+        if let displayName = firstTapDisplayName {
+            return "\(displayName) - \(String(localized: "tap again for double-tap…"))"
+        }
+
+        return pendingModifierString.isEmpty
+            ? String(localized: "Press a key or mouse button…")
+            : pendingModifierString
     }
 
     private var pendingModifierString: String {

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -6,57 +6,30 @@ struct HotkeySettingsView: View {
     var body: some View {
         Form {
             Section(String(localized: "Hotkeys")) {
-                HotkeyRecorderView(
-                    label: dictation.hybridHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .hybrid,
                     title: String(localized: "Hybrid"),
-                    subtitle: String(localized: "Short press to toggle, hold to push-to-talk."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .hybrid) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .hybrid)
-                    },
-                    onClear: { dictation.clearHotkey(for: .hybrid) }
+                    subtitle: String(localized: "Short press to toggle, hold to push-to-talk.")
                 )
 
-                HotkeyRecorderView(
-                    label: dictation.pttHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .pushToTalk,
                     title: String(localized: "Push-to-Talk"),
-                    subtitle: String(localized: "Hold to record, release to stop."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .pushToTalk) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .pushToTalk)
-                    },
-                    onClear: { dictation.clearHotkey(for: .pushToTalk) }
+                    subtitle: String(localized: "Hold to record, release to stop.")
                 )
 
-                HotkeyRecorderView(
-                    label: dictation.toggleHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .toggle,
                     title: String(localized: "Toggle"),
-                    subtitle: String(localized: "Press to start, press again to stop."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .toggle) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .toggle)
-                    },
-                    onClear: { dictation.clearHotkey(for: .toggle) }
+                    subtitle: String(localized: "Press to start, press again to stop.")
                 )
             }
 
             Section(localizedAppText("Workflow Palette", de: "Workflow-Palette")) {
-                HotkeyRecorderView(
-                    label: dictation.promptPaletteHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .promptPalette,
                     title: localizedAppText("Palette shortcut", de: "Palette-Shortcut"),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .promptPalette) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .promptPalette)
-                    },
-                    onClear: { dictation.clearHotkey(for: .promptPalette) }
+                    subtitle: nil
                 )
 
                 Text(localizedAppText(
@@ -68,50 +41,120 @@ struct HotkeySettingsView: View {
             }
 
             Section(String(localized: "settings.tab.recorder")) {
-                HotkeyRecorderView(
-                    label: dictation.recorderToggleHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .recorderToggle,
                     title: String(localized: "recorder.shortcut.title"),
-                    subtitle: String(localized: "recorder.shortcut.description"),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .recorderToggle) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .recorderToggle)
-                    },
-                    onClear: { dictation.clearHotkey(for: .recorderToggle) }
+                    subtitle: String(localized: "recorder.shortcut.description")
                 )
             }
 
             Section(String(localized: "Recent Transcriptions")) {
-                HotkeyRecorderView(
-                    label: dictation.recentTranscriptionsHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .recentTranscriptions,
                     title: String(localized: "Recent transcription shortcut"),
-                    subtitle: String(localized: "Open your latest transcriptions and insert one into the focused app."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .recentTranscriptions) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .recentTranscriptions)
-                    },
-                    onClear: { dictation.clearHotkey(for: .recentTranscriptions) }
+                    subtitle: String(localized: "Open your latest transcriptions and insert one into the focused app.")
                 )
 
-                HotkeyRecorderView(
-                    label: dictation.copyLastTranscriptionHotkeyLabel,
+                MultiHotkeySlotRecorder(
+                    slot: .copyLastTranscription,
                     title: String(localized: "Copy last transcription shortcut"),
-                    subtitle: String(localized: "Copy your latest transcription to the clipboard."),
-                    onRecord: { hotkey in
-                        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: .copyLastTranscription) {
-                            dictation.clearHotkey(for: conflict)
-                        }
-                        dictation.setHotkey(hotkey, for: .copyLastTranscription)
-                    },
-                    onClear: { dictation.clearHotkey(for: .copyLastTranscription) }
+                    subtitle: String(localized: "Copy your latest transcription to the clipboard.")
                 )
             }
         }
         .formStyle(.grouped)
         .padding()
         .frame(minWidth: 500, minHeight: 300)
+    }
+}
+
+private struct MultiHotkeySlotRecorder: View {
+    @ObservedObject private var dictation = DictationViewModel.shared
+
+    let slot: HotkeySlotType
+    let title: String
+    let subtitle: String?
+
+    var body: some View {
+        let hotkeys = dictation.hotkeys(for: slot)
+
+        Group {
+            if hotkeys.isEmpty {
+                HotkeyRecorderView(
+                    label: "",
+                    title: title,
+                    subtitle: subtitle,
+                    onRecord: { hotkey in record(hotkey) },
+                    onClear: { dictation.clearHotkey(for: slot) }
+                )
+            } else {
+                assignedHotkeysRow(hotkeys)
+            }
+        }
+    }
+
+    private func assignedHotkeysRow(_ hotkeys: [UnifiedHotkey]) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: 8) {
+                ForEach(hotkeys, id: \.self) { hotkey in
+                    HotkeyRecorderView(
+                        label: HotkeyService.displayName(for: hotkey),
+                        presentation: .compactChip,
+                        onRecord: { newHotkey in record(newHotkey, replacing: hotkey) },
+                        onClear: { dictation.removeHotkey(hotkey, for: slot) }
+                    )
+                }
+
+                addShortcutButton
+            }
+        }
+    }
+
+    private var addShortcutButton: some View {
+        HotkeyRecorderView(
+            label: "",
+            title: localizedAppText("Add Shortcut", de: "Shortcut hinzufügen"),
+            presentation: .iconButton(systemName: "plus.circle"),
+            onRecord: { hotkey in record(hotkey) },
+            onClear: {}
+        )
+    }
+
+    private func record(_ hotkey: UnifiedHotkey, replacing existingHotkey: UnifiedHotkey? = nil) {
+        if let existingHotkey, existingHotkey.conflicts(with: hotkey) {
+            dictation.replaceHotkey(existingHotkey, with: hotkey, for: slot)
+            return
+        }
+
+        let currentHotkeys = dictation.hotkeys(for: slot)
+        if currentHotkeys.contains(where: { candidate in
+            if let existingHotkey, candidate == existingHotkey {
+                return false
+            }
+            return candidate.conflicts(with: hotkey)
+        }) {
+            return
+        }
+
+        if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: slot) {
+            dictation.removeConflictingHotkey(hotkey, for: conflict)
+        }
+
+        if let existingHotkey {
+            dictation.replaceHotkey(existingHotkey, with: hotkey, for: slot)
+        } else {
+            dictation.addHotkey(hotkey, for: slot)
+        }
     }
 }

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -27,11 +27,11 @@ struct SetupWizardView: View {
         _selectedIndustryPreset = State(initialValue: IndustryPreset.selected())
         _promptProcessingService = ObservedObject(wrappedValue: PromptActionsViewModel.shared.promptProcessingService)
 
-        if UserDefaults.standard.data(forKey: UserDefaultsKeys.hybridHotkey) != nil {
+        if !DictationSettingsHandler.loadHotkeys(for: .hybrid).isEmpty {
             _selectedHotkeyMode = State(initialValue: .hybrid)
-        } else if UserDefaults.standard.data(forKey: UserDefaultsKeys.pttHotkey) != nil {
+        } else if !DictationSettingsHandler.loadHotkeys(for: .pushToTalk).isEmpty {
             _selectedHotkeyMode = State(initialValue: .pushToTalk)
-        } else if UserDefaults.standard.data(forKey: UserDefaultsKeys.toggleHotkey) != nil {
+        } else if !DictationSettingsHandler.loadHotkeys(for: .toggle).isEmpty {
             _selectedHotkeyMode = State(initialValue: .toggle)
         } else {
             _selectedHotkeyMode = State(initialValue: .hybrid)
@@ -1194,8 +1194,9 @@ struct SetupWizardView: View {
     }
 
     private var hasAnyHotkeySet: Bool {
-        [UserDefaultsKeys.hybridHotkey, UserDefaultsKeys.pttHotkey, UserDefaultsKeys.toggleHotkey]
-            .contains { UserDefaults.standard.data(forKey: $0) != nil }
+        !DictationSettingsHandler.loadHotkeys(for: .hybrid).isEmpty
+            || !DictationSettingsHandler.loadHotkeys(for: .pushToTalk).isEmpty
+            || !DictationSettingsHandler.loadHotkeys(for: .toggle).isEmpty
     }
 
     private func hotkeyLabel(for mode: HotkeySlotType) -> String {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -5532,6 +5532,116 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testGlobalSlotCanTriggerFromMultipleHotkeys() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeysForTesting([spaceHotkey(), commandOptionAHotkey()], for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+
+        let firstDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        let secondDown = try makeKeyboardEvent(
+            keyCode: 0x00,
+            keyDown: true,
+            flags: [.maskCommand, .maskAlternate]
+        )
+
+        XCTAssertTrue(service.processEventForTesting(firstDown, source: .monitor))
+        service.cancelDictation()
+        XCTAssertTrue(service.processEventForTesting(secondDown, source: .monitor))
+        XCTAssertEqual(startCount, 2)
+    }
+
+    @MainActor
+    func testLoadHotkeysMigratesLegacySingularUserDefaults() throws {
+        try withCleanHotkeyDefaults {
+            let defaults = UserDefaults.standard
+            let legacyHotkey = commandShiftCHotkey()
+            defaults.set(try JSONEncoder().encode(legacyHotkey), forKey: HotkeySlotType.copyLastTranscription.defaultsKey)
+
+            let service = HotkeyService()
+            service.loadHotkeysForTesting()
+
+            XCTAssertEqual(service.hotkeys(for: .copyLastTranscription), [legacyHotkey])
+
+            let pluralData = try XCTUnwrap(defaults.data(forKey: HotkeySlotType.copyLastTranscription.hotkeysDefaultsKey))
+            XCTAssertEqual(try JSONDecoder().decode([UnifiedHotkey].self, from: pluralData), [legacyHotkey])
+
+            let legacyData = try XCTUnwrap(defaults.data(forKey: HotkeySlotType.copyLastTranscription.defaultsKey))
+            XCTAssertEqual(try JSONDecoder().decode(UnifiedHotkey.self, from: legacyData), legacyHotkey)
+        }
+    }
+
+    @MainActor
+    func testClearingGlobalSlotRemovesPluralAndLegacyPersistence() throws {
+        try withCleanHotkeyDefaults {
+            let defaults = UserDefaults.standard
+            let service = HotkeyService()
+            service.suspendMonitoring()
+
+            service.updateHotkey(spaceHotkey(), for: .toggle)
+            service.appendHotkey(commandOptionAHotkey(), for: .toggle)
+
+            XCTAssertNotNil(defaults.data(forKey: HotkeySlotType.toggle.defaultsKey))
+            XCTAssertNotNil(defaults.data(forKey: HotkeySlotType.toggle.hotkeysDefaultsKey))
+
+            service.clearHotkey(for: .toggle)
+            service.suspendMonitoring()
+
+            XCTAssertNil(defaults.data(forKey: HotkeySlotType.toggle.defaultsKey))
+            XCTAssertNil(defaults.data(forKey: HotkeySlotType.toggle.hotkeysDefaultsKey))
+            XCTAssertTrue(service.hotkeys(for: .toggle).isEmpty)
+        }
+    }
+
+    @MainActor
+    func testRemovingConflictingGlobalHotkeyPreservesOtherBindingsInSlot() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeysForTesting([spaceHotkey(), commandOptionAHotkey()], for: .toggle)
+
+        service.removeConflictingHotkey(spaceHotkey(), for: .toggle)
+        service.suspendMonitoring()
+
+        XCTAssertEqual(service.hotkeys(for: .toggle), [commandOptionAHotkey()])
+    }
+
+    @MainActor
+    func testWorkflowConflictCheckDetectsAnyGlobalSlotBinding() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeysForTesting([spaceHotkey(), commandOptionAHotkey()], for: .toggle)
+
+        XCTAssertEqual(service.isHotkeyAssignedToGlobalSlot(commandOptionAHotkey()), .toggle)
+    }
+
+    private func withCleanHotkeyDefaults(_ body: () throws -> Void) throws {
+        let defaults = UserDefaults.standard
+        let keys = HotkeySlotType.allCases.flatMap { [$0.defaultsKey, $0.hotkeysDefaultsKey] }
+        let originals = keys.reduce(into: [String: Any]()) { result, key in
+            if let value = defaults.object(forKey: key) {
+                result[key] = value
+            }
+        }
+        keys.forEach { defaults.removeObject(forKey: $0) }
+        defer {
+            keys.forEach { key in
+                if let value = originals[key] {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+
+        try body()
+    }
+
+    @MainActor
     private func spaceHotkey() -> UnifiedHotkey {
         UnifiedHotkey(
             keyCode: 0x31,


### PR DESCRIPTION
## Summary
- Implements multiple global hotkey bindings per `HotkeySlotType`, including plural persistence, legacy singular migration, and first-binding mirrors for compatibility.
- Updates global hotkey conflict handling so conflicts are detected across all bindings and only the conflicting binding is removed from another slot.
- Refreshes the Hotkeys settings UI so assigned bindings appear inline as editable/removable chips with a compact add button.

## Issue Context
Issue #535 asks for each global Hotkeys settings action to store, display, edit, remove, and trigger multiple `UnifiedHotkey` bindings while keeping existing single-hotkey settings compatible. This PR keeps workflow hotkeys as-is and updates only the global hotkey slots and conflict lookup behavior.

Closes #535

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
