### PR TITLE
Restore workflow action targets

### DIFF
--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -838,6 +838,10 @@ private struct WorkflowEditorPage: View {
                     )
                 }
 
+                if shouldShowActionTargetSection {
+                    actionTargetSection
+                }
+
                 VStack(alignment: .leading, spacing: 0) {
                     Button {
                         withAnimation(.easeInOut(duration: 0.16)) {
@@ -902,6 +906,73 @@ private struct WorkflowEditorPage: View {
                         .padding(.top, 4)
                     }
                 }
+            }
+        }
+    }
+
+    private var shouldShowActionTargetSection: Bool {
+        draft.template != .dictation
+            && (!sortedActionPlugins.isEmpty || draft.targetActionPluginId != nil)
+    }
+
+    private var sortedActionPlugins: [ActionPlugin] {
+        pluginManager.actionPlugins.sorted {
+            $0.actionName.localizedCaseInsensitiveCompare($1.actionName) == .orderedAscending
+        }
+    }
+
+    private var selectedActionTargetIsUnavailable: Bool {
+        guard let targetActionPluginId = draft.targetActionPluginId else { return false }
+        return !sortedActionPlugins.contains { $0.actionId == targetActionPluginId }
+    }
+
+    private var actionTargetSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(localizedAppText("Action Target", de: "Action-Ziel"))
+                .font(.subheadline.weight(.semibold))
+
+            Picker(
+                localizedAppText("Target", de: "Ziel"),
+                selection: $draft.targetActionPluginId
+            ) {
+                Text(localizedAppText("Insert Text", de: "Text einfügen"))
+                    .tag(nil as String?)
+
+                ForEach(sortedActionPlugins, id: \.actionId) { plugin in
+                    Label(plugin.actionName, systemImage: plugin.actionIcon)
+                        .tag(plugin.actionId as String?)
+                }
+
+                if let targetActionPluginId = draft.targetActionPluginId,
+                   selectedActionTargetIsUnavailable {
+                    Text(
+                        localizedAppText(
+                            "Unavailable Action Target (\(targetActionPluginId))",
+                            de: "Nicht verfügbares Action-Ziel (\(targetActionPluginId))"
+                        )
+                    )
+                    .tag(targetActionPluginId as String?)
+                }
+            }
+
+            Text(
+                localizedAppText(
+                    "Leave this on Insert Text unless the workflow result should trigger a plugin action.",
+                    de: "Lass dies auf Text einfügen, wenn das Workflow-Ergebnis keine Plugin-Aktion auslösen soll."
+                )
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if selectedActionTargetIsUnavailable {
+                Text(
+                    localizedAppText(
+                        "The selected action target is not currently enabled or installed. Saving keeps it unless you choose Insert Text or another action.",
+                        de: "Das ausgewählte Action-Ziel ist aktuell nicht aktiviert oder installiert. Speichern behält es bei, solange du nicht Text einfügen oder eine andere Aktion wählst."
+                    )
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
             }
         }
     }
