### PR TITLE
Fix recording start sound playback

### DIFF
--- a/TypeWhisper/Services/SoundService.swift
+++ b/TypeWhisper/Services/SoundService.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import UniformTypeIdentifiers
 
 enum SoundChoice: Hashable, Sendable {
@@ -111,13 +112,49 @@ enum SoundEvent: CaseIterable {
 }
 
 @MainActor
+protocol OneShotSoundPlaying: AnyObject {
+    @discardableResult
+    func play(url: URL) -> Bool
+}
+
+@MainActor
+final class AVAudioOneShotSoundPlayer: OneShotSoundPlaying {
+    private var activePlayers: [AVAudioPlayer] = []
+
+    @discardableResult
+    func play(url: URL) -> Bool {
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.prepareToPlay()
+            guard player.play() else { return false }
+            activePlayers.append(player)
+            release(player, after: player.duration)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func release(_ player: AVAudioPlayer, after duration: TimeInterval) {
+        let nanoseconds = UInt64(max(duration + 0.5, 0.5) * 1_000_000_000)
+        Task { @MainActor [weak self, weak player] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard let player else { return }
+            self?.activePlayers.removeAll { $0 === player }
+        }
+    }
+}
+
+@MainActor
 class SoundService {
     private var sounds: [SoundEvent: NSSound] = [:]
     private var choices: [SoundEvent: SoundChoice] = [:]
     private var resolvedSounds: [SoundChoice: NSSound] = [:]
     private var previewSound: NSSound?
+    private let oneShotPlayer: OneShotSoundPlaying
 
-    init() {
+    init(oneShotPlayer: OneShotSoundPlaying = AVAudioOneShotSoundPlayer()) {
+        self.oneShotPlayer = oneShotPlayer
         preloadSounds()
         loadChoices()
     }
@@ -125,6 +162,10 @@ class SoundService {
     func play(_ event: SoundEvent, enabled: Bool) {
         guard enabled else { return }
         let choice = choices[event] ?? event.defaultChoice
+        if let playbackURL = filePlaybackURL(for: choice),
+           oneShotPlayer.play(url: playbackURL) {
+            return
+        }
         guard let sound = sound(for: choice) else { return }
         sound.stop()
         sound.play()
@@ -197,6 +238,23 @@ class SoundService {
         guard let sound else { return nil }
         resolvedSounds[choice] = sound
         return sound
+    }
+
+    private func filePlaybackURL(for choice: SoundChoice) -> URL? {
+        switch choice {
+        case .bundled(let name):
+            return Bundle.main.url(forResource: name, withExtension: "wav")
+        case .system(let name):
+            let url = URL(fileURLWithPath: "/System/Library/Sounds")
+                .appendingPathComponent(name)
+                .appendingPathExtension("aiff")
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        case .custom(let filename):
+            let url = SoundChoice.customSoundsDirectory.appendingPathComponent(filename)
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        case .none:
+            return nil
+        }
     }
 
     private func preloadSounds() {

--- a/TypeWhisperTests/SoundServiceTests.swift
+++ b/TypeWhisperTests/SoundServiceTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import TypeWhisper
 
@@ -104,6 +105,73 @@ final class SoundServiceTests: XCTestCase {
         XCTAssertEqual(SoundChoice.installedCustomSounds(), [])
     }
 
+    @MainActor
+    func testPlayRecordingStartedUsesFilePlaybackInsteadOfPreviewSoundResolver() {
+        let storedDefaults = captureSoundDefaults()
+        defer { restoreSoundDefaults(storedDefaults) }
+
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.soundRecordingStarted)
+
+        let oneShotPlayer = SpyOneShotSoundPlayer()
+        let service = PreviewSoundResolverSpy(oneShotPlayer: oneShotPlayer)
+
+        service.play(.recordingStarted, enabled: true)
+
+        XCTAssertEqual(oneShotPlayer.playedURLs.map(\.lastPathComponent), ["recording_start.wav"])
+        XCTAssertTrue(service.resolvedChoices.isEmpty)
+    }
+
+    @MainActor
+    func testPlayRecordingStartedUsesFilePlaybackForCustomSound() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let storedDefaults = captureSoundDefaults()
+        defer {
+            restoreSoundDefaults(storedDefaults)
+            AppConstants.testAppSupportDirectoryOverride = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        AppConstants.testAppSupportDirectoryOverride = appSupportDirectory
+        let oneShotPlayer = SpyOneShotSoundPlayer()
+        let service = PreviewSoundResolverSpy(oneShotPlayer: oneShotPlayer)
+        let filename = try service.importCustomSound(from: testSoundURL)
+
+        service.updateChoice(for: .recordingStarted, choice: .custom(filename))
+        service.play(.recordingStarted, enabled: true)
+
+        XCTAssertEqual(oneShotPlayer.playedURLs.map(\.lastPathComponent), [filename])
+        XCTAssertTrue(service.resolvedChoices.isEmpty)
+    }
+
+    @MainActor
+    func testPlayRecordingStartedUsesFilePlaybackForSystemSound() throws {
+        let storedDefaults = captureSoundDefaults()
+        defer { restoreSoundDefaults(storedDefaults) }
+
+        let systemSoundName = try XCTUnwrap(
+            SoundChoice.systemSounds.first { name in
+                FileManager.default.fileExists(atPath: "/System/Library/Sounds/\(name).aiff")
+            }
+        )
+        let oneShotPlayer = SpyOneShotSoundPlayer()
+        let service = PreviewSoundResolverSpy(oneShotPlayer: oneShotPlayer)
+
+        service.updateChoice(for: .recordingStarted, choice: .system(systemSoundName))
+        service.play(.recordingStarted, enabled: true)
+
+        XCTAssertEqual(oneShotPlayer.playedURLs.map(\.lastPathComponent), ["\(systemSoundName).aiff"])
+        XCTAssertTrue(service.resolvedChoices.isEmpty)
+    }
+
+    @MainActor
+    func testPreviewStillUsesPreviewSoundResolver() {
+        let service = PreviewSoundResolverSpy()
+
+        service.preview(.bundled("recording_start"))
+
+        XCTAssertEqual(service.resolvedChoices, [.bundled("recording_start")])
+    }
+
     private var testSoundURL: URL {
         TestSupport.repoRoot.appendingPathComponent("TypeWhisper/Resources/Sounds/error.wav", isDirectory: false)
     }
@@ -123,6 +191,26 @@ final class SoundServiceTests: XCTestCase {
             } else {
                 UserDefaults.standard.removeObject(forKey: key)
             }
+        }
+    }
+
+    @MainActor
+    private final class PreviewSoundResolverSpy: SoundService {
+        private(set) var resolvedChoices: [SoundChoice] = []
+
+        override func sound(for choice: SoundChoice) -> NSSound? {
+            resolvedChoices.append(choice)
+            return nil
+        }
+    }
+
+    @MainActor
+    private final class SpyOneShotSoundPlayer: OneShotSoundPlaying {
+        private(set) var playedURLs: [URL] = []
+
+        func play(url: URL) -> Bool {
+            playedURLs.append(url)
+            return true
         }
     }
 


### PR DESCRIPTION
## Issue context

Issue #601 reports that the configured "Recording started" sound previews correctly in Settings and the transcription success sound still plays, but the start sound is not audible during real Hybrid/Push-to-Talk dictation in TypeWhisper 1.4.0.

Closes #601

## Summary

- Route real sound feedback through a short-lived file-backed `AVAudioPlayer` path for bundled, custom, and system sound files.
- Keep Settings preview on the existing `NSSound` resolver so preview behavior stays unchanged.
- Preserve the delayed first-buffer recording cue and the existing Bluetooth start-sound skip policy.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/SoundServiceTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_defersStartSoundUntilInputIsReady -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_skipsStartSoundForBluetoothInput -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_keepsStartSoundForUSBInputAfterInputIsReady`
- [x] `git diff --check`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/caaf/typewhisper-mac`
- [x] Dev app launch/process check: `pgrep -fl TypeWhisper` and `osascript -e 'application id "com.typewhisper.mac.dev" is running'`
- [ ] Manual smoke: enable sound feedback, choose a recording-start sound, verify preview still plays, then start Hybrid/PTT dictation and confirm the start sound is audible before success sound. Not run by Codex in this non-interactive audio environment; the dev app was built, signed, launched, and verified running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sound playback with improved audio file handling
  * Added support for bundled, system, and custom audio sources

* **Tests**
  * Added comprehensive test coverage for sound playback scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->