### PR TITLE
Fix Apple Speech selected model status

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -104,10 +104,23 @@ final class ModelManagerService: ObservableObject {
 
     var activeModelName: String? {
         guard let providerId = selectedProviderId,
-              let plugin = PluginManager.shared.transcriptionEngine(for: providerId),
-              let selectedId = plugin.selectedModelId,
-              let model = plugin.transcriptionModels.first(where: { $0.id == selectedId }) else { return nil }
-        return model.displayName
+              let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else { return nil }
+        return Self.activeModelName(for: plugin)
+    }
+
+    static func activeModelName(for plugin: any TranscriptionEnginePlugin) -> String? {
+        if let selectedId = plugin.selectedModelId {
+            if let model = plugin.modelCatalog.first(where: { $0.id == selectedId }) {
+                return model.displayName
+            }
+            return plugin.providerDisplayName
+        }
+
+        if plugin.isConfigured {
+            return plugin.providerDisplayName
+        }
+
+        return nil
     }
 
     func selectProvider(_ providerId: String) {

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -55,10 +55,18 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
     }
 
     var transcriptionModels: [PluginModelInfo] {
-        guard let loadedModelId else { return [] }
+        guard let selectedModelId else { return [] }
         return cachedModels
-            .filter { $0.id == loadedModelId }
-            .map { PluginModelInfo(id: $0.id, displayName: $0.displayName, sizeDescription: "System-managed", languageCount: 1) }
+            .filter { $0.id == selectedModelId }
+            .map {
+                PluginModelInfo(
+                    id: $0.id,
+                    displayName: $0.displayName,
+                    sizeDescription: "System-managed",
+                    languageCount: 1,
+                    loaded: $0.id == loadedModelId
+                )
+            }
     }
 
     var availableModels: [PluginModelInfo] {
@@ -73,7 +81,13 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
         }
     }
 
-    var selectedModelId: String? { loadedModelId }
+    var selectedModelId: String? {
+        Self.selectedModelId(loadedModelId: loadedModelId, host: host)
+    }
+
+    static func selectedModelId(loadedModelId: String?, host: HostServices?) -> String? {
+        loadedModelId ?? (host?.userDefault(forKey: "loadedModel") as? String)
+    }
 
     func selectModel(_ modelId: String) {
         // Selecting a different model requires unloading and reloading

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -897,6 +897,184 @@ final class PluginDictionaryGuardTests: XCTestCase {
     }
 }
 