@@ -1987,7 +2058,7 @@ struct WorkflowDraft {
     var cloudModel: String?
     private let temperatureModeRaw: String?
     private let temperatureValue: Double?
-    private let targetActionPluginId: String?
+    var targetActionPluginId: String?
 
     init(template: WorkflowTemplate) {
         self.name = template.definition.name
@@ -2048,7 +2119,7 @@ struct WorkflowDraft {
         self.cloudModel = behavior.cloudModel
         self.temperatureModeRaw = behavior.temperatureModeRaw
         self.temperatureValue = behavior.temperatureValue
-        self.targetActionPluginId = output.targetActionPluginId
+        self.targetActionPluginId = workflow.template == .dictation ? nil : output.targetActionPluginId
 
         if let trigger = workflow.trigger {
             self.appBundleIdentifiers = trigger.appBundleIdentifiers
@@ -2109,24 +2180,25 @@ struct WorkflowDraft {
             " Spoken language: \(workflowInputLanguageSummary(for: inputLanguageSelection)).",
             de: " Gesprochene Sprache: \(workflowInputLanguageSummary(for: inputLanguageSelection))."
         )
+        let outputRouteSentence = workflowOutputRouteSentence(targetActionPluginId: targetActionPluginId)
 
         if triggerMode == .manual {
             return localizedAppText(
-                "\(resolvedName) is available as \(template.definition.name) from the Workflow Palette.\(languageSentence)",
-                de: "\(resolvedName) ist als \(template.definition.name) über die Workflow-Palette verfügbar.\(languageSentence)"
+                "\(resolvedName) is available as \(template.definition.name) from the Workflow Palette.\(languageSentence)\(outputRouteSentence)",
+                de: "\(resolvedName) ist als \(template.definition.name) über die Workflow-Palette verfügbar.\(languageSentence)\(outputRouteSentence)"
             )
         }
 
         if triggerMode == .global {
             return localizedAppText(
-                "\(resolvedName) runs always as \(template.definition.name).\(languageSentence)",
-                de: "\(resolvedName) läuft immer als \(template.definition.name).\(languageSentence)"
+                "\(resolvedName) runs always as \(template.definition.name).\(languageSentence)\(outputRouteSentence)",
+                de: "\(resolvedName) läuft immer als \(template.definition.name).\(languageSentence)\(outputRouteSentence)"
             )
         }
 
         return localizedAppText(
-            "\(resolvedName) runs as \(template.definition.name) via \(triggerReviewText).\(languageSentence)",
-            de: "\(resolvedName) läuft als \(template.definition.name) über \(triggerReviewText).\(languageSentence)"
+            "\(resolvedName) runs as \(template.definition.name) via \(triggerReviewText).\(languageSentence)\(outputRouteSentence)",
+            de: "\(resolvedName) läuft als \(template.definition.name) über \(triggerReviewText).\(languageSentence)\(outputRouteSentence)"
         )
     }
 
@@ -2159,6 +2231,7 @@ struct WorkflowDraft {
             outputFormat = ""
             providerId = nil
             cloudModel = nil
+            targetActionPluginId = nil
             if triggerMode == .manual {
                 triggerMode = .automatic
             }
@@ -2538,6 +2611,14 @@ private func workflowSummaryText(for workflow: Workflow) -> String {
     }
 }
 
+private func workflowOutputRouteSentence(targetActionPluginId: String?) -> String {
+    guard targetActionPluginId != nil else { return "" }
+    return localizedAppText(
+        " Output: action plugin.",
+        de: " Ausgabe: Action-Plugin."
+    )
+}
+
 private func workflowInputLanguageSummary(for selection: LanguageSelection) -> String {
     switch selection {
     case .inheritGlobal:
@@ -2651,31 +2732,32 @@ private func workflowReviewText(for workflow: Workflow) -> String {
         ". Spoken language: \(workflowInputLanguageSummary(for: workflow.inputLanguageSelection))",
         de: ". Gesprochene Sprache: \(workflowInputLanguageSummary(for: workflow.inputLanguageSelection))"
     )
+    let outputRouteSentence = workflowOutputRouteSentence(targetActionPluginId: workflow.output.targetActionPluginId)
 
     if workflow.trigger?.kind == .global {
         return localizedAppText(
-            "\(summary) runs always\(languageSentence)",
-            de: "\(summary) läuft immer\(languageSentence)"
+            "\(summary) runs always\(languageSentence)\(outputRouteSentence)",
+            de: "\(summary) läuft immer\(languageSentence)\(outputRouteSentence)"
         )
     }
 
     if workflow.trigger?.kind == .manual {
         return localizedAppText(
-            "\(summary) is available from the Workflow Palette\(languageSentence)",
-            de: "\(summary) ist über die Workflow-Palette verfügbar\(languageSentence)"
+            "\(summary) is available from the Workflow Palette\(languageSentence)\(outputRouteSentence)",
+            de: "\(summary) ist über die Workflow-Palette verfügbar\(languageSentence)\(outputRouteSentence)"
         )
     }
 
     if triggerDetail.isEmpty {
         return localizedAppText(
-            "\(summary) via \(triggerSummary)\(languageSentence)",
-            de: "\(summary) über \(triggerSummary)\(languageSentence)"
+            "\(summary) via \(triggerSummary)\(languageSentence)\(outputRouteSentence)",
+            de: "\(summary) über \(triggerSummary)\(languageSentence)\(outputRouteSentence)"
         )
     }
 
     return localizedAppText(
-        "\(summary) via \(triggerSummary): \(triggerDetail)\(languageSentence)",
-        de: "\(summary) über \(triggerSummary): \(triggerDetail)\(languageSentence)"
+        "\(summary) via \(triggerSummary): \(triggerDetail)\(languageSentence)\(outputRouteSentence)",
+        de: "\(summary) über \(triggerSummary): \(triggerDetail)\(languageSentence)\(outputRouteSentence)"
     )
 }
 

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -90,6 +90,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "LinearPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/LinearPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "ObsidianPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/ObsidianPlugin",
@@ -215,6 +225,15 @@ let package = Package(
                 "FileJobScriptPlugin",
             ],
             path: "Plugins/FileJobScriptPlugin/Tests"
+        ),
+        .testTarget(
+            name: "LinearPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "LinearPlugin",
+            ],
+            path: "Plugins/LinearPlugin/Tests"
         ),
         .testTarget(
             name: "ObsidianPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/LinearPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/LinearPlugin.swift
@@ -519,12 +519,12 @@ private struct LinearSettingsView: View {
 
                 Divider()
 
-                // Recommended prompt
+                // Recommended workflow instruction
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Recommended Prompt", bundle: bundle)
+                    Text("Workflow Instruction", bundle: bundle)
                         .font(.headline)
 
-                    Text("Create a Workflow with this system prompt and set \"Create Linear Issue\" as the action target:", bundle: bundle)
+                    Text("Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Create Linear Issue\".", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -538,7 +538,7 @@ private struct LinearSettingsView: View {
                         .background(Color(NSColor.controlBackgroundColor))
                         .cornerRadius(6)
 
-                    Button(String(localized: "Copy Prompt", bundle: bundle)) {
+                    Button(String(localized: "Copy Instruction", bundle: bundle)) {
                         NSPasteboard.general.clearContents()
                         NSPasteboard.general.setString(prompt, forType: .string)
                     }

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/LinearPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/LinearPlugin.swift
@@ -524,7 +524,7 @@ private struct LinearSettingsView: View {
                     Text("Recommended Prompt", bundle: bundle)
                         .font(.headline)
 
-                    Text("Create a new PromptAction with this system prompt and set \"Create Linear Issue\" as the action target:", bundle: bundle)
+                    Text("Create a Workflow with this system prompt and set \"Create Linear Issue\" as the action target:", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
 

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/Localizable.xcstrings
@@ -21,22 +21,22 @@
         }
       }
     },
-    "Copy Prompt" : {
+    "Copy Instruction" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prompt kopieren"
+            "value" : "Anweisung kopieren"
           }
         }
       }
     },
-    "Create a Workflow with this system prompt and set \"Create Linear Issue\" as the action target:" : {
+    "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Create Linear Issue\"." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erstelle einen Workflow mit diesem Prompt und setze \"Create Linear Issue\" als Action-Ziel:"
+            "value" : "Erstelle einen eigenen Workflow, füge dies in Anweisung ein und setze das Action-Ziel auf \"Create Linear Issue\"."
           }
         }
       }
@@ -121,12 +121,12 @@
         }
       }
     },
