### PR TITLE
Add standalone setup wizard

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		AA00000000000000000196 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000186 /* Assets.xcassets */; };
 		AA00000000000000000197 /* WidgetDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000180 /* WidgetDataService.swift */; };
 		AA00000000000000000198 /* TypeWhisperWidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */ = {isa = PBXBuildFile; fileRef = BB00000000000000000159 /* SpeechAnalyzerPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AA00000000000000000199 /* VoxtralPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000191 /* VoxtralPlugin.swift */; };
 		AA00000000000000000200 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000192 /* manifest.json */; };
 		AA00000000000000000201 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000193 /* Localizable.xcstrings */; };
@@ -423,6 +424,13 @@
 			remoteGlobalIDString = DD00000000000000000014;
 			remoteInfo = TypeWhisperWidgetExtension;
 		};
+		5E7A00000000000000000003 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE00000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD00000000000000000012;
+			remoteInfo = SpeechAnalyzerPlugin;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -457,6 +465,17 @@
 				AA00000000000000000198 /* TypeWhisperWidgetExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5E7A00000000000000000002 /* Embed Built-In Plugins */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */,
+			);
+			name = "Embed Built-In Plugins";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -2064,12 +2083,14 @@
 				FF00000000000000000004 /* CopyFiles */,
 				FF00000000000000000036 /* Embed Frameworks */,
 				FF00000000000000000081 /* Embed App Extensions */,
+				5E7A00000000000000000002 /* Embed Built-In Plugins */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				GG00000000000000000001 /* PBXTargetDependency */,
 				GG00000000000000000009 /* PBXTargetDependency */,
+				5E7A00000000000000000004 /* PBXTargetDependency */,
 			);
 			name = TypeWhisper;
 			packageProductDependencies = (
@@ -3876,6 +3897,11 @@
 			isa = PBXTargetDependency;
 			target = DD00000000000000000014 /* TypeWhisperWidgetExtension */;
 			targetProxy = HH00000000000000000009 /* PBXContainerItemProxy */;
+		};
+		5E7A00000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD00000000000000000012 /* SpeechAnalyzerPlugin */;
+			targetProxy = 5E7A00000000000000000003 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -17,6 +17,7 @@ extension UserDefaults {
 
 extension Notification.Name {
     static let openManagedAppWindow = Notification.Name("openManagedAppWindow")
+    static let resetSetupWizardWindow = Notification.Name("resetSetupWizardWindow")
 }
 
 enum DockIconBehavior: String, CaseIterable {
@@ -50,6 +51,7 @@ enum MenuBarIconState {
 }
 
 private struct MenuBarExtraLabel: View {
+    @Environment(\.openWindow) private var openWindow
     @ObservedObject private var dictation = DictationViewModel.shared
     @ObservedObject private var recorder = AudioRecorderViewModel.shared
 
@@ -75,6 +77,25 @@ private struct MenuBarExtraLabel: View {
                     ? Text(String(localized: "Recording..."))
                     : Text(String(localized: "Idle"))
             )
+            .onAppear {
+                ManagedAppWindowOpener.shared.openWindow = openWindow
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openManagedAppWindow)) { notification in
+                guard let id = notification.userInfo?["id"] as? String else { return }
+                ManagedAppWindowOpener.shared.openWindow = openWindow
+                openWindow(id: id)
+            }
+    }
+}
+
+private struct ManagedWindowOpenerRegistrar: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        EmptyView()
+            .onAppear {
+                ManagedAppWindowOpener.shared.openWindow = openWindow
+            }
     }
 }
 
@@ -152,8 +173,20 @@ struct TypeWhisperApp: App {
             }
         }
         .menuBarExtraStyle(.menu)
+        .commands {
+            CommandGroup(after: .appInfo) {
+                ManagedWindowOpenerRegistrar()
+            }
+        }
 
         settingsScene
+
+        Window(String(localized: "TypeWhisper Setup"), id: "setup") {
+            setupContent
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 820, height: 560)
 
         Window(String(localized: "History"), id: "history") {
             historyContent
@@ -208,6 +241,15 @@ struct TypeWhisperApp: App {
                 .task {
                     refreshStartupSheet()
                 }
+        }
+    }
+
+    @ViewBuilder
+    private var setupContent: some View {
+        if AppConstants.isRunningTests {
+            EmptyView()
+        } else {
+            SetupWizardView()
         }
     }
 
@@ -341,6 +383,10 @@ final class ManagedAppWindowOpener {
     var openWindow: OpenWindowAction?
 
     func open(id: String) {
+        open(id: id, remainingAttempts: 10)
+    }
+
+    private func open(id: String, remainingAttempts: Int) {
         let sourceApplication = sourceApplicationForActivation()
         NSApp.setActivationPolicy(.regular)
 
@@ -360,6 +406,11 @@ final class ManagedAppWindowOpener {
                 object: nil,
                 userInfo: ["id": id]
             )
+            if remainingAttempts > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    self.open(id: id, remainingAttempts: remainingAttempts - 1)
+                }
+            }
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
@@ -493,13 +544,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             AudioRecorderViewModel.shared.toggleRecording()
         }
 
-        // Auto-open Settings with setup wizard when microphone permission is not yet granted
-        if AVAudioApplication.shared.recordPermission != .granted {
+        // Auto-open the standalone setup assistant while first-run setup is incomplete.
+        if HomeViewModel.shared.showSetupWizard {
             UserDefaults.standard.set(false, forKey: UserDefaultsKeys.setupWizardCompleted)
             HomeViewModel.shared.showSetupWizard = true
             NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.openSettingsWindow()
+                self.openSetupWindow()
             }
         } else if PostUpdatePromptCoordinator.shared.shouldAutoOpenSettingsOnLaunch {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
@@ -555,7 +606,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
         if !hasVisibleManagedWindow {
-            openSettingsWindow()
+            if HomeViewModel.shared.showSetupWizard {
+                openSetupWindow()
+            } else {
+                openSettingsWindow()
+            }
         }
         return true
     }
@@ -570,6 +625,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         ManagedAppWindowOpener.shared.open(id: "settings")
     }
 
