### PR TITLE
feat: manage downloaded plugin models

### DIFF
--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -183,6 +183,26 @@ enum ExternalBundleNotice: Equatable {
     }
 }
 
+enum PluginModelManagementError: LocalizedError {
+    case pluginNotFound
+    case pluginNotLoaded(String)
+    case unsupported(String)
+    case modelNotFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .pluginNotFound:
+            return "Plugin not found."
+        case .pluginNotLoaded(let name):
+            return "\(name) is disabled. Enable the plugin before managing downloaded models."
+        case .unsupported(let name):
+            return "\(name) does not expose downloaded model management."
+        case .modelNotFound(let modelId):
+            return "Downloaded model '\(modelId)' was not found."
+        }
+    }
+}
+
 // MARK: - Plugin Manager
 
 @MainActor
@@ -645,6 +665,29 @@ final class PluginManager: ObservableObject {
     /// Notify observers that plugin state changed (e.g. a model was loaded/unloaded)
     func notifyPluginStateChanged() {
         readinessRevision += 1
+    }
+
+    func deleteDownloadedModel(pluginId: String, modelId: String) async throws {
+        guard let plugin = loadedPlugins.first(where: { $0.manifest.id == pluginId }) else {
+            throw PluginModelManagementError.pluginNotFound
+        }
+        guard plugin.isRuntimeLoaded else {
+            throw PluginModelManagementError.pluginNotLoaded(plugin.manifest.name)
+        }
+        guard let modelManager = plugin.instance as? any PluginDownloadedModelManaging else {
+            throw PluginModelManagementError.unsupported(plugin.manifest.name)
+        }
+        guard modelManager.downloadedModels.contains(where: { $0.id == modelId }) else {
+            throw PluginModelManagementError.modelNotFound(modelId)
+        }
+
+        try await modelManager.deleteDownloadedModel(modelId)
+
+        if modelManager.downloadedModels.isEmpty {
+            setPluginEnabled(pluginId, enabled: false)
+        } else {
+            notifyPluginStateChanged()
+        }
     }
 
     // MARK: - Dynamic Plugin Management

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -188,6 +188,7 @@ enum PluginModelManagementError: LocalizedError {
     case pluginNotLoaded(String)
     case unsupported(String)
     case modelNotFound(String)
+    case pluginBusy(String)
 
     var errorDescription: String? {
         switch self {
@@ -199,6 +200,8 @@ enum PluginModelManagementError: LocalizedError {
             return "\(name) does not expose downloaded model management."
         case .modelNotFound(let modelId):
             return "Downloaded model '\(modelId)' was not found."
+        case .pluginBusy(let name):
+            return "\(name) is currently updating models. Try again when the operation finishes."
         }
     }
 }
@@ -216,6 +219,7 @@ final class PluginManager: ObservableObject {
     let pluginsDirectory: URL
     private var ruleNamesProvider: @MainActor () -> [String] = { [] }
     private var workflowProvider: @MainActor () -> [PluginWorkflowInfo] = { [] }
+    private var deletingModelPluginIds = Set<String>()
 
     var postProcessors: [PostProcessorPlugin] {
         loadedPlugins
@@ -677,8 +681,19 @@ final class PluginManager: ObservableObject {
         guard let modelManager = plugin.instance as? any PluginDownloadedModelManaging else {
             throw PluginModelManagementError.unsupported(plugin.manifest.name)
         }
+        if let activityReporter = plugin.instance as? any PluginSettingsActivityReporting,
+           let activity = activityReporter.currentSettingsActivity,
+           !activity.isError {
+            throw PluginModelManagementError.pluginBusy(plugin.manifest.name)
+        }
         guard modelManager.downloadedModels.contains(where: { $0.id == modelId }) else {
             throw PluginModelManagementError.modelNotFound(modelId)
+        }
+        guard deletingModelPluginIds.insert(pluginId).inserted else {
+            throw PluginModelManagementError.pluginBusy(plugin.manifest.name)
+        }
+        defer {
+            deletingModelPluginIds.remove(pluginId)
         }
 
         try await modelManager.deleteDownloadedModel(modelId)

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1012,104 +1012,218 @@ private struct InstalledPluginRow: View {
     let onUpdate: () -> Void
     let onUninstall: () -> Void
     @State private var pluginActivity: PluginSettingsActivity?
+    @State private var modelsExpanded = false
+    @State private var modelPendingDeletion: PluginModelInfo?
+    @State private var deletingModelId: String?
+    @State private var modelDeleteError: String?
 
     private let activityTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            IntegrationIcon(
-                systemName: registryPlugin?.iconSystemName ?? plugin.manifest.iconSystemName ?? "puzzlepiece.extension",
-                tint: source.tint,
-                resourceURL: plugin.iconResourceURL
-            )
+        let models = downloadedModels
 
-            VStack(alignment: .leading, spacing: 5) {
-                HStack(spacing: 6) {
-                    Text(plugin.manifest.name)
-                        .font(.headline)
-                        .lineLimit(1)
-                    Text("v\(plugin.manifest.version)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                IntegrationIcon(
+                    systemName: registryPlugin?.iconSystemName ?? plugin.manifest.iconSystemName ?? "puzzlepiece.extension",
+                    tint: source.tint,
+                    resourceURL: plugin.iconResourceURL
+                )
 
-                PluginBadgeLine(source: source, hosting: hosting, categories: categories)
-
-                if let description = registryPlugin?.localizedDescription {
-                    Text(description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                } else if let author = plugin.manifest.author {
-                    Text(author)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-
-                if let externalNotice {
-                    Text(externalNotice.detailText)
-                        .font(.caption2)
-                        .foregroundStyle(externalNotice.badgeColor)
-                        .lineLimit(1)
-                }
-
-                if let state = installState {
-                    PluginInstallStateView(state: state, name: plugin.manifest.name)
-                } else if case .updateAvailable = installInfo {
-                    Button {
-                        onUpdate()
-                    } label: {
-                        Label(String(localized: "Update"), systemImage: "arrow.down.circle")
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 6) {
+                        Text(plugin.manifest.name)
+                            .font(.headline)
+                            .lineLimit(1)
+                        Text("v\(plugin.manifest.version)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
-                    .controlSize(.small)
-                } else if let pluginActivity {
-                    PluginSettingsActivityView(activity: pluginActivity)
+
+                    PluginBadgeLine(source: source, hosting: hosting, categories: categories)
+
+                    if let description = registryPlugin?.localizedDescription {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    } else if let author = plugin.manifest.author {
+                        Text(author)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    if !models.isEmpty {
+                        Button {
+                            modelsExpanded.toggle()
+                        } label: {
+                            HStack(spacing: 5) {
+                                Image(systemName: modelsExpanded ? "chevron.down" : "chevron.right")
+                                    .font(.caption2.weight(.semibold))
+                                    .frame(width: 10)
+                                Label(downloadedModelCountTitle(models.count), systemImage: "externaldrive")
+                                    .labelStyle(.titleAndIcon)
+                            }
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(downloadedModelCountTitle(models.count))
+                    }
+
+                    if let externalNotice {
+                        Text(externalNotice.detailText)
+                            .font(.caption2)
+                            .foregroundStyle(externalNotice.badgeColor)
+                            .lineLimit(1)
+                    }
+
+                    if let state = installState {
+                        PluginInstallStateView(state: state, name: plugin.manifest.name)
+                    } else if case .updateAvailable = installInfo {
+                        Button {
+                            onUpdate()
+                        } label: {
+                            Label(String(localized: "Update"), systemImage: "arrow.down.circle")
+                        }
+                        .controlSize(.small)
+                    } else if let pluginActivity {
+                        PluginSettingsActivityView(activity: pluginActivity)
+                    }
+                }
+
+                Spacer(minLength: 12)
+
+                HStack(spacing: 8) {
+                    Toggle("", isOn: Binding(
+                        get: { plugin.isEnabled },
+                        set: { enabled in
+                            PluginManager.shared.setPluginEnabled(plugin.id, enabled: enabled)
+                        }
+                    ))
+                    .labelsHidden()
+                    .accessibilityLabel(String(localized: "Enable \(plugin.manifest.name)"))
+
+                    if plugin.supportsSettingsWindow {
+                        Button {
+                            PluginSettingsWindowManager.shared.present(plugin)
+                        } label: {
+                            Image(systemName: "gear")
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel(String(localized: "Settings for \(plugin.manifest.name)"))
+                    }
+
+                    if !plugin.isBundled {
+                        Button {
+                            onUninstall()
+                        } label: {
+                            Image(systemName: "trash")
+                                .foregroundStyle(.red)
+                        }
+                        .buttonStyle(.borderless)
+                        .help(String(localized: "Uninstall"))
+                        .accessibilityLabel(String(localized: "Uninstall \(plugin.manifest.name)"))
+                    }
                 }
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
 
-            Spacer(minLength: 12)
+            if modelsExpanded && !models.isEmpty {
+                VStack(spacing: 0) {
+                    ForEach(Array(models.enumerated()), id: \.element.id) { index, model in
+                        DownloadedPluginModelRow(
+                            model: model,
+                            isDeleting: deletingModelId == model.id,
+                            onDelete: {
+                                modelPendingDeletion = model
+                            }
+                        )
+                        .disabled(deletingModelId != nil)
 
-            HStack(spacing: 8) {
-                Toggle("", isOn: Binding(
-                    get: { plugin.isEnabled },
-                    set: { enabled in
-                        PluginManager.shared.setPluginEnabled(plugin.id, enabled: enabled)
+                        if index < models.count - 1 {
+                            Divider()
+                                .padding(.leading, 96)
+                        }
                     }
-                ))
-                .labelsHidden()
-                .accessibilityLabel(String(localized: "Enable \(plugin.manifest.name)"))
-
-                if plugin.supportsSettingsWindow {
-                    Button {
-                        PluginSettingsWindowManager.shared.present(plugin)
-                    } label: {
-                        Image(systemName: "gear")
-                    }
-                    .buttonStyle(.borderless)
-                    .accessibilityLabel(String(localized: "Settings for \(plugin.manifest.name)"))
                 }
-
-                if !plugin.isBundled {
-                    Button {
-                        onUninstall()
-                    } label: {
-                        Image(systemName: "trash")
-                            .foregroundStyle(.red)
-                    }
-                    .buttonStyle(.borderless)
-                    .help(String(localized: "Uninstall"))
-                    .accessibilityLabel(String(localized: "Uninstall \(plugin.manifest.name)"))
-                }
+                .padding(.bottom, 8)
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
         .onAppear {
             refreshPluginActivity()
         }
         .onReceive(activityTimer) { _ in
             refreshPluginActivity()
+        }
+        .alert(
+            String(localized: "Remove Downloaded Model"),
+            isPresented: Binding(
+                get: { modelPendingDeletion != nil },
+                set: { if !$0 { modelPendingDeletion = nil } }
+            ),
+            presenting: modelPendingDeletion
+        ) { model in
+            Button(String(localized: "Remove"), role: .destructive) {
+                deleteDownloadedModel(model)
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                modelPendingDeletion = nil
+            }
+        } message: { model in
+            Text(deleteConfirmationMessage(for: model, downloadedCount: models.count))
+        }
+        .alert(
+            String(localized: "Could Not Remove Model"),
+            isPresented: Binding(
+                get: { modelDeleteError != nil },
+                set: { if !$0 { modelDeleteError = nil } }
+            )
+        ) {
+            Button(String(localized: "OK")) { modelDeleteError = nil }
+        } message: {
+            if let modelDeleteError {
+                Text(modelDeleteError)
+            }
+        }
+    }
+
+    private var downloadedModels: [PluginModelInfo] {
+        guard plugin.isRuntimeLoaded,
+              let modelManager = plugin.instance as? any PluginDownloadedModelManaging else {
+            return []
+        }
+        return modelManager.downloadedModels
+            .sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+    }
+
+    private func downloadedModelCountTitle(_ count: Int) -> String {
+        if count == 1 {
+            return String(localized: "1 downloaded model")
+        }
+        return String(localized: "\(count) downloaded models")
+    }
+
+    private func deleteConfirmationMessage(for model: PluginModelInfo, downloadedCount: Int) -> String {
+        if downloadedCount <= 1 {
+            return String(localized: "Remove \(model.displayName)? This will delete the downloaded model files and disable \(plugin.manifest.name).")
+        }
+        return String(localized: "Remove \(model.displayName)? This will delete the downloaded model files. \(plugin.manifest.name) will stay installed and enabled.")
+    }
+
+    private func deleteDownloadedModel(_ model: PluginModelInfo) {
+        modelPendingDeletion = nil
+        deletingModelId = model.id
+
+        Task { @MainActor in
+            do {
+                try await PluginManager.shared.deleteDownloadedModel(pluginId: plugin.id, modelId: model.id)
+            } catch {
+                modelDeleteError = error.localizedDescription
+            }
+            deletingModelId = nil
         }
     }
 
@@ -1119,6 +1233,72 @@ private struct InstalledPluginRow: View {
             return
         }
         pluginActivity = (plugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
+    }
+}
+
+private struct DownloadedPluginModelRow: View {
+    let model: PluginModelInfo
+    let isDeleting: Bool
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: model.loaded == true ? "checkmark.circle.fill" : "externaldrive")
+                .foregroundStyle(model.loaded == true ? .green : .secondary)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(model.displayName)
+                        .font(.caption.weight(.medium))
+                        .lineLimit(1)
+
+                    if model.loaded == true {
+                        Text(String(localized: "Loaded"))
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.green)
+                    }
+                }
+
+                if !model.sizeDescription.isEmpty || model.languageCount > 0 {
+                    Text(modelDetailText)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 12)
+
+            if isDeleting {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Button {
+                    onDelete()
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.borderless)
+                .help(String(localized: "Remove downloaded model"))
+                .accessibilityLabel(String(localized: "Remove \(model.displayName)"))
+            }
+        }
+        .padding(.leading, 62)
+        .padding(.trailing, 14)
+        .padding(.vertical, 7)
+    }
+
+    private var modelDetailText: String {
+        var parts: [String] = []
+        if !model.sizeDescription.isEmpty {
+            parts.append(model.sizeDescription)
+        }
+        if model.languageCount > 0 {
+            parts.append(String(localized: "\(model.languageCount) languages"))
+        }
+        return parts.joined(separator: " - ")
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -90,7 +90,7 @@ private struct Gemma4TokenizerLoader: TokenizerLoader {
 // MARK: - Plugin Entry Point
 
 @objc(Gemma4Plugin)
-final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, @unchecked Sendable {
+final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gemma4"
     static let pluginName = "Gemma 4"
     static let defaultGenerationTemperature = 0.1
@@ -176,6 +176,41 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         return Self.availableModels
             .filter { $0.id == loadedModelId }
             .map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        Self.availableModels
+            .filter { hasDownloadedModel($0) }
+            .map { def in
+                PluginModelInfo(
+                    id: def.id,
+                    displayName: def.displayName,
+                    sizeDescription: def.sizeDescription,
+                    downloaded: true,
+                    loaded: def.id == loadedModelId
+                )
+            }
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard let modelDef = Self.modelDefinition(for: modelId) else { return }
+
+        if loadedModelId == modelId {
+            modelContainer = nil
+            loadedModelId = nil
+            downloadProgress = 0
+            modelState = .notLoaded
+        }
+        if _selectedLLMModelId == modelId {
+            _selectedLLMModelId = nil
+            host?.setUserDefault(nil, forKey: "selectedLLMModel")
+        }
+        if host?.userDefault(forKey: "loadedModel") as? String == modelId {
+            host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+
+        deleteModelFiles(modelDef)
+        host?.notifyCapabilitiesChanged()
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -209,7 +209,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
 
-        deleteModelFiles(modelDef)
+        try deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -439,9 +439,11 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         host?.notifyCapabilitiesChanged()
     }
 
-    func deleteModelFiles(_ modelDef: Gemma4ModelDef) {
+    func deleteModelFiles(_ modelDef: Gemma4ModelDef) throws {
         let repoDir = localModelDirectory(for: modelDef.repoId)
-        try? FileManager.default.removeItem(at: repoDir)
+        if FileManager.default.fileExists(atPath: repoDir.path) {
+            try FileManager.default.removeItem(at: repoDir)
+        }
     }
 
     func resetCachedModel(_ modelDef: Gemma4ModelDef) {
@@ -450,7 +452,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         downloadProgress = 0
         modelState = .notLoaded
         host?.setUserDefault(nil, forKey: "loadedModel")
-        deleteModelFiles(modelDef)
+        try? deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
     }
 

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -9,7 +9,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(GranitePlugin)
-final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.granite"
     static let pluginName = "Granite Speech"
 
@@ -63,9 +63,42 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
                 id: def.id,
                 displayName: def.displayName,
                 sizeDescription: def.sizeDescription,
+                downloaded: hasDownloadedModel(def),
                 loaded: def.id == loadedModelId
             )
         }
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        Self.availableModels
+            .filter { hasDownloadedModel($0) }
+            .map { def in
+                PluginModelInfo(
+                    id: def.id,
+                    displayName: def.displayName,
+                    sizeDescription: def.sizeDescription,
+                    downloaded: true,
+                    loaded: def.id == loadedModelId
+                )
+            }
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else { return }
+
+        if loadedModelId == modelId {
+            unloadModel(clearPersistence: true)
+        }
+        if _selectedModelId == modelId {
+            _selectedModelId = nil
+            host?.setUserDefault(nil, forKey: "selectedModel")
+        }
+        if host?.userDefault(forKey: "loadedModel") as? String == modelId {
+            host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+
+        deleteModelFiles(modelDef)
+        host?.notifyCapabilitiesChanged()
     }
 
     var supportedLanguages: [String] {

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -97,7 +97,7 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
 
-        deleteModelFiles(modelDef)
+        try deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -219,13 +219,15 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         host?.notifyCapabilitiesChanged()
     }
 
-    fileprivate func deleteModelFiles(_ modelDef: GraniteModelDef) {
+    fileprivate func deleteModelFiles(_ modelDef: GraniteModelDef) throws {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
         let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
         let modelDir = modelsDir
             .appendingPathComponent("mlx-audio")
             .appendingPathComponent(subdirectory)
-        try? FileManager.default.removeItem(at: modelDir)
+        if FileManager.default.fileExists(atPath: modelDir.path) {
+            try FileManager.default.removeItem(at: modelDir)
+        }
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -535,7 +537,7 @@ private struct GraniteSettingsView: View {
                         .foregroundStyle(.green)
                     Button(String(localized: "Unload", bundle: bundle)) {
                         plugin.unloadModel()
-                        plugin.deleteModelFiles(modelDef)
+                        try? plugin.deleteModelFiles(modelDef)
                         modelState = plugin.modelState
                     }
                     .buttonStyle(.bordered)

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 
@@ -79,9 +79,42 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
                 id: def.id,
                 displayName: def.displayName,
                 sizeDescription: def.sizeDescription,
+                downloaded: hasDownloadedModel(def),
                 loaded: def.id == loadedModelId
             )
         }
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        Self.availableModels
+            .filter { hasDownloadedModel($0) }
+            .map { def in
+                PluginModelInfo(
+                    id: def.id,
+                    displayName: def.displayName,
+                    sizeDescription: def.sizeDescription,
+                    downloaded: true,
+                    loaded: def.id == loadedModelId
+                )
+            }
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else { return }
+
+        if loadedModelId == modelId {
+            unloadModel(clearPersistence: true)
+        }
+        if _selectedModelId == modelId {
+            _selectedModelId = nil
+            host?.setUserDefault(nil, forKey: "selectedModel")
+        }
+        if host?.userDefault(forKey: "loadedModel") as? String == modelId {
+            host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+
+        deleteModelFiles(modelDef)
+        host?.notifyCapabilitiesChanged()
     }
 
     var supportedLanguages: [String] {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -113,7 +113,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
 
-        deleteModelFiles(modelDef)
+        try deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -231,13 +231,15 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         host?.notifyCapabilitiesChanged()
     }
 
-    fileprivate func deleteModelFiles(_ modelDef: Qwen3ModelDef) {
+    fileprivate func deleteModelFiles(_ modelDef: Qwen3ModelDef) throws {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
         let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
         let modelDir = modelsDir
             .appendingPathComponent("mlx-audio")
             .appendingPathComponent(subdirectory)
-        try? FileManager.default.removeItem(at: modelDir)
+        if FileManager.default.fileExists(atPath: modelDir.path) {
+            try FileManager.default.removeItem(at: modelDir)
+        }
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -886,7 +888,7 @@ private struct Qwen3SettingsView: View {
                         .foregroundStyle(.green)
                     Button(String(localized: "Unload", bundle: bundle)) {
                         plugin.unloadModel()
-                        plugin.deleteModelFiles(modelDef)
+                        try? plugin.deleteModelFiles(modelDef)
                         modelState = plugin.modelState
                     }
                     .buttonStyle(.bordered)

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import TypeWhisperPluginSDK
+import TypeWhisperPluginSDKTesting
 @testable import Qwen3Plugin
 
 final class Qwen3PluginTests: XCTestCase {
@@ -114,5 +115,30 @@ final class Qwen3PluginTests: XCTestCase {
                 "qwen3-asr-1.7b-8bit",
             ]
         )
+    }
+
+    func testDeleteDownloadedModelRemovesCacheAndClearsSelection() async throws {
+        let model = try XCTUnwrap(Qwen3Plugin.availableModels.first)
+        let host = try PluginTestHostServices(defaults: ["selectedModel": model.id])
+        let plugin = Qwen3Plugin()
+
+        plugin.activate(host: host)
+        host.setUserDefault(model.id, forKey: "loadedModel")
+
+        let modelDirectory = host.pluginDataDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("mlx-audio", isDirectory: true)
+            .appendingPathComponent(model.repoId.replacingOccurrences(of: "/", with: "_"), isDirectory: true)
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+
+        try await plugin.deleteDownloadedModel(model.id)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertNil(plugin.selectedModelId)
+        XCTAssertNil(host.userDefault(forKey: "selectedModel"))
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicModelAssetManager.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicModelAssetManager.swift
@@ -169,8 +169,10 @@ struct SupertonicModelAssetManager: Sendable {
         try install(files: files, licenseAccepted: true)
     }
 
-    func deleteModelFiles() {
-        try? FileManager.default.removeItem(at: modelDirectory)
+    func deleteModelFiles() throws {
+        if FileManager.default.fileExists(atPath: modelDirectory.path) {
+            try FileManager.default.removeItem(at: modelDirectory)
+        }
     }
 
     private func remoteAssetPaths(token: String?) async throws -> [String] {

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
@@ -58,9 +58,10 @@ protocol SupertonicSynthesizing: AnyObject, Sendable {
 }
 
 @objc(SupertonicPlugin)
-final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivityReporting, @unchecked Sendable {
+final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.tts.supertonic"
     static let pluginName = "Supertonic (Experimental)"
+    private static let downloadedModelId = "supertonic-3"
 
     private let logger = Logger(subsystem: "com.typewhisper.tts.supertonic", category: "Plugin")
     private var host: HostServices?
@@ -110,6 +111,24 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
     var settingsSummary: String? {
         let voice = selectedVoiceId ?? "M1"
         return "Voice: \(voice) - Speed: \(String(format: "%.2fx", selectedSpeed)) - \(selectedQuality.displayName)"
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        guard modelAssetManager.hasDownloadedModel() else { return [] }
+        return [
+            PluginModelInfo(
+                id: Self.downloadedModelId,
+                displayName: "Supertonic 3",
+                sizeDescription: "Local TTS assets",
+                downloaded: true,
+                loaded: modelState == .ready
+            )
+        ]
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard modelId == Self.downloadedModelId else { return }
+        deleteCachedModel()
     }
 
     @MainActor

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
@@ -128,7 +128,7 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
 
     func deleteDownloadedModel(_ modelId: String) async throws {
         guard modelId == Self.downloadedModelId else { return }
-        deleteCachedModel()
+        try deleteCachedModel()
     }
 
     @MainActor
@@ -229,9 +229,9 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
         }
     }
 
-    func deleteCachedModel() {
+    func deleteCachedModel() throws {
         clearSynthesizerCache()
-        modelAssetManager.deleteModelFiles()
+        try modelAssetManager.deleteModelFiles()
         downloadProgress = 0
         modelState = .notDownloaded
         host?.notifyCapabilitiesChanged()
@@ -386,7 +386,7 @@ private struct SupertonicSettingsView: View {
                         .foregroundStyle(.green)
                     Spacer()
                     Button("Delete cached model") {
-                        plugin.deleteCachedModel()
+                        try? plugin.deleteCachedModel()
                         refreshFromPlugin()
                     }
                     .controlSize(.small)

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -9,7 +9,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(VoxtralPlugin)
-final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.voxtral"
     static let pluginName = "Voxtral"
 
@@ -79,9 +79,42 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
                 id: def.id,
                 displayName: def.displayName,
                 sizeDescription: def.sizeDescription,
+                downloaded: hasDownloadedModel(def),
                 loaded: def.id == loadedModelId
             )
         }
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        Self.availableModels
+            .filter { hasDownloadedModel($0) }
+            .map { def in
+                PluginModelInfo(
+                    id: def.id,
+                    displayName: def.displayName,
+                    sizeDescription: def.sizeDescription,
+                    downloaded: true,
+                    loaded: def.id == loadedModelId
+                )
+            }
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else { return }
+
+        if loadedModelId == modelId {
+            unloadModel(clearPersistence: true)
+        }
+        if _selectedModelId == modelId {
+            _selectedModelId = nil
+            host?.setUserDefault(nil, forKey: "selectedModel")
+        }
+        if host?.userDefault(forKey: "loadedModel") as? String == modelId {
+            host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+
+        deleteModelFiles(modelDef)
+        host?.notifyCapabilitiesChanged()
     }
 
     var supportedLanguages: [String] {

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -113,7 +113,7 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
 
-        deleteModelFiles(modelDef)
+        try deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -240,14 +240,16 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         host?.notifyCapabilitiesChanged()
     }
 
-    fileprivate func deleteModelFiles(_ modelDef: VoxtralModelDef) {
+    fileprivate func deleteModelFiles(_ modelDef: VoxtralModelDef) throws {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
         let repoDir = modelsDir.appendingPathComponent("huggingface")
             .appendingPathComponent("hub")
         // HubCache stores repos under models--org--name pattern
         let subdirectory = "models--" + modelDef.repoId.replacingOccurrences(of: "/", with: "--")
         let modelDir = repoDir.appendingPathComponent(subdirectory)
-        try? FileManager.default.removeItem(at: modelDir)
+        if FileManager.default.fileExists(atPath: modelDir.path) {
+            try FileManager.default.removeItem(at: modelDir)
+        }
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -541,7 +543,7 @@ private struct VoxtralSettingsView: View {
                         .foregroundStyle(.green)
                     Button(String(localized: "Unload", bundle: bundle)) {
                         plugin.unloadModel()
-                        plugin.deleteModelFiles(modelDef)
+                        try? plugin.deleteModelFiles(modelDef)
                         modelState = plugin.modelState
                     }
                     .buttonStyle(.bordered)

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -6,7 +6,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(WhisperKitPlugin)
-final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.whisperkit"
     static let pluginName = "WhisperKit"
     private static let maxConditioningPromptChars = 500
@@ -90,9 +90,43 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
                 displayName: def.displayName,
                 sizeDescription: def.sizeDescription,
                 languageCount: 99,
+                downloaded: isModelDownloaded(def),
                 loaded: def.id == loadedModelId
             )
         }
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        Self.availableModels
+            .filter { isModelDownloaded($0) }
+            .map { def in
+                PluginModelInfo(
+                    id: def.id,
+                    displayName: def.displayName,
+                    sizeDescription: def.sizeDescription,
+                    languageCount: 99,
+                    downloaded: true,
+                    loaded: def.id == loadedModelId
+                )
+            }
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else { return }
+
+        if loadedModelId == modelId {
+            unloadModel(clearPersistence: true)
+        }
+        if _selectedModelId == modelId {
+            _selectedModelId = nil
+            host?.setUserDefault(nil, forKey: "selectedModel")
+        }
+        if host?.userDefault(forKey: "loadedModel") as? String == modelId {
+            host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+
+        deleteModelFiles(modelDef)
+        host?.notifyCapabilitiesChanged()
     }
 
     var selectedModelId: String? { _selectedModelId }

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -125,7 +125,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
 
-        deleteModelFiles(modelDef)
+        try deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -451,9 +451,11 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
         host?.notifyCapabilitiesChanged()
     }
 
-    fileprivate func deleteModelFiles(_ modelDef: WhisperModelDef) {
+    fileprivate func deleteModelFiles(_ modelDef: WhisperModelDef) throws {
         let modelPath = resolvedModelPath(for: modelDef)
-        try? FileManager.default.removeItem(at: modelPath)
+        if FileManager.default.fileExists(atPath: modelPath.path) {
+            try FileManager.default.removeItem(at: modelPath)
+        }
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -1141,7 +1143,7 @@ private struct WhisperKitSettingsView: View {
         if case .ready(let loadedId) = modelState, loadedId == modelDef.id {
             plugin.unloadModel()
         }
-        plugin.deleteModelFiles(modelDef)
+        try? plugin.deleteModelFiles(modelDef)
         syncViewStateFromPlugin()
     }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -163,6 +163,14 @@ public protocol LLMProviderPlugin: TypeWhisperPlugin {
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String
 }
 
+/// Optional extension for plugins that manage downloaded model assets.
+/// Hosts can use this to show and remove model caches without knowing the
+/// plugin's storage layout.
+public protocol PluginDownloadedModelManaging: TypeWhisperPlugin {
+    var downloadedModels: [PluginModelInfo] { get }
+    func deleteDownloadedModel(_ modelId: String) async throws
+}
+
 /// Optional protocol for LLM plugins that can describe why they are currently unavailable.
 /// This lets the host distinguish local model setup from missing remote credentials.
 public protocol LLMProviderSetupStatusProviding {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -96,6 +96,33 @@ private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin
     }
 }
 
+@objc(MockDownloadedModelPlugin)
+private final class MockDownloadedModelPlugin: NSObject, TypeWhisperPlugin, PluginDownloadedModelManaging, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.downloaded-models"
+    static let pluginName = "Mock Downloaded Models"
+
+    private(set) var deletedModelIds: [String] = []
+    var downloadedModels: [PluginModelInfo] = [
+        PluginModelInfo(
+            id: "local-small",
+            displayName: "Local Small",
+            sizeDescription: "1 GB",
+            downloaded: true,
+            loaded: true
+        )
+    ]
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        deletedModelIds.append(modelId)
+        downloadedModels.removeAll { $0.id == modelId }
+    }
+}
+
 @objc(MockAuthRoleStatusPlugin)
 private final class MockAuthRoleStatusPlugin: NSObject, TypeWhisperPlugin, PluginAuthRoleStatusProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.auth-roles"
@@ -459,6 +486,21 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertFalse(legacyPlugin is any TranscriptionModelCatalogProviding)
         XCTAssertEqual(legacyPlugin.modelCatalog.map(\.id), ["tiny"])
         XCTAssertEqual(catalogPlugin.modelCatalog.map(\.id), ["tiny", "large"])
+    }
+
+    func testDownloadedModelManagingProtocolIsOptionalAndUsesModelInfo() async throws {
+        let legacyPlugin = MockTranscriptionPlugin()
+        let downloadedModelPlugin = MockDownloadedModelPlugin()
+
+        XCTAssertFalse(legacyPlugin is any PluginDownloadedModelManaging)
+        XCTAssertEqual(downloadedModelPlugin.downloadedModels.map(\.id), ["local-small"])
+        XCTAssertEqual(downloadedModelPlugin.downloadedModels.first?.downloaded, true)
+        XCTAssertEqual(downloadedModelPlugin.downloadedModels.first?.loaded, true)
+
+        try await downloadedModelPlugin.deleteDownloadedModel("local-small")
+
+        XCTAssertEqual(downloadedModelPlugin.deletedModelIds, ["local-small"])
+        XCTAssertTrue(downloadedModelPlugin.downloadedModels.isEmpty)
     }
 
     func testStructuredTranscriptionProtocolIsOptionalAndCarriesSpeakerMetadata() async throws {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -100,12 +100,16 @@ final class PluginManifestValidationTests: XCTestCase {
 
 @MainActor
 final class PluginDownloadedModelManagementTests: XCTestCase {
-    private final class MockDownloadedModelPlugin: NSObject, TypeWhisperPlugin, PluginDownloadedModelManaging, @unchecked Sendable {
+    private final class MockDownloadedModelPlugin: NSObject, TypeWhisperPlugin, PluginDownloadedModelManaging, PluginSettingsActivityReporting, @unchecked Sendable {
         static let pluginId = "com.typewhisper.tests.downloaded-models"
         static let pluginName = "Downloaded Models Test Plugin"
 
         var downloadedModels: [PluginModelInfo]
+        var currentSettingsActivity: PluginSettingsActivity?
         var shouldFailDeletion = false
+        var shouldSuspendDeletion = false
+        var deletionDidStart: (() -> Void)?
+        private var deletionResume: CheckedContinuation<Void, Never>?
         private(set) var deletedModelIds: [String] = []
         private(set) var didDeactivate = false
 
@@ -134,8 +138,20 @@ final class PluginDownloadedModelManagementTests: XCTestCase {
                 )
             }
 
+            deletionDidStart?()
+            if shouldSuspendDeletion {
+                await withCheckedContinuation { continuation in
+                    deletionResume = continuation
+                }
+            }
+
             deletedModelIds.append(modelId)
             downloadedModels.removeAll { $0.id == modelId }
+        }
+
+        func resumeDeletion() {
+            deletionResume?.resume()
+            deletionResume = nil
         }
     }
 
@@ -222,6 +238,77 @@ final class PluginDownloadedModelManagementTests: XCTestCase {
         }
 
         XCTAssertEqual(plugin.downloadedModels.map(\.id), ["only"])
+        XCTAssertEqual(manager.loadedPlugins.first?.isEnabled, true)
+        XCTAssertFalse(plugin.didDeactivate)
+    }
+
+    func testDeletionDuringPluginModelActivityThrowsBusyAndLeavesModel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginDownloadedModels")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pluginId = "com.typewhisper.tests.downloaded.busy"
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let plugin = MockDownloadedModelPlugin(downloadedModels: [
+            PluginModelInfo(id: "only", displayName: "Only", downloaded: true)
+        ])
+        plugin.currentSettingsActivity = PluginSettingsActivity(message: "Downloading model", progress: 0.5)
+        manager.loadedPlugins = [
+            try makeLoadedPlugin(plugin: plugin, pluginId: pluginId, directory: appSupportDirectory)
+        ]
+
+        do {
+            try await manager.deleteDownloadedModel(pluginId: pluginId, modelId: "only")
+            XCTFail("Expected deletion to be blocked while the plugin reports activity")
+        } catch PluginModelManagementError.pluginBusy(let name) {
+            XCTAssertEqual(name, "Downloaded Models Test Plugin")
+        } catch {
+            XCTFail("Expected pluginBusy, got \(error)")
+        }
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), ["only"])
+        XCTAssertTrue(plugin.deletedModelIds.isEmpty)
+        XCTAssertEqual(manager.loadedPlugins.first?.isEnabled, true)
+        XCTAssertFalse(plugin.didDeactivate)
+    }
+
+    func testConcurrentDeletionForSamePluginThrowsBusy() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginDownloadedModels")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pluginId = "com.typewhisper.tests.downloaded.concurrent"
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let plugin = MockDownloadedModelPlugin(downloadedModels: [
+            PluginModelInfo(id: "one", displayName: "One", downloaded: true),
+            PluginModelInfo(id: "two", displayName: "Two", downloaded: true),
+        ])
+        plugin.shouldSuspendDeletion = true
+        let deletionStarted = expectation(description: "first deletion started")
+        plugin.deletionDidStart = {
+            deletionStarted.fulfill()
+        }
+        manager.loadedPlugins = [
+            try makeLoadedPlugin(plugin: plugin, pluginId: pluginId, directory: appSupportDirectory)
+        ]
+
+        let firstDeletion = Task {
+            try await manager.deleteDownloadedModel(pluginId: pluginId, modelId: "one")
+        }
+        await fulfillment(of: [deletionStarted], timeout: 1)
+
+        do {
+            try await manager.deleteDownloadedModel(pluginId: pluginId, modelId: "two")
+            XCTFail("Expected concurrent deletion to be blocked")
+        } catch PluginModelManagementError.pluginBusy(let name) {
+            XCTAssertEqual(name, "Downloaded Models Test Plugin")
+        } catch {
+            XCTFail("Expected pluginBusy, got \(error)")
+        }
+
+        plugin.resumeDeletion()
+        try await firstDeletion.value
+
+        XCTAssertEqual(plugin.deletedModelIds, ["one"])
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), ["two"])
         XCTAssertEqual(manager.loadedPlugins.first?.isEnabled, true)
         XCTAssertFalse(plugin.didDeactivate)
     }

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -99,6 +99,175 @@ final class PluginManifestValidationTests: XCTestCase {
 }
 
 @MainActor
+final class PluginDownloadedModelManagementTests: XCTestCase {
+    private final class MockDownloadedModelPlugin: NSObject, TypeWhisperPlugin, PluginDownloadedModelManaging, @unchecked Sendable {
+        static let pluginId = "com.typewhisper.tests.downloaded-models"
+        static let pluginName = "Downloaded Models Test Plugin"
+
+        var downloadedModels: [PluginModelInfo]
+        var shouldFailDeletion = false
+        private(set) var deletedModelIds: [String] = []
+        private(set) var didDeactivate = false
+
+        required override init() {
+            self.downloadedModels = []
+            super.init()
+        }
+
+        init(downloadedModels: [PluginModelInfo]) {
+            self.downloadedModels = downloadedModels
+            super.init()
+        }
+
+        func activate(host: HostServices) {}
+
+        func deactivate() {
+            didDeactivate = true
+        }
+
+        func deleteDownloadedModel(_ modelId: String) async throws {
+            if shouldFailDeletion {
+                throw NSError(
+                    domain: "PluginDownloadedModelManagementTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Deletion failed"]
+                )
+            }
+
+            deletedModelIds.append(modelId)
+            downloadedModels.removeAll { $0.id == modelId }
+        }
+    }
+
+    func testDeletingOneOfMultipleDownloadedModelsKeepsPluginEnabled() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginDownloadedModels")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let plugin = MockDownloadedModelPlugin(downloadedModels: [
+            PluginModelInfo(id: "small", displayName: "Small", downloaded: true),
+            PluginModelInfo(id: "large", displayName: "Large", downloaded: true),
+        ])
+        manager.loadedPlugins = [
+            try makeLoadedPlugin(
+                plugin: plugin,
+                pluginId: "com.typewhisper.tests.downloaded.multiple",
+                directory: appSupportDirectory
+            )
+        ]
+
+        let initialRevision = manager.readinessRevision
+
+        try await manager.deleteDownloadedModel(
+            pluginId: "com.typewhisper.tests.downloaded.multiple",
+            modelId: "small"
+        )
+
+        XCTAssertEqual(plugin.deletedModelIds, ["small"])
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), ["large"])
+        XCTAssertEqual(manager.loadedPlugins.first?.isEnabled, true)
+        XCTAssertFalse(plugin.didDeactivate)
+        XCTAssertEqual(manager.readinessRevision, initialRevision + 1)
+    }
+
+    func testDeletingLastDownloadedModelDisablesPlugin() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginDownloadedModels")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pluginId = "com.typewhisper.tests.downloaded.single"
+        let defaultsKey = "plugin.\(pluginId).enabled"
+        let originalValue = UserDefaults.standard.object(forKey: defaultsKey)
+        defer { restoreDefault(key: defaultsKey, value: originalValue) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let plugin = MockDownloadedModelPlugin(downloadedModels: [
+            PluginModelInfo(id: "only", displayName: "Only", downloaded: true)
+        ])
+        manager.loadedPlugins = [
+            try makeLoadedPlugin(plugin: plugin, pluginId: pluginId, directory: appSupportDirectory)
+        ]
+
+        try await manager.deleteDownloadedModel(pluginId: pluginId, modelId: "only")
+
+        XCTAssertEqual(plugin.deletedModelIds, ["only"])
+        XCTAssertTrue(plugin.downloadedModels.isEmpty)
+        XCTAssertEqual(manager.loadedPlugins.first?.isEnabled, false)
+        XCTAssertTrue(plugin.didDeactivate)
+        XCTAssertEqual(UserDefaults.standard.bool(forKey: defaultsKey), false)
+    }
+
+    func testDeletionFailureDoesNotDisablePluginOrDropModel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginDownloadedModels")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pluginId = "com.typewhisper.tests.downloaded.failure"
+        let defaultsKey = "plugin.\(pluginId).enabled"
+        let originalValue = UserDefaults.standard.object(forKey: defaultsKey)
+        defer { restoreDefault(key: defaultsKey, value: originalValue) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let plugin = MockDownloadedModelPlugin(downloadedModels: [
+            PluginModelInfo(id: "only", displayName: "Only", downloaded: true)
+        ])
+        plugin.shouldFailDeletion = true
+        manager.loadedPlugins = [
+            try makeLoadedPlugin(plugin: plugin, pluginId: pluginId, directory: appSupportDirectory)
+        ]
+
+        do {
+            try await manager.deleteDownloadedModel(pluginId: pluginId, modelId: "only")
+            XCTFail("Expected deletion to fail")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Deletion failed")
+        }
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), ["only"])
+        XCTAssertEqual(manager.loadedPlugins.first?.isEnabled, true)
+        XCTAssertFalse(plugin.didDeactivate)
+    }
+
+    private func makeLoadedPlugin(
+        plugin: MockDownloadedModelPlugin,
+        pluginId: String,
+        directory: URL
+    ) throws -> LoadedPlugin {
+        let bundleURL = directory.appendingPathComponent("\(pluginId).bundle", isDirectory: true)
+        let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+        let infoPlist: [String: Any] = [
+            "CFBundleIdentifier": pluginId,
+            "CFBundleName": "Downloaded Models Test Plugin",
+            "CFBundlePackageType": "BNDL",
+            "CFBundleVersion": "1",
+        ]
+        let infoData = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+        try infoData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let manifest = PluginManifest(
+            id: pluginId,
+            name: "Downloaded Models Test Plugin",
+            version: "1.0.0",
+            principalClass: "MockDownloadedModelPlugin"
+        )
+        return LoadedPlugin(
+            manifest: manifest,
+            instance: plugin,
+            bundle: bundle,
+            sourceURL: bundleURL,
+            isEnabled: true
+        )
+    }
+
+    private func restoreDefault(key: String, value: Any?) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+}
+
+@MainActor
 final class Gemma4PluginModelPolicyTests: XCTestCase {
     private actor RequestRecorder {
         private var request: URLRequest?
@@ -297,6 +466,37 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.modelState, .notLoaded)
         XCTAssertEqual(plugin.currentDownloadProgress, 0)
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 2)
+    }
+
+    func testGemma4DeleteDownloadedModelClearsSelectionAndCache() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: ["selectedLLMModel": model.id]
+        )
+        let plugin = Gemma4Plugin()
+        let modelDirectory = appSupportDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(model.repoId, isDirectory: true)
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+
+        plugin.activate(host: host)
+        try await Task.sleep(nanoseconds: 10_000_000)
+        host.setUserDefault(model.id, forKey: "loadedModel")
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+
+        try await plugin.deleteDownloadedModel(model.id)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertNil(plugin.selectedLLMModelId)
+        XCTAssertNil(host.userDefault(forKey: "selectedLLMModel"))
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
     }
 
     func testGemma4ValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -119,4 +119,66 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
         XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
     }
+
+    func testDeleteDownloadedModelRemovesFilesAndClearsPersistedSelection() async throws {
+        let modelId = "openai_whisper-tiny"
+        let host = try makeHost(defaults: ["selectedModel": modelId])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        host.setUserDefault(modelId, forKey: "loadedModel")
+
+        let modelDirectory = try makeUsableWhisperModelDirectory(host: host, modelId: modelId)
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [modelId])
+
+        try await plugin.deleteDownloadedModel(modelId)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertNil(plugin.selectedModelId)
+        XCTAssertNil(host.userDefault(forKey: "selectedModel"))
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    private func makeUsableWhisperModelDirectory(
+        host: MockHostServices,
+        modelId: String
+    ) throws -> URL {
+        let modelDirectory = host.pluginDataDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("argmaxinc", isDirectory: true)
+            .appendingPathComponent("whisperkit-coreml", isDirectory: true)
+            .appendingPathComponent(modelId, isDirectory: true)
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+
+        try Data("{}".utf8).write(to: modelDirectory.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: modelDirectory.appendingPathComponent("generation_config.json"))
+
+        for component in ["MelSpectrogram", "AudioEncoder", "TextDecoder"] {
+            let componentDirectory = modelDirectory.appendingPathComponent("\(component).mlmodelc", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: componentDirectory.appendingPathComponent("analytics", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: componentDirectory.appendingPathComponent("weights", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+
+            for file in ["metadata.json", "model.mil", "coremldata.bin"] {
+                try Data("x".utf8).write(to: componentDirectory.appendingPathComponent(file))
+            }
+            try Data("x".utf8).write(to: componentDirectory.appendingPathComponent("analytics/coremldata.bin"))
+            try Data("x".utf8).write(to: componentDirectory.appendingPathComponent("weights/weight.bin"))
+
+            if component == "AudioEncoder" || component == "TextDecoder" {
+                try Data("x".utf8).write(to: componentDirectory.appendingPathComponent("model.mlmodel"))
+            }
+        }
+
+        return modelDirectory
+    }
 }


### PR DESCRIPTION
## Issue context

Issue #569 asks for downloaded plugin models to be visible from Integrations, removable one-by-one, and for TypeWhisper to disable a plugin only when its last plugin-managed downloaded model is removed.

Closes #569

## Summary

- Added the optional `PluginDownloadedModelManaging` SDK protocol so plugins can expose downloaded model state and plugin-owned deletion without changing required plugin protocols or bumping SDK compatibility.
- Added central `PluginManager.deleteDownloadedModel(pluginId:modelId:)` behavior that delegates deletion to the plugin, refreshes plugin state, and disables the plugin when no managed downloaded models remain.
- Extended the Integrations installed-plugin row with an expandable downloaded-model list showing model name, size/detail text, loaded state, confirmation before removal, per-model deletion progress, and error reporting.
- Opted in first-party local cache plugins: WhisperKit, Gemma4, Qwen3, Voxtral, Granite, and Supertonic. SpeechAnalyzer remains excluded because its assets are system-managed; Parakeet remains excluded because this change avoids deleting shared cache state without a clearly plugin-owned deletion path.
- Added regression coverage for the SDK contract, manager enable/disable semantics, deletion failure behavior, and plugin cache cleanup for WhisperKit, Gemma4, and Qwen3.

## Test Coverage

All new code paths added in this PR have targeted XCTest/SwiftPM coverage:

- SDK opt-in protocol remains optional for legacy plugins and reuses `PluginModelInfo`.
- Deleting one of multiple downloaded models keeps the plugin enabled.
- Deleting the last downloaded model disables the plugin.
- Plugin deletion errors leave the plugin enabled and leave the model list unchanged.
- WhisperKit, Gemma4, and Qwen3 deletion clears persisted selection/loaded-model state and removes cache files.

## Pre-Landing Review

No blocking issues found in local diff review.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`

Note: Xcode prints a local CoreSimulator version warning in this environment, but the macOS XCTest run and dev build both completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete downloaded plugin models from plugin settings with per-model UI, confirmations, and progress feedback.
  * Settings show which models are downloaded and which are currently loaded.
  * Deleting the last downloaded model will disable the plugin.

* **Bug Fixes**
  * Deletion clears cached files and persisted selections, and updates plugin state/readiness.

* **Tests**
  * Added tests covering deletion behavior, error cases, concurrency and filesystem removals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->