### PR TITLE
feat: add dictionary HTTP API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,36 @@ curl "http://localhost:8978/v1/history?q=meeting&limit=10&offset=0"
 curl -X DELETE "http://localhost:8978/v1/history?id=<uuid>"
 ```
 
+### Dictionary
+
+```bash
+# List recognition terms
+curl http://localhost:8978/v1/dictionary/terms
+
+# Merge terms, or set replace=true to replace all terms
+curl -X PUT http://localhost:8978/v1/dictionary/terms \
+  -H "Content-Type: application/json" \
+  -d '{"terms":["TypeWhisper","WhisperKit"],"replace":false}'
+
+# Delete one term
+curl -X DELETE http://localhost:8978/v1/dictionary/terms \
+  -H "Content-Type: application/json" \
+  -d '{"term":"TypeWhisper"}'
+
+# List post-transcription corrections
+curl http://localhost:8978/v1/dictionary/corrections
+
+# Add or update one correction by original text
+curl -X PUT http://localhost:8978/v1/dictionary/corrections \
+  -H "Content-Type: application/json" \
+  -d '{"original":"teh","replacement":"the","caseSensitive":false}'
+
+# Delete one correction
+curl -X DELETE http://localhost:8978/v1/dictionary/corrections \
+  -H "Content-Type: application/json" \
+  -d '{"original":"teh"}'
+```
+
 ### Workflows
 
 ```bash

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -6,6 +6,20 @@ import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "DictionaryService")
 
