### PR TITLE
chore: gate downloaded model plugin releases to 1.4

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
     "version": "1.0.1",
-    "minHostVersion": "0.11.0",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [
         "arm64"

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.granite",
     "name": "Granite Speech",
     "version": "1.0.2",
-    "minHostVersion": "1.2.1",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
     "version": "1.1.0",
-    "minHostVersion": "1.2.1",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.voxtral",
     "name": "Voxtral",
     "version": "1.0.6",
-    "minHostVersion": "1.2.1",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
     "version": "1.0.16",
-    "minHostVersion": "1.2.1",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -54,6 +54,24 @@ final class PluginManifestValidationTests: XCTestCase {
         }
     }
 
+    func testDownloadedModelManagingPluginReleasesRequireHost14() throws {
+        let manifestPaths = [
+            "TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json",
+            "TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json",
+            "TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json",
+            "TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json",
+            "TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json",
+            "TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json",
+        ]
+
+        for relativePath in manifestPaths {
+            let manifestURL = TestSupport.repoRoot.appendingPathComponent(relativePath)
+            let data = try Data(contentsOf: manifestURL)
+            let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+            XCTAssertEqual(manifest.minHostVersion, "1.4.0", relativePath)
+        }
+    }
+
     func testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)


### PR DESCRIPTION
## Context

PR #570 implemented downloaded model management for local-cache plugins. The plugin release workflow publishes the manifest `minHostVersion` into the registry, so plugin binaries that opt into the new SDK protocol must not be offered to pre-1.4 hosts.

Follow-up to #569 / #570.

## Changes

- Set `minHostVersion` to `1.4.0` for WhisperKit, Gemma4, Qwen3, Voxtral, and Granite.
- Keep Supertonic at its existing `1.4.0` gate.
- Add a manifest validation test that locks all downloaded-model-managing plugin releases to host 1.4.

## Test Plan

- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/PluginManifestValidationTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version requirements to mandate host version 1.4.0 minimum across multiple plugins

* **Tests**
  * Added validation test to verify plugin compatibility with updated host version requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->