### PR TITLE
Add plugin update-state diagnostics and repair action

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -264,6 +264,8 @@ final class ServiceContainer: ObservableObject {
         // Validate LLM provider selection against loaded plugins
         promptProcessingService.validateSelectionAfterPluginLoad()
 
+        pluginRegistryService.checkForUpdatesInBackground()
+
         // Start memory service
         memoryService.startListening()
 

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -94,8 +94,8 @@ enum PluginDiagnosticsSupport {
         for url: URL,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
     ) -> String {
-        let path = url.standardizedFileURL.path
-        let homePath = homeDirectory.standardizedFileURL.path
+        let path = url.resolvingSymlinksInPath().standardizedFileURL.path
+        let homePath = homeDirectory.resolvingSymlinksInPath().standardizedFileURL.path
         if path == homePath {
             return "~"
         }
@@ -111,8 +111,8 @@ enum PluginDiagnosticsSupport {
         builtInPluginsURL: URL?,
         pluginsDirectory: URL,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
-    ) -> DiagnosticPluginSourceInfo {
-        let executableInfo = executableInfo(bundle: bundle, sourceURL: sourceURL)
+    ) async -> DiagnosticPluginSourceInfo {
+        let executableInfo = await executableInfo(bundle: bundle, sourceURL: sourceURL)
         let infoDictionary = bundle?.infoDictionary ?? bundleInfoDictionary(sourceURL: sourceURL)
         return DiagnosticPluginSourceInfo(
             sourceKind: pluginSourceKind(
@@ -129,13 +129,13 @@ enum PluginDiagnosticsSupport {
         )
     }
 
-    static func executableInfo(bundle: Bundle?, sourceURL: URL) -> DiagnosticExecutableInfo {
+    static func executableInfo(bundle: Bundle?, sourceURL: URL) async -> DiagnosticExecutableInfo {
         guard let executableURL = executableURL(bundle: bundle, sourceURL: sourceURL) else {
             return DiagnosticExecutableInfo(sizeBytes: nil, sha256: nil)
         }
 
         let size = (try? executableURL.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(Int64.init)
-        return DiagnosticExecutableInfo(sizeBytes: size, sha256: sha256HexDigest(for: executableURL))
+        return DiagnosticExecutableInfo(sizeBytes: size, sha256: await sha256HexDigest(for: executableURL))
     }
 
     private static func executableURL(bundle: Bundle?, sourceURL: URL) -> URL? {
@@ -167,21 +167,23 @@ enum PluginDiagnosticsSupport {
         return dictionary
     }
 
-    private static func sha256HexDigest(for url: URL) -> String? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        defer { try? handle.close() }
+    private static func sha256HexDigest(for url: URL) async -> String? {
+        await Task.detached(priority: .utility) {
+            guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+            defer { try? handle.close() }
 
-        var hasher = SHA256()
-        while true {
-            do {
-                guard let chunk = try handle.read(upToCount: 1024 * 1024), !chunk.isEmpty else { break }
-                hasher.update(data: chunk)
-            } catch {
-                return nil
+            var hasher = SHA256()
+            while true {
+                do {
+                    guard let chunk = try handle.read(upToCount: 1024 * 1024), !chunk.isEmpty else { break }
+                    hasher.update(data: chunk)
+                } catch {
+                    return nil
+                }
             }
-        }
 
-        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+            return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        }.value
     }
 }
 
@@ -375,16 +377,18 @@ final class ErrorLogService: ObservableObject {
         saveEntries()
     }
 
-    func exportDiagnostics(to url: URL) throws {
-        let report = diagnosticsReport()
+    func exportDiagnostics(to url: URL) async throws {
+        let report = await diagnosticsReport()
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(report)
-        try data.write(to: url, options: .atomic)
+        try await Task.detached(priority: .utility) {
+            try data.write(to: url, options: .atomic)
+        }.value
     }
 
-    private func diagnosticsReport() -> DiagnosticsReport {
+    private func diagnosticsReport() async -> DiagnosticsReport {
         let container = ServiceContainer.shared
         let defaults = UserDefaults.standard
         let pluginManager = PluginManager.shared ?? container.pluginManager
@@ -393,6 +397,77 @@ final class ErrorLogService: ObservableObject {
         let indicatorStyle = DictationViewModel.loadIndicatorStyle(defaults: defaults)
         let indicatorPreviewEnabled = DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults)
         let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
+
+        var pluginDiagnostics: [DiagnosticsReport.PluginInfo] = []
+        for loadedPlugin in pluginManager.loadedPlugins {
+            let engine = loadedPlugin.instance as? TranscriptionEnginePlugin
+            let fallbackPolicy = engine as? TranscriptPreviewFallbackPolicyProviding
+            let allowsTranscriptPreviewFallback: Bool? = if engine != nil {
+                fallbackPolicy?.allowsTranscriptPreviewFallback ?? true
+            } else {
+                nil
+            }
+            let activity = (loadedPlugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
+            let registryEntry = container.pluginRegistryService.registry.first { $0.id == loadedPlugin.manifest.id }
+            let externalNotice = pluginManager.externalBundleNotice(
+                for: loadedPlugin.manifest.id,
+                registryPlugin: registryEntry
+            )
+            let pluginSource = await PluginDiagnosticsSupport.sourceInfo(
+                bundle: loadedPlugin.bundle,
+                sourceURL: loadedPlugin.sourceURL,
+                builtInPluginsURL: Bundle.main.builtInPlugInsURL,
+                pluginsDirectory: pluginManager.pluginsDirectory
+            )
+
+            pluginDiagnostics.append(DiagnosticsReport.PluginInfo(
+                id: loadedPlugin.manifest.id,
+                name: loadedPlugin.manifest.name,
+                version: loadedPlugin.manifest.version,
+                enabled: loadedPlugin.isEnabled,
+                bundled: loadedPlugin.isBundled,
+                runtimeLoaded: loadedPlugin.isRuntimeLoaded,
+                providerId: engine?.providerId,
+                selectedModelId: engine?.selectedModelId,
+                isConfigured: engine?.isConfigured,
+                supportsStreaming: engine?.supportsStreaming,
+                supportsLiveTranscriptionSession: engine.map { $0 is LiveTranscriptionCapablePlugin },
+                allowsTranscriptPreviewFallback: allowsTranscriptPreviewFallback,
+                storedSelectedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedModel")),
+                storedLoadedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "loadedModel")),
+                storedSelectedVersion: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedVersion")),
+                source: pluginSource,
+                currentSettingsActivity: activity.map(DiagnosticPluginActivityInfo.init),
+                registryVersion: registryEntry?.version,
+                registrySource: registryEntry?.source.rawValue,
+                externalBundleNotice: externalNotice?.diagnosticsValue
+            ))
+        }
+
+        var skippedExternalBundleDiagnostics: [DiagnosticsReport.SkippedExternalBundleInfo] = []
+        for bundle in pluginManager.incompatibleExternalBundles.values.sorted(by: { $0.pluginName < $1.pluginName }) {
+            let registryEntry = container.pluginRegistryService.registry.first(where: { $0.id == bundle.pluginId })
+            let pluginSource = await PluginDiagnosticsSupport.sourceInfo(
+                bundle: Bundle(url: bundle.bundleURL),
+                sourceURL: bundle.bundleURL,
+                builtInPluginsURL: Bundle.main.builtInPlugInsURL,
+                pluginsDirectory: pluginManager.pluginsDirectory
+            )
+            skippedExternalBundleDiagnostics.append(DiagnosticsReport.SkippedExternalBundleInfo(
+                id: bundle.pluginId,
+                name: bundle.pluginName,
+                version: bundle.version,
+                reason: bundle.reason.diagnosticsValue,
+                source: pluginSource,
+                registryVersion: registryEntry?.version,
+                registrySource: registryEntry?.source.rawValue,
+                externalBundleNotice: PluginManager.externalBundleNotice(
+                    loadedPlugin: pluginManager.loadedPlugins.first(where: { $0.manifest.id == bundle.pluginId }),
+                    registryPlugin: registryEntry,
+                    incompatibleExternalBundle: bundle
+                )?.diagnosticsValue
+            ))
+        }
 
         return DiagnosticsReport(
             schemaVersion: 5,
@@ -451,72 +526,8 @@ final class ErrorLogService: ObservableObject {
                 },
                 inputDiagnostics: container.audioDeviceService.diagnosticsReport()
             ),
-            plugins: pluginManager.loadedPlugins.map { loadedPlugin in
-                let engine = loadedPlugin.instance as? TranscriptionEnginePlugin
-                let fallbackPolicy = engine as? TranscriptPreviewFallbackPolicyProviding
-                let allowsTranscriptPreviewFallback: Bool? = if engine != nil {
-                    fallbackPolicy?.allowsTranscriptPreviewFallback ?? true
-                } else {
-                    nil
-                }
-                let activity = (loadedPlugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
-                let registryEntry = container.pluginRegistryService.registry.first { $0.id == loadedPlugin.manifest.id }
-                let externalNotice = pluginManager.externalBundleNotice(
-                    for: loadedPlugin.manifest.id,
-                    registryPlugin: registryEntry
-                )
-                return DiagnosticsReport.PluginInfo(
-                    id: loadedPlugin.manifest.id,
-                    name: loadedPlugin.manifest.name,
-                    version: loadedPlugin.manifest.version,
-                    enabled: loadedPlugin.isEnabled,
-                    bundled: loadedPlugin.isBundled,
-                    runtimeLoaded: loadedPlugin.isRuntimeLoaded,
-                    providerId: engine?.providerId,
-                    selectedModelId: engine?.selectedModelId,
-                    isConfigured: engine?.isConfigured,
-                    supportsStreaming: engine?.supportsStreaming,
-                    supportsLiveTranscriptionSession: engine.map { $0 is LiveTranscriptionCapablePlugin },
-                    allowsTranscriptPreviewFallback: allowsTranscriptPreviewFallback,
-                    storedSelectedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedModel")),
-                    storedLoadedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "loadedModel")),
-                    storedSelectedVersion: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedVersion")),
-                    source: PluginDiagnosticsSupport.sourceInfo(
-                        bundle: loadedPlugin.bundle,
-                        sourceURL: loadedPlugin.sourceURL,
-                        builtInPluginsURL: Bundle.main.builtInPlugInsURL,
-                        pluginsDirectory: pluginManager.pluginsDirectory
-                    ),
-                    currentSettingsActivity: activity.map(DiagnosticPluginActivityInfo.init),
-                    registryVersion: registryEntry?.version,
-                    registrySource: registryEntry?.source.rawValue,
-                    externalBundleNotice: externalNotice?.diagnosticsValue
-                )
-            },
-            skippedExternalBundles: pluginManager.incompatibleExternalBundles.values
-                .sorted { $0.pluginName < $1.pluginName }
-                .map { bundle in
-                    let registryEntry = container.pluginRegistryService.registry.first(where: { $0.id == bundle.pluginId })
-                    return DiagnosticsReport.SkippedExternalBundleInfo(
-                        id: bundle.pluginId,
-                        name: bundle.pluginName,
-                        version: bundle.version,
-                        reason: bundle.reason.diagnosticsValue,
-                        source: PluginDiagnosticsSupport.sourceInfo(
-                            bundle: Bundle(url: bundle.bundleURL),
-                            sourceURL: bundle.bundleURL,
-                            builtInPluginsURL: Bundle.main.builtInPlugInsURL,
-                            pluginsDirectory: pluginManager.pluginsDirectory
-                        ),
-                        registryVersion: registryEntry?.version,
-                        registrySource: registryEntry?.source.rawValue,
-                        externalBundleNotice: PluginManager.externalBundleNotice(
-                            loadedPlugin: pluginManager.loadedPlugins.first(where: { $0.manifest.id == bundle.pluginId }),
-                            registryPlugin: registryEntry,
-                            incompatibleExternalBundle: bundle
-                        )?.diagnosticsValue
-                    )
-                },
+            plugins: pluginDiagnostics,
+            skippedExternalBundles: skippedExternalBundleDiagnostics,
             settings: .init(
                 bundledReleaseChannel: AppConstants.releaseChannel.rawValue,
                 selectedUpdateChannel: AppConstants.effectiveUpdateChannel.rawValue,

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -1,9 +1,189 @@
 import AVFoundation
+import CryptoKit
 import Foundation
 import os.log
 import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "ErrorLogService")
+
+enum DiagnosticBundlePathKind: String, Encodable, Equatable {
+    case systemApplications
+    case userApplications
+    case development
+    case temporary
+    case other
+}
+
+enum DiagnosticPluginSourceKind: String, Encodable, Equatable {
+    case bundled
+    case managedExternal
+    case externalOther
+}
+
+struct DiagnosticExecutableInfo: Encodable, Equatable {
+    let sizeBytes: Int64?
+    let sha256: String?
+}
+
+struct DiagnosticPluginSourceInfo: Encodable, Equatable {
+    let sourceKind: DiagnosticPluginSourceKind
+    let pathHint: String
+    let bundleIdentifier: String?
+    let bundleShortVersion: String?
+    let bundleVersion: String?
+    let executableSizeBytes: Int64?
+    let executableSHA256: String?
+}
+
+struct DiagnosticPluginActivityInfo: Encodable, Equatable {
+    let message: String
+    let progress: Double?
+    let isError: Bool
+
+    init(_ activity: PluginSettingsActivity) {
+        self.message = activity.message
+        self.progress = activity.progress
+        self.isError = activity.isError
+    }
+}
+
+enum PluginDiagnosticsSupport {
+    static func appBundlePathKind(
+        for bundleURL: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        isDevelopment: Bool = AppConstants.isDevelopment
+    ) -> DiagnosticBundlePathKind {
+        let path = bundleURL.standardizedFileURL.path
+        let homePath = homeDirectory.standardizedFileURL.path
+
+        if isDevelopment || path.contains("/DerivedData/") {
+            return .development
+        }
+        if path.hasPrefix(homePath + "/Applications/") {
+            return .userApplications
+        }
+        if path.hasPrefix("/Applications/") {
+            return .systemApplications
+        }
+        if path.hasPrefix("/tmp/") || path.hasPrefix("/private/tmp/") || path.hasPrefix("/private/var/folders/") {
+            return .temporary
+        }
+        return .other
+    }
+
+    static func pluginSourceKind(
+        sourceURL: URL,
+        builtInPluginsURL: URL?,
+        pluginsDirectory: URL
+    ) -> DiagnosticPluginSourceKind {
+        let sourcePath = sourceURL.resolvingSymlinksInPath().standardizedFileURL.path
+        if let builtInPath = builtInPluginsURL?.resolvingSymlinksInPath().standardizedFileURL.path,
+           sourcePath.hasPrefix(builtInPath + "/") || sourcePath == builtInPath {
+            return .bundled
+        }
+
+        let pluginsPath = pluginsDirectory.resolvingSymlinksInPath().standardizedFileURL.path
+        if sourcePath.hasPrefix(pluginsPath + "/") || sourcePath == pluginsPath {
+            return .managedExternal
+        }
+
+        return .externalOther
+    }
+
+    static func pathHint(
+        for url: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> String {
+        let path = url.standardizedFileURL.path
+        let homePath = homeDirectory.standardizedFileURL.path
+        if path == homePath {
+            return "~"
+        }
+        if path.hasPrefix(homePath + "/") {
+            return "~" + String(path.dropFirst(homePath.count))
+        }
+        return path
+    }
+
+    static func sourceInfo(
+        bundle: Bundle?,
+        sourceURL: URL,
+        builtInPluginsURL: URL?,
+        pluginsDirectory: URL,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> DiagnosticPluginSourceInfo {
+        let executableInfo = executableInfo(bundle: bundle, sourceURL: sourceURL)
+        let infoDictionary = bundle?.infoDictionary ?? bundleInfoDictionary(sourceURL: sourceURL)
+        return DiagnosticPluginSourceInfo(
+            sourceKind: pluginSourceKind(
+                sourceURL: sourceURL,
+                builtInPluginsURL: builtInPluginsURL,
+                pluginsDirectory: pluginsDirectory
+            ),
+            pathHint: pathHint(for: sourceURL, homeDirectory: homeDirectory),
+            bundleIdentifier: bundle?.bundleIdentifier ?? infoDictionary["CFBundleIdentifier"] as? String,
+            bundleShortVersion: infoDictionary["CFBundleShortVersionString"] as? String,
+            bundleVersion: infoDictionary["CFBundleVersion"] as? String,
+            executableSizeBytes: executableInfo.sizeBytes,
+            executableSHA256: executableInfo.sha256
+        )
+    }
+
+    static func executableInfo(bundle: Bundle?, sourceURL: URL) -> DiagnosticExecutableInfo {
+        guard let executableURL = executableURL(bundle: bundle, sourceURL: sourceURL) else {
+            return DiagnosticExecutableInfo(sizeBytes: nil, sha256: nil)
+        }
+
+        let size = (try? executableURL.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(Int64.init)
+        return DiagnosticExecutableInfo(sizeBytes: size, sha256: sha256HexDigest(for: executableURL))
+    }
+
+    private static func executableURL(bundle: Bundle?, sourceURL: URL) -> URL? {
+        if let executableURL = bundle?.executableURL {
+            return executableURL
+        }
+
+        let executableName = (bundle?.object(forInfoDictionaryKey: "CFBundleExecutable") as? String)
+            ?? bundleInfoDictionary(sourceURL: sourceURL)["CFBundleExecutable"] as? String
+        if let executableName {
+            return sourceURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent(executableName)
+        }
+
+        return nil
+    }
+
+    private static func bundleInfoDictionary(sourceURL: URL) -> [String: Any] {
+        let infoPlistURL = sourceURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoPlistURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dictionary = plist as? [String: Any] else {
+            return [:]
+        }
+        return dictionary
+    }
+
+    private static func sha256HexDigest(for url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while true {
+            do {
+                guard let chunk = try handle.read(upToCount: 1024 * 1024), !chunk.isEmpty else { break }
+                hasher.update(data: chunk)
+            } catch {
+                return nil
+            }
+        }
+
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
 
 private struct DiagnosticsReport: Encodable {
     struct AppInfo: Encodable {
@@ -11,6 +191,9 @@ private struct DiagnosticsReport: Encodable {
         let build: String
         let bundleIdentifier: String
         let isDevelopment: Bool
+        let bundlePathKind: DiagnosticBundlePathKind
+        let launchTimestamp: Date
+        let uptimeSeconds: Double
     }
 
     struct SystemInfo: Encodable {
@@ -77,6 +260,22 @@ private struct DiagnosticsReport: Encodable {
         let storedSelectedModelId: String?
         let storedLoadedModelId: String?
         let storedSelectedVersion: String?
+        let source: DiagnosticPluginSourceInfo
+        let currentSettingsActivity: DiagnosticPluginActivityInfo?
+        let registryVersion: String?
+        let registrySource: String?
+        let externalBundleNotice: String?
+    }
+
+    struct SkippedExternalBundleInfo: Encodable {
+        let id: String
+        let name: String
+        let version: String
+        let reason: String
+        let source: DiagnosticPluginSourceInfo
+        let registryVersion: String?
+        let registrySource: String?
+        let externalBundleNotice: String?
     }
 
     struct SettingsSnapshot: Encodable {
@@ -137,6 +336,7 @@ private struct DiagnosticsReport: Encodable {
     let api: APIInfo
     let audio: AudioInfo
     let plugins: [PluginInfo]
+    let skippedExternalBundles: [SkippedExternalBundleInfo]
     let settings: SettingsSnapshot
     let lastIndicatorFullscreenSuppression: IndicatorFullscreenSuppressionDiagnostics?
     let counts: Counts
@@ -149,6 +349,7 @@ final class ErrorLogService: ObservableObject {
 
     private static let maxEntries = 200
     private let fileURL: URL
+    private let launchTimestamp = Date()
 
     init(appSupportDirectory: URL = AppConstants.appSupportDirectory) {
         let dir = appSupportDirectory
@@ -194,13 +395,18 @@ final class ErrorLogService: ObservableObject {
         let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
 
         return DiagnosticsReport(
-            schemaVersion: 4,
+            schemaVersion: 5,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,
                 build: AppConstants.buildVersion,
                 bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.typewhisper.mac",
-                isDevelopment: AppConstants.isDevelopment
+                isDevelopment: AppConstants.isDevelopment,
+                bundlePathKind: PluginDiagnosticsSupport.appBundlePathKind(
+                    for: Bundle.main.bundleURL
+                ),
+                launchTimestamp: launchTimestamp,
+                uptimeSeconds: Date().timeIntervalSince(launchTimestamp)
             ),
             system: .init(
                 macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
@@ -245,32 +451,72 @@ final class ErrorLogService: ObservableObject {
                 },
                 inputDiagnostics: container.audioDeviceService.diagnosticsReport()
             ),
-            plugins: pluginManager.loadedPlugins.map {
-                let engine = $0.instance as? TranscriptionEnginePlugin
+            plugins: pluginManager.loadedPlugins.map { loadedPlugin in
+                let engine = loadedPlugin.instance as? TranscriptionEnginePlugin
                 let fallbackPolicy = engine as? TranscriptPreviewFallbackPolicyProviding
                 let allowsTranscriptPreviewFallback: Bool? = if engine != nil {
                     fallbackPolicy?.allowsTranscriptPreviewFallback ?? true
                 } else {
                     nil
                 }
+                let activity = (loadedPlugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
+                let registryEntry = container.pluginRegistryService.registry.first { $0.id == loadedPlugin.manifest.id }
+                let externalNotice = pluginManager.externalBundleNotice(
+                    for: loadedPlugin.manifest.id,
+                    registryPlugin: registryEntry
+                )
                 return DiagnosticsReport.PluginInfo(
-                    id: $0.manifest.id,
-                    name: $0.manifest.name,
-                    version: $0.manifest.version,
-                    enabled: $0.isEnabled,
-                    bundled: $0.isBundled,
-                    runtimeLoaded: $0.isRuntimeLoaded,
+                    id: loadedPlugin.manifest.id,
+                    name: loadedPlugin.manifest.name,
+                    version: loadedPlugin.manifest.version,
+                    enabled: loadedPlugin.isEnabled,
+                    bundled: loadedPlugin.isBundled,
+                    runtimeLoaded: loadedPlugin.isRuntimeLoaded,
                     providerId: engine?.providerId,
                     selectedModelId: engine?.selectedModelId,
                     isConfigured: engine?.isConfigured,
                     supportsStreaming: engine?.supportsStreaming,
                     supportsLiveTranscriptionSession: engine.map { $0 is LiveTranscriptionCapablePlugin },
                     allowsTranscriptPreviewFallback: allowsTranscriptPreviewFallback,
-                    storedSelectedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: $0.manifest.id, key: "selectedModel")),
-                    storedLoadedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: $0.manifest.id, key: "loadedModel")),
-                    storedSelectedVersion: defaults.string(forKey: Self.pluginDefaultKey(pluginId: $0.manifest.id, key: "selectedVersion"))
+                    storedSelectedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedModel")),
+                    storedLoadedModelId: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "loadedModel")),
+                    storedSelectedVersion: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedVersion")),
+                    source: PluginDiagnosticsSupport.sourceInfo(
+                        bundle: loadedPlugin.bundle,
+                        sourceURL: loadedPlugin.sourceURL,
+                        builtInPluginsURL: Bundle.main.builtInPlugInsURL,
+                        pluginsDirectory: pluginManager.pluginsDirectory
+                    ),
+                    currentSettingsActivity: activity.map(DiagnosticPluginActivityInfo.init),
+                    registryVersion: registryEntry?.version,
+                    registrySource: registryEntry?.source.rawValue,
+                    externalBundleNotice: externalNotice?.diagnosticsValue
                 )
             },
+            skippedExternalBundles: pluginManager.incompatibleExternalBundles.values
+                .sorted { $0.pluginName < $1.pluginName }
+                .map { bundle in
+                    let registryEntry = container.pluginRegistryService.registry.first(where: { $0.id == bundle.pluginId })
+                    return DiagnosticsReport.SkippedExternalBundleInfo(
+                        id: bundle.pluginId,
+                        name: bundle.pluginName,
+                        version: bundle.version,
+                        reason: bundle.reason.diagnosticsValue,
+                        source: PluginDiagnosticsSupport.sourceInfo(
+                            bundle: Bundle(url: bundle.bundleURL),
+                            sourceURL: bundle.bundleURL,
+                            builtInPluginsURL: Bundle.main.builtInPlugInsURL,
+                            pluginsDirectory: pluginManager.pluginsDirectory
+                        ),
+                        registryVersion: registryEntry?.version,
+                        registrySource: registryEntry?.source.rawValue,
+                        externalBundleNotice: PluginManager.externalBundleNotice(
+                            loadedPlugin: pluginManager.loadedPlugins.first(where: { $0.manifest.id == bundle.pluginId }),
+                            registryPlugin: registryEntry,
+                            incompatibleExternalBundle: bundle
+                        )?.diagnosticsValue
+                    )
+                },
             settings: .init(
                 bundledReleaseChannel: AppConstants.releaseChannel.rawValue,
                 selectedUpdateChannel: AppConstants.effectiveUpdateChannel.rawValue,

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -169,6 +169,18 @@ struct IncompatibleExternalBundle: Equatable, Sendable {
     let reason: Reason
 }
 
+extension IncompatibleExternalBundle.Reason {
+    var diagnosticsValue: String {
+        switch self {
+        case .sdkCompatibility(let expected, let actual):
+            if let actual {
+                return "sdkCompatibility:expected=\(expected),actual=\(actual)"
+            }
+            return "sdkCompatibility:expected=\(expected),actual=missing"
+        }
+    }
+}
+
 enum ExternalBundleNotice: Equatable {
     case legacyBundlePresent(version: String)
     case incompatibleWithCurrentRuntime(version: String)
@@ -180,6 +192,19 @@ enum ExternalBundleNotice: Equatable {
             return true
         }
         return false
+    }
+
+    var diagnosticsValue: String {
+        switch self {
+        case .legacyBundlePresent(let version):
+            return "legacyBundlePresent:version=\(version)"
+        case .incompatibleWithCurrentRuntime(let version):
+            return "incompatibleWithCurrentRuntime:version=\(version)"
+        case .bundledFallbackActive(let version):
+            return "bundledFallbackActive:version=\(version)"
+        case .boundaryUpgradeRequired(let installedVersion, let availableVersion):
+            return "boundaryUpgradeRequired:installed=\(installedVersion),available=\(availableVersion)"
+        }
     }
 }
 

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -361,6 +361,7 @@ final class PluginRegistryService: ObservableObject {
     private let fetchData: (URLRequest) async throws -> (Data, URLResponse)
     private let cacheDirectory: URL
     private static let lastUpdateCheckKey = "pluginRegistryLastUpdateCheck"
+    private static let lastHostFingerprintCheckKey = "pluginRegistryLastHostFingerprintCheck"
 
     enum FetchState: Equatable {
         case idle
@@ -462,18 +463,50 @@ final class PluginRegistryService: ObservableObject {
 
     // MARK: - Background Update Check
 
-    /// Check for plugin updates on app launch (at most once per 24h).
+    /// Check for plugin updates on app launch (at most once per 24h), and force
+    /// one refresh after each host app update so bundled registry gates are not
+    /// hidden behind the previous build's throttle window.
     func checkForUpdatesInBackground() {
-        let lastCheck = userDefaults.double(forKey: Self.lastUpdateCheckKey)
-        let hoursSinceLastCheck = (Date().timeIntervalSince1970 - lastCheck) / 3600
-        guard hoursSinceLastCheck >= 24 || lastCheck == 0 else { return }
-
         Task {
-            lastFetchDate = nil
-            await fetchRegistry(force: true)
-            updateAvailableUpdatesCount()
-            userDefaults.set(Date().timeIntervalSince1970, forKey: Self.lastUpdateCheckKey)
+            await refreshRegistryForHostUpdateIfNeeded()
         }
+    }
+
+    @discardableResult
+    func refreshRegistryForHostUpdateIfNeeded(
+        currentFingerprint: String = AppConstants.currentReleaseFingerprint,
+        now: Date = Date()
+    ) async -> Bool {
+        let lastCheck = userDefaults.double(forKey: Self.lastUpdateCheckKey)
+        let hoursSinceLastCheck = (now.timeIntervalSince1970 - lastCheck) / 3600
+        let lastFingerprint = userDefaults.string(forKey: Self.lastHostFingerprintCheckKey)
+        let hostChanged = lastFingerprint != currentFingerprint
+
+        guard hostChanged || hoursSinceLastCheck >= 24 || lastCheck == 0 else {
+            return false
+        }
+
+        lastFetchDate = nil
+        await fetchRegistry(force: true)
+        updateAvailableUpdatesCount()
+        userDefaults.set(now.timeIntervalSince1970, forKey: Self.lastUpdateCheckKey)
+        userDefaults.set(currentFingerprint, forKey: Self.lastHostFingerprintCheckKey)
+        return true
+    }
+
+    static func canRepairInstalledPlugin(
+        isBundled: Bool,
+        registryPlugin: RegistryPlugin?,
+        installInfo: PluginInstallInfo,
+        installState: InstallState?
+    ) -> Bool {
+        guard !isBundled, registryPlugin != nil, installState == nil else {
+            return false
+        }
+        if case .installed = installInfo {
+            return true
+        }
+        return false
     }
 
     func updateAvailableUpdatesCount() {

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -424,12 +424,13 @@ final class PluginRegistryService: ObservableObject {
 
     // MARK: - Fetch Registry
 
-    func fetchRegistry(force: Bool = false) async {
+    @discardableResult
+    func fetchRegistry(force: Bool = false) async -> Bool {
         if !force,
            let lastFetch = lastFetchDate,
            Date().timeIntervalSince(lastFetch) < cacheDuration,
            !registry.isEmpty {
-            return
+            return true
         }
 
         fetchState = .loading
@@ -444,19 +445,22 @@ final class PluginRegistryService: ObservableObject {
             request.cachePolicy = .reloadIgnoringLocalCacheData
             let (data, _) = try await fetchData(request)
 
-            try applyRegistryData(data, feed: feed)
+            try applyRegistryData(data, feed: feed, markFetchDate: true)
             try cacheRegistryData(data, feed: feed)
             logger.info("Fetched \(self.registry.count) plugin(s) from registry feed \(feed.rawValue, privacy: .public)")
+            return true
         } catch {
             do {
                 let cachedData = try Data(contentsOf: cacheURL(for: feed))
-                try applyRegistryData(cachedData, feed: feed)
+                try applyRegistryData(cachedData, feed: feed, markFetchDate: false)
                 logger.warning(
                     "Using cached plugin registry feed \(feed.rawValue, privacy: .public) after fetch failure: \(error.localizedDescription, privacy: .public)"
                 )
+                return false
             } catch {
                 fetchState = .error(error.localizedDescription)
                 logger.error("Failed to fetch registry: \(error.localizedDescription)")
+                return false
             }
         }
     }
@@ -487,8 +491,10 @@ final class PluginRegistryService: ObservableObject {
         }
 
         lastFetchDate = nil
-        await fetchRegistry(force: true)
-        updateAvailableUpdatesCount()
+        let refreshSucceeded = await fetchRegistry(force: true)
+        guard refreshSucceeded else {
+            return false
+        }
         userDefaults.set(now.timeIntervalSince1970, forKey: Self.lastUpdateCheckKey)
         userDefaults.set(currentFingerprint, forKey: Self.lastHostFingerprintCheckKey)
         return true
@@ -851,13 +857,15 @@ final class PluginRegistryService: ObservableObject {
         cacheDirectory.appendingPathComponent(feed.pathComponent)
     }
 
-    private func applyRegistryData(_ data: Data, feed: RegistryFeed) throws {
+    private func applyRegistryData(_ data: Data, feed: RegistryFeed, markFetchDate: Bool) throws {
         let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
         registry = response.resolvedPlugins(
             appVersion: resolvedAppVersion,
             sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion
         )
-        lastFetchDate = Date()
+        if markFetchDate {
+            lastFetchDate = Date()
+        }
         fetchState = .loaded
         updateAvailableUpdatesCount()
         logger.info("Resolved \(self.registry.count) compatible plugin(s) from \(feed.rawValue, privacy: .public)")

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -443,11 +443,13 @@ struct AdvancedSettingsView: View {
 
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
-            do {
-                try errorLogService.exportDiagnostics(to: url)
-            } catch {
-                diagnosticsExportErrorMessage = error.localizedDescription
-                showDiagnosticsExportError = true
+            Task { @MainActor in
+                do {
+                    try await errorLogService.exportDiagnostics(to: url)
+                } catch {
+                    diagnosticsExportErrorMessage = error.localizedDescription
+                    showDiagnosticsExportError = true
+                }
             }
         }
     }

--- a/TypeWhisper/Views/ErrorLogView.swift
+++ b/TypeWhisper/Views/ErrorLogView.swift
@@ -117,10 +117,12 @@ struct ErrorLogView: View {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        do {
-            try errorLogService.exportDiagnostics(to: url)
-        } catch {
-            exportErrorMessage = error.localizedDescription
+        Task { @MainActor in
+            do {
+                try await errorLogService.exportDiagnostics(to: url)
+            } catch {
+                exportErrorMessage = error.localizedDescription
+            }
         }
     }
 }

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -410,6 +410,11 @@ struct PluginSettingsView: View {
                                 startInstall(registryPlugin)
                             }
                         },
+                        onRepair: {
+                            if let registryPlugin = registryService.registry.first(where: { $0.id == plugin.id }) {
+                                startInstall(registryPlugin)
+                            }
+                        },
                         onUninstall: {
                             pluginToUninstall = plugin
                             showUninstallAlert = true
@@ -1010,6 +1015,7 @@ private struct InstalledPluginRow: View {
     let hosting: PluginHosting
     let registryPlugin: RegistryPlugin?
     let onUpdate: () -> Void
+    let onRepair: () -> Void
     let onUninstall: () -> Void
     @State private var pluginActivity: PluginSettingsActivity?
     @State private var modelsExpanded = false
@@ -1079,18 +1085,7 @@ private struct InstalledPluginRow: View {
                             .lineLimit(1)
                     }
 
-                    if let state = installState {
-                        PluginInstallStateView(state: state, name: plugin.manifest.name)
-                    } else if case .updateAvailable = installInfo {
-                        Button {
-                            onUpdate()
-                        } label: {
-                            Label(String(localized: "Update"), systemImage: "arrow.down.circle")
-                        }
-                        .controlSize(.small)
-                    } else if let pluginActivity {
-                        PluginSettingsActivityView(activity: pluginActivity)
-                    }
+                    pluginActions
                 }
 
                 Spacer(minLength: 12)
@@ -1197,6 +1192,41 @@ private struct InstalledPluginRow: View {
         }
         return modelManager.downloadedModels
             .sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+    }
+
+    @ViewBuilder
+    private var pluginActions: some View {
+        if let state = installState {
+            PluginInstallStateView(state: state, name: plugin.manifest.name)
+        } else if case .updateAvailable = installInfo {
+            Button {
+                onUpdate()
+            } label: {
+                Label(String(localized: "Update"), systemImage: "arrow.down.circle")
+            }
+            .controlSize(.small)
+        } else {
+            if let pluginActivity {
+                PluginSettingsActivityView(activity: pluginActivity)
+            }
+            if canRepairInstallation {
+                Button {
+                    onRepair()
+                } label: {
+                    Label(String(localized: "Repair Installation"), systemImage: "arrow.clockwise.circle")
+                }
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private var canRepairInstallation: Bool {
+        PluginRegistryService.canRepairInstalledPlugin(
+            isBundled: plugin.isBundled,
+            registryPlugin: registryPlugin,
+            installInfo: installInfo,
+            installState: installState
+        )
     }
 
     private func downloadedModelCountTitle(_ count: Int) -> String {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1593,7 +1593,7 @@ final class PluginRegistryDestinationTests: XCTestCase {
 }
 
 final class PluginDiagnosticsSupportTests: XCTestCase {
-    func testPluginSourceClassifiesBundledManagedAndExternalPaths() throws {
+    func testPluginSourceClassifiesBundledManagedAndExternalPaths() async throws {
         let root = try TestSupport.makeTemporaryDirectory(prefix: "PluginDiagnostics")
         defer { TestSupport.remove(root) }
 
@@ -1605,21 +1605,21 @@ final class PluginDiagnosticsSupportTests: XCTestCase {
         let managedURL = try makeMockBundle(in: pluginsDirectory, name: "ManagedPlugin")
         let externalURL = try makeMockBundle(in: externalDirectory, name: "ExternalPlugin")
 
-        let bundled = PluginDiagnosticsSupport.sourceInfo(
+        let bundled = await PluginDiagnosticsSupport.sourceInfo(
             bundle: try XCTUnwrap(Bundle(url: bundledURL)),
             sourceURL: bundledURL,
             builtInPluginsURL: builtInPluginsURL,
             pluginsDirectory: pluginsDirectory,
             homeDirectory: root
         )
-        let managed = PluginDiagnosticsSupport.sourceInfo(
+        let managed = await PluginDiagnosticsSupport.sourceInfo(
             bundle: try XCTUnwrap(Bundle(url: managedURL)),
             sourceURL: managedURL,
             builtInPluginsURL: builtInPluginsURL,
             pluginsDirectory: pluginsDirectory,
             homeDirectory: root
         )
-        let external = PluginDiagnosticsSupport.sourceInfo(
+        let external = await PluginDiagnosticsSupport.sourceInfo(
             bundle: try XCTUnwrap(Bundle(url: externalURL)),
             sourceURL: externalURL,
             builtInPluginsURL: builtInPluginsURL,
@@ -1634,7 +1634,35 @@ final class PluginDiagnosticsSupportTests: XCTestCase {
         XCTAssertFalse(managed.pathHint.contains(root.path))
     }
 
-    func testPluginSourceReportsExecutableSizeAndHash() throws {
+    func testPluginSourcePathHintCanonicalizesSymlinkedBundles() async throws {
+        let root = try TestSupport.makeTemporaryDirectory(prefix: "PluginDiagnosticsSymlink")
+        defer { TestSupport.remove(root) }
+
+        let realHome = root.appendingPathComponent("real-home", isDirectory: true)
+        let symlinkHome = root.appendingPathComponent("symlink-home", isDirectory: true)
+        try FileManager.default.createDirectory(at: realHome, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: symlinkHome, withDestinationURL: realHome)
+
+        let pluginsDirectory = realHome.appendingPathComponent("Application Support/TypeWhisper/Plugins", isDirectory: true)
+        let bundleURL = try makeMockBundle(in: pluginsDirectory, name: "SymlinkPlugin")
+        let symlinkedBundleURL = symlinkHome
+            .appendingPathComponent("Application Support/TypeWhisper/Plugins", isDirectory: true)
+            .appendingPathComponent(bundleURL.lastPathComponent, isDirectory: true)
+
+        let source = await PluginDiagnosticsSupport.sourceInfo(
+            bundle: try XCTUnwrap(Bundle(url: symlinkedBundleURL)),
+            sourceURL: symlinkedBundleURL,
+            builtInPluginsURL: nil,
+            pluginsDirectory: pluginsDirectory,
+            homeDirectory: realHome
+        )
+
+        XCTAssertEqual(source.sourceKind, .managedExternal)
+        XCTAssertTrue(source.pathHint.hasPrefix("~/"))
+        XCTAssertFalse(source.pathHint.contains(symlinkHome.path))
+    }
+
+    func testPluginSourceReportsExecutableSizeAndHash() async throws {
         let root = try TestSupport.makeTemporaryDirectory(prefix: "PluginDiagnosticsHash")
         defer { TestSupport.remove(root) }
 
@@ -1645,7 +1673,7 @@ final class PluginDiagnosticsSupportTests: XCTestCase {
             executableData: Data("hash me".utf8)
         )
 
-        let source = PluginDiagnosticsSupport.sourceInfo(
+        let source = await PluginDiagnosticsSupport.sourceInfo(
             bundle: try XCTUnwrap(Bundle(url: bundleURL)),
             sourceURL: bundleURL,
             builtInPluginsURL: nil,

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1496,6 +1496,204 @@ final class PluginRegistryDestinationTests: XCTestCase {
 
         XCTAssertEqual(destination, pluginsDirectory.appendingPathComponent("ParakeetPlugin.bundle"))
     }
+
+    func testRepairEligibilityRequiresRegistryBackedExternalInstalledPlugin() {
+        let registryPlugin = makeRegistryPlugin(id: "com.typewhisper.qwen3")
+
+        XCTAssertTrue(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: false,
+                registryPlugin: registryPlugin,
+                installInfo: .installed(version: "1.1.1"),
+                installState: nil
+            )
+        )
+        XCTAssertFalse(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: true,
+                registryPlugin: registryPlugin,
+                installInfo: .installed(version: "1.1.1"),
+                installState: nil
+            )
+        )
+        XCTAssertFalse(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: false,
+                registryPlugin: nil,
+                installInfo: .installed(version: "1.1.1"),
+                installState: nil
+            )
+        )
+        XCTAssertFalse(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: false,
+                registryPlugin: registryPlugin,
+                installInfo: .updateAvailable(installed: "1.1.0", available: "1.1.1"),
+                installState: nil
+            )
+        )
+        XCTAssertFalse(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: false,
+                registryPlugin: registryPlugin,
+                installInfo: .installed(version: "1.1.1"),
+                installState: .extracting
+            )
+        )
+    }
+
+    func testRepairInstallKeepsManagedBundlePathAndPluginDataDirectory() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRepairDestination")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pluginsDirectory = appSupportDirectory.appendingPathComponent("Plugins", isDirectory: true)
+        let pluginDataDirectory = appSupportDirectory
+            .appendingPathComponent("PluginData", isDirectory: true)
+            .appendingPathComponent("com.typewhisper.qwen3", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginsDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: pluginDataDirectory, withIntermediateDirectories: true)
+        let sentinelURL = pluginDataDirectory.appendingPathComponent("model-cache-sentinel")
+        try Data("keep model cache".utf8).write(to: sentinelURL)
+
+        let existingURL = pluginsDirectory.appendingPathComponent("Qwen3Plugin.bundle", isDirectory: true)
+        let destination = PluginRegistryService.resolveInstallDestinationURL(
+            currentURL: existingURL,
+            builtInPluginsURL: nil,
+            pluginsDirectory: pluginsDirectory,
+            incomingBundleName: "Qwen3Plugin.bundle"
+        )
+
+        XCTAssertEqual(destination, existingURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinelURL.path))
+    }
+
+    private func makeRegistryPlugin(id: String) -> RegistryPlugin {
+        RegistryPlugin(
+            id: id,
+            source: .official,
+            name: "Qwen3 ASR",
+            version: "1.1.1",
+            minHostVersion: "1.4.0",
+            sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+            minOSVersion: "14.0",
+            supportedArchitectures: ["arm64"],
+            author: "TypeWhisper",
+            description: "Local model plugin",
+            category: "transcription",
+            categories: ["transcription"],
+            size: 1,
+            downloadURL: "https://example.com/Qwen3Plugin.zip",
+            iconSystemName: "cpu",
+            requiresAPIKey: false,
+            hosting: .local,
+            descriptions: nil,
+            downloadCount: nil
+        )
+    }
+}
+
+final class PluginDiagnosticsSupportTests: XCTestCase {
+    func testPluginSourceClassifiesBundledManagedAndExternalPaths() throws {
+        let root = try TestSupport.makeTemporaryDirectory(prefix: "PluginDiagnostics")
+        defer { TestSupport.remove(root) }
+
+        let builtInPluginsURL = root.appendingPathComponent("TypeWhisper.app/Contents/PlugIns", isDirectory: true)
+        let pluginsDirectory = root.appendingPathComponent("Application Support/TypeWhisper/Plugins", isDirectory: true)
+        let externalDirectory = root.appendingPathComponent("External", isDirectory: true)
+
+        let bundledURL = try makeMockBundle(in: builtInPluginsURL, name: "BundledPlugin")
+        let managedURL = try makeMockBundle(in: pluginsDirectory, name: "ManagedPlugin")
+        let externalURL = try makeMockBundle(in: externalDirectory, name: "ExternalPlugin")
+
+        let bundled = PluginDiagnosticsSupport.sourceInfo(
+            bundle: try XCTUnwrap(Bundle(url: bundledURL)),
+            sourceURL: bundledURL,
+            builtInPluginsURL: builtInPluginsURL,
+            pluginsDirectory: pluginsDirectory,
+            homeDirectory: root
+        )
+        let managed = PluginDiagnosticsSupport.sourceInfo(
+            bundle: try XCTUnwrap(Bundle(url: managedURL)),
+            sourceURL: managedURL,
+            builtInPluginsURL: builtInPluginsURL,
+            pluginsDirectory: pluginsDirectory,
+            homeDirectory: root
+        )
+        let external = PluginDiagnosticsSupport.sourceInfo(
+            bundle: try XCTUnwrap(Bundle(url: externalURL)),
+            sourceURL: externalURL,
+            builtInPluginsURL: builtInPluginsURL,
+            pluginsDirectory: pluginsDirectory,
+            homeDirectory: root
+        )
+
+        XCTAssertEqual(bundled.sourceKind, .bundled)
+        XCTAssertEqual(managed.sourceKind, .managedExternal)
+        XCTAssertEqual(external.sourceKind, .externalOther)
+        XCTAssertTrue(managed.pathHint.hasPrefix("~/"))
+        XCTAssertFalse(managed.pathHint.contains(root.path))
+    }
+
+    func testPluginSourceReportsExecutableSizeAndHash() throws {
+        let root = try TestSupport.makeTemporaryDirectory(prefix: "PluginDiagnosticsHash")
+        defer { TestSupport.remove(root) }
+
+        let pluginsDirectory = root.appendingPathComponent("Plugins", isDirectory: true)
+        let bundleURL = try makeMockBundle(
+            in: pluginsDirectory,
+            name: "HashPlugin",
+            executableData: Data("hash me".utf8)
+        )
+
+        let source = PluginDiagnosticsSupport.sourceInfo(
+            bundle: try XCTUnwrap(Bundle(url: bundleURL)),
+            sourceURL: bundleURL,
+            builtInPluginsURL: nil,
+            pluginsDirectory: pluginsDirectory,
+            homeDirectory: root
+        )
+
+        XCTAssertEqual(source.executableSizeBytes, 7)
+        XCTAssertEqual(source.executableSHA256?.count, 64)
+        XCTAssertEqual(source.bundleIdentifier, "com.typewhisper.tests.HashPlugin")
+        XCTAssertEqual(source.bundleShortVersion, "1.0.0")
+        XCTAssertEqual(source.bundleVersion, "1")
+    }
+
+    private func makeMockBundle(
+        in parentDirectory: URL,
+        name: String,
+        executableData: Data = Data("mock executable".utf8)
+    ) throws -> URL {
+        let bundleURL = parentDirectory.appendingPathComponent("\(name).bundle", isDirectory: true)
+        let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let macOSURL = contentsURL.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macOSURL, withIntermediateDirectories: true)
+
+        let infoPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleExecutable</key>
+            <string>\(name)</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.typewhisper.tests.\(name)</string>
+            <key>CFBundleName</key>
+            <string>\(name)</string>
+            <key>CFBundlePackageType</key>
+            <string>BNDL</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0.0</string>
+            <key>CFBundleVersion</key>
+            <string>1</string>
+        </dict>
+        </plist>
+        """
+        try Data(infoPlist.utf8).write(to: contentsURL.appendingPathComponent("Info.plist"))
+        try executableData.write(to: macOSURL.appendingPathComponent(name))
+        return bundleURL
+    }
 }
 
 final class OpenAIPluginTokenParameterTests: XCTestCase {

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -665,4 +665,130 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(service.fetchState, .loaded)
         XCTAssertEqual(service.registry.map(\.id), ["com.typewhisper.cached"])
     }
+
+    @MainActor
+    func testHostFingerprintChangeForcesRegistryRefreshInsideThrottleWindow() async throws {
+        let suiteName = "PluginRegistryServiceTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRegistryFingerprint")
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        var requestCount = 0
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            cacheDuration: 0,
+            userDefaults: defaults,
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.4.0",
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.stable.rawValue,
+            ],
+            fetchData: { request in
+                requestCount += 1
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                return (Self.registryPayload(pluginId: "com.typewhisper.fingerprint"), response)
+            }
+        )
+        let now = Date(timeIntervalSince1970: 2_000)
+
+        let initialFetch = await service.refreshRegistryForHostUpdateIfNeeded(currentFingerprint: "1.4.0+803@stable", now: now)
+        let throttledFetch = await service.refreshRegistryForHostUpdateIfNeeded(
+            currentFingerprint: "1.4.0+803@stable",
+            now: now.addingTimeInterval(60)
+        )
+        let fingerprintFetch = await service.refreshRegistryForHostUpdateIfNeeded(
+            currentFingerprint: "1.4.1+804@stable",
+            now: now.addingTimeInterval(120)
+        )
+
+        XCTAssertTrue(initialFetch)
+        XCTAssertFalse(throttledFetch)
+        XCTAssertTrue(fingerprintFetch)
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    @MainActor
+    func testUnchangedHostFingerprintPreservesBackgroundUpdateThrottle() async throws {
+        let suiteName = "PluginRegistryServiceTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRegistryFingerprintThrottle")
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        var requestCount = 0
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            cacheDuration: 0,
+            userDefaults: defaults,
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.4.0",
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.stable.rawValue,
+            ],
+            fetchData: { request in
+                requestCount += 1
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                return (Self.registryPayload(pluginId: "com.typewhisper.throttle"), response)
+            }
+        )
+        let now = Date(timeIntervalSince1970: 3_000)
+
+        let initialFetch = await service.refreshRegistryForHostUpdateIfNeeded(currentFingerprint: "1.4.0+803@stable", now: now)
+        let throttledFetch = await service.refreshRegistryForHostUpdateIfNeeded(
+            currentFingerprint: "1.4.0+803@stable",
+            now: now.addingTimeInterval(23 * 3600)
+        )
+        let expiredFetch = await service.refreshRegistryForHostUpdateIfNeeded(
+            currentFingerprint: "1.4.0+803@stable",
+            now: now.addingTimeInterval(25 * 3600)
+        )
+
+        XCTAssertTrue(initialFetch)
+        XCTAssertFalse(throttledFetch)
+        XCTAssertTrue(expiredFetch)
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    private static func registryPayload(pluginId: String) -> Data {
+        Data(
+            """
+            {
+              "schemaVersion": 1,
+              "plugins": [
+                {
+                  "id": "\(pluginId)",
+                  "name": "Cached Plugin",
+                  "author": "TypeWhisper",
+                  "description": "Cacheable entry",
+                  "category": "utility",
+                  "releases": [
+                    {
+                      "version": "1.0.0",
+                      "minHostVersion": "1.4.0",
+                      "sdkCompatibilityVersion": "v1",
+                      "size": 10,
+                      "downloadURL": "https://example.com/cached.zip"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+    }
 }

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -764,6 +764,52 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(requestCount, 2)
     }
 
+    @MainActor
+    func testHostFingerprintRefreshDoesNotAdvanceThrottleWhenOnlyCacheFallbackLoads() async throws {
+        let suiteName = "PluginRegistryServiceTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRegistryFingerprintCacheFallback")
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        try Self.registryPayload(pluginId: "com.typewhisper.cached-fallback")
+            .write(to: cacheDirectory.appendingPathComponent("plugins-community-v1.json"))
+
+        var requestCount = 0
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            cacheDuration: 0,
+            userDefaults: defaults,
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.4.0",
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.stable.rawValue,
+            ],
+            fetchData: { _ in
+                requestCount += 1
+                throw URLError(.notConnectedToInternet)
+            }
+        )
+        let now = Date(timeIntervalSince1970: 4_000)
+
+        let fallbackFetch = await service.refreshRegistryForHostUpdateIfNeeded(
+            currentFingerprint: "1.4.0+803@stable",
+            now: now
+        )
+        let retryFetch = await service.refreshRegistryForHostUpdateIfNeeded(
+            currentFingerprint: "1.4.0+803@stable",
+            now: now.addingTimeInterval(60)
+        )
+
+        XCTAssertFalse(fallbackFetch)
+        XCTAssertFalse(retryFetch)
+        XCTAssertEqual(requestCount, 2)
+        XCTAssertEqual(service.fetchState, .loaded)
+        XCTAssertEqual(service.registry.map(\.id), ["com.typewhisper.cached-fallback"])
+    }
+
     private static func registryPayload(pluginId: String) -> Data {
         Data(
             """


### PR DESCRIPTION
## Issue context

Refs #596. The report points to a repeated post-update plugin state pattern around the Qwen3 external plugin. This PR treats the case as update-path/plugin-state observability plus a safe manual repair path, not as a proven Qwen3 ASR model bug. It intentionally does not close #596; reporter validation is still needed.

## Changes

- Bumps support diagnostics to schema v5 with app bundle path kind, launch timestamp, uptime, per-plugin source/version/hash/activity/registry details, and skipped incompatible external bundle diagnostics.
- Adds a Repair Installation action for installed registry-backed external plugins when no newer update is available, reusing the existing registry download/install path while preserving plugin data and downloaded model caches.
- Forces one plugin registry refresh after the host release fingerprint changes, so app updates do not wait behind the existing 24h plugin-update throttle.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/PluginManifestValidationTests -only-testing:TypeWhisperTests/PluginRegistryServiceTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin repair action in plugin settings and repair eligibility logic.
  * Background plugin registry checks now run at startup and when host release changes.
  * Expanded diagnostics: richer plugin/source metadata, executable size & SHA‑256, uptime/launch timestamp, schema upgrade, and async diagnostics export.

* **Tests**
  * Added unit tests for repair eligibility, diagnostics reporting, host-fingerprint refresh gating, and registry fetch fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->