### PR TITLE
Fix Live Transcript duplicate segments

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
@@ -281,7 +281,9 @@ final class LiveTranscriptViewModel: ObservableObject {
         // Ring buffer dedup: ignore exact duplicates
         if recentTexts.contains(cleaned) { return }
 
-        let merged = mergeTranscript(previous: previousFullText, incoming: cleaned)
+        let merged = removeConsecutiveDuplicateSentences(
+            mergeTranscript(previous: previousFullText, incoming: cleaned)
+        )
         guard merged != previousFullText else {
             return
         }

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/Tests/LiveTranscriptPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/Tests/LiveTranscriptPluginTests.swift
@@ -89,6 +89,15 @@ final class LiveTranscriptPluginTests: XCTestCase {
         XCTAssertEqual(displayedText(from: viewModel), "First sentence. Second sentence. Third sentence.")
     }
 
+    func testViewModelDeduplicatesCleanedSegmentUpdatesAfterAppend() {
+        let viewModel = LiveTranscriptViewModel()
+
+        viewModel.updateText("This is a test sentence.", isFinal: false)
+        viewModel.updateText("This is test sentence. Now the next sentence.", isFinal: false)
+
+        XCTAssertEqual(displayedText(from: viewModel), "This is a test sentence. Now the next sentence.")
+    }
+
     func testViewModelIgnoresShorterResetUpdates() {
         let viewModel = LiveTranscriptViewModel()
 


### PR DESCRIPTION
## Summary
- Fixes a follow-up report in #472 after `LiveTranscriptPlugin v1.0.8`: the window now keeps old text, but Parakeet cleanup/sliding updates can still make already visible sentences appear again.
- Runs the merged transcript through the existing sentence de-duplication pass after overlap-aware merge, so near-duplicate sentences created across update boundaries are removed.
- Adds a ViewModel regression test for a cleaned segment update that previously appended the same sentence twice.

Closes #472

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter LiveTranscriptPluginTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run LiveTranscriptPlugin "$(pwd)"`
