### PR TITLE
Add recorder-specific transcription engine overrides

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 			3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */; };
 			533A00000000000000000002 /* DictationRecoveryAudioStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */; };
 			533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533A00000000000000000003 /* DictationRecoveryAudioStore.swift */; };
+			604D00000000000000000002 /* AudioRecorderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604D00000000000000000001 /* AudioRecorderViewModelTests.swift */; };
 			533B00000000000000000002 /* FileTranscriptionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533B00000000000000000001 /* FileTranscriptionViewModelTests.swift */; };
 			533C00000000000000000002 /* DictationRecoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C00000000000000000001 /* DictationRecoveryViewModel.swift */; };
 			533C00000000000000000004 /* DictationRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C00000000000000000003 /* DictationRecoveryView.swift */; };
@@ -485,6 +486,7 @@
 			3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
 			533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStoreTests.swift; sourceTree = "<group>"; };
 			533A00000000000000000003 /* DictationRecoveryAudioStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStore.swift; sourceTree = "<group>"; };
+			604D00000000000000000001 /* AudioRecorderViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioRecorderViewModelTests.swift; sourceTree = "<group>"; };
 			533B00000000000000000001 /* FileTranscriptionViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FileTranscriptionViewModelTests.swift; sourceTree = "<group>"; };
 			3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
 		B91F00000000000000000001 /* SelectionPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPalettePanel.swift; sourceTree = "<group>"; };
@@ -2008,6 +2010,7 @@
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
 					6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
 					E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
+					604D00000000000000000001 /* AudioRecorderViewModelTests.swift */,
 					533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */,
 					533B00000000000000000001 /* FileTranscriptionViewModelTests.swift */,
 					AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
@@ -3358,6 +3361,7 @@
 					7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */,
 					E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,
 					3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,
+					604D00000000000000000002 /* AudioRecorderViewModelTests.swift in Sources */,
 					533A00000000000000000002 /* DictationRecoveryAudioStoreTests.swift in Sources */,
 					533B00000000000000000002 /* FileTranscriptionViewModelTests.swift in Sources */,
 					BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -234,6 +234,7 @@ final class ServiceContainer: ObservableObject {
         fileTranscriptionViewModel.observePluginManager()
         dictationRecoveryViewModel.observePluginManager()
         settingsViewModel.observePluginManager()
+        audioRecorderViewModel.observePluginManager()
         watchFolderViewModel.observePluginManager()
     }
 
