### PR TITLE
Fix indicator suppression for maximized VS Code windows

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -253,6 +253,7 @@ enum IndicatorWindowFrameLookup {
 enum IndicatorFullscreenSuppressionPolicy {
     private static let minimumHorizontalCoverage: CGFloat = 0.5
     private static let minimumVerticalCoverage: CGFloat = 0.5
+    private static let minimumFullscreenDimensionCoverage: CGFloat = 0.98
     @MainActor private static var lastSuppression: IndicatorFullscreenSuppressionDiagnostics?
 
     @MainActor
@@ -324,7 +325,9 @@ enum IndicatorFullscreenSuppressionPolicy {
         let screenFrame = screenFrame.standardized
         let windowFrame = candidateWindowFrame.standardized
 
-        if let focusedWindowIsFullscreen, !focusedWindowIsFullscreen {
+        if let focusedWindowIsFullscreen {
+            guard focusedWindowIsFullscreen else { return false }
+        } else if !isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
             return false
         }
 
@@ -346,6 +349,16 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         return horizontalCoverage >= minimumHorizontalCoverage
             && verticalCoverage >= minimumVerticalCoverage
+    }
+
+    private static func isFullscreenLikeWindow(screenFrame: CGRect, windowFrame: CGRect) -> Bool {
+        guard screenFrame.width > 0, screenFrame.height > 0 else { return false }
+
+        let widthCoverage = min(windowFrame.width / screenFrame.width, 1)
+        let heightCoverage = min(windowFrame.height / screenFrame.height, 1)
+
+        return widthCoverage >= minimumFullscreenDimensionCoverage
+            && heightCoverage >= minimumFullscreenDimensionCoverage
     }
 
     private static func isTypeWhisperBundleIdentifier(

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -256,6 +256,22 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testDoesNotSuppressForeignMaximizedWindowWhenAXFullscreenIsUnavailable() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let maximizedWindowBelowMenuBar = CGRect(x: 7, y: 46, width: 1497, height: 929)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: maximizedWindowBelowMenuBar,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.microsoft.VSCode",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
     func testDoesNotSuppressOnNonNotchedScreen() {
         let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
 


### PR DESCRIPTION
## Summary
- Fixes the fullscreen-suppression fallback so normal maximized windows are not treated as fullscreen when AXFullScreen is unavailable.
- Keeps the existing guard for real fullscreen-like foreign windows by requiring both screen-wide and screen-tall coverage before applying the notch-strip overlap rule.
- Adds a regression test using the VS Code geometry from the reporter diagnostics.

## Issue context
Issue #565 reports that the Notch/Overlay live transcript preview can disappear over maximized normal windows, especially Visual Studio Code, while recording and final insertion still work. The reporter diagnostics show `lastIndicatorFullscreenSuppression` for `com.microsoft.VSCode` with a 1512x982 screen, a 1497x929 window, and no `focusedWindowIsFullscreen` value. That means the old fallback suppressed solely from notch-strip overlap even though the window covered only about 94.6% of the screen height.

Local VS Code did not reproduce the disappearance because AX reported `AXFullScreen=false` here, but the diagnostics reproduce the failing policy path directly.

Closes #565

## Test plan
- `git fetch origin main && git merge origin/main --no-edit`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`\n- `git diff --check`\n\n## Manual diagnostics check\n- Reporter settings: `indicatorStyle=notch`, live transcript preview enabled, `notchIndicatorDisplay=activeScreen`, `notchIndicatorVisibility=duringActivity`, Parakeet selected and ready.\n- Suppression evidence: `frontmostBundleIdentifier=com.microsoft.VSCode`, `focusedWindowIsFullscreen` absent, width coverage `0.9901`, height coverage `0.9460`, notch-strip vertical coverage `0.78125`.\n- New fallback result: the same VS Code window no longer qualifies as fullscreen-like because height coverage is below `0.98`.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fullscreen window detection for more reliable indicator suppression, including improved handling when system information is unavailable.

* **Tests**
  * Added test coverage for maximized window scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->