### PR TITLE
Add recording state menu bar logo

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -65,8 +65,9 @@ private struct MenuBarExtraLabel: View {
     }
 
     var body: some View {
-        TypeWhisperLogoMark()
-            .foregroundStyle(isRecordingActive ? Color.red : Color.accentColor)
+        Image(nsImage: MenuBarLogoMarkImage.image(isRecordingActive: isRecordingActive))
+            .resizable()
+            .renderingMode(isRecordingActive ? .original : .template)
             .frame(width: 18, height: 18)
             .accessibilityLabel(Text(verbatim: title))
             .accessibilityValue(
@@ -77,24 +78,51 @@ private struct MenuBarExtraLabel: View {
     }
 }
 
-private struct TypeWhisperLogoMark: View {
-    private let relativeBarHeights: [CGFloat] = [0.5, 0.75, 1.0, 0.75, 0.5]
+enum MenuBarLogoMarkImage {
+    static let size = CGSize(width: 18, height: 18)
+    private static let relativeBarHeights: [CGFloat] = [0.5, 0.75, 1.0, 0.75, 0.5]
 
-    var body: some View {
-        GeometryReader { proxy in
-            let size = min(proxy.size.width, proxy.size.height)
-            let barWidth = size * 0.18
-            let spacing = size * 0.08
+    static func image(isRecordingActive: Bool) -> NSImage {
+        let image = NSImage(size: size)
+        image.lockFocus()
 
-            HStack(alignment: .center, spacing: spacing) {
-                ForEach(Array(relativeBarHeights.enumerated()), id: \.offset) { _, height in
-                    Capsule()
-                        .frame(width: barWidth, height: size * height)
-                }
-            }
-            .frame(width: proxy.size.width, height: proxy.size.height)
+        NSGraphicsContext.current?.shouldAntialias = true
+        (isRecordingActive ? NSColor.systemRed : NSColor.black).setFill()
+
+        for rect in barRects(in: CGRect(origin: .zero, size: size)) {
+            NSBezierPath(
+                roundedRect: rect,
+                xRadius: rect.width / 2,
+                yRadius: rect.width / 2
+            ).fill()
         }
-        .aspectRatio(1, contentMode: .fit)
+
+        image.unlockFocus()
+        image.isTemplate = !isRecordingActive
+        return image
+    }
+
+    static func barRects(in rect: CGRect) -> [CGRect] {
+        let side = min(rect.width, rect.height) * 0.875
+        let barWidth = side / 7
+        let spacing = barWidth / 2
+        let totalWidth = (barWidth * CGFloat(relativeBarHeights.count))
+            + (spacing * CGFloat(relativeBarHeights.count - 1))
+        var x = rect.midX - (totalWidth / 2)
+
+        return relativeBarHeights.map { relativeHeight in
+            let height = side * relativeHeight
+            defer {
+                x += barWidth + spacing
+            }
+
+            return CGRect(
+                x: x,
+                y: rect.midY - (height / 2),
+                width: barWidth,
+                height: height
+            )
+        }
     }
 }
 

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -40,6 +40,64 @@ enum DockIconVisibility {
     }
 }
 
+enum MenuBarIconState {
+    static func isRecordingActive(
+        dictationState: DictationViewModel.State,
+        recorderState: AudioRecorderViewModel.RecorderState
+    ) -> Bool {
+        dictationState == .recording || recorderState == .recording
+    }
+}
+
+private struct MenuBarExtraLabel: View {
+    @ObservedObject private var dictation = DictationViewModel.shared
+    @ObservedObject private var recorder = AudioRecorderViewModel.shared
+
+    private var title: String {
+        AppConstants.isDevelopment ? "TypeWhisper Dev" : "TypeWhisper"
+    }
+
+    private var isRecordingActive: Bool {
+        MenuBarIconState.isRecordingActive(
+            dictationState: dictation.state,
+            recorderState: recorder.state
+        )
+    }
+
+    var body: some View {
+        TypeWhisperLogoMark()
+            .foregroundStyle(isRecordingActive ? Color.red : Color.accentColor)
+            .frame(width: 18, height: 18)
+            .accessibilityLabel(Text(verbatim: title))
+            .accessibilityValue(
+                isRecordingActive
+                    ? Text(String(localized: "Recording..."))
+                    : Text(String(localized: "Idle"))
+            )
+    }
+}
+
+private struct TypeWhisperLogoMark: View {
+    private let relativeBarHeights: [CGFloat] = [0.5, 0.75, 1.0, 0.75, 0.5]
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = min(proxy.size.width, proxy.size.height)
+            let barWidth = size * 0.18
+            let spacing = size * 0.08
+
+            HStack(alignment: .center, spacing: spacing) {
+                ForEach(Array(relativeBarHeights.enumerated()), id: \.offset) { _, height in
+                    Capsule()
+                        .frame(width: barWidth, height: size * height)
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+        }
+        .aspectRatio(1, contentMode: .fit)
+    }
+}
+
 struct TypeWhisperApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @AppStorage(UserDefaultsKeys.showMenuBarIcon) private var showMenuBarIcon = true
@@ -56,8 +114,14 @@ struct TypeWhisperApp: App {
     }
 
     var body: some Scene {
-        MenuBarExtra(AppConstants.isDevelopment ? "TypeWhisper Dev" : "TypeWhisper", systemImage: "waveform", isInserted: $showMenuBarIcon) {
+        MenuBarExtra(isInserted: $showMenuBarIcon) {
             menuBarContent
+        } label: {
+            if AppConstants.isRunningTests {
+                EmptyView()
+            } else {
+                MenuBarExtraLabel()
+            }
         }
         .menuBarExtraStyle(.menu)
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AppKit
 @testable import TypeWhisper
 
 final class DictationViewModelIndicatorSettingsTests: XCTestCase {
@@ -388,6 +389,31 @@ final class MenuBarIconStateTests: XCTestCase {
                 recorderState: .idle
             )
         )
+    }
+}
+
+final class MenuBarLogoMarkImageTests: XCTestCase {
+    func testBarLayoutFitsWithinMenuBarSlotWithVisibleGaps() {
+        let rects = MenuBarLogoMarkImage.barRects(in: CGRect(x: 0, y: 0, width: 18, height: 18))
+
+        XCTAssertEqual(rects.count, 5)
+        XCTAssertGreaterThanOrEqual(rects[0].minX, 0)
+        XCTAssertLessThanOrEqual(rects[4].maxX, 18)
+        XCTAssertGreaterThan(rects[2].height, rects[0].height)
+
+        for index in 1..<rects.count {
+            XCTAssertGreaterThanOrEqual(rects[index].minX - rects[index - 1].maxX, 1)
+        }
+    }
+
+    func testIdleImageIsTemplateAndRecordingImageIsOriginalRedArtwork() {
+        let idleImage = MenuBarLogoMarkImage.image(isRecordingActive: false)
+        let recordingImage = MenuBarLogoMarkImage.image(isRecordingActive: true)
+
+        XCTAssertEqual(idleImage.size, MenuBarLogoMarkImage.size)
+        XCTAssertEqual(recordingImage.size, MenuBarLogoMarkImage.size)
+        XCTAssertTrue(idleImage.isTemplate)
+        XCTAssertFalse(recordingImage.isTemplate)
     }
 }
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -353,6 +353,44 @@ final class MenuBarGroupingTests: XCTestCase {
     }
 }
 
+final class MenuBarIconStateTests: XCTestCase {
+    func testRecordingIndicatorIsActiveDuringDictationRecording() {
+        XCTAssertTrue(
+            MenuBarIconState.isRecordingActive(
+                dictationState: .recording,
+                recorderState: .idle
+            )
+        )
+    }
+
+    func testRecordingIndicatorIsActiveDuringRecorderRecording() {
+        XCTAssertTrue(
+            MenuBarIconState.isRecordingActive(
+                dictationState: .idle,
+                recorderState: .recording
+            )
+        )
+    }
+
+    func testRecordingIndicatorIsInactiveWhileRecorderFinalizes() {
+        XCTAssertFalse(
+            MenuBarIconState.isRecordingActive(
+                dictationState: .idle,
+                recorderState: .finalizing
+            )
+        )
+    }
+
+    func testRecordingIndicatorIsInactiveWithoutActiveRecording() {
+        XCTAssertFalse(
+            MenuBarIconState.isRecordingActive(
+                dictationState: .processing,
+                recorderState: .idle
+            )
+        )
+    }
+}
+
 final class RecorderMenuActionStateTests: XCTestCase {
     func testRecorderToggleIsEnabledWhenIdleAndMicIsEnabled() {
         XCTAssertTrue(


### PR DESCRIPTION
## Summary
- Replace the fixed SF Symbol menu bar extra icon with a TypeWhisper logo mark.
- Tint the menu bar logo red while either Dictation or Recorder is actively recording.
- Add regression coverage for the shared menu bar recording-state helper.

## Issue context
Follow-up from #412 and @zamai's comment asking for a visually distinct active recording state in the menu bar so recordings are not accidentally left running:
https://github.com/TypeWhisper/typewhisper-mac/issues/412#issuecomment-4460321935

Closes #550

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/MenuBarIconStateTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/851b/typewhisper-mac`

## Notes
- The dev app was built and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.
- Manual start/stop recording visual confirmation still needs a human pass because the menu bar icon color change depends on interactive recording state.