+    private func openSetupWindow() {
+        ManagedAppWindowOpener.shared.open(id: "setup")
+    }
+
     private func handleIncomingURL(_ url: URL) {
         guard SupporterDiscordService.canHandleCallbackURL(url) else { return }
 
@@ -582,13 +641,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     private func isManagedWindow(_ window: NSWindow) -> Bool {
         if let identifier = window.identifier?.rawValue.lowercased() {
-            if identifier.contains("settings") || identifier.contains("history") || identifier.contains("errors") {
+            if identifier.contains("settings")
+                || identifier.contains("setup")
+                || identifier.contains("history")
+                || identifier.contains("errors") {
                 return true
             }
         }
 
         let title = window.title
         return title == String(localized: "Settings")
+            || title == String(localized: "TypeWhisper Setup")
             || title == String(localized: "History")
             || title == String(localized: "Error Log")
     }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import ApplicationServices
 import Carbon.HIToolbox
 import Combine
 import os
@@ -284,6 +285,8 @@ final class HotkeyService: ObservableObject {
     private var recentEventTapDispatches: [HotkeyDispatchKey: Date] = [:]
     private var capsLockOriginSuppressionUntil: Date?
 
+    var accessibilityTrustedProvider: () -> Bool = { AXIsProcessTrusted() }
+
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "HotkeyService")
 
     // Modifier keyCodes that generate flagsChanged instead of keyDown/keyUp
@@ -477,6 +480,12 @@ final class HotkeyService: ObservableObject {
     private func setupMonitor() {
         tearDownMonitor()
 
+        guard accessibilityTrustedProvider() else {
+            logger.info("Accessibility permission not granted, installing local hotkey monitor only")
+            installLocalEventMonitor()
+            return
+        }
+
         // Try CGEventTap first - it can suppress hotkey events from reaching other apps
         if setupEventTap() {
             logger.info("Using tail-appended CGEventTap for hotkey monitoring with NSEvent compatibility fallback")
@@ -487,6 +496,14 @@ final class HotkeyService: ObservableObject {
         // Fallback: NSEvent monitors (no event suppression)
         logger.info("CGEventTap unavailable, falling back to NSEvent monitors (hotkey events will pass through)")
         installEventMonitors(includeMouse: true)
+    }
+
+    private func installLocalEventMonitor() {
+        let mask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .keyUp]
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            _ = self?.handleEvent(event, source: .monitor)
+            return event
+        }
     }
 
     private func installEventMonitors(includeMouse: Bool) {

--- a/TypeWhisper/ViewModels/DictationSettingsHandler.swift
+++ b/TypeWhisper/ViewModels/DictationSettingsHandler.swift
@@ -144,6 +144,7 @@ final class DictationSettingsHandler {
             guard let self else { return false }
             return !self.textInsertionService.isAccessibilityGranted
         }
+        var hasResumedHotkeyMonitoring = !needsAccessibility()
         permissionPollTask?.cancel()
         permissionPollTask = Task { [weak self] in
             for _ in 0..<30 {
@@ -151,6 +152,10 @@ final class DictationSettingsHandler {
                 guard !Task.isCancelled else { return }
                 DispatchQueue.main.async { [weak self] in
                     self?.onObjectWillChange?()
+                    if !hasResumedHotkeyMonitoring, !needsAccessibility() {
+                        hasResumedHotkeyMonitoring = true
+                        self?.hotkeyService.resumeMonitoring()
+                    }
                 }
                 if !needsMic(), !needsAccessibility() { return }
             }

--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -74,6 +74,28 @@ struct AboutSettingsView: View {
             }
 
             Section {
+                HStack {
+                    Spacer()
+                    Button {
+                        openSetupWizard()
+                    } label: {
+                        Label(
+                            localizedAppText("Open Setup Wizard", de: "Setup-Wizard öffnen"),
+                            systemImage: "sparkles"
+                        )
+                    }
+                    Spacer()
+                }
+
+                Text(localizedAppText(
+                    "Run the first-time setup flow again without changing your saved settings.",
+                    de: "Starte den Einrichtungsassistenten erneut, ohne deine gespeicherten Einstellungen zu ändern."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section {
                 VStack(spacing: 4) {
                     Text(String(localized: "\u{00A9} 2024-2026 TypeWhisper Contributors"))
                         .font(.caption)
@@ -89,5 +111,11 @@ struct AboutSettingsView: View {
         .formStyle(.grouped)
         .padding()
         .frame(minWidth: 500, minHeight: 300)
+    }
+
+    private func openSetupWizard() {
+        UserDefaults.standard.set(0, forKey: UserDefaultsKeys.setupWizardCurrentStep)
+        NotificationCenter.default.post(name: .resetSetupWizardWindow, object: nil)
+        ManagedAppWindowOpener.shared.open(id: "setup")
     }
 }

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -9,12 +9,7 @@ struct HomeSettingsView: View {
     @AppStorage(UserDefaultsKeys.workUsagePromptDismissed) private var workUsagePromptDismissed = false
 
     var body: some View {
-        if viewModel.showSetupWizard {
-            SetupWizardView()
-                .frame(minWidth: 500, minHeight: 400)
-        } else {
-            dashboardView
-        }
+        dashboardView
     }
 
     private var dashboardView: some View {
@@ -56,19 +51,6 @@ struct HomeSettingsView: View {
 
                     // Row 3: Recent transcriptions
                     recentTranscriptionsSection
-
-                    // Footer
-                    HStack {
-                        Spacer()
-                        Button {
-                            viewModel.resetSetupWizard()
-                        } label: {
-                            Label(String(localized: "Run setup again"), systemImage: "arrow.counterclockwise")
-                        }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.secondary)
-                        .font(.caption)
-                    }
 
                     #if DEBUG
                     HStack(spacing: 8) {

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -2,29 +2,30 @@ import SwiftUI
 import TypeWhisperPluginSDK
 
 struct SetupWizardView: View {
+    @Environment(\.dismiss) private var dismiss
+
     @ObservedObject private var dictation = DictationViewModel.shared
     @ObservedObject private var pluginManager = PluginManager.shared
     @ObservedObject private var registryService = PluginRegistryService.shared
-    @ObservedObject private var audioDevice = ServiceContainer.shared.audioDeviceService
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
-    @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
-    @ObservedObject private var dictionaryViewModel = DictionaryViewModel.shared
     @ObservedObject private var promptProcessingService: PromptProcessingService
 
     @State private var currentStep: Int
-    @State private var selectedProvider: String?
     @State private var selectedHotkeyMode: HotkeySlotType
-    @State private var selectedIndustryPreset: IndustryPreset
     @State private var trialSuccess = false
     @State private var trialText = ""
+    @State private var didAnnounceInitialStep = false
+    @State private var isPreparingAppleSpeechFallback = false
+    @State private var isActivatingParakeet = false
+    @State private var manuallySelectedSetupProviderId: String?
     @FocusState private var isTrialFieldFocused: Bool
 
-    private let totalSteps = 6
+    private let accessibilityAnnouncementService = ServiceContainer.shared.accessibilityAnnouncementService
 
     init() {
         let saved = UserDefaults.standard.integer(forKey: UserDefaultsKeys.setupWizardCurrentStep)
-        _currentStep = State(initialValue: min(saved, 5))
-        _selectedIndustryPreset = State(initialValue: IndustryPreset.selected())
+        let maxStep = SetupWizardStep.allCases.count - 1
+        _currentStep = State(initialValue: min(max(saved, 0), maxStep))
         _promptProcessingService = ObservedObject(wrappedValue: PromptActionsViewModel.shared.promptProcessingService)
 
         if !DictationSettingsHandler.loadHotkeys(for: .hybrid).isEmpty {
@@ -39,498 +40,699 @@ struct SetupWizardView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            if currentStep == 0 {
-                welcomeStep
-            } else {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.02, green: 0.05, blue: 0.07),
+                    Color(red: 0.04, green: 0.09, blue: 0.12),
+                    Color.black
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
                 header
-                Divider()
+
                 stepContent
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                Divider()
-                navigation
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                footer
             }
         }
-        .frame(minHeight: 350)
+        .frame(minWidth: 760, idealWidth: 820, maxWidth: 860, minHeight: 520, idealHeight: 560)
+        .preferredColorScheme(.dark)
         .onChange(of: currentStep) { _, newValue in
             UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.setupWizardCurrentStep)
+            announceCurrentStep()
+        }
+        .task {
+            if !didAnnounceInitialStep {
+                didAnnounceInitialStep = true
+                announceCurrentStep()
+            }
+
+            if registryService.fetchState == .idle {
+                await registryService.fetchRegistry()
+            }
+        }
+        .task(id: currentStep) {
+            guard currentWizardStep == .engineAI || currentWizardStep == .finish else { return }
+            await preparePreferredSetupEngineIfNeeded()
+        }
+        .onReceive(pluginManager.$loadedPlugins) { _ in
+            guard currentWizardStep == .engineAI || currentWizardStep == .finish else { return }
+            Task { await preparePreferredSetupEngineIfNeeded() }
+        }
+        .onChange(of: pluginManager.readinessRevision) { _, _ in
+            guard currentWizardStep == .engineAI || currentWizardStep == .finish else { return }
+            Task { await preparePreferredSetupEngineIfNeeded() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .resetSetupWizardWindow)) { _ in
+            restartWizardFromBeginning()
         }
     }
 
-    // MARK: - Header
+    // MARK: - Shell
+
+    private var currentWizardStep: SetupWizardStep {
+        SetupWizardStep(rawValue: currentStep) ?? .welcome
+    }
+
+    private func announceCurrentStep() {
+        accessibilityAnnouncementService.announce(localizedAppText(
+            "\(currentWizardStep.title). Step \(currentStep + 1) of \(SetupWizardStep.allCases.count). \(currentWizardStep.subtitle)",
+            de: "\(currentWizardStep.title). Schritt \(currentStep + 1) von \(SetupWizardStep.allCases.count). \(currentWizardStep.subtitle)"
+        ))
+    }
+
+    private func restartWizardFromBeginning() {
+        trialSuccess = false
+        trialText = ""
+        manuallySelectedSetupProviderId = nil
+        UserDefaults.standard.set(0, forKey: UserDefaultsKeys.setupWizardCurrentStep)
+        withAnimation(.easeInOut(duration: 0.18)) {
+            currentStep = 0
+        }
+    }
 
     private var header: some View {
-        HStack {
-            Text(stepTitle)
-                .font(.title2)
-                .fontWeight(.semibold)
+        VStack(spacing: 16) {
+            Text(localizedAppText("TypeWhisper Setup", de: "TypeWhisper Setup"))
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(.primary)
 
-            Spacer()
+            HStack(spacing: 10) {
+                ForEach(SetupWizardStep.allCases) { step in
+                    progressItem(for: step)
 
-            Text(String(localized: "Step \(currentStep) of \(totalSteps - 1)"))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 6) {
-                ForEach(1..<totalSteps, id: \.self) { index in
-                    Circle()
-                        .fill(index <= currentStep ? Color.accentColor : Color.secondary.opacity(0.3))
-                        .frame(width: 8, height: 8)
+                    if step.rawValue < SetupWizardStep.allCases.count - 1 {
+                        Rectangle()
+                            .fill(step.rawValue < currentStep ? Color.blue : Color.white.opacity(0.14))
+                            .frame(width: 46, height: 1)
+                            .accessibilityHidden(true)
+                    }
                 }
             }
-            .accessibilityHidden(true)
+            .frame(maxWidth: .infinity)
         }
-        .padding()
+        .padding(.top, 18)
+        .padding(.horizontal, 34)
+        .padding(.bottom, 10)
     }
 
-    private var stepTitle: String {
-        switch currentStep {
-        case 1: return String(localized: "Permissions")
-        case 2: return String(localized: "Transcription Engine")
-        case 3: return String(localized: "Hotkey")
-        case 4: return String(localized: "Prompts & AI")
-        case 5: return String(localized: "Try It Out")
-        default: return String(localized: "Setup")
+    private func progressItem(for step: SetupWizardStep) -> some View {
+        VStack(spacing: 7) {
+            ZStack {
+                Circle()
+                    .fill(progressFill(for: step))
+                    .frame(width: 26, height: 26)
+
+                if step.rawValue < currentStep {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white)
+                } else {
+                    Text("\(step.rawValue + 1)")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(step.rawValue <= currentStep ? .white : .secondary)
+                }
+            }
+
+            Text(step.progressTitle)
+                .font(.caption2.weight(step == currentWizardStep ? .semibold : .regular))
+                .foregroundStyle(step == currentWizardStep ? .primary : .secondary)
+                .lineLimit(1)
         }
+        .frame(width: 82)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(localizedAppText(
+            "Step \(step.rawValue + 1) of \(SetupWizardStep.allCases.count), \(step.progressTitle)",
+            de: "Schritt \(step.rawValue + 1) von \(SetupWizardStep.allCases.count), \(step.progressTitle)"
+        ))
+        .accessibilityValue(progressAccessibilityStatus(for: step))
     }
 
-    // MARK: - Step Content
+    private func progressFill(for step: SetupWizardStep) -> Color {
+        if step.rawValue <= currentStep {
+            return .blue
+        }
+        return Color.white.opacity(0.16)
+    }
 
-    @ViewBuilder
+    private func progressAccessibilityStatus(for step: SetupWizardStep) -> String {
+        if step.rawValue < currentStep {
+            return localizedAppText("Completed", de: "Abgeschlossen")
+        }
+        if step == currentWizardStep {
+            return localizedAppText("Current", de: "Aktuell")
+        }
+        return localizedAppText("Upcoming", de: "Ausstehend")
+    }
+
     private var stepContent: some View {
         ScrollView {
-            switch currentStep {
-            case 1: permissionsStep
-            case 2: engineStep
-            case 3: hotkeyStep
-            case 4: promptsAIStep
-            case 5: tryItOutStep
-            default: EmptyView()
-            }
-        }
-        .padding()
-    }
+            VStack(spacing: 18) {
+                VStack(spacing: 5) {
+                    Text(currentWizardStep.title)
+                        .font(.title2.weight(.bold))
+                        .multilineTextAlignment(.center)
+                        .accessibilityAddTraits(.isHeader)
 
-    // MARK: - Step 0: Welcome
+                    Text(currentWizardStep.subtitle)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.top, 12)
 
-    private var welcomeStep: some View {
-        VStack(spacing: 0) {
-            GeometryReader { proxy in
-                ScrollView {
-                    welcomeContent(twoColumn: proxy.size.width >= 640)
-                        .padding(.horizontal, proxy.size.width >= 520 ? 14 : 28)
-                        .padding(.top, 24)
-                        .padding(.bottom, 14)
-                        .frame(maxWidth: .infinity, minHeight: proxy.size.height, alignment: .top)
+                switch currentWizardStep {
+                case .welcome:
+                    welcomeStep
+                case .permissions:
+                    permissionsStep
+                case .hotkey:
+                    hotkeyStep
+                case .engineAI:
+                    engineAIStep
+                case .finish:
+                    finishStep
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-            Divider()
-
-            VStack(spacing: 8) {
-                Button(String(localized: "Get Started")) {
-                    applyIndustrySelection()
-                    withAnimation { currentStep = 1 }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-
-                Button(String(localized: "Skip Setup")) {
-                    HomeViewModel.shared.completeSetupWizard()
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .font(.callout)
-            }
+            .frame(maxWidth: 620)
             .frame(maxWidth: .infinity)
-            .padding(.horizontal, 28)
-            .padding(.vertical, 12)
+            .padding(.horizontal, 34)
+            .padding(.bottom, 18)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .scrollIndicators(.never)
     }
 
-    @ViewBuilder
-    private func welcomeContent(twoColumn: Bool) -> some View {
-        if twoColumn {
-            VStack(spacing: 16) {
-                welcomeHeader
-
-                HStack(alignment: .top, spacing: 24) {
-                    welcomeFeatureColumn
-                        .frame(width: 230, alignment: .leading)
-                    industryPresetColumn
-                        .frame(width: 360, alignment: .leading)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-        } else {
-            VStack(spacing: 16) {
-                welcomeHeader
-                welcomeFeatureColumn
-                industryPresetColumn
-            }
-            .frame(maxWidth: .infinity)
-        }
-    }
-
-    private var welcomeHeader: some View {
+    private var footer: some View {
         HStack(spacing: 12) {
-            Image(nsImage: NSApplication.shared.applicationIconImage)
-                .resizable()
-                .frame(width: 68, height: 68)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(String(localized: "Welcome to TypeWhisper"))
-                    .font(.title.weight(.bold))
-                    .lineLimit(1)
-
-                Text(String(localized: "Voice-powered typing for your Mac"))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
-    }
-
-    private var welcomeFeatureColumn: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            featureHighlight(
-                icon: "waveform",
-                title: String(localized: "Speak"),
-                description: String(localized: "Press a hotkey and talk naturally in any app.")
-            )
-            featureHighlight(
-                icon: "text.cursor",
-                title: String(localized: "Type"),
-                description: String(localized: "Your words appear as text instantly.")
-            )
-            featureHighlight(
-                icon: "wand.and.stars",
-                title: String(localized: "Enhance"),
-                description: String(localized: "AI prompts can rewrite, translate, or summarize.")
-            )
-        }
-        .frame(maxWidth: 230, alignment: .leading)
-    }
-
-    private var industryPresetColumn: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(String(localized: "What kind of writing do you do most?"))
-                .font(.title3.weight(.semibold))
-
-            ForEach(IndustryPreset.allCases) { preset in
-                industryOption(preset)
-            }
-
-            Text(String(localized: "Industry term packs are prepared during setup and activated automatically when a commercial license is active."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: 360, alignment: .leading)
-    }
-
-    private func industryOption(_ preset: IndustryPreset) -> some View {
-        let isSelected = selectedIndustryPreset == preset
-
-        return HStack(spacing: 10) {
-            Image(systemName: isSelected ? "largecircle.fill.circle" : preset.systemImage)
-                .font(.callout)
-                .foregroundStyle(isSelected ? Color.accentColor : .secondary)
-                .frame(width: 22)
-
-            VStack(alignment: .leading, spacing: 1) {
-                Text(preset.displayName)
-                    .font(.headline)
-                Text(preset.description)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+            if currentStep > 0 {
+                Button(localizedAppText("Back", de: "Zurück")) {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        currentStep -= 1
+                    }
+                }
+                .buttonStyle(.bordered)
+                .keyboardShortcut(.leftArrow, modifiers: [.command])
             }
 
             Spacer()
+
+            Button(localizedAppText("Skip Setup", de: "Setup überspringen")) {
+                completeSetupAndOpenHome()
+            }
+            .buttonStyle(.bordered)
+            .keyboardShortcut(.cancelAction)
+
+            Button(primaryActionTitle) {
+                handlePrimaryAction()
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(primaryKeyboardShortcut)
+            .accessibilityHint(primaryActionAccessibilityHint)
+            .disabled(!canProceed)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 9)
-        .background(RoundedRectangle(cornerRadius: 8).fill(isSelected ? Color.accentColor.opacity(0.08) : Color.secondary.opacity(0.08)))
-        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(isSelected ? Color.accentColor.opacity(0.35) : Color.clear, lineWidth: 1))
-        .contentShape(Rectangle())
-        .onTapGesture {
-            selectedIndustryPreset = preset
+        .padding(.horizontal, 34)
+        .padding(.vertical, 18)
+        .background(Color.black.opacity(0.18))
+    }
+
+    private var primaryActionTitle: String {
+        if currentWizardStep == .permissions, dictation.needsMicPermission {
+            return localizedAppText("Grant Microphone Access", de: "Mikrofonzugriff erlauben")
+        }
+
+        return currentWizardStep == .finish
+            ? localizedAppText("Complete Setup", de: "Setup abschließen")
+            : localizedAppText("Continue", de: "Weiter")
+    }
+
+    private var primaryKeyboardShortcut: KeyboardShortcut {
+        currentWizardStep == .finish
+            ? KeyboardShortcut(.return, modifiers: [.command])
+            : .defaultAction
+    }
+
+    private var primaryActionAccessibilityHint: String {
+        if currentWizardStep == .finish {
+            return localizedAppText("Press Command Return to complete setup.", de: "Drücke Befehlstaste Return, um das Setup abzuschließen.")
+        }
+
+        return localizedAppText("Press Return to continue.", de: "Drücke Return, um fortzufahren.")
+    }
+
+    private func handlePrimaryAction() {
+        if currentWizardStep == .permissions, dictation.needsMicPermission {
+            dictation.requestMicPermission()
+            return
+        }
+
+        if currentWizardStep == .hotkey {
+            applyRecommendedHotkeyIfNeeded()
+        }
+
+        if currentWizardStep == .finish {
+            completeSetupAndOpenHome()
+            return
+        }
+
+        withAnimation(.easeInOut(duration: 0.18)) {
+            currentStep = min(currentStep + 1, SetupWizardStep.allCases.count - 1)
         }
     }
 
-    private func applyIndustrySelection() {
-        dictionaryViewModel.applyIndustryPreset(selectedIndustryPreset)
+    private func completeSetupAndOpenHome() {
+        HomeViewModel.shared.completeSetupWizard()
+        SettingsNavigationCoordinator.shared?.navigate(to: .home)
+        dismiss()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            ManagedAppWindowOpener.shared.open(id: "settings")
+        }
     }
 
-    private func featureHighlight(icon: String, title: String, description: String) -> some View {
-        HStack(alignment: .top, spacing: 10) {
+    // MARK: - Welcome
+
+    private var welcomeStep: some View {
+        VStack(spacing: 22) {
+            Image(nsImage: NSApplication.shared.applicationIconImage)
+                .resizable()
+                .frame(width: 74, height: 74)
+                .shadow(color: .blue.opacity(0.35), radius: 16)
+
+            VStack(alignment: .leading, spacing: 14) {
+                setupFeatureRow(
+                    icon: "mic.fill",
+                    title: localizedAppText("Speak naturally", de: "Natürlich sprechen"),
+                    description: localizedAppText("Press a hotkey and talk in any app.", de: "Drücke einen Hotkey und sprich in jeder App.")
+                )
+                setupFeatureRow(
+                    icon: "text.cursor",
+                    title: localizedAppText("Type instantly", de: "Sofort schreiben"),
+                    description: localizedAppText("Your words appear as text right away.", de: "Deine Worte erscheinen direkt als Text.")
+                )
+                setupFeatureRow(
+                    icon: "wand.and.stars",
+                    title: localizedAppText("Enhance with AI", de: "Mit KI verbessern"),
+                    description: localizedAppText("Rewrite, translate, summarize, and more.", de: "Umschreiben, übersetzen, zusammenfassen und mehr.")
+                )
+            }
+            .frame(maxWidth: 390, alignment: .leading)
+        }
+        .padding(.top, 4)
+    }
+
+    private func setupFeatureRow(icon: String, title: String, description: String) -> some View {
+        HStack(alignment: .top, spacing: 14) {
             Image(systemName: icon)
                 .font(.title3)
                 .foregroundStyle(.blue)
-                .frame(width: 24)
+                .frame(width: 30, height: 28)
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.headline)
                 Text(description)
                     .font(.callout)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
 
-    // MARK: - Step 1: Permissions
+    // MARK: - Permissions
 
     private var permissionsStep: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            permissionRow(
-                label: String(localized: "Microphone"),
-                iconGranted: "mic.fill",
-                iconMissing: "mic.slash",
+        VStack(spacing: 12) {
+            permissionCard(
+                title: localizedAppText("Microphone Access", de: "Mikrofonzugriff"),
+                description: localizedAppText("Required to capture your voice.", de: "Erforderlich, um deine Stimme aufzunehmen."),
+                systemImage: "mic.fill",
                 isGranted: !dictation.needsMicPermission,
-                isRequired: true
-            ) {
-                dictation.requestMicPermission()
-            }
+                isRequired: true,
+                action: { dictation.requestMicPermission() }
+            )
 
-            if dictation.needsMicPermission {
-                Text(String(localized: "Microphone access is required to continue."))
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            permissionRow(
-                label: String(localized: "Accessibility"),
-                iconGranted: "lock.shield.fill",
-                iconMissing: "lock.shield",
+            permissionCard(
+                title: localizedAppText("Accessibility Access", de: "Bedienungshilfen-Zugriff"),
+                description: localizedAppText("Required to type into other apps.", de: "Erforderlich, um in andere Apps zu schreiben."),
+                systemImage: "figure.stand",
                 isGranted: !dictation.needsAccessibilityPermission,
-                isRequired: false
-            ) {
-                dictation.requestAccessibilityPermission()
-            }
+                isRequired: false,
+                action: { dictation.requestAccessibilityPermission() }
+            )
 
-            if dictation.needsAccessibilityPermission {
-                Text(String(localized: "Recommended for pasting text into other apps. You can grant this later."))
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-
-            if !dictation.needsMicPermission {
-                Divider()
-
-                Text(String(localized: "Select your preferred microphone:"))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-
-                Picker(String(localized: "Microphone"), selection: $audioDevice.selectedDeviceUID) {
-                    Text(String(localized: "System Default")).tag(nil as String?)
-                    Divider()
-                    ForEach(audioDevice.inputDevices) { device in
-                        Text(audioDevice.displayName(for: device)).tag(device.uid as String?)
-                    }
-                }
-
-                if let message = audioDevice.selectedDeviceStatusMessage {
-                    Label(message, systemImage: "exclamationmark.triangle")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                }
-
-                if audioDevice.isPreviewActive {
-                    HStack(spacing: 8) {
-                        Image(systemName: "mic.fill")
-                            .foregroundStyle(.secondary)
-                            .font(.caption)
-
-                        GeometryReader { geo in
-                            ZStack(alignment: .leading) {
-                                RoundedRectangle(cornerRadius: 3)
-                                    .fill(.quaternary)
-
-                                RoundedRectangle(cornerRadius: 3)
-                                    .fill(.green.gradient)
-                                    .frame(width: max(0, geo.size.width * CGFloat(audioDevice.previewAudioLevel)))
-                                    .animation(.easeOut(duration: 0.08), value: audioDevice.previewAudioLevel)
-                            }
-                        }
-                        .frame(height: 6)
-                    }
-                    .padding(.vertical, 4)
-                }
-
-                Button(audioDevice.isPreviewActive
-                    ? String(localized: "Stop Preview")
-                    : String(localized: "Test Microphone")
-                ) {
-                    if audioDevice.isPreviewActive {
-                        audioDevice.stopPreview()
-                    } else {
-                        audioDevice.startPreview()
-                    }
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
-                if let error = audioDevice.previewError {
-                    Label(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-            }
+            Label(
+                localizedAppText("You can change permissions anytime in System Settings.", de: "Du kannst diese Berechtigungen jederzeit in den Systemeinstellungen ändern."),
+                systemImage: "lock"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 6)
         }
     }
 
-    private func permissionRow(
-        label: String,
-        iconGranted: String,
-        iconMissing: String,
+    private func permissionCard(
+        title: String,
+        description: String,
+        systemImage: String,
         isGranted: Bool,
         isRequired: Bool,
         action: @escaping () -> Void
     ) -> some View {
-        HStack {
-            Label(label, systemImage: isGranted ? iconGranted : iconMissing)
-                .foregroundStyle(isGranted ? .green : (isRequired ? .red : .orange))
+        setupCard(isSelected: false) {
+            HStack(spacing: 16) {
+                Image(systemName: systemImage)
+                    .font(.title)
+                    .foregroundStyle(isGranted ? .green : .blue)
+                    .frame(width: 38)
+                    .accessibilityHidden(true)
 
-            if !isGranted {
-                Text(isRequired ? String(localized: "Required") : String(localized: "Recommended"))
-                    .font(.caption2)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background((isRequired ? Color.red : Color.orange).opacity(0.1))
-                    .foregroundStyle(isRequired ? .red : .orange)
-                    .clipShape(Capsule())
-            }
-
-            Spacer()
-
-            if isGranted {
-                Text(String(localized: "Granted"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                Button(String(localized: "Grant Access")) {
-                    action()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-        }
-        .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
-    }
-
-    // MARK: - Step 2: Engine
-
-    private var engineStep: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            if hasAnyEngineReady {
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "You have a transcription engine ready."))
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.headline)
+                    Text(description)
+                        .font(.callout)
                         .foregroundStyle(.secondary)
                 }
-                .font(.callout)
-            } else {
-                Text(String(localized: "Install a transcription engine to get started."))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
 
-            Text(String(localized: "Recommended"))
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.secondary)
+                Spacer()
 
-            recommendationCard(
-                manifestId: "com.typewhisper.parakeet",
-                title: "Parakeet",
-                badge: String(localized: "Works Offline"),
-                description: String(localized: "Runs locally on your Mac. No API key needed."),
-                systemImage: "desktopcomputer"
-            )
+                if isGranted {
+                    statusPill(
+                        localizedAppText("Granted", de: "Erlaubt"),
+                        systemImage: "checkmark.circle.fill",
+                        color: .green
+                    )
+                } else {
+                    VStack(alignment: .trailing, spacing: 8) {
+                        statusPill(
+                            localizedAppText("Needs Access", de: "Zugriff nötig"),
+                            systemImage: isRequired ? "exclamationmark.circle.fill" : "circle",
+                            color: isRequired ? .orange : .secondary
+                        )
 
-            recommendationCard(
-                manifestId: "com.typewhisper.groq",
-                title: "Groq",
-                badge: String(localized: "Fastest"),
-                description: String(localized: "Cloud-based transcription. Requires a free API key."),
-                systemImage: "bolt.fill"
-            )
-
-            let otherEngines = pluginManager.loadedPlugins
-                .filter { !recommendedManifestIds.contains($0.manifest.id) }
-                .compactMap { $0.instance as? any TranscriptionEnginePlugin }
-            if !otherEngines.isEmpty {
-                Text(String(localized: "Also Installed"))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                ForEach(otherEngines, id: \.providerId) { engine in
-                    SetupEngineRow(engine: engine)
-                }
-            }
-
-            if pluginManager.transcriptionEngines.count > 1 {
-                Picker(String(localized: "Default Engine"), selection: $selectedProvider) {
-                    ForEach(pluginManager.transcriptionEngines, id: \.providerId) { engine in
-                        HStack {
-                            Text(engine.providerDisplayName)
-                            if !engine.isConfigured {
-                                Text("(\(String(localized: "not ready")))")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }.tag(engine.providerId as String?)
-                    }
-                }
-                .onChange(of: selectedProvider) { _, newValue in
-                    if let newValue {
-                        modelManager.selectProvider(newValue)
+                        Button(localizedAppText("Grant Access", de: "Zugriff erlauben")) {
+                            action()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
                     }
                 }
             }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isGranted ? [] : .isButton)
+        .accessibilityLabel(permissionAccessibilityLabel(title: title, description: description, isGranted: isGranted))
+        .accessibilityHint(isGranted ? "" : localizedAppText("Use the grant access button to continue setup.", de: "Nutze die Schaltfläche Zugriff erlauben, um fortzufahren."))
+        .accessibilityAction(named: Text(localizedAppText("Grant Access", de: "Zugriff erlauben"))) {
+            guard !isGranted else { return }
+            action()
+        }
+    }
 
-            if case .error(let message) = registryService.fetchState {
-                HStack {
-                    Text(message)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                    Spacer()
-                    Button(String(localized: "Retry")) {
-                        Task { await registryService.fetchRegistry(force: true) }
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
+    private func permissionAccessibilityLabel(title: String, description: String, isGranted: Bool) -> String {
+        let status = isGranted
+            ? localizedAppText("Granted", de: "Erlaubt")
+            : localizedAppText("Needs access", de: "Zugriff nötig")
+        return "\(title). \(description) \(status)."
+    }
+
+    // MARK: - Hotkey
+
+    private var hotkeyStep: some View {
+        VStack(spacing: 12) {
+            recommendedHotkeyCard
+
+            VStack(spacing: 8) {
+                compactHotkeyModeCard(
+                    mode: .pushToTalk,
+                    title: localizedAppText("Push-to-Talk", de: "Push-to-Talk"),
+                    description: localizedAppText("Hold to record, release to stop.", de: "Zum Aufnehmen halten, zum Stoppen loslassen.")
+                )
+
+                compactHotkeyModeCard(
+                    mode: .toggle,
+                    title: localizedAppText("Toggle", de: "Toggle"),
+                    description: localizedAppText("Press to start, press again to stop.", de: "Zum Starten drücken, zum Stoppen erneut drücken.")
+                )
             }
 
-            Text(String(localized: "You can install more engines from the Integrations tab after setup."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .task {
-            if registryService.fetchState == .idle {
-                await registryService.fetchRegistry()
-            }
-        }
-        .onAppear {
-            selectedProvider = modelManager.selectedProviderId
-        }
-        .onChange(of: pluginManager.transcriptionEngines.map(\.providerId)) { _, engines in
-            if selectedProvider == nil || !engines.contains(where: { $0 == selectedProvider }),
-               let first = engines.first {
-                selectedProvider = first
-                modelManager.selectProvider(first)
+            if let hotkeyMessage {
+                Label(hotkeyMessage.text, systemImage: hotkeyMessage.systemImage)
+                    .font(.caption)
+                    .foregroundStyle(hotkeyMessage.color)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
             }
         }
     }
 
-    private let recommendedManifestIds: Set<String> = ["com.typewhisper.parakeet", "com.typewhisper.groq"]
+    private var recommendedHotkeyCard: some View {
+        setupCard(isSelected: selectedHotkeyMode == .hybrid) {
+            VStack(spacing: 12) {
+                HStack(spacing: 14) {
+                    Image(systemName: selectedHotkeyMode == .hybrid ? "largecircle.fill.circle" : "circle")
+                        .foregroundStyle(selectedHotkeyMode == .hybrid ? .blue : .secondary)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 8) {
+                            Text(localizedAppText("Hybrid", de: "Hybrid"))
+                                .font(.headline)
+
+                            Text(localizedAppText("Recommended", de: "Empfohlen"))
+                                .font(.caption2.weight(.semibold))
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .background(Color.blue.opacity(0.18))
+                                .foregroundStyle(.blue)
+                                .clipShape(Capsule())
+                        }
+
+                        Text(localizedAppText("Short press to toggle, hold to push-to-talk.", de: "Kurz drücken zum Umschalten, halten für Push-to-Talk."))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    hotkeyChip(label: displayedHotkeyLabel(for: .hybrid))
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { selectedHotkeyMode = .hybrid }
+
+                if selectedHotkeyMode == .hybrid, shouldShowRecorder(for: .hybrid) {
+                    hotkeyRecorder(for: .hybrid)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(hotkeyModeAccessibilityLabel(
+            title: localizedAppText("Hybrid", de: "Hybrid"),
+            description: localizedAppText("Short press to toggle, hold to push-to-talk.", de: "Kurz drücken zum Umschalten, halten für Push-to-Talk."),
+            label: displayedHotkeyLabel(for: .hybrid)
+        ))
+        .accessibilityValue(selectedHotkeyMode == .hybrid ? localizedAppText("Selected", de: "Ausgewählt") : "")
+        .accessibilityHint(localizedAppText("Recommended. Press Return to continue with this shortcut.", de: "Empfohlen. Drücke Return, um mit diesem Shortcut fortzufahren."))
+        .accessibilityAction(named: Text(localizedAppText("Select", de: "Auswählen"))) {
+            selectedHotkeyMode = .hybrid
+        }
+    }
+
+    private func compactHotkeyModeCard(mode: HotkeySlotType, title: String, description: String) -> some View {
+        setupCard(isSelected: selectedHotkeyMode == mode) {
+            VStack(spacing: 10) {
+                HStack(spacing: 14) {
+                    Image(systemName: selectedHotkeyMode == mode ? "largecircle.fill.circle" : "circle")
+                        .foregroundStyle(selectedHotkeyMode == mode ? .blue : .secondary)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .font(.headline)
+                        Text(description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    if !dictation.hotkeys(for: mode).isEmpty {
+                        hotkeyChip(label: displayedHotkeyLabel(for: mode))
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { selectedHotkeyMode = mode }
+
+                if selectedHotkeyMode == mode, shouldShowRecorder(for: mode) {
+                    hotkeyRecorder(for: mode)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(hotkeyModeAccessibilityLabel(
+            title: title,
+            description: description,
+            label: displayedHotkeyLabel(for: mode)
+        ))
+        .accessibilityValue(selectedHotkeyMode == mode ? localizedAppText("Selected", de: "Ausgewählt") : "")
+        .accessibilityHint(localizedAppText("Selects this hotkey mode.", de: "Wählt diesen Hotkey-Modus aus."))
+        .accessibilityAction(named: Text(localizedAppText("Select", de: "Auswählen"))) {
+            selectedHotkeyMode = mode
+        }
+    }
+
+    private func hotkeyModeAccessibilityLabel(title: String, description: String, label: String) -> String {
+        "\(title). \(description) \(localizedAppText("Shortcut", de: "Shortcut")): \(label)."
+    }
+
+    private func shouldShowRecorder(for mode: HotkeySlotType) -> Bool {
+        if mode != selectedHotkeyMode { return false }
+        if !dictation.hotkeys(for: mode).isEmpty { return false }
+        return mode != .hybrid || !recommendedHotkeyResolution.shouldApply
+    }
+
+    private func hotkeyRecorder(for mode: HotkeySlotType) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "keyboard")
+                .foregroundStyle(.blue)
+
+            HotkeyRecorderView(
+                label: hotkeyLabel(for: mode),
+                title: localizedAppText("Shortcut", de: "Shortcut"),
+                onRecord: { hotkey in
+                    if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: mode) {
+                        dictation.clearHotkey(for: conflict)
+                    }
+                    dictation.setHotkey(hotkey, for: mode)
+                },
+                onClear: { dictation.clearHotkey(for: mode) }
+            )
+            .fixedSize()
+
+            Spacer()
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.blue.opacity(0.08)))
+    }
+
+    private var hotkeyMessage: (text: String, systemImage: String, color: Color)? {
+        if hasAnyTriggerHotkey {
+            return (
+                localizedAppText("Your existing shortcut will stay unchanged.", de: "Dein bestehender Shortcut bleibt unverändert."),
+                "checkmark.circle.fill",
+                .green
+            )
+        }
+
+        if selectedHotkeyMode == .hybrid, recommendedHotkeyResolution.shouldApply {
+            return (
+                localizedAppText("Fn will be set automatically when you continue.", de: "Fn wird beim Fortfahren automatisch gesetzt."),
+                "keyboard",
+                .secondary
+            )
+        }
+
+        if selectedHotkeyMode == .hybrid,
+           case .conflictingSlot(let slot) = recommendedHotkeyResolution.blockedReason {
+            return (
+                localizedAppText(
+                    "Fn is already used by \(hotkeyModeTitle(for: slot)). Record another shortcut to continue.",
+                    de: "Fn wird bereits von \(hotkeyModeTitle(for: slot)) verwendet. Nimm einen anderen Shortcut auf, um fortzufahren."
+                ),
+                "exclamationmark.triangle.fill",
+                .orange
+            )
+        }
+
+        return (
+            localizedAppText("Record a shortcut to use this mode.", de: "Nimm einen Shortcut auf, um diesen Modus zu verwenden."),
+            "keyboard",
+            .secondary
+        )
+    }
+
+    // MARK: - Engine & AI
+
+    private var engineAIStep: some View {
+        VStack(spacing: 10) {
+            localReadinessCard
+
+            recommendationCard(
+                manifestId: SetupWizardParakeetRecommendation.manifestId,
+                title: "Parakeet",
+                badge: localizedAppText("Recommended", de: "Empfohlen"),
+                description: SetupWizardParakeetRecommendation.description,
+                systemImage: "desktopcomputer",
+                isProminent: true
+            )
+
+            appleSpeechCard
+
+            appleIntelligenceCard
+
+            cloudProvidersHint
+        }
+    }
+
+    private var cloudProvidersHint: some View {
+        Label(
+            localizedAppText(
+                "Cloud providers can be added later in Settings.",
+                de: "Cloud-Provider kannst du später in den Einstellungen hinzufügen."
+            ),
+            systemImage: "cloud"
+        )
+        .font(.caption.weight(.medium))
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 4)
+    }
+
+    private var localReadinessCard: some View {
+        let isReady = hasEngineReadyForSetupTest
+
+        return HStack(spacing: 10) {
+            Image(systemName: isReady ? "checkmark.circle.fill" : "circle.dashed")
+                .foregroundStyle(isReady ? .green : .secondary)
+            Text(localReadinessText)
+            .font(.callout.weight(.medium))
+            .foregroundStyle(isReady ? .green : .secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.06)))
+    }
+
+    private var localReadinessText: String {
+        if isActivatingParakeet {
+            return localizedAppText("Activating Parakeet for local dictation", de: "Parakeet wird für lokales Diktieren aktiviert")
+        }
+        if hasEngineReadyForSetupTest {
+            if selectedTranscriptionEngineForSetup?.providerId == SetupWizardAppleSpeechFallback.providerId {
+                return localizedAppText("Apple Speech is ready for local dictation", de: "Apple Speech ist für lokales Diktieren bereit")
+            }
+            if selectedTranscriptionEngineForSetup?.providerId == SetupWizardParakeetRecommendation.providerId {
+                return localizedAppText("Parakeet is ready for local dictation", de: "Parakeet ist für lokales Diktieren bereit")
+            }
+            return localizedAppText("Ready to use locally", de: "Lokal einsatzbereit")
+        }
+        if isPreparingAppleSpeechFallback {
+            return localizedAppText("Preparing Apple Speech for the first test", de: "Apple Speech wird für den ersten Test vorbereitet")
+        }
+        if canUseAppleSpeechFallback {
+            return localizedAppText("Apple Speech can be used locally", de: "Apple Speech kann lokal genutzt werden")
+        }
+        return localizedAppText("Choose a local engine now or continue and finish later", de: "Wähle jetzt eine lokale Engine oder fahre fort und schließe später ab")
+    }
 
     @ViewBuilder
     private func recommendationCard(
@@ -538,12 +740,14 @@ struct SetupWizardView: View {
         title: String,
         badge: String,
         description: String,
-        systemImage: String
+        systemImage: String,
+        isProminent: Bool = false
     ) -> some View {
         let loadedPlugin = pluginManager.loadedPlugins.first { $0.manifest.id == manifestId }
         let isInstalled = loadedPlugin != nil
         let engine = loadedPlugin?.instance as? any TranscriptionEnginePlugin
         let isReady = engine?.isConfigured ?? false
+        let isSelected = engine?.providerId == modelManager.selectedProviderId
         let registryPlugin = registryService.registry.first { $0.id == manifestId }
         let installState = registryService.installStates[manifestId]
         let availability = SetupWizardRecommendationAvailability.resolve(
@@ -554,83 +758,200 @@ struct SetupWizardView: View {
             installState: installState,
             fetchState: registryService.fetchState
         )
-        let resolvedDescription = recommendationDescription(
-            fallback: description,
-            availability: availability
+        let isInteractive = recommendationCardIsInteractive(
+            manifestId: manifestId,
+            availability: availability,
+            isSelected: isSelected
         )
+        let card = setupCard(isSelected: isSelected) {
+            HStack(spacing: 14) {
+                Image(systemName: systemImage)
+                    .font(.title2)
+                    .foregroundStyle(.blue)
+                    .frame(width: 36)
 
-        HStack(spacing: 12) {
-            Image(systemName: systemImage)
-                .font(.title2)
-                .foregroundStyle(.blue)
-                .frame(width: 40, height: 40)
-                .background(Circle().fill(.blue.opacity(0.1)))
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 7) {
+                        Text(title)
+                            .font(.headline)
+                        Text(badge)
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Color.blue.opacity(isProminent ? 0.22 : 0.18))
+                            .foregroundStyle(.blue)
+                            .clipShape(Capsule())
+                    }
 
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(title)
-                        .font(.body.weight(.medium))
-
-                    Text(badge)
-                        .font(.caption2.weight(.semibold))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.blue.opacity(0.1))
-                        .foregroundStyle(.blue)
-                        .clipShape(Capsule())
+                    Text(recommendationDescription(fallback: description, availability: availability))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Text(resolvedDescription)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Spacer()
+
+                recommendationStatus(
+                    manifestId: manifestId,
+                    availability: availability,
+                    registryPlugin: registryPlugin,
+                    isSelected: isSelected
+                )
             }
+        }
 
-            Spacer()
+        if isInteractive {
+            card
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    Task { await handleRecommendationCardAction(manifestId: manifestId, registryPlugin: registryPlugin) }
+                }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint(recommendationCardAccessibilityHint(manifestId: manifestId, availability: availability))
+        } else {
+            card
+        }
+    }
 
+    @ViewBuilder
+    private func recommendationStatus(
+        manifestId: String,
+        availability: SetupWizardRecommendationAvailability,
+        registryPlugin: RegistryPlugin?,
+        isSelected: Bool
+    ) -> some View {
+        if manifestId == SetupWizardParakeetRecommendation.manifestId, isActivatingParakeet {
+            ProgressView()
+                .controlSize(.small)
+        } else {
             switch availability {
             case .ready:
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "Ready"))
-                        .font(.caption)
-                        .foregroundStyle(.green)
+                if manifestId == SetupWizardParakeetRecommendation.manifestId, isSelected {
+                    statusPill(localizedAppText("Selected", de: "Ausgewählt"), systemImage: "checkmark.circle.fill", color: .blue)
+                } else if manifestId == SetupWizardParakeetRecommendation.manifestId {
+                    statusPill(localizedAppText("Select", de: "Auswählen"), systemImage: "circle", color: .blue)
+                } else {
+                    statusPill(localizedAppText("Ready", de: "Bereit"), systemImage: "checkmark.circle.fill", color: .green)
                 }
             case .setupRequired:
-                RecommendationSettingsButton(manifestId: manifestId)
+                if manifestId == SetupWizardParakeetRecommendation.manifestId {
+                    statusPill(localizedAppText("Activate", de: "Aktivieren"), systemImage: "play.circle.fill", color: .blue)
+                } else {
+                    RecommendationSettingsButton(manifestId: manifestId)
+                }
             case .installState(let installState):
                 switch installState {
                 case .downloading(let progress):
                     ProgressView(value: progress)
-                        .frame(width: 60)
+                        .frame(width: 70)
                 case .extracting:
                     ProgressView()
                         .controlSize(.small)
-                case .error(let message):
-                    Text(message)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(1)
+                case .error:
+                    statusPill(localizedAppText("Retry later", de: "Später erneut"), systemImage: "exclamationmark.triangle.fill", color: .orange)
                 }
             case .installAvailable:
-                Button(String(localized: "Install")) {
-                    Task {
-                        guard let registryPlugin else { return }
-                        await registryService.downloadAndInstall(registryPlugin)
-                        PluginManager.shared.setPluginEnabled(registryPlugin.id, enabled: true)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                statusPill(localizedAppText("Install", de: "Installieren"), systemImage: "arrow.down.circle.fill", color: .blue)
             case .loading:
                 ProgressView()
                     .controlSize(.small)
             case .unavailable(let reason):
-                unavailableRecommendationView(reason)
+                statusPill(reason.title, systemImage: "exclamationmark.triangle.fill", color: .orange)
+                    .help(reason.message)
             }
         }
-        .padding(12)
-        .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
+    }
+
+    private func recommendationCardIsInteractive(
+        manifestId: String,
+        availability: SetupWizardRecommendationAvailability,
+        isSelected: Bool
+    ) -> Bool {
+        guard manifestId == SetupWizardParakeetRecommendation.manifestId, !isSelected else {
+            return false
+        }
+
+        switch availability {
+        case .ready, .setupRequired, .installAvailable:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func recommendationCardAccessibilityHint(
+        manifestId: String,
+        availability: SetupWizardRecommendationAvailability
+    ) -> String {
+        guard manifestId == SetupWizardParakeetRecommendation.manifestId else {
+            return ""
+        }
+
+        switch availability {
+        case .installAvailable:
+            return localizedAppText("Installs and selects Parakeet.", de: "Installiert und wählt Parakeet aus.")
+        case .setupRequired:
+            return localizedAppText("Activates Parakeet.", de: "Aktiviert Parakeet.")
+        default:
+            return localizedAppText("Selects Parakeet.", de: "Wählt Parakeet aus.")
+        }
+    }
+
+    @MainActor
+    private func handleRecommendationCardAction(manifestId: String, registryPlugin: RegistryPlugin?) async {
+        guard manifestId == SetupWizardParakeetRecommendation.manifestId else { return }
+        await activateParakeetForSetup(registryPlugin: registryPlugin)
+    }
+
+    @MainActor
+    private func activateParakeetForSetup(registryPlugin: RegistryPlugin? = nil) async {
+        guard !isActivatingParakeet else { return }
+
+        manuallySelectedSetupProviderId = SetupWizardParakeetRecommendation.providerId
+        isActivatingParakeet = true
+        defer { isActivatingParakeet = false }
+
+        if parakeetEngine == nil {
+            if let registryPlugin,
+               pluginManager.loadedPlugins.first(where: { $0.manifest.id == registryPlugin.id }) == nil {
+                await registryService.downloadAndInstall(registryPlugin)
+            }
+
+            if let loaded = pluginManager.loadedPlugins.first(where: { $0.manifest.id == SetupWizardParakeetRecommendation.manifestId }),
+               !loaded.isEnabled {
+                pluginManager.setPluginEnabled(SetupWizardParakeetRecommendation.manifestId, enabled: true)
+            }
+        }
+
+        guard let engine = await waitForParakeetEngine() else { return }
+
+        modelManager.selectProvider(engine.providerId)
+
+        if !engine.isConfigured {
+            let modelId = engine.selectedModelId
+                ?? SetupWizardParakeetRecommendation.preferredModelId(from: engine.modelCatalog)
+            if let modelId {
+                engine.selectModel(modelId)
+            }
+        }
+
+        for _ in 0..<240 {
+            if Task.isCancelled || engine.isConfigured { return }
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+    }
+
+    @MainActor
+    private func waitForParakeetEngine() async -> TranscriptionEnginePlugin? {
+        for _ in 0..<40 {
+            if Task.isCancelled { return nil }
+            if let parakeetEngine {
+                return parakeetEngine
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+
+        return parakeetEngine
     }
 
     private func recommendationDescription(
@@ -642,503 +963,203 @@ struct SetupWizardView: View {
         }
 
         return localizedAppText(
-            "Parakeet runs locally and requires Apple Silicon. Intel Macs can use cloud Whisper through Groq or OpenAI.",
-            de: "Parakeet läuft lokal und braucht Apple Silicon. Intel-Macs können Cloud-Whisper über Groq oder OpenAI nutzen."
+            "Best local quality, but requires Apple Silicon. Intel Macs can use Apple Speech for setup.",
+            de: "Beste lokale Qualität, braucht aber Apple Silicon. Intel-Macs können Apple Speech für das Setup nutzen."
         )
     }
 
-    private func unavailableRecommendationView(_ reason: SetupWizardRecommendationUnavailableReason) -> some View {
-        VStack(alignment: .trailing, spacing: 2) {
-            Label(reason.title, systemImage: "exclamationmark.triangle.fill")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.orange)
+    @ViewBuilder
+    private var appleSpeechCard: some View {
+        let isSelected = modelManager.selectedProviderId == SetupWizardAppleSpeechFallback.providerId
+        let card = setupCard(isSelected: isSelected) {
+            HStack(spacing: 14) {
+                Image(systemName: "waveform.badge.mic")
+                    .font(.title2)
+                    .foregroundStyle(.blue)
+                    .frame(width: 36)
 
-            Text(reason.message)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.trailing)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: 190, alignment: .trailing)
-        }
-    }
-
-    // MARK: - Step 3: Hotkey
-
-    private var hotkeyStep: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(String(localized: "Choose how you want to trigger dictation, then record a shortcut."))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: 8) {
-                hotkeyModeOption(
-                    mode: .hybrid,
-                    title: String(localized: "Hybrid"),
-                    description: String(localized: "Short press to toggle, hold to push-to-talk."),
-                    recommended: true
-                )
-
-                hotkeyModeOption(
-                    mode: .pushToTalk,
-                    title: String(localized: "Push-to-Talk"),
-                    description: String(localized: "Hold to record, release to stop.")
-                )
-
-                hotkeyModeOption(
-                    mode: .toggle,
-                    title: String(localized: "Toggle"),
-                    description: String(localized: "Press to start, press again to stop.")
-                )
-            }
-
-            if !hasAnyHotkeySet {
-                HStack(spacing: 4) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text(String(localized: "No hotkey set. You won't be able to start dictation without one."))
-                        .foregroundStyle(.orange)
-                }
-                .font(.caption)
-            }
-        }
-    }
-
-    private func hotkeyModeOption(
-        mode: HotkeySlotType,
-        title: String,
-        description: String,
-        recommended: Bool = false
-    ) -> some View {
-        let isSelected = selectedHotkeyMode == mode
-
-        return VStack(spacing: 0) {
-            HStack {
-                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(title)
-                            .font(.body.weight(.medium))
-                        if recommended {
-                            Text(String(localized: "Recommended"))
-                                .font(.caption2.weight(.semibold))
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(.blue.opacity(0.1))
-                                .foregroundStyle(.blue)
-                                .clipShape(Capsule())
-                        }
-                    }
-                    Text(description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-            }
-            .padding(10)
-            .contentShape(Rectangle())
-            .onTapGesture { selectedHotkeyMode = mode }
-
-            if isSelected {
-                Divider()
-                    .padding(.horizontal, 10)
-
-                HStack(spacing: 8) {
-                    Spacer()
-
-                    Image(systemName: "keyboard")
-                        .foregroundStyle(.blue)
-
-                    HotkeyRecorderView(
-                        label: hotkeyLabel(for: mode),
-                        title: String(localized: "Shortcut"),
-                        onRecord: { hotkey in
-                            if let conflict = dictation.isHotkeyAssigned(hotkey, excluding: mode) {
-                                dictation.clearHotkey(for: conflict)
-                            }
-                            dictation.setHotkey(hotkey, for: mode)
-                        },
-                        onClear: { dictation.clearHotkey(for: mode) }
-                    )
-                    .fixedSize()
-                }
-                .padding(10)
-                .background(RoundedRectangle(cornerRadius: 6).fill(.blue.opacity(0.06)))
-                .padding(.horizontal, 6)
-                .padding(.bottom, 6)
-            }
-        }
-        .background(RoundedRectangle(cornerRadius: 8).fill(isSelected ? AnyShapeStyle(Color.accentColor.opacity(0.08)) : AnyShapeStyle(.quaternary)))
-        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1))
-    }
-
-    // MARK: - Step 4: Prompts & AI
-
-    private var promptsAIStep: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(String(localized: "Process your dictated text with AI - translate, reformat, summarize, and more."))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-
-            if hasAnyLLMProvider {
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "You have an LLM provider ready."))
-                        .foregroundStyle(.secondary)
-                }
-                .font(.callout)
-            }
-
-            Text(String(localized: "Recommended"))
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.secondary)
-
-            if #available(macOS 26, *) {
-                appleIntelligenceCard
-            }
-
-            llmProviderCard(
-                manifestId: "com.typewhisper.groq",
-                title: "Groq",
-                badge: groqAlreadyInstalled
-                    ? String(localized: "Already Installed")
-                    : String(localized: "Free API Key"),
-                description: groqAlreadyInstalled
-                    ? String(localized: "Groq is already installed and also works as an LLM provider.")
-                    : String(localized: "Fast cloud AI. Also supports transcription. Requires a free API key."),
-                systemImage: "bolt.fill"
-            )
-
-            let otherProviders = pluginManager.llmProviders
-                .filter { $0.providerName.caseInsensitiveCompare("Groq") != .orderedSame }
-            if !otherProviders.isEmpty {
-                Text(String(localized: "Also Available"))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                ForEach(otherProviders, id: \.providerName) { provider in
-                    HStack {
-                        Text(provider.providerName)
-                            .font(.body.weight(.medium))
-                        Spacer()
-                        if provider.isAvailable {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                Text(String(localized: "Ready"))
-                                    .font(.caption)
-                                    .foregroundStyle(.green)
-                            }
-                        } else {
-                            Text(String(localized: "API key required"))
-                                .font(.caption)
-                                .foregroundStyle(.orange)
-                        }
-                    }
-                    .padding(10)
-                    .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
-                }
-            }
-
-            if case .error(let message) = registryService.fetchState {
-                HStack {
-                    Text(message)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                    Spacer()
-                    Button(String(localized: "Retry")) {
-                        Task { await registryService.fetchRegistry(force: true) }
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-            }
-
-            Divider()
-
-            Text(String(localized: "Prompt Presets"))
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.secondary)
-
-            HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(String(localized: "Built-in prompts for common tasks like translation, email drafting, and formatting."))
-                        .font(.caption)
+                    HStack(spacing: 7) {
+                        Text("Apple Speech")
+                            .font(.headline)
+                        Text(localizedAppText("Built-in", de: "Integriert"))
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Color.blue.opacity(0.18))
+                            .foregroundStyle(.blue)
+                            .clipShape(Capsule())
+                    }
+
+                    Text(appleSpeechDescription)
+                        .font(.callout)
                         .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer()
 
-                if promptActionsViewModel.availablePresets.isEmpty && !promptActionsViewModel.promptActions.isEmpty {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text(String(localized: "All imported"))
-                            .font(.caption)
-                            .foregroundStyle(.green)
-                    }
-                } else {
-                    Button(String(localized: "Import Presets")) {
-                        promptActionsViewModel.loadPresets()
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                appleSpeechStatus
+            }
+        }
+
+        if canSelectAppleSpeechForSetup {
+            card
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    Task { await activateAppleSpeechForSetup() }
                 }
-            }
-            .padding(12)
-            .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
-
-            Text(String(localized: "You can manage prompts and install more providers in the Prompts and Integrations tabs after setup."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .task {
-            if registryService.fetchState == .idle {
-                await registryService.fetchRegistry()
-            }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint(localizedAppText("Selects Apple Speech as the local dictation engine.", de: "Wählt Apple Speech als lokale Diktier-Engine aus."))
+        } else {
+            card
         }
     }
 
-    private var hasAnyLLMProvider: Bool {
-        if #available(macOS 26, *) {
-            if promptProcessingService.isAppleIntelligenceAvailable { return true }
+    private var appleSpeechDescription: String {
+        if isPreparingAppleSpeechFallback {
+            return localizedAppText(
+                "Preparing the built-in speech engine for the first dictation test.",
+                de: "Die integrierte Spracherkennung wird für den ersten Diktat-Test vorbereitet."
+            )
         }
-        return !pluginManager.llmProviders.isEmpty
-    }
 
-    private var groqAlreadyInstalled: Bool {
-        pluginManager.loadedPlugins.contains { $0.manifest.id == "com.typewhisper.groq" }
+        return localizedAppText(
+            "Lightweight built-in option with no large local model. Parakeet gives better quality for daily dictation.",
+            de: "Leichte integrierte Option ohne großes lokales Modell. Parakeet liefert bessere Qualität fürs tägliche Diktieren."
+        )
     }
 
     @ViewBuilder
-    private func llmProviderCard(
-        manifestId: String,
-        title: String,
-        badge: String,
-        description: String,
-        systemImage: String
-    ) -> some View {
-        let loadedPlugin = pluginManager.loadedPlugins.first { $0.manifest.id == manifestId }
-        let isInstalled = loadedPlugin != nil
-        let llmProvider = loadedPlugin?.instance as? any LLMProviderPlugin
-        let isReady = llmProvider?.isAvailable ?? false
-        let registryPlugin = registryService.registry.first { $0.id == manifestId }
-        let installState = registryService.installStates[manifestId]
-
-        HStack(spacing: 12) {
-            Image(systemName: systemImage)
-                .font(.title2)
-                .foregroundStyle(.blue)
-                .frame(width: 40, height: 40)
-                .background(Circle().fill(.blue.opacity(0.1)))
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(title)
-                        .font(.body.weight(.medium))
-
-                    Text(badge)
-                        .font(.caption2.weight(.semibold))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.blue.opacity(0.1))
-                        .foregroundStyle(.blue)
-                        .clipShape(Capsule())
+    private var appleSpeechStatus: some View {
+        if #available(macOS 26, *) {
+            if appleSpeechEngine?.isConfigured == true {
+                if modelManager.selectedProviderId == SetupWizardAppleSpeechFallback.providerId {
+                    statusPill(localizedAppText("Selected", de: "Ausgewählt"), systemImage: "checkmark.circle.fill", color: .blue)
+                } else {
+                    statusPill(localizedAppText("Select", de: "Auswählen"), systemImage: "circle", color: .blue)
                 }
-
-                Text(description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            if isReady {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "Ready"))
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                }
-            } else if isInstalled {
-                RecommendationSettingsButton(manifestId: manifestId)
-            } else if let installState {
-                switch installState {
-                case .downloading(let progress):
-                    ProgressView(value: progress)
-                        .frame(width: 60)
-                case .extracting:
-                    ProgressView()
-                        .controlSize(.small)
-                case .error(let message):
-                    Text(message)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(1)
-                }
-            } else if let registryPlugin {
-                Button(String(localized: "Install")) {
-                    Task {
-                        await registryService.downloadAndInstall(registryPlugin)
-                        PluginManager.shared.setPluginEnabled(registryPlugin.id, enabled: true)
-                    }
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            } else {
+            } else if isPreparingAppleSpeechFallback {
                 ProgressView()
                     .controlSize(.small)
+            } else if modelManager.selectedProviderId == SetupWizardAppleSpeechFallback.providerId {
+                statusPill(localizedAppText("Active", de: "Aktiv"), systemImage: "checkmark.circle.fill", color: .blue)
+            } else if let appleSpeechEngine, modelManager.canUseForTranscription(appleSpeechEngine) {
+                statusPill(localizedAppText("Select", de: "Auswählen"), systemImage: "circle", color: .blue)
+            } else {
+                statusPill(localizedAppText("Unavailable", de: "Nicht verfügbar"), systemImage: "circle", color: .secondary)
             }
+        } else {
+            statusPill(localizedAppText("macOS 26", de: "macOS 26"), systemImage: "circle", color: .secondary)
         }
-        .padding(12)
-        .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
     }
 
-    @available(macOS 26, *)
+    @ViewBuilder
     private var appleIntelligenceCard: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "wand.and.stars")
-                .font(.title2)
-                .foregroundStyle(.blue)
-                .frame(width: 40, height: 40)
-                .background(Circle().fill(.blue.opacity(0.1)))
+        setupCard(isSelected: false) {
+            HStack(spacing: 14) {
+                Image(systemName: "wand.and.stars")
+                    .font(.title2)
+                    .foregroundStyle(.blue)
+                    .frame(width: 36)
 
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text("Apple Intelligence")
-                        .font(.body.weight(.medium))
-
-                    Text(String(localized: "Built-in"))
-                        .font(.caption2.weight(.semibold))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.blue.opacity(0.1))
-                        .foregroundStyle(.blue)
-                        .clipShape(Capsule())
-                }
-
-                Text(String(localized: "On-device AI processing. No API key needed."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            if promptProcessingService.isAppleIntelligenceAvailable {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "Ready"))
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                }
-            } else {
-                Text(String(localized: "Enable in System Settings"))
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-        }
-        .padding(12)
-        .background(RoundedRectangle(cornerRadius: 10).fill(.quaternary))
-    }
-
-    // MARK: - Step 5: Try It Out
-
-    private var tryItOutStep: some View {
-        VStack(spacing: 20) {
-            if !hasAnyEngineReady || !hasAnyHotkeySet {
-                VStack(spacing: 12) {
-                    Image(systemName: "exclamationmark.circle")
-                        .font(.system(size: 36))
-                        .foregroundStyle(.secondary)
-
-                    if !hasAnyEngineReady {
-                        Text(String(localized: "No transcription engine is ready. Go back to set one up."))
-                            .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 7) {
+                        Text("Apple Intelligence")
+                            .font(.headline)
+                        Text(localizedAppText("Built-in", de: "Integriert"))
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Color.blue.opacity(0.18))
+                            .foregroundStyle(.blue)
+                            .clipShape(Capsule())
                     }
-                    if !hasAnyHotkeySet {
-                        Text(String(localized: "No hotkey is configured. Go back to set one up."))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 40)
-            } else if trialSuccess {
-                VStack(spacing: 12) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 48))
-                        .foregroundStyle(.green)
 
-                    Text(String(localized: "You're all set!"))
-                        .font(.title2.weight(.semibold))
-
-                    Text(String(localized: "TypeWhisper is ready to use in any app."))
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 20)
-                .transition(.opacity.combined(with: .scale(scale: 0.9)))
-            } else {
-                VStack(spacing: 12) {
-                    Text(String(localized: "Click the text field below, then press your hotkey and say something!"))
+                    Text(localizedAppText("On-device AI processing. No API key needed.", de: "KI-Verarbeitung auf dem Gerät. Kein API-Key nötig."))
                         .font(.callout)
                         .foregroundStyle(.secondary)
+                }
 
-                    HStack(spacing: 6) {
-                        Image(systemName: "keyboard")
-                            .foregroundStyle(.blue)
-                        Text(hotkeyLabel(for: selectedHotkeyMode))
-                            .font(.body.weight(.medium))
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(RoundedRectangle(cornerRadius: 6).fill(.blue.opacity(0.1)))
+                Spacer()
+
+                if #available(macOS 26, *) {
+                    if promptProcessingService.isAppleIntelligenceAvailable {
+                        statusPill(localizedAppText("Ready", de: "Bereit"), systemImage: "checkmark.circle.fill", color: .green)
+                    } else {
+                        statusPill(localizedAppText("Optional", de: "Optional"), systemImage: "circle", color: .secondary)
                     }
+                } else {
+                    statusPill(localizedAppText("macOS 26", de: "macOS 26"), systemImage: "circle", color: .secondary)
+                }
+            }
+        }
+    }
 
-                    TextEditor(text: $trialText)
-                        .font(.body)
-                        .frame(minHeight: 100)
-                        .scrollContentBackground(.hidden)
-                        .padding(8)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
-                        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.tertiary, lineWidth: 1))
-                        .focused($isTrialFieldFocused)
+    // MARK: - Finish
 
-                    if dictation.state == .recording {
-                        HStack(spacing: 6) {
-                            Circle()
-                                .fill(.red)
-                                .frame(width: 8, height: 8)
-                            Text(String(localized: "Recording..."))
+    private var finishStep: some View {
+        VStack(spacing: 14) {
+            HStack(spacing: 8) {
+                Image(systemName: "keyboard")
+                    .foregroundStyle(.blue)
+                hotkeyChip(label: primaryHotkeyLabel)
+            }
+            .font(.callout)
+
+            TextEditor(text: $trialText)
+                .font(.body)
+                .frame(minHeight: 112)
+                .scrollContentBackground(.hidden)
+                .padding(10)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.07)))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.white.opacity(0.16), lineWidth: 1))
+                .focused($isTrialFieldFocused)
+                .accessibilityLabel(localizedAppText("Try dictation text field", de: "Diktat-Testfeld"))
+                .accessibilityHint(localizedAppText("Press your hotkey and dictate. Inserted text appears here.", de: "Drücke deinen Hotkey und diktiere. Eingefügter Text erscheint hier."))
+
+            if trialSuccess {
+                setupCard(isSelected: false) {
+                    HStack(spacing: 14) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(.green)
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(localizedAppText("You're all set!", de: "Alles bereit!"))
+                                .font(.headline)
+                            Text(localizedAppText("TypeWhisper is ready to help you work faster.", de: "TypeWhisper ist bereit, damit du schneller arbeiten kannst."))
+                                .font(.callout)
                                 .foregroundStyle(.secondary)
                         }
-                        .font(.caption)
-                    } else if dictation.state == .processing {
-                        HStack(spacing: 6) {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text(String(localized: "Processing..."))
+
+                        Spacer()
+                    }
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            } else {
+                setupCard(isSelected: false) {
+                    HStack(spacing: 14) {
+                        Image(systemName: readinessIcon)
+                            .font(.title2)
+                            .foregroundStyle(readinessColor)
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(readinessTitle)
+                                .font(.headline)
+                            Text(readinessDescription)
+                                .font(.callout)
                                 .foregroundStyle(.secondary)
                         }
-                        .font(.caption)
-                    } else if case .error(let message) = dictation.state {
-                        HStack(spacing: 4) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.red)
-                            Text(message)
-                                .foregroundStyle(.red)
-                        }
-                        .font(.caption)
+
+                        Spacer()
                     }
                 }
             }
         }
         .onChange(of: dictation.state) { oldValue, newValue in
             if case .inserting = oldValue, case .idle = newValue {
-                withAnimation(.spring(duration: 0.4)) {
+                withAnimation(.spring(duration: 0.35)) {
                     trialSuccess = true
                 }
             }
@@ -1149,99 +1170,265 @@ struct SetupWizardView: View {
         }
     }
 
-    // MARK: - Navigation
-
-    private var navigation: some View {
-        HStack {
-            if currentStep == 5 && trialSuccess {
-                Spacer()
-            } else {
-                Button(currentStep == 5
-                    ? String(localized: "I'll try later")
-                    : String(localized: "Skip Setup")
-                ) {
-                    HomeViewModel.shared.completeSetupWizard()
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .font(.callout)
-
-                Spacer()
-            }
-
-            if currentStep == 5 {
-                if trialSuccess {
-                    Button(String(localized: "Try Again")) {
-                        trialSuccess = false
-                        trialText = ""
-                        Task {
-                            try? await Task.sleep(for: .milliseconds(50))
-                            isTrialFieldFocused = true
-                        }
-                    }
-                    .buttonStyle(.bordered)
-
-                    Button(String(localized: "Go to Dashboard")) {
-                        HomeViewModel.shared.completeSetupWizard()
-                    }
-                    .buttonStyle(.borderedProminent)
-                } else {
-                    Button(String(localized: "Back")) {
-                        withAnimation { currentStep -= 1 }
-                    }
-                    .buttonStyle(.bordered)
-                }
-            } else {
-                if currentStep > 1 {
-                    Button(String(localized: "Back")) {
-                        withAnimation { currentStep -= 1 }
-                    }
-                    .buttonStyle(.bordered)
-                }
-
-                nextButton
-            }
-        }
-        .padding()
+    private var readinessIcon: String {
+        hasEngineReadyForSetupTest && hasAnyTriggerHotkey ? "sparkles" : "exclamationmark.triangle.fill"
     }
 
-    @ViewBuilder
-    private var nextButton: some View {
-        if canProceed {
-            Button(String(localized: "Next")) {
-                withAnimation { currentStep += 1 }
-            }
-            .buttonStyle(.borderedProminent)
-            .frame(minWidth: 72)
-        } else {
-            Button(String(localized: "Next")) {}
-                .buttonStyle(.bordered)
-                .disabled(true)
-                .frame(minWidth: 72)
-        }
+    private var readinessColor: Color {
+        hasEngineReadyForSetupTest && hasAnyTriggerHotkey ? .blue : .orange
     }
 
-    // MARK: - Helpers
+    private var readinessTitle: String {
+        hasEngineReadyForSetupTest && hasAnyTriggerHotkey
+            ? localizedAppText("Try it out", de: "Probier es aus")
+            : localizedAppText("Setup can be finished later", de: "Setup kann später abgeschlossen werden")
+    }
+
+    private var readinessDescription: String {
+        if isPreparingAppleSpeechFallback {
+            return localizedAppText(
+                "Apple Speech is being prepared for this test.",
+                de: "Apple Speech wird gerade für diesen Test vorbereitet."
+            )
+        }
+        if !hasEngineReadyForSetupTest {
+            return localizedAppText(
+                "Apple Speech or another engine still needs to be enabled before dictation can run.",
+                de: "Apple Speech oder eine andere Engine muss noch aktiviert werden, bevor Diktieren funktioniert."
+            )
+        }
+        if !hasAnyTriggerHotkey {
+            return localizedAppText("A hotkey still needs to be set before dictation can start.", de: "Ein Hotkey muss noch gesetzt werden, bevor Diktieren starten kann.")
+        }
+        return localizedAppText("Press your hotkey and say something.", de: "Drücke deinen Hotkey und sag etwas.")
+    }
+
+    // MARK: - Shared Helpers
 
     private var canProceed: Bool {
-        switch currentStep {
-        case 1: return !dictation.needsMicPermission
-        case 2: return hasAnyEngineReady
-        case 3: return true
-        case 4: return true
-        default: return true
+        switch currentWizardStep {
+        case .permissions:
+            return true
+        case .hotkey:
+            return canProceedFromHotkey
+        default:
+            return true
         }
     }
 
-    private var hasAnyEngineReady: Bool {
-        _ = pluginManager.readinessRevision
-        return pluginManager.transcriptionEngines.contains { $0.isConfigured }
+    private var canProceedFromHotkey: Bool {
+        if hasAnyTriggerHotkey { return true }
+        if !dictation.hotkeys(for: selectedHotkeyMode).isEmpty { return true }
+        return selectedHotkeyMode == .hybrid && recommendedHotkeyResolution.shouldApply
     }
 
-    private var hasAnyHotkeySet: Bool {
-        !DictationSettingsHandler.loadHotkeys(for: .hybrid).isEmpty
-            || !DictationSettingsHandler.loadHotkeys(for: .pushToTalk).isEmpty
-            || !DictationSettingsHandler.loadHotkeys(for: .toggle).isEmpty
+    private var hasEngineReadyForSetupTest: Bool {
+        _ = pluginManager.readinessRevision
+        guard let engine = selectedTranscriptionEngineForSetup else { return false }
+        return canUseEngineForSetupTest(engine)
+    }
+
+    private var selectedTranscriptionEngineForSetup: TranscriptionEnginePlugin? {
+        guard let providerId = modelManager.selectedProviderId else { return nil }
+        return pluginManager.transcriptionEngine(for: providerId)
+    }
+
+    private var appleSpeechEngine: TranscriptionEnginePlugin? {
+        pluginManager.transcriptionEngine(for: SetupWizardAppleSpeechFallback.providerId)
+    }
+
+    private var parakeetEngine: TranscriptionEnginePlugin? {
+        pluginManager.transcriptionEngine(for: SetupWizardParakeetRecommendation.providerId)
+    }
+
+    private var isParakeetReadyForSetup: Bool {
+        guard let parakeetEngine else { return false }
+        return canUseEngineForSetupTest(parakeetEngine)
+    }
+
+    private var canUseAppleSpeechFallback: Bool {
+        canUseAppleSpeechFallbackEngine(appleSpeechEngine)
+    }
+
+    private var canSelectAppleSpeechForSetup: Bool {
+        canUseAppleSpeechFallback
+    }
+
+    private func canUseEngineForSetupTest(_ engine: TranscriptionEnginePlugin) -> Bool {
+        guard modelManager.canUseForTranscription(engine) else { return false }
+        if engine.isConfigured { return true }
+        return engine.providerId != SetupWizardAppleSpeechFallback.providerId && engine.selectedModelId != nil
+    }
+
+    private func canUseAppleSpeechFallbackEngine(_ engine: TranscriptionEnginePlugin?) -> Bool {
+        guard #available(macOS 26, *) else { return false }
+        guard let engine, modelManager.canUseForTranscription(engine) else { return false }
+        return engine.isConfigured || !engine.modelCatalog.isEmpty
+    }
+
+    @MainActor
+    private func activateAppleSpeechForSetup() async {
+        manuallySelectedSetupProviderId = SetupWizardAppleSpeechFallback.providerId
+        ensureAppleSpeechPluginEnabledIfPossible()
+
+        guard let appleSpeechEngine = await waitForAppleSpeechEngine(),
+              modelManager.canUseForTranscription(appleSpeechEngine) else {
+            return
+        }
+
+        modelManager.selectProvider(appleSpeechEngine.providerId)
+        guard !appleSpeechEngine.isConfigured else { return }
+
+        isPreparingAppleSpeechFallback = true
+        defer { isPreparingAppleSpeechFallback = false }
+
+        for _ in 0..<40 {
+            if Task.isCancelled { return }
+            if appleSpeechEngine.isConfigured { return }
+            if let modelId = SetupWizardAppleSpeechFallback.preferredModelId(from: appleSpeechEngine.modelCatalog) {
+                appleSpeechEngine.selectModel(modelId)
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+
+        for _ in 0..<40 {
+            if Task.isCancelled || appleSpeechEngine.isConfigured { return }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+    }
+
+    @MainActor
+    private func preparePreferredSetupEngineIfNeeded() async {
+        guard !isActivatingParakeet else { return }
+
+        if let manuallySelectedSetupProviderId,
+           let manuallySelectedEngine = pluginManager.transcriptionEngine(for: manuallySelectedSetupProviderId),
+           canUseEngineForSetupTest(manuallySelectedEngine) {
+            modelManager.selectProvider(manuallySelectedEngine.providerId)
+            return
+        }
+
+        let selectedEngineReady = selectedTranscriptionEngineForSetup.map(canUseEngineForSetupTest) ?? false
+        let preferredProviderId = SetupWizardEngineSelection.preferredProviderId(
+            selectedProviderId: modelManager.selectedProviderId,
+            selectedEngineReady: selectedEngineReady,
+            parakeetReady: isParakeetReadyForSetup,
+            appleSpeechAvailable: canUseAppleSpeechFallback
+        )
+
+        if preferredProviderId == SetupWizardParakeetRecommendation.providerId, let parakeetEngine {
+            modelManager.selectProvider(parakeetEngine.providerId)
+            return
+        }
+
+        if let selectedEngine = selectedTranscriptionEngineForSetup,
+           selectedEngineReady,
+           preferredProviderId == selectedEngine.providerId {
+            modelManager.selectProvider(selectedEngine.providerId)
+            return
+        }
+
+        guard !isPreparingAppleSpeechFallback else {
+            return
+        }
+
+        ensureAppleSpeechPluginEnabledIfPossible()
+
+        guard let appleSpeechEngine = await waitForAppleSpeechEngine(),
+              modelManager.canUseForTranscription(appleSpeechEngine),
+              SetupWizardEngineSelection.preferredProviderId(
+                selectedProviderId: modelManager.selectedProviderId,
+                selectedEngineReady: selectedEngineReady,
+                parakeetReady: isParakeetReadyForSetup,
+                appleSpeechAvailable: true
+              ) == SetupWizardAppleSpeechFallback.providerId else {
+            return
+        }
+
+        modelManager.selectProvider(appleSpeechEngine.providerId)
+        guard !appleSpeechEngine.isConfigured else { return }
+
+        isPreparingAppleSpeechFallback = true
+        defer { isPreparingAppleSpeechFallback = false }
+
+        for _ in 0..<40 {
+            if Task.isCancelled { return }
+            if appleSpeechEngine.isConfigured { return }
+            if let modelId = SetupWizardAppleSpeechFallback.preferredModelId(from: appleSpeechEngine.modelCatalog) {
+                appleSpeechEngine.selectModel(modelId)
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+
+        for _ in 0..<40 {
+            if Task.isCancelled || appleSpeechEngine.isConfigured { return }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+    }
+
+    @MainActor
+    private func ensureAppleSpeechPluginEnabledIfPossible() {
+        guard appleSpeechEngine == nil,
+              let loaded = pluginManager.loadedPlugins.first(where: { $0.manifest.id == SetupWizardAppleSpeechFallback.manifestId }),
+              !loaded.isEnabled else {
+            return
+        }
+
+        pluginManager.setPluginEnabled(SetupWizardAppleSpeechFallback.manifestId, enabled: true)
+    }
+
+    @MainActor
+    private func waitForAppleSpeechEngine() async -> TranscriptionEnginePlugin? {
+        for _ in 0..<20 {
+            if Task.isCancelled { return nil }
+            if let appleSpeechEngine {
+                return appleSpeechEngine
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+
+        return appleSpeechEngine
+    }
+
+    private var hasAnyTriggerHotkey: Bool {
+        SetupWizardDefaultHotkey.triggerSlots.contains { !dictation.hotkeys(for: $0).isEmpty }
+    }
+
+    private var recommendedHotkeyResolution: SetupWizardDefaultHotkey.Resolution {
+        SetupWizardDefaultHotkey.resolve(
+            existingTriggerHotkeys: SetupWizardDefaultHotkey.triggerSlots.reduce(into: [:]) { result, slot in
+                result[slot] = dictation.hotkeys(for: slot)
+            },
+            conflictingSlot: dictation.isHotkeyAssigned(SetupWizardDefaultHotkey.recommendedHybridHotkey, excluding: .hybrid)
+        )
+    }
+
+    private func applyRecommendedHotkeyIfNeeded() {
+        guard selectedHotkeyMode == .hybrid,
+              recommendedHotkeyResolution.shouldApply else {
+            return
+        }
+
+        dictation.setHotkey(SetupWizardDefaultHotkey.recommendedHybridHotkey, for: .hybrid)
+    }
+
+    private var primaryHotkeyLabel: String {
+        for slot in SetupWizardDefaultHotkey.triggerSlots {
+            let label = hotkeyLabel(for: slot)
+            if !label.isEmpty { return label }
+        }
+        return localizedAppText("No hotkey", de: "Kein Hotkey")
+    }
+
+    private func displayedHotkeyLabel(for mode: HotkeySlotType) -> String {
+        let label = hotkeyLabel(for: mode)
+        if !label.isEmpty { return label }
+        if mode == .hybrid, recommendedHotkeyResolution.shouldApply {
+            return HotkeyService.displayName(for: SetupWizardDefaultHotkey.recommendedHybridHotkey)
+        }
+        return localizedAppText("Not set", de: "Nicht gesetzt")
     }
 
     private func hotkeyLabel(for mode: HotkeySlotType) -> String {
@@ -1258,13 +1445,235 @@ struct SetupWizardView: View {
 
     private func hotkeyModeTitle(for mode: HotkeySlotType) -> String {
         switch mode {
-        case .hybrid: return String(localized: "Hybrid")
-        case .pushToTalk: return String(localized: "Push-to-Talk")
-        case .toggle: return String(localized: "Toggle")
+        case .hybrid: return localizedAppText("Hybrid", de: "Hybrid")
+        case .pushToTalk: return localizedAppText("Push-to-Talk", de: "Push-to-Talk")
+        case .toggle: return localizedAppText("Toggle", de: "Toggle")
         case .promptPalette: return localizedAppText("Workflow Palette", de: "Workflow-Palette")
         case .recentTranscriptions: return String(localized: "Recent Transcriptions")
         case .copyLastTranscription: return String(localized: "Copy Last Transcription")
         case .recorderToggle: return String(localized: "settings.tab.recorder")
+        }
+    }
+
+    private func setupCard<Content: View>(
+        isSelected: Bool,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.blue.opacity(0.12) : Color.white.opacity(0.07))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(isSelected ? Color.blue.opacity(0.65) : Color.white.opacity(0.11), lineWidth: 1)
+            )
+    }
+
+    private func statusPill(_ text: String, systemImage: String, color: Color) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(color.opacity(0.16))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+            .lineLimit(1)
+    }
+
+    private func hotkeyChip(label: String) -> some View {
+        Text(label)
+            .font(.callout.weight(.semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.10)))
+            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Color.white.opacity(0.14), lineWidth: 1))
+            .lineLimit(1)
+    }
+}
+
+private enum SetupWizardStep: Int, CaseIterable, Identifiable {
+    case welcome
+    case permissions
+    case hotkey
+    case engineAI
+    case finish
+
+    var id: Int { rawValue }
+
+    var progressTitle: String {
+        switch self {
+        case .welcome:
+            localizedAppText("Welcome", de: "Willkommen")
+        case .permissions:
+            localizedAppText("Permissions", de: "Rechte")
+        case .hotkey:
+            localizedAppText("Hotkey", de: "Hotkey")
+        case .engineAI:
+            localizedAppText("AI & Engine", de: "KI & Engine")
+        case .finish:
+            localizedAppText("Finish", de: "Fertig")
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .welcome:
+            localizedAppText("Welcome to TypeWhisper", de: "Willkommen bei TypeWhisper")
+        case .permissions:
+            localizedAppText("Permissions", de: "Berechtigungen")
+        case .hotkey:
+            localizedAppText("Choose Your Hotkey", de: "Wähle deinen Hotkey")
+        case .engineAI:
+            localizedAppText("AI & Engine", de: "KI & Engine")
+        case .finish:
+            localizedAppText("Try It Out", de: "Probier es aus")
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .welcome:
+            localizedAppText("Set up voice typing in a few simple steps.", de: "Richte Voice Typing in wenigen Schritten ein.")
+        case .permissions:
+            localizedAppText("TypeWhisper needs access to work on your Mac.", de: "TypeWhisper braucht Zugriff, um auf deinem Mac zu funktionieren.")
+        case .hotkey:
+            localizedAppText("Start and stop dictation without leaving your app.", de: "Starte und stoppe Diktat, ohne deine App zu verlassen.")
+        case .engineAI:
+            localizedAppText("Local defaults are ready first; cloud providers can wait.", de: "Lokale Defaults zuerst; Cloud-Provider können warten.")
+        case .finish:
+            localizedAppText("Press your hotkey and say something.", de: "Drücke deinen Hotkey und sag etwas.")
+        }
+    }
+}
+
+enum SetupWizardDefaultHotkey {
+    enum BlockedReason: Equatable {
+        case existingTriggerHotkey
+        case conflictingSlot(HotkeySlotType)
+    }
+
+    struct Resolution: Equatable {
+        let shouldApply: Bool
+        let blockedReason: BlockedReason?
+    }
+
+    static let triggerSlots: [HotkeySlotType] = [.hybrid, .pushToTalk, .toggle]
+    static let recommendedHybridHotkey = UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
+
+    static func resolve(
+        existingTriggerHotkeys: [HotkeySlotType: [UnifiedHotkey]],
+        conflictingSlot: HotkeySlotType?
+    ) -> Resolution {
+        if triggerSlots.contains(where: { !(existingTriggerHotkeys[$0] ?? []).isEmpty }) {
+            return Resolution(shouldApply: false, blockedReason: .existingTriggerHotkey)
+        }
+
+        if let conflictingSlot {
+            return Resolution(shouldApply: false, blockedReason: .conflictingSlot(conflictingSlot))
+        }
+
+        return Resolution(shouldApply: true, blockedReason: nil)
+    }
+}
+
+enum SetupWizardParakeetRecommendation {
+    static let providerId = "parakeet"
+    static let manifestId = "com.typewhisper.parakeet"
+
+    static var description: String {
+        localizedAppText(
+            "Best local quality for daily dictation. Runs offline with no API key.",
+            de: "Beste lokale Qualität für tägliches Diktieren. Läuft offline ohne API-Key."
+        )
+    }
+
+    static func preferredModelId(from models: [PluginModelInfo]) -> String? {
+        models.first { $0.id == "parakeet-tdt-0.6b-v3" }?.id
+            ?? models.first { $0.id.localizedCaseInsensitiveContains("v3") }?.id
+            ?? models.first?.id
+    }
+}
+
+enum SetupWizardEngineSelection {
+    static func preferredProviderId(
+        selectedProviderId: String?,
+        selectedEngineReady: Bool,
+        parakeetReady: Bool,
+        appleSpeechAvailable: Bool
+    ) -> String? {
+        if parakeetReady, selectedProviderId == SetupWizardAppleSpeechFallback.providerId {
+            return SetupWizardParakeetRecommendation.providerId
+        }
+
+        if selectedEngineReady {
+            return selectedProviderId
+        }
+
+        if parakeetReady {
+            return SetupWizardParakeetRecommendation.providerId
+        }
+
+        if appleSpeechAvailable {
+            return SetupWizardAppleSpeechFallback.providerId
+        }
+
+        return nil
+    }
+}
+
+enum SetupWizardAppleSpeechFallback {
+    static let providerId = "speechAnalyzer"
+    static let manifestId = "com.typewhisper.speechanalyzer"
+
+    static func preferredModelId(
+        from models: [PluginModelInfo],
+        localeIdentifier: String = Locale.current.identifier,
+        languageCode: String? = Locale.current.language.languageCode?.identifier
+    ) -> String? {
+        guard !models.isEmpty else { return nil }
+
+        for modelId in localeModelIds(for: localeIdentifier) {
+            if models.contains(where: { $0.id == modelId }) {
+                return modelId
+            }
+        }
+
+        if let languageCode {
+            let languageModelId = "speechanalyzer-\(languageCode)"
+            if models.contains(where: { $0.id == languageModelId }) {
+                return languageModelId
+            }
+
+            if let match = models.first(where: { modelLanguageCode(for: $0.id) == languageCode }) {
+                return match.id
+            }
+        }
+
+        return models.first?.id
+    }
+
+    private static func localeModelIds(for localeIdentifier: String) -> [String] {
+        uniqueModelIds([
+            localeIdentifier,
+            localeIdentifier.replacingOccurrences(of: "-", with: "_"),
+            localeIdentifier.replacingOccurrences(of: "_", with: "-")
+        ])
+        .map { "speechanalyzer-\($0)" }
+    }
+
+    private static func modelLanguageCode(for modelId: String) -> String? {
+        let prefix = "speechanalyzer-"
+        guard modelId.hasPrefix(prefix) else { return nil }
+        let localeIdentifier = String(modelId.dropFirst(prefix.count))
+        return Locale(identifier: localeIdentifier).language.languageCode?.identifier
+    }
+
+    private static func uniqueModelIds(_ values: [String]) -> [String] {
+        values.reduce(into: []) { result, value in
+            guard !value.isEmpty, !result.contains(value) else { return }
+            result.append(value)
         }
     }
 }
@@ -1317,6 +1726,10 @@ enum SetupWizardRecommendationAvailability: Equatable {
         fetchState: PluginRegistryService.FetchState,
         architecture: String = RuntimeArchitecture.current
     ) -> SetupWizardRecommendationAvailability {
+        if manifestId == SetupWizardParakeetRecommendation.manifestId, architecture != "arm64" {
+            return .unavailable(.appleSiliconOnly)
+        }
+
         if isReady {
             return .ready
         }
@@ -1337,9 +1750,6 @@ enum SetupWizardRecommendationAvailability: Equatable {
         case .idle, .loading:
             return .loading
         case .loaded, .error(_):
-            if manifestId == "com.typewhisper.parakeet", architecture != "arm64" {
-                return .unavailable(.appleSiliconOnly)
-            }
             return .unavailable(.marketplaceUnavailable)
         }
     }
@@ -1362,65 +1772,10 @@ private struct RecommendationSettingsButton: View {
                 }
             }
         } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "gear")
-                Text(String(localized: "Setup"))
-                    .font(.caption)
-            }
+            Label(localizedAppText("Setup", de: "Setup"), systemImage: "gear")
+                .font(.caption)
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-    }
-}
-
-// MARK: - Engine Row
-
-private struct SetupEngineRow: View {
-    let engine: any TranscriptionEnginePlugin
-    @ObservedObject private var pluginManager = PluginManager.shared
-
-    var body: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(engine.providerDisplayName)
-                    .font(.body.weight(.medium))
-
-                if engine.isConfigured, let modelId = engine.selectedModelId,
-                   let model = engine.transcriptionModels.first(where: { $0.id == modelId }) {
-                    Text(model.displayName)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Spacer()
-
-            if engine.isConfigured {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "Ready"))
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                }
-            } else {
-                Text(String(localized: "Not configured"))
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-
-            if let loaded = PluginManager.shared.loadedPlugins.first(where: {
-                ($0.instance as? any TranscriptionEnginePlugin)?.providerId == engine.providerId
-            }), loaded.instance.settingsView != nil {
-                Button {
-                    PluginSettingsWindowManager.shared.present(loaded)
-                } label: {
-                    Image(systemName: "gear")
-                }
-                .buttonStyle(.borderless)
-            }
-        }
-        .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
     }
 }

--- a/TypeWhisperTests/SetupWizardRecommendationAvailabilityTests.swift
+++ b/TypeWhisperTests/SetupWizardRecommendationAvailabilityTests.swift
@@ -1,8 +1,185 @@
 import XCTest
+import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
-    func testParakeetOnIntelIsUnavailableAfterRegistryLoaded() {
+    func testAppleSpeechFallbackPrefersExactLocaleModel() {
+        let modelId = SetupWizardAppleSpeechFallback.preferredModelId(
+            from: [
+                PluginModelInfo(id: "speechanalyzer-en_US", displayName: "English"),
+                PluginModelInfo(id: "speechanalyzer-de_DE", displayName: "German")
+            ],
+            localeIdentifier: "de_DE",
+            languageCode: "de"
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-de_DE")
+    }
+
+    func testAppleSpeechFallbackMatchesLocaleSeparatorVariant() {
+        let modelId = SetupWizardAppleSpeechFallback.preferredModelId(
+            from: [
+                PluginModelInfo(id: "speechanalyzer-de-DE", displayName: "German"),
+                PluginModelInfo(id: "speechanalyzer-en_US", displayName: "English")
+            ],
+            localeIdentifier: "de_DE",
+            languageCode: "de"
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-de-DE")
+    }
+
+    func testAppleSpeechFallbackUsesLanguageModelWhenExactLocaleIsMissing() {
+        let modelId = SetupWizardAppleSpeechFallback.preferredModelId(
+            from: [
+                PluginModelInfo(id: "speechanalyzer-en_US", displayName: "English"),
+                PluginModelInfo(id: "speechanalyzer-de_CH", displayName: "German Switzerland")
+            ],
+            localeIdentifier: "de_DE",
+            languageCode: "de"
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-de_CH")
+    }
+
+    func testAppleSpeechFallbackUsesFirstModelWhenLocaleCannotMatch() {
+        let modelId = SetupWizardAppleSpeechFallback.preferredModelId(
+            from: [
+                PluginModelInfo(id: "speechanalyzer-fr_FR", displayName: "French"),
+                PluginModelInfo(id: "speechanalyzer-en_US", displayName: "English")
+            ],
+            localeIdentifier: "de_DE",
+            languageCode: "de"
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-fr_FR")
+    }
+
+    func testAppleSpeechFallbackReturnsNilForEmptyModelCatalog() {
+        let modelId = SetupWizardAppleSpeechFallback.preferredModelId(
+            from: [],
+            localeIdentifier: "de_DE",
+            languageCode: "de"
+        )
+
+        XCTAssertNil(modelId)
+    }
+
+    func testEngineSelectionUsesAppleSpeechWhenNoEngineAndParakeetIsUnavailable() {
+        let providerId = SetupWizardEngineSelection.preferredProviderId(
+            selectedProviderId: nil,
+            selectedEngineReady: false,
+            parakeetReady: false,
+            appleSpeechAvailable: true
+        )
+
+        XCTAssertEqual(providerId, SetupWizardAppleSpeechFallback.providerId)
+    }
+
+    func testEngineSelectionKeepsReadySelectedEngine() {
+        let providerId = SetupWizardEngineSelection.preferredProviderId(
+            selectedProviderId: "groq",
+            selectedEngineReady: true,
+            parakeetReady: true,
+            appleSpeechAvailable: true
+        )
+
+        XCTAssertEqual(providerId, "groq")
+    }
+
+    func testEngineSelectionPrefersReadyParakeetOverReadyAppleSpeechFallback() {
+        let providerId = SetupWizardEngineSelection.preferredProviderId(
+            selectedProviderId: SetupWizardAppleSpeechFallback.providerId,
+            selectedEngineReady: true,
+            parakeetReady: true,
+            appleSpeechAvailable: true
+        )
+
+        XCTAssertEqual(providerId, SetupWizardParakeetRecommendation.providerId)
+    }
+
+    func testEngineSelectionPrefersParakeetBeforeAppleSpeech() {
+        let providerId = SetupWizardEngineSelection.preferredProviderId(
+            selectedProviderId: nil,
+            selectedEngineReady: false,
+            parakeetReady: true,
+            appleSpeechAvailable: true
+        )
+
+        XCTAssertEqual(providerId, SetupWizardParakeetRecommendation.providerId)
+    }
+
+    func testEngineSelectionReturnsNilWhenNoLocalFallbackIsAvailable() {
+        let providerId = SetupWizardEngineSelection.preferredProviderId(
+            selectedProviderId: nil,
+            selectedEngineReady: false,
+            parakeetReady: false,
+            appleSpeechAvailable: false
+        )
+
+        XCTAssertNil(providerId)
+    }
+
+    func testParakeetRecommendationPrefersV3Model() {
+        let modelId = SetupWizardParakeetRecommendation.preferredModelId(
+            from: [
+                PluginModelInfo(id: "parakeet-tdt-0.6b-v2", displayName: "Parakeet TDT v2"),
+                PluginModelInfo(id: "parakeet-tdt-0.6b-v3", displayName: "Parakeet TDT v3")
+            ]
+        )
+
+        XCTAssertEqual(modelId, "parakeet-tdt-0.6b-v3")
+    }
+
+    func testRecommendedHybridFnCanBeAppliedWhenTriggerSlotsAreEmpty() {
+        let state = SetupWizardDefaultHotkey.resolve(
+            existingTriggerHotkeys: [:],
+            conflictingSlot: nil
+        )
+
+        XCTAssertEqual(
+            state,
+            SetupWizardDefaultHotkey.Resolution(shouldApply: true, blockedReason: nil)
+        )
+        XCTAssertEqual(
+            SetupWizardDefaultHotkey.recommendedHybridHotkey,
+            UnifiedHotkey(keyCode: 0, modifierFlags: 0, isFn: true)
+        )
+    }
+
+    func testRecommendedHybridFnDoesNotOverrideExistingTriggerHotkey() {
+        let state = SetupWizardDefaultHotkey.resolve(
+            existingTriggerHotkeys: [
+                .pushToTalk: [UnifiedHotkey(keyCode: 0x69, modifierFlags: 0, isFn: false)]
+            ],
+            conflictingSlot: nil
+        )
+
+        XCTAssertEqual(
+            state,
+            SetupWizardDefaultHotkey.Resolution(
+                shouldApply: false,
+                blockedReason: .existingTriggerHotkey
+            )
+        )
+    }
+
+    func testRecommendedHybridFnDoesNotOverrideConflictingSlot() {
+        let state = SetupWizardDefaultHotkey.resolve(
+            existingTriggerHotkeys: [:],
+            conflictingSlot: .promptPalette
+        )
+
+        XCTAssertEqual(
+            state,
+            SetupWizardDefaultHotkey.Resolution(
+                shouldApply: false,
+                blockedReason: .conflictingSlot(.promptPalette)
+            )
+        )
+    }
+
+    func testParakeetOnIntelIsUnavailableImmediately() {
         let state = SetupWizardRecommendationAvailability.resolve(
             manifestId: "com.typewhisper.parakeet",
             isInstalled: false,
@@ -16,7 +193,7 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
         XCTAssertEqual(state, .unavailable(.appleSiliconOnly))
     }
 
-    func testMissingPluginStillLoadsWhileRegistryIsLoading() {
+    func testParakeetOnIntelDoesNotShowLoadingWhileRegistryIsLoading() {
         let state = SetupWizardRecommendationAvailability.resolve(
             manifestId: "com.typewhisper.parakeet",
             isInstalled: false,
@@ -27,7 +204,21 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
             architecture: "x86_64"
         )
 
-        XCTAssertEqual(state, .loading)
+        XCTAssertEqual(state, .unavailable(.appleSiliconOnly))
+    }
+
+    func testParakeetOnIntelDoesNotShowInstallState() {
+        let state = SetupWizardRecommendationAvailability.resolve(
+            manifestId: "com.typewhisper.parakeet",
+            isInstalled: false,
+            isReady: false,
+            registryPlugin: nil,
+            installState: .downloading(0.42),
+            fetchState: .loaded,
+            architecture: "x86_64"
+        )
+
+        XCTAssertEqual(state, .unavailable(.appleSiliconOnly))
     }
 
     func testCompatibleRegistryEntryCanBeInstalled() {
@@ -44,7 +235,7 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
         XCTAssertEqual(state, .installAvailable)
     }
 
-    func testInstallStateTakesPrecedenceOverUnavailableRecommendation() {
+    func testInstallStateTakesPrecedenceForCompatibleArchitecture() {
         let state = SetupWizardRecommendationAvailability.resolve(
             manifestId: "com.typewhisper.parakeet",
             isInstalled: false,
@@ -52,13 +243,13 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
             registryPlugin: nil,
             installState: .downloading(0.42),
             fetchState: .loaded,
-            architecture: "x86_64"
+            architecture: "arm64"
         )
 
         XCTAssertEqual(state, .installState(.downloading(0.42)))
     }
 
-    func testReadyStateTakesPrecedenceOverUnavailableRecommendation() {
+    func testReadyStateTakesPrecedenceForCompatibleArchitecture() {
         let state = SetupWizardRecommendationAvailability.resolve(
             manifestId: "com.typewhisper.parakeet",
             isInstalled: true,
@@ -66,13 +257,13 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
             registryPlugin: nil,
             installState: nil,
             fetchState: .loaded,
-            architecture: "x86_64"
+            architecture: "arm64"
         )
 
         XCTAssertEqual(state, .ready)
     }
 
-    func testInstalledStateTakesPrecedenceOverUnavailableRecommendation() {
+    func testInstalledStateTakesPrecedenceForCompatibleArchitecture() {
         let state = SetupWizardRecommendationAvailability.resolve(
             manifestId: "com.typewhisper.parakeet",
             isInstalled: true,
@@ -80,13 +271,13 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
             registryPlugin: nil,
             installState: nil,
             fetchState: .loaded,
-            architecture: "x86_64"
+            architecture: "arm64"
         )
 
         XCTAssertEqual(state, .setupRequired)
     }
 
-    func testErrorInstallStateTakesPrecedenceOverUnavailableRecommendation() {
+    func testErrorInstallStateTakesPrecedenceForCompatibleArchitecture() {
         let state = SetupWizardRecommendationAvailability.resolve(
             manifestId: "com.typewhisper.parakeet",
             isInstalled: false,
@@ -94,7 +285,7 @@ final class SetupWizardRecommendationAvailabilityTests: XCTestCase {
             registryPlugin: nil,
             installState: .error("Download failed"),
             fetchState: .loaded,
-            architecture: "x86_64"
+            architecture: "arm64"
         )
 
         XCTAssertEqual(state, .installState(.error("Download failed")))


### PR DESCRIPTION
## Summary
- Move first-run setup into a standalone macOS setup window instead of rendering it in Home settings.
- Rework setup into five focused installer steps: welcome, permissions, hotkey, AI & Engine, and finish.
- Add Fn as the recommended Hybrid hotkey default, preserve existing hotkeys, and expose a manual `Open Setup Wizard` action from About.
- Bundle and prepare Apple Speech as a local fallback while keeping Parakeet visually recommended and selectable from the full row.

## Issue Context
No GitHub issue. This implements the requested product/UI iteration from local review of the TypeWhisper setup flow.

## Test Plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/SetupWizardRecommendationAvailabilityTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/33b9/typewhisper-mac`

## Verification
- Full app XCTest suite passed: 718 tests, 0 failures.
- Dev app rebuilt and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup wizard now auto-launches on first application run.
  * Added option to reopen setup wizard from About Settings.

* **Improvements**
  * Enhanced accessibility permission handling for hotkey functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->