### PR TITLE
Show indicators for active recorder sessions

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -3,6 +3,123 @@ import AppKit
 import Combine
 import ApplicationServices
 
+struct IndicatorPresentationState: Equatable {
+    enum Source: Equatable {
+        case dictation
+        case recorder
+    }
+
+    let source: Source
+    let state: DictationViewModel.State
+
+    var isActiveDuringActivity: Bool {
+        switch state {
+        case .recording, .processing, .inserting, .error:
+            return true
+        case .idle, .promptSelection, .promptProcessing:
+            return false
+        }
+    }
+
+    static func resolve(
+        dictationState: DictationViewModel.State,
+        recorderState: AudioRecorderViewModel.RecorderState
+    ) -> IndicatorPresentationState {
+        switch dictationState {
+        case .recording, .processing, .inserting, .error:
+            return IndicatorPresentationState(source: .dictation, state: dictationState)
+        case .idle, .promptSelection, .promptProcessing:
+            if recorderState == .recording {
+                return IndicatorPresentationState(source: .recorder, state: .recording)
+            }
+            return IndicatorPresentationState(source: .dictation, state: dictationState)
+        }
+    }
+
+    static func shouldShow(
+        visibility: NotchIndicatorVisibility,
+        presentation: IndicatorPresentationState
+    ) -> Bool {
+        switch visibility {
+        case .always:
+            return true
+        case .duringActivity:
+            return presentation.isActiveDuringActivity
+        case .never:
+            return false
+        }
+    }
+}
+
+struct IndicatorPresentationData {
+    let source: IndicatorPresentationState.Source
+    let state: DictationViewModel.State
+    let recordingDuration: TimeInterval
+    let audioLevel: Float
+    let partialText: String
+    let activeRuleName: String?
+    let activeAppIcon: NSImage?
+    let isRecordingInputReady: Bool
+    let recordingCancelWarningMessage: String?
+    let processingPhase: String?
+    let actionFeedbackMessage: String?
+    let actionFeedbackIcon: String?
+    let actionFeedbackIsError: Bool
+    let externalStreamingDisplayCount: Int
+
+    var isRecorder: Bool {
+        source == .recorder
+    }
+
+    @MainActor
+    static func make(
+        dictation: DictationViewModel,
+        recorder: AudioRecorderViewModel
+    ) -> IndicatorPresentationData {
+        let presentation = IndicatorPresentationState.resolve(
+            dictationState: dictation.state,
+            recorderState: recorder.state
+        )
+
+        switch presentation.source {
+        case .dictation:
+            return IndicatorPresentationData(
+                source: .dictation,
+                state: presentation.state,
+                recordingDuration: dictation.recordingDuration,
+                audioLevel: dictation.audioLevel,
+                partialText: dictation.partialText,
+                activeRuleName: dictation.activeRuleName,
+                activeAppIcon: dictation.activeAppIcon,
+                isRecordingInputReady: dictation.isRecordingInputReady,
+                recordingCancelWarningMessage: dictation.recordingCancelWarningMessage,
+                processingPhase: dictation.processingPhase,
+                actionFeedbackMessage: dictation.actionFeedbackMessage,
+                actionFeedbackIcon: dictation.actionFeedbackIcon,
+                actionFeedbackIsError: dictation.actionFeedbackIsError,
+                externalStreamingDisplayCount: dictation.externalStreamingDisplayCount
+            )
+        case .recorder:
+            return IndicatorPresentationData(
+                source: .recorder,
+                state: presentation.state,
+                recordingDuration: recorder.duration,
+                audioLevel: max(recorder.micLevel, recorder.systemLevel),
+                partialText: recorder.partialText,
+                activeRuleName: nil,
+                activeAppIcon: nil,
+                isRecordingInputReady: true,
+                recordingCancelWarningMessage: nil,
+                processingPhase: nil,
+                actionFeedbackMessage: nil,
+                actionFeedbackIcon: nil,
+                actionFeedbackIsError: false,
+                externalStreamingDisplayCount: dictation.externalStreamingDisplayCount
+            )
+        }
+    }
+}
+
 /// Coordinates the display of different indicator styles (Notch vs Overlay).
 @MainActor
 final class IndicatorCoordinator {
@@ -47,15 +164,15 @@ final class IndicatorCoordinator {
         case .notch:
             overlayPanel.dismiss()
             minimalPanel.dismiss()
-            notchPanel.updateVisibility(state: vm.state, vm: vm)
+            notchPanel.updateVisibility(vm: vm)
         case .overlay:
             notchPanel.dismiss()
             minimalPanel.dismiss()
-            overlayPanel.updateVisibility(state: vm.state, vm: vm)
+            overlayPanel.updateVisibility(vm: vm)
         case .minimal:
             notchPanel.dismiss()
             overlayPanel.dismiss()
-            minimalPanel.updateVisibility(state: vm.state, vm: vm)
+            minimalPanel.updateVisibility(vm: vm)
         }
     }
 

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -43,18 +43,26 @@ class MinimalIndicatorPanel: NSPanel {
 
     func startObserving() {
         let vm = DictationViewModel.shared
+        let recorder = AudioRecorderViewModel.shared
 
         vm.$state
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                self?.updateVisibility(state: state, vm: vm)
+            .sink { [weak self] _ in
+                self?.updateVisibility(vm: vm, recorder: recorder)
+            }
+            .store(in: &cancellables)
+
+        recorder.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
         vm.$notchIndicatorVisibility
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.updateVisibility(state: vm.state, vm: vm)
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
@@ -62,7 +70,7 @@ class MinimalIndicatorPanel: NSPanel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.cachedScreen = nil
-                self?.updateVisibility(state: vm.state, vm: vm)
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
@@ -75,23 +83,25 @@ class MinimalIndicatorPanel: NSPanel {
             .store(in: &cancellables)
     }
 
-    func updateVisibility(state: DictationViewModel.State, vm: DictationViewModel) {
+    func updateVisibility(
+        vm: DictationViewModel = DictationViewModel.shared,
+        recorder: AudioRecorderViewModel = AudioRecorderViewModel.shared
+    ) {
         guard vm.indicatorStyle == .minimal else {
             dismiss()
             return
         }
 
-        switch vm.notchIndicatorVisibility {
-        case .always:
+        let presentation = IndicatorPresentationState.resolve(
+            dictationState: vm.state,
+            recorderState: recorder.state
+        )
+        if IndicatorPresentationState.shouldShow(
+            visibility: vm.notchIndicatorVisibility,
+            presentation: presentation
+        ) {
             show()
-        case .duringActivity:
-            switch state {
-            case .recording, .processing, .inserting, .error:
-                show()
-            case .idle, .promptSelection, .promptProcessing:
-                dismiss()
-            }
-        case .never:
+        } else {
             dismiss()
         }
     }

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Compact floating indicator for power users who only want essential status.
 struct MinimalIndicatorView: View {
     @ObservedObject private var viewModel = DictationViewModel.shared
+    @ObservedObject private var recorder = AudioRecorderViewModel.shared
     @State private var dotPulse = false
 
     private let sizing: IndicatorSizing = .minimal
@@ -10,6 +11,10 @@ struct MinimalIndicatorView: View {
     private let processingWidth: CGFloat = 76
     private let insertingWidth: CGFloat = 44
     private let messageWidth: CGFloat = 320
+
+    private var presentation: IndicatorPresentationData {
+        IndicatorPresentationData.make(dictation: viewModel, recorder: recorder)
+    }
 
     private var recordingWidth: CGFloat {
         switch viewModel.notchIndicatorRightContent {
@@ -22,7 +27,7 @@ struct MinimalIndicatorView: View {
         case .timer:
             return 118
         case .profile:
-            guard let name = viewModel.activeRuleName, !name.isEmpty else {
+            guard let name = presentation.activeRuleName, !name.isEmpty else {
                 return idleWidth
             }
             let estimatedTextWidth = CGFloat(min(name.count, 18)) * 7
@@ -35,17 +40,17 @@ struct MinimalIndicatorView: View {
     }
 
     private var actionFeedbackMessage: String? {
-        guard viewModel.state == .inserting else { return nil }
-        return viewModel.actionFeedbackMessage
+        guard presentation.state == .inserting else { return nil }
+        return presentation.actionFeedbackMessage
     }
 
     private var recordingCancelWarningMessage: String? {
-        guard viewModel.state == .recording else { return nil }
-        return viewModel.recordingCancelWarningMessage
+        guard presentation.state == .recording else { return nil }
+        return presentation.recordingCancelWarningMessage
     }
 
     private var errorMessage: String? {
-        guard case let .error(message) = viewModel.state else { return nil }
+        guard case let .error(message) = presentation.state else { return nil }
         return message
     }
 
@@ -58,7 +63,7 @@ struct MinimalIndicatorView: View {
             return messageWidth
         }
 
-        switch viewModel.state {
+        switch presentation.state {
         case .recording:
             return recordingWidth
         case .processing:
@@ -86,10 +91,10 @@ struct MinimalIndicatorView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isTop ? .top : .bottom)
             .preferredColorScheme(.dark)
             .animation(.easeInOut(duration: 0.2), value: currentWidth)
-            .animation(.easeInOut(duration: 0.2), value: viewModel.state)
+            .animation(.easeInOut(duration: 0.2), value: presentation.state)
             .animation(.easeInOut(duration: 1.0), value: dotPulse)
-            .onChange(of: viewModel.state) {
-                if viewModel.state == .recording {
+            .onChange(of: presentation.state) {
+                if presentation.state == .recording {
                     withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
                         dotPulse = true
                     }
@@ -110,11 +115,11 @@ struct MinimalIndicatorView: View {
             return message
         }
 
-        switch viewModel.state {
+        switch presentation.state {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
-            if !viewModel.isRecordingInputReady {
+            if !presentation.isRecordingInputReady {
                 return String(localized: "Preparing microphone")
             }
             return String(localized: "Recording")
@@ -144,8 +149,8 @@ struct MinimalIndicatorView: View {
             } else if let message = actionFeedbackMessage {
                 compactMessage(
                     text: message,
-                    icon: viewModel.actionFeedbackIcon ?? (viewModel.actionFeedbackIsError ? "xmark.circle.fill" : "checkmark.circle.fill"),
-                    iconColor: viewModel.actionFeedbackIsError ? .red : .green
+                    icon: presentation.actionFeedbackIcon ?? (presentation.actionFeedbackIsError ? "xmark.circle.fill" : "checkmark.circle.fill"),
+                    iconColor: presentation.actionFeedbackIsError ? .red : .green
                 )
             } else {
                 compactStatus
@@ -163,11 +168,11 @@ struct MinimalIndicatorView: View {
 
     @ViewBuilder
     private var compactStatus: some View {
-        switch viewModel.state {
+        switch presentation.state {
         case .recording:
             HStack(spacing: viewModel.notchIndicatorRightContent == .none ? 0 : 8) {
                 IndicatorLeftStatus(
-                    viewModel: viewModel,
+                    presentation: presentation,
                     sizing: sizing,
                     dotPulse: dotPulse,
                     hasActionFeedback: false
@@ -175,7 +180,7 @@ struct MinimalIndicatorView: View {
 
                 if viewModel.notchIndicatorRightContent != .none {
                     IndicatorRecordingContent(
-                        viewModel: viewModel,
+                        presentation: presentation,
                         content: viewModel.notchIndicatorRightContent,
                         sizing: sizing,
                         dotPulse: dotPulse
@@ -184,7 +189,7 @@ struct MinimalIndicatorView: View {
             }
         case .processing:
             HStack(spacing: 8) {
-                if let icon = viewModel.activeAppIcon {
+                if let icon = presentation.activeAppIcon {
                     IndicatorAppIconView(icon: icon, sizing: sizing)
                 }
                 ProgressView()
@@ -193,7 +198,7 @@ struct MinimalIndicatorView: View {
             }
         case .inserting:
             IndicatorLeftStatus(
-                viewModel: viewModel,
+                presentation: presentation,
                 sizing: sizing,
                 dotPulse: false,
                 hasActionFeedback: false

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -78,18 +78,26 @@ class NotchIndicatorPanel: NSPanel {
 
     func startObserving() {
         let vm = DictationViewModel.shared
+        let recorder = AudioRecorderViewModel.shared
 
         vm.$state
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                self?.updateVisibility(state: state, vm: vm)
+            .sink { [weak self] _ in
+                self?.updateVisibility(vm: vm, recorder: recorder)
+            }
+            .store(in: &cancellables)
+
+        recorder.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
         vm.$notchIndicatorVisibility
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.updateVisibility(state: vm.state, vm: vm)
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
@@ -97,28 +105,30 @@ class NotchIndicatorPanel: NSPanel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.cachedScreen = nil
-                self?.updateVisibility(state: vm.state, vm: vm)
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
     }
 
-    func updateVisibility(state: DictationViewModel.State, vm: DictationViewModel) {
+    func updateVisibility(
+        vm: DictationViewModel = DictationViewModel.shared,
+        recorder: AudioRecorderViewModel = AudioRecorderViewModel.shared
+    ) {
         guard vm.indicatorStyle == .notch else {
             dismiss()
             return
         }
 
-        switch vm.notchIndicatorVisibility {
-        case .always:
+        let presentation = IndicatorPresentationState.resolve(
+            dictationState: vm.state,
+            recorderState: recorder.state
+        )
+        if IndicatorPresentationState.shouldShow(
+            visibility: vm.notchIndicatorVisibility,
+            presentation: presentation
+        ) {
             show()
-        case .duringActivity:
-            switch state {
-            case .recording, .processing, .inserting, .error:
-                show()
-            case .idle, .promptSelection, .promptProcessing:
-                dismiss()
-            }
-        case .never:
+        } else {
             dismiss()
         }
     }

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// Blue glow emanates from the notch shape, reacting to audio level.
 struct NotchIndicatorView: View {
     @ObservedObject private var viewModel = DictationViewModel.shared
+    @ObservedObject private var recorder = AudioRecorderViewModel.shared
     @ObservedObject var geometry: NotchGeometry
     @State private var textExpanded = false
     @State private var dotPulse = false
@@ -16,15 +17,19 @@ struct NotchIndicatorView: View {
     private let processingBodyHeight: CGFloat = 28
     private let feedbackBodyHeight: CGFloat = 52
 
+    private var presentation: IndicatorPresentationData {
+        IndicatorPresentationData.make(dictation: viewModel, recorder: recorder)
+    }
+
     private var closedWidth: CGFloat {
-        if case .recording = viewModel.state {
+        if case .recording = presentation.state {
             return NotchIndicatorLayout.recordingClosedWidth(
                 hasNotch: geometry.hasNotch,
                 notchWidth: geometry.notchWidth,
                 leftContent: viewModel.notchIndicatorLeftContent,
                 rightContent: viewModel.notchIndicatorRightContent,
-                recordingDuration: viewModel.recordingDuration,
-                activeRuleName: viewModel.activeRuleName
+                recordingDuration: presentation.recordingDuration,
+                activeRuleName: presentation.activeRuleName
             )
         }
 
@@ -32,32 +37,32 @@ struct NotchIndicatorView: View {
     }
 
     private var leftStatusSpacing: CGFloat {
-        guard case .recording = viewModel.state else {
+        guard case .recording = presentation.state else {
             return 0
         }
 
         let leftContentWidth = NotchIndicatorLayout.recordingContentWidth(
             viewModel.notchIndicatorLeftContent,
-            recordingDuration: viewModel.recordingDuration,
-            activeRuleName: viewModel.activeRuleName
+            recordingDuration: presentation.recordingDuration,
+            activeRuleName: presentation.activeRuleName
         )
         return leftContentWidth > 0 ? NotchIndicatorLayout.leftContentSpacing : 0
     }
 
     private var suppressStreamingText: Bool {
-        viewModel.externalStreamingDisplayCount > 0
+        !presentation.isRecorder && presentation.externalStreamingDisplayCount > 0
     }
 
     private var hasActionFeedback: Bool {
-        viewModel.state == .inserting && viewModel.actionFeedbackMessage != nil
+        presentation.state == .inserting && presentation.actionFeedbackMessage != nil
     }
 
     private var hasRecordingCancelWarning: Bool {
-        viewModel.state == .recording && viewModel.recordingCancelWarningMessage != nil
+        presentation.state == .recording && presentation.recordingCancelWarningMessage != nil
     }
 
     private var hasProcessingPhase: Bool {
-        viewModel.state == .processing && viewModel.processingPhase != nil
+        presentation.state == .processing && presentation.processingPhase != nil
     }
 
     private var showTranscriptPreview: Bool {
@@ -65,11 +70,11 @@ struct NotchIndicatorView: View {
     }
 
     private var hasTranscriptSection: Bool {
-        viewModel.state == .recording && showTranscriptPreview
+        presentation.state == .recording && showTranscriptPreview
     }
 
     private var transcriptBodyVisible: Bool {
-        viewModel.state == .recording && showTranscriptPreview && textExpanded
+        presentation.state == .recording && showTranscriptPreview && textExpanded
     }
 
     private var expansionMode: NotchExpansionMode {
@@ -145,17 +150,17 @@ struct NotchIndicatorView: View {
         .animation(.easeOut(duration: 0.22), value: geometry.isPresented)
         .animation(.easeOut(duration: 0.24), value: currentWidth)
         .animation(.easeOut(duration: 0.24), value: expandedBodyHeight)
-        .animation(.easeInOut(duration: 0.18), value: viewModel.state)
-        .animation(.easeOut(duration: 0.08), value: viewModel.audioLevel)
-        .onChange(of: viewModel.partialText) {
-            if showTranscriptPreview, !viewModel.partialText.isEmpty, !textExpanded {
+        .animation(.easeInOut(duration: 0.18), value: presentation.state)
+        .animation(.easeOut(duration: 0.08), value: presentation.audioLevel)
+        .onChange(of: presentation.partialText) {
+            if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
                 withAnimation(.easeOut(duration: 0.24)) {
                     textExpanded = true
                 }
             }
         }
-        .onChange(of: viewModel.state) {
-            if viewModel.state == .recording {
+        .onChange(of: presentation.state) {
+            if presentation.state == .recording {
                 withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
                     dotPulse = true
                 }
@@ -172,7 +177,7 @@ struct NotchIndicatorView: View {
             }
         }
         .onChange(of: viewModel.indicatorTranscriptPreviewEnabled) {
-            if showTranscriptPreview, viewModel.state == .recording, !viewModel.partialText.isEmpty {
+            if showTranscriptPreview, presentation.state == .recording, !presentation.partialText.isEmpty {
                 withAnimation(.easeOut(duration: 0.24)) {
                     textExpanded = true
                 }
@@ -188,21 +193,21 @@ struct NotchIndicatorView: View {
     }
 
     private var notchAccessibilityLabel: String {
-        switch viewModel.state {
+        switch presentation.state {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
-            if let warning = viewModel.recordingCancelWarningMessage {
+            if let warning = presentation.recordingCancelWarningMessage {
                 return warning
             }
-            if !viewModel.isRecordingInputReady {
+            if !presentation.isRecordingInputReady {
                 return String(localized: "Preparing microphone")
             }
             return String(localized: "Recording")
         case .processing:
             return String(localized: "Processing transcription")
         case .inserting:
-            if let feedback = viewModel.actionFeedbackMessage {
+            if let feedback = presentation.actionFeedbackMessage {
                 return feedback
             }
             return String(localized: "Inserting text")
@@ -232,7 +237,7 @@ struct NotchIndicatorView: View {
     private var expandedBodyContent: some View {
         if hasRecordingCancelWarning {
             IndicatorActionFeedback(
-                message: viewModel.recordingCancelWarningMessage ?? "",
+                message: presentation.recordingCancelWarningMessage ?? "",
                 icon: "exclamationmark.triangle.fill",
                 isError: false,
                 iconColor: .yellow,
@@ -240,7 +245,7 @@ struct NotchIndicatorView: View {
             )
         } else if hasTranscriptSection {
             IndicatorExpandableText(
-                text: viewModel.partialText,
+                text: presentation.partialText,
                 fontSize: transcriptFontSize,
                 expandedHeight: viewModel.indicatorTranscriptPreviewExpandedHeight(for: .notch),
                 expanded: true,
@@ -248,16 +253,16 @@ struct NotchIndicatorView: View {
             )
             .opacity(textExpanded ? 1 : 0.72)
         } else if hasProcessingPhase {
-            Text(viewModel.processingPhase ?? "")
+            Text(presentation.processingPhase ?? "")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.white.opacity(0.7))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 6)
         } else if hasActionFeedback {
             IndicatorActionFeedback(
-                message: viewModel.actionFeedbackMessage ?? "",
-                icon: viewModel.actionFeedbackIcon,
-                isError: viewModel.actionFeedbackIsError,
+                message: presentation.actionFeedbackMessage ?? "",
+                icon: presentation.actionFeedbackIcon,
+                isError: presentation.actionFeedbackIsError,
                 iconColor: nil,
                 contentPadding: contentPadding
             )
@@ -271,7 +276,7 @@ struct NotchIndicatorView: View {
         HStack(spacing: 0) {
             HStack(spacing: leftStatusSpacing) {
                 IndicatorLeftStatus(
-                    viewModel: viewModel,
+                    presentation: presentation,
                     sizing: sizing,
                     dotPulse: dotPulse,
                     hasActionFeedback: hasActionFeedback
@@ -296,9 +301,9 @@ struct NotchIndicatorView: View {
 
     @ViewBuilder
     private var leftContent: some View {
-        if case .recording = viewModel.state {
+        if case .recording = presentation.state {
             IndicatorRecordingContent(
-                viewModel: viewModel,
+                presentation: presentation,
                 content: viewModel.notchIndicatorLeftContent,
                 sizing: sizing,
                 dotPulse: dotPulse
@@ -308,14 +313,14 @@ struct NotchIndicatorView: View {
 
     @ViewBuilder
     private var rightContent: some View {
-        if case .recording = viewModel.state {
+        if case .recording = presentation.state {
             IndicatorRecordingContent(
-                viewModel: viewModel,
+                presentation: presentation,
                 content: viewModel.notchIndicatorRightContent,
                 sizing: sizing,
                 dotPulse: dotPulse
             )
-        } else if case .processing = viewModel.state {
+        } else if case .processing = presentation.state {
             ProgressView()
                 .controlSize(.mini)
                 .tint(.white)

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -43,18 +43,26 @@ class OverlayIndicatorPanel: NSPanel {
 
     func startObserving() {
         let vm = DictationViewModel.shared
+        let recorder = AudioRecorderViewModel.shared
 
         vm.$state
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                self?.updateVisibility(state: state, vm: vm)
+            .sink { [weak self] _ in
+                self?.updateVisibility(vm: vm, recorder: recorder)
+            }
+            .store(in: &cancellables)
+
+        recorder.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
         vm.$notchIndicatorVisibility
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.updateVisibility(state: vm.state, vm: vm)
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
@@ -62,7 +70,7 @@ class OverlayIndicatorPanel: NSPanel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.cachedScreen = nil
-                self?.updateVisibility(state: vm.state, vm: vm)
+                self?.updateVisibility(vm: vm, recorder: recorder)
             }
             .store(in: &cancellables)
 
@@ -75,23 +83,25 @@ class OverlayIndicatorPanel: NSPanel {
             .store(in: &cancellables)
     }
 
-    func updateVisibility(state: DictationViewModel.State, vm: DictationViewModel) {
+    func updateVisibility(
+        vm: DictationViewModel = DictationViewModel.shared,
+        recorder: AudioRecorderViewModel = AudioRecorderViewModel.shared
+    ) {
         guard vm.indicatorStyle == .overlay else {
             dismiss()
             return
         }
 
-        switch vm.notchIndicatorVisibility {
-        case .always:
+        let presentation = IndicatorPresentationState.resolve(
+            dictationState: vm.state,
+            recorderState: recorder.state
+        )
+        if IndicatorPresentationState.shouldShow(
+            visibility: vm.notchIndicatorVisibility,
+            presentation: presentation
+        ) {
             show()
-        case .duringActivity:
-            switch state {
-            case .recording, .processing, .inserting, .error:
-                show()
-            case .idle, .promptSelection, .promptProcessing:
-                dismiss()
-            }
-        case .never:
+        } else {
             dismiss()
         }
     }

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Supports top and bottom positioning.
 struct OverlayIndicatorView: View {
     @ObservedObject private var viewModel = DictationViewModel.shared
+    @ObservedObject private var recorder = AudioRecorderViewModel.shared
     @State private var textExpanded = false
     @State private var dotPulse = false
 
@@ -11,16 +12,20 @@ struct OverlayIndicatorView: View {
     private let sizing: IndicatorSizing = .overlay
     private var closedWidth: CGFloat { 280 }
 
+    private var presentation: IndicatorPresentationData {
+        IndicatorPresentationData.make(dictation: viewModel, recorder: recorder)
+    }
+
     private var suppressStreamingText: Bool {
-        viewModel.externalStreamingDisplayCount > 0
+        !presentation.isRecorder && presentation.externalStreamingDisplayCount > 0
     }
 
     private var hasActionFeedback: Bool {
-        viewModel.state == .inserting && viewModel.actionFeedbackMessage != nil
+        presentation.state == .inserting && presentation.actionFeedbackMessage != nil
     }
 
     private var hasRecordingCancelWarning: Bool {
-        viewModel.state == .recording && viewModel.recordingCancelWarningMessage != nil
+        presentation.state == .recording && presentation.recordingCancelWarningMessage != nil
     }
 
     private var showTranscriptPreview: Bool {
@@ -74,10 +79,10 @@ struct OverlayIndicatorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isTop ? .top : .bottom)
         .preferredColorScheme(.dark)
         .animation(.easeInOut(duration: 0.3), value: textExpanded)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.state)
-        .animation(.easeOut(duration: 0.08), value: viewModel.audioLevel)
-        .onChange(of: viewModel.state) {
-            if viewModel.state == .recording {
+        .animation(.easeInOut(duration: 0.2), value: presentation.state)
+        .animation(.easeOut(duration: 0.08), value: presentation.audioLevel)
+        .onChange(of: presentation.state) {
+            if presentation.state == .recording {
                 withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
                     dotPulse = true
                 }
@@ -94,7 +99,7 @@ struct OverlayIndicatorView: View {
             }
         }
         .onChange(of: viewModel.indicatorTranscriptPreviewEnabled) {
-            if showTranscriptPreview, viewModel.state == .recording, !viewModel.partialText.isEmpty {
+            if showTranscriptPreview, presentation.state == .recording, !presentation.partialText.isEmpty {
                 withAnimation(.easeOut(duration: 0.25)) {
                     textExpanded = true
                 }
@@ -110,19 +115,19 @@ struct OverlayIndicatorView: View {
     }
 
     private var accessibilityLabel: String {
-        if let warning = viewModel.recordingCancelWarningMessage, viewModel.state == .recording {
+        if let warning = presentation.recordingCancelWarningMessage, presentation.state == .recording {
             return warning
         }
 
-        if let feedback = viewModel.actionFeedbackMessage, viewModel.state == .inserting {
+        if let feedback = presentation.actionFeedbackMessage, presentation.state == .inserting {
             return feedback
         }
 
-        switch viewModel.state {
+        switch presentation.state {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
-            if !viewModel.isRecordingInputReady {
+            if !presentation.isRecordingInputReady {
                 return String(localized: "Preparing microphone")
             }
             return String(localized: "Recording")
@@ -141,7 +146,7 @@ struct OverlayIndicatorView: View {
     private var expandableContent: some View {
         if hasRecordingCancelWarning {
             IndicatorActionFeedback(
-                message: viewModel.recordingCancelWarningMessage ?? "",
+                message: presentation.recordingCancelWarningMessage ?? "",
                 icon: "exclamationmark.triangle.fill",
                 isError: false,
                 iconColor: .yellow,
@@ -149,16 +154,16 @@ struct OverlayIndicatorView: View {
             )
         } else if isTop {
             // Top position: text expands downward, action feedback below text
-            if viewModel.state == .recording, showTranscriptPreview {
+            if presentation.state == .recording, showTranscriptPreview {
                 IndicatorExpandableText(
-                    text: viewModel.partialText,
+                    text: presentation.partialText,
                     fontSize: transcriptFontSize,
                     expandedHeight: transcriptExpandedHeight,
                     expanded: textExpanded,
                     contentPadding: contentPadding
                 )
-                .onChange(of: viewModel.partialText) {
-                    if showTranscriptPreview, !viewModel.partialText.isEmpty, !textExpanded {
+                .onChange(of: presentation.partialText) {
+                    if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
                         withAnimation(.easeOut(duration: 0.25)) {
                             textExpanded = true
                         }
@@ -169,9 +174,9 @@ struct OverlayIndicatorView: View {
             if hasActionFeedback {
                 Divider().background(Color.white.opacity(0.1))
                 IndicatorActionFeedback(
-                    message: viewModel.actionFeedbackMessage ?? "",
-                    icon: viewModel.actionFeedbackIcon,
-                    isError: viewModel.actionFeedbackIsError,
+                    message: presentation.actionFeedbackMessage ?? "",
+                    icon: presentation.actionFeedbackIcon,
+                    isError: presentation.actionFeedbackIsError,
                     iconColor: nil,
                     contentPadding: contentPadding
                 )
@@ -180,25 +185,25 @@ struct OverlayIndicatorView: View {
             // Bottom position: action feedback on top, text above status bar
             if hasActionFeedback {
                 IndicatorActionFeedback(
-                    message: viewModel.actionFeedbackMessage ?? "",
-                    icon: viewModel.actionFeedbackIcon,
-                    isError: viewModel.actionFeedbackIsError,
+                    message: presentation.actionFeedbackMessage ?? "",
+                    icon: presentation.actionFeedbackIcon,
+                    isError: presentation.actionFeedbackIsError,
                     iconColor: nil,
                     contentPadding: contentPadding
                 )
                 Divider().background(Color.white.opacity(0.1))
             }
 
-            if viewModel.state == .recording, showTranscriptPreview {
+            if presentation.state == .recording, showTranscriptPreview {
                 IndicatorExpandableText(
-                    text: viewModel.partialText,
+                    text: presentation.partialText,
                     fontSize: transcriptFontSize,
                     expandedHeight: transcriptExpandedHeight,
                     expanded: textExpanded,
                     contentPadding: contentPadding
                 )
-                .onChange(of: viewModel.partialText) {
-                    if showTranscriptPreview, !viewModel.partialText.isEmpty, !textExpanded {
+                .onChange(of: presentation.partialText) {
+                    if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
                         withAnimation(.easeOut(duration: 0.25)) {
                             textExpanded = true
                         }
@@ -214,15 +219,15 @@ struct OverlayIndicatorView: View {
     private var statusBar: some View {
         HStack(spacing: 12) {
             IndicatorLeftStatus(
-                viewModel: viewModel,
+                presentation: presentation,
                 sizing: sizing,
                 dotPulse: dotPulse,
                 hasActionFeedback: hasActionFeedback
             )
 
-            if case .recording = viewModel.state {
+            if case .recording = presentation.state {
                 IndicatorRecordingContent(
-                    viewModel: viewModel,
+                    presentation: presentation,
                     content: viewModel.notchIndicatorLeftContent,
                     sizing: sizing,
                     dotPulse: dotPulse
@@ -231,15 +236,15 @@ struct OverlayIndicatorView: View {
 
             Spacer()
 
-            if case .recording = viewModel.state {
+            if case .recording = presentation.state {
                 IndicatorRecordingContent(
-                    viewModel: viewModel,
+                    presentation: presentation,
                     content: viewModel.notchIndicatorRightContent,
                     sizing: sizing,
                     dotPulse: dotPulse
                 )
-            } else if case .processing = viewModel.state {
-                if let phase = viewModel.processingPhase {
+            } else if case .processing = presentation.state {
+                if let phase = presentation.processingPhase {
                     Text(phase)
                         .font(.system(size: 12))
                         .foregroundStyle(.white.opacity(0.7))

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -81,7 +81,7 @@ struct IndicatorAppIconView: View {
 // MARK: - Left Status Indicator
 
 struct IndicatorLeftStatus: View {
-    @ObservedObject var viewModel: DictationViewModel
+    let presentation: IndicatorPresentationData
     let sizing: IndicatorSizing
     let dotPulse: Bool
     let hasActionFeedback: Bool
@@ -93,19 +93,19 @@ struct IndicatorLeftStatus: View {
 
     @ViewBuilder
     private var statusContent: some View {
-        switch viewModel.state {
+        switch presentation.state {
         case .idle, .promptSelection, .promptProcessing:
             Color.clear.frame(width: 0, height: 0)
         case .recording:
-            if !viewModel.isRecordingInputReady {
+            if !presentation.isRecordingInputReady {
                 IndicatorPreparingView(sizing: sizing)
-            } else if let icon = viewModel.activeAppIcon {
+            } else if let icon = presentation.activeAppIcon {
                 IndicatorAppIconView(icon: icon, sizing: sizing)
             } else {
-                IndicatorDot(audioLevel: viewModel.audioLevel, dotPulse: dotPulse, sizing: sizing)
+                IndicatorDot(audioLevel: presentation.audioLevel, dotPulse: dotPulse, sizing: sizing)
             }
         case .processing:
-            if let icon = viewModel.activeAppIcon {
+            if let icon = presentation.activeAppIcon {
                 IndicatorAppIconView(icon: icon, sizing: sizing)
             } else {
                 ProgressView()
@@ -115,7 +115,7 @@ struct IndicatorLeftStatus: View {
         case .inserting:
             if hasActionFeedback {
                 Color.clear.frame(width: 0, height: 0)
-            } else if let icon = viewModel.activeAppIcon {
+            } else if let icon = presentation.activeAppIcon {
                 IndicatorAppIconView(icon: icon, sizing: sizing)
             } else {
                 Image(systemName: "checkmark.circle.fill")
@@ -123,7 +123,7 @@ struct IndicatorLeftStatus: View {
                     .font(.system(size: sizing.symbolSize))
             }
         case .error:
-            if let icon = viewModel.activeAppIcon {
+            if let icon = presentation.activeAppIcon {
                 IndicatorAppIconView(icon: icon, borderColor: .red, sizing: sizing)
             } else {
                 Image(systemName: "xmark.circle.fill")
@@ -168,7 +168,7 @@ struct IndicatorDot: View {
 // MARK: - Recording Content
 
 struct IndicatorRecordingContent: View {
-    @ObservedObject var viewModel: DictationViewModel
+    let presentation: IndicatorPresentationData
     let content: NotchIndicatorContent
     let sizing: IndicatorSizing
     let dotPulse: Bool
@@ -176,27 +176,27 @@ struct IndicatorRecordingContent: View {
     var body: some View {
         switch content {
         case .indicator:
-            if viewModel.isRecordingInputReady {
-                IndicatorDot(audioLevel: viewModel.audioLevel, dotPulse: dotPulse, sizing: sizing)
+            if presentation.isRecordingInputReady {
+                IndicatorDot(audioLevel: presentation.audioLevel, dotPulse: dotPulse, sizing: sizing)
             } else {
                 IndicatorPreparingView(sizing: sizing)
             }
         case .timer:
-            Text(formatDuration(viewModel.recordingDuration))
+            Text(formatDuration(presentation.recordingDuration))
                 .font(.system(size: sizing.timerFontSize, weight: .medium).monospacedDigit())
                 .foregroundStyle(.white.opacity(sizing.timerOpacity))
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 .accessibilityLabel(String(localized: "Recording timer"))
-                .accessibilityValue(formatDuration(viewModel.recordingDuration))
+                .accessibilityValue(formatDuration(presentation.recordingDuration))
         case .waveform:
             AudioWaveformView(
-                audioLevel: viewModel.audioLevel,
-                isSetup: !viewModel.isRecordingInputReady || (viewModel.recordingDuration < 0.5 && viewModel.audioLevel < 0.05),
+                audioLevel: presentation.audioLevel,
+                isSetup: !presentation.isRecordingInputReady || (presentation.recordingDuration < 0.5 && presentation.audioLevel < 0.05),
                 compact: true
             )
         case .profile:
-            if let name = viewModel.activeRuleName {
+            if let name = presentation.activeRuleName {
                 Text(name)
                     .font(.system(size: sizing.profileFontSize, weight: .medium))
                     .foregroundStyle(.white)

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -438,6 +438,78 @@ final class MenuBarIconStateTests: XCTestCase {
     }
 }
 
+final class IndicatorPresentationStateTests: XCTestCase {
+    func testRecorderRecordingShowsRecordingPresentationWhenDictationIsIdle() {
+        let presentation = IndicatorPresentationState.resolve(
+            dictationState: .idle,
+            recorderState: .recording
+        )
+
+        XCTAssertEqual(presentation.source, .recorder)
+        XCTAssertEqual(presentation.state, .recording)
+        XCTAssertTrue(presentation.isActiveDuringActivity)
+    }
+
+    func testRecorderFinalizingDoesNotShowRecorderActivity() {
+        let presentation = IndicatorPresentationState.resolve(
+            dictationState: .idle,
+            recorderState: .finalizing
+        )
+
+        XCTAssertEqual(presentation.source, .dictation)
+        XCTAssertEqual(presentation.state, .idle)
+        XCTAssertFalse(presentation.isActiveDuringActivity)
+    }
+
+    func testDictationActiveStatesWinOverRecorderRecording() {
+        let activeDictationStates: [DictationViewModel.State] = [
+            .recording,
+            .processing,
+            .inserting,
+            .error("failed")
+        ]
+
+        for state in activeDictationStates {
+            let presentation = IndicatorPresentationState.resolve(
+                dictationState: state,
+                recorderState: .recording
+            )
+
+            XCTAssertEqual(presentation.source, .dictation)
+            XCTAssertEqual(presentation.state, state)
+            XCTAssertTrue(presentation.isActiveDuringActivity)
+        }
+    }
+
+    func testVisibilityPolicyPreservesAlwaysDuringActivityAndNever() {
+        let recorderPresentation = IndicatorPresentationState.resolve(
+            dictationState: .idle,
+            recorderState: .recording
+        )
+        let idlePresentation = IndicatorPresentationState.resolve(
+            dictationState: .idle,
+            recorderState: .idle
+        )
+
+        XCTAssertTrue(IndicatorPresentationState.shouldShow(
+            visibility: .always,
+            presentation: idlePresentation
+        ))
+        XCTAssertTrue(IndicatorPresentationState.shouldShow(
+            visibility: .duringActivity,
+            presentation: recorderPresentation
+        ))
+        XCTAssertFalse(IndicatorPresentationState.shouldShow(
+            visibility: .duringActivity,
+            presentation: idlePresentation
+        ))
+        XCTAssertFalse(IndicatorPresentationState.shouldShow(
+            visibility: .never,
+            presentation: recorderPresentation
+        ))
+    }
+}
+
 final class MenuBarLogoMarkImageTests: XCTestCase {
     func testBarLayoutFitsWithinMenuBarSlotWithVisibleGaps() {
         let rects = MenuBarLogoMarkImage.barRects(in: CGRect(x: 0, y: 0, width: 18, height: 18))


### PR DESCRIPTION
## Summary
- Add an internal indicator presentation resolver that combines dictation and recorder state in the host app.
- Observe recorder state from the Notch, Overlay, and Minimal indicator panels so active recorder capture can drive visibility.
- Render recorder mode with recorder duration, max mic/system level, and recorder partial text while keeping dictation active states prioritized.

## Issue context
Issue #586 reports that Recorder sessions started from the UI or `POST /v1/recorder/start` do not show the configured floating indicator even though dictation sessions do. This keeps the fix host-app local with no HostServices, plugin SDK, HTTP response, README, or release-note changes.

Closes #586

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/IndicatorPresentationStateTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testRecorderEndpointsReturnSessionIDAndCompletedTranscript`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indicator visibility coordination when both dictation and audio recording are active simultaneously, ensuring panels display correctly across all styles (notch, overlay, minimal).

* **Tests**
  * Added validation tests for indicator state resolution and visibility logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->