### PR TITLE
Fix live preview over maximized app windows

### DIFF
--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -91,6 +91,8 @@ private struct DiagnosticsReport: Encodable {
         let memoryEnabled: Bool
         let memoryCaptureScope: String
         let appFormattingEnabled: Bool
+        let modelAutoUnloadSeconds: Int
+        let modelAutoUnloadPolicy: String
         let indicatorStyle: String
         let indicatorSupportsTranscriptPreview: Bool
         let indicatorTranscriptPreviewEnabled: Bool
@@ -185,6 +187,7 @@ final class ErrorLogService: ObservableObject {
         let defaults = UserDefaults.standard
         let pluginManager = PluginManager.shared ?? container.pluginManager
         let outputSnapshot = CoreAudioOutputVolumeController().defaultOutputSnapshot()
+        let modelAutoUnloadSeconds = defaults.integer(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
         let indicatorStyle = DictationViewModel.loadIndicatorStyle(defaults: defaults)
         let indicatorPreviewEnabled = DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults)
         let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
@@ -279,6 +282,8 @@ final class ErrorLogService: ObservableObject {
                 memoryEnabled: defaults.bool(forKey: UserDefaultsKeys.memoryEnabled),
                 memoryCaptureScope: MemoryCaptureScope.load(from: defaults).rawValue,
                 appFormattingEnabled: defaults.bool(forKey: UserDefaultsKeys.appFormattingEnabled),
+                modelAutoUnloadSeconds: modelAutoUnloadSeconds,
+                modelAutoUnloadPolicy: Self.modelAutoUnloadPolicy(seconds: modelAutoUnloadSeconds),
                 indicatorStyle: indicatorStyle.rawValue,
                 indicatorSupportsTranscriptPreview: indicatorStyle.supportsTranscriptPreview,
                 indicatorTranscriptPreviewEnabled: indicatorPreviewEnabled,
@@ -314,6 +319,17 @@ final class ErrorLogService: ObservableObject {
 
     private static func pluginDefaultKey(pluginId: String, key: String) -> String {
         "plugin.\(pluginId).\(key)"
+    }
+
+    private static func modelAutoUnloadPolicy(seconds: Int) -> String {
+        switch seconds {
+        case 0:
+            return "never"
+        case -1:
+            return "immediate"
+        default:
+            return "afterSeconds"
+        }
     }
 
     private func loadEntries() {

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 import os.log
+import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "ErrorLogService")
 
@@ -29,6 +30,8 @@ private struct DiagnosticsReport: Encodable {
         let selectedModelId: String?
         let isModelReady: Bool
         let supportsStreaming: Bool
+        let supportsLiveTranscriptionSession: Bool
+        let allowsTranscriptPreviewFallback: Bool
         let supportsTranslation: Bool
     }
 
@@ -64,6 +67,16 @@ private struct DiagnosticsReport: Encodable {
         let version: String
         let enabled: Bool
         let bundled: Bool
+        let runtimeLoaded: Bool
+        let providerId: String?
+        let selectedModelId: String?
+        let isConfigured: Bool?
+        let supportsStreaming: Bool?
+        let supportsLiveTranscriptionSession: Bool?
+        let allowsTranscriptPreviewFallback: Bool?
+        let storedSelectedModelId: String?
+        let storedLoadedModelId: String?
+        let storedSelectedVersion: String?
     }
 
     struct SettingsSnapshot: Encodable {
@@ -78,6 +91,15 @@ private struct DiagnosticsReport: Encodable {
         let memoryEnabled: Bool
         let memoryCaptureScope: String
         let appFormattingEnabled: Bool
+        let indicatorStyle: String
+        let indicatorSupportsTranscriptPreview: Bool
+        let indicatorTranscriptPreviewEnabled: Bool
+        let indicatorTranscriptPreviewAvailable: Bool
+        let indicatorTranscriptPreviewFontSizeOffset: Int
+        let notchIndicatorVisibility: String
+        let notchIndicatorDisplay: String
+        let overlayPosition: String
+        let externalStreamingDisplayCount: Int?
         let soundFeedbackEnabled: Bool
         let spokenFeedbackEnabled: Bool
         let showMenuBarIcon: Bool
@@ -163,9 +185,12 @@ final class ErrorLogService: ObservableObject {
         let defaults = UserDefaults.standard
         let pluginManager = PluginManager.shared ?? container.pluginManager
         let outputSnapshot = CoreAudioOutputVolumeController().defaultOutputSnapshot()
+        let indicatorStyle = DictationViewModel.loadIndicatorStyle(defaults: defaults)
+        let indicatorPreviewEnabled = DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults)
+        let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
 
         return DiagnosticsReport(
-            schemaVersion: 2,
+            schemaVersion: 3,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,
@@ -188,6 +213,8 @@ final class ErrorLogService: ObservableObject {
                 selectedModelId: container.modelManagerService.selectedModelId,
                 isModelReady: container.modelManagerService.isModelReady,
                 supportsStreaming: container.modelManagerService.supportsStreaming,
+                supportsLiveTranscriptionSession: container.modelManagerService.supportsLiveTranscriptionSession(),
+                allowsTranscriptPreviewFallback: container.modelManagerService.allowsTranscriptPreviewFallback(),
                 supportsTranslation: container.modelManagerService.supportsTranslation
             ),
             api: .init(
@@ -215,12 +242,29 @@ final class ErrorLogService: ObservableObject {
                 inputDiagnostics: container.audioDeviceService.diagnosticsReport()
             ),
             plugins: pluginManager.loadedPlugins.map {
-                .init(
+                let engine = $0.instance as? TranscriptionEnginePlugin
+                let fallbackPolicy = engine as? TranscriptPreviewFallbackPolicyProviding
+                let allowsTranscriptPreviewFallback: Bool? = if engine != nil {
+                    fallbackPolicy?.allowsTranscriptPreviewFallback ?? true
+                } else {
+                    nil
+                }
+                return DiagnosticsReport.PluginInfo(
                     id: $0.manifest.id,
                     name: $0.manifest.name,
                     version: $0.manifest.version,
                     enabled: $0.isEnabled,
-                    bundled: $0.isBundled
+                    bundled: $0.isBundled,
+                    runtimeLoaded: $0.isRuntimeLoaded,
+                    providerId: engine?.providerId,
+                    selectedModelId: engine?.selectedModelId,
+                    isConfigured: engine?.isConfigured,
+                    supportsStreaming: engine?.supportsStreaming,
+                    supportsLiveTranscriptionSession: engine.map { $0 is LiveTranscriptionCapablePlugin },
+                    allowsTranscriptPreviewFallback: allowsTranscriptPreviewFallback,
+                    storedSelectedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: $0.manifest.id, key: "selectedModel")),
+                    storedLoadedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: $0.manifest.id, key: "loadedModel")),
+                    storedSelectedVersion: defaults.string(forKey: Self.pluginDefaultKey(pluginId: $0.manifest.id, key: "selectedVersion"))
                 )
             },
             settings: .init(
@@ -235,6 +279,15 @@ final class ErrorLogService: ObservableObject {
                 memoryEnabled: defaults.bool(forKey: UserDefaultsKeys.memoryEnabled),
                 memoryCaptureScope: MemoryCaptureScope.load(from: defaults).rawValue,
                 appFormattingEnabled: defaults.bool(forKey: UserDefaultsKeys.appFormattingEnabled),
+                indicatorStyle: indicatorStyle.rawValue,
+                indicatorSupportsTranscriptPreview: indicatorStyle.supportsTranscriptPreview,
+                indicatorTranscriptPreviewEnabled: indicatorPreviewEnabled,
+                indicatorTranscriptPreviewAvailable: indicatorStyle.supportsTranscriptPreview && indicatorPreviewEnabled,
+                indicatorTranscriptPreviewFontSizeOffset: indicatorPreviewOffset,
+                notchIndicatorVisibility: defaults.string(forKey: UserDefaultsKeys.notchIndicatorVisibility) ?? NotchIndicatorVisibility.duringActivity.rawValue,
+                notchIndicatorDisplay: defaults.string(forKey: UserDefaultsKeys.notchIndicatorDisplay) ?? NotchIndicatorDisplay.activeScreen.rawValue,
+                overlayPosition: defaults.string(forKey: UserDefaultsKeys.overlayPosition) ?? OverlayPosition.top.rawValue,
+                externalStreamingDisplayCount: DictationViewModel._shared?.externalStreamingDisplayCount,
                 soundFeedbackEnabled: defaults.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true,
                 spokenFeedbackEnabled: defaults.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled),
                 showMenuBarIcon: defaults.object(forKey: UserDefaultsKeys.showMenuBarIcon) as? Bool ?? true,
@@ -257,6 +310,10 @@ final class ErrorLogService: ObservableObject {
                 .init(timestamp: $0.timestamp, category: $0.category, message: $0.message)
             }
         )
+    }
+
+    private static func pluginDefaultKey(pluginId: String, key: String) -> String {
+        "plugin.\(pluginId).\(key)"
     }
 
     private func loadEntries() {

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -138,6 +138,7 @@ private struct DiagnosticsReport: Encodable {
     let audio: AudioInfo
     let plugins: [PluginInfo]
     let settings: SettingsSnapshot
+    let lastIndicatorFullscreenSuppression: IndicatorFullscreenSuppressionDiagnostics?
     let counts: Counts
     let errors: [ErrorEntrySnapshot]
 }
@@ -193,7 +194,7 @@ final class ErrorLogService: ObservableObject {
         let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
 
         return DiagnosticsReport(
-            schemaVersion: 3,
+            schemaVersion: 4,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,
@@ -301,6 +302,7 @@ final class ErrorLogService: ObservableObject {
                 setupWizardCompleted: defaults.bool(forKey: UserDefaultsKeys.setupWizardCompleted),
                 preferredAppLanguage: defaults.string(forKey: UserDefaultsKeys.preferredAppLanguage)
             ),
+            lastIndicatorFullscreenSuppression: IndicatorFullscreenSuppressionPolicy.lastSuppressionDiagnostics(),
             counts: .init(
                 historyRecords: container.historyService.records.count,
                 profiles: container.profileService.profiles.count,

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -160,29 +160,9 @@ enum IndicatorWindowFrameLookup {
     }
 
     nonisolated static func focusedWindowFrame() -> CGRect? {
-        let systemWide = AXUIElementCreateSystemWide()
-
-        var focusedApplication: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            systemWide,
-            kAXFocusedApplicationAttribute as CFString,
-            &focusedApplication
-        ) == .success,
-              let focusedApplication else {
+        guard let windowElement = focusedWindowElement() else {
             return nil
         }
-        let applicationElement = focusedApplication as! AXUIElement
-
-        var focusedWindow: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            applicationElement,
-            kAXFocusedWindowAttribute as CFString,
-            &focusedWindow
-        ) == .success,
-              let focusedWindow else {
-            return nil
-        }
-        let windowElement = focusedWindow as! AXUIElement
 
         var positionValue: AnyObject?
         guard AXUIElementCopyAttributeValue(
@@ -218,6 +198,54 @@ enum IndicatorWindowFrameLookup {
 
         return CGRect(origin: position, size: size)
     }
+
+    nonisolated static func focusedWindowIsFullscreen() -> Bool? {
+        guard let windowElement = focusedWindowElement() else {
+            return nil
+        }
+
+        var fullScreenValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            windowElement,
+            "AXFullScreen" as CFString,
+            &fullScreenValue
+        ) == .success,
+              let fullScreenValue else {
+            return nil
+        }
+
+        if let isFullscreen = fullScreenValue as? Bool {
+            return isFullscreen
+        }
+
+        return (fullScreenValue as? NSNumber)?.boolValue
+    }
+
+    private nonisolated static func focusedWindowElement() -> AXUIElement? {
+        let systemWide = AXUIElementCreateSystemWide()
+
+        var focusedApplication: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedApplicationAttribute as CFString,
+            &focusedApplication
+        ) == .success,
+              let focusedApplication else {
+            return nil
+        }
+        let applicationElement = focusedApplication as! AXUIElement
+
+        var focusedWindow: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindow
+        ) == .success,
+              let focusedWindow else {
+            return nil
+        }
+        return focusedWindow as! AXUIElement
+    }
 }
 
 enum IndicatorFullscreenSuppressionPolicy {
@@ -236,6 +264,7 @@ enum IndicatorFullscreenSuppressionPolicy {
             ActivationSourceTracker.shared.lastExternalApplication ?? NSWorkspace.shared.frontmostApplication
         },
         focusedWindowFrameProvider: () -> CGRect? = IndicatorWindowFrameLookup.focusedWindowFrame,
+        focusedWindowFullscreenProvider: () -> Bool? = IndicatorWindowFrameLookup.focusedWindowIsFullscreen,
         windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
         appBundleIdentifier: String? = Bundle.main.bundleIdentifier
     ) -> Bool {
@@ -249,11 +278,13 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         let windowFrame = focusedWindowFrameProvider()
             ?? windowFrameProvider(application.processIdentifier)
+        let focusedWindowIsFullscreen = focusedWindowFullscreenProvider()
 
         let shouldSuppress = shouldSuppressIndicator(
             screenFrame: screen.frame,
             safeAreaTopInset: screen.safeAreaInsets.top,
             windowFrame: windowFrame,
+            focusedWindowIsFullscreen: focusedWindowIsFullscreen,
             frontmostBundleIdentifier: application.bundleIdentifier,
             appBundleIdentifier: appBundleIdentifier
         )
@@ -263,6 +294,7 @@ enum IndicatorFullscreenSuppressionPolicy {
                 screenFrame: screen.frame,
                 safeAreaTopInset: screen.safeAreaInsets.top,
                 windowFrame: windowFrame,
+                focusedWindowIsFullscreen: focusedWindowIsFullscreen,
                 frontmostApplication: application
             )
         }
@@ -274,6 +306,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         screenFrame: CGRect,
         safeAreaTopInset: CGFloat,
         windowFrame: CGRect?,
+        focusedWindowIsFullscreen: Bool? = nil,
         frontmostBundleIdentifier: String?,
         appBundleIdentifier: String?
     ) -> Bool {
@@ -287,6 +320,11 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         let screenFrame = screenFrame.standardized
         let windowFrame = candidateWindowFrame.standardized
+
+        if let focusedWindowIsFullscreen, !focusedWindowIsFullscreen {
+            return false
+        }
+
         let notchStripHeight = min(safeAreaTopInset, screenFrame.height)
         let notchStrip = CGRect(
             x: screenFrame.minX,
@@ -324,6 +362,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         screenFrame: CGRect,
         safeAreaTopInset: CGFloat,
         windowFrame: CGRect?,
+        focusedWindowIsFullscreen: Bool?,
         frontmostApplication: NSRunningApplication
     ) {
         guard let windowFrame else { return }
@@ -349,6 +388,7 @@ enum IndicatorFullscreenSuppressionPolicy {
             screenFrame: .init(screenFrame),
             safeAreaTopInset: Double(safeAreaTopInset),
             windowFrame: .init(standardizedWindowFrame),
+            focusedWindowIsFullscreen: focusedWindowIsFullscreen,
             horizontalCoverage: Double(horizontalCoverage),
             verticalCoverage: Double(verticalCoverage)
         )
@@ -363,6 +403,7 @@ struct IndicatorFullscreenSuppressionDiagnostics: Encodable, Equatable, Sendable
     let screenFrame: IndicatorRectDiagnostics
     let safeAreaTopInset: Double
     let windowFrame: IndicatorRectDiagnostics
+    let focusedWindowIsFullscreen: Bool?
     let horizontalCoverage: Double
     let verticalCoverage: Double
 }

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -160,9 +160,10 @@ enum IndicatorWindowFrameLookup {
     }
 
     nonisolated static func focusedWindowFrame() -> CGRect? {
-        guard let windowElement = focusedWindowElement() else {
+        guard let focusedWindow = focusedWindowElement() else {
             return nil
         }
+        let windowElement = focusedWindow as! AXUIElement
 
         var positionValue: AnyObject?
         guard AXUIElementCopyAttributeValue(
@@ -200,9 +201,10 @@ enum IndicatorWindowFrameLookup {
     }
 
     nonisolated static func focusedWindowIsFullscreen() -> Bool? {
-        guard let windowElement = focusedWindowElement() else {
+        guard let focusedWindow = focusedWindowElement() else {
             return nil
         }
+        let windowElement = focusedWindow as! AXUIElement
 
         var fullScreenValue: AnyObject?
         guard AXUIElementCopyAttributeValue(
@@ -221,7 +223,7 @@ enum IndicatorWindowFrameLookup {
         return (fullScreenValue as? NSNumber)?.boolValue
     }
 
-    private nonisolated static func focusedWindowElement() -> AXUIElement? {
+    private nonisolated static func focusedWindowElement() -> AnyObject? {
         let systemWide = AXUIElementCreateSystemWide()
 
         var focusedApplication: AnyObject?
@@ -244,7 +246,7 @@ enum IndicatorWindowFrameLookup {
               let focusedWindow else {
             return nil
         }
-        return focusedWindow as! AXUIElement
+        return focusedWindow
     }
 }
 

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -223,6 +223,11 @@ enum IndicatorWindowFrameLookup {
 enum IndicatorFullscreenSuppressionPolicy {
     private static let minimumHorizontalCoverage: CGFloat = 0.5
     private static let minimumVerticalCoverage: CGFloat = 0.5
+    private nonisolated(unsafe) static var lastSuppression: IndicatorFullscreenSuppressionDiagnostics?
+
+    nonisolated static func lastSuppressionDiagnostics() -> IndicatorFullscreenSuppressionDiagnostics? {
+        lastSuppression
+    }
 
     @MainActor
     static func shouldSuppressIndicator(
@@ -245,13 +250,24 @@ enum IndicatorFullscreenSuppressionPolicy {
         let windowFrame = focusedWindowFrameProvider()
             ?? windowFrameProvider(application.processIdentifier)
 
-        return shouldSuppressIndicator(
+        let shouldSuppress = shouldSuppressIndicator(
             screenFrame: screen.frame,
             safeAreaTopInset: screen.safeAreaInsets.top,
             windowFrame: windowFrame,
             frontmostBundleIdentifier: application.bundleIdentifier,
             appBundleIdentifier: appBundleIdentifier
         )
+
+        if shouldSuppress {
+            recordSuppression(
+                screenFrame: screen.frame,
+                safeAreaTopInset: screen.safeAreaInsets.top,
+                windowFrame: windowFrame,
+                frontmostApplication: application
+            )
+        }
+
+        return shouldSuppress
     }
 
     static func shouldSuppressIndicator(
@@ -302,6 +318,66 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         return bundleIdentifier == "com.typewhisper.mac"
             || bundleIdentifier == "com.typewhisper.mac.dev"
+    }
+
+    private static func recordSuppression(
+        screenFrame: CGRect,
+        safeAreaTopInset: CGFloat,
+        windowFrame: CGRect?,
+        frontmostApplication: NSRunningApplication
+    ) {
+        guard let windowFrame else { return }
+
+        let screenFrame = screenFrame.standardized
+        let standardizedWindowFrame = windowFrame.standardized
+        let notchStripHeight = min(safeAreaTopInset, screenFrame.height)
+        let notchStrip = CGRect(
+            x: screenFrame.minX,
+            y: screenFrame.maxY - notchStripHeight,
+            width: screenFrame.width,
+            height: notchStripHeight
+        )
+        let intersection = standardizedWindowFrame.intersection(notchStrip)
+        let horizontalCoverage = intersection.isNull || intersection.isEmpty ? 0 : intersection.width / notchStrip.width
+        let verticalCoverage = intersection.isNull || intersection.isEmpty ? 0 : intersection.height / notchStrip.height
+
+        lastSuppression = IndicatorFullscreenSuppressionDiagnostics(
+            timestamp: Date(),
+            frontmostBundleIdentifier: frontmostApplication.bundleIdentifier,
+            frontmostLocalizedName: frontmostApplication.localizedName,
+            frontmostProcessIdentifier: frontmostApplication.processIdentifier,
+            screenFrame: .init(screenFrame),
+            safeAreaTopInset: Double(safeAreaTopInset),
+            windowFrame: .init(standardizedWindowFrame),
+            horizontalCoverage: Double(horizontalCoverage),
+            verticalCoverage: Double(verticalCoverage)
+        )
+    }
+}
+
+struct IndicatorFullscreenSuppressionDiagnostics: Encodable, Equatable, Sendable {
+    let timestamp: Date
+    let frontmostBundleIdentifier: String?
+    let frontmostLocalizedName: String?
+    let frontmostProcessIdentifier: pid_t
+    let screenFrame: IndicatorRectDiagnostics
+    let safeAreaTopInset: Double
+    let windowFrame: IndicatorRectDiagnostics
+    let horizontalCoverage: Double
+    let verticalCoverage: Double
+}
+
+struct IndicatorRectDiagnostics: Encodable, Equatable, Sendable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ rect: CGRect) {
+        x = Double(rect.origin.x)
+        y = Double(rect.origin.y)
+        width = Double(rect.size.width)
+        height = Double(rect.size.height)
     }
 }
 

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -253,9 +253,10 @@ enum IndicatorWindowFrameLookup {
 enum IndicatorFullscreenSuppressionPolicy {
     private static let minimumHorizontalCoverage: CGFloat = 0.5
     private static let minimumVerticalCoverage: CGFloat = 0.5
-    private nonisolated(unsafe) static var lastSuppression: IndicatorFullscreenSuppressionDiagnostics?
+    @MainActor private static var lastSuppression: IndicatorFullscreenSuppressionDiagnostics?
 
-    nonisolated static func lastSuppressionDiagnostics() -> IndicatorFullscreenSuppressionDiagnostics? {
+    @MainActor
+    static func lastSuppressionDiagnostics() -> IndicatorFullscreenSuppressionDiagnostics? {
         lastSuppression
     }
 
@@ -360,6 +361,7 @@ enum IndicatorFullscreenSuppressionPolicy {
             || bundleIdentifier == "com.typewhisper.mac.dev"
     }
 
+    @MainActor
     private static func recordSuppression(
         screenFrame: CGRect,
         safeAreaTopInset: CGFloat,

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -226,6 +226,36 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testSuppressesForeignAXFullscreenWindowThatOverlapsNotchStrip() {
+        let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenWindow,
+                focusedWindowIsFullscreen: true,
+                frontmostBundleIdentifier: "com.apple.ScreenSharing",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
+    func testDoesNotSuppressForeignMaximizedWindowWhenAXReportsNotFullscreen() {
+        let maximizedWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: maximizedWindow,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.google.Chrome",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
     func testDoesNotSuppressOnNonNotchedScreen() {
         let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
 


### PR DESCRIPTION
## Summary
- Add live-preview-specific support diagnostics for issue #531 follow-up.
- Record indicator fullscreen-suppression diagnostics, including app/window/screen geometry and AX fullscreen state.
- Fix Notch/Overlay suppression so normal maximized windows with `AXFullScreen == false` can still show live transcript preview, while preserving the geometry fallback for windows where AX fullscreen state is unavailable.

## Context
Follow-up for #531 after the reporter confirmed final Parakeet dictation works, live preview appears in small normal windows, but Notch/Overlay disappears when apps such as Chrome / VS Code / ChatGPT are resized to fill the available screen area without entering macOS full-screen mode.

The previous suppression policy only used notch-strip geometry, which can classify a normal maximized window like a foreign fullscreen notch window. This now uses the focused window's Accessibility `AXFullScreen` value when available: explicit non-fullscreen windows are not suppressed; explicit fullscreen windows and unavailable-AX fallback geometry remain protected for the original remote-session/fullscreen guard.

## Test Plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics schema bumped to v4: richer model and plugin info, live-transcription support, transcript-preview fallback, persisted plugin IDs/versions, and expanded runtime/provider/model details.
  * Settings snapshot expanded: auto-unload timing/policy, indicator style, transcript-preview availability/state and font offset, notch/overlay/display counts, and last fullscreen-suppression flag.
  * Indicator diagnostics now record and expose recent fullscreen-suppression decisions with screen/safe-area/window geometry and coverage metrics.

* **Tests**
  * Added tests for fullscreen suppression behavior driven by accessibility fullscreen reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->