### PR TITLE
Prepare TypeWhisper 1.4.0 stable release notes

### DIFF
--- a/docs/release-notes/1.4.0.md
+++ b/docs/release-notes/1.4.0.md
@@ -1,0 +1,34 @@
+TypeWhisper `1.4.0` is the stable release for the new Integrations and community-plugin foundation. It brings the redesigned plugin hub, the `1.4` community registry feed, downloaded model management, new local automation APIs, and a broad reliability pass across workflows, live transcript, indicators, audio capture, and first-party plugins.
+
+## Highlights
+
+- Added the `plugins-community-v1.json` registry feed for `1.4` builds while keeping the `1.3.x` line on the existing official marketplace feed.
+- Redesigned Integrations with Installed, Discover, and Manual tabs, grouped plugin lists, source and hosting metadata, and capability filtering for local, cloud, transcription, LLM, action, and memory plugins.
+- Added support for community plugin registry publishing and mirrored first-party plugin releases into the community registry feed.
+- Added downloaded model management for local model plugins, including host-version gating for the Qwen3, Granite, Voxtral, Gemma 4, WhisperKit, and Supertonic release line.
+- Added the Smallest AI Pulse transcription plugin, the xAI Grok plugin, the experimental Supertonic TTS plugin, and refreshed OpenAI voice and Qwen3 ASR integrations for `1.4`.
+- Added local Recorder and Dictionary HTTP API endpoints so trusted local clients can inspect recorder state, start transcriptions, and manage dictionary terms through the app API.
+- Added watch-folder file job automation, per-dictation STT engine/model overrides, workflow drag reordering, and multiple global hotkeys per action.
+- Added Parakeet live transcription support and the WhisperKit Distil Large v3 Turbo model.
+- Added licensed industry term packs and localized built-in term pack metadata.
+
+## Reliability and Fixes
+
+- Tightened workflow input boundaries so dictated text and Apple Intelligence scaffold output are treated as source content instead of executable instructions.
+- Improved live transcript stability, sentence accumulation, correction handling, preview latency, and maximized-window behavior.
+- Kept recording indicators visible for active recorder sessions while hiding supported indicator windows from screen captures.
+- Improved fullscreen, fixed-display, foreign-window, and maximized-window indicator handling.
+- Reduced hotkey recording startup latency and fixed exact modifier-combination matching.
+- Recovered failed dictation audio and added audio diagnostics export for troubleshooting capture failures.
+- Improved selected USB microphone capture, multichannel input handling, and system-audio recorder sample handling.
+- Deferred the recording start cue until input is ready and improved Parakeet onboarding/setup status.
+- Made plugin settings windows scrollable and restored workflow action targets.
+- Improved onboarding layout, transcription helper compatibility, memory extraction for normal dictations, and plugin registry release metadata.
+- Hardened webhook sensitive header storage and local API token enforcement.
+
+## Developer and Distribution Notes
+
+- The stable Sparkle appcast entry for `1.4.0` uses the default channel and requires macOS 14.0 or later.
+- Homebrew updates are intentionally stable-only and are triggered by the final `v1.4.0` tag.
+- Release candidates and daily builds remain on their dedicated Sparkle channels and do not update Homebrew.
+- Plugin SDK workflow snapshots expose read-only workflow metadata without handing plugins internal app model objects.


### PR DESCRIPTION
## Summary
- Adds curated stable release notes for TypeWhisper `1.4.0`.
- Keeps the release-prep branch scoped to documentation only.
- Leaves PR #592 and other open feature/plugin PRs out of the stable release cut.

## Release Context
`v1.4.0` is planned as the stable release for the existing `1.4` release train. The release workflow will use `docs/release-notes/1.4.0.md` automatically when the final stable tag is pushed.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`\n- [x] `swift test --package-path TypeWhisperPluginSDK`\n- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee build.log`\n- [x] `bash scripts/check_first_party_warnings.sh build.log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for TypeWhisper 1.4.0, detailing new integrations, plugin hub/community registry features, model management capabilities, local automation and HTTP APIs, transcription/model additions, and reliability/security improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->