+enum DictionaryServiceMutationError: LocalizedError {
+    case unavailable
+    case saveFailed(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Dictionary storage is unavailable"
+        case .saveFailed(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
 @MainActor
 final class DictionaryService: ObservableObject {
     private var modelContainer: ModelContainer?
@@ -240,7 +254,17 @@ final class DictionaryService: ObservableObject {
     }
 
     func setTerms(_ rawTerms: [String], replaceExisting: Bool) {
-        guard let context = modelContext else { return }
+        do {
+            try setAPITerms(rawTerms, replaceExisting: replaceExisting)
+        } catch {
+            logger.error("Failed to set terms: \(error.localizedDescription)")
+        }
+    }
+
+    func setAPITerms(_ rawTerms: [String], replaceExisting: Bool) throws {
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
 
         let normalized = PluginDictionaryTerms.normalizedTerms(from: rawTerms)
         let normalizedByKey = Dictionary(uniqueKeysWithValues: normalized.map {
@@ -273,7 +297,37 @@ final class DictionaryService: ObservableObject {
                 loadEntries()
             } catch {
                 logger.error("Failed to set terms: \(error.localizedDescription)")
+                throw DictionaryServiceMutationError.saveFailed(error)
             }
+        }
+    }
+
+    func deleteAPITerm(_ rawTerm: String) throws -> Bool {
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
+
+        guard let normalizedTerm = PluginDictionaryTerms.normalizedTerms(from: [rawTerm]).first else {
+            return false
+        }
+
+        let desiredKey = normalizedTerm.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        guard let entry = entries.first(where: {
+            $0.type == .term &&
+            $0.original.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current) == desiredKey
+        }) else {
+            return false
+        }
+
+        context.delete(entry)
+
+        do {
+            try context.save()
+            loadEntries()
+            return true
+        } catch {
+            logger.error("Failed to delete term: \(error.localizedDescription)")
+            throw DictionaryServiceMutationError.saveFailed(error)
         }
     }
 
@@ -348,6 +402,63 @@ final class DictionaryService: ObservableObject {
             replacement: replacement,
             caseSensitive: false
         )
+    }
+
+    func upsertAPICorrection(original: String, replacement: String, caseSensitive: Bool) throws {
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
+
+        if let entry = entries.first(where: {
+            $0.type == .correction &&
+            $0.original.caseInsensitiveCompare(original) == .orderedSame
+        }) {
+            entry.original = original
+            entry.replacement = replacement
+            entry.caseSensitive = caseSensitive
+            entry.isEnabled = true
+        } else {
+            let entry = DictionaryEntry(
+                type: .correction,
+                original: original,
+                replacement: replacement,
+                caseSensitive: caseSensitive,
+                isEnabled: true
+            )
+            context.insert(entry)
+        }
+
+        do {
+            try context.save()
+            loadEntries()
+        } catch {
+            logger.error("Failed to upsert correction: \(error.localizedDescription)")
+            throw DictionaryServiceMutationError.saveFailed(error)
+        }
+    }
+
+    func deleteAPICorrection(original: String) throws -> Bool {
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
+
+        guard let entry = entries.first(where: {
+            $0.type == .correction &&
+            $0.original.caseInsensitiveCompare(original) == .orderedSame
+        }) else {
+            return false
+        }
+
+        context.delete(entry)
+
+        do {
+            try context.save()
+            loadEntries()
+            return true
+        } catch {
+            logger.error("Failed to delete correction: \(error.localizedDescription)")
+            throw DictionaryServiceMutationError.saveFailed(error)
+        }
     }
 
     private func incrementUsageCount(for entry: DictionaryEntry) {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -48,6 +48,9 @@ final class APIHandlers: @unchecked Sendable {
         router.register("GET", "/v1/dictionary/terms", handler: handleGetDictionaryTerms)
         router.register("PUT", "/v1/dictionary/terms", handler: handlePutDictionaryTerms)
         router.register("DELETE", "/v1/dictionary/terms", handler: handleDeleteDictionaryTerms)
+        router.register("GET", "/v1/dictionary/corrections", handler: handleGetDictionaryCorrections)
+        router.register("PUT", "/v1/dictionary/corrections", handler: handlePutDictionaryCorrections)
+        router.register("DELETE", "/v1/dictionary/corrections", handler: handleDeleteDictionaryCorrections)
     }
 
     // MARK: - POST /v1/transcribe
@@ -712,23 +715,157 @@ final class APIHandlers: @unchecked Sendable {
             let count: Int
         }
 
-        return await MainActor.run {
-            dictionaryService.setTerms(payload.terms, replaceExisting: payload.replace ?? false)
-            let terms = dictionaryService.enabledTerms()
-            return .json(DictionaryTermsResponse(terms: terms, count: terms.count))
+        do {
+            return try await MainActor.run {
+                try dictionaryService.setAPITerms(payload.terms, replaceExisting: payload.replace ?? false)
+                let terms = dictionaryService.enabledTerms()
+                return .json(DictionaryTermsResponse(terms: terms, count: terms.count))
+            }
+        } catch {
+            return .error(status: 500, message: "Failed to save dictionary: \(error.localizedDescription)")
         }
     }
 
     private func handleDeleteDictionaryTerms(_ request: HTTPRequest) async -> HTTPResponse {
+        struct DeleteDictionaryTermRequest: Decodable {
+            let term: String
+        }
+
         struct DeleteResponse: Encodable {
             let deleted: Bool
             let count: Int
         }
 
-        return await MainActor.run {
-            dictionaryService.removeAllTerms()
-            return .json(DeleteResponse(deleted: true, count: 0))
+        guard !request.body.isEmpty else {
+            return .error(status: 400, message: "Missing JSON body")
         }
+
+        let payload: DeleteDictionaryTermRequest
+        do {
+            payload = try JSONDecoder().decode(DeleteDictionaryTermRequest.self, from: request.body)
+        } catch {
+            return .error(status: 400, message: "Invalid JSON body")
+        }
+
+        let term = payload.term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else {
+            return .error(status: 400, message: "Missing or empty 'term'")
+        }
+
+        do {
+            return try await MainActor.run {
+                let deleted = try dictionaryService.deleteAPITerm(term)
+                let terms = dictionaryService.enabledTerms()
+                return .json(DeleteResponse(deleted: deleted, count: terms.count))
+            }
+        } catch {
+            return .error(status: 500, message: "Failed to save dictionary: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - /v1/dictionary/corrections
+
+    private struct DictionaryCorrectionEntry: Encodable {
+        let original: String
+        let replacement: String
+        let caseSensitive: Bool
+    }
+
+    private struct DictionaryCorrectionsResponse: Encodable {
+        let corrections: [DictionaryCorrectionEntry]
+        let count: Int
+    }
+
+    private func handleGetDictionaryCorrections(_ request: HTTPRequest) async -> HTTPResponse {
+        await MainActor.run {
+            dictionaryCorrectionsResponse()
+        }
+    }
+
+    private func handlePutDictionaryCorrections(_ request: HTTPRequest) async -> HTTPResponse {
+        struct DictionaryCorrectionRequest: Decodable {
+            let original: String
+            let replacement: String
+            let caseSensitive: Bool?
+        }
+
+        guard !request.body.isEmpty else {
+            return .error(status: 400, message: "Missing JSON body")
+        }
+
+        let payload: DictionaryCorrectionRequest
+        do {
+            payload = try JSONDecoder().decode(DictionaryCorrectionRequest.self, from: request.body)
+        } catch {
+            return .error(status: 400, message: "Invalid JSON body")
+        }
+
+        let original = payload.original.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !original.isEmpty else {
+            return .error(status: 400, message: "Missing or empty 'original'")
+        }
+
+        do {
+            return try await MainActor.run {
+                try dictionaryService.upsertAPICorrection(
+                    original: original,
+                    replacement: payload.replacement,
+                    caseSensitive: payload.caseSensitive ?? false
+                )
+                return dictionaryCorrectionsResponse()
+            }
+        } catch {
+            return .error(status: 500, message: "Failed to save dictionary: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleDeleteDictionaryCorrections(_ request: HTTPRequest) async -> HTTPResponse {
+        struct DeleteDictionaryCorrectionRequest: Decodable {
+            let original: String
+        }
+
+        struct DeleteResponse: Encodable {
+            let deleted: Bool
+            let count: Int
+        }
+
+        guard !request.body.isEmpty else {
+            return .error(status: 400, message: "Missing JSON body")
+        }
+
+        let payload: DeleteDictionaryCorrectionRequest
+        do {
+            payload = try JSONDecoder().decode(DeleteDictionaryCorrectionRequest.self, from: request.body)
+        } catch {
+            return .error(status: 400, message: "Invalid JSON body")
+        }
+
+        let original = payload.original.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !original.isEmpty else {
+            return .error(status: 400, message: "Missing or empty 'original'")
+        }
+
+        do {
+            return try await MainActor.run {
+                let deleted = try dictionaryService.deleteAPICorrection(original: original)
+                let count = dictionaryService.corrections.count
+                return .json(DeleteResponse(deleted: deleted, count: count))
+            }
+        } catch {
+            return .error(status: 500, message: "Failed to save dictionary: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    private func dictionaryCorrectionsResponse() -> HTTPResponse {
+        let corrections = dictionaryService.corrections.map {
+            DictionaryCorrectionEntry(
+                original: $0.original,
+                replacement: $0.replacement ?? "",
+                caseSensitive: $0.caseSensitive
+            )
+        }
+        return .json(DictionaryCorrectionsResponse(corrections: corrections, count: corrections.count))
     }
 
     // MARK: - GET /v1/rules

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -842,7 +842,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual((toggledRules["rules"] as? [[String: Any]])?.first?["is_enabled"] as? Bool, false)
     }
 
-    func testDictionaryTermsEndpointsReplaceNormalizeAndClearTerms() async throws {
+    func testDictionaryTermsEndpointsReplaceMergeAndDeleteSingleTerm() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?
         defer {
@@ -871,23 +871,210 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(putResponse["count"] as? Int, 3)
         XCTAssertEqual(putResponse["terms"] as? [String], expectedTerms)
 
+        let mergeBody = try JSONSerialization.data(withJSONObject: [
+            "terms": ["Raycast", "qwen3"],
+        ])
+        let mergeResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "PUT",
+                path: "/v1/dictionary/terms",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: mergeBody
+            )
+        ))
+        let expectedMergedTerms = ["qwen3", "Raycast", "TypeWhisper", "WhisperKit"]
+        XCTAssertEqual(mergeResponse["count"] as? Int, 4)
+        XCTAssertEqual(mergeResponse["terms"] as? [String], expectedMergedTerms)
+
         let getResponse = try Self.jsonObject(await router.route(
             HTTPRequest(method: "GET", path: "/v1/dictionary/terms", queryParams: [:], headers: [:], body: Data())
         ))
-        XCTAssertEqual(getResponse["terms"] as? [String], expectedTerms)
+        XCTAssertEqual(getResponse["terms"] as? [String], expectedMergedTerms)
         let enabledTerms = await MainActor.run { apiContext.dictionaryService.enabledTerms() }
-        XCTAssertEqual(enabledTerms, expectedTerms)
+        XCTAssertEqual(enabledTerms, expectedMergedTerms)
 
+        let deleteBody = try JSONSerialization.data(withJSONObject: ["term": "typewhisper"])
         let deleteResponse = try Self.jsonObject(await router.route(
-            HTTPRequest(method: "DELETE", path: "/v1/dictionary/terms", queryParams: [:], headers: [:], body: Data())
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/dictionary/terms",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: deleteBody
+            )
         ))
         XCTAssertEqual(deleteResponse["deleted"] as? Bool, true)
-        XCTAssertEqual(deleteResponse["count"] as? Int, 0)
+        XCTAssertEqual(deleteResponse["count"] as? Int, 3)
 
         let finalGet = try Self.jsonObject(await router.route(
             HTTPRequest(method: "GET", path: "/v1/dictionary/terms", queryParams: [:], headers: [:], body: Data())
         ))
-        XCTAssertEqual(finalGet["terms"] as? [String], [])
+        XCTAssertEqual(finalGet["terms"] as? [String], ["qwen3", "Raycast", "WhisperKit"])
+
+        let missingDeleteResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/dictionary/terms",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["term": "Missing"])
+            )
+        ))
+        XCTAssertEqual(missingDeleteResponse["deleted"] as? Bool, false)
+        XCTAssertEqual(missingDeleteResponse["count"] as? Int, 3)
+
+        let missingTermDelete = await router.route(
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/dictionary/terms",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: [:])
+            )
+        )
+        XCTAssertEqual(missingTermDelete.status, 400)
+
+        let emptyDelete = await router.route(
+            HTTPRequest(method: "DELETE", path: "/v1/dictionary/terms", queryParams: [:], headers: [:], body: Data())
+        )
+        XCTAssertEqual(emptyDelete.status, 400)
+    }
+
+    func testDictionaryCorrectionsEndpointsListUpsertDeleteAndValidateInput() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+
+        let initialGet = try Self.jsonObject(await router.route(
+            HTTPRequest(method: "GET", path: "/v1/dictionary/corrections", queryParams: [:], headers: [:], body: Data())
+        ))
+        XCTAssertEqual(initialGet["count"] as? Int, 0)
+        XCTAssertEqual((initialGet["corrections"] as? [[String: Any]])?.count, 0)
+
+        let putBody = try JSONSerialization.data(withJSONObject: [
+            "original": "teh",
+            "replacement": "the",
+            "caseSensitive": false,
+        ])
+        let putResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "PUT",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: putBody
+            )
+        ))
+        var corrections = try XCTUnwrap(putResponse["corrections"] as? [[String: Any]])
+        XCTAssertEqual(putResponse["count"] as? Int, 1)
+        XCTAssertEqual(corrections.first?["original"] as? String, "teh")
+        XCTAssertEqual(corrections.first?["replacement"] as? String, "the")
+        XCTAssertEqual(corrections.first?["caseSensitive"] as? Bool, false)
+
+        let upsertBody = try JSONSerialization.data(withJSONObject: [
+            "original": "TEH",
+            "replacement": "The",
+            "caseSensitive": true,
+        ])
+        let upsertResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "PUT",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: upsertBody
+            )
+        ))
+        corrections = try XCTUnwrap(upsertResponse["corrections"] as? [[String: Any]])
+        XCTAssertEqual(upsertResponse["count"] as? Int, 1)
+        XCTAssertEqual(corrections.first?["original"] as? String, "TEH")
+        XCTAssertEqual(corrections.first?["replacement"] as? String, "The")
+        XCTAssertEqual(corrections.first?["caseSensitive"] as? Bool, true)
+        let serviceCorrectionsCount = await MainActor.run { apiContext.dictionaryService.correctionsCount }
+        XCTAssertEqual(serviceCorrectionsCount, 1)
+
+        let emptyReplacementBody = try JSONSerialization.data(withJSONObject: [
+            "original": "¿",
+            "replacement": "",
+            "caseSensitive": false,
+        ])
+        let emptyReplacementResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "PUT",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: emptyReplacementBody
+            )
+        ))
+        XCTAssertEqual(emptyReplacementResponse["count"] as? Int, 2)
+
+        let deleteBody = try JSONSerialization.data(withJSONObject: ["original": "teh"])
+        let deleteResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: deleteBody
+            )
+        ))
+        XCTAssertEqual(deleteResponse["deleted"] as? Bool, true)
+        XCTAssertEqual(deleteResponse["count"] as? Int, 1)
+
+        let missingDeleteBody = try JSONSerialization.data(withJSONObject: ["original": "missing"])
+        let missingDeleteResponse = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: missingDeleteBody
+            )
+        ))
+        XCTAssertEqual(missingDeleteResponse["deleted"] as? Bool, false)
+        XCTAssertEqual(missingDeleteResponse["count"] as? Int, 1)
+
+        let missingOriginalPut = await router.route(
+            HTTPRequest(
+                method: "PUT",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["replacement": "value"])
+            )
+        )
+        XCTAssertEqual(missingOriginalPut.status, 400)
+
+        let missingReplacementPut = await router.route(
+            HTTPRequest(
+                method: "PUT",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["original": "value"])
+            )
+        )
+        XCTAssertEqual(missingReplacementPut.status, 400)
+
+        let missingOriginalDelete = await router.route(
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/dictionary/corrections",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: [:])
+            )
+        )
+        XCTAssertEqual(missingOriginalDelete.status, 400)
     }
 
     func testTranscribeEndpointPassesDictionaryTermsAsPrompt() async throws {

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -111,6 +111,41 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testAPITermHelpersDeleteSingleTermWithoutClearingOthers() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        try service.setAPITerms([" TypeWhisper ", "WhisperKit", "typewhisper"], replaceExisting: true)
+
+        XCTAssertTrue(try service.deleteAPITerm("typewhisper"))
+        XCTAssertEqual(service.enabledTerms(), ["WhisperKit"])
+        XCTAssertFalse(try service.deleteAPITerm("Missing"))
+    }
+
+    @MainActor
+    func testAPICorrectionHelpersUpsertCaseInsensitiveAndPreserveUsageCount() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        try service.upsertAPICorrection(original: "teh", replacement: "the", caseSensitive: false)
+        XCTAssertEqual(service.applyCorrections(to: "teh"), "the")
+        XCTAssertEqual(service.corrections.first?.usageCount, 1)
+
+        try service.upsertAPICorrection(original: "TEH", replacement: "The", caseSensitive: true)
+
+        XCTAssertEqual(service.correctionsCount, 1)
+        XCTAssertEqual(service.corrections.first?.original, "TEH")
+        XCTAssertEqual(service.corrections.first?.replacement, "The")
+        XCTAssertEqual(service.corrections.first?.caseSensitive, true)
+        XCTAssertEqual(service.corrections.first?.usageCount, 1)
+        XCTAssertTrue(try service.deleteAPICorrection(original: "teh"))
+        XCTAssertEqual(service.correctionsCount, 0)
+        XCTAssertFalse(try service.deleteAPICorrection(original: "missing"))
+    }
+
+    @MainActor
     func testEnabledTermsAreNormalizedAndPromptRendererStaysBackwardCompatible() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Issue Context

