### PR TITLE
Fix Intel Parakeet setup recommendation

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		C23000000000000000000010 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
 		91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */; };
+		545000000000000000000002 /* SetupWizardRecommendationAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545000000000000000000001 /* SetupWizardRecommendationAvailabilityTests.swift */; };
 		91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */; };
 		9A584149706C7567496E0100 /* XAIPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A584149706C7567496E0101 /* XAIPluginTests.swift */; };
 		9A584149706C7567496E0200 /* XAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A584149706C7567496E0210 /* XAIPlugin.swift */; };
@@ -741,6 +742,7 @@
 		2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardInferenceServiceTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionsViewModelWizardTests.swift; sourceTree = "<group>"; };
 		91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginRegistryServiceTests.swift; sourceTree = "<group>"; };
+		545000000000000000000001 /* SetupWizardRecommendationAvailabilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetupWizardRecommendationAvailabilityTests.swift; sourceTree = "<group>"; };
 		D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBufferTests.swift; sourceTree = "<group>"; };
 		91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StreamingHandlerTests.swift; sourceTree = "<group>"; };
 		9A584149706C7567496E0101 /* XAIPluginTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XAIPluginTests.swift; sourceTree = "<group>"; };
@@ -1968,6 +1970,7 @@
 				A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
+				545000000000000000000001 /* SetupWizardRecommendationAvailabilityTests.swift */,
 				B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */,
 				2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */,
 				2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */,
@@ -3297,6 +3300,7 @@
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
 				F18A00000000000000000006 /* FillerWordsPlugin.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
+				545000000000000000000002 /* SetupWizardRecommendationAvailabilityTests.swift in Sources */,
 				A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */,
 				1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */,
 				1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */,

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -546,6 +546,18 @@ struct SetupWizardView: View {
         let isReady = engine?.isConfigured ?? false
         let registryPlugin = registryService.registry.first { $0.id == manifestId }
         let installState = registryService.installStates[manifestId]
+        let availability = SetupWizardRecommendationAvailability.resolve(
+            manifestId: manifestId,
+            isInstalled: isInstalled,
+            isReady: isReady,
+            registryPlugin: registryPlugin,
+            installState: installState,
+            fetchState: registryService.fetchState
+        )
+        let resolvedDescription = recommendationDescription(
+            fallback: description,
+            availability: availability
+        )
 
         HStack(spacing: 12) {
             Image(systemName: systemImage)
@@ -568,14 +580,15 @@ struct SetupWizardView: View {
                         .clipShape(Capsule())
                 }
 
-                Text(description)
+                Text(resolvedDescription)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             Spacer()
 
-            if isReady {
+            switch availability {
+            case .ready:
                 HStack(spacing: 4) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
@@ -583,9 +596,9 @@ struct SetupWizardView: View {
                         .font(.caption)
                         .foregroundStyle(.green)
                 }
-            } else if isInstalled {
+            case .setupRequired:
                 RecommendationSettingsButton(manifestId: manifestId)
-            } else if let installState {
+            case .installState(let installState):
                 switch installState {
                 case .downloading(let progress):
                     ProgressView(value: progress)
@@ -599,22 +612,54 @@ struct SetupWizardView: View {
                         .foregroundStyle(.red)
                         .lineLimit(1)
                 }
-            } else if let registryPlugin {
+            case .installAvailable:
                 Button(String(localized: "Install")) {
                     Task {
+                        guard let registryPlugin else { return }
                         await registryService.downloadAndInstall(registryPlugin)
                         PluginManager.shared.setPluginEnabled(registryPlugin.id, enabled: true)
                     }
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-            } else {
+            case .loading:
                 ProgressView()
                     .controlSize(.small)
+            case .unavailable(let reason):
+                unavailableRecommendationView(reason)
             }
         }
         .padding(12)
         .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
+    }
+
+    private func recommendationDescription(
+        fallback: String,
+        availability: SetupWizardRecommendationAvailability
+    ) -> String {
+        guard availability == .unavailable(.appleSiliconOnly) else {
+            return fallback
+        }
+
+        return localizedAppText(
+            "Parakeet runs locally and requires Apple Silicon. Intel Macs can use cloud Whisper through Groq or OpenAI.",
+            de: "Parakeet läuft lokal und braucht Apple Silicon. Intel-Macs können Cloud-Whisper über Groq oder OpenAI nutzen."
+        )
+    }
+
+    private func unavailableRecommendationView(_ reason: SetupWizardRecommendationUnavailableReason) -> some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Label(reason.title, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.orange)
+
+            Text(reason.message)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 190, alignment: .trailing)
+        }
     }
 
     // MARK: - Step 3: Hotkey
