### PR TITLE
Fix Script Runner add dialog

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ScriptPlugin/ScriptPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ScriptPlugin/ScriptPlugin.swift
@@ -130,6 +130,15 @@ final class ScriptService: ObservableObject, @unchecked Sendable {
         saveConfig()
     }
 
+    func saveScript(_ script: ScriptConfig) {
+        if let index = scripts.firstIndex(where: { $0.id == script.id }) {
+            scripts[index] = script
+        } else {
+            scripts.append(script)
+        }
+        saveConfig()
+    }
+
     func addExampleScript() {
         addScript(ScriptConfig(
             name: "UPPERCASE Example",
@@ -330,7 +339,7 @@ struct ScriptSettingsView: View {
                 .buttonStyle(.bordered)
                 .controlSize(.small)
                 Button {
-                    service.addScript(ScriptConfig())
+                    editingScript = ScriptConfig()
                 } label: {
                     Label(String(localized: "Add Script", bundle: bundle), systemImage: "plus")
                 }
@@ -388,12 +397,13 @@ struct ScriptSettingsView: View {
                 script: script,
                 availableProfiles: service.host.availableRuleNames,
                 onSave: { updated in
-                    service.updateScript(updated)
+                    service.saveScript(updated)
                     editingScript = nil
                 },
                 onCancel: { editingScript = nil }
             )
         }
+        .frame(minHeight: 400)
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes the Script Runner settings regression where Add Script saved an empty script without opening the editor.
- Reuses the existing edit sheet for new scripts and only persists the script when Save is clicked.
- Gives the Script Runner settings view enough height for added/example rows to remain visible inside the plugin settings window.

## Issue Context
Issue #619 reports that in Script Runner settings, clicking Add Script or Add Example leaves users with only the settings Done button visible where the script input should be. The expected behavior is that users can enter a shell command for the new script, matching previous builds.

Closes #619

## Test Plan
- `git diff --check`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme ScriptPlugin -configuration Debug build`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' build`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run ScriptPlugin /Users/marco/Projects/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned script creation and editing workflow with a dedicated editor interface for significantly improved usability and consistency.
  * Enhanced user experience with an intuitive dialog-based editor for seamlessly adding and modifying scripts with better organization.

* **Bug Fixes**
  * Fixed script persistence mechanism to properly handle both creation of new scripts and reliable updates to existing scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->