### PR TITLE
Fix indicator suppression for foreign fullscreen notch windows

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -116,6 +116,195 @@ final class IndicatorCoordinator {
     }
 }
 
+enum IndicatorWindowFrameLookup {
+    nonisolated static func frontmostWindowFrame(for processIdentifier: pid_t) -> CGRect? {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return nil
+        }
+
+        var fallbackFrame: CGRect?
+
+        for windowInfo in windowList {
+            guard let rawBounds = windowInfo[kCGWindowBounds as String] else {
+                continue
+            }
+
+            let boundsDictionary = rawBounds as! CFDictionary
+
+            guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+                  ownerPID == processIdentifier,
+                  let bounds = CGRect(
+                    dictionaryRepresentation: boundsDictionary
+                  ),
+                  !bounds.isEmpty else {
+                continue
+            }
+
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
+            guard alpha > 0 else { continue }
+
+            let layer = windowInfo[kCGWindowLayer as String] as? Int ?? 0
+            if layer == 0 {
+                return bounds
+            }
+
+            if fallbackFrame == nil {
+                fallbackFrame = bounds
+            }
+        }
+
+        return fallbackFrame
+    }
+
+    nonisolated static func focusedWindowFrame() -> CGRect? {
+        let systemWide = AXUIElementCreateSystemWide()
+
+        var focusedApplication: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedApplicationAttribute as CFString,
+            &focusedApplication
+        ) == .success,
+              let focusedApplication else {
+            return nil
+        }
+        let applicationElement = focusedApplication as! AXUIElement
+
+        var focusedWindow: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindow
+        ) == .success,
+              let focusedWindow else {
+            return nil
+        }
+        let windowElement = focusedWindow as! AXUIElement
+
+        var positionValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            windowElement,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+              let positionValue else {
+            return nil
+        }
+        let axPosition = positionValue as! AXValue
+
+        var sizeValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            windowElement,
+            kAXSizeAttribute as CFString,
+            &sizeValue
+        ) == .success,
+              let sizeValue else {
+            return nil
+        }
+        let axSize = sizeValue as! AXValue
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        guard AXValueGetValue(axPosition, .cgPoint, &position),
+              AXValueGetValue(axSize, .cgSize, &size),
+              size.width > 0,
+              size.height > 0 else {
+            return nil
+        }
+
+        return CGRect(origin: position, size: size)
+    }
+}
+
+enum IndicatorFullscreenSuppressionPolicy {
+    private static let minimumHorizontalCoverage: CGFloat = 0.5
+    private static let minimumVerticalCoverage: CGFloat = 0.5
+
+    @MainActor
+    static func shouldSuppressIndicator(
+        on screen: NSScreen,
+        frontmostApplicationProvider: () -> NSRunningApplication? = {
+            ActivationSourceTracker.shared.lastExternalApplication ?? NSWorkspace.shared.frontmostApplication
+        },
+        focusedWindowFrameProvider: () -> CGRect? = IndicatorWindowFrameLookup.focusedWindowFrame,
+        windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
+        appBundleIdentifier: String? = Bundle.main.bundleIdentifier
+    ) -> Bool {
+        guard let application = frontmostApplicationProvider() else {
+            return false
+        }
+
+        guard application.processIdentifier != NSRunningApplication.current.processIdentifier else {
+            return false
+        }
+
+        let windowFrame = focusedWindowFrameProvider()
+            ?? windowFrameProvider(application.processIdentifier)
+
+        return shouldSuppressIndicator(
+            screenFrame: screen.frame,
+            safeAreaTopInset: screen.safeAreaInsets.top,
+            windowFrame: windowFrame,
+            frontmostBundleIdentifier: application.bundleIdentifier,
+            appBundleIdentifier: appBundleIdentifier
+        )
+    }
+
+    static func shouldSuppressIndicator(
+        screenFrame: CGRect,
+        safeAreaTopInset: CGFloat,
+        windowFrame: CGRect?,
+        frontmostBundleIdentifier: String?,
+        appBundleIdentifier: String?
+    ) -> Bool {
+        guard safeAreaTopInset > 0,
+              let candidateWindowFrame = windowFrame,
+              !screenFrame.isEmpty,
+              !candidateWindowFrame.isEmpty,
+              !isTypeWhisperBundleIdentifier(frontmostBundleIdentifier, appBundleIdentifier: appBundleIdentifier) else {
+            return false
+        }
+
+        let screenFrame = screenFrame.standardized
+        let windowFrame = candidateWindowFrame.standardized
+        let notchStripHeight = min(safeAreaTopInset, screenFrame.height)
+        let notchStrip = CGRect(
+            x: screenFrame.minX,
+            y: screenFrame.maxY - notchStripHeight,
+            width: screenFrame.width,
+            height: notchStripHeight
+        )
+
+        let intersection = windowFrame.intersection(notchStrip)
+        guard !intersection.isNull, !intersection.isEmpty else {
+            return false
+        }
+
+        let horizontalCoverage = intersection.width / notchStrip.width
+        let verticalCoverage = intersection.height / notchStrip.height
+
+        return horizontalCoverage >= minimumHorizontalCoverage
+            && verticalCoverage >= minimumVerticalCoverage
+    }
+
+    private static func isTypeWhisperBundleIdentifier(
+        _ bundleIdentifier: String?,
+        appBundleIdentifier: String?
+    ) -> Bool {
+        guard let bundleIdentifier else { return false }
+        if let appBundleIdentifier, bundleIdentifier == appBundleIdentifier {
+            return true
+        }
+
+        return bundleIdentifier == "com.typewhisper.mac"
+            || bundleIdentifier == "com.typewhisper.mac.dev"
+    }
+}
+
 @MainActor
 final class IndicatorScreenResolver {
     typealias FocusedElementPositionProvider = () -> CGPoint?
@@ -138,14 +327,14 @@ final class IndicatorScreenResolver {
         focusedElementPositionProvider: @escaping FocusedElementPositionProvider = {
             ServiceContainer.shared.textInsertionService.focusedElementPosition()
         },
-        focusedWindowFrameProvider: @escaping FocusedWindowFrameProvider = IndicatorScreenResolver.focusedWindowFrame,
+        focusedWindowFrameProvider: @escaping FocusedWindowFrameProvider = IndicatorWindowFrameLookup.focusedWindowFrame,
         frontmostApplicationProvider: @escaping FrontmostApplicationProvider = {
             ActivationSourceTracker.shared.lastExternalApplication ?? NSWorkspace.shared.frontmostApplication
         },
         mouseLocationProvider: @escaping MouseLocationProvider = { NSEvent.mouseLocation },
         screensProvider: @escaping ScreensProvider = { NSScreen.screens },
         mainScreenProvider: @escaping MainScreenProvider = { NSScreen.main },
-        windowFrameProvider: @escaping WindowFrameProvider = IndicatorScreenResolver.frontmostWindowFrame(for:)
+        windowFrameProvider: @escaping WindowFrameProvider = IndicatorWindowFrameLookup.frontmostWindowFrame(for:)
     ) {
         self.focusedElementPositionProvider = focusedElementPositionProvider
         self.focusedWindowFrameProvider = focusedWindowFrameProvider
@@ -210,108 +399,6 @@ final class IndicatorScreenResolver {
 
         let center = CGPoint(x: frame.midX, y: frame.midY)
         return screen(containing: center)
-    }
-
-    nonisolated private static func frontmostWindowFrame(for processIdentifier: pid_t) -> CGRect? {
-        guard let windowList = CGWindowListCopyWindowInfo(
-            [.optionOnScreenOnly, .excludeDesktopElements],
-            kCGNullWindowID
-        ) as? [[String: Any]] else {
-            return nil
-        }
-
-        var fallbackFrame: CGRect?
-
-        for windowInfo in windowList {
-            guard let rawBounds = windowInfo[kCGWindowBounds as String] else {
-                continue
-            }
-
-            let boundsDictionary = rawBounds as! CFDictionary
-
-            guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
-                  ownerPID == processIdentifier,
-                  let bounds = CGRect(
-                    dictionaryRepresentation: boundsDictionary
-                  ),
-                  !bounds.isEmpty else {
-                continue
-            }
-
-            let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
-            guard alpha > 0 else { continue }
-
-            let layer = windowInfo[kCGWindowLayer as String] as? Int ?? 0
-            if layer == 0 {
-                return bounds
-            }
-
-            if fallbackFrame == nil {
-                fallbackFrame = bounds
-            }
-        }
-
-        return fallbackFrame
-    }
-
-    nonisolated private static func focusedWindowFrame() -> CGRect? {
-        let systemWide = AXUIElementCreateSystemWide()
-
-        var focusedApplication: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            systemWide,
-            kAXFocusedApplicationAttribute as CFString,
-            &focusedApplication
-        ) == .success,
-              let focusedApplication else {
-            return nil
-        }
-        let applicationElement = focusedApplication as! AXUIElement
-
-        var focusedWindow: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            applicationElement,
-            kAXFocusedWindowAttribute as CFString,
-            &focusedWindow
-        ) == .success,
-              let focusedWindow else {
-            return nil
-        }
-        let windowElement = focusedWindow as! AXUIElement
-
-        var positionValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            windowElement,
-            kAXPositionAttribute as CFString,
-            &positionValue
-        ) == .success,
-              let positionValue else {
-            return nil
-        }
-        let axPosition = positionValue as! AXValue
-
-        var sizeValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            windowElement,
-            kAXSizeAttribute as CFString,
-            &sizeValue
-        ) == .success,
-              let sizeValue else {
-            return nil
-        }
-        let axSize = sizeValue as! AXValue
-
-        var position = CGPoint.zero
-        var size = CGSize.zero
-
-        guard AXValueGetValue(axPosition, .cgPoint, &position),
-              AXValueGetValue(axSize, .cgSize, &size),
-              size.width > 0,
-              size.height > 0 else {
-            return nil
-        }
-
-        return CGRect(origin: position, size: size)
     }
 
 }

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -105,6 +105,11 @@ class MinimalIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
+        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen) {
+            suppressForForeignFullscreen()
+            return
+        }
+
         let screenFrame = screen.visibleFrame
         let x = screenFrame.midX - Self.panelWidth / 2
 
