### PR TITLE
Add smart trailing space after dictation

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1258,14 +1258,15 @@ final class DictationViewModel: ObservableObject {
                         activeApp: activeApp, language: language, originalText: result.text
                     )
                 } else {
+                    let insertionText = DictationInsertionTextFormatter.textForInsertion(text)
                     _ = try await textInsertionService.insertText(
-                        text,
+                        insertionText,
                         preserveClipboard: preserveClipboard,
                         autoEnter: self.effectiveAutoEnterEnabled,
                         outputFormat: self.effectiveOutputFormat
                     )
                     EventBus.shared.emit(.textInserted(TextInsertedPayload(
-                        text: text,
+                        text: insertionText,
                         appName: activeApp.name,
                         bundleIdentifier: activeApp.bundleId
                     )))
@@ -1786,6 +1787,14 @@ enum ShortSpeechDecision: Equatable {
 func hasConfirmedTranscriptionResultText(_ result: TranscriptionResult?) -> Bool {
     guard let result else { return false }
     return !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+}
+
+enum DictationInsertionTextFormatter {
+    static func textForInsertion(_ text: String) -> String {
+        guard let lastScalar = text.unicodeScalars.last else { return text }
+        guard !CharacterSet.whitespacesAndNewlines.contains(lastScalar) else { return text }
+        return text + " "
+    }
 }
 
 func classifyShortSpeech(

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2587,6 +2587,62 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testDictationDirectInsertionAddsTrailingSpaceWithoutMutatingStoredTranscription() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let historyEnabledKey = UserDefaultsKeys.historyEnabled
+        let originalHistoryEnabled = UserDefaults.standard.object(forKey: historyEnabledKey)
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            if let originalHistoryEnabled {
+                UserDefaults.standard.set(originalHistoryEnabled, forKey: historyEnabledKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: historyEnabledKey)
+            }
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        UserDefaults.standard.set(true, forKey: historyEnabledKey)
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        let pasteboard = NSPasteboard.withUniqueName()
+        context.textInsertionService.pasteboardProvider = { pasteboard }
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Notes", "com.apple.Notes", nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.pasteSimulatorOverride = {}
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<40 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        let session = try XCTUnwrap(context.dictationViewModel.apiDictationSession(id: sessionID))
+        XCTAssertEqual(session.status, .completed)
+        XCTAssertEqual(pasteboard.string(forType: .string), "transcribed ")
+        XCTAssertEqual(session.transcription?.text, "transcribed")
+        XCTAssertEqual(context.historyService.records.first?.finalText, "transcribed")
+        XCTAssertEqual(
+            context.recentTranscriptionStore.latestEntry(historyRecords: context.historyService.records)?.finalText,
+            "transcribed"
+        )
+    }
+
+    @MainActor
     func testApiStartRecording_pausesMediaAfterAudioStart() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var events: [String] = []

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -177,3 +177,21 @@ final class DictationShortSpeechTests: XCTestCase {
         return [Float](repeating: 0.1, count: count)
     }
 }
+
+final class DictationInsertionTextFormatterTests: XCTestCase {
+    func testAddsTrailingSpaceToNonEmptyTextWithoutTrailingWhitespace() {
+        XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion("Hello"), "Hello ")
+    }
+
+    func testLeavesExistingTrailingSpaceUntouched() {
+        XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion("Hello "), "Hello ")
+    }
+
+    func testLeavesExistingTrailingNewlineUntouched() {
+        XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion("Hello\n"), "Hello\n")
+    }
+
+    func testLeavesEmptyTextUntouched() {
+        XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion(""), "")
+    }
+}


### PR DESCRIPTION
## Summary
- Add smart trailing-space formatting for direct dictation insertions so consecutive dictations do not concatenate words.
- Keep stored transcription surfaces clean: API session text, history, recent transcriptions, readback, and action plugins continue to use the final post-processed text without the synthetic space.
- Cover the formatter and direct insertion behavior with regression tests.

Closes #593

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationInsertionTextFormatterTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testDictationDirectInsertionAddsTrailingSpaceWithoutMutatingStoredTranscription`
- `git diff --check`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/513e/typewhisper-mac`

## Verification Note
- Also attempted `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS'`; the local run was interrupted after about 9 minutes because `xcodebuild` / `TypeWhisper.app` sat at 0% CPU with no further output. The targeted regression suite above passed before and after that interruption.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dictation transcription insertion now automatically adds trailing spacing to ensure proper text formatting when text is inserted into documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->