-    "Recommended Prompt" : {
+    "Workflow Instruction" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Empfohlener Prompt"
+            "value" : "Workflow-Anweisung"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/Localizable.xcstrings
@@ -31,12 +31,12 @@
         }
       }
     },
-    "Create a new PromptAction with this system prompt and set \"Create Linear Issue\" as the action target:" : {
+    "Create a Workflow with this system prompt and set \"Create Linear Issue\" as the action target:" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erstelle eine neue PromptAction mit diesem Prompt und setze \"Create Linear Issue\" als Aktionsziel:"
+            "value" : "Erstelle einen Workflow mit diesem Prompt und setze \"Create Linear Issue\" als Action-Ziel:"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/Tests/LinearPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/Tests/LinearPluginTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import TypeWhisperPluginSDK
+import TypeWhisperPluginSDKTesting
+import XCTest
+@testable import LinearPlugin
+
+final class LinearPluginTests: XCTestCase {
+    private static let workflowInstructionTitle = "Workflow Instruction"
+    private static let workflowInstructionHelp = "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Create Linear Issue\"."
+    private static let copyInstructionTitle = "Copy Instruction"
+
+    func testExecuteFailsWhenApiKeyIsMissing() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = LinearPlugin()
+        plugin.activate(host: host)
+
+        let result = try await plugin.execute(
+            input: "Fix the onboarding copy",
+            context: ActionContext(appName: "Notes", originalText: "Fix the onboarding copy")
+        )
+
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(result.message, "Linear API key not configured")
+    }
+
+    func testSettingsPersistToHostServices() throws {
+        let host = try PluginTestHostServices()
+        let plugin = LinearPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.isConfigured)
+
+        plugin.setApiKey("lin_api_test")
+        plugin.setDefaultTeam("team-1")
+        plugin.setDefaultProject("project-1")
+        plugin.setDefaultLabels(["label-a", "label-b"])
+
+        XCTAssertTrue(plugin.isConfigured)
+        XCTAssertEqual(host.loadSecret(key: "api-key"), "lin_api_test")
+        XCTAssertEqual(host.userDefault(forKey: "defaultTeamId") as? String, "team-1")
+        XCTAssertEqual(host.userDefault(forKey: "defaultProjectId") as? String, "project-1")
+        XCTAssertEqual(host.userDefault(forKey: "defaultLabels") as? [String], ["label-a", "label-b"])
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    func testActionNameMatchesWorkflowInstructionTarget() {
+        let plugin = LinearPlugin()
+
+        XCTAssertEqual(plugin.actionName, "Create Linear Issue")
+        XCTAssertTrue(Self.workflowInstructionHelp.contains("\"\(plugin.actionName)\""))
+    }
+
+    func testSettingsCopyDescribesWorkflowActionTarget() throws {
+        let source = try String(contentsOf: Self.pluginRoot.appendingPathComponent("LinearPlugin.swift"), encoding: .utf8)
+        let catalog = try Self.loadStringCatalog()
+
+        XCTAssertTrue(source.contains(Self.workflowInstructionTitle))
+        XCTAssertTrue(source.contains("Create a Custom Workflow"))
+        XCTAssertTrue(source.contains("Action Target"))
+        XCTAssertTrue(source.contains("Create Linear Issue"))
+        XCTAssertTrue(source.contains(Self.copyInstructionTitle))
+        XCTAssertEqual(catalog.localizedValue(for: Self.workflowInstructionTitle), "Workflow-Anweisung")
+        XCTAssertEqual(
+            catalog.localizedValue(for: Self.workflowInstructionHelp),
+            "Erstelle einen eigenen Workflow, füge dies in Anweisung ein und setze das Action-Ziel auf \"Create Linear Issue\"."
+        )
+        XCTAssertEqual(catalog.localizedValue(for: Self.copyInstructionTitle), "Anweisung kopieren")
+    }
+
+    func testSettingsCopyDoesNotReferenceLegacyPromptActionFlow() throws {
+        let source = try String(contentsOf: Self.pluginRoot.appendingPathComponent("LinearPlugin.swift"), encoding: .utf8)
+        let catalog = try String(contentsOf: Self.pluginRoot.appendingPathComponent("Localizable.xcstrings"), encoding: .utf8)
+        let combinedCopy = source + "\n" + catalog
+
+        for staleTerm in ["PromptAction", "Recommended Prompt", "Copy Prompt", "Create a new PromptAction"] {
+            XCTAssertFalse(combinedCopy.contains(staleTerm), "\(staleTerm) should not appear in Linear settings copy")
+        }
+    }
+
+    private static var pluginRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func loadStringCatalog() throws -> StringCatalog {
+        try JSONDecoder().decode(
+            StringCatalog.self,
+            from: Data(contentsOf: pluginRoot.appendingPathComponent("Localizable.xcstrings"))
+        )
+    }
+}
+
+private struct StringCatalog: Decodable {
+    struct Entry: Decodable {
+        let localizations: [String: Localization]?
+    }
+
+    struct Localization: Decodable {
+        let stringUnit: StringUnit?
+    }
+
+    struct StringUnit: Decodable {
+        let value: String
+    }
+
+    let strings: [String: Entry]
+
+    func localizedValue(for key: String, language: String = "de") -> String? {
+        strings[key]?.localizations?[language]?.stringUnit?.value
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
@@ -51,22 +51,22 @@
         }
       }
     },
