### PR TITLE
Fix start sound ducking order

### DIFF
--- a/TypeWhisper/Services/SoundService.swift
+++ b/TypeWhisper/Services/SoundService.swift
@@ -175,8 +175,9 @@ class SoundService {
     func playbackDuration(for event: SoundEvent, enabled: Bool) -> TimeInterval? {
         guard enabled else { return nil }
         let choice = choices[event] ?? event.defaultChoice
-        if let playbackURL = filePlaybackURL(for: choice) {
-            return Self.audioFileDuration(for: playbackURL)
+        if let playbackURL = filePlaybackURL(for: choice),
+           let duration = Self.audioFileDuration(for: playbackURL) {
+            return duration
         }
         return sound(for: choice)?.duration
     }

--- a/TypeWhisper/Services/SoundService.swift
+++ b/TypeWhisper/Services/SoundService.swift
@@ -159,16 +159,26 @@ class SoundService {
         loadChoices()
     }
 
-    func play(_ event: SoundEvent, enabled: Bool) {
-        guard enabled else { return }
+    @discardableResult
+    func play(_ event: SoundEvent, enabled: Bool) -> Bool {
+        guard enabled else { return false }
         let choice = choices[event] ?? event.defaultChoice
         if let playbackURL = filePlaybackURL(for: choice),
            oneShotPlayer.play(url: playbackURL) {
-            return
+            return true
         }
-        guard let sound = sound(for: choice) else { return }
+        guard let sound = sound(for: choice) else { return false }
         sound.stop()
-        sound.play()
+        return sound.play()
+    }
+
+    func playbackDuration(for event: SoundEvent, enabled: Bool) -> TimeInterval? {
+        guard enabled else { return nil }
+        let choice = choices[event] ?? event.defaultChoice
+        if let playbackURL = filePlaybackURL(for: choice) {
+            return Self.audioFileDuration(for: playbackURL)
+        }
+        return sound(for: choice)?.duration
     }
 
     func choice(for event: SoundEvent) -> SoundChoice {
@@ -255,6 +265,11 @@ class SoundService {
         case .none:
             return nil
         }
+    }
+
+    private static func audioFileDuration(for url: URL) -> TimeInterval? {
+        guard let player = try? AVAudioPlayer(contentsOf: url) else { return nil }
+        return player.duration
     }
 
     private func preloadSounds() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -242,6 +242,7 @@ final class DictationViewModel: ObservableObject {
     private var pendingRecordingStartedPayload: RecordingStartedPayload?
     private var shouldPlayRecordingStartSoundWhenReady = false
     private var pendingRecordingAudioDuckingLevel: Float?
+    private var pendingRecordingAudioDuckingTask: Task<Void, Never>?
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
@@ -620,17 +621,35 @@ final class DictationViewModel: ObservableObject {
         recordingStartCuePending = false
         isRecordingInputReady = true
         if shouldPlayRecordingStartSoundWhenReady {
-            soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
+            let startSoundDuration = soundService.playbackDuration(for: .recordingStarted, enabled: soundFeedbackEnabled)
+            if !soundService.play(.recordingStarted, enabled: soundFeedbackEnabled) {
+                applyPendingRecordingAudioDuckingIfNeeded()
+            } else {
+                applyPendingRecordingAudioDuckingIfNeeded(after: startSoundDuration)
+            }
+        } else {
+            applyPendingRecordingAudioDuckingIfNeeded()
         }
-        applyPendingRecordingAudioDuckingIfNeeded()
         accessibilityAnnouncementService.announceRecordingStarted()
         EventBus.shared.emit(.recordingStarted(payload))
     }
 
-    private func applyPendingRecordingAudioDuckingIfNeeded() {
+    private func applyPendingRecordingAudioDuckingIfNeeded(after delay: TimeInterval? = nil) {
         guard let level = pendingRecordingAudioDuckingLevel else { return }
         pendingRecordingAudioDuckingLevel = nil
-        audioDuckingService.duckAudio(to: level)
+        pendingRecordingAudioDuckingTask?.cancel()
+        guard let delay, delay > 0 else {
+            audioDuckingService.duckAudio(to: level)
+            return
+        }
+
+        let nanoseconds = UInt64((delay * 1_000_000_000).rounded(.up))
+        pendingRecordingAudioDuckingTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.audioDuckingService.duckAudio(to: level)
+            self?.pendingRecordingAudioDuckingTask = nil
+        }
     }
 
     private func clearRecordingStartCueState(resetReadiness: Bool = true) {
@@ -642,6 +661,8 @@ final class DictationViewModel: ObservableObject {
         pendingRecordingStartedPayload = nil
         shouldPlayRecordingStartSoundWhenReady = false
         pendingRecordingAudioDuckingLevel = nil
+        pendingRecordingAudioDuckingTask?.cancel()
+        pendingRecordingAudioDuckingTask = nil
     }
 
     private func clearDeferredRecordingContext() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -241,6 +241,7 @@ final class DictationViewModel: ObservableObject {
     private var firstRecordingAudioBufferSeen = false
     private var pendingRecordingStartedPayload: RecordingStartedPayload?
     private var shouldPlayRecordingStartSoundWhenReady = false
+    private var pendingRecordingAudioDuckingLevel: Float?
     private var dictationSessions: [UUID: DictationSessionSnapshot] = [:]
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
@@ -621,8 +622,15 @@ final class DictationViewModel: ObservableObject {
         if shouldPlayRecordingStartSoundWhenReady {
             soundService.play(.recordingStarted, enabled: soundFeedbackEnabled)
         }
+        applyPendingRecordingAudioDuckingIfNeeded()
         accessibilityAnnouncementService.announceRecordingStarted()
         EventBus.shared.emit(.recordingStarted(payload))
+    }
+
+    private func applyPendingRecordingAudioDuckingIfNeeded() {
+        guard let level = pendingRecordingAudioDuckingLevel else { return }
+        pendingRecordingAudioDuckingLevel = nil
+        audioDuckingService.duckAudio(to: level)
     }
 
     private func clearRecordingStartCueState(resetReadiness: Bool = true) {
@@ -633,6 +641,7 @@ final class DictationViewModel: ObservableObject {
         firstRecordingAudioBufferSeen = false
         pendingRecordingStartedPayload = nil
         shouldPlayRecordingStartSoundWhenReady = false
+        pendingRecordingAudioDuckingLevel = nil
     }
 
     private func clearDeferredRecordingContext() {
@@ -862,9 +871,7 @@ final class DictationViewModel: ObservableObject {
                 logger.info("Skipping recording start sound for Bluetooth input device")
             }
             if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
-            if audioDuckingEnabled {
-                audioDuckingService.duckAudio(to: Float(audioDuckingLevel))
-            }
+            pendingRecordingAudioDuckingLevel = audioDuckingEnabled ? Float(audioDuckingLevel) : nil
             state = .recording
             // Reset hotkey timer so hybrid threshold counts from recording start,
             // not from key press. Slow device init (e.g. iPhone Continuity ~2-3s)

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -892,7 +892,11 @@ final class DictationViewModel: ObservableObject {
                 logger.info("Skipping recording start sound for Bluetooth input device")
             }
             if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
-            pendingRecordingAudioDuckingLevel = audioDuckingEnabled ? Float(audioDuckingLevel) : nil
+            if audioDuckingEnabled {
+                pendingRecordingAudioDuckingLevel = max(0, min(1, Float(audioDuckingLevel)))
+            } else {
+                pendingRecordingAudioDuckingLevel = nil
+            }
             state = .recording
             // Reset hotkey timer so hybrid threshold counts from recording start,
             // not from key press. Slow device init (e.g. iPhone Continuity ~2-3s)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2976,6 +2976,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         context.dictationViewModel.audioDuckingLevel = 1.5
         context.audioRecordingService.hasMicrophonePermissionOverride = true
         context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
 
         _ = context.dictationViewModel.apiStartRecording()
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -618,9 +618,18 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     private final class MockAudioDuckingService: AudioDuckingService {
         let onRestore: () -> Void
+        let onDuck: (Float) -> Void
 
-        init(onRestore: @escaping () -> Void = {}) {
+        init(
+            onRestore: @escaping () -> Void = {},
+            onDuck: @escaping (Float) -> Void = { _ in }
+        ) {
             self.onRestore = onRestore
+            self.onDuck = onDuck
+        }
+
+        override func duckAudio(to factor: Float) {
+            onDuck(factor)
         }
 
         override func restoreAudio() {
@@ -2768,15 +2777,122 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testApiStartRecording_ducksAudioAfterStartSoundWhenInputIsReady() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
+        let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        var events: [String] = []
+        let soundService = MockSoundService { event, enabled in
+            guard event == .recordingStarted, enabled else { return }
+            events.append("start_sound")
+        }
+        let audioDuckingService = MockAudioDuckingService(onDuck: { factor in
+            events.append("duck_audio_\(factor)")
+        })
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalAudioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled)
+            Self.restoreUserDefault(originalAudioDuckingLevel, forKey: UserDefaultsKeys.audioDuckingLevel)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService,
+            soundService: soundService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.soundFeedbackEnabled = true
+        context.dictationViewModel.audioDuckingEnabled = true
+        context.dictationViewModel.audioDuckingLevel = 0.2
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            events.append("start_audio")
+        }
+
+        _ = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
+        XCTAssertEqual(events, ["start_audio", "start_sound", "duck_audio_0.2"])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+    }
+
+    @MainActor
+    func testApiStartRecording_ducksAudioAfterInputReadyWhenStartSoundIsDisabled() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
+        let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
+        let originalSoundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        var events: [String] = []
+        let soundService = MockSoundService { event, enabled in
+            guard event == .recordingStarted, enabled else { return }
+            events.append("start_sound")
+        }
+        let audioDuckingService = MockAudioDuckingService(onDuck: { factor in
+            events.append("duck_audio_\(factor)")
+        })
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalAudioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled)
+            Self.restoreUserDefault(originalAudioDuckingLevel, forKey: UserDefaultsKeys.audioDuckingLevel)
+            Self.restoreUserDefault(originalSoundFeedbackEnabled, forKey: UserDefaultsKeys.soundFeedbackEnabled)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService,
+            soundService: soundService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.soundFeedbackEnabled = false
+        context.dictationViewModel.audioDuckingEnabled = true
+        context.dictationViewModel.audioDuckingLevel = 0.25
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            events.append("start_audio")
+        }
+
+        _ = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
+        XCTAssertEqual(events, ["start_audio", "duck_audio_0.25"])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+    }
+
+    @MainActor
     func testApiStartRecording_skipsStartSoundForBluetoothInput() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
+        let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
         var events: [String] = []
         let bluetoothDeviceID = AudioDeviceID(409)
         let soundService = MockSoundService { event, enabled in
             guard event == .recordingStarted, enabled else { return }
             events.append("start_sound")
         }
+        let audioDuckingService = MockAudioDuckingService(onDuck: { factor in
+            events.append("duck_audio_\(factor)")
+        })
         let transportResolver = FakeAudioDeviceTransportResolver(
             transports: [bluetoothDeviceID: kAudioDeviceTransportTypeBluetooth]
         ) { deviceID in
@@ -2800,10 +2916,13 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictationContext = nil
             TestSupport.remove(appSupportDirectory)
             Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalAudioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled)
+            Self.restoreUserDefault(originalAudioDuckingLevel, forKey: UserDefaultsKeys.audioDuckingLevel)
         }
 
         dictationContext = Self.makeDictationContext(
             appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService,
             soundService: soundService,
             audioDeviceTransportResolver: transportResolver,
             audioDeviceBluetoothInputRouteStabilizer: deviceRouteStabilizer,
@@ -2812,6 +2931,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
         let context = try XCTUnwrap(dictationContext)
         context.dictationViewModel.soundFeedbackEnabled = true
+        context.dictationViewModel.audioDuckingEnabled = true
+        context.dictationViewModel.audioDuckingLevel = 0.3
         context.audioDeviceService.inputDevices = [
             AudioInputDevice(deviceID: bluetoothDeviceID, name: "AirPods Max", uid: "bt-input")
         ]
@@ -2836,7 +2957,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
 
-        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertEqual(events, ["start_audio", "duck_audio_0.3"])
         XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
         XCTAssertTrue(context.audioRecordingService.hasExplicitDeviceSelection)
     }
@@ -3816,6 +3937,14 @@ final class APIRouterAndHandlersTests: XCTestCase {
             UserDefaults.standard.set(value, forKey: UserDefaultsKeys.selectedInputDeviceUID)
         } else {
             UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        }
+    }
+
+    private static func restoreUserDefault(_ value: Any?, forKey key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
         }
     }
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2943,6 +2943,49 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testApiStartRecording_clampsPendingAudioDuckingLevel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
+        let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
+        let originalSoundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        var duckingLevels: [Float] = []
+        let audioDuckingService = MockAudioDuckingService(onDuck: { factor in
+            duckingLevels.append(factor)
+        })
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalAudioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled)
+            Self.restoreUserDefault(originalAudioDuckingLevel, forKey: UserDefaultsKeys.audioDuckingLevel)
+            Self.restoreUserDefault(originalSoundFeedbackEnabled, forKey: UserDefaultsKeys.soundFeedbackEnabled)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.soundFeedbackEnabled = false
+        context.dictationViewModel.audioDuckingEnabled = true
+        context.dictationViewModel.audioDuckingLevel = 1.5
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+
+        _ = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertTrue(duckingLevels.isEmpty)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
+        XCTAssertEqual(duckingLevels, [1.0])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+    }
+
+    @MainActor
     func testApiStartRecording_skipsStartSoundForBluetoothInput() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -640,14 +640,24 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     private final class MockSoundService: SoundService {
         let onPlay: (SoundEvent, Bool) -> Void
+        let playbackDurationForEvent: (SoundEvent, Bool) -> TimeInterval?
 
-        init(onPlay: @escaping (SoundEvent, Bool) -> Void = { _, _ in }) {
+        init(
+            onPlay: @escaping (SoundEvent, Bool) -> Void = { _, _ in },
+            playbackDurationForEvent: @escaping (SoundEvent, Bool) -> TimeInterval? = { _, _ in nil }
+        ) {
             self.onPlay = onPlay
+            self.playbackDurationForEvent = playbackDurationForEvent
             super.init()
         }
 
-        override func play(_ event: SoundEvent, enabled: Bool) {
+        override func play(_ event: SoundEvent, enabled: Bool) -> Bool {
             onPlay(event, enabled)
+            return enabled
+        }
+
+        override func playbackDuration(for event: SoundEvent, enabled: Bool) -> TimeInterval? {
+            playbackDurationForEvent(event, enabled)
         }
     }
 
@@ -2824,6 +2834,60 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(events, ["start_audio", "start_sound", "duck_audio_0.2"])
         XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+    }
+
+    @MainActor
+    func testApiStartRecording_waitsForStartSoundDurationBeforeDuckingAudio() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
+        let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        var events: [String] = []
+        let soundService = MockSoundService(
+            onPlay: { event, enabled in
+                guard event == .recordingStarted, enabled else { return }
+                events.append("start_sound")
+            },
+            playbackDurationForEvent: { event, enabled in
+                event == .recordingStarted && enabled ? 0.05 : nil
+            }
+        )
+        let audioDuckingService = MockAudioDuckingService(onDuck: { factor in
+            events.append("duck_audio_\(factor)")
+        })
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalAudioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled)
+            Self.restoreUserDefault(originalAudioDuckingLevel, forKey: UserDefaultsKeys.audioDuckingLevel)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDuckingService: audioDuckingService,
+            soundService: soundService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.soundFeedbackEnabled = true
+        context.dictationViewModel.audioDuckingEnabled = true
+        context.dictationViewModel.audioDuckingLevel = 0.2
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            events.append("start_audio")
+        }
+
+        _ = context.dictationViewModel.apiStartRecording()
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
+        XCTAssertEqual(events, ["start_audio", "start_sound"])
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(events, ["start_audio", "start_sound", "duck_audio_0.2"])
     }
 
     @MainActor

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2853,8 +2853,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 event == .recordingStarted && enabled ? 0.05 : nil
             }
         )
