### PR TITLE
Fix: indicator panels invisible over fullscreen apps

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -367,6 +367,21 @@ enum IndicatorWindowFrameLookup {
     }
 }
 
+/// Where an indicator panel renders relative to the display's notch safe area.
+///
+/// The fullscreen-suppression policy exists to avoid drawing the indicator
+/// underneath a foreign fullscreen window that has expanded into the notch
+/// strip on notched MacBooks (see #373, #543). Indicators that render away
+/// from the notch strip (e.g. a bottom-aligned overlay) cannot collide with
+/// that area, so suppression should not apply to them (see #602).
+enum IndicatorPlacement {
+    /// Indicator renders inside or adjacent to the notch safe-area strip.
+    case notchStrip
+    /// Indicator renders entirely outside the notch safe-area strip
+    /// (for example, a bottom-aligned overlay).
+    case nonNotchArea
+}
+
 enum IndicatorFullscreenSuppressionPolicy {
     private static let minimumHorizontalCoverage: CGFloat = 0.5
     private static let minimumVerticalCoverage: CGFloat = 0.5
@@ -381,6 +396,7 @@ enum IndicatorFullscreenSuppressionPolicy {
     @MainActor
     static func shouldSuppressIndicator(
         on screen: NSScreen,
+        placement: IndicatorPlacement = .notchStrip,
         frontmostApplicationProvider: () -> NSRunningApplication? = {
             ActivationSourceTracker.shared.lastExternalApplication ?? NSWorkspace.shared.frontmostApplication
         },
@@ -389,6 +405,10 @@ enum IndicatorFullscreenSuppressionPolicy {
         windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
         appBundleIdentifier: String? = Bundle.main.bundleIdentifier
     ) -> Bool {
+        guard placement == .notchStrip else {
+            return false
+        }
+
         guard let application = frontmostApplicationProvider() else {
             return false
         }
@@ -407,7 +427,8 @@ enum IndicatorFullscreenSuppressionPolicy {
             windowFrame: windowFrame,
             focusedWindowIsFullscreen: focusedWindowIsFullscreen,
             frontmostBundleIdentifier: application.bundleIdentifier,
-            appBundleIdentifier: appBundleIdentifier
+            appBundleIdentifier: appBundleIdentifier,
+            placement: placement
         )
 
         if shouldSuppress {
@@ -429,8 +450,13 @@ enum IndicatorFullscreenSuppressionPolicy {
         windowFrame: CGRect?,
         focusedWindowIsFullscreen: Bool? = nil,
         frontmostBundleIdentifier: String?,
-        appBundleIdentifier: String?
+        appBundleIdentifier: String?,
+        placement: IndicatorPlacement = .notchStrip
     ) -> Bool {
+        guard placement == .notchStrip else {
+            return false
+        }
+
         guard safeAreaTopInset > 0,
               let candidateWindowFrame = windowFrame,
               !screenFrame.isEmpty,

--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -8,14 +8,14 @@ enum FloatingPanelSpacePolicy {
 
     private static let activeSpaceIndicatorCollectionBehavior: NSWindow.CollectionBehavior = [
         .moveToActiveSpace,
-        .fullScreenNone,
+        .fullScreenAuxiliary,
         .stationary,
         .ignoresCycle
     ]
 
     private static let fixedDisplayIndicatorCollectionBehavior: NSWindow.CollectionBehavior = [
         .canJoinAllSpaces,
-        .fullScreenNone,
+        .fullScreenAuxiliary,
         .stationary,
         .ignoresCycle
     ]

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -115,7 +115,9 @@ class MinimalIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
-        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen) {
+        let overlayPosition = DictationViewModel.shared.overlayPosition
+        let placement: IndicatorPlacement = overlayPosition == .top ? .notchStrip : .nonNotchArea
+        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen, placement: placement) {
             suppressForForeignFullscreen()
             return
         }
@@ -124,7 +126,7 @@ class MinimalIndicatorPanel: NSPanel {
         let x = screenFrame.midX - Self.panelWidth / 2
 
         let y: CGFloat
-        switch DictationViewModel.shared.overlayPosition {
+        switch overlayPosition {
         case .bottom:
             y = screenFrame.origin.y + 20
         case .top:

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -147,7 +147,7 @@ class NotchIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
-        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen) {
+        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen, placement: .notchStrip) {
             suppressForForeignFullscreen()
             return
         }

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -115,7 +115,9 @@ class OverlayIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
-        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen) {
+        let overlayPosition = DictationViewModel.shared.overlayPosition
+        let placement: IndicatorPlacement = overlayPosition == .top ? .notchStrip : .nonNotchArea
+        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen, placement: placement) {
             suppressForForeignFullscreen()
             return
         }
@@ -124,7 +126,7 @@ class OverlayIndicatorPanel: NSPanel {
         let x = screenFrame.midX - Self.panelWidth / 2
 
         let y: CGFloat
-        switch DictationViewModel.shared.overlayPosition {
+        switch overlayPosition {
         case .bottom:
             y = screenFrame.origin.y + 20
         case .top:

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -313,6 +313,36 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
             )
         )
     }
+
+    func testDoesNotSuppressNonNotchPlacementEvenOverForeignFullscreenWindow() {
+        let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenWindow,
+                frontmostBundleIdentifier: "com.apple.ScreenSharing",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea
+            )
+        )
+    }
+
+    func testNotchStripPlacementStillSuppressesAsBefore() {
+        let fullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenWindow,
+                frontmostBundleIdentifier: "com.apple.ScreenSharing",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .notchStrip
+            )
+        )
+    }
 }
 
 final class DockIconVisibilityTests: XCTestCase {

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -18,16 +18,16 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
 
         XCTAssertTrue(primaryBehavior.contains(.canJoinAllSpaces))
         XCTAssertFalse(primaryBehavior.contains(.moveToActiveSpace))
-        XCTAssertFalse(primaryBehavior.contains(.fullScreenAuxiliary))
-        XCTAssertTrue(primaryBehavior.contains(.fullScreenNone))
+        XCTAssertTrue(primaryBehavior.contains(.fullScreenAuxiliary))
+        XCTAssertFalse(primaryBehavior.contains(.fullScreenNone))
         XCTAssertEqual(primaryBehavior, builtInBehavior)
     }
 
-    func testActiveScreenIndicatorPolicyDoesNotJoinForeignFullscreenSpaces() {
-        XCTAssertFalse(
+    func testActiveScreenIndicatorPolicyRemainsVisibleOverFullscreenApps() {
+        XCTAssertTrue(
             FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .activeScreen).contains(.fullScreenAuxiliary)
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             FloatingPanelSpacePolicy.indicatorCollectionBehavior(for: .activeScreen).contains(.fullScreenNone)
         )
     }


### PR DESCRIPTION
## Summary

Fixes the fullscreen Space visibility path for indicator panels by updating both layers involved in showing the UI:

- `FloatingPanelSpacePolicy` now uses `.fullScreenAuxiliary` instead of `.fullScreenNone` for indicator panels, so AppKit can place them in fullscreen-app Spaces.
- `IndicatorFullscreenSuppressionPolicy` is now placement-aware via `IndicatorPlacement` (`.notchStrip` / `.nonNotchArea`).
- Bottom-aligned Overlay and Minimal indicators pass `.nonNotchArea`, so they are no longer hidden by the notch-strip fullscreen suppression.
- Notch style and top-aligned Overlay / Minimal still pass `.notchStrip`, preserving the #373 / #543 behavior that prevents drawing over a foreign fullscreen window occupying the notch strip on notched displays.

Scope note: this intentionally fixes the fullscreen visibility issue for indicators that render outside the notch strip. It does not make Notch style or top-aligned Overlay / Minimal appear over a foreign fullscreen window that overlaps the notch strip on notched displays.

Closes #602

## Test Plan

```bash
xcodebuild test \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO \
  -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests \
  -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests \
  CODE_SIGN_IDENTITY='-' \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO
```

Manual verification:

- [ ] Set indicator style to Overlay or Minimal, Position = Bottom, Display = Active Screen, Visibility = Always.
- [ ] Put Safari, Chrome, Xcode, or another app into fullscreen mode via the green button.
- [ ] Confirm the bottom-aligned indicator appears over the fullscreen app.
- [ ] Switch back to a regular Space and confirm indicator behavior remains unchanged.
- [ ] Repeat with Display = Primary Screen and Display = Built-in Display.
- [ ] On a notched display, confirm Notch style and top-aligned Overlay / Minimal remain suppressed when a foreign fullscreen window overlaps the notch strip.
