### PR TITLE
Defer recording start cue until input is ready

### DIFF
--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -94,6 +94,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     var inputAvailabilityOverride: ((AudioDeviceID?) -> Bool)?
     var startRecordingOverride: (() throws -> Void)?
     var stopRecordingOverride: ((StopPolicy) async -> [Float])?
+    var onFirstRecordingAudioBuffer: (() -> Void)?
 
     /// CoreAudio device ID to use for recording. nil = system default input.
     var selectedDeviceID: AudioDeviceID? {
@@ -1004,12 +1005,14 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(samples.count))
         let normalizedLevel = AudioLevelMeter.normalizedLevel(rms: rms)
         var requestToFirstBufferMs: Double?
+        var didReceiveFirstBuffer = false
 
         bufferLock.lock()
         sampleBuffer.append(contentsOf: samples)
         if rms > _peakRawAudioLevel { _peakRawAudioLevel = rms }
         if !hasLoggedFirstConvertedSample {
             hasLoggedFirstConvertedSample = true
+            didReceiveFirstBuffer = true
             requestToFirstBufferMs = Self.elapsedMilliseconds(
                 from: recordingRequestUptimeNanoseconds,
                 to: DispatchTime.now().uptimeNanoseconds
@@ -1028,8 +1031,17 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             guard let self else { return }
             self.audioLevel = normalizedLevel
             self.rawAudioLevel = rms
+            if didReceiveFirstBuffer {
+                self.onFirstRecordingAudioBuffer?()
+            }
         }
     }
