### PR TITLE
Add recorder HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,77 @@ curl http://localhost:8978/v1/dictation/status
 curl "http://localhost:8978/v1/dictation/transcription?id=<uuid>"
 ```
 
+Dictation control records microphone audio for system-wide insertion. A completed dictation session returns text that TypeWhisper can paste back into the active app.
+
+### Recorder Control
+
+Recorder control uses the same recorder path as the TypeWhisper UI, including microphone capture, optional system audio capture, mixing, finalization, and final transcription. Use it for automations that need a saved recording file or meeting/system-audio transcription without auto-pasting into another app.
+
+```bash
+# Start recorder with microphone and system audio
+curl -X POST "http://localhost:8978/v1/recorder/start?mic=true&system_audio=true"
+
+# Stop the active API recorder session
+curl -X POST http://localhost:8978/v1/recorder/stop
+
+# Check whether the recorder is currently recording
+curl http://localhost:8978/v1/recorder/status
+
+# Fetch status/result for a specific recorder session
+curl "http://localhost:8978/v1/recorder/session?id=<uuid>"
+```
+
+`POST /v1/recorder/start` accepts optional query flags:
+- `mic` - `true`, `false`, `1`, or `0`. If omitted, TypeWhisper uses the current recorder microphone setting.
+- `system_audio` - `true`, `false`, `1`, or `0`. If omitted, TypeWhisper uses the current recorder system-audio setting.
+
+At least one source must be enabled. If both resolved sources are disabled, the API returns `400 Bad Request`.
+
+Start response:
+
+```json
+{
+  "id": "8F8C1F45-6D03-44D2-A38C-0C4DE4F7E5F7",
+  "status": "recording"
+}
+```
+
+Stop response:
+
+```json
+{
+  "id": "8F8C1F45-6D03-44D2-A38C-0C4DE4F7E5F7",
+  "status": "finalizing"
+}
+```
+
+Status response:
+
+```json
+{
+  "recording": true
+}
+```
+
+Session response:
+
+```json
+{
+  "id": "8F8C1F45-6D03-44D2-A38C-0C4DE4F7E5F7",
+  "status": "completed",
+  "text": "Meeting notes from the recording.",
+  "output_file": "/Users/alex/Documents/TypeWhisper Recordings/Recording 2026-05-20 14-30-00.m4a"
+}
+```
+
+Recorder sessions move through `recording -> finalizing -> completed` or `failed`. If recorder transcription is disabled or produces no transcript, `text` is omitted and `output_file` still points to the finalized recording when available. Failed sessions include an `error` field.
+
+Conflict and lookup behavior:
+- Starting while the recorder is already recording or finalizing returns `409 Conflict`.
+- Stopping without an active API recorder session returns `409 Conflict`.
+- Polling with a missing or invalid `id` returns `400 Bad Request`.
+- Polling a valid but unknown session id returns `404 Not Found`.
+
 ## CLI Tool
 
 TypeWhisper includes a command-line tool for shell-friendly transcription. It is part of the advanced automation surface and connects to the running local API server.

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -153,6 +153,11 @@ final class ServiceContainer: ObservableObject {
             errorLogService: errorLogService,
             mediaPlaybackService: mediaPlaybackService
         )
+        audioRecorderViewModel = AudioRecorderViewModel(
+            recorderService: audioRecorderService,
+            modelManager: modelManagerService,
+            dictionaryService: dictionaryService
+        )
 
 
         // HTTP API
@@ -165,7 +170,8 @@ final class ServiceContainer: ObservableObject {
             historyService: historyService,
             workflowService: workflowService,
             dictionaryService: dictionaryService,
-            dictationViewModel: dictationViewModel
+            dictationViewModel: dictationViewModel,
+            audioRecorderViewModel: audioRecorderViewModel
         )
         handlers.register(on: router)
         httpServer = HTTPServer(router: router)
@@ -193,7 +199,6 @@ final class ServiceContainer: ObservableObject {
             promptProcessingService: promptProcessingService,
             profileService: profileService
         )
-        audioRecorderViewModel = AudioRecorderViewModel(recorderService: audioRecorderService, modelManager: modelManagerService, dictionaryService: dictionaryService)
         watchFolderViewModel = WatchFolderViewModel(
             watchFolderService: watchFolderService,
             modelManager: modelManagerService

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -454,6 +454,10 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     @Published private(set) var micLevel: Float = 0
     @Published private(set) var systemLevel: Float = 0
     @Published private(set) var systemAudioWarningMessage: String?
+    var recordingsDirectoryOverride: URL?
+    var startRecordingOverride: ((_ micEnabled: Bool, _ systemAudioEnabled: Bool, _ format: OutputFormat, _ outputURL: URL) async throws -> URL)?
+    var stopRecordingOverride: ((_ outputURL: URL) async throws -> URL?)?
+    var currentBufferOverride: (() -> [Float])?
 
     private var audioEngine: AVAudioEngine?
     private let micFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
@@ -488,7 +492,10 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     static let recordingsDirectoryName = "TypeWhisper Recordings"
 
     var recordingsDirectory: URL {
-        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        if let recordingsDirectoryOverride {
+            return recordingsDirectoryOverride
+        }
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent(Self.recordingsDirectoryName)
     }
 
@@ -496,6 +503,9 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     /// Thread-safe snapshot of the current 16kHz mono buffer for streaming transcription.
     func getCurrentBuffer() -> [Float] {
+        if let currentBufferOverride {
+            return currentBufferOverride()
+        }
         let micEnabled = self.micEnabled
         let systemAudioEnabled = self.systemAudioEnabled
         let micDuckingMode = self.micDuckingMode
@@ -517,6 +527,11 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     /// Returns at most the last `maxDuration` seconds of 16kHz audio.
     func getRecentBuffer(maxDuration: TimeInterval) -> [Float] {
+        if let currentBufferOverride {
+            let samples = currentBufferOverride()
+            let maxSampleCount = Int(maxDuration * Self.transcriptionSampleRate)
+            return Array(samples.suffix(maxSampleCount))
+        }
         let micEnabled = self.micEnabled
         let systemAudioEnabled = self.systemAudioEnabled
         let micDuckingMode = self.micDuckingMode
@@ -540,6 +555,11 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     /// Returns audio appended since `sampleOffset` and the updated absolute offset.
     func getBufferDelta(since sampleOffset: Int) -> (samples: [Float], nextOffset: Int) {
+        if let currentBufferOverride {
+            let samples = currentBufferOverride()
+            let startIndex = min(max(0, sampleOffset), samples.count)
+            return (Array(samples.dropFirst(startIndex)), samples.count)
+        }
         let micEnabled = self.micEnabled
         let systemAudioEnabled = self.systemAudioEnabled
         let micDuckingMode = self.micDuckingMode
@@ -562,6 +582,9 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     /// Total duration of transcription buffer in seconds.
     var totalBufferDuration: TimeInterval {
+        if let currentBufferOverride {
+            return Double(currentBufferOverride().count) / Self.transcriptionSampleRate
+        }
         return transcriptionBufferLock.withLock { buffer in
             Double(buffer.mixedSampleCount) / Self.transcriptionSampleRate
         }
@@ -591,31 +614,40 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let outputURL = dir.appendingPathComponent("Recording \(timestamp).\(format.fileExtension)")
         self.finalOutputURL = outputURL
 
-        // Setup temp files
-        let tempDir = FileManager.default.temporaryDirectory
-        let sessionId = UUID().uuidString
+        if let startRecordingOverride {
+            do {
+                self.finalOutputURL = try await startRecordingOverride(micEnabled, systemAudioEnabled, format, outputURL)
+            } catch {
+                await rollbackFailedStart()
+                throw error
+            }
+        } else {
+            // Setup temp files
+            let tempDir = FileManager.default.temporaryDirectory
+            let sessionId = UUID().uuidString
 
-        do {
-            // Start mic recording
-            if micEnabled {
-                guard AVAudioApplication.shared.recordPermission == .granted else {
-                    throw RecorderError.microphonePermissionDenied
+            do {
+                // Start mic recording
+                if micEnabled {
+                    guard AVAudioApplication.shared.recordPermission == .granted else {
+                        throw RecorderError.microphonePermissionDenied
+                    }
+
+                    let micURL = tempDir.appendingPathComponent("mic-\(sessionId).wav")
+                    self.micTempURL = micURL
+                    try startMicRecording(outputURL: micURL)
                 }
 
-                let micURL = tempDir.appendingPathComponent("mic-\(sessionId).wav")
-                self.micTempURL = micURL
-                try startMicRecording(outputURL: micURL)
+                // Start system audio recording
+                if systemAudioEnabled {
+                    let sysURL = tempDir.appendingPathComponent("sys-\(sessionId).wav")
+                    self.systemTempURL = sysURL
+                    try await startSystemAudioRecording(outputURL: sysURL)
+                }
+            } catch {
+                await rollbackFailedStart()
+                throw error
             }
-
-            // Start system audio recording
-            if systemAudioEnabled {
-                let sysURL = tempDir.appendingPathComponent("sys-\(sessionId).wav")
-                self.systemTempURL = sysURL
-                try await startSystemAudioRecording(outputURL: sysURL)
-            }
-        } catch {
-            await rollbackFailedStart()
-            throw error
         }
 
         // Start duration timer
@@ -634,7 +666,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             self.isRecording = true
         }
 
-        return outputURL
+        return finalOutputURL ?? outputURL
     }
 
     func stopRecording() async -> URL? {
@@ -642,6 +674,33 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         durationTimer?.invalidate()
         durationTimer = nil
         endSystemAudioMonitoring()
+
+        if let stopRecordingOverride, let finalURL = finalOutputURL {
+            let completedURL: URL?
+            do {
+                completedURL = try await stopRecordingOverride(finalURL)
+            } catch {
+                logger.error("Failed to finalize recording with override: \(error.localizedDescription)")
+                cleanupTempFile(finalURL)
+                completedURL = nil
+            }
+
+            cleanupTempFile(micTempURL)
+            cleanupTempFile(systemTempURL)
+            micTempURL = nil
+            systemTempURL = nil
+            finalOutputURL = nil
+            startTime = nil
+
+            DispatchQueue.main.async {
+                self.isRecording = false
+                self.duration = 0
+                self.micLevel = 0
+                self.systemLevel = 0
+            }
+
+            return completedURL
+        }
 
         // Stop mic
         if micEnabled {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -11,6 +11,7 @@ final class APIHandlers: @unchecked Sendable {
     private let workflowService: WorkflowService
     private let dictionaryService: DictionaryService
     private let dictationViewModel: DictationViewModel
+    private let audioRecorderViewModel: AudioRecorderViewModel
 
     init(
         modelManager: ModelManagerService,
@@ -19,7 +20,8 @@ final class APIHandlers: @unchecked Sendable {
         historyService: HistoryService,
         workflowService: WorkflowService,
         dictionaryService: DictionaryService,
-        dictationViewModel: DictationViewModel
+        dictationViewModel: DictationViewModel,
+        audioRecorderViewModel: AudioRecorderViewModel
     ) {
         self.modelManager = modelManager
         self.audioFileService = audioFileService
@@ -28,6 +30,7 @@ final class APIHandlers: @unchecked Sendable {
         self.workflowService = workflowService
         self.dictionaryService = dictionaryService
         self.dictationViewModel = dictationViewModel
+        self.audioRecorderViewModel = audioRecorderViewModel
     }
 
     func register(on router: APIRouter) {
@@ -45,6 +48,10 @@ final class APIHandlers: @unchecked Sendable {
         router.register("POST", "/v1/dictation/stop", handler: handleStopDictation)
         router.register("GET", "/v1/dictation/status", handler: handleDictationStatus)
         router.register("GET", "/v1/dictation/transcription", handler: handleDictationTranscription)
+        router.register("POST", "/v1/recorder/start", handler: handleStartRecorder)
+        router.register("POST", "/v1/recorder/stop", handler: handleStopRecorder)
+        router.register("GET", "/v1/recorder/status", handler: handleRecorderStatus)
+        router.register("GET", "/v1/recorder/session", handler: handleRecorderSession)
         router.register("GET", "/v1/dictionary/terms", handler: handleGetDictionaryTerms)
         router.register("PUT", "/v1/dictionary/terms", handler: handlePutDictionaryTerms)
         router.register("DELETE", "/v1/dictionary/terms", handler: handleDeleteDictionaryTerms)
@@ -1067,7 +1074,118 @@ final class APIHandlers: @unchecked Sendable {
         }
     }
 
+    // MARK: - POST /v1/recorder/start
+
+    private func handleStartRecorder(_ request: HTTPRequest) async -> HTTPResponse {
+        let micEnabled: Bool?
+        let systemAudioEnabled: Bool?
+        do {
+            micEnabled = try parseOptionalBooleanQuery(request, name: "mic")
+            systemAudioEnabled = try parseOptionalBooleanQuery(request, name: "system_audio")
+        } catch {
+            return .error(status: 400, message: error.localizedDescription)
+        }
+
+        do {
+            let id = try await audioRecorderViewModel.apiStartRecording(
+                micEnabled: micEnabled,
+                systemAudioEnabled: systemAudioEnabled
+            )
+
+            struct StartResponse: Encodable {
+                let id: String
+                let status: String
+            }
+            return .json(StartResponse(id: id.uuidString, status: "recording"))
+        } catch AudioRecorderViewModel.RecorderAPIError.noSourceEnabled {
+            return .error(status: 400, message: AudioRecorderViewModel.RecorderAPIError.noSourceEnabled.localizedDescription)
+        } catch AudioRecorderViewModel.RecorderAPIError.alreadyRecording {
+            return .error(status: 409, message: AudioRecorderViewModel.RecorderAPIError.alreadyRecording.localizedDescription)
+        } catch AudioRecorderViewModel.RecorderAPIError.finalizing {
+            return .error(status: 409, message: AudioRecorderViewModel.RecorderAPIError.finalizing.localizedDescription)
+        } catch {
+            return .error(status: 409, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - POST /v1/recorder/stop
+
+    private func handleStopRecorder(_ request: HTTPRequest) async -> HTTPResponse {
+        do {
+            let id = try await audioRecorderViewModel.apiStopRecording()
+
+            struct StopResponse: Encodable {
+                let id: String
+                let status: String
+            }
+            return .json(StopResponse(id: id.uuidString, status: "finalizing"))
+        } catch {
+            return .error(status: 409, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - GET /v1/recorder/status
+
+    private func handleRecorderStatus(_ request: HTTPRequest) async -> HTTPResponse {
+        let recording = await audioRecorderViewModel.apiRecorderIsRecording
+
+        struct RecorderStatusResponse: Encodable {
+            let recording: Bool
+        }
+        return .json(RecorderStatusResponse(recording: recording))
+    }
+
+    // MARK: - GET /v1/recorder/session
+
+    private func handleRecorderSession(_ request: HTTPRequest) async -> HTTPResponse {
+        guard let idString = request.queryParams["id"],
+              let uuid = UUID(uuidString: idString) else {
+            return .error(status: 400, message: "Missing or invalid 'id' query parameter")
+        }
+        guard let session = await audioRecorderViewModel.apiRecorderSession(id: uuid) else {
+            return .error(status: 404, message: "Recorder session not found")
+        }
+
+        struct RecorderSessionResponse: Encodable {
+            let id: String
+            let status: String
+            let text: String?
+            let output_file: String?
+            let error: String?
+        }
+        return .json(RecorderSessionResponse(
+            id: session.id.uuidString,
+            status: session.status.rawValue,
+            text: session.text,
+            output_file: session.outputFile,
+            error: session.error
+        ))
+    }
+
     // MARK: - Helpers
+
+    private enum BooleanQueryError: LocalizedError {
+        case invalid(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalid(let name):
+                "Invalid '\(name)' query parameter"
+            }
+        }
+    }
+
+    private func parseOptionalBooleanQuery(_ request: HTTPRequest, name: String) throws -> Bool? {
+        guard let value = request.queryParams[name] else { return nil }
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "true", "1":
+            return true
+        case "false", "0":
+            return false
+        default:
+            throw BooleanQueryError.invalid(name)
+        }
+    }
 
     private func extractBoundary(from contentType: String) -> String? {
         for part in contentType.components(separatedBy: ";") {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -21,6 +21,38 @@ final class AudioRecorderViewModel: ObservableObject {
         case idle, recording, finalizing
     }
 
+    enum RecorderAPISessionStatus: String {
+        case recording, finalizing, completed, failed
+    }
+
+    struct RecorderAPISessionSnapshot {
+        let id: UUID
+        let status: RecorderAPISessionStatus
+        let text: String?
+        let outputFile: String?
+        let error: String?
+    }
+
+    enum RecorderAPIError: LocalizedError {
+        case noSourceEnabled
+        case alreadyRecording
+        case finalizing
+        case notRecording
+
+        var errorDescription: String? {
+            switch self {
+            case .noSourceEnabled:
+                "At least one audio source must be enabled."
+            case .alreadyRecording:
+                "Already recording"
+            case .finalizing:
+                "Recorder is finalizing"
+            case .notRecording:
+                "Not recording"
+            }
+        }
+    }
+
     private struct FinalTranscriptionRequest {
         let outputURL: URL
         let buffer: [Float]
@@ -97,6 +129,8 @@ final class AudioRecorderViewModel: ObservableObject {
     private let streamingHandler: StreamingHandler
     private var cancellables = Set<AnyCancellable>()
     private var currentOutputURL: URL?
+    private var activeRecorderAPISessionID: UUID?
+    private var recorderAPISessions: [UUID: RecorderAPISessionSnapshot] = [:]
 
     init(recorderService: AudioRecorderService, modelManager: ModelManagerService, dictionaryService: DictionaryService) {
         self.recorderService = recorderService
@@ -224,27 +258,13 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     func startRecording() {
-        guard state == .idle else { return }
-        errorMessage = nil
-        systemAudioWarningMessage = nil
-        partialText = ""
         Task {
             do {
-                let url = try await recorderService.startRecording(
+                _ = try await beginRecording(
                     micEnabled: micEnabled,
                     systemAudioEnabled: systemAudioEnabled,
-                    format: outputFormat
+                    apiSessionID: nil
                 )
-                currentOutputURL = url
-                state = .recording
-
-                EventBus.shared.emit(.recordingStarted(RecordingStartedPayload()))
-
-                if transcriptionEnabled {
-                    startStreamingTranscription()
-                } else {
-                    isTranscribing = false
-                }
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -252,6 +272,64 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     func stopRecording() {
+        stopRecording(apiSessionID: nil)
+    }
+
+    @discardableResult
+    private func beginRecording(
+        micEnabled requestedMicEnabled: Bool,
+        systemAudioEnabled requestedSystemAudioEnabled: Bool,
+        apiSessionID: UUID?
+    ) async throws -> URL {
+        switch state {
+        case .idle:
+            break
+        case .recording:
+            throw RecorderAPIError.alreadyRecording
+        case .finalizing:
+            throw RecorderAPIError.finalizing
+        }
+
+        guard requestedMicEnabled || requestedSystemAudioEnabled else {
+            throw RecorderAPIError.noSourceEnabled
+        }
+
+        errorMessage = nil
+        systemAudioWarningMessage = nil
+        partialText = ""
+
+        let url = try await recorderService.startRecording(
+            micEnabled: requestedMicEnabled,
+            systemAudioEnabled: requestedSystemAudioEnabled,
+            format: outputFormat
+        )
+        currentOutputURL = url
+
+        if let apiSessionID {
+            activeRecorderAPISessionID = apiSessionID
+            storeRecorderAPISession(RecorderAPISessionSnapshot(
+                id: apiSessionID,
+                status: .recording,
+                text: nil,
+                outputFile: url.path,
+                error: nil
+            ))
+        }
+
+        state = .recording
+
+        EventBus.shared.emit(.recordingStarted(RecordingStartedPayload()))
+
+        if transcriptionEnabled {
+            startStreamingTranscription()
+        } else {
+            isTranscribing = false
+        }
+
+        return url
+    }
+
+    private func stopRecording(apiSessionID: UUID?) {
         let recordingDuration = duration
 
         Task {
@@ -271,6 +349,9 @@ final class AudioRecorderViewModel: ObservableObject {
                     liveSessionResult: liveSessionResult
                 )
                 state = .finalizing
+                if let apiSessionID {
+                    markRecorderAPISessionFinalizing(id: apiSessionID, outputURL: url)
+                }
             } else {
                 finalTranscriptionRequest = nil
                 state = .idle
@@ -294,6 +375,93 @@ final class AudioRecorderViewModel: ObservableObject {
             if url != nil {
                 loadRecordings()
             }
+
+            if let apiSessionID {
+                if let url {
+                    completeRecorderAPISession(id: apiSessionID, outputURL: url)
+                } else {
+                    failRecorderAPISession(id: apiSessionID, error: "Failed to finalize recording")
+                }
+            }
+        }
+    }
+
+    // MARK: - HTTP API
+
+    var apiRecorderIsRecording: Bool {
+        state == .recording
+    }
+
+    func apiStartRecording(micEnabled micOverride: Bool?, systemAudioEnabled systemAudioOverride: Bool?) async throws -> UUID {
+        let resolvedMicEnabled = micOverride ?? micEnabled
+        let resolvedSystemAudioEnabled = systemAudioOverride ?? systemAudioEnabled
+        let sessionID = UUID()
+        _ = try await beginRecording(
+            micEnabled: resolvedMicEnabled,
+            systemAudioEnabled: resolvedSystemAudioEnabled,
+            apiSessionID: sessionID
+        )
+        return sessionID
+    }
+
+    func apiStopRecording() throws -> UUID {
+        guard state == .recording else {
+            throw RecorderAPIError.notRecording
+        }
+        guard let sessionID = activeRecorderAPISessionID else {
+            throw RecorderAPIError.notRecording
+        }
+        if let currentOutputURL {
+            markRecorderAPISessionFinalizing(id: sessionID, outputURL: currentOutputURL)
+        }
+        state = .finalizing
+        stopRecording(apiSessionID: sessionID)
+        return sessionID
+    }
+
+    func apiRecorderSession(id: UUID) -> RecorderAPISessionSnapshot? {
+        recorderAPISessions[id]
+    }
+
+    private func storeRecorderAPISession(_ session: RecorderAPISessionSnapshot) {
+        recorderAPISessions[session.id] = session
+    }
+
+    private func markRecorderAPISessionFinalizing(id: UUID, outputURL: URL) {
+        storeRecorderAPISession(RecorderAPISessionSnapshot(
+            id: id,
+            status: .finalizing,
+            text: nil,
+            outputFile: outputURL.path,
+            error: nil
+        ))
+    }
+
+    private func completeRecorderAPISession(id: UUID, outputURL: URL) {
+        let text = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
+        storeRecorderAPISession(RecorderAPISessionSnapshot(
+            id: id,
+            status: .completed,
+            text: text.isEmpty ? nil : text,
+            outputFile: outputURL.path,
+            error: nil
+        ))
+        if activeRecorderAPISessionID == id {
+            activeRecorderAPISessionID = nil
+        }
+    }
+
+    private func failRecorderAPISession(id: UUID, error: String) {
+        let outputFile = recorderAPISessions[id]?.outputFile
+        storeRecorderAPISession(RecorderAPISessionSnapshot(
+            id: id,
+            status: .failed,
+            text: nil,
+            outputFile: outputFile,
+            error: error
+        ))
+        if activeRecorderAPISessionID == id {
+            activeRecorderAPISessionID = nil
         }
     }
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -272,7 +272,7 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     func stopRecording() {
-        stopRecording(apiSessionID: nil)
+        stopRecording(apiSessionID: activeRecorderAPISessionID)
     }
 
     @discardableResult
@@ -297,12 +297,24 @@ final class AudioRecorderViewModel: ObservableObject {
         errorMessage = nil
         systemAudioWarningMessage = nil
         partialText = ""
+        state = .recording
 
-        let url = try await recorderService.startRecording(
-            micEnabled: requestedMicEnabled,
-            systemAudioEnabled: requestedSystemAudioEnabled,
-            format: outputFormat
-        )
+        let url: URL
+        do {
+            url = try await recorderService.startRecording(
+                micEnabled: requestedMicEnabled,
+                systemAudioEnabled: requestedSystemAudioEnabled,
+                format: outputFormat
+            )
+        } catch {
+            state = .idle
+            currentOutputURL = nil
+            if let apiSessionID {
+                activeRecorderAPISessionID = nil
+                recorderAPISessions.removeValue(forKey: apiSessionID)
+            }
+            throw error
+        }
         currentOutputURL = url
 
         if let apiSessionID {
@@ -315,8 +327,6 @@ final class AudioRecorderViewModel: ObservableObject {
                 error: nil
             ))
         }
-
-        state = .recording
 
         EventBus.shared.emit(.recordingStarted(RecordingStartedPayload()))
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -519,6 +519,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let dictionaryService: DictionaryService
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
+        let audioRecorderViewModel: AudioRecorderViewModel
+        let audioRecorderService: AudioRecorderService
         let textInsertionService: TextInsertionService
         let ttsProvider: MockTTSProviderPlugin
         private let retainedObjects: [AnyObject]
@@ -532,6 +534,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictionaryService: DictionaryService,
             dictationViewModel: DictationViewModel,
             audioRecordingService: AudioRecordingService,
+            audioRecorderViewModel: AudioRecorderViewModel,
+            audioRecorderService: AudioRecorderService,
             textInsertionService: TextInsertionService,
             ttsProvider: MockTTSProviderPlugin,
             retainedObjects: [AnyObject]
@@ -544,6 +548,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.dictionaryService = dictionaryService
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
+            self.audioRecorderViewModel = audioRecorderViewModel
+            self.audioRecorderService = audioRecorderService
             self.textInsertionService = textInsertionService
             self.ttsProvider = ttsProvider
             self.retainedObjects = retainedObjects
@@ -1468,6 +1474,252 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(response.status, 400)
         XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Use either 'language' or 'language_hint', not both")
+    }
+
+    func testRaycastDictationAPIContractRemainsStable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let statusResponse = await router.route(
+            HTTPRequest(method: "GET", path: "/v1/dictation/status", queryParams: [:], headers: [:], body: Data())
+        )
+        let statusJSON = try Self.jsonObject(statusResponse)
+        XCTAssertEqual(statusResponse.status, 200)
+        XCTAssertEqual(statusJSON["is_recording"] as? Bool, false)
+
+        let stopResponse = await router.route(
+            HTTPRequest(method: "POST", path: "/v1/dictation/stop", queryParams: [:], headers: [:], body: Data())
+        )
+        let stopJSON = try Self.jsonObject(stopResponse)
+        XCTAssertEqual(stopResponse.status, 409)
+        XCTAssertEqual((stopJSON["error"] as? [String: Any])?["message"] as? String, "Not recording")
+
+        let transcriptionResponse = await router.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/dictation/transcription",
+                queryParams: ["id": "not-a-uuid"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let transcriptionJSON = try Self.jsonObject(transcriptionResponse)
+        XCTAssertEqual(transcriptionResponse.status, 400)
+        XCTAssertEqual(
+            (transcriptionJSON["error"] as? [String: Any])?["message"] as? String,
+            "Missing or invalid 'id' query parameter"
+        )
+    }
+
+    func testRecorderStatusEndpointReturnsRecordingBoolean() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let response = await router.route(
+            HTTPRequest(method: "GET", path: "/v1/recorder/status", queryParams: [:], headers: [:], body: Data())
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(json["recording"] as? Bool, false)
+    }
+
+    func testRecorderStartRejectsWhenNoSourceIsEnabled() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let response = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/recorder/start",
+                queryParams: ["mic": "false", "system_audio": "false"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 400)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "At least one audio source must be enabled.")
+    }
+
+    func testRecorderStopWithoutRecordingReturnsConflict() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let response = await router.route(
+            HTTPRequest(method: "POST", path: "/v1/recorder/stop", queryParams: [:], headers: [:], body: Data())
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 409)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Not recording")
+    }
+
+    func testRecorderEndpointsReturnSessionIDAndCompletedTranscript() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+        let recordingsDirectory = appSupportDirectory.appendingPathComponent("recordings")
+
+        await MainActor.run {
+            apiContext.audioRecorderService.recordingsDirectoryOverride = recordingsDirectory
+            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL in
+                try Data("placeholder".utf8).write(to: outputURL)
+                return outputURL
+            }
+            apiContext.audioRecorderService.stopRecordingOverride = { outputURL in
+                try Data("recorded".utf8).write(to: outputURL)
+                return outputURL
+            }
+            apiContext.audioRecorderService.currentBufferOverride = {
+                Array(repeating: 0.25, count: Int(AudioRecorderService.transcriptionSampleRate))
+            }
+            apiContext.audioRecorderViewModel.transcriptionEnabled = true
+        }
+
+        let startResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/recorder/start",
+                queryParams: ["mic": "true", "system_audio": "false"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let start = try Self.jsonObject(startResponse)
+        let startID = try XCTUnwrap(start["id"] as? String)
+        XCTAssertEqual(startResponse.status, 200)
+        XCTAssertEqual(start["status"] as? String, "recording")
+        XCTAssertNotNil(UUID(uuidString: startID))
+
+        let statusWhileRecording = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "GET", path: "/v1/recorder/status", queryParams: [:], headers: [:], body: Data()))
+        )
+        XCTAssertEqual(statusWhileRecording["recording"] as? Bool, true)
+
+        let stopResponse = await router.route(
+            HTTPRequest(method: "POST", path: "/v1/recorder/stop", queryParams: [:], headers: [:], body: Data())
+        )
+        let stop = try Self.jsonObject(stopResponse)
+        XCTAssertEqual(stopResponse.status, 200)
+        XCTAssertEqual(stop["id"] as? String, startID)
+        XCTAssertEqual(stop["status"] as? String, "finalizing")
+
+        var completedResponse: [String: Any]?
+        for _ in 0..<40 {
+            let response = try Self.jsonObject(
+                await router.route(
+                    HTTPRequest(
+                        method: "GET",
+                        path: "/v1/recorder/session",
+                        queryParams: ["id": startID],
+                        headers: [:],
+                        body: Data()
+                    )
+                )
+            )
+            if response["status"] as? String == "completed" {
+                completedResponse = response
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        let completed = try XCTUnwrap(completedResponse)
+        XCTAssertEqual(completed["id"] as? String, startID)
+        XCTAssertEqual(completed["text"] as? String, "transcribed")
+        let outputFile = try XCTUnwrap(completed["output_file"] as? String)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputFile))
+    }
+
+    func testRecorderSessionRejectsInvalidID() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let response = await router.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/recorder/session",
+                queryParams: ["id": "not-a-uuid"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 400)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Missing or invalid 'id' query parameter")
+    }
+
+    func testRecorderSessionReturnsNotFoundForUnknownID() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let router = try XCTUnwrap(context?.router)
+
+        let response = await router.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/recorder/session",
+                queryParams: ["id": UUID().uuidString],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 404)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Recorder session not found")
     }
 
     func testDictationStartReturnsConflictWhenRecordingCannotStart() async throws {
@@ -2932,6 +3184,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
         let audioFileService = AudioFileService()
         let audioRecordingService = AudioRecordingService()
+        let audioRecorderService = AudioRecorderService()
         let hotkeyService = HotkeyService()
         let textInsertionService = TextInsertionService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
@@ -2983,6 +3236,11 @@ final class APIRouterAndHandlersTests: XCTestCase {
             errorLogService: errorLogService,
             mediaPlaybackService: MediaPlaybackService(startListening: false)
         )
+        let audioRecorderViewModel = AudioRecorderViewModel(
+            recorderService: audioRecorderService,
+            modelManager: modelManager,
+            dictionaryService: dictionaryService
+        )
 
         let router = APIRouter()
         let handlers = APIHandlers(
@@ -2992,7 +3250,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             historyService: historyService,
             workflowService: workflowService,
             dictionaryService: dictionaryService,
-            dictationViewModel: dictationViewModel
+            dictationViewModel: dictationViewModel,
+            audioRecorderViewModel: audioRecorderViewModel
         )
         handlers.register(on: router)
 
@@ -3005,6 +3264,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel,
             audioRecordingService: audioRecordingService,
+            audioRecorderViewModel: audioRecorderViewModel,
+            audioRecorderService: audioRecorderService,
             textInsertionService: textInsertionService,
             ttsProvider: ttsProvider,
             retainedObjects: [
@@ -3013,6 +3274,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 modelManager,
                 audioFileService,
                 audioRecordingService,
+                audioRecorderService,
                 hotkeyService,
                 textInsertionService,
                 historyService,
@@ -3030,6 +3292,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 errorLogService,
                 settingsViewModel,
                 dictationViewModel,
+                audioRecorderViewModel,
                 router,
                 handlers
             ]

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -20,6 +20,42 @@ private func rtfAttributedStringContainsFontTrait(
 }
 
 final class APIRouterAndHandlersTests: XCTestCase {
+    private actor RecorderStartGate {
+        private var entries = 0
+        private var firstEntryContinuation: CheckedContinuation<Void, Never>?
+        private var releaseContinuation: CheckedContinuation<Void, Never>?
+        private var released = false
+
+        func enter() -> Int {
+            entries += 1
+            if entries == 1 {
+                firstEntryContinuation?.resume()
+                firstEntryContinuation = nil
+            }
+            return entries
+        }
+
+        func waitForFirstEntry() async {
+            if entries > 0 { return }
+            await withCheckedContinuation { continuation in
+                firstEntryContinuation = continuation
+            }
+        }
+
+        func waitForRelease() async {
+            if released { return }
+            await withCheckedContinuation { continuation in
+                releaseContinuation = continuation
+            }
+        }
+
+        func release() {
+            released = true
+            releaseContinuation?.resume()
+            releaseContinuation = nil
+        }
+    }
+
     @objc(APIRouterMockLLMProviderPlugin)
     private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderSetupStatusProviding, LLMTemperatureControllableProvider, PluginSettingsActivityReporting, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.llm" }
@@ -1668,6 +1704,143 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(completed["text"] as? String, "transcribed")
         let outputFile = try XCTUnwrap(completed["output_file"] as? String)
         XCTAssertTrue(FileManager.default.fileExists(atPath: outputFile))
+    }
+
+    func testRecorderSessionCompletesWhenAPIStartedRecordingStopsFromUI() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+        let recordingsDirectory = appSupportDirectory.appendingPathComponent("recordings")
+
+        await MainActor.run {
+            apiContext.audioRecorderService.recordingsDirectoryOverride = recordingsDirectory
+            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL in
+                try Data("placeholder".utf8).write(to: outputURL)
+                return outputURL
+            }
+            apiContext.audioRecorderService.stopRecordingOverride = { outputURL in
+                try Data("recorded".utf8).write(to: outputURL)
+                return outputURL
+            }
+            apiContext.audioRecorderViewModel.transcriptionEnabled = false
+        }
+
+        let startResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/recorder/start",
+                queryParams: ["mic": "true", "system_audio": "false"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let start = try Self.jsonObject(startResponse)
+        let startID = try XCTUnwrap(start["id"] as? String)
+        XCTAssertEqual(startResponse.status, 200)
+
+        await MainActor.run {
+            apiContext.audioRecorderViewModel.stopRecording()
+        }
+
+        var completedResponse: [String: Any]?
+        for _ in 0..<40 {
+            let response = try Self.jsonObject(
+                await router.route(
+                    HTTPRequest(
+                        method: "GET",
+                        path: "/v1/recorder/session",
+                        queryParams: ["id": startID],
+                        headers: [:],
+                        body: Data()
+                    )
+                )
+            )
+            if response["status"] as? String == "completed" {
+                completedResponse = response
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        let completed = try XCTUnwrap(completedResponse)
+        XCTAssertEqual(completed["id"] as? String, startID)
+        let outputFile = try XCTUnwrap(completed["output_file"] as? String)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputFile))
+    }
+
+    func testRecorderStartRejectsConcurrentStartWhileRecorderIsStarting() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { Self.makeAPIContext(appSupportDirectory: appSupportDirectory) }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+        let recordingsDirectory = appSupportDirectory.appendingPathComponent("recordings")
+        let gate = RecorderStartGate()
+
+        await MainActor.run {
+            apiContext.audioRecorderService.recordingsDirectoryOverride = recordingsDirectory
+            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL in
+                try Data("placeholder".utf8).write(to: outputURL)
+                let entry = await gate.enter()
+                if entry == 1 {
+                    await gate.waitForRelease()
+                }
+                return outputURL
+            }
+            apiContext.audioRecorderService.stopRecordingOverride = { outputURL in
+                try Data("recorded".utf8).write(to: outputURL)
+                return outputURL
+            }
+            apiContext.audioRecorderViewModel.transcriptionEnabled = false
+        }
+
+        let firstStartTask = Task {
+            await router.route(
+                HTTPRequest(
+                    method: "POST",
+                    path: "/v1/recorder/start",
+                    queryParams: ["mic": "true", "system_audio": "false"],
+                    headers: [:],
+                    body: Data()
+                )
+            )
+        }
+        await gate.waitForFirstEntry()
+
+        let secondStartResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/recorder/start",
+                queryParams: ["mic": "true", "system_audio": "false"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let secondStart = try Self.jsonObject(secondStartResponse)
+
+        await gate.release()
+        let firstStartResponse = await firstStartTask.value
+        XCTAssertEqual(firstStartResponse.status, 200)
+
+        let stopResponse = await router.route(
+            HTTPRequest(method: "POST", path: "/v1/recorder/stop", queryParams: [:], headers: [:], body: Data())
+        )
+        XCTAssertEqual(stopResponse.status, 200)
+
+        XCTAssertEqual(secondStartResponse.status, 409)
+        XCTAssertEqual((secondStart["error"] as? [String: Any])?["message"] as? String, "Already recording")
     }
 
     func testRecorderSessionRejectsInvalidID() async throws {


### PR DESCRIPTION
## Summary
- Adds local recorder HTTP endpoints for start, stop, status, and session polling, wired through `AudioRecorderViewModel` and `AudioRecorderService` so mic capture, system audio, mixing, finalization, and transcript sidecars stay on the existing recorder path.
- Supports optional `mic` and `system_audio` query flags with current-settings defaults plus 400/404/409 responses for invalid sources, invalid or unknown sessions, and recorder conflicts.
- Adds API regression coverage for the existing Raycast dictation contract alongside the new recorder endpoint coverage.

## Issue Context
Issue #582 requests HTTP control for the recorder because the existing `/v1/dictation/*` endpoints cannot capture system audio. The new `/v1/recorder/*` endpoints provide session-oriented recorder control for meeting/system-audio transcription without changing the dictation endpoints consumed by Raycast.

Closes #582

## Raycast Regression
- Leaves `/v1/dictation/status`, `/v1/dictation/start`, `/v1/dictation/stop`, `/v1/dictation/transcription`, `/v1/history`, `/v1/profiles`, and `/v1/transcribe` unchanged.
- Adds `testRaycastDictationAPIContractRemainsStable` to pin key Raycast-facing dictation response shapes and error messages.
- Verified `/Users/marco/Projects/typewhisper-raycast` with lint and build; no Raycast files were changed.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- [x] `cd /Users/marco/Projects/typewhisper-raycast && npm run lint`
- [x] `cd /Users/marco/Projects/typewhisper-raycast && npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP recorder endpoints (start/stop/status/session) with mic and optional system audio, per-session UUIDs, lifecycle states (recording → finalizing → completed/failed), and session snapshot/transcript/output retrieval.

* **Tests**
  * Added coverage for recorder API flows, conflict/error cases, session lifecycle and polling.

* **Documentation**
  * Added Recorder Control docs with API usage, flags, examples, and expected behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->