-    "Copy Prompt" : {
+    "Copy Instruction" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prompt kopieren"
+            "value" : "Anweisung kopieren"
           }
         }
       }
     },
-    "Create a Workflow with this system prompt and set \"Save to Obsidian\" as the action target:" : {
+    "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Save to Obsidian\"." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erstelle einen Workflow mit diesem Prompt und setze \"Save to Obsidian\" als Action-Ziel:"
+            "value" : "Erstelle einen eigenen Workflow, füge dies in Anweisung ein und setze das Action-Ziel auf \"Save to Obsidian\"."
           }
         }
       }
@@ -141,12 +141,12 @@
         }
       }
     },
-    "Recommended Prompt" : {
+    "Workflow Instruction" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Empfohlener Prompt"
+            "value" : "Workflow-Anweisung"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
@@ -61,12 +61,12 @@
         }
       }
     },
-    "Create a new PromptAction with this system prompt and set \"Save to Obsidian\" as the action target:" : {
+    "Create a Workflow with this system prompt and set \"Save to Obsidian\" as the action target:" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erstelle eine neue PromptAction mit diesem Prompt und setze \"Save to Obsidian\" als Aktionsziel:"
+            "value" : "Erstelle einen Workflow mit diesem Prompt und setze \"Save to Obsidian\" als Action-Ziel:"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -499,7 +499,7 @@ private struct ObsidianSettingsView: View {
                     Text("Recommended Prompt", bundle: bundle)
                         .font(.headline)
 
-                    Text("Create a new PromptAction with this system prompt and set \"Save to Obsidian\" as the action target:", bundle: bundle)
+                    Text("Create a Workflow with this system prompt and set \"Save to Obsidian\" as the action target:", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
 

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -494,12 +494,12 @@ private struct ObsidianSettingsView: View {
 
                 Divider()
 
-                // Recommended Prompt
+                // Recommended workflow instruction
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Recommended Prompt", bundle: bundle)
+                    Text("Workflow Instruction", bundle: bundle)
                         .font(.headline)
 
-                    Text("Create a Workflow with this system prompt and set \"Save to Obsidian\" as the action target:", bundle: bundle)
+                    Text("Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Save to Obsidian\".", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -513,7 +513,7 @@ private struct ObsidianSettingsView: View {
                         .background(Color(NSColor.controlBackgroundColor))
                         .cornerRadius(6)
 
-                    Button(String(localized: "Copy Prompt", bundle: bundle)) {
+                    Button(String(localized: "Copy Instruction", bundle: bundle)) {
                         NSPasteboard.general.clearContents()
                         NSPasteboard.general.setString(prompt, forType: .string)
                     }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -5,6 +5,10 @@ import XCTest
 @testable import ObsidianPlugin
 
 final class ObsidianPluginTests: XCTestCase {
+    private static let workflowInstructionTitle = "Workflow Instruction"
+    private static let workflowInstructionHelp = "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Save to Obsidian\"."
+    private static let copyInstructionTitle = "Copy Instruction"
+
     func testExecuteFailsForInvalidVaultPath() async throws {
         let invalidVaultURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("obsidian-invalid-\(UUID().uuidString)", isDirectory: false)
@@ -117,10 +121,77 @@ final class ObsidianPluginTests: XCTestCase {
         XCTAssertTrue(content.contains("Second entry"))
     }
 
+    func testActionNameMatchesWorkflowInstructionTarget() {
+        let plugin = ObsidianPlugin()
+
+        XCTAssertEqual(plugin.actionName, "Save to Obsidian")
+        XCTAssertTrue(Self.workflowInstructionHelp.contains("\"\(plugin.actionName)\""))
+    }
+
+    func testSettingsCopyDescribesWorkflowActionTarget() throws {
+        let source = try String(contentsOf: Self.pluginRoot.appendingPathComponent("ObsidianPlugin.swift"), encoding: .utf8)
+        let catalog = try Self.loadStringCatalog()
+
+        XCTAssertTrue(source.contains(Self.workflowInstructionTitle))
+        XCTAssertTrue(source.contains("Create a Custom Workflow"))
+        XCTAssertTrue(source.contains("Action Target"))
+        XCTAssertTrue(source.contains("Save to Obsidian"))
+        XCTAssertTrue(source.contains(Self.copyInstructionTitle))
+        XCTAssertEqual(catalog.localizedValue(for: Self.workflowInstructionTitle), "Workflow-Anweisung")
+        XCTAssertEqual(
+            catalog.localizedValue(for: Self.workflowInstructionHelp),
+            "Erstelle einen eigenen Workflow, füge dies in Anweisung ein und setze das Action-Ziel auf \"Save to Obsidian\"."
+        )
+        XCTAssertEqual(catalog.localizedValue(for: Self.copyInstructionTitle), "Anweisung kopieren")
+    }
+
+    func testSettingsCopyDoesNotReferenceLegacyPromptActionFlow() throws {
+        let source = try String(contentsOf: Self.pluginRoot.appendingPathComponent("ObsidianPlugin.swift"), encoding: .utf8)
+        let catalog = try String(contentsOf: Self.pluginRoot.appendingPathComponent("Localizable.xcstrings"), encoding: .utf8)
+        let combinedCopy = source + "\n" + catalog
+
+        for staleTerm in ["PromptAction", "Recommended Prompt", "Copy Prompt", "Create a new PromptAction"] {
+            XCTAssertFalse(combinedCopy.contains(staleTerm), "\(staleTerm) should not appear in Obsidian settings copy")
+        }
+    }
+
     private static func makeTemporaryDirectory(prefix: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+
+    private static var pluginRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func loadStringCatalog() throws -> StringCatalog {
+        try JSONDecoder().decode(
+            StringCatalog.self,
+            from: Data(contentsOf: pluginRoot.appendingPathComponent("Localizable.xcstrings"))
+        )
+    }
+}
+
+private struct StringCatalog: Decodable {
+    struct Entry: Decodable {
+        let localizations: [String: Localization]?
+    }
+
+    struct Localization: Decodable {
+        let stringUnit: StringUnit?
+    }
+
+    struct StringUnit: Decodable {
+        let value: String
+    }
+
+    let strings: [String: Entry]
+
+    func localizedValue(for key: String, language: String = "de") -> String? {
+        strings[key]?.localizations?[language]?.stringUnit?.value
     }
 }

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import TypeWhisperPluginSDK
 import XCTest
 @testable import TypeWhisper
 
@@ -236,6 +237,87 @@ final class PromptPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(insertedText, "Processed: Selected source")
     }
 
+    func testDirectWorkflowHotkeyRoutesProcessedTextToActionPluginInsteadOfInsertion() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let previousPluginManager = PluginManager.shared
+        let actionPlugin = PromptPaletteActionPluginSpy()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: PromptPaletteActionPluginSpy.pluginId,
+                    name: PromptPaletteActionPluginSpy.pluginName,
+                    version: "1.0.0",
+                    principalClass: "PromptPaletteActionPluginSpy",
+                    requiresAPIKey: false
+                ),
+                instance: actionPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        defer { PluginManager.shared = previousPluginManager }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        let selectedElement = AXUIElementCreateSystemWide()
+        textInsertionService.textSelectionOverride = {
+            TextInsertionService.TextSelection(text: "Selected source", element: selectedElement)
+        }
+
+        var insertedText: String?
+        textInsertionService.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = Workflow(
+            name: "Send to Action",
+            template: .summary,
+            trigger: .hotkeys([
+                UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)
+            ], behavior: .processSelectedText),
+            output: WorkflowOutput(targetActionPluginId: actionPlugin.actionId)
+        )
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            promptProcessingService: PromptProcessingService(),
+            workflowTextProcessingService: WorkflowTextProcessingService(
+                promptProcessor: { _, text, _, _, _ in "Processed: \(text)" },
+                appleTranslator: nil
+            ),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: PromptPaletteControllerSpy()
+        )
+
+        var routedInput: String?
+        var routedOriginalText: String?
+        handler.executeActionPlugin = { plugin, pluginId, text, _, originalText, _ in
+            routedInput = text
+            routedOriginalText = originalText
+            XCTAssertEqual(pluginId, actionPlugin.actionId)
+            XCTAssertTrue(plugin === actionPlugin)
+        }
+
+        handler.processWorkflowDirectly(
+            workflow: workflow,
+            currentState: .idle,
+            soundFeedbackEnabled: false
+        )
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(routedInput, "Processed: Selected source")
+        XCTAssertEqual(routedOriginalText, "Selected source")
+        XCTAssertNil(insertedText)
+    }
+
     func testDirectWorkflowHotkeyUsesClipboardFallbackWhenSelectionIsUnavailable() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -401,6 +483,27 @@ final class PromptPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(controller.lastWorkflows?.map(\.name), ["Translate"])
         XCTAssertEqual(controller.lastSourceText, "Selected text")
         XCTAssertNil(shownError)
+    }
+}
+
+private final class PromptPaletteActionPluginSpy: NSObject, ActionPlugin, @unchecked Sendable {
+    static let pluginId = "plugin.action"
+    static let pluginName = "Action Plugin"
+
+    let actionName = "Send to Action"
+    let actionId = "plugin.action"
+    let actionIcon = "paperplane"
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+
+    func deactivate() {}
+
+    func execute(input: String, context: ActionContext) async throws -> ActionResult {
+        ActionResult(success: true, message: "Done")
     }
 }
 

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -248,6 +248,53 @@ final class WorkflowServiceTests: XCTestCase {
         XCTAssertEqual(trigger.hotkeyBehavior, .processSelectedText)
     }
 
+    func testWorkflowDraftPersistsEditedActionTargetForNonDictationWorkflow() throws {
+        var draft = WorkflowDraft(template: .summary)
+
+        draft.targetActionPluginId = "plugin.action"
+
+        XCTAssertEqual(draft.resolvedOutput().targetActionPluginId, "plugin.action")
+    }
+
+    func testWorkflowDraftDropsActionTargetForDictationTemplate() throws {
+        var draft = WorkflowDraft(template: .summary)
+        draft.targetActionPluginId = "plugin.action"
+
+        draft.selectTemplate(.dictation)
+
+        XCTAssertNil(draft.targetActionPluginId)
+        XCTAssertNil(draft.resolvedOutput().targetActionPluginId)
+    }
+
+    func testWorkflowDraftDropsStoredActionTargetForDictationWorkflow() throws {
+        let workflow = Workflow(
+            name: "Plain Dictation",
+            template: .dictation,
+            trigger: .hotkeys([
+                UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)
+            ]),
+            output: WorkflowOutput(targetActionPluginId: "plugin.action")
+        )
+
+        let draft = WorkflowDraft(workflow)
+
+        XCTAssertNil(draft.targetActionPluginId)
+        XCTAssertNil(draft.resolvedOutput().targetActionPluginId)
+    }
+
+    func testWorkflowDraftPreservesUnavailableActionTargetWhenSaving() throws {
+        let workflow = Workflow(
+            name: "Archive Note",
+            template: .summary,
+            trigger: .manual(),
+            output: WorkflowOutput(targetActionPluginId: "plugin.unavailable")
+        )
+
+        let output = WorkflowDraft(workflow).resolvedOutput()
+
+        XCTAssertEqual(output.targetActionPluginId, "plugin.unavailable")
+    }
+
     func testWorkflowDraftPreservesDictationTranscriptionOverridesWhenSaving() throws {
         let hotkey = UnifiedHotkey(keyCode: 15, modifierFlags: NSEvent.ModifierFlags.command.rawValue, isFn: false)
         let workflow = Workflow(


### PR DESCRIPTION
## Summary

- Restore the Workflow editor Action Target picker for non-dictation workflows so enabled ActionPlugins can be selected again.
- Preserve existing `WorkflowOutput.targetActionPluginId` values, including currently unavailable action targets, while normalizing Dictation Only drafts back to text insertion.
- Update Obsidian and Linear settings copy from legacy PromptAction guidance to Workflow guidance and cover that copy with plugin-level tests.

## Issue context

Issue #552 reports a regression where the new Workflows UI no longer exposes action-plugin targets even though the runtime and stored workflow model still support `WorkflowOutput.targetActionPluginId`. This blocked users from configuring Obsidian `Save to Obsidian` and Linear `Create Linear Issue` workflows from the current UI.

Closes #552

## Test Plan

- `swift test --package-path TypeWhisperPluginSDK --filter 'ObsidianPluginTests|LinearPluginTests'`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/PromptPaletteHandlerTests`
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows can now specify a target action plugin to execute
  * Linear plugin integration is available
  * Workflow output routes now display selected action plugin information

* **Style**
  * Updated UI terminology: "Workflow Instruction" replaces "Recommended Prompt" for improved clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->