### PR TITLE
Stabilize live transcript preview

### DIFF
--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -7,12 +7,55 @@ final class StreamingHandler: @unchecked Sendable {
     private struct SharedState {
         var confirmedStreamingText = ""
         var liveSessionHandle: ModelManagerService.LiveTranscriptionSessionHandle?
+        var livePreviewAudioGate = LivePreviewAudioGate()
         var sampleCursor = 0
     }
 
     private static let liveSessionPollInterval: Duration = .milliseconds(350)
     private static let fallbackPollInterval: Duration = .seconds(3)
     private static let fallbackPreviewWindowDuration: TimeInterval = 10
+    private static let livePreviewSampleRate: Double = 16_000
+    private static let livePreviewAnalysisFrameDuration: TimeInterval = 0.1
+    private static let livePreviewSpeechRMSFloor: Float = 0.004
+    private static let livePreviewSustainedSilenceDuration: TimeInterval = 1.4
+
+    private struct LivePreviewAudioActivity {
+        var duration: TimeInterval
+        var containsSpeech: Bool
+        var trailingQuietDuration: TimeInterval
+    }
+
+    private struct LivePreviewAudioGate {
+        var hasObservedSpeech = false
+        var consecutiveQuietDuration: TimeInterval = 0
+
+        mutating func update(with activity: LivePreviewAudioActivity) -> LivePreviewAudioGateSnapshot {
+            if activity.containsSpeech {
+                hasObservedSpeech = true
+                consecutiveQuietDuration = activity.trailingQuietDuration
+            } else {
+                consecutiveQuietDuration += activity.duration
+            }
+
+            return snapshot
+        }
+
+        var snapshot: LivePreviewAudioGateSnapshot {
+            LivePreviewAudioGateSnapshot(
+                hasObservedSpeech: hasObservedSpeech,
+                consecutiveQuietDuration: consecutiveQuietDuration
+            )
+        }
+    }
+
+    private struct LivePreviewAudioGateSnapshot {
+        var hasObservedSpeech: Bool
+        var consecutiveQuietDuration: TimeInterval
+
+        var suppressesAdditivePreview: Bool {
+            !hasObservedSpeech || consecutiveQuietDuration >= StreamingHandler.livePreviewSustainedSilenceDuration
+        }
+    }
 
     private var streamingTask: Task<Void, Never>?
     private let progressText = OSAllocatedUnfairLock(initialState: "")
@@ -80,13 +123,11 @@ final class StreamingHandler: @unchecked Sendable {
                 prompt: streamPrompt,
                 onProgress: { [weak self] text in
                     guard let self else { return false }
-                    let confirmed = self.progressText.withLock { $0 }
-                    let stable = Self.stabilizeText(confirmed: confirmed, new: text)
-                    self.progressText.withLock { $0 = stable }
-                    self.sharedState.withLock { $0.confirmedStreamingText = stable }
-                    Task { @MainActor [weak self] in
-                        self?.onPartialTextUpdate?(stable)
-                    }
+                    _ = self.processPreviewUpdate(
+                        text,
+                        audioGate: self.currentLivePreviewAudioGateSnapshot(),
+                        persist: true
+                    )
                     return true
                 }
             ) {
@@ -179,6 +220,7 @@ final class StreamingHandler: @unchecked Sendable {
 
             if !delta.samples.isEmpty,
                let handle = sharedState.withLock({ $0.liveSessionHandle }) {
+                _ = recordLivePreviewAudio(delta.samples)
                 do {
                     try await handle.session.appendAudio(samples: delta.samples)
                 } catch {
@@ -205,8 +247,9 @@ final class StreamingHandler: @unchecked Sendable {
             guard await stateCheck() else { break }
             let buffer = recentBufferProvider(Self.fallbackPreviewWindowDuration)
             let bufferDuration = Double(buffer.count) / 16000.0
+            let audioActivity = Self.livePreviewAudioActivity(in: buffer)
 
-            if bufferDuration > 0.5 {
+            if bufferDuration > 0.5, Self.shouldRunFallbackPreview(for: audioActivity) {
                 do {
                     let result = try await modelManager.transcribe(
                         audioSamples: buffer,
@@ -217,24 +260,11 @@ final class StreamingHandler: @unchecked Sendable {
                         prompt: streamPrompt,
                         onProgress: { [weak self] text in
                             guard let self, !Task.isCancelled else { return false }
-                            let confirmed = self.progressText.withLock { $0 }
-                            let stable = Self.stabilizeText(confirmed: confirmed, new: text)
-                            Task { @MainActor [weak self] in
-                                self?.onPartialTextUpdate?(stable)
-                            }
+                            _ = self.processPreviewUpdate(text, audioGate: nil, persist: false)
                             return true
                         }
                     )
-                    let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !text.isEmpty {
-                        let confirmed = confirmedStreamingText()
-                        let stable = Self.stabilizeText(confirmed: confirmed, new: text)
-                        progressText.withLock { $0 = stable }
-                        sharedState.withLock { $0.confirmedStreamingText = stable }
-                        await MainActor.run { [weak self] in
-                            self?.onPartialTextUpdate?(stable)
-                        }
-                    }
+                    _ = processPreviewUpdate(result.text, audioGate: nil, persist: true)
                 } catch {
                     logger.warning("Streaming preview error: \(error.localizedDescription)")
                 }
@@ -268,46 +298,376 @@ final class StreamingHandler: @unchecked Sendable {
         }
     }
 
-    private func confirmedStreamingText() -> String {
-        sharedState.withLock { $0.confirmedStreamingText }
+    @discardableResult
+    private func recordLivePreviewAudio(_ samples: [Float]) -> LivePreviewAudioGateSnapshot {
+        let activity = Self.livePreviewAudioActivity(in: samples)
+        return sharedState.withLock { state in
+            state.livePreviewAudioGate.update(with: activity)
+        }
+    }
+
+    private func currentLivePreviewAudioGateSnapshot() -> LivePreviewAudioGateSnapshot {
+        sharedState.withLock { $0.livePreviewAudioGate.snapshot }
+    }
+
+    @discardableResult
+    private func processPreviewUpdate(
+        _ text: String,
+        audioGate: LivePreviewAudioGateSnapshot?,
+        persist: Bool
+    ) -> Bool {
+        let preview = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !preview.isEmpty else { return false }
+
+        let confirmed = progressText.withLock { $0 }
+        let stable = Self.stabilizeText(confirmed: confirmed, new: preview)
+        if Self.shouldSuppressLivePreviewUpdate(confirmed: confirmed, stable: stable, audioGate: audioGate) {
+            logger.debug("Live transcript preview update suppressed during sustained silence")
+            return false
+        }
+
+        if persist {
+            progressText.withLock { $0 = stable }
+            sharedState.withLock { $0.confirmedStreamingText = stable }
+        }
+
+        Task { @MainActor [weak self] in
+            self?.onPartialTextUpdate?(stable)
+        }
+        return true
+    }
+
+    private nonisolated static func shouldRunFallbackPreview(for activity: LivePreviewAudioActivity) -> Bool {
+        activity.containsSpeech && activity.trailingQuietDuration < livePreviewSustainedSilenceDuration
+    }
+
+    private nonisolated static func shouldSuppressLivePreviewUpdate(
+        confirmed: String,
+        stable: String,
+        audioGate: LivePreviewAudioGateSnapshot?
+    ) -> Bool {
+        guard let audioGate, audioGate.suppressesAdditivePreview else { return false }
+
+        let confirmed = confirmed.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stable = stable.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stable.isEmpty else { return false }
+
+        let confirmedWordCount = transcriptWords(in: confirmed).count
+        let stableWordCount = transcriptWords(in: stable).count
+        guard stableWordCount > confirmedWordCount else { return false }
+
+        return confirmed.isEmpty || stable.hasPrefix(confirmed)
+    }
+
+    private nonisolated static func livePreviewAudioActivity(in samples: [Float]) -> LivePreviewAudioActivity {
+        guard !samples.isEmpty else {
+            return LivePreviewAudioActivity(duration: 0, containsSpeech: false, trailingQuietDuration: 0)
+        }
+
+        let frameSize = max(1, Int(livePreviewSampleRate * livePreviewAnalysisFrameDuration))
+        let duration = Double(samples.count) / livePreviewSampleRate
+        var containsSpeech = false
+        var trailingQuietDuration: TimeInterval = 0
+
+        var offset = 0
+        while offset < samples.count {
+            let end = min(samples.count, offset + frameSize)
+            let frame = samples[offset..<end]
+            let rms = sqrt(frame.reduce(Float(0)) { $0 + $1 * $1 } / Float(frame.count))
+            let frameDuration = Double(end - offset) / livePreviewSampleRate
+
+            if rms >= livePreviewSpeechRMSFloor {
+                containsSpeech = true
+                trailingQuietDuration = 0
+            } else {
+                trailingQuietDuration += frameDuration
+            }
+
+            offset = end
+        }
+
+        return LivePreviewAudioActivity(
+            duration: duration,
+            containsSpeech: containsSpeech,
+            trailingQuietDuration: trailingQuietDuration
+        )
     }
 
     /// Keeps confirmed text stable and only appends new content.
     nonisolated static func stabilizeText(confirmed: String, new: String) -> String {
+        let confirmed = confirmed.trimmingCharacters(in: .whitespacesAndNewlines)
         let new = new.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !confirmed.isEmpty else { return new }
         guard !new.isEmpty else { return confirmed }
 
+        if new == confirmed { return confirmed }
         if new.hasPrefix(confirmed) { return new }
+        if confirmed.hasPrefix(new) || confirmed.contains(new) { return confirmed }
 
-        let confirmedChars = Array(confirmed.unicodeScalars)
-        let newChars = Array(new.unicodeScalars)
-        var matchEnd = 0
-        for i in 0..<min(confirmedChars.count, newChars.count) {
-            if confirmedChars[i] == newChars[i] {
-                matchEnd = i + 1
-            } else {
-                break
+        if looksLikeProviderCorrection(confirmed: confirmed, new: new) {
+            return new
+        }
+
+        if let overlapLength = suffixPrefixOverlapLength(confirmed: confirmed, new: new) {
+            let newTail = String(new.unicodeScalars.dropFirst(overlapLength))
+            return appendPreviewText(confirmed, newTail)
+        }
+
+        if let fuzzyOverlapTail = fuzzyWordOverlapTail(confirmed: confirmed, new: new) {
+            return appendPreviewText(confirmed, fuzzyOverlapTail)
+        }
+
+        if let repeatedPrefixTail = repeatedEarlierPrefixTail(confirmed: confirmed, new: new) {
+            return appendPreviewText(confirmed, repeatedPrefixTail)
+        }
+
+        return appendPreviewText(confirmed, new)
+    }
+
+    private nonisolated static func looksLikeProviderCorrection(confirmed: String, new: String) -> Bool {
+        let confirmedScalars = Array(confirmed.unicodeScalars)
+        let newScalars = Array(new.unicodeScalars)
+        let shortestCount = min(confirmedScalars.count, newScalars.count)
+        guard shortestCount > 0 else { return false }
+
+        var commonPrefixCount = 0
+        for index in 0..<shortestCount {
+            guard confirmedScalars[index] == newScalars[index] else { break }
+            commonPrefixCount += 1
+        }
+
+        let minimumCommonPrefix = max(8, shortestCount / 2)
+        let lengthRatio = Double(max(confirmedScalars.count, newScalars.count)) / Double(shortestCount)
+        if commonPrefixCount >= minimumCommonPrefix && lengthRatio <= 1.6 {
+            return true
+        }
+
+        return looksLikeProviderCorrectionByWords(confirmed: confirmed, new: new)
+    }
+
+    private nonisolated static func looksLikeProviderCorrectionByWords(confirmed: String, new: String) -> Bool {
+        let confirmedWords = transcriptWords(in: confirmed)
+        let newWords = transcriptWords(in: new)
+        guard confirmedWords.count >= 4, newWords.count >= 4 else { return false }
+
+        let matchedCount = approximateWordMatchCount(newWords, in: confirmedWords)
+        let newCoverage = Double(matchedCount) / Double(newWords.count)
+        let confirmedCoverage = Double(matchedCount) / Double(confirmedWords.count)
+        let wordCountRatio = Double(max(confirmedWords.count, newWords.count)) / Double(min(confirmedWords.count, newWords.count))
+
+        return newCoverage >= 0.72 && confirmedCoverage >= 0.60 && wordCountRatio <= 1.5
+    }
+
+    private nonisolated static func approximateWordMatchCount(
+        _ lhs: [(normalized: String, endIndex: String.Index)],
+        in rhs: [(normalized: String, endIndex: String.Index)]
+    ) -> Int {
+        guard !lhs.isEmpty, !rhs.isEmpty else { return 0 }
+
+        var previous = Array(repeating: 0, count: rhs.count + 1)
+        for lhsWord in lhs {
+            var current = Array(repeating: 0, count: rhs.count + 1)
+            for rhsIndex in rhs.indices {
+                let currentIndex = rhsIndex + 1
+                if transcriptWordsMatch(lhsWord.normalized, rhs[rhsIndex].normalized) {
+                    current[currentIndex] = previous[currentIndex - 1] + 1
+                } else {
+                    current[currentIndex] = max(previous[currentIndex], current[currentIndex - 1])
+                }
+            }
+            previous = current
+        }
+
+        return previous[rhs.count]
+    }
+
+    private nonisolated static func suffixPrefixOverlapLength(confirmed: String, new: String) -> Int? {
+        let confirmedScalars = Array(confirmed.unicodeScalars)
+        let newScalars = Array(new.unicodeScalars)
+        let maxOverlap = min(confirmedScalars.count, newScalars.count)
+        guard maxOverlap > 0 else { return nil }
+
+        let minimumOverlap = min(maxOverlap, max(8, min(20, maxOverlap / 4)))
+        guard minimumOverlap <= maxOverlap else { return nil }
+
+        for overlapLength in stride(from: maxOverlap, through: minimumOverlap, by: -1) {
+            let suffix = Array(confirmedScalars.suffix(overlapLength))
+            let prefix = Array(newScalars.prefix(overlapLength))
+            if suffix == prefix {
+                return overlapLength
             }
         }
 
-        if matchEnd > confirmed.count / 2 {
-            let newContent = String(new.unicodeScalars.dropFirst(matchEnd))
-            return confirmed + newContent
+        return nil
+    }
+
+    private nonisolated static func fuzzyWordOverlapTail(confirmed: String, new: String) -> String? {
+        let confirmedWords = transcriptWords(in: confirmed)
+        let newWords = transcriptWords(in: new)
+        let maxPrefixCount = min(confirmedWords.count, newWords.count, 8)
+        guard maxPrefixCount >= 2 else { return nil }
+
+        for prefixCount in stride(from: maxPrefixCount, through: 2, by: -1) {
+            let newPrefix = Array(newWords.prefix(prefixCount))
+            let maxConfirmedWindowCount = min(confirmedWords.count, prefixCount + 2)
+
+            for confirmedWindowCount in stride(from: maxConfirmedWindowCount, through: prefixCount, by: -1) {
+                let confirmedSuffix = Array(confirmedWords.suffix(confirmedWindowCount))
+                guard newPrefixWords(newPrefix, matchAsSubsequenceOf: confirmedSuffix) else {
+                    continue
+                }
+
+                let tailStart = newPrefix.last?.endIndex ?? new.startIndex
+                let tail = String(new[tailStart...])
+                return tail.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
         }
 
-        let minOverlap = min(20, confirmedChars.count / 4)
-        let maxShift = min(confirmedChars.count - minOverlap, 150)
-        if maxShift > 0 {
-            for dropCount in 1...maxShift {
-                let suffix = String(confirmed.unicodeScalars.dropFirst(dropCount))
-                if new.hasPrefix(suffix) {
-                    let newTail = String(new.unicodeScalars.dropFirst(confirmed.unicodeScalars.count - dropCount))
-                    return newTail.isEmpty ? confirmed : confirmed + newTail
+        return nil
+    }
+
+    private nonisolated static func repeatedEarlierPrefixTail(confirmed: String, new: String) -> String? {
+        let confirmedWords = transcriptWords(in: confirmed)
+        let newWords = transcriptWords(in: new)
+        guard confirmedWords.count >= 6, newWords.count >= 6 else { return nil }
+
+        let firstSentenceCount = firstSentenceWordCount(in: new, words: newWords)
+        let maxPrefixCount = min(firstSentenceCount ?? (newWords.count - 1), 14)
+        guard maxPrefixCount >= 6 else { return nil }
+
+        for prefixCount in stride(from: maxPrefixCount, through: 6, by: -1) {
+            let newPrefix = Array(newWords.prefix(prefixCount))
+            let maxConfirmedWindowCount = min(confirmedWords.count, prefixCount + 4)
+
+            for confirmedWindowCount in stride(from: maxConfirmedWindowCount, through: prefixCount, by: -1) {
+                guard confirmedWords.count >= confirmedWindowCount else { continue }
+
+                for startIndex in 0...(confirmedWords.count - confirmedWindowCount) {
+                    let endIndex = startIndex + confirmedWindowCount
+                    let confirmedWindow = Array(confirmedWords[startIndex..<endIndex])
+                    guard newPrefixWords(newPrefix, matchAsSubsequenceOf: confirmedWindow) else {
+                        continue
+                    }
+
+                    let tailStart = newPrefix.last?.endIndex ?? new.startIndex
+                    return String(new[tailStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
                 }
             }
         }
 
-        return new
+        return nil
+    }
+
+    private nonisolated static func firstSentenceWordCount(
+        in text: String,
+        words: [(normalized: String, endIndex: String.Index)]
+    ) -> Int? {
+        guard let sentenceEnd = text.firstIndex(where: { ".!?".contains($0) }) else {
+            return nil
+        }
+
+        let count = words.prefix { $0.endIndex <= sentenceEnd }.count
+        return count > 0 ? count : nil
+    }
+
+    private nonisolated static func newPrefixWords(
+        _ newPrefix: [(normalized: String, endIndex: String.Index)],
+        matchAsSubsequenceOf confirmedSuffix: [(normalized: String, endIndex: String.Index)]
+    ) -> Bool {
+        var searchIndex = confirmedSuffix.startIndex
+        var matchedCount = 0
+        var skippedNewWords = 0
+        var lastMatchedNewWordIndex: Int?
+        let allowedSkippedNewWords = min(2, max(0, newPrefix.count / 3))
+
+        for (newWordIndex, word) in newPrefix.enumerated() {
+            guard searchIndex < confirmedSuffix.endIndex,
+                  let matchIndex = confirmedSuffix[searchIndex...].firstIndex(where: {
+                      transcriptWordsMatch($0.normalized, word.normalized)
+                  }) else {
+                skippedNewWords += 1
+                guard skippedNewWords <= allowedSkippedNewWords else { return false }
+                continue
+            }
+            matchedCount += 1
+            lastMatchedNewWordIndex = newWordIndex
+            searchIndex = confirmedSuffix.index(after: matchIndex)
+        }
+
+        return matchedCount >= max(2, newPrefix.count - allowedSkippedNewWords)
+            && lastMatchedNewWordIndex == newPrefix.count - 1
+    }
+
+    private nonisolated static func transcriptWordsMatch(_ lhs: String, _ rhs: String) -> Bool {
+        if lhs == rhs { return true }
+
+        let lhsCount = lhs.count
+        let rhsCount = rhs.count
+        let shorterCount = min(lhsCount, rhsCount)
+        let longerCount = max(lhsCount, rhsCount)
+        guard shorterCount >= 4, longerCount - shorterCount <= 2 else { return false }
+
+        return lhs.hasPrefix(rhs) || rhs.hasPrefix(lhs)
+    }
+
+    private nonisolated static func transcriptWords(in text: String) -> [(normalized: String, endIndex: String.Index)] {
+        var words: [(normalized: String, endIndex: String.Index)] = []
+        var wordStart: String.Index?
+
+        var index = text.startIndex
+        while index < text.endIndex {
+            let scalar = text[index].unicodeScalars.first
+            let isWordCharacter = scalar.map {
+                CharacterSet.alphanumerics.contains($0) || $0 == "'"
+            } ?? false
+
+            if isWordCharacter {
+                if wordStart == nil { wordStart = index }
+            } else if let start = wordStart {
+                appendTranscriptWord(from: start, to: index, in: text, to: &words)
+                wordStart = nil
+            }
+
+            index = text.index(after: index)
+        }
+
+        if let start = wordStart {
+            appendTranscriptWord(from: start, to: text.endIndex, in: text, to: &words)
+        }
+
+        return words
+    }
+
+    private nonisolated static func appendTranscriptWord(
+        from start: String.Index,
+        to end: String.Index,
+        in text: String,
+        to words: inout [(normalized: String, endIndex: String.Index)]
+    ) {
+        let normalized = String(text[start..<end])
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+        guard !normalized.isEmpty else { return }
+        words.append((normalized, end))
+    }
+
+    private nonisolated static func appendPreviewText(_ confirmed: String, _ newTail: String) -> String {
+        var tail = newTail.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tail.isEmpty else { return confirmed }
+
+        if let firstScalar = tail.unicodeScalars.first,
+           let lastScalar = confirmed.trimmingCharacters(in: .whitespacesAndNewlines).unicodeScalars.last,
+           CharacterSet.punctuationCharacters.contains(firstScalar),
+           firstScalar == lastScalar {
+            tail.removeFirst()
+            tail = tail.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !tail.isEmpty else { return confirmed }
+        }
+
+        if let firstScalar = tail.unicodeScalars.first,
+           CharacterSet.punctuationCharacters.contains(firstScalar) {
+            return confirmed + tail
+        }
+
+        return confirmed + " " + tail
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
@@ -9,6 +9,26 @@ struct PluginHotkey: Codable, Equatable {
     let modifierFlags: UInt
 }
 
+// MARK: - Appearance
+
+private enum LiveTranscriptAppearance {
+    static let defaultFontSize = 14.0
+    static let defaultWindowWidth = 420.0
+    static let defaultWindowHeight = 320.0
+    static let defaultBackgroundOpacity = 0.92
+
+    static let fontSizeRange = 10.0...24.0
+    static let windowWidthRange = 300.0...900.0
+    static let windowHeightRange = 180.0...650.0
+    static let backgroundOpacityRange = 0.20...0.95
+
+    static let minimumWindowSize = NSSize(width: 250, height: 150)
+
+    static func clamped(_ value: Double, to range: ClosedRange<Double>) -> Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+}
+
 // MARK: - Plugin Entry Point
 
 @objc(LiveTranscriptPlugin)
@@ -23,7 +43,10 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     private var autoCloseTask: Task<Void, Never>?
 
     fileprivate var _autoOpen: Bool = false
-    fileprivate var _fontSize: Double = 14.0
+    fileprivate var _fontSize: Double = LiveTranscriptAppearance.defaultFontSize
+    fileprivate var _windowWidth: Double = LiveTranscriptAppearance.defaultWindowWidth
+    fileprivate var _windowHeight: Double = LiveTranscriptAppearance.defaultWindowHeight
+    fileprivate var _backgroundOpacity: Double = LiveTranscriptAppearance.defaultBackgroundOpacity
     private let autoCloseDelay: Double = 4.0
 
     fileprivate var toggleHotkey: PluginHotkey?
@@ -31,6 +54,7 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     private var localMonitor: Any?
     private var hotkeyIsDown: Bool = false
     private var streamingDisplayActive = false
+    private var hasCompletedTranscript = false
 
     required override init() {
         super.init()
@@ -39,7 +63,30 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     func activate(host: HostServices) {
         self.host = host
         _autoOpen = host.userDefault(forKey: "autoOpen") as? Bool ?? false
-        _fontSize = host.userDefault(forKey: "fontSize") as? Double ?? 14.0
+        _fontSize = Self.clampedUserDefault(
+            host,
+            key: "fontSize",
+            defaultValue: LiveTranscriptAppearance.defaultFontSize,
+            range: LiveTranscriptAppearance.fontSizeRange
+        )
+        _windowWidth = Self.clampedUserDefault(
+            host,
+            key: "windowWidth",
+            defaultValue: LiveTranscriptAppearance.defaultWindowWidth,
+            range: LiveTranscriptAppearance.windowWidthRange
+        )
+        _windowHeight = Self.clampedUserDefault(
+            host,
+            key: "windowHeight",
+            defaultValue: LiveTranscriptAppearance.defaultWindowHeight,
+            range: LiveTranscriptAppearance.windowHeightRange
+        )
+        _backgroundOpacity = Self.clampedUserDefault(
+            host,
+            key: "backgroundOpacity",
+            defaultValue: LiveTranscriptAppearance.defaultBackgroundOpacity,
+            range: LiveTranscriptAppearance.backgroundOpacityRange
+        )
 
         if let data = host.userDefault(forKey: "toggleHotkey") as? Data {
             toggleHotkey = try? JSONDecoder().decode(PluginHotkey.self, from: data)
@@ -74,10 +121,47 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     }
 
     @MainActor
+    var displayedTextForTesting: String {
+        viewModel?.paragraphs.map(\.text).joined(separator: " ") ?? ""
+    }
+
+    var appearanceForTesting: (fontSize: Double, windowWidth: Double, windowHeight: Double, backgroundOpacity: Double) {
+        (_fontSize, _windowWidth, _windowHeight, _backgroundOpacity)
+    }
+
+    @MainActor
     func updateAutoOpenPreference(_ enabled: Bool) {
         _autoOpen = enabled
         host?.setUserDefault(enabled, forKey: "autoOpen")
         refreshStreamingDisplayActive()
+    }
+
+    @MainActor
+    func updateFontSizePreference(_ value: Double) {
+        _fontSize = LiveTranscriptAppearance.clamped(value, to: LiveTranscriptAppearance.fontSizeRange)
+        host?.setUserDefault(_fontSize, forKey: "fontSize")
+        applyAppearanceToVisiblePanel()
+    }
+
+    @MainActor
+    func updateWindowWidthPreference(_ value: Double) {
+        _windowWidth = LiveTranscriptAppearance.clamped(value, to: LiveTranscriptAppearance.windowWidthRange)
+        host?.setUserDefault(_windowWidth, forKey: "windowWidth")
+        applyAppearanceToVisiblePanel(applyWindowSize: true)
+    }
+
+    @MainActor
+    func updateWindowHeightPreference(_ value: Double) {
+        _windowHeight = LiveTranscriptAppearance.clamped(value, to: LiveTranscriptAppearance.windowHeightRange)
+        host?.setUserDefault(_windowHeight, forKey: "windowHeight")
+        applyAppearanceToVisiblePanel(applyWindowSize: true)
+    }
+
+    @MainActor
+    func updateBackgroundOpacityPreference(_ value: Double) {
+        _backgroundOpacity = LiveTranscriptAppearance.clamped(value, to: LiveTranscriptAppearance.backgroundOpacityRange)
+        host?.setUserDefault(_backgroundOpacity, forKey: "backgroundOpacity")
+        applyAppearanceToVisiblePanel()
     }
 
     private func setStreamingDisplayActiveIfNeeded(_ active: Bool) {
@@ -91,6 +175,24 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
         setStreamingDisplayActiveIfNeeded(_autoOpen || panel?.isVisible == true)
     }
 
+    private static func clampedUserDefault(
+        _ host: HostServices,
+        key: String,
+        defaultValue: Double,
+        range: ClosedRange<Double>
+    ) -> Double {
+        let rawValue: Double?
+        if let value = host.userDefault(forKey: key) as? Double {
+            rawValue = value
+        } else if let value = host.userDefault(forKey: key) as? Int {
+            rawValue = Double(value)
+        } else {
+            rawValue = nil
+        }
+
+        return LiveTranscriptAppearance.clamped(rawValue ?? defaultValue, to: range)
+    }
+
     // MARK: - Event Handling
 
     @MainActor
@@ -98,12 +200,19 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
         switch event {
         case .recordingStarted:
             autoCloseTask?.cancel()
+            hasCompletedTranscript = false
             if _autoOpen { showPanel() }
             viewModel?.reset()
 
         case .partialTranscriptionUpdate(let payload):
+            guard !hasCompletedTranscript else { return }
             viewModel?.updateText(payload.text, isFinal: payload.isFinal)
             if payload.isFinal { scheduleAutoClose() }
+
+        case .transcriptionCompleted(let payload):
+            hasCompletedTranscript = true
+            viewModel?.updateText(payload.finalText, isFinal: true)
+            scheduleAutoClose()
 
         case .recordingStopped:
             scheduleAutoClose()
@@ -118,12 +227,28 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     @MainActor
     private func showPanel() {
         if panel == nil {
-            let vm = viewModel ?? LiveTranscriptViewModel()
+            let vm = viewModel ?? LiveTranscriptViewModel(
+                fontSize: _fontSize,
+                backgroundOpacity: _backgroundOpacity
+            )
             viewModel = vm
-            panel = LiveTranscriptPanel(viewModel: vm, fontSize: _fontSize)
+            panel = LiveTranscriptPanel(viewModel: vm, windowSize: configuredWindowSize)
         }
+        applyAppearanceToVisiblePanel()
         panel?.orderFront(nil)
         refreshStreamingDisplayActive()
+    }
+
+    private var configuredWindowSize: NSSize {
+        NSSize(width: _windowWidth, height: _windowHeight)
+    }
+
+    @MainActor
+    private func applyAppearanceToVisiblePanel(applyWindowSize: Bool = false) {
+        viewModel?.updateAppearance(fontSize: _fontSize, backgroundOpacity: _backgroundOpacity)
+        if applyWindowSize {
+            panel?.applyWindowSize(configuredWindowSize)
+        }
     }
 
     @MainActor
@@ -245,12 +370,10 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
 final class LiveTranscriptViewModel: ObservableObject {
     @Published var paragraphs: [TranscriptParagraph] = []
     @Published var isAutoScrollEnabled: Bool = true
+    @Published var fontSize: Double
+    @Published var backgroundOpacity: Double
 
-    private var confirmedSentences: [String] = []
-    private var mutableSentences: [String] = []
-    private var liveTail: String?
-    private var recentTexts: [String] = []
-    private let sentencesPerParagraph: Int = 3
+    private var currentText: String?
 
     struct TranscriptParagraph: Identifiable {
         let id: UUID
@@ -262,12 +385,22 @@ final class LiveTranscriptViewModel: ObservableObject {
         }
     }
 
+    init(
+        fontSize: Double = LiveTranscriptAppearance.defaultFontSize,
+        backgroundOpacity: Double = LiveTranscriptAppearance.defaultBackgroundOpacity
+    ) {
+        self.fontSize = fontSize
+        self.backgroundOpacity = backgroundOpacity
+    }
+
+    func updateAppearance(fontSize: Double, backgroundOpacity: Double) {
+        self.fontSize = fontSize
+        self.backgroundOpacity = backgroundOpacity
+    }
+
     func reset() {
         paragraphs = []
-        confirmedSentences = []
-        mutableSentences = []
-        liveTail = nil
-        recentTexts = []
+        currentText = nil
         isAutoScrollEnabled = true
     }
 
@@ -275,375 +408,101 @@ final class LiveTranscriptViewModel: ObservableObject {
         isAutoScrollEnabled = true
     }
 
-    func updateText(_ fullText: String, isFinal: Bool) {
-        let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-
-        let cleaned = removeConsecutiveDuplicateSentences(trimmed)
-        guard !cleaned.isEmpty else { return }
-
-        // Ring buffer dedup: ignore exact duplicates
-        if recentTexts.contains(cleaned) { return }
-
-        let previousRenderedText = renderedText()
-        let segments = splitIntoCompletedSentencesAndTail(cleaned)
-
-        mergeCompletedSentences(segments.completed, isFinal: isFinal)
-        mergeLiveTail(segments.tail)
-
-        let merged = renderedText()
-        guard merged != previousRenderedText else {
-            return
-        }
-
-        recentTexts.append(cleaned)
-        if recentTexts.count > 3 { recentTexts.removeFirst() }
-
-        let renderedSegments = completedSentences() + (liveTail.map { [$0] } ?? [])
-        var newTexts = splitSegmentsIntoParagraphs(renderedSegments, sentencesPerParagraph: sentencesPerParagraph)
-        if newTexts.isEmpty { newTexts = [merged] }
-
-        paragraphs = reconcileParagraphs(old: paragraphs, new: newTexts)
-    }
-
-    // MARK: - Helpers
-
-    private func mergeCompletedSentences(_ incomingSentences: [String], isFinal: Bool) {
-        let incoming = deduplicatedSentences(incomingSentences)
-        guard !incoming.isEmpty else { return }
-
-        var working = completedSentences()
-        if working.isEmpty || isCumulativeReplacement(incoming, previous: working) {
-            working = incoming
-        } else if let replacement = replacementMatch(
-            previous: working,
-            incoming: incoming,
-            minimumStartIndex: confirmedSentences.count
-        ) {
-            working = Array(working.prefix(replacement.startIndex)) + incoming
-        } else {
-            for sentence in incoming where !isAlreadyRepresented(sentence, in: working) {
-                working.append(sentence)
-            }
-        }
-
-        applyCompletedSentences(working, isFinal: isFinal)
-        liveTail = nil
-    }
-
-    private func mergeLiveTail(_ tail: String?) {
-        guard let tail = tail?.trimmingCharacters(in: .whitespacesAndNewlines), !tail.isEmpty else {
-            liveTail = nil
-            return
-        }
-
-        if isAlreadyRepresented(tail) {
-            liveTail = nil
-            return
-        }
-
-        if let current = liveTail {
-            if tail.hasPrefix(current) || sentenceKey(tail) == sentenceKey(current) {
-                liveTail = tail
-                return
-            }
-            if current.hasPrefix(tail) {
-                return
-            }
-        }
-
-        liveTail = tail
-    }
-
-    private func completedSentences() -> [String] {
-        confirmedSentences + mutableSentences
-    }
-
-    private func applyCompletedSentences(_ sentences: [String], isFinal: Bool) {
-        if isFinal || sentences.count <= sentencesPerParagraph {
-            confirmedSentences = isFinal ? sentences : []
-            mutableSentences = isFinal ? [] : sentences
-            return
-        }
-
-        confirmedSentences = Array(sentences.dropLast(sentencesPerParagraph))
-        mutableSentences = Array(sentences.suffix(sentencesPerParagraph))
-    }
-
-    private func isCumulativeReplacement(_ incoming: [String], previous: [String]) -> Bool {
-        guard incoming.count >= previous.count else { return false }
-        guard !previous.isEmpty else { return true }
-
-        for index in previous.indices {
-            guard sentenceKey(previous[index]) == sentenceKey(incoming[index]) else {
-                return false
-            }
-        }
-
-        return true
-    }
-
-    private func replacementMatch(
-        previous: [String],
-        incoming: [String],
-        minimumStartIndex: Int
-    ) -> (startIndex: Int, length: Int)? {
-        let maxLength = min(previous.count, incoming.count)
-        guard maxLength > 0 else { return nil }
-        guard minimumStartIndex < previous.count else { return nil }
-
-        for length in stride(from: maxLength, through: 2, by: -1) {
-            guard minimumStartIndex <= previous.count - length else { continue }
-            let incomingSlice = incoming.prefix(length)
-            for startIndex in minimumStartIndex...(previous.count - length) {
-                let previousSlice = previous[startIndex..<(startIndex + length)]
-                if zip(previousSlice, incomingSlice).allSatisfy(sentenceMatchesForSequence) {
-                    return (startIndex, length)
-                }
-            }
-        }
-
-        return nil
-    }
-
-    private func isAlreadyRepresented(_ sentence: String) -> Bool {
-        isAlreadyRepresented(sentence, in: completedSentences())
-    }
-
-    private func isAlreadyRepresented(_ sentence: String, in candidates: [String]) -> Bool {
-        candidates.contains { existing in
-            sentencesRepresentSameMeaning(existing, sentence) ||
-                isPartialDuplicate(existing: existing, incoming: sentence)
-        }
-    }
-
-    private func renderedText() -> String {
-        let segments = completedSentences() + (liveTail.map { [$0] } ?? [])
-        return segments.joined(separator: " ")
-    }
-
-    private func deduplicatedSentences(_ sentences: [String]) -> [String] {
-        var result: [String] = []
-        for sentence in sentences {
-            let isDuplicate = result.contains { sentencesRepresentSameMeaning($0, sentence) }
-            if !isDuplicate {
-                result.append(sentence)
-            }
-        }
-        return result
-    }
-
-    private func splitIntoCompletedSentencesAndTail(_ text: String) -> (completed: [String], tail: String?) {
-        var sentences: [String] = []
-        var currentStart = text.startIndex
-        var i = text.startIndex
-
-        while i < text.endIndex {
-            if text[i] == "." || text[i] == "!" || text[i] == "?" {
-                let sentenceEnd = text.index(after: i)
-                let sentence = String(text[currentStart..<sentenceEnd]).trimmingCharacters(in: .whitespaces)
-                if !sentence.isEmpty { sentences.append(sentence) }
-                currentStart = sentenceEnd
-            }
-            i = text.index(after: i)
-        }
-
-        let tail: String?
-        if currentStart < text.endIndex {
-            let remaining = String(text[currentStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
-            tail = remaining.isEmpty ? nil : remaining
-        } else {
-            tail = nil
-        }
-
-        return (sentences, tail)
-    }
-
-    private func splitSegmentsIntoParagraphs(_ segments: [String], sentencesPerParagraph: Int) -> [String] {
-        guard !segments.isEmpty else { return [] }
-
-        var paragraphs: [String] = []
-        var current: [String] = []
-
-        for segment in segments {
-            current.append(segment)
-            if current.count >= sentencesPerParagraph {
-                paragraphs.append(current.joined(separator: " "))
-                current.removeAll()
-            }
-        }
-
-        if !current.isEmpty {
-            paragraphs.append(current.joined(separator: " "))
-        }
-
-        return paragraphs
-    }
-
-    private func sentenceMatchesForSequence(_ a: String, _ b: String) -> Bool {
-        if sentenceKey(a) == sentenceKey(b) {
-            return true
-        }
-        return sentencesRepresentSameMeaning(a, b) ||
-            isPartialDuplicate(existing: a, incoming: b) ||
-            isPartialDuplicate(existing: b, incoming: a)
-    }
-
-    private func sentencesRepresentSameMeaning(_ a: String, _ b: String) -> Bool {
-        let aWords = sentenceWords(a)
-        let bWords = sentenceWords(b)
-        guard aWords.count >= 2 && bWords.count >= 2 else { return false }
-
-        if sentenceKey(a) == sentenceKey(b) {
-            return true
-        }
-
-        return isSimilarSentence(a, b)
-    }
-
-    private func isPartialDuplicate(existing: String, incoming: String) -> Bool {
-        let existingWords = sentenceWords(existing)
-        let incomingWords = sentenceWords(incoming)
-        guard existingWords.count >= 4 && incomingWords.count >= 4 else { return false }
-
-        var matchedIndexes = Set<Int>()
-        var matchCount = 0
-
-        for incomingWord in incomingWords {
-            guard let matchIndex = existingWords.indices.first(where: { index in
-                !matchedIndexes.contains(index) && tokensMatch(existingWords[index], incomingWord)
-            }) else {
-                continue
-            }
-
-            matchedIndexes.insert(matchIndex)
-            matchCount += 1
-        }
-
-        let coverage = Double(matchCount) / Double(incomingWords.count)
-        return matchCount >= 4 && coverage >= 0.6
-    }
-
-    private func sentenceKey(_ sentence: String) -> String {
-        sentenceWords(sentence).joined(separator: " ")
-    }
-
-    private func sentenceWords(_ sentence: String) -> [String] {
-        sentence.lowercased().split(separator: " ").compactMap { rawWord in
-            let word = rawWord.trimmingCharacters(in: .punctuationCharacters)
-            return word.isEmpty ? nil : word
-        }
-    }
-
-    private func tokensMatch(_ a: String, _ b: String) -> Bool {
-        if a == b { return true }
-
-        let shortest = min(a.count, b.count)
-        let longest = max(a.count, b.count)
-        guard shortest >= 4 else { return false }
-
-        let allowedDistance = max(1, longest / 4)
-        return levenshteinDistance(a, b) <= allowedDistance
-    }
-
-    private func levenshteinDistance(_ a: String, _ b: String) -> Int {
-        let aChars = Array(a)
-        let bChars = Array(b)
-
-        if aChars.isEmpty { return bChars.count }
-        if bChars.isEmpty { return aChars.count }
-
-        var previousRow = Array(0...bChars.count)
-        var currentRow = Array(repeating: 0, count: bChars.count + 1)
-
-        for (aIndex, aChar) in aChars.enumerated() {
-            currentRow[0] = aIndex + 1
-
-            for (bIndex, bChar) in bChars.enumerated() {
-                let substitutionCost = aChar == bChar ? 0 : 1
-                currentRow[bIndex + 1] = min(
-                    previousRow[bIndex + 1] + 1,
-                    currentRow[bIndex] + 1,
-                    previousRow[bIndex] + substitutionCost
-                )
-            }
-
-            previousRow = currentRow
-        }
-
-        return previousRow[bChars.count]
-    }
-
-    private func removeConsecutiveDuplicateSentences(_ text: String) -> String {
-        let sentences = splitIntoSentences(text)
-        guard sentences.count >= 2 else { return text }
-
-        var result: [String] = [sentences[0]]
-        for i in 1..<sentences.count {
-            let isDuplicate = result.contains { isSimilarSentence($0, sentences[i]) }
-            if !isDuplicate {
-                result.append(sentences[i])
-            }
-        }
-
-        return result.joined(separator: " ")
-    }
-
-    private func splitIntoSentences(_ text: String) -> [String] {
-        var sentences: [String] = []
-        var currentStart = text.startIndex
-        var i = text.startIndex
-
-        while i < text.endIndex {
-            if text[i] == "." || text[i] == "!" || text[i] == "?" {
-                let sentenceEnd = text.index(after: i)
-                let sentence = String(text[currentStart..<sentenceEnd]).trimmingCharacters(in: .whitespaces)
-                if !sentence.isEmpty { sentences.append(sentence) }
-                currentStart = sentenceEnd
-            }
-            i = text.index(after: i)
-        }
-
-        if currentStart < text.endIndex {
-            let remaining = String(text[currentStart...]).trimmingCharacters(in: .whitespaces)
-            if !remaining.isEmpty { sentences.append(remaining) }
-        }
-
-        return sentences
-    }
-
-    private func isSimilarSentence(_ a: String, _ b: String) -> Bool {
-        let aWords = Set(sentenceWords(a))
-        let bWords = Set(sentenceWords(b))
-
-        guard aWords.count >= 2 && bWords.count >= 2 else { return false }
-
-        let intersection = aWords.intersection(bWords)
-        let similarity = Double(intersection.count) / Double(max(aWords.count, bWords.count))
-        return similarity >= 0.7
-    }
-
-    private func reconcileParagraphs(old: [TranscriptParagraph], new: [String]) -> [TranscriptParagraph] {
-        var result: [TranscriptParagraph] = []
-        for (index, text) in new.enumerated() {
-            if index < old.count && old[index].text == text {
-                result.append(old[index])
-            } else if index < old.count {
-                result.append(TranscriptParagraph(id: old[index].id, text: text))
-            } else {
-                result.append(TranscriptParagraph(text: text))
-            }
-        }
-        return result
+    func updateText(_ fullText: String, isFinal _: Bool) {
+        let text = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, text != currentText else { return }
+
+        currentText = text
+        paragraphs = [TranscriptParagraph(id: paragraphs.first?.id ?? UUID(), text: text)]
     }
 }
 
 // MARK: - Panel
 
-final class LiveTranscriptPanel: NSPanel {
-    init(viewModel: LiveTranscriptViewModel, fontSize: Double) {
+enum LiveTranscriptPanelFrameStore {
+    static func defaultsKey(for autosaveName: String) -> String {
+        "LiveTranscriptPanelFrame.\(autosaveName)"
+    }
+
+    static func storedString(for frame: NSRect) -> String {
+        NSStringFromRect(frame)
+    }
+
+    static func restorableFrame(
+        from storedString: String?,
+        screenVisibleFrames: [NSRect],
+        minimumSize: NSSize
+    ) -> NSRect? {
+        guard let storedString, !storedString.isEmpty else { return nil }
+
+        let storedFrame = NSRectFromString(storedString)
+        guard isFinite(storedFrame) else { return nil }
+        guard storedFrame.width > 0, storedFrame.height > 0 else { return nil }
+
+        let frame = NSRect(
+            x: storedFrame.minX,
+            y: storedFrame.minY,
+            width: max(storedFrame.width, minimumSize.width),
+            height: max(storedFrame.height, minimumSize.height)
+        )
+        guard isVisibleEnough(frame, in: screenVisibleFrames) else { return nil }
+
+        return frame
+    }
+
+    static func restore(
+        autosaveName: String,
+        defaults: UserDefaults = .standard,
+        screenVisibleFrames: [NSRect] = NSScreen.screens.map(\.visibleFrame),
+        minimumSize: NSSize
+    ) -> NSRect? {
+        restorableFrame(
+            from: defaults.string(forKey: defaultsKey(for: autosaveName)),
+            screenVisibleFrames: screenVisibleFrames,
+            minimumSize: minimumSize
+        )
+    }
+
+    static func save(frame: NSRect, autosaveName: String, defaults: UserDefaults = .standard) {
+        defaults.set(storedString(for: frame), forKey: defaultsKey(for: autosaveName))
+    }
+
+    private static func isFinite(_ frame: NSRect) -> Bool {
+        frame.minX.isFinite &&
+            frame.minY.isFinite &&
+            frame.width.isFinite &&
+            frame.height.isFinite
+    }
+
+    private static func isVisibleEnough(_ frame: NSRect, in screenVisibleFrames: [NSRect]) -> Bool {
+        guard !screenVisibleFrames.isEmpty else { return true }
+
+        let minimumVisibleWidth = min(80.0, max(1.0, frame.width))
+        let minimumVisibleHeight = min(80.0, max(1.0, frame.height))
+
+        return screenVisibleFrames.contains { screenFrame in
+            let intersection = frame.intersection(screenFrame)
+            return !intersection.isNull &&
+                !intersection.isEmpty &&
+                intersection.width >= minimumVisibleWidth &&
+                intersection.height >= minimumVisibleHeight
+        }
+    }
+}
+
+final class LiveTranscriptPanel: NSPanel, NSWindowDelegate {
+    private let transcriptFrameAutosaveName: String
+    private var shouldPersistFrameChanges = false
+
+    init(
+        viewModel: LiveTranscriptViewModel,
+        windowSize: NSSize,
+        frameAutosaveName: String = "LiveTranscriptPanel"
+    ) {
+        self.transcriptFrameAutosaveName = frameAutosaveName
+
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 320),
+            contentRect: NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height),
             styleMask: [.resizable, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -659,26 +518,57 @@ final class LiveTranscriptPanel: NSPanel {
         hidesOnDeactivate = false
         isMovableByWindowBackground = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        minSize = NSSize(width: 250, height: 150)
+        minSize = LiveTranscriptAppearance.minimumWindowSize
         animationBehavior = .utilityWindow
-        setFrameAutosaveName("LiveTranscriptPanel")
+        delegate = self
 
-        let hostingView = NSHostingView(rootView: LiveTranscriptView(viewModel: viewModel, fontSize: fontSize))
+        let hostingView = NSHostingView(rootView: LiveTranscriptView(viewModel: viewModel))
         hostingView.sizingOptions = []
         contentView = hostingView
 
-        center()
+        if let savedFrame = LiveTranscriptPanelFrameStore.restore(
+            autosaveName: frameAutosaveName,
+            minimumSize: LiveTranscriptAppearance.minimumWindowSize
+        ) {
+            setFrame(savedFrame, display: false)
+        } else {
+            center()
+        }
+        shouldPersistFrameChanges = true
+        persistCurrentFrame()
     }
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    func windowDidMove(_: Notification) {
+        persistCurrentFrame()
+    }
+
+    func windowDidResize(_: Notification) {
+        persistCurrentFrame()
+    }
+
+    override func close() {
+        persistCurrentFrame()
+        delegate = nil
+        super.close()
+    }
+
+    func applyWindowSize(_ size: NSSize) {
+        setContentSize(size)
+    }
+
+    private func persistCurrentFrame() {
+        guard shouldPersistFrameChanges else { return }
+        LiveTranscriptPanelFrameStore.save(frame: frame, autosaveName: transcriptFrameAutosaveName)
+    }
 }
 
 // MARK: - Main View
 
 struct LiveTranscriptView: View {
     @ObservedObject var viewModel: LiveTranscriptViewModel
-    let fontSize: Double
     private let bundle = pluginModuleBundle
 
     var body: some View {
@@ -687,7 +577,7 @@ struct LiveTranscriptView: View {
                 LazyVStack(alignment: .leading, spacing: 12) {
                     ForEach(viewModel.paragraphs) { paragraph in
                         Text(paragraph.text)
-                            .font(.system(size: CGFloat(fontSize)))
+                            .font(.system(size: CGFloat(viewModel.fontSize)))
                             .foregroundStyle(.white.opacity(0.85))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .fixedSize(horizontal: false, vertical: true)
@@ -746,7 +636,7 @@ struct LiveTranscriptView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(Color.black.opacity(0.92))
+                .fill(Color.black.opacity(viewModel.backgroundOpacity))
         )
     }
 }
@@ -806,76 +696,132 @@ private struct ScrollWheelDetector: NSViewRepresentable {
 private struct LiveTranscriptSettingsView: View {
     let plugin: LiveTranscriptPlugin
     @State private var autoOpen: Bool = false
-    @State private var fontSize: Double = 14.0
+    @State private var fontSize: Double = LiveTranscriptAppearance.defaultFontSize
+    @State private var windowWidth: Double = LiveTranscriptAppearance.defaultWindowWidth
+    @State private var windowHeight: Double = LiveTranscriptAppearance.defaultWindowHeight
+    @State private var backgroundOpacity: Double = LiveTranscriptAppearance.defaultBackgroundOpacity
     @State private var currentHotkey: PluginHotkey?
     @State private var isRecording: Bool = false
     private let bundle = Bundle(for: LiveTranscriptPlugin.self)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Toggle(isOn: $autoOpen) {
-                VStack(alignment: .leading) {
-                    Text("Auto-open on recording", bundle: bundle)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Toggle(isOn: $autoOpen) {
+                    VStack(alignment: .leading) {
+                        Text("Auto-open on recording", bundle: bundle)
+                            .font(.headline)
+                        Text("Show the transcript window automatically when recording starts.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: autoOpen) { _, newValue in
+                    plugin.updateAutoOpenPreference(newValue)
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Font size", bundle: bundle)
                         .font(.headline)
-                    Text("Show the transcript window automatically when recording starts.", bundle: bundle)
+                    HStack {
+                        Slider(value: $fontSize, in: LiveTranscriptAppearance.fontSizeRange, step: 1)
+                            .onChange(of: fontSize) { _, newValue in
+                                plugin.updateFontSizePreference(newValue)
+                            }
+                        Text("\(Int(fontSize))pt")
+                            .monospacedDigit()
+                            .frame(width: 40, alignment: .trailing)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Window size", bundle: bundle)
+                        .font(.headline)
+                    HStack {
+                        Text("Width", bundle: bundle)
+                            .frame(width: 48, alignment: .leading)
+                        Slider(value: $windowWidth, in: LiveTranscriptAppearance.windowWidthRange, step: 20)
+                            .onChange(of: windowWidth) { _, newValue in
+                                plugin.updateWindowWidthPreference(newValue)
+                            }
+                        Text("\(Int(windowWidth))")
+                            .monospacedDigit()
+                            .frame(width: 44, alignment: .trailing)
+                    }
+                    HStack {
+                        Text("Height", bundle: bundle)
+                            .frame(width: 48, alignment: .leading)
+                        Slider(value: $windowHeight, in: LiveTranscriptAppearance.windowHeightRange, step: 20)
+                            .onChange(of: windowHeight) { _, newValue in
+                                plugin.updateWindowHeightPreference(newValue)
+                            }
+                        Text("\(Int(windowHeight))")
+                            .monospacedDigit()
+                            .frame(width: 44, alignment: .trailing)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Background opacity", bundle: bundle)
+                        .font(.headline)
+                    HStack {
+                        Slider(value: $backgroundOpacity, in: LiveTranscriptAppearance.backgroundOpacityRange, step: 0.05)
+                            .onChange(of: backgroundOpacity) { _, newValue in
+                                plugin.updateBackgroundOpacityPreference(newValue)
+                            }
+                        Text("\(Int(backgroundOpacity * 100))%")
+                            .monospacedDigit()
+                            .frame(width: 44, alignment: .trailing)
+                    }
+                    Text("Lower values keep more of the app behind the transcript visible.", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-            }
-            .onChange(of: autoOpen) { _, newValue in
-                plugin.updateAutoOpenPreference(newValue)
-            }
 
-            Divider()
+                Divider()
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Font size", bundle: bundle)
-                    .font(.headline)
-                HStack {
-                    Slider(value: $fontSize, in: 10...24, step: 1)
-                        .onChange(of: fontSize) { _, newValue in
-                            plugin._fontSize = newValue
-                            plugin.host?.setUserDefault(newValue, forKey: "fontSize")
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Toggle Shortcut", bundle: bundle)
+                        .font(.headline)
+                    Text("Show or hide the transcript window with a keyboard shortcut.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 8) {
+                        HotkeyRecorderButton(
+                            hotkey: $currentHotkey,
+                            isRecording: $isRecording,
+                            plugin: plugin
+                        )
+
+                        if currentHotkey != nil {
+                            Button {
+                                currentHotkey = nil
+                                plugin.updateHotkey(nil)
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
                         }
-                    Text("\(Int(fontSize))pt")
-                        .monospacedDigit()
-                        .frame(width: 40, alignment: .trailing)
-                }
-            }
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Toggle Shortcut", bundle: bundle)
-                    .font(.headline)
-                Text("Show or hide the transcript window with a keyboard shortcut.", bundle: bundle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                HStack(spacing: 8) {
-                    HotkeyRecorderButton(
-                        hotkey: $currentHotkey,
-                        isRecording: $isRecording,
-                        plugin: plugin
-                    )
-
-                    if currentHotkey != nil {
-                        Button {
-                            currentHotkey = nil
-                            plugin.updateHotkey(nil)
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
                     }
                 }
             }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding()
         .onAppear {
             autoOpen = plugin._autoOpen
             fontSize = plugin._fontSize
+            windowWidth = plugin._windowWidth
+            windowHeight = plugin._windowHeight
+            backgroundOpacity = plugin._backgroundOpacity
             currentHotkey = plugin.toggleHotkey
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/LiveTranscriptPlugin.swift
@@ -32,7 +32,7 @@ private enum LiveTranscriptAppearance {
 // MARK: - Plugin Entry Point
 
 @objc(LiveTranscriptPlugin)
-final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendable {
+final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, ObservableObject, @unchecked Sendable {
     static let pluginId = "com.typewhisper.livetranscript"
     static let pluginName = "Live Transcript"
 
@@ -44,8 +44,8 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
 
     fileprivate var _autoOpen: Bool = false
     fileprivate var _fontSize: Double = LiveTranscriptAppearance.defaultFontSize
-    fileprivate var _windowWidth: Double = LiveTranscriptAppearance.defaultWindowWidth
-    fileprivate var _windowHeight: Double = LiveTranscriptAppearance.defaultWindowHeight
+    @Published fileprivate var _windowWidth: Double = LiveTranscriptAppearance.defaultWindowWidth
+    @Published fileprivate var _windowHeight: Double = LiveTranscriptAppearance.defaultWindowHeight
     fileprivate var _backgroundOpacity: Double = LiveTranscriptAppearance.defaultBackgroundOpacity
     private let autoCloseDelay: Double = 4.0
 
@@ -158,6 +158,18 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
     }
 
     @MainActor
+    private func updateWindowSizeFromPanel(_ size: NSSize) {
+        let width = LiveTranscriptAppearance.clamped(Double(size.width), to: LiveTranscriptAppearance.windowWidthRange)
+        let height = LiveTranscriptAppearance.clamped(Double(size.height), to: LiveTranscriptAppearance.windowHeightRange)
+        guard width != _windowWidth || height != _windowHeight else { return }
+
+        _windowWidth = width
+        _windowHeight = height
+        host?.setUserDefault(width, forKey: "windowWidth")
+        host?.setUserDefault(height, forKey: "windowHeight")
+    }
+
+    @MainActor
     func updateBackgroundOpacityPreference(_ value: Double) {
         _backgroundOpacity = LiveTranscriptAppearance.clamped(value, to: LiveTranscriptAppearance.backgroundOpacityRange)
         host?.setUserDefault(_backgroundOpacity, forKey: "backgroundOpacity")
@@ -232,7 +244,13 @@ final class LiveTranscriptPlugin: NSObject, TypeWhisperPlugin, @unchecked Sendab
                 backgroundOpacity: _backgroundOpacity
             )
             viewModel = vm
-            panel = LiveTranscriptPanel(viewModel: vm, windowSize: configuredWindowSize)
+            panel = LiveTranscriptPanel(
+                viewModel: vm,
+                windowSize: configuredWindowSize,
+                onContentSizeChanged: { [weak self] size in
+                    self?.updateWindowSizeFromPanel(size)
+                }
+            )
         }
         applyAppearanceToVisiblePanel()
         panel?.orderFront(nil)
@@ -408,9 +426,15 @@ final class LiveTranscriptViewModel: ObservableObject {
         isAutoScrollEnabled = true
     }
 
-    func updateText(_ fullText: String, isFinal _: Bool) {
+    func updateText(_ fullText: String, isFinal: Bool) {
         let text = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, text != currentText else { return }
+        if text.isEmpty {
+            guard isFinal else { return }
+            currentText = ""
+            paragraphs = []
+            return
+        }
+        guard text != currentText || isFinal else { return }
 
         currentText = text
         paragraphs = [TranscriptParagraph(id: paragraphs.first?.id ?? UUID(), text: text)]
@@ -492,14 +516,18 @@ enum LiveTranscriptPanelFrameStore {
 
 final class LiveTranscriptPanel: NSPanel, NSWindowDelegate {
     private let transcriptFrameAutosaveName: String
+    private let onContentSizeChanged: ((NSSize) -> Void)?
     private var shouldPersistFrameChanges = false
+    private var lastNotifiedContentSize: NSSize?
 
     init(
         viewModel: LiveTranscriptViewModel,
         windowSize: NSSize,
-        frameAutosaveName: String = "LiveTranscriptPanel"
+        frameAutosaveName: String = "LiveTranscriptPanel",
+        onContentSizeChanged: ((NSSize) -> Void)? = nil
     ) {
         self.transcriptFrameAutosaveName = frameAutosaveName
+        self.onContentSizeChanged = onContentSizeChanged
 
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height),
@@ -557,11 +585,22 @@ final class LiveTranscriptPanel: NSPanel, NSWindowDelegate {
 
     func applyWindowSize(_ size: NSSize) {
         setContentSize(size)
+        persistCurrentFrame()
     }
 
     private func persistCurrentFrame() {
         guard shouldPersistFrameChanges else { return }
         LiveTranscriptPanelFrameStore.save(frame: frame, autosaveName: transcriptFrameAutosaveName)
+        notifyContentSizeIfNeeded()
+    }
+
+    private func notifyContentSizeIfNeeded() {
+        let size = contentLayoutRect.size
+        guard lastNotifiedContentSize?.width != size.width ||
+            lastNotifiedContentSize?.height != size.height else { return }
+
+        lastNotifiedContentSize = size
+        onContentSizeChanged?(size)
     }
 }
 
@@ -694,11 +733,9 @@ private struct ScrollWheelDetector: NSViewRepresentable {
 // MARK: - Settings View
 
 private struct LiveTranscriptSettingsView: View {
-    let plugin: LiveTranscriptPlugin
+    @ObservedObject var plugin: LiveTranscriptPlugin
     @State private var autoOpen: Bool = false
     @State private var fontSize: Double = LiveTranscriptAppearance.defaultFontSize
-    @State private var windowWidth: Double = LiveTranscriptAppearance.defaultWindowWidth
-    @State private var windowHeight: Double = LiveTranscriptAppearance.defaultWindowHeight
     @State private var backgroundOpacity: Double = LiveTranscriptAppearance.defaultBackgroundOpacity
     @State private var currentHotkey: PluginHotkey?
     @State private var isRecording: Bool = false
@@ -744,22 +781,34 @@ private struct LiveTranscriptSettingsView: View {
                     HStack {
                         Text("Width", bundle: bundle)
                             .frame(width: 48, alignment: .leading)
-                        Slider(value: $windowWidth, in: LiveTranscriptAppearance.windowWidthRange, step: 20)
-                            .onChange(of: windowWidth) { _, newValue in
-                                plugin.updateWindowWidthPreference(newValue)
-                            }
-                        Text("\(Int(windowWidth))")
+                        Slider(
+                            value: Binding(
+                                get: { plugin._windowWidth },
+                                set: { newValue in
+                                    plugin.updateWindowWidthPreference(newValue)
+                                }
+                            ),
+                            in: LiveTranscriptAppearance.windowWidthRange,
+                            step: 20
+                        )
+                        Text("\(Int(plugin._windowWidth))")
                             .monospacedDigit()
                             .frame(width: 44, alignment: .trailing)
                     }
                     HStack {
                         Text("Height", bundle: bundle)
                             .frame(width: 48, alignment: .leading)
-                        Slider(value: $windowHeight, in: LiveTranscriptAppearance.windowHeightRange, step: 20)
-                            .onChange(of: windowHeight) { _, newValue in
-                                plugin.updateWindowHeightPreference(newValue)
-                            }
-                        Text("\(Int(windowHeight))")
+                        Slider(
+                            value: Binding(
+                                get: { plugin._windowHeight },
+                                set: { newValue in
+                                    plugin.updateWindowHeightPreference(newValue)
+                                }
+                            ),
+                            in: LiveTranscriptAppearance.windowHeightRange,
+                            step: 20
+                        )
+                        Text("\(Int(plugin._windowHeight))")
                             .monospacedDigit()
                             .frame(width: 44, alignment: .trailing)
                     }
@@ -819,8 +868,6 @@ private struct LiveTranscriptSettingsView: View {
         .onAppear {
             autoOpen = plugin._autoOpen
             fontSize = plugin._fontSize
-            windowWidth = plugin._windowWidth
-            windowHeight = plugin._windowHeight
             backgroundOpacity = plugin._backgroundOpacity
             currentHotkey = plugin.toggleHotkey
         }

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/Tests/LiveTranscriptPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/Tests/LiveTranscriptPluginTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import TypeWhisperPluginSDK
 import TypeWhisperPluginSDKTesting
 import XCTest
 @testable import LiveTranscriptPlugin
@@ -7,10 +9,6 @@ import XCTest
 final class LiveTranscriptPluginTests: XCTestCase {
     private func displayedText(from viewModel: LiveTranscriptViewModel) -> String {
         viewModel.paragraphs.map(\.text).joined(separator: " ")
-    }
-
-    private func paragraphTexts(from viewModel: LiveTranscriptViewModel) -> [String] {
-        viewModel.paragraphs.map(\.text)
     }
 
     func testAutoOpenDefaultsToDisabledWhenUnset() throws {
@@ -50,6 +48,145 @@ final class LiveTranscriptPluginTests: XCTestCase {
         XCTAssertEqual(host.streamingDisplayActiveValues, [true])
     }
 
+    func testStoredAppearancePreferencesAreLoadedOnActivation() throws {
+        let host = try PluginTestHostServices(defaults: [
+            "fontSize": 18.0,
+            "windowWidth": 640.0,
+            "windowHeight": 440.0,
+            "backgroundOpacity": 0.55,
+        ])
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        let appearance = plugin.appearanceForTesting
+        XCTAssertEqual(appearance.fontSize, 18.0)
+        XCTAssertEqual(appearance.windowWidth, 640.0)
+        XCTAssertEqual(appearance.windowHeight, 440.0)
+        XCTAssertEqual(appearance.backgroundOpacity, 0.55)
+    }
+
+    func testAppearancePreferenceUpdatesPersistClampedValues() throws {
+        let host = try PluginTestHostServices()
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        plugin.updateFontSizePreference(40.0)
+        plugin.updateWindowWidthPreference(1200.0)
+        plugin.updateWindowHeightPreference(80.0)
+        plugin.updateBackgroundOpacityPreference(0.05)
+
+        let appearance = plugin.appearanceForTesting
+        XCTAssertEqual(appearance.fontSize, 24.0)
+        XCTAssertEqual(appearance.windowWidth, 900.0)
+        XCTAssertEqual(appearance.windowHeight, 180.0)
+        XCTAssertEqual(appearance.backgroundOpacity, 0.20)
+        XCTAssertEqual(host.userDefault(forKey: "fontSize") as? Double, 24.0)
+        XCTAssertEqual(host.userDefault(forKey: "windowWidth") as? Double, 900.0)
+        XCTAssertEqual(host.userDefault(forKey: "windowHeight") as? Double, 180.0)
+        XCTAssertEqual(host.userDefault(forKey: "backgroundOpacity") as? Double, 0.20)
+    }
+
+    func testAutoOpenedPanelRestoresSavedFrameInsteadOfConfiguredDefaultSize() async throws {
+        let autosaveKey = LiveTranscriptPanelFrameStore.defaultsKey(for: "LiveTranscriptPanel")
+        let previousAutosaveValue = UserDefaults.standard.object(forKey: autosaveKey)
+        defer {
+            NSApp.windows.compactMap { $0 as? LiveTranscriptPanel }.forEach { $0.close() }
+            if let previousAutosaveValue {
+                UserDefaults.standard.set(previousAutosaveValue, forKey: autosaveKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: autosaveKey)
+            }
+        }
+
+        UserDefaults.standard.removeObject(forKey: autosaveKey)
+        let visibleFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1200, height: 800)
+        let savedFrame = NSRect(
+            x: visibleFrame.minX + 80,
+            y: visibleFrame.minY + 80,
+            width: 560,
+            height: 360
+        )
+        UserDefaults.standard.set(LiveTranscriptPanelFrameStore.storedString(for: savedFrame), forKey: autosaveKey)
+
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(defaults: [
+            "autoOpen": true,
+            "windowWidth": 420.0,
+            "windowHeight": 320.0,
+        ], eventBus: eventBus)
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        await eventBus.emit(.recordingStarted(RecordingStartedPayload(appName: "Notes")))
+
+        let panel = try XCTUnwrap(NSApp.windows.compactMap { $0 as? LiveTranscriptPanel }.last)
+        XCTAssertEqual(panel.frame.width, savedFrame.width, accuracy: 1)
+        XCTAssertEqual(panel.frame.height, savedFrame.height, accuracy: 1)
+        XCTAssertEqual(panel.frame.minX, savedFrame.minX, accuracy: 1)
+        XCTAssertEqual(panel.frame.minY, savedFrame.minY, accuracy: 1)
+    }
+
+    func testPanelFrameStoreAcceptsSavedFrameOnSecondaryDisplay() throws {
+        let mainDisplay = NSRect(x: 0, y: 0, width: 1728, height: 1079)
+        let wideSecondaryDisplay = NSRect(x: 1728, y: -220, width: 3440, height: 1440)
+        let savedFrame = NSRect(x: 2200, y: 140, width: 820, height: 480)
+        let storedFrame = LiveTranscriptPanelFrameStore.storedString(for: savedFrame)
+
+        let restoredFrame = try XCTUnwrap(LiveTranscriptPanelFrameStore.restorableFrame(
+            from: storedFrame,
+            screenVisibleFrames: [mainDisplay, wideSecondaryDisplay],
+            minimumSize: NSSize(width: 250, height: 150)
+        ))
+
+        XCTAssertEqual(restoredFrame.minX, savedFrame.minX, accuracy: 1)
+        XCTAssertEqual(restoredFrame.minY, savedFrame.minY, accuracy: 1)
+        XCTAssertEqual(restoredFrame.width, savedFrame.width, accuracy: 1)
+        XCTAssertEqual(restoredFrame.height, savedFrame.height, accuracy: 1)
+    }
+
+    func testPanelPersistsFrameWhenMoved() throws {
+        let autosaveName = "LiveTranscriptPanelImmediateMoveTest"
+        let autosaveKey = LiveTranscriptPanelFrameStore.defaultsKey(for: autosaveName)
+        let previousAutosaveValue = UserDefaults.standard.object(forKey: autosaveKey)
+        defer {
+            NSApp.windows.compactMap { $0 as? LiveTranscriptPanel }.forEach { $0.close() }
+            if let previousAutosaveValue {
+                UserDefaults.standard.set(previousAutosaveValue, forKey: autosaveKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: autosaveKey)
+            }
+        }
+
+        UserDefaults.standard.removeObject(forKey: autosaveKey)
+        let panel = LiveTranscriptPanel(
+            viewModel: LiveTranscriptViewModel(),
+            windowSize: NSSize(width: 420, height: 320),
+            frameAutosaveName: autosaveName
+        )
+        let movedFrame = NSRect(x: 2400, y: 180, width: 860, height: 500)
+
+        panel.setFrame(movedFrame, display: false)
+        panel.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: panel))
+
+        let storedFrame = try XCTUnwrap(UserDefaults.standard.string(forKey: autosaveKey))
+        let restoredFrame = try XCTUnwrap(LiveTranscriptPanelFrameStore.restorableFrame(
+            from: storedFrame,
+            screenVisibleFrames: [NSRect(x: 1728, y: -220, width: 3440, height: 1440)],
+            minimumSize: NSSize(width: 250, height: 150)
+        ))
+
+        XCTAssertEqual(restoredFrame.minX, movedFrame.minX, accuracy: 1)
+        XCTAssertEqual(restoredFrame.minY, movedFrame.minY, accuracy: 1)
+        XCTAssertEqual(restoredFrame.width, movedFrame.width, accuracy: 1)
+        XCTAssertEqual(restoredFrame.height, movedFrame.height, accuracy: 1)
+    }
+
     func testDeactivationUnsubscribesAndClearsStreamingDisplay() throws {
         let eventBus = PluginTestEventBus()
         let host = try PluginTestHostServices(eventBus: eventBus)
@@ -66,7 +203,38 @@ final class LiveTranscriptPluginTests: XCTestCase {
         XCTAssertEqual(eventBus.subscriberCount, 0)
     }
 
-    func testViewModelPreservesCumulativeTranscriptUpdates() {
+    func testCompletionTextWinsOverLateFinalPreviewUpdate() async throws {
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(eventBus: eventBus, activeAppName: "Notes")
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        plugin.updateAutoOpenPreference(true)
+        await eventBus.emit(.recordingStarted(RecordingStartedPayload(appName: "Notes")))
+        await eventBus.emit(.partialTranscriptionUpdate(PartialTranscriptionPayload(
+            text: "Jetzt funktioniert es perfekt. funktioniert perfekt. Viel zu viel Preview.",
+            elapsedSeconds: 2
+        )))
+        await eventBus.emit(.transcriptionCompleted(TranscriptionCompletedPayload(
+            rawText: "raw",
+            finalText: "Jetzt funktioniert es perfekt.",
+            engineUsed: "parakeet",
+            durationSeconds: 3,
+            appName: "Notes",
+            ruleName: nil
+        )))
+        await eventBus.emit(.partialTranscriptionUpdate(PartialTranscriptionPayload(
+            text: "Jetzt funktioniert es perfekt. funktioniert perfekt. Viel zu viel Preview.",
+            isFinal: true,
+            elapsedSeconds: 3
+        )))
+
+        XCTAssertEqual(plugin.displayedTextForTesting, "Jetzt funktioniert es perfekt.")
+    }
+
+    func testViewModelDisplaysLatestCumulativeTranscriptSnapshot() {
         let viewModel = LiveTranscriptViewModel()
 
         viewModel.updateText("First sentence.", isFinal: false)
@@ -75,58 +243,25 @@ final class LiveTranscriptPluginTests: XCTestCase {
         XCTAssertEqual(displayedText(from: viewModel), "First sentence. Second sentence.")
     }
 
-    func testViewModelAppendsDisjointSegmentUpdates() {
+    func testViewModelShowsLatestDisjointProviderSnapshotWithoutAppending() {
         let viewModel = LiveTranscriptViewModel()
 
         viewModel.updateText("First sentence.", isFinal: false)
         viewModel.updateText("Second sentence.", isFinal: false)
 
-        XCTAssertEqual(displayedText(from: viewModel), "First sentence. Second sentence.")
+        XCTAssertEqual(displayedText(from: viewModel), "Second sentence.")
     }
 
-    func testViewModelMergesOverlappingSlidingWindowUpdates() {
+    func testViewModelShowsLatestOverlappingProviderSnapshotWithoutMerging() {
         let viewModel = LiveTranscriptViewModel()
 
         viewModel.updateText("First sentence. Second sentence.", isFinal: false)
         viewModel.updateText("Second sentence. Third sentence.", isFinal: false)
 
-        XCTAssertEqual(displayedText(from: viewModel), "First sentence. Second sentence. Third sentence.")
+        XCTAssertEqual(displayedText(from: viewModel), "Second sentence. Third sentence.")
     }
 
-    func testViewModelKeepsThreeSentenceParagraphsForCumulativeUpdates() {
-        let viewModel = LiveTranscriptViewModel()
-
-        viewModel.updateText("First sentence. Second sentence. Third sentence.", isFinal: false)
-        viewModel.updateText("First sentence. Second sentence. Third sentence. Fourth sentence.", isFinal: false)
-
-        XCTAssertEqual(paragraphTexts(from: viewModel), [
-            "First sentence. Second sentence. Third sentence.",
-            "Fourth sentence.",
-        ])
-    }
-
-    func testViewModelMergesTwoSentenceSlidingWindowUpdates() {
-        let viewModel = LiveTranscriptViewModel()
-
-        viewModel.updateText("First sentence. Second sentence. Third sentence. Fourth sentence.", isFinal: false)
-        viewModel.updateText("Third sentence. Fourth sentence. Fifth sentence.", isFinal: false)
-
-        XCTAssertEqual(
-            displayedText(from: viewModel),
-            "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence."
-        )
-    }
-
-    func testViewModelDeduplicatesCleanedSegmentUpdatesAfterAppend() {
-        let viewModel = LiveTranscriptViewModel()
-
-        viewModel.updateText("This is a test sentence.", isFinal: false)
-        viewModel.updateText("This is test sentence. Now the next sentence.", isFinal: false)
-
-        XCTAssertEqual(displayedText(from: viewModel), "This is a test sentence. Now the next sentence.")
-    }
-
-    func testViewModelDropsNoisyReporterSlidingWindowPrefix() {
+    func testViewModelShowsNoisyProviderSnapshotVerbatim() {
         let viewModel = LiveTranscriptViewModel()
 
         viewModel.updateText(
@@ -140,28 +275,37 @@ final class LiveTranscriptPluginTests: XCTestCase {
 
         XCTAssertEqual(
             displayedText(from: viewModel),
-            "Das hier ist das klassische DJI-Setup. Also das sieht aus wie beim Mini 1, einfach dass die Dinger 2 sind. Das ueberrascht mich ein bisschen. Aber jetzt muessen wir nichts anderes angucken."
+            "Mini 1, einlech dass sie Dinge 2 ist. Aber jetzt muessen wir nichts anderes angucken."
         )
     }
 
-    func testViewModelPreservesLegitimateShortRepetitions() {
+    func testViewModelShowsLatestShorterProviderSnapshot() {
         let viewModel = LiveTranscriptViewModel()
 
-        viewModel.updateText("Eins. Eins. Zwei.", isFinal: false)
+        viewModel.updateText("First sentence. Second sentence.", isFinal: false)
+        viewModel.updateText("First sentence.", isFinal: false)
 
-        XCTAssertEqual(displayedText(from: viewModel), "Eins. Eins. Zwei.")
+        XCTAssertEqual(displayedText(from: viewModel), "First sentence.")
     }
 
-    func testViewModelReplacesLiveTailWithCompletedSentence() {
+    func testViewModelDoesNotInterpretSpokenParagraphCommands() {
         let viewModel = LiveTranscriptViewModel()
 
-        viewModel.updateText("This is a partial", isFinal: false)
-        viewModel.updateText("This is a partial sentence.", isFinal: false)
+        viewModel.updateText("Erster Teil. Neuer Absatz. Zweiter Teil.", isFinal: false)
 
-        XCTAssertEqual(displayedText(from: viewModel), "This is a partial sentence.")
+        XCTAssertEqual(displayedText(from: viewModel), "Erster Teil. Neuer Absatz. Zweiter Teil.")
     }
 
-    func testViewModelAllowsRecentVolatileSentencesToBeCorrected() {
+    func testFinalUpdateReplacesPreviewText() {
+        let viewModel = LiveTranscriptViewModel()
+
+        viewModel.updateText("Vorheriger Live-Text. Ich bin an Koin.", isFinal: false)
+        viewModel.updateText("Ich bin an Koeln.", isFinal: true)
+
+        XCTAssertEqual(displayedText(from: viewModel), "Ich bin an Koeln.")
+    }
+
+    func testViewModelAllowsProviderCorrectionsByReplacingSnapshot() {
         let viewModel = LiveTranscriptViewModel()
 
         viewModel.updateText(
@@ -179,30 +323,13 @@ final class LiveTranscriptPluginTests: XCTestCase {
         )
     }
 
-    func testViewModelDoesNotReplaceConfirmedTextWhenLaterWindowRepeatsOldSentences() {
-        let viewModel = LiveTranscriptViewModel()
-
-        viewModel.updateText(
-            "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence.",
-            isFinal: false
-        )
-        viewModel.updateText(
-            "First sentence. Second sentence. New quoted sentence.",
-            isFinal: false
-        )
-
-        XCTAssertEqual(
-            displayedText(from: viewModel),
-            "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence. New quoted sentence."
-        )
-    }
-
-    func testViewModelIgnoresShorterResetUpdates() {
+    func testViewModelIgnoresDuplicateSnapshots() {
         let viewModel = LiveTranscriptViewModel()
 
         viewModel.updateText("First sentence. Second sentence.", isFinal: false)
-        viewModel.updateText("Second sentence.", isFinal: false)
+        viewModel.updateText("First sentence. Second sentence.", isFinal: false)
 
         XCTAssertEqual(displayedText(from: viewModel), "First sentence. Second sentence.")
+        XCTAssertEqual(viewModel.paragraphs.count, 1)
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/Tests/LiveTranscriptPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/Tests/LiveTranscriptPluginTests.swift
@@ -187,6 +187,45 @@ final class LiveTranscriptPluginTests: XCTestCase {
         XCTAssertEqual(restoredFrame.height, movedFrame.height, accuracy: 1)
     }
 
+    func testManualPanelResizePersistsWindowSizePreferences() async throws {
+        let autosaveKey = LiveTranscriptPanelFrameStore.defaultsKey(for: "LiveTranscriptPanel")
+        let previousAutosaveValue = UserDefaults.standard.object(forKey: autosaveKey)
+        defer {
+            NSApp.windows.compactMap { $0 as? LiveTranscriptPanel }.forEach { $0.close() }
+            if let previousAutosaveValue {
+                UserDefaults.standard.set(previousAutosaveValue, forKey: autosaveKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: autosaveKey)
+            }
+        }
+
+        UserDefaults.standard.removeObject(forKey: autosaveKey)
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(defaults: [
+            "autoOpen": true,
+            "windowWidth": 420.0,
+            "windowHeight": 320.0,
+        ], eventBus: eventBus)
+        let plugin = LiveTranscriptPlugin()
+
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        await eventBus.emit(.recordingStarted(RecordingStartedPayload(appName: "Notes")))
+
+        let panel = try XCTUnwrap(NSApp.windows.compactMap { $0 as? LiveTranscriptPanel }.last)
+        panel.setContentSize(NSSize(width: 760, height: 460))
+        panel.windowDidResize(Notification(name: NSWindow.didResizeNotification, object: panel))
+
+        let storedWidth = try XCTUnwrap(host.userDefault(forKey: "windowWidth") as? Double)
+        let storedHeight = try XCTUnwrap(host.userDefault(forKey: "windowHeight") as? Double)
+        let appearance = plugin.appearanceForTesting
+        XCTAssertEqual(storedWidth, 760.0, accuracy: 1)
+        XCTAssertEqual(storedHeight, 460.0, accuracy: 1)
+        XCTAssertEqual(appearance.windowWidth, 760.0, accuracy: 1)
+        XCTAssertEqual(appearance.windowHeight, 460.0, accuracy: 1)
+    }
+
     func testDeactivationUnsubscribesAndClearsStreamingDisplay() throws {
         let eventBus = PluginTestEventBus()
         let host = try PluginTestHostServices(eventBus: eventBus)
@@ -303,6 +342,16 @@ final class LiveTranscriptPluginTests: XCTestCase {
         viewModel.updateText("Ich bin an Koeln.", isFinal: true)
 
         XCTAssertEqual(displayedText(from: viewModel), "Ich bin an Koeln.")
+    }
+
+    func testFinalEmptyUpdateClearsPreviewText() {
+        let viewModel = LiveTranscriptViewModel()
+
+        viewModel.updateText("Incorrect live preview.", isFinal: false)
+        viewModel.updateText("   ", isFinal: true)
+
+        XCTAssertEqual(displayedText(from: viewModel), "")
+        XCTAssertTrue(viewModel.paragraphs.isEmpty)
     }
 
     func testViewModelAllowsProviderCorrectionsByReplacingSnapshot() {

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -1,55 +1,13 @@
-@preconcurrency import AVFoundation
 import Foundation
 import OSLog
 import SwiftUI
 import FluidAudio
 import TypeWhisperPluginSDK
 
-private let parakeetLiveSampleRate: Double = 16_000
-let parakeetLivePreviewConfig = SlidingWindowAsrConfig.streaming
-
-private func makeParakeetLiveAudioBuffer(from samples: [Float]) throws -> AVAudioPCMBuffer {
-    guard let format = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: parakeetLiveSampleRate,
-        channels: 1,
-        interleaved: false
-    ) else {
-        throw PluginTranscriptionError.apiError("Unable to create Parakeet live audio format")
-    }
-
-    guard let buffer = AVAudioPCMBuffer(
-        pcmFormat: format,
-        frameCapacity: AVAudioFrameCount(samples.count)
-    ) else {
-        throw PluginTranscriptionError.apiError("Unable to create Parakeet live audio buffer")
-    }
-
-    buffer.frameLength = AVAudioFrameCount(samples.count)
-    guard let destination = buffer.floatChannelData?.pointee else {
-        throw PluginTranscriptionError.apiError("Unable to access Parakeet live audio buffer")
-    }
-
-    samples.withUnsafeBufferPointer { source in
-        if let baseAddress = source.baseAddress {
-            destination.update(from: baseAddress, count: samples.count)
-        }
-    }
-
-    return buffer
-}
-
-private func combinedParakeetLiveTranscript(confirmed: String, volatile: String) -> String {
-    [confirmed, volatile]
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
-        .joined(separator: " ")
-}
-
 // MARK: - Plugin Entry Point
 
 @objc(ParakeetPlugin)
-final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class ParakeetPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
     private static let logger = Logger(subsystem: "com.typewhisper.plugin.parakeet", category: "Transcription")
@@ -148,7 +106,7 @@ final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, Dictionary
     }
 
     var selectedModelId: String? { _selectedModelId }
-    var allowsTranscriptPreviewFallback: Bool { false }
+    var allowsTranscriptPreviewFallback: Bool { true }
     var supportsStreaming: Bool { true }
 
     func selectModel(_ modelId: String) {
@@ -237,64 +195,6 @@ final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, Dictionary
         }
 
         return PluginTranscriptionResult(text: finalResult.text, detectedLanguage: nil, segments: segments)
-    }
-
-    func createLiveTranscriptionSession(
-        language: String?,
-        translate: Bool,
-        prompt: String?,
-        onProgress: @Sendable @escaping (String) -> Bool
-    ) async throws -> any LiveTranscriptionSession {
-        guard !translate else {
-            throw PluginTranscriptionError.apiError("Parakeet does not support translation")
-        }
-
-        guard let loadedAsrModels else {
-            throw PluginTranscriptionError.notConfigured
-        }
-
-        if vocabularyBoostingEnabled {
-            await configureBoostingIfNeeded(prompt: prompt)
-        }
-
-        let manager = SlidingWindowAsrManager(config: parakeetLivePreviewConfig)
-        try await manager.loadModels(loadedAsrModels)
-
-        if vocabularyBoostingEnabled,
-           let customVocabulary,
-           let ctcModels {
-            do {
-                try await manager.configureVocabularyBoosting(
-                    vocabulary: customVocabulary,
-                    ctcModels: ctcModels
-                )
-            } catch {
-                Self.logger.warning("Live vocabulary boosting setup failed: \(error.localizedDescription)")
-            }
-        }
-
-        try await manager.startStreaming(source: .microphone)
-        return ParakeetLiveTranscriptionSession(
-            manager: manager,
-            onProgress: onProgress,
-            finalTranscribe: { [weak self] samples in
-                guard let self else {
-                    throw PluginTranscriptionError.notConfigured
-                }
-
-                let audio = AudioData(
-                    samples: samples,
-                    wavData: Data(),
-                    duration: Double(samples.count) / parakeetLiveSampleRate
-                )
-                return try await self.transcribe(
-                    audio: audio,
-                    language: language,
-                    translate: false,
-                    prompt: prompt
-                )
-            }
-        )
     }
 
     private static func fluidAudioLanguage(for language: String?) -> Language? {
@@ -667,95 +567,6 @@ final class ParakeetPlugin: NSObject, LiveTranscriptionCapablePlugin, Dictionary
 
     func applyHuggingFaceTokenToEnvironment() {
         PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
-    }
-}
-
-// MARK: - Live Transcription
-
-private actor ParakeetLiveTranscriptionSession: LiveTranscriptionSession {
-    private let manager: SlidingWindowAsrManager
-    private let finalTranscribe: @Sendable ([Float]) async throws -> PluginTranscriptionResult
-    private var updateTask: Task<Void, Never>?
-    private var audioSamples: [Float] = []
-    private var isCancelled = false
-
-    init(
-        manager: SlidingWindowAsrManager,
-        onProgress: @escaping @Sendable (String) -> Bool,
-        finalTranscribe: @escaping @Sendable ([Float]) async throws -> PluginTranscriptionResult
-    ) {
-        self.manager = manager
-        self.finalTranscribe = finalTranscribe
-        self.updateTask = Self.startUpdateTask(manager: manager, onProgress: onProgress)
-    }
-
-    func appendAudio(samples: [Float]) async throws {
-        guard !isCancelled, !samples.isEmpty else { return }
-        audioSamples.append(contentsOf: samples)
-        let buffer = try makeParakeetLiveAudioBuffer(from: samples)
-        await manager.streamAudio(buffer)
-    }
-
-    func finish() async throws -> PluginTranscriptionResult {
-        guard !isCancelled else {
-            return PluginTranscriptionResult(text: "", detectedLanguage: nil, segments: [])
-        }
-
-        do {
-            _ = try await manager.finish()
-            let finalSamples = audioSamples
-            await stop(cancelManager: false)
-            guard !finalSamples.isEmpty else {
-                return PluginTranscriptionResult(text: "", detectedLanguage: nil, segments: [])
-            }
-            return try await finalTranscribe(finalSamples)
-        } catch {
-            await stop()
-            throw error
-        }
-    }
-
-    func cancel() async {
-        await stop()
-    }
-
-    private func stop(cancelManager: Bool = true) async {
-        guard !isCancelled else { return }
-        isCancelled = true
-        updateTask?.cancel()
-        updateTask = nil
-        if cancelManager {
-            await manager.cancel()
-        }
-    }
-
-    private static func startUpdateTask(
-        manager: SlidingWindowAsrManager,
-        onProgress: @escaping @Sendable (String) -> Bool
-    ) -> Task<Void, Never> {
-        Task {
-            var lastProgressText = ""
-
-            for await _ in await manager.transcriptionUpdates {
-                guard !Task.isCancelled else { return }
-
-                let confirmed = await manager.confirmedTranscript
-                let volatile = await manager.volatileTranscript
-                let combinedText = combinedParakeetLiveTranscript(
-                    confirmed: confirmed,
-                    volatile: volatile
-                )
-                guard !combinedText.isEmpty, combinedText != lastProgressText else {
-                    continue
-                }
-
-                lastProgressText = combinedText
-                if !onProgress(combinedText) {
-                    await manager.cancel()
-                    return
-                }
-            }
-        }
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -106,25 +106,19 @@ final class ParakeetPluginTests: XCTestCase {
         XCTAssertEqual(plugin.huggingFaceToken, "hf_parakeet_saved")
     }
 
-    func testDisablesTranscriptPreviewFallback() throws {
+    func testAllowsTranscriptPreviewFallback() throws {
         let fallbackPolicy: any TranscriptPreviewFallbackPolicyProviding = ParakeetPlugin()
 
-        XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
+        XCTAssertTrue(fallbackPolicy.allowsTranscriptPreviewFallback)
     }
 
-    func testProvidesLiveTranscriptionSessionCapability() throws {
+    func testUsesBatchFallbackForLivePreview() throws {
         let plugin = ParakeetPlugin()
-        let livePlugin: any LiveTranscriptionCapablePlugin = plugin
         let fallbackPolicy: any TranscriptPreviewFallbackPolicyProviding = plugin
 
-        XCTAssertTrue(livePlugin.supportsStreaming)
-        XCTAssertFalse(fallbackPolicy.allowsTranscriptPreviewFallback)
-    }
-
-    func testLivePreviewConfigUsesStableStreamingWindow() throws {
-        XCTAssertEqual(parakeetLivePreviewConfig.chunkSeconds, 11.0)
-        XCTAssertEqual(parakeetLivePreviewConfig.rightContextSeconds, 2.0)
-        XCTAssertEqual(parakeetLivePreviewConfig.minContextForConfirmation, 10.0)
+        XCTAssertTrue(plugin.supportsStreaming)
+        XCTAssertTrue(fallbackPolicy.allowsTranscriptPreviewFallback)
+        XCTAssertNil(plugin as? any LiveTranscriptionCapablePlugin)
     }
 
     func testDictionaryTermsSupportReflectsStoredBoostingPreference() throws {

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -268,14 +268,25 @@ final class StreamingHandlerTests: XCTestCase {
     private actor MockLiveSession: LiveTranscriptionSession {
         private var appendedChunkSizes: [Int] = []
         private var onProgress: (@Sendable (String) -> Bool)?
+        private var progressUpdates: [String] = []
 
         func setOnProgress(_ onProgress: @escaping @Sendable (String) -> Bool) {
             self.onProgress = onProgress
         }
 
+        func setProgressUpdates(_ progressUpdates: [String]) {
+            self.progressUpdates = progressUpdates
+        }
+
         func appendAudio(samples: [Float]) async throws {
             appendedChunkSizes.append(samples.count)
-            _ = onProgress?("chunk-\(samples.count)")
+            let progressText: String
+            if progressUpdates.isEmpty {
+                progressText = "chunk-\(samples.count)"
+            } else {
+                progressText = progressUpdates.removeFirst()
+            }
+            _ = onProgress?(progressText)
         }
 
         func finish() async throws -> PluginTranscriptionResult {
@@ -560,6 +571,147 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertEqual(plugin.recordedSampleCounts, [16_000])
     }
 
+    func testStreamingFallbackSkipsPreviewWhenRecentWindowEndsInSustainedSilence() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockStreamingFallbackPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.streaming-fallback",
+                    name: "Mock Streaming Fallback",
+                    version: "1.0.0",
+                    principalClass: "MockStreamingFallbackPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let updatesLock = OSAllocatedUnfairLock(initialState: [String]())
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: {
+                XCTFail("full buffer provider should not be used for fallback previews")
+                return []
+            },
+            recentBufferProvider: { _ in
+                Array(repeating: Float(0.2), count: 16_000)
+                    + Array(repeating: Float(0.0001), count: 40_000)
+            },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 3.5 }
+        )
+        handler.onPartialTextUpdate = { text in
+            updatesLock.withLock { $0.append(text) }
+        }
+
+        handler.start(
+            streamPrompt: "Fallback Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("de"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        try await Task.sleep(for: .milliseconds(3400))
+        handler.stop()
+
+        XCTAssertEqual(plugin.transcribeCallCount, 0)
+        XCTAssertTrue(updatesLock.withLock { $0 }.isEmpty)
+    }
+
+    func testStabilizeTextAppendsDisjointPreviewWindows() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: "First sentence.",
+            new: "Second sentence."
+        )
+
+        XCTAssertEqual(stable, "First sentence. Second sentence.")
+    }
+
+    func testStabilizeTextMergesOverlappingPreviewWindows() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: "First sentence. Second sentence.",
+            new: "Second sentence. Third sentence."
+        )
+
+        XCTAssertEqual(stable, "First sentence. Second sentence. Third sentence.")
+    }
+
+    func testStabilizeTextMergesFuzzyOverlappingPreviewWindows() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: "Jetzt funktioniert es perfekt.",
+            new: "funktioniert perfekt. Faellt dir noch was ein, was wir vorm testen sollten?"
+        )
+
+        XCTAssertEqual(
+            stable,
+            "Jetzt funktioniert es perfekt. Faellt dir noch was ein, was wir vorm testen sollten?"
+        )
+    }
+
+    func testStabilizeTextReplacesRestatedPreviewWindowInsteadOfAppending() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: "Ich rede jetzt und rede jetzt ein bisschen laenger.",
+            new: "Ich rede jetzt. Ich drehe jetzt ein bisschen laenger."
+        )
+
+        XCTAssertEqual(
+            stable,
+            "Ich rede jetzt. Ich drehe jetzt ein bisschen laenger."
+        )
+    }
+
+    func testStabilizeTextMergesApproximateOverlappingPreviewWindow() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: "Ich rede jetzt. Ich drehe jetzt ein bisschen laenger.",
+            new: "Dreh dir jetzt ein bisschen laenger. Dreh dir immer noch."
+        )
+
+        XCTAssertEqual(
+            stable,
+            "Ich rede jetzt. Ich drehe jetzt ein bisschen laenger. Dreh dir immer noch."
+        )
+    }
+
+    func testStabilizeTextDropsRepeatedEarlierPreviewPrefixAfterPause() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: """
+            Super. Koennen wir jetzt noch einmal... einbauen, also ein bisschen zumindest dieses Abstand vom Ding, wenn man lange... man lange Pause macht. Man muss ja nicht dann letztendlich.
+            """,
+            new: """
+            dieses Abstand vom Ding, wenn man lange Pause macht. Das muss ja nicht ein letztlich haben muss., ist das. Aber wie das ist erstmal so. Ist das? Aber wir lassen es erstmal so.
+            """
+        )
+
+        XCTAssertEqual(
+            stable,
+            """
+            Super. Koennen wir jetzt noch einmal... einbauen, also ein bisschen zumindest dieses Abstand vom Ding, wenn man lange... man lange Pause macht. Man muss ja nicht dann letztendlich. Das muss ja nicht ein letztlich haben muss., ist das. Aber wie das ist erstmal so. Ist das? Aber wir lassen es erstmal so.
+            """
+        )
+    }
+
+    func testStabilizeTextReplacesProviderCorrectionInsteadOfAppendingSuffix() {
+        let stable = StreamingHandler.stabilizeText(
+            confirmed: "Ich bin an Koin.",
+            new: "Ich bin an Koeln."
+        )
+
+        XCTAssertEqual(stable, "Ich bin an Koeln.")
+    }
+
     func testPreviewFallbackOptOutSkipsIntermediateWorkAndAllowsFinalTranscription() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -699,6 +851,170 @@ final class StreamingHandlerTests: XCTestCase {
         let recorded = await plugin.session.recordedChunks()
         XCTAssertEqual(recorded, chunks.map(\.count))
         XCTAssertEqual(plugin.lastPrompt, "Live Terms")
+    }
+
+    func testLiveSessionProgressAllowsProviderCorrections() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockLivePlugin()
+        await plugin.session.setProgressUpdates([
+            "Ich bin an Koin.",
+            "Ich bin an Koeln.",
+        ])
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.live",
+                    name: "Mock Live",
+                    version: "1.0.0",
+                    principalClass: "MockLivePlugin",
+                    requiresAPIKey: false
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let chunks = [
+            Array(repeating: Float(0.2), count: 4000),
+            Array(repeating: Float(0.3), count: 4000),
+        ]
+        let indexLock = NSLock()
+        var index = 0
+        var nextOffset = 0
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: { [] },
+            recentBufferProvider: { _ in [] },
+            bufferDeltaProvider: { _ in
+                indexLock.lock()
+                defer { indexLock.unlock() }
+                guard index < chunks.count else {
+                    return ([], nextOffset)
+                }
+                let chunk = chunks[index]
+                index += 1
+                nextOffset += chunk.count
+                return (chunk, nextOffset)
+            },
+            bufferedDurationProvider: { 0.5 }
+        )
+
+        let updatesLock = OSAllocatedUnfairLock(initialState: [String]())
+        handler.onPartialTextUpdate = { text in
+            updatesLock.withLock { $0.append(text) }
+        }
+
+        var activeChecks = 0
+        handler.start(
+            streamPrompt: "Live Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("de"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: {
+                activeChecks += 1
+                return activeChecks <= 3
+            }
+        )
+
+        try await Task.sleep(for: .milliseconds(900))
+        handler.stop()
+
+        let updates = updatesLock.withLock { $0 }
+        XCTAssertEqual(updates.last, "Ich bin an Koeln.")
+        XCTAssertFalse(updates.contains("Ich bin an Koin.eln."))
+    }
+
+    func testLiveSessionSuppressesAdditiveProgressDuringSustainedSilence() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockLivePlugin()
+        await plugin.session.setProgressUpdates([
+            "Gesprochener Satz.",
+            "Gesprochener Satz. Halluzinierter Nachsatz.",
+        ])
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.live",
+                    name: "Mock Live",
+                    version: "1.0.0",
+                    principalClass: "MockLivePlugin",
+                    requiresAPIKey: false
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let chunks = [
+            Array(repeating: Float(0.2), count: 16_000),
+            Array(repeating: Float(0.0001), count: 40_000),
+        ]
+        let indexLock = NSLock()
+        var index = 0
+        var nextOffset = 0
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: { [] },
+            recentBufferProvider: { _ in [] },
+            bufferDeltaProvider: { _ in
+                indexLock.lock()
+                defer { indexLock.unlock() }
+                guard index < chunks.count else {
+                    return ([], nextOffset)
+                }
+                let chunk = chunks[index]
+                index += 1
+                nextOffset += chunk.count
+                return (chunk, nextOffset)
+            },
+            bufferedDurationProvider: { 3.5 }
+        )
+
+        let updatesLock = OSAllocatedUnfairLock(initialState: [String]())
+        handler.onPartialTextUpdate = { text in
+            updatesLock.withLock { $0.append(text) }
+        }
+
+        var activeChecks = 0
+        handler.start(
+            streamPrompt: "Live Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("de"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: {
+                activeChecks += 1
+                return activeChecks <= 3
+            }
+        )
+
+        try await Task.sleep(for: .milliseconds(900))
+        handler.stop()
+
+        XCTAssertEqual(updatesLock.withLock { $0 }, ["Gesprochener Satz."])
     }
 
     func testModelManagerUsesHintAwarePluginWhenMultipleHintsAreSelected() async throws {


### PR DESCRIPTION
## Summary
- Simplify the LiveTranscript overlay so it renders the latest provider snapshot verbatim and lets completed transcription replace late preview text.
- Add LiveTranscript appearance controls for font size, window size, and background opacity.
- Persist the LiveTranscript panel frame across opens, including secondary/wide monitor positions, and save movement/resize immediately.
- Gate noisy live-preview updates during sustained silence and let Parakeet use the batch fallback for live preview.

## Issue Context
Closes #560.
Closes #472.

The latest #472 feedback reports sticky words and suspected context loss when Live Transcript splits sentences. This PR addresses that by removing Live Transcript's plugin-side sentence/paragraph accumulation path: the overlay now shows the latest stabilized provider snapshot verbatim, while the final completed transcript replaces late preview text.

Refs #555 for the related production-vs-dev timing discussion. This PR does not auto-close #555 because the issue explicitly asks to keep the discussion open, and the measured signed production audio-startup gap remains a separate investigation.

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter 'LiveTranscriptPluginTests|ParakeetPluginTests'`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' -only-testing:TypeWhisperTests/StreamingHandlerTests`
- `git diff --check`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run LiveTranscriptPlugin /Users/marco/.codex/worktrees/a805/typewhisper-mac`