### PR TITLE
Fix repair installation action visibility

### DIFF
--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -619,9 +619,13 @@ final class PluginRegistryService: ObservableObject {
         isBundled: Bool,
         registryPlugin: RegistryPlugin?,
         installInfo: PluginInstallInfo,
-        installState: InstallState?
+        installState: InstallState?,
+        externalNotice: ExternalBundleNotice?
     ) -> Bool {
-        guard !isBundled, registryPlugin != nil, installState == nil else {
+        guard !isBundled,
+              registryPlugin != nil,
+              installState == nil,
+              externalNotice?.requiresConfirmation == true else {
             return false
         }
         if case .installed = installInfo {

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1727,7 +1727,8 @@ private struct InstalledPluginRow: View {
             isBundled: plugin.isBundled,
             registryPlugin: registryPlugin,
             installInfo: installInfo,
-            installState: installState
+            installState: installState,
+            externalNotice: externalNotice
         )
     }
 

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1708,15 +1708,38 @@ final class PluginRegistryDestinationTests: XCTestCase {
         XCTAssertEqual(destination, pluginsDirectory.appendingPathComponent("ParakeetPlugin.bundle"))
     }
 
-    func testRepairEligibilityRequiresRegistryBackedExternalInstalledPlugin() {
+    func testRepairEligibilityRequiresActionableExternalBundleNotice() {
         let registryPlugin = makeRegistryPlugin(id: "com.typewhisper.qwen3")
+        let boundaryNotice = ExternalBundleNotice.boundaryUpgradeRequired(
+            installedVersion: "1.1.0",
+            availableVersion: "1.1.1"
+        )
 
         XCTAssertTrue(
             PluginRegistryService.canRepairInstalledPlugin(
                 isBundled: false,
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
-                installState: nil
+                installState: nil,
+                externalNotice: boundaryNotice
+            )
+        )
+        XCTAssertFalse(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: false,
+                registryPlugin: registryPlugin,
+                installInfo: .installed(version: "1.1.1"),
+                installState: nil,
+                externalNotice: nil
+            )
+        )
+        XCTAssertFalse(
+            PluginRegistryService.canRepairInstalledPlugin(
+                isBundled: false,
+                registryPlugin: registryPlugin,
+                installInfo: .installed(version: "1.1.1"),
+                installState: nil,
+                externalNotice: .legacyBundlePresent(version: "1.1.0")
             )
         )
         XCTAssertFalse(
@@ -1724,7 +1747,8 @@ final class PluginRegistryDestinationTests: XCTestCase {
                 isBundled: true,
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
-                installState: nil
+                installState: nil,
+                externalNotice: boundaryNotice
             )
         )
         XCTAssertFalse(
@@ -1732,7 +1756,8 @@ final class PluginRegistryDestinationTests: XCTestCase {
                 isBundled: false,
                 registryPlugin: nil,
                 installInfo: .installed(version: "1.1.1"),
-                installState: nil
+                installState: nil,
+                externalNotice: boundaryNotice
             )
         )
         XCTAssertFalse(
@@ -1740,7 +1765,8 @@ final class PluginRegistryDestinationTests: XCTestCase {
                 isBundled: false,
                 registryPlugin: registryPlugin,
                 installInfo: .updateAvailable(installed: "1.1.0", available: "1.1.1"),
-                installState: nil
+                installState: nil,
+                externalNotice: boundaryNotice
             )
         )
         XCTAssertFalse(
@@ -1748,7 +1774,8 @@ final class PluginRegistryDestinationTests: XCTestCase {
                 isBundled: false,
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
-                installState: .extracting
+                installState: .extracting,
+                externalNotice: boundaryNotice
             )
         )
     }


### PR DESCRIPTION
## Summary
- Hide the generic `Repair Installation` action for healthy installed registry plugins.
- Require an actionable external bundle notice before showing the repair/replacement affordance.
- Keep the existing repair install flow for SDK/runtime boundary replacement cases.

## Issue Context
Issue #612 reports that the Integrations tab shows multiple `Repair Installation` actions even when it is unclear what needs repair. Clicking one briefly shows 0% progress and then returns to the same action, because healthy installed registry plugins were eligible for repair again after the reinstall completed.

Closes #612

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryDestinationTests`
- `git diff --check`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/090d/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined plugin repair eligibility logic to incorporate external bundle notice status, affecting when the repair installation action is available for installed plugins.

* **Tests**
  * Added comprehensive test coverage for plugin repair eligibility scenarios involving external bundle notice conditions across various plugin installation states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->