@@ -259,6 +260,7 @@ final class ServiceContainer: ObservableObject {
 
         // Re-restore provider selection now that plugins are loaded
         modelManagerService.restoreProviderSelection()
+        audioRecorderViewModel.reconcileSelectionWithAvailablePlugins()
         watchFolderViewModel.reconcileSelectionWithAvailablePlugins()
 
         // Validate LLM provider selection against loaded plugins

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -108,6 +108,8 @@ enum UserDefaultsKeys {
     static let recorderSystemAudioEnabled = "recorderSystemAudioEnabled"
     static let recorderOutputFormat = "recorderOutputFormat"
     static let recorderTranscriptionEnabled = "recorderTranscriptionEnabled"
+    static let recorderTranscriptionEngine = "recorderTranscriptionEngine"
+    static let recorderTranscriptionModel = "recorderTranscriptionModel"
     static let recorderMicDuckingMode = "recorderMicDuckingMode"
     static let recorderTrackMode = "recorderTrackMode"
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -79,28 +79,39 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var micLevel: Float = 0
     @Published var systemLevel: Float = 0
     @Published var micEnabled: Bool {
-        didSet { UserDefaults.standard.set(micEnabled, forKey: UserDefaultsKeys.recorderMicEnabled) }
+        didSet { defaults.set(micEnabled, forKey: UserDefaultsKeys.recorderMicEnabled) }
     }
     @Published var systemAudioEnabled: Bool {
-        didSet { UserDefaults.standard.set(systemAudioEnabled, forKey: UserDefaultsKeys.recorderSystemAudioEnabled) }
+        didSet { defaults.set(systemAudioEnabled, forKey: UserDefaultsKeys.recorderSystemAudioEnabled) }
     }
     @Published var outputFormat: AudioRecorderService.OutputFormat {
-        didSet { UserDefaults.standard.set(outputFormat.rawValue, forKey: UserDefaultsKeys.recorderOutputFormat) }
+        didSet { defaults.set(outputFormat.rawValue, forKey: UserDefaultsKeys.recorderOutputFormat) }
     }
     @Published var micDuckingMode: AudioRecorderService.MicDuckingMode {
         didSet {
-            UserDefaults.standard.set(micDuckingMode.rawValue, forKey: UserDefaultsKeys.recorderMicDuckingMode)
+            defaults.set(micDuckingMode.rawValue, forKey: UserDefaultsKeys.recorderMicDuckingMode)
             recorderService.micDuckingMode = micDuckingMode
         }
     }
     @Published var trackMode: AudioRecorderService.TrackMode {
         didSet {
-            UserDefaults.standard.set(trackMode.rawValue, forKey: UserDefaultsKeys.recorderTrackMode)
+            defaults.set(trackMode.rawValue, forKey: UserDefaultsKeys.recorderTrackMode)
             recorderService.trackMode = trackMode
         }
     }
     @Published var transcriptionEnabled: Bool {
-        didSet { UserDefaults.standard.set(transcriptionEnabled, forKey: UserDefaultsKeys.recorderTranscriptionEnabled) }
+        didSet { defaults.set(transcriptionEnabled, forKey: UserDefaultsKeys.recorderTranscriptionEnabled) }
+    }
+    @Published var selectedEngine: String? {
+        didSet {
+            defaults.set(selectedEngine, forKey: UserDefaultsKeys.recorderTranscriptionEngine)
+            guard isInitialized, oldValue != selectedEngine else { return }
+            selectedModel = nil
+            normalizeLanguageSelectionForResolvedEngine()
+        }
+    }
+    @Published var selectedModel: String? {
+        didSet { defaults.set(selectedModel, forKey: UserDefaultsKeys.recorderTranscriptionModel) }
     }
     @Published var languageSelection: LanguageSelection = .auto
     @Published var selectedTask: TranscriptionTask = .transcribe
@@ -110,10 +121,36 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var partialText: String = ""
     @Published var isTranscribing: Bool = false
 
-    var activeEngineName: String? { modelManager.activeEngineName }
-    var activeModelName: String? { modelManager.activeModelName }
-    var isModelReady: Bool { modelManager.isModelReady }
-    var supportsTranslation: Bool { modelManager.supportsTranslation }
+    var activeEngineName: String? { resolvedEngine?.providerDisplayName }
+    var activeModelName: String? {
+        modelManager.resolvedModelDisplayName(
+            engineOverrideId: selectedEngine,
+            cloudModelOverride: selectedModel
+        )
+    }
+    var isModelReady: Bool {
+        guard let engine = resolvedEngine else { return false }
+        guard modelManager.canUseForTranscription(engine) else { return false }
+        return engine.isConfigured
+    }
+    var supportsTranslation: Bool { resolvedEngine?.supportsTranslation ?? false }
+    var effectiveProviderId: String? {
+        selectedEngine ?? modelManager.selectedProviderId
+    }
+    var effectiveModelId: String? {
+        modelManager.resolvedModelId(
+            engineOverrideId: selectedEngine,
+            cloudModelOverride: selectedModel
+        )
+    }
+    var resolvedEngine: TranscriptionEnginePlugin? {
+        guard let providerId = effectiveProviderId else { return nil }
+        guard let pluginManager = PluginManager.shared else { return nil }
+        return pluginManager.transcriptionEngine(for: providerId)
+    }
+    var selectedEngineSupportedLanguages: [String] {
+        resolvedEngine?.supportedLanguages.sorted() ?? []
+    }
     var selectedLanguage: String? { languageSelection.requestedLanguage }
     var canToggleRecording: Bool {
         Self.canToggleRecording(
@@ -126,16 +163,24 @@ final class AudioRecorderViewModel: ObservableObject {
     private let recorderService: AudioRecorderService
     private let modelManager: ModelManagerService
     private let dictionaryService: DictionaryService
+    private let defaults: UserDefaults
     private let streamingHandler: StreamingHandler
     private var cancellables = Set<AnyCancellable>()
     private var currentOutputURL: URL?
     private var activeRecorderAPISessionID: UUID?
     private var recorderAPISessions: [UUID: RecorderAPISessionSnapshot] = [:]
+    private var isInitialized = false
 
-    init(recorderService: AudioRecorderService, modelManager: ModelManagerService, dictionaryService: DictionaryService) {
+    init(
+        recorderService: AudioRecorderService,
+        modelManager: ModelManagerService,
+        dictionaryService: DictionaryService,
+        defaults: UserDefaults = .standard
+    ) {
         self.recorderService = recorderService
         self.modelManager = modelManager
         self.dictionaryService = dictionaryService
+        self.defaults = defaults
         self.streamingHandler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { [weak recorderService] in
@@ -153,7 +198,6 @@ final class AudioRecorderViewModel: ObservableObject {
         )
 
         // Load saved preferences with defaults
-        let defaults = UserDefaults.standard
         if defaults.object(forKey: UserDefaultsKeys.recorderMicEnabled) == nil {
             self.micEnabled = true
         } else {
@@ -187,6 +231,8 @@ final class AudioRecorderViewModel: ObservableObject {
         } else {
             self.transcriptionEnabled = defaults.bool(forKey: UserDefaultsKeys.recorderTranscriptionEnabled)
         }
+        self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionEngine)
+        self.selectedModel = defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel)
 
         recorderService.micDuckingMode = micDuckingMode
         recorderService.trackMode = trackMode
@@ -205,6 +251,9 @@ final class AudioRecorderViewModel: ObservableObject {
         streamingHandler.onStreamingStateChange = { [weak self] streaming in
             self?.isTranscribing = streaming
         }
+
+        isInitialized = true
+        reconcileSelectionWithAvailablePlugins()
     }
 
     private func setupBindings() {
@@ -227,6 +276,39 @@ final class AudioRecorderViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in self?.systemAudioWarningMessage = value }
             .store(in: &cancellables)
+    }
+
+    func observePluginManager() {
+        guard let pluginManager = PluginManager.shared else { return }
+        pluginManager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reconcileSelectionWithAvailablePlugins()
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    func canUseForTranscription(_ engine: TranscriptionEnginePlugin) -> Bool {
+        modelManager.canUseForTranscription(engine)
+    }
+
+    func reconcileSelectionWithAvailablePlugins() {
+        guard let pluginManager = PluginManager.shared else { return }
+        if let selectedEngine,
+           pluginManager.transcriptionEngine(for: selectedEngine) == nil {
+            self.selectedEngine = nil
+            selectedModel = nil
+        }
+        normalizeLanguageSelectionForResolvedEngine()
+    }
+
+    private func normalizeLanguageSelectionForResolvedEngine() {
+        guard let engine = resolvedEngine else { return }
+        let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
+        if normalized != languageSelection {
+            languageSelection = normalized
+        }
     }
 
     nonisolated static func canToggleRecording(
@@ -348,14 +430,15 @@ final class AudioRecorderViewModel: ObservableObject {
 
             let finalTranscriptionRequest: FinalTranscriptionRequest?
             if transcriptionEnabled, let url {
+                let providerId = effectiveProviderId
                 finalTranscriptionRequest = FinalTranscriptionRequest(
                     outputURL: url,
                     buffer: recorderService.getCurrentBuffer(),
                     languageSelection: languageSelection,
                     task: selectedTask,
-                    providerId: modelManager.selectedProviderId,
-                    modelId: modelManager.selectedModelId,
-                    prompt: dictionaryService.getTermsForPrompt(providerId: modelManager.selectedProviderId),
+                    providerId: providerId,
+                    modelId: selectedModel,
+                    prompt: dictionaryService.getTermsForPrompt(providerId: providerId),
                     liveSessionResult: liveSessionResult
                 )
                 state = .finalizing
@@ -565,8 +648,12 @@ final class AudioRecorderViewModel: ObservableObject {
     // MARK: - Streaming Transcription
 
     private func startStreamingTranscription() {
-        guard let providerId = modelManager.selectedProviderId,
-              let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
+        guard let pluginManager = PluginManager.shared else {
+            logger.info("Plugin manager unavailable, skipping live transcription")
+            return
+        }
+        guard let providerId = effectiveProviderId,
+              let plugin = pluginManager.transcriptionEngine(for: providerId) else {
             logger.info("No transcription engine available, skipping live transcription")
             return
         }
@@ -578,7 +665,7 @@ final class AudioRecorderViewModel: ObservableObject {
             selectedProviderId: modelManager.selectedProviderId,
             languageSelection: languageSelection,
             task: task,
-            cloudModelOverride: nil,
+            cloudModelOverride: selectedModel,
             allowLiveTranscription: true,
             stateCheck: { [weak self] in self?.state == .recording }
         )
@@ -607,7 +694,8 @@ final class AudioRecorderViewModel: ObservableObject {
         let effectiveTask: TranscriptionTask
         if request.task == .translate,
            let providerId = request.providerId,
-           let plugin = PluginManager.shared.transcriptionEngine(for: providerId),
+           let pluginManager = PluginManager.shared,
+           let plugin = pluginManager.transcriptionEngine(for: providerId),
            !plugin.supportsTranslation {
             effectiveTask = .transcribe
         } else {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -59,7 +59,7 @@ final class AudioRecorderViewModel: ObservableObject {
         let languageSelection: LanguageSelection
         let task: TranscriptionTask
         let providerId: String?
-        let modelId: String?
+        let resolvedModelId: String?
         let prompt: String?
         let liveSessionResult: TranscriptionResult?
     }
@@ -125,7 +125,7 @@ final class AudioRecorderViewModel: ObservableObject {
     var activeModelName: String? {
         modelManager.resolvedModelDisplayName(
             engineOverrideId: selectedEngine,
-            cloudModelOverride: selectedModel
+            cloudModelOverride: effectiveModelId
         )
     }
     var isModelReady: Bool {
@@ -276,6 +276,16 @@ final class AudioRecorderViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in self?.systemAudioWarningMessage = value }
             .store(in: &cancellables)
+
+        modelManager.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                DispatchQueue.main.async { [weak self] in
+                    self?.reconcileSelectionWithAvailablePlugins()
+                    self?.objectWillChange.send()
+                }
+            }
+            .store(in: &cancellables)
     }
 
     func observePluginManager() {
@@ -300,7 +310,21 @@ final class AudioRecorderViewModel: ObservableObject {
             self.selectedEngine = nil
             selectedModel = nil
         }
+        clearUnavailableSelectedModelForResolvedEngine()
         normalizeLanguageSelectionForResolvedEngine()
+    }
+
+    private func clearUnavailableSelectedModelForResolvedEngine() {
+        guard let selectedModel else { return }
+        guard let engine = resolvedEngine else {
+            self.selectedModel = nil
+            return
+        }
+
+        let modelIds = Set((engine.modelCatalog + engine.transcriptionModels).map(\.id))
+        if !modelIds.contains(selectedModel) {
+            self.selectedModel = nil
+        }
     }
 
     private func normalizeLanguageSelectionForResolvedEngine() {
@@ -379,6 +403,7 @@ final class AudioRecorderViewModel: ObservableObject {
         errorMessage = nil
         systemAudioWarningMessage = nil
         partialText = ""
+        reconcileSelectionWithAvailablePlugins()
         state = .recording
 
         let url: URL
@@ -430,6 +455,7 @@ final class AudioRecorderViewModel: ObservableObject {
 
             let finalTranscriptionRequest: FinalTranscriptionRequest?
             if transcriptionEnabled, let url {
+                reconcileSelectionWithAvailablePlugins()
                 let providerId = effectiveProviderId
                 finalTranscriptionRequest = FinalTranscriptionRequest(
                     outputURL: url,
@@ -437,7 +463,7 @@ final class AudioRecorderViewModel: ObservableObject {
                     languageSelection: languageSelection,
                     task: selectedTask,
                     providerId: providerId,
-                    modelId: selectedModel,
+                    resolvedModelId: effectiveModelId,
                     prompt: dictionaryService.getTermsForPrompt(providerId: providerId),
                     liveSessionResult: liveSessionResult
                 )
@@ -652,6 +678,7 @@ final class AudioRecorderViewModel: ObservableObject {
             logger.info("Plugin manager unavailable, skipping live transcription")
             return
         }
+        reconcileSelectionWithAvailablePlugins()
         guard let providerId = effectiveProviderId,
               let plugin = pluginManager.transcriptionEngine(for: providerId) else {
             logger.info("No transcription engine available, skipping live transcription")
@@ -665,7 +692,7 @@ final class AudioRecorderViewModel: ObservableObject {
             selectedProviderId: modelManager.selectedProviderId,
             languageSelection: languageSelection,
             task: task,
-            cloudModelOverride: selectedModel,
+            cloudModelOverride: effectiveModelId,
             allowLiveTranscription: true,
             stateCheck: { [weak self] in self?.state == .recording }
         )
@@ -711,7 +738,7 @@ final class AudioRecorderViewModel: ObservableObject {
                     languageSelection: request.languageSelection,
                     task: effectiveTask,
                     engineOverrideId: request.providerId,
-                    cloudModelOverride: request.modelId,
+                    cloudModelOverride: request.resolvedModelId,
                     prompt: request.prompt
                 )
             }

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -5,7 +5,6 @@ struct AudioRecorderView: View {
     @ObservedObject var viewModel: AudioRecorderViewModel
     @ObservedObject private var pluginManager = PluginManager.shared
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
-    @State private var selectedProvider: String?
 
     private var isEditingLocked: Bool {
         viewModel.state != .idle
@@ -167,18 +166,13 @@ struct AudioRecorderView: View {
                 if viewModel.transcriptionEnabled {
                     // Engine picker
                     let engines = pluginManager.transcriptionEngines
-                    Picker(String(localized: "Engine"), selection: $selectedProvider) {
-                        Text(String(localized: "None")).tag(nil as String?)
+                    Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
+                        Text(String(localized: "Default Engine")).tag(nil as String?)
                         Divider()
                         ForEach(engines, id: \.providerId) { engine in
                             enginePickerLabel(for: engine)
                                 .tag(engine.providerId as String?)
-                                .disabled(!modelManager.canUseForTranscription(engine))
-                        }
-                    }
-                    .onChange(of: selectedProvider) { _, newValue in
-                        if let newValue {
-                            modelManager.selectProvider(newValue)
+                                .disabled(!viewModel.canUseForTranscription(engine))
                         }
                     }
                     .disabled(isEditingLocked)
@@ -190,15 +184,13 @@ struct AudioRecorderView: View {
                     }
 
                     // Model picker
-                    if let providerId = selectedProvider,
-                       let engine = pluginManager.transcriptionEngine(for: providerId),
-                       modelManager.canUseForTranscription(engine) {
+                    if let engine = viewModel.resolvedEngine,
+                       viewModel.canUseForTranscription(engine) {
                         let models = engine.transcriptionModels
                         if models.count > 1 {
-                            Picker(String(localized: "Model"), selection: Binding(
-                                get: { engine.selectedModelId },
-                                set: { if let id = $0 { modelManager.selectModel(providerId, modelId: id) } }
-                            )) {
+                            Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
+                                Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
+                                Divider()
                                 ForEach(models, id: \.id) { model in
                                     Text(model.displayName).tag(model.id as String?)
                                 }
@@ -206,7 +198,7 @@ struct AudioRecorderView: View {
                             .disabled(isEditingLocked)
                         }
 
-                        if !modelManager.supportsLiveTranscriptionSession(engineOverrideId: providerId) {
+                        if !modelManager.supportsLiveTranscriptionSession(engineOverrideId: engine.providerId) {
                             Label(
                                 localizedAppText(
                                     "This engine uses a lightweight live preview that updates every few seconds. Final transcription still runs on the full recording after you stop.",
@@ -220,12 +212,11 @@ struct AudioRecorderView: View {
                     }
 
                     let languageOptions: [(code: String, name: String)] = {
-                        guard let providerId = selectedProvider,
-                              let engine = pluginManager.transcriptionEngine(for: providerId),
-                              !engine.supportedLanguages.isEmpty else {
+                        let supportedLanguages = viewModel.selectedEngineSupportedLanguages
+                        guard !supportedLanguages.isEmpty else {
                             return SettingsViewModel.shared.availableLanguages
                         }
-                        return localizedAppLanguageOptions(for: engine.supportedLanguages)
+                        return localizedAppLanguageOptions(for: supportedLanguages)
                             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
                             .map { (code: $0.code, name: $0.name) }
                     }()
@@ -266,7 +257,7 @@ struct AudioRecorderView: View {
             }
             .onAppear {
                 modelManager.restoreProviderSelection()
-                selectedProvider = modelManager.selectedProviderId
+                viewModel.reconcileSelectionWithAvailablePlugins()
             }
 
             // Recordings list

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+@MainActor
+final class AudioRecorderViewModelTests: XCTestCase {
+    func testRecorderSelectionPersistsSeparatelyFromGlobalDefault() throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        setupPluginManager()
+        UserDefaults.standard.set("groq", forKey: UserDefaultsKeys.selectedEngine)
+
+        let viewModel = makeViewModel(defaults: defaults)
+
+        viewModel.selectedEngine = "assemblyai"
+        viewModel.selectedModel = "universal-3-pro"
+
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionEngine), "assemblyai")
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel), "universal-3-pro")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine), "groq")
+        XCTAssertEqual(viewModel.effectiveProviderId, "assemblyai")
+        XCTAssertEqual(viewModel.effectiveModelId, "universal-3-pro")
+    }
+
+    func testRecorderSelectionFallsBackToGlobalDefaultWhenUnset() throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        setupPluginManager()
+        UserDefaults.standard.set("groq", forKey: UserDefaultsKeys.selectedEngine)
+
+        let viewModel = makeViewModel(defaults: defaults)
+
+        XCTAssertNil(viewModel.selectedEngine)
+        XCTAssertNil(viewModel.selectedModel)
+        XCTAssertEqual(viewModel.effectiveProviderId, "groq")
+        XCTAssertEqual(viewModel.effectiveModelId, "whisper-large-v3")
+        XCTAssertEqual(viewModel.resolvedEngine?.providerId, "groq")
+    }
+
+    func testRecorderSelectionUsesModelOverrideWithDefaultEngine() throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        setupPluginManager()
+        UserDefaults.standard.set("groq", forKey: UserDefaultsKeys.selectedEngine)
+
+        let viewModel = makeViewModel(defaults: defaults)
+        viewModel.selectedModel = "whisper-small"
+
+        XCTAssertNil(viewModel.selectedEngine)
+        XCTAssertEqual(viewModel.effectiveProviderId, "groq")
+        XCTAssertEqual(viewModel.effectiveModelId, "whisper-small")
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel), "whisper-small")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine), "groq")
+    }
+
+    func testRecorderSelectionClearsMissingSavedEngineAndModel() throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        defaults.set("missing-engine", forKey: UserDefaultsKeys.recorderTranscriptionEngine)
+        defaults.set("old-model", forKey: UserDefaultsKeys.recorderTranscriptionModel)
+        setupPluginManager()
+        UserDefaults.standard.set("groq", forKey: UserDefaultsKeys.selectedEngine)
+
+        let viewModel = makeViewModel(defaults: defaults)
+        viewModel.reconcileSelectionWithAvailablePlugins()
+
+        XCTAssertNil(viewModel.selectedEngine)
+        XCTAssertNil(viewModel.selectedModel)
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionEngine))
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel))
+        XCTAssertEqual(viewModel.effectiveProviderId, "groq")
+    }
+
+    private func makeViewModel(defaults: UserDefaults) -> AudioRecorderViewModel {
+        AudioRecorderViewModel(
+            recorderService: AudioRecorderService(),
+            modelManager: ModelManagerService(),
+            dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
+            defaults: defaults
+        )
+    }
+
+    private func setupPluginManager() {
+        let previousPluginManager = PluginManager.shared
+        addTeardownBlock {
+            PluginManager.shared = previousPluginManager
+        }
+
+        let appSupportDirectory = makeTemporaryDirectory()
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.groq",
+                    name: "Groq",
+                    version: "1.0.0",
+                    principalClass: "AudioRecorderMockTranscriptionPlugin"
+                ),
+                instance: AudioRecorderMockTranscriptionPlugin(
+                    providerId: "groq",
+                    displayName: "Groq",
+                    models: [
+                        PluginModelInfo(id: "whisper-large-v3", displayName: "Whisper Large V3"),
+                        PluginModelInfo(id: "whisper-small", displayName: "Whisper Small")
+                    ],
+                    selectedModelId: "whisper-large-v3"
+                ),
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ),
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.assemblyai",
+                    name: "AssemblyAI",
+                    version: "1.0.0",
+                    principalClass: "AudioRecorderMockTranscriptionPlugin"
+                ),
+                instance: AudioRecorderMockTranscriptionPlugin(
+                    providerId: "assemblyai",
+                    displayName: "AssemblyAI",
+                    models: [
+                        PluginModelInfo(id: "universal-3-pro", displayName: "Universal-3 Pro"),
+                        PluginModelInfo(id: "universal-2", displayName: "Universal-2")
+                    ],
+                    selectedModelId: "universal-2"
+                ),
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
+    }
+
+    private func preserveStandardDefaults() throws {
+        let keys = [
+            UserDefaultsKeys.selectedEngine,
+            UserDefaultsKeys.selectedModelId
+        ]
+        let originals = Dictionary(uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) })
+        for key in keys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        addTeardownBlock {
+            for key in keys {
+                if let value = originals[key] {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+    }
+
+    private func makeDefaults() throws -> UserDefaults {
+        let name = "AudioRecorderViewModelTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: name)
+        }
+        return defaults
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioRecorderViewModelTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+}
+
+private final class AudioRecorderMockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.audio-recorder"
+    static let pluginName = "Audio Recorder Mock"
+
+    let providerId: String
+    let providerDisplayName: String
+    let transcriptionModels: [PluginModelInfo]
+    var selectedModelId: String?
+    var isConfigured = true
+    var supportsTranslation = true
+
+    required override init() {
+        self.providerId = "mock"
+        self.providerDisplayName = "Mock"
+        self.transcriptionModels = []
+        self.selectedModelId = nil
+        super.init()
+    }
+
+    init(
+        providerId: String,
+        displayName: String,
+        models: [PluginModelInfo],
+        selectedModelId: String?
+    ) {
+        self.providerId = providerId
+        self.providerDisplayName = displayName
+        self.transcriptionModels = models
+        self.selectedModelId = selectedModelId
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    func selectModel(_ modelId: String) {
+        selectedModelId = modelId
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "mock transcription")
+    }
+}

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -53,6 +53,28 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine), "groq")
     }
 
+    func testDefaultEngineModelOverrideClearsWhenGlobalProviderChanges() throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        setupPluginManager()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+
+        let viewModel = makeViewModel(defaults: defaults, modelManager: modelManager)
+        viewModel.selectedModel = "whisper-small"
+        XCTAssertEqual(viewModel.effectiveProviderId, "groq")
+        XCTAssertEqual(viewModel.effectiveModelId, "whisper-small")
+
+        modelManager.selectProvider("assemblyai")
+        viewModel.reconcileSelectionWithAvailablePlugins()
+
+        XCTAssertNil(viewModel.selectedEngine)
+        XCTAssertNil(viewModel.selectedModel)
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel))
+        XCTAssertEqual(viewModel.effectiveProviderId, "assemblyai")
+        XCTAssertEqual(viewModel.effectiveModelId, "universal-2")
+    }
+
     func testRecorderSelectionClearsMissingSavedEngineAndModel() throws {
         try preserveStandardDefaults()
         let defaults = try makeDefaults()
@@ -71,10 +93,13 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.effectiveProviderId, "groq")
     }
 
-    private func makeViewModel(defaults: UserDefaults) -> AudioRecorderViewModel {
+    private func makeViewModel(
+        defaults: UserDefaults,
+        modelManager: ModelManagerService = ModelManagerService()
+    ) -> AudioRecorderViewModel {
         AudioRecorderViewModel(
             recorderService: AudioRecorderService(),
-            modelManager: ModelManagerService(),
+            modelManager: modelManager,
             dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
             defaults: defaults
         )


### PR DESCRIPTION
## Summary
- Adds recorder-specific transcription engine/model settings with fallback to the global dictation default.
- Uses the effective recorder engine/model for live preview, final transcription, dictionary prompts, translation fallback, and language options.
- Keeps global dictation provider selection unchanged when the Recorder chooses Groq, AssemblyAI, or another plugin.

## Issue Context
Issue #604 requests separating the Recorder transcription provider from the global dictation engine so meeting recordings can use a dedicated provider/model without changing the all-day dictation default. This implements that narrow recorder-specific override without changing the Plugin SDK or local HTTP API contracts. API-started recorder sessions use the same persisted recorder override settings as the UI.

Closes #604

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioRecorderViewModelTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio recorder now persists transcription engine, model, and language preferences separately and drives UI selection from the recorder view model.
* **Bug Fixes**
  * Better reconciliation and normalization of recorder selections when available transcription plugins change; live transcription now safely skips when providers are unavailable.
* **Tests**
  * Added comprehensive unit tests covering recorder preference storage, resolution, overrides, and reconciliation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->