@@ -121,6 +126,11 @@ class MinimalIndicatorPanel: NSPanel {
             self,
             displayMode: DictationViewModel.shared.notchIndicatorDisplay
         )
+    }
+
+    private func suppressForForeignFullscreen() {
+        cachedScreen = nil
+        orderOut(nil)
     }
 
     private func resolveScreen() -> NSScreen {

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -136,6 +136,12 @@ class NotchIndicatorPanel: NSPanel {
             screen = resolveScreen()
             cachedScreen = screen
         }
+
+        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen) {
+            suppressForForeignFullscreen()
+            return
+        }
+
         notchGeometry.update(for: screen)
 
         let screenFrame = screen.frame
@@ -167,6 +173,16 @@ class NotchIndicatorPanel: NSPanel {
             }
             self.showTask = nil
         }
+    }
+
+    private func suppressForForeignFullscreen() {
+        cachedScreen = nil
+        showTask?.cancel()
+        showTask = nil
+        dismissTask?.cancel()
+        dismissTask = nil
+        notchGeometry.isPresented = false
+        orderOut(nil)
     }
 
     private func resolveScreen() -> NSScreen {

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -105,6 +105,11 @@ class OverlayIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
+        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen) {
+            suppressForForeignFullscreen()
+            return
+        }
+
         let screenFrame = screen.visibleFrame
         let x = screenFrame.midX - Self.panelWidth / 2
 