+final class ModelManagerActiveModelNameTests: XCTestCase {
+    @MainActor
+    func testActiveModelNameUsesCatalogDisplayNameForPersistedSelection() {
+        let plugin = CatalogBackedTranscriptionPlugin(
+            providerDisplayName: "Apple Speech",
+            isConfigured: false,
+            transcriptionModels: [],
+            availableModels: [
+                PluginModelInfo(id: "speechanalyzer-de_DE", displayName: "German (Germany)")
+            ],
+            selectedModelId: "speechanalyzer-de_DE"
+        )
+
+        XCTAssertEqual(ModelManagerService.activeModelName(for: plugin), "German (Germany)")
+    }
+
+    @MainActor
+    func testActiveModelNameFallsBackToProviderNameForConfiguredModelessEngine() {
+        let plugin = CatalogBackedTranscriptionPlugin(
+            providerDisplayName: "Modeless Engine",
+            isConfigured: true,
+            transcriptionModels: [],
+            availableModels: [],
+            selectedModelId: nil
+        )
+
+        XCTAssertEqual(ModelManagerService.activeModelName(for: plugin), "Modeless Engine")
+    }
+
+    @MainActor
+    func testActiveModelNameFallsBackToProviderNameForSelectedModelWithoutCatalog() {
+        let plugin = CatalogBackedTranscriptionPlugin(
+            providerDisplayName: "Apple Speech",
+            isConfigured: false,
+            transcriptionModels: [],
+            availableModels: [],
+            selectedModelId: "speechanalyzer-de_DE"
+        )
+
+        XCTAssertEqual(ModelManagerService.activeModelName(for: plugin), "Apple Speech")
+    }
+
+    @MainActor
+    func testActiveModelNameIsNilForUnconfiguredEngineWithoutSelection() {
+        let plugin = CatalogBackedTranscriptionPlugin(
+            providerDisplayName: "Unconfigured Engine",
+            isConfigured: false,
+            transcriptionModels: [],
+            availableModels: [],
+            selectedModelId: nil
+        )
+
+        XCTAssertNil(ModelManagerService.activeModelName(for: plugin))
+    }
+}
+
+@available(macOS 26, *)
+final class SpeechAnalyzerSelectionPersistenceTests: XCTestCase {
+    func testSelectedModelIdUsesPersistedLoadedModelWhenRuntimeModelIsUnloaded() {
+        let host = TestHostServices(userDefaults: ["loadedModel": "speechanalyzer-de_DE"])
+
+        XCTAssertEqual(
+            SpeechAnalyzerPlugin.selectedModelId(loadedModelId: nil, host: host),
+            "speechanalyzer-de_DE"
+        )
+    }
+
+    func testSelectedModelIdPrefersRuntimeModelOverPersistedLoadedModel() {
+        let host = TestHostServices(userDefaults: ["loadedModel": "speechanalyzer-de_DE"])
+
+        XCTAssertEqual(
+            SpeechAnalyzerPlugin.selectedModelId(loadedModelId: "speechanalyzer-en_US", host: host),
+            "speechanalyzer-en_US"
+        )
+    }
+}
+
+private final class CatalogBackedTranscriptionPlugin: NSObject, TranscriptionModelCatalogProviding, @unchecked Sendable {
+    static let pluginId = "test.catalog-backed-transcription-plugin"
+    static let pluginName = "Catalog Backed Transcription Plugin"
+
+    let providerId: String
+    let providerDisplayName: String
+    let isConfigured: Bool
+    let transcriptionModels: [PluginModelInfo]
+    let availableModels: [PluginModelInfo]
+    let selectedModelId: String?
+    let supportsTranslation = false
+    let supportsStreaming = false
+    let supportedLanguages: [String] = []
+
+    required override init() {
+        self.providerId = Self.pluginId
+        self.providerDisplayName = Self.pluginName
+        self.isConfigured = false
+        self.transcriptionModels = []
+        self.availableModels = []
+        self.selectedModelId = nil
+        super.init()
+    }
+
+    init(
+        providerId: String = "catalogBacked",
+        providerDisplayName: String,
+        isConfigured: Bool,
+        transcriptionModels: [PluginModelInfo],
+        availableModels: [PluginModelInfo],
+        selectedModelId: String?
+    ) {
+        self.providerId = providerId
+        self.providerDisplayName = providerDisplayName
+        self.isConfigured = isConfigured
+        self.transcriptionModels = transcriptionModels
+        self.availableModels = availableModels
+        self.selectedModelId = selectedModelId
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func selectModel(_ modelId: String) {}
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        throw PluginTranscriptionError.notConfigured
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        throw PluginTranscriptionError.notConfigured
+    }
+}
+
+private final class TestHostServices: HostServices, @unchecked Sendable {
+    private var userDefaults: [String: Any]
+
+    let pluginDataDirectory: URL
+    let eventBus: EventBusProtocol = TestEventBus()
+    let activeAppBundleId: String? = nil
+    let activeAppName: String? = nil
+    let availableRuleNames: [String] = []
+    let availableWorkflows: [PluginWorkflowInfo] = []
+
+    init(userDefaults: [String: Any] = [:]) {
+        self.userDefaults = userDefaults
+        self.pluginDataDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TypeWhisperTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    func storeSecret(key: String, value: String) throws {}
+    func loadSecret(key: String) -> String? { nil }
+    func userDefault(forKey key: String) -> Any? { userDefaults[key] }
+
+    func setUserDefault(_ value: Any?, forKey key: String) {
+        userDefaults[key] = value
+    }
+
+    func notifyCapabilitiesChanged() {}
+    func setStreamingDisplayActive(_ active: Bool) {}
+}
+
+private final class TestEventBus: EventBusProtocol, @unchecked Sendable {
+    func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID {
+        UUID()
+    }
+
+    func unsubscribe(id: UUID) {}
+}
+
 final class WhisperKitSettingsStateTests: XCTestCase {
     func testApplyingNotLoadedStateClearsStaleLoadingAndStopsPolling() {
         let initial = WhisperKitSettingsPollState(


### PR DESCRIPTION
## Summary
- keep Apple Speech's persisted `loadedModel` visible through `selectedModelId` after runtime unloads
- use the broader model catalog when rendering the active model name, with a provider-name fallback while the catalog is still loading
- add regression coverage for persisted Apple Speech selections and menu/status fallback behavior

## Issue Context
A local report showed Settings configured to use Apple Speech while the menu bar still displayed "No model loaded". The underlying issue was that Apple Speech cleared its runtime `loadedModelId` on unload but kept the persisted `loadedModel`, and the menu status only looked at currently loaded transcription models.

No GitHub issue number was provided for this report.

## Test Plan
- `git diff --check origin/main..HEAD`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/ModelManagerActiveModelNameTests -only-testing:TypeWhisperTests/SpeechAnalyzerSelectionPersistenceTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/f38c/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model selection lookup so the correct selected model is identified and display names fall back to provider names when needed.
  * Ensured model lists mark which model is currently loaded for accurate UI indication.

* **Tests**
  * Added coverage validating model selection resolution and persistence across configurations and reloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->