+        let duckingApplied = expectation(description: "ducking applied after start sound duration")
         let audioDuckingService = MockAudioDuckingService(onDuck: { factor in
             events.append("duck_audio_\(factor)")
+            duckingApplied.fulfill()
         })
         var dictationContext: DictationContext?
         defer {
@@ -2885,7 +2887,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(events, ["start_audio", "start_sound"])
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        await fulfillment(of: [duckingApplied], timeout: 1.0)
 
         XCTAssertEqual(events, ["start_audio", "start_sound", "duck_audio_0.2"])
     }

--- a/TypeWhisperTests/SoundServiceTests.swift
+++ b/TypeWhisperTests/SoundServiceTests.swift
@@ -164,6 +164,28 @@ final class SoundServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testPlaybackDurationFallsBackToSoundResolverWhenFileDurationUnavailable() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let storedDefaults = captureSoundDefaults()
+        defer {
+            restoreSoundDefaults(storedDefaults)
+            AppConstants.testAppSupportDirectoryOverride = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        AppConstants.testAppSupportDirectoryOverride = appSupportDirectory
+        let soundsDirectory = SoundChoice.customSoundsDirectory
+        try FileManager.default.createDirectory(at: soundsDirectory, withIntermediateDirectories: true)
+        let filename = "invalid.wav"
+        try Data("not a playable audio file".utf8).write(to: soundsDirectory.appendingPathComponent(filename))
+        let service = PreviewSoundResolverSpy()
+        service.updateChoice(for: .recordingStarted, choice: .custom(filename))
+
+        XCTAssertNil(service.playbackDuration(for: .recordingStarted, enabled: true))
+        XCTAssertEqual(service.resolvedChoices, [.custom(filename)])
+    }
+
+    @MainActor
     func testPreviewStillUsesPreviewSoundResolver() {
         let service = PreviewSoundResolverSpy()
 


### PR DESCRIPTION
## Summary
- Defers system audio ducking until the recording-start cue has been emitted and its expected playback duration has elapsed.
- Snapshots the ducking level at recording start, clamps that snapshot to `0...1`, and cancels pending ducking if recording start is aborted, stopped, cancelled, or superseded.
- Preserves duration fallback behavior when `AVAudioPlayer` cannot read a cue duration.
- Adds ordering regression coverage for enabled start sound, delayed cue playback, disabled sound feedback, Bluetooth start-sound suppression, clamped ducking levels, and duration fallback.

## Issue Context
Issue #613 reports that enabling "Reduce system volume during recording" lowers the "Recording Started" sound. The root cause is that ducking started immediately after audio capture, while the start cue is emitted only after the first input buffer arrives. Because cue playback is asynchronous, ducking also needs to wait for the cue duration rather than only wait for `play(...)` to be called.

Closes #613

## Test Plan
- `git diff --check`
- Original issue regression command:
```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_ducksAudioAfterStartSoundWhenInputIsReady -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_ducksAudioAfterInputReadyWhenStartSoundIsDisabled -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_defersStartSoundUntilInputIsReady CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```
- CI follow-up regression command:
```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_clampsPendingAudioDuckingLevel CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```
- Final focused command after review feedback:
```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_ducksAudioAfterStartSoundWhenInputIsReady -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_waitsForStartSoundDurationBeforeDuckingAudio -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_ducksAudioAfterInputReadyWhenStartSoundIsDisabled -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_clampsPendingAudioDuckingLevel -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_defersStartSoundUntilInputIsReady -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testApiStartRecording_skipsStartSoundForBluetoothInput -only-testing:TypeWhisperTests/SoundServiceTests/testPlaybackDurationFallsBackToSoundResolverWhenFileDurationUnavailable -only-testing:TypeWhisperTests/SoundServiceTests/testPlayRecordingStartedUsesFilePlaybackInsteadOfPreviewSoundResolver -only-testing:TypeWhisperTests/SoundServiceTests/testPlayRecordingStartedUsesFilePlaybackForCustomSound -only-testing:TypeWhisperTests/SoundServiceTests/testPlayRecordingStartedUsesFilePlaybackForSystemSound CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```
- Full app test command:
```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```
- Local dev app smoke:
```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/3960/typewhisper-mac
```

The automated proof checks event ordering and the async delay before ducking. Human-audible volume confirmation still requires local app testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio ducking now waits until the app is actually ready and (if enabled) until the "recording started" sound finishes, preventing premature volume reduction.
  * When start-sound feedback is disabled, the start sound is skipped but ducking still applies once input is ready.

* **New Features**
  * Improved detection of start-sound playback duration to ensure ducking timing matches actual playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->