Issue #574 requests a local HTTP Dictionary API so external tools can manage recognition terms and post-transcription corrections without switching into the TypeWhisper UI. The requested use cases include Raycast/Alfred shortcuts, bulk onboarding via `curl`, cross-machine sync, and CI seeding.

Closes #574

## Summary

- Adds single-item Dictionary API mutation support for terms, including `DELETE /v1/dictionary/terms` with the required JSON body `{ "term": "..." }`.
- Adds `GET`, `PUT`, and `DELETE` routes for `/v1/dictionary/corrections`, including case-insensitive upsert/delete by `original` and `caseSensitive` request/response support.
- Extends `DictionaryService` with throwing API-facing helpers while preserving existing non-throwing UI methods and SwiftData-backed storage behavior.
- Documents concise local API `curl` examples for terms and corrections in the README.

## Test Coverage

All new API paths have XCTest coverage:

- Terms merge, replace/list behavior, single-term delete, missing target success, empty body, and missing `term` validation.
- Corrections list, case-insensitive upsert, empty-string replacement, single delete, missing target success, and bad/missing request body validation.
- DictionaryService helper behavior for single-term delete and correction upsert/delete preserving existing entry state.

## Pre-Landing Review

No issues found.

## Design Review

No frontend UI files changed, design review skipped.

## Eval Results

No prompt-related files changed, evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: implement the local Dictionary API requested in #574.

Delivered: local HTTP terms/corrections endpoints, service mutations, README examples, and focused XCTest coverage.

## Plan Completion

Plan completion: PASS. All requested API contract, implementation, docs, and test items are addressed.

## Verification Results

- Full macOS XCTest suite passed: 666 tests, 0 failures.
- Focused Dictionary/API suite passed: 106 tests, 0 failures.
- Dev app build passed and produced `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

Note: Xcode still reports the known CoreSimulator out-of-date warning before macOS tests/builds; it did not block the macOS XCTest suite or dev build.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/DictionaryServiceTests`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dictionary corrections management via API with support for creating, listing, and deleting corrections.
  * Updated dictionary terms deletion to support removing individual terms instead of clearing all at once.
  * Added `replace` option for term management operations.

* **Documentation**
  * Added comprehensive HTTP API documentation with example requests for dictionary management endpoints.

* **Bug Fixes**
  * Improved error reporting for dictionary storage and save failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->