+
+#if DEBUG
+    func testingNotifyFirstRecordingAudioBuffer() {
+        onFirstRecordingAudioBuffer?()
+    }
+#endif
 
     private func setLastStopGraceCaptureApplied(_ applied: Bool) {
         stopStateLock.withLock {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -147,6 +147,7 @@ final class DictationViewModel: ObservableObject {
     @Published var activeRuleReasonLabel: String?
     @Published var activeRuleExplanation: String?
     @Published var processingPhase: String?
+    @Published private(set) var isRecordingInputReady = false
     @Published var actionFeedbackMessage: String?
     @Published var actionFeedbackIcon: String?
     @Published var actionFeedbackIsError: Bool = false
@@ -236,6 +237,10 @@ final class DictationViewModel: ObservableObject {
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
     private var pendingPushToTalkDiscardMessage: String?
+    private var recordingStartCuePending = false
+    private var firstRecordingAudioBufferSeen = false
+    private var pendingRecordingStartedPayload: RecordingStartedPayload?
+    private var shouldPlayRecordingStartSoundWhenReady = false
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
@@ -377,6 +382,9 @@ final class DictationViewModel: ObservableObject {
         }
         streamingHandler.onStreamingStateChange = { [weak self] streaming in
             self?.isStreaming = streaming
+        }
+        audioRecordingService.onFirstRecordingAudioBuffer = { [weak self] in
+            self?.handleFirstRecordingAudioBuffer()
         }
 
         promptPaletteHandler.onShowNotchFeedback = { [weak self] message, icon, duration, isError, category in
@@ -579,6 +587,54 @@ final class DictationViewModel: ObservableObject {
         mediaPlaybackService.resumeIfWePaused()
     }
 
+    private func prepareRecordingStartCue(playsSound: Bool) {
+        isRecordingInputReady = false
+        recordingStartCuePending = true
+        firstRecordingAudioBufferSeen = false
+        pendingRecordingStartedPayload = nil
+        shouldPlayRecordingStartSoundWhenReady = playsSound
+    }
+
+    private func updateRecordingStartCuePayload(activeApp: (name: String?, bundleId: String?, url: String?)?) {
+        pendingRecordingStartedPayload = RecordingStartedPayload(
+            appName: activeApp?.name,
+            bundleIdentifier: activeApp?.bundleId
+        )
+        emitRecordingStartCueIfReady()
+    }
+
+    private func handleFirstRecordingAudioBuffer() {
+        firstRecordingAudioBufferSeen = true
+        emitRecordingStartCueIfReady()
+    }
+
+    private func emitRecordingStartCueIfReady() {
+        guard recordingStartCuePending,
+              firstRecordingAudioBufferSeen,
+              state == .recording,
+              let payload = pendingRecordingStartedPayload else {
+            return
+        }
+
+        recordingStartCuePending = false
+        isRecordingInputReady = true
+        if shouldPlayRecordingStartSoundWhenReady {
+            soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
+        }
+        accessibilityAnnouncementService.announceRecordingStarted()
+        EventBus.shared.emit(.recordingStarted(payload))
+    }
+
+    private func clearRecordingStartCueState(resetReadiness: Bool = true) {
+        if resetReadiness {
+            isRecordingInputReady = false
+        }
+        recordingStartCuePending = false
+        firstRecordingAudioBufferSeen = false
+        pendingRecordingStartedPayload = nil
+        shouldPlayRecordingStartSoundWhenReady = false
+    }
+
     private func clearDeferredRecordingContext() {
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
@@ -588,6 +644,7 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func abortActiveRecordingImmediately(sessionMessage: String, preserveRecoveryAudio: Bool = false) {
+        clearRecordingStartCueState()
         clearDeferredRecordingContext()
         restoreRecordingSideEffects()
         streamingHandler.stop()
@@ -747,6 +804,7 @@ final class DictationViewModel: ObservableObject {
         requestUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
     ) {
         let startTimestamp = CFAbsoluteTimeGetCurrent()
+        clearRecordingStartCueState()
 
         // Cancel any pending transcription from a previous recording
         if transcriptionTask != nil {
@@ -785,6 +843,7 @@ final class DictationViewModel: ObservableObject {
             audioRecordingService.hasExplicitDeviceSelection = audioDeviceService.selectedDeviceUID != nil
             let selectedInputUsesBluetooth = audioDeviceService.selectedDeviceUsesBluetoothTransport
             audioRecordingService.selectedInputDeviceUsesBluetoothTransport = selectedInputUsesBluetooth
+            prepareRecordingStartCue(playsSound: !selectedInputUsesBluetooth)
             let audioStartTimestamp = DispatchTime.now().uptimeNanoseconds
             try audioRecordingService.startRecording(requestUptimeNanoseconds: requestUptimeNanoseconds)
             let audioStartCompletedTimestamp = DispatchTime.now().uptimeNanoseconds
@@ -801,8 +860,6 @@ final class DictationViewModel: ObservableObject {
             modelManager.cancelAutoUnloadTimer()
             if selectedInputUsesBluetooth {
                 logger.info("Skipping recording start sound for Bluetooth input device")
-            } else {
-                soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
             }
             if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
             if audioDuckingEnabled {
@@ -813,7 +870,6 @@ final class DictationViewModel: ObservableObject {
             // not from key press. Slow device init (e.g. iPhone Continuity ~2-3s)
             // would otherwise make the hold appear as "long press" → PTT stop.
             hotkeyService.resetKeyDownTime()
-            accessibilityAnnouncementService.announceRecordingStarted()
             partialText = ""
             isStopInFlight = false
             recordingStartTime = Date()
@@ -835,13 +891,10 @@ final class DictationViewModel: ObservableObject {
             } else {
                 clearActiveRuleState()
             }
+            updateRecordingStartCuePayload(activeApp: activeApp)
             let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
 
             startLiveStreaming(allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0)
-            EventBus.shared.emit(.recordingStarted(RecordingStartedPayload(
-                appName: capturedActiveApp?.name,
-                bundleIdentifier: capturedActiveApp?.bundleId
-            )))
             scheduleDeferredRecordingMetadataCapture(
                 activeApp: activeApp,
                 forcedWorkflowId: forcedWorkflowId
@@ -852,6 +905,7 @@ final class DictationViewModel: ObservableObject {
                 "Recording started: requestToAudioStartMs=\(Self.formatMilliseconds(requestToAudioStartMs), privacy: .public), audioStartMs=\(Self.formatMilliseconds(audioStartMs), privacy: .public), contextMs=\(String(format: "%.1f", contextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
             )
         } catch {
+            clearRecordingStartCueState()
             clearDeferredRecordingContext()
             restoreRecordingSideEffects()
             let errorMessage: String
@@ -996,6 +1050,7 @@ final class DictationViewModel: ObservableObject {
     private func finalizeStopDictation() async {
         let sessionID = activeDictationSessionID
 
+        clearRecordingStartCueState(resetReadiness: false)
         restoreRecordingSideEffects()
         if let discardMessage = pendingPushToTalkDiscardMessage {
             pendingPushToTalkDiscardMessage = nil
@@ -1339,6 +1394,7 @@ final class DictationViewModel: ObservableObject {
         isStopInFlight = false
         activeDictationSessionID = nil
         pendingPushToTalkDiscardMessage = nil
+        clearRecordingStartCueState()
         clearRecordingCancelWarning()
         state = .idle
         partialText = ""

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -114,6 +114,9 @@ struct MinimalIndicatorView: View {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
+            if !viewModel.isRecordingInputReady {
+                return String(localized: "Preparing microphone")
+            }
             return String(localized: "Recording")
         case .processing:
             return String(localized: "Processing transcription")

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -195,6 +195,9 @@ struct NotchIndicatorView: View {
             if let warning = viewModel.recordingCancelWarningMessage {
                 return warning
             }
+            if !viewModel.isRecordingInputReady {
+                return String(localized: "Preparing microphone")
+            }
             return String(localized: "Recording")
         case .processing:
             return String(localized: "Processing transcription")

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -105,6 +105,34 @@ struct OverlayIndicatorView: View {
             }
         }
         .animation(.easeInOut(duration: 1.0), value: dotPulse)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        if let warning = viewModel.recordingCancelWarningMessage, viewModel.state == .recording {
+            return warning
+        }
+
+        if let feedback = viewModel.actionFeedbackMessage, viewModel.state == .inserting {
+            return feedback
+        }
+
+        switch viewModel.state {
+        case .idle, .promptSelection, .promptProcessing:
+            return String(localized: "Idle")
+        case .recording:
+            if !viewModel.isRecordingInputReady {
+                return String(localized: "Preparing microphone")
+            }
+            return String(localized: "Recording")
+        case .processing:
+            return String(localized: "Processing transcription")
+        case .inserting:
+            return String(localized: "Inserting text")
+        case .error(let message):
+            return String(localized: "Error - \(message)")
+        }
     }
 
     // MARK: - Expandable content (text + action feedback)

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -97,7 +97,9 @@ struct IndicatorLeftStatus: View {
         case .idle, .promptSelection, .promptProcessing:
             Color.clear.frame(width: 0, height: 0)
         case .recording:
-            if let icon = viewModel.activeAppIcon {
+            if !viewModel.isRecordingInputReady {
+                IndicatorPreparingView(sizing: sizing)
+            } else if let icon = viewModel.activeAppIcon {
                 IndicatorAppIconView(icon: icon, sizing: sizing)
             } else {
                 IndicatorDot(audioLevel: viewModel.audioLevel, dotPulse: dotPulse, sizing: sizing)
@@ -132,6 +134,20 @@ struct IndicatorLeftStatus: View {
     }
 }
 
+// MARK: - Preparing Indicator
+
+struct IndicatorPreparingView: View {
+    let sizing: IndicatorSizing
+
+    var body: some View {
+        ProgressView()
+            .controlSize(.mini)
+            .tint(.white)
+            .frame(width: max(sizing.iconSize, sizing.dotSize), height: max(sizing.iconSize, sizing.dotSize))
+            .accessibilityHidden(true)
+    }
+}
+
 // MARK: - Recording Dot
 
 struct IndicatorDot: View {
@@ -160,7 +176,11 @@ struct IndicatorRecordingContent: View {
     var body: some View {
         switch content {
         case .indicator:
-            IndicatorDot(audioLevel: viewModel.audioLevel, dotPulse: dotPulse, sizing: sizing)
+            if viewModel.isRecordingInputReady {
+                IndicatorDot(audioLevel: viewModel.audioLevel, dotPulse: dotPulse, sizing: sizing)
+            } else {
+                IndicatorPreparingView(sizing: sizing)
+            }
         case .timer:
             Text(formatDuration(viewModel.recordingDuration))
                 .font(.system(size: sizing.timerFontSize, weight: .medium).monospacedDigit())
@@ -172,7 +192,7 @@ struct IndicatorRecordingContent: View {
         case .waveform:
             AudioWaveformView(
                 audioLevel: viewModel.audioLevel,
-                isSetup: viewModel.recordingDuration < 0.5 && viewModel.audioLevel < 0.05,
+                isSetup: !viewModel.isRecordingInputReady || (viewModel.recordingDuration < 0.5 && viewModel.audioLevel < 0.05),
                 compact: true
             )
         case .profile:

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2052,6 +2052,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let sessionID = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(events, ["start_audio"])
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
         XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, "Audio start failed")
         XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
@@ -2059,7 +2060,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testApiStartRecording_playsStartSoundAfterAudioStart() async throws {
+    func testApiStartRecording_defersStartSoundUntilInputIsReady() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -2089,7 +2090,13 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         _ = context.dictationViewModel.apiStartRecording()
 
+        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
         XCTAssertEqual(events, ["start_audio", "start_sound"])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
     }
 
     @MainActor
@@ -2157,11 +2164,17 @@ final class APIRouterAndHandlersTests: XCTestCase {
         _ = context.dictationViewModel.apiStartRecording()
 
         XCTAssertEqual(events, ["start_audio"])
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
+        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
         XCTAssertTrue(context.audioRecordingService.hasExplicitDeviceSelection)
     }
 
     @MainActor
-    func testApiStartRecording_keepsStartSoundForUSBInputAfterAudioStart() async throws {
+    func testApiStartRecording_keepsStartSoundForUSBInputAfterInputIsReady() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         var events: [String] = []
@@ -2212,7 +2225,13 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         _ = context.dictationViewModel.apiStartRecording()
 
+        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
         XCTAssertEqual(events, ["start_audio", "start_sound"])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
     }
 
     #if !APPSTORE


### PR DESCRIPTION
## Summary
- Treat the existing recording indicator and start sound as an input-ready cue instead of firing immediately after AVAudioEngine startup.
- Mark recording input ready only after the first converted audio buffer arrives, then emit the existing recording-start sound, accessibility announcement, and plugin/event bus notification.
- Show a preparing state in the existing notch/overlay/minimal indicators without adding another button.

## Issue context
Issue #540 reports an audible/user-visible dictation delay on `v1.4.0-daily.20260514`. The reporter logs show hotkey request to audio start at roughly 468-487 ms and hotkey request to first input buffer at roughly 567-589 ms, with app/workflow context work under 1 ms. This points to the remaining delay being audio startup before the first input buffer rather than workflow matching or pre-audio app work.

This PR keeps the existing Push-to-Talk flow and changes the readiness cue so users are not told recording is ready until TypeWhisper has actually received input audio. It does not add an extra button or an opt-in pre-roll/ring-buffer mode.

Closes #540

## Test plan
```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_defersStartSoundUntilInputIsReady -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_skipsStartSoundForBluetoothInput -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_keepsStartSoundForUSBInputAfterInputIsReady -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecordingFailureSkipsPostAudioStartSideEffects
```

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests
```

```bash
git diff --check
```