@@ -122,6 +127,11 @@ class OverlayIndicatorPanel: NSPanel {
             self,
             displayMode: DictationViewModel.shared.notchIndicatorDisplay
         )
+    }
+
+    private func suppressForForeignFullscreen() {
+        cachedScreen = nil
+        orderOut(nil)
     }
 
     private func resolveScreen() -> NSScreen {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -208,6 +208,66 @@ final class IndicatorScreenResolverTests: XCTestCase {
     }
 }
 
+final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
+    private let notchedScreenFrame = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+    func testSuppressesForeignFullscreenWindowThatOverlapsNotchStrip() {
+        let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenWindow,
+                frontmostBundleIdentifier: "com.apple.ScreenSharing",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
+    func testDoesNotSuppressOnNonNotchedScreen() {
+        let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 0,
+                windowFrame: fullscreenWindow,
+                frontmostBundleIdentifier: "com.apple.ScreenSharing",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
+    func testDoesNotSuppressNormalWindowBelowNotchStrip() {
+        let maximizedWindowBelowMenuBar = CGRect(x: 0, y: 0, width: 3024, height: 1880)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: maximizedWindowBelowMenuBar,
+                frontmostBundleIdentifier: "com.apple.TextEdit",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
+    func testDoesNotSuppressTypeWhisperWindows() {
+        let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenWindow,
+                frontmostBundleIdentifier: "com.typewhisper.mac.dev",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+}
+
 final class DockIconVisibilityTests: XCTestCase {
     func testDockIconStaysHiddenWhenMenuBarIconIsVisibleAndNoWindowIsOpen() {
         XCTAssertFalse(


### PR DESCRIPTION
## Issue context
Issue #373 reports that TypeWhisper's Notch, Overlay, and Minimal indicator panels can remain visible in the notch strip when another app draws fullscreen content on a notched MacBook display.

## Summary
- Add an internal runtime suppression policy for indicator panels on notched displays.
- Reuse the existing focused/frontmost window geometry lookup through a shared helper.
- Hide Notch, Overlay, and Minimal indicator panels before ordering them front when a foreign app window substantially overlaps the target screen's top notch strip.
- Keep the existing window level, space behavior, user settings, and Selection Palette fullscreen behavior unchanged.

## Verification
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/6a59/typewhisper-mac`

## Blind-fix note
I could not reproduce or visually test the exact Screen Sharing / Omnissa Horizon Client / Citrix fullscreen scenario locally. This is a blind, conservative geometry-based fix backed by unit tests and the full app test suite.

Closes #373
