### PR TITLE
Reduce Parakeet live preview latency

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -6,6 +6,14 @@ import FluidAudio
 import TypeWhisperPluginSDK
 
 private let parakeetLiveSampleRate: Double = 16_000
+let parakeetLivePreviewConfig = SlidingWindowAsrConfig(
+    chunkSeconds: 2.0,
+    hypothesisChunkSeconds: 1.0,
+    leftContextSeconds: 2.0,
+    rightContextSeconds: 0.5,
+    minContextForConfirmation: 10.0,
+    confirmationThreshold: 0.80
+)
 
 private func makeParakeetLiveAudioBuffer(from samples: [Float]) throws -> AVAudioPCMBuffer {
     guard let format = AVAudioFormat(
@@ -256,7 +264,7 @@ final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, Dictionary
             await configureBoostingIfNeeded(prompt: prompt)
         }
 
-        let manager = SlidingWindowAsrManager(config: .streaming)
+        let manager = SlidingWindowAsrManager(config: parakeetLivePreviewConfig)
         try await manager.loadModels(loadedAsrModels)
 
         if vocabularyBoostingEnabled,
@@ -273,7 +281,27 @@ final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, Dictionary
         }
 
         try await manager.startStreaming(source: .microphone)
-        return ParakeetLiveTranscriptionSession(manager: manager, onProgress: onProgress)
+        return ParakeetLiveTranscriptionSession(
+            manager: manager,
+            onProgress: onProgress,
+            finalTranscribe: { [weak self] samples in
+                guard let self else {
+                    throw PluginTranscriptionError.notConfigured
+                }
+
+                let audio = AudioData(
+                    samples: samples,
+                    wavData: Data(),
+                    duration: Double(samples.count) / parakeetLiveSampleRate
+                )
+                return try await self.transcribe(
+                    audio: audio,
+                    language: language,
+                    translate: false,
+                    prompt: prompt
+                )
+            }
+        )
     }
 
     private static func fluidAudioLanguage(for language: String?) -> Language? {
@@ -653,19 +681,24 @@ final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, Dictionary
 
 private actor ParakeetLiveTranscriptionSession: LiveTranscriptionSession {
     private let manager: SlidingWindowAsrManager
+    private let finalTranscribe: @Sendable ([Float]) async throws -> PluginTranscriptionResult
     private var updateTask: Task<Void, Never>?
+    private var audioSamples: [Float] = []
     private var isCancelled = false
 
     init(
         manager: SlidingWindowAsrManager,
-        onProgress: @escaping @Sendable (String) -> Bool
+        onProgress: @escaping @Sendable (String) -> Bool,
+        finalTranscribe: @escaping @Sendable ([Float]) async throws -> PluginTranscriptionResult
     ) {
         self.manager = manager
+        self.finalTranscribe = finalTranscribe
         self.updateTask = Self.startUpdateTask(manager: manager, onProgress: onProgress)
     }
 
     func appendAudio(samples: [Float]) async throws {
         guard !isCancelled, !samples.isEmpty else { return }
+        audioSamples.append(contentsOf: samples)
         let buffer = try makeParakeetLiveAudioBuffer(from: samples)
         await manager.streamAudio(buffer)
     }
@@ -676,13 +709,13 @@ private actor ParakeetLiveTranscriptionSession: LiveTranscriptionSession {
         }
 
         do {
-            let finalText = try await manager.finish()
-            await stop()
-            return PluginTranscriptionResult(
-                text: finalText.trimmingCharacters(in: .whitespacesAndNewlines),
-                detectedLanguage: nil,
-                segments: []
-            )
+            _ = try await manager.finish()
+            let finalSamples = audioSamples
+            await stop(cancelManager: false)
+            guard !finalSamples.isEmpty else {
+                return PluginTranscriptionResult(text: "", detectedLanguage: nil, segments: [])
+            }
+            return try await finalTranscribe(finalSamples)
         } catch {
             await stop()
             throw error
@@ -693,12 +726,14 @@ private actor ParakeetLiveTranscriptionSession: LiveTranscriptionSession {
         await stop()
     }
 
-    private func stop() async {
+    private func stop(cancelManager: Bool = true) async {
         guard !isCancelled else { return }
         isCancelled = true
         updateTask?.cancel()
         updateTask = nil
-        await manager.cancel()
+        if cancelManager {
+            await manager.cancel()
+        }
     }
 
     private static func startUpdateTask(

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -121,6 +121,14 @@ final class ParakeetPluginTests: XCTestCase {
         XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
     }
 
+    func testLivePreviewConfigUsesLowLatencyWindow() throws {
+        let firstUpdateLatency = parakeetLivePreviewConfig.chunkSeconds
+            + parakeetLivePreviewConfig.rightContextSeconds
+
+        XCTAssertLessThanOrEqual(firstUpdateLatency, 3.0)
+        XCTAssertEqual(parakeetLivePreviewConfig.minContextForConfirmation, 10.0)
+    }
+
     func testDictionaryTermsSupportReflectsStoredBoostingPreference() throws {
         let defaultHost = try PluginTestHostServices()
         let defaultPlugin = makePlugin()

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
-    "version": "1.2.12",
+    "version": "1.2.13",
     "minHostVersion": "1.2.1",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary
- lowers Parakeet's live-preview sliding-window latency from the FluidAudio streaming default to a 2.5s first-update window
- keeps final Parakeet dictation on the normal batch transcription path so preview tuning does not trade off final text quality
- bumps the Parakeet plugin manifest to 1.2.13 so the marketplace/plugin release can deliver the follow-up fix to users still on 1.2.12

## Issue context
Issue #531 was reopened after a user reported that `v1.4.0-daily.20260515` still did not show live Parakeet text while speaking. The attached diagnostics show app `1.4.0` build `783`, Parakeet plugin `1.2.12`, selected model `parakeet-tdt-0.6b-v3`, and `supportsStreaming=false` for that installed plugin.

The app build includes the earlier live-session implementation, but the remaining runtime behavior is still effectively no live preview for short dictations: FluidAudio's default sliding-window streaming config waits for an 11s chunk plus 2s right context before the first update. This PR uses a TypeWhisper-specific live-preview config while preserving the batch final path.

Closes #531

## Test plan
- [x] `swift test --package-path TypeWhisperPluginSDK --filter ParakeetPluginTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/StreamingHandlerTests`
- [x] `git diff --check`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run ParakeetPlugin "$(pwd)"`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$(pwd)"`
- [x] Verified installed dev plugin manifest reports `1.2.13`
- [x] Verified dev app is running from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`

## Manual acceptance to verify from the dev app
- Parakeet v3 selected, live transcript preview enabled, indicator mode Notch
- During speech, Notch/Overlay live text updates after the low-latency preview window instead of waiting for the old 13s window
- On stop, final dictation still completes and inserts text
- With preview disabled, normal final transcription remains unchanged