@@ -1220,6 +1265,82 @@ struct SetupWizardView: View {
         case .recentTranscriptions: return String(localized: "Recent Transcriptions")
         case .copyLastTranscription: return String(localized: "Copy Last Transcription")
         case .recorderToggle: return String(localized: "settings.tab.recorder")
+        }
+    }
+}
+
+// MARK: - Recommendation Availability
+
+enum SetupWizardRecommendationUnavailableReason: Equatable {
+    case appleSiliconOnly
+    case marketplaceUnavailable
+
+    var title: String {
+        switch self {
+        case .appleSiliconOnly:
+            localizedAppText("Apple Silicon only", de: "Nur Apple Silicon")
+        case .marketplaceUnavailable:
+            localizedAppText("Unavailable", de: "Nicht verfügbar")
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .appleSiliconOnly:
+            localizedAppText(
+                "Use Groq or OpenAI with a cloud Whisper model on Intel.",
+                de: "Nutze auf Intel Groq oder OpenAI mit einem Cloud-Whisper-Modell."
+            )
+        case .marketplaceUnavailable:
+            localizedAppText(
+                "No compatible download is available for this Mac.",
+                de: "Für diesen Mac ist kein kompatibler Download verfügbar."
+            )
+        }
+    }
+}
+
+enum SetupWizardRecommendationAvailability: Equatable {
+    case ready
+    case setupRequired
+    case installState(PluginRegistryService.InstallState)
+    case installAvailable
+    case loading
+    case unavailable(SetupWizardRecommendationUnavailableReason)
+
+    static func resolve(
+        manifestId: String,
+        isInstalled: Bool,
+        isReady: Bool,
+        registryPlugin: RegistryPlugin?,
+        installState: PluginRegistryService.InstallState?,
+        fetchState: PluginRegistryService.FetchState,
+        architecture: String = RuntimeArchitecture.current
+    ) -> SetupWizardRecommendationAvailability {
+        if isReady {
+            return .ready
+        }
+
+        if isInstalled {
+            return .setupRequired
+        }
+
+        if let installState {
+            return .installState(installState)
+        }
+
+        if registryPlugin != nil {
+            return .installAvailable
+        }
+
+        switch fetchState {
+        case .idle, .loading:
+            return .loading
+        case .loaded, .error(_):
+            if manifestId == "com.typewhisper.parakeet", architecture != "arm64" {
+                return .unavailable(.appleSiliconOnly)
+            }
+            return .unavailable(.marketplaceUnavailable)
         }
     }
 }

--- a/TypeWhisperTests/SetupWizardRecommendationAvailabilityTests.swift
+++ b/TypeWhisperTests/SetupWizardRecommendationAvailabilityTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import TypeWhisper
+
+final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
+    func testParakeetOnIntelIsUnavailableAfterRegistryLoaded() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: false,
+            isReady: false,
+            registryPlugin: nil,
+            installState: nil,
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .unavailable(.appleSiliconOnly))
+    }
+
+    func testMissingPluginStillLoadsWhileRegistryIsLoading() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: false,
+            isReady: false,
+            registryPlugin: nil,
+            installState: nil,
+            fetchState: .loading,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .loading)
+    }
+
+    func testCompatibleRegistryEntryCanBeInstalled() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.groq",
+            isInstalled: false,
+            isReady: false,
+            registryPlugin: makeRegistryPlugin(id: "com.typewhisper.groq"),
+            installState: nil,
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .installAvailable)
+    }
+
+    func testInstallStateTakesPrecedenceOverUnavailableRecommendation() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: false,
+            isReady: false,
+            registryPlugin: nil,
+            installState: .downloading(0.42),
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .installState(.downloading(0.42)))
+    }
+
+    func testReadyStateTakesPrecedenceOverUnavailableRecommendation() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: true,
+            isReady: true,
+            registryPlugin: nil,
+            installState: nil,
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .ready)
+    }
+
+    func testInstalledStateTakesPrecedenceOverUnavailableRecommendation() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: true,
+            isReady: false,
+            registryPlugin: nil,
+            installState: nil,
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .setupRequired)
+    }
+
+    func testErrorInstallStateTakesPrecedenceOverUnavailableRecommendation() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: false,
+            isReady: false,
+            registryPlugin: nil,
+            installState: .error("Download failed"),
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .installState(.error("Download failed")))
+    }
+
+    private func makeRegistryPlugin(id: String) -> RegistryPlugin {
+        RegistryPlugin(
+            id: id,
+            source: .official,
+            name: "Compatible Plugin",
+            version: "1.0.0",
+            minHostVersion: "1.0.0",
+            sdkCompatibilityVersion: "v1",
+            minOSVersion: "14.0",
+            supportedArchitectures: nil,
+            author: "TypeWhisper",
+            description: "Compatible transcription engine",
+            category: "transcription",
+            categories: ["transcription"],
+            size: 1,
+            downloadURL: "https://example.com/plugin.zip",
+            iconSystemName: nil,
+            requiresAPIKey: nil,
+            hosting: nil,
+            descriptions: nil,
+            downloadCount: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fix the setup wizard recommendation card state when a recommended plugin is absent after registry load.
- Show Parakeet as Apple Silicon only on Intel and point users to Groq/OpenAI with cloud Whisper models.
- Keep plugin compatibility, registry filtering, model loading, and Parakeet manifest behavior unchanged.

## Issue Context
Issue #545 reports TypeWhisper 1.3 on an Intel Mac with OCLP appearing to endlessly download Parakeet. Parakeet is already Apple-Silicon-only and filtered out on Intel; the confusing surface is the setup wizard generic loading fallback when the recommended Parakeet registry entry is not present.

Closes #545

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/SetupWizardRecommendationAvailabilityTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginArchitectureCompatibilityTests/testPluginManagerRejectsArm64OnlyManifestOnIntel -only-testing:TypeWhisperTests/PluginRegistryServiceTests/testMultiReleaseRegistryFiltersIncompatibleReleasesByArchitectureAndOS`
- `git diff --check`

Note: Xcode printed a CoreSimulator out-of-date warning on this machine; the macOS test runs still completed successfully.