### PR TITLE
Hide indicators from supported screen captures

### DIFF
--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -38,6 +38,9 @@ enum FloatingPanelSpacePolicy {
     static func applyIndicatorPolicy(to panel: NSPanel, displayMode: NotchIndicatorDisplay) {
         panel.level = indicatorWindowLevel
         panel.collectionBehavior = indicatorCollectionBehavior(for: displayMode)
+        // Best-effort: keep passive indicators visible locally while excluding the
+        // window from capture APIs that honor AppKit sharing policy.
+        panel.sharingType = .none
     }
 
     @MainActor

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -48,4 +48,18 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
         XCTAssertGreaterThan(level.rawValue, NSWindow.Level.statusBar.rawValue)
         XCTAssertLessThan(level.rawValue, Int(CGShieldingWindowLevel()))
     }
+
+    @MainActor
+    func testIndicatorPolicyExcludesPanelFromScreenCapture() {
+        let panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: panel, displayMode: .activeScreen)
+
+        XCTAssertEqual(panel.sharingType, .none)
+    }
 }


### PR DESCRIPTION
## Summary
- Applies AppKit `NSWindow.sharingType = .none` through the shared indicator panel policy.
- Keeps Notch, Overlay, and Minimal indicators visible locally while excluding those passive indicator windows from capture APIs that honor AppKit window sharing policy.
- Avoids adding another user-facing setting; this is a best-effort platform behavior, not a built-in screen recorder or a guarantee for every capture pipeline.

## Issue context
Issue #584 asks for the dictation indicator to stay visible to the local user while being hidden from screen recordings or screen shares. macOS exposes this at the window level via `NSWindow.sharingType`, so the implementation belongs in the shared indicator window policy rather than in a new recorder or capture-detection flow.

Closes #584

## Test plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Indicator panels are now properly excluded from screen capture and system capture APIs while remaining visible in the application.

* **Tests**
  * Added test coverage for indicator panel exclusion from capture functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->