### PR TITLE
Fix overlay live transcript preview expansion

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		C2300000000000000000000F /* SpeechAnalyzerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000160 /* SpeechAnalyzerPlugin.swift */; };
 		C23000000000000000000010 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
 		2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */; };
+		2F4D6A8B0C1E3F5A7B9D2C50 /* IndicatorTranscriptPreviewSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D6A8B0C1E3F5A7B9D2C51 /* IndicatorTranscriptPreviewSizingTests.swift */; };
 		91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */; };
 		545000000000000000000002 /* SetupWizardRecommendationAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545000000000000000000001 /* SetupWizardRecommendationAvailabilityTests.swift */; };
 		91B4D7E2C5A809F1632E4B7E /* StreamingHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */; };
@@ -768,6 +769,7 @@
 		E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRouterAndHandlersTests.swift; sourceTree = "<group>"; };
 		E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TypeWhisperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationViewModelIndicatorSettingsTests.swift; sourceTree = "<group>"; };
+		2F4D6A8B0C1E3F5A7B9D2C51 /* IndicatorTranscriptPreviewSizingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IndicatorTranscriptPreviewSizingTests.swift; sourceTree = "<group>"; };
 		6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FloatingPanelSpacePolicyTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardComposerTests.swift; sourceTree = "<group>"; };
 		2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptWizardInferenceServiceTests.swift; sourceTree = "<group>"; };
@@ -2008,6 +2010,7 @@
 				CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */,
 				FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
+				2F4D6A8B0C1E3F5A7B9D2C51 /* IndicatorTranscriptPreviewSizingTests.swift */,
 					6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
 					E5A1B2C3D4F5061728394A5E /* NotchIndicatorLayoutTests.swift */,
 					604D00000000000000000001 /* AudioRecorderViewModelTests.swift */,
@@ -3358,6 +3361,7 @@
 				7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */,
 				A40500000000000000000101 /* CLIClient.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */,
+				2F4D6A8B0C1E3F5A7B9D2C50 /* IndicatorTranscriptPreviewSizingTests.swift in Sources */,
 					7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */,
 					E5A1B2C3D4F5061728394A5D /* NotchIndicatorLayoutTests.swift in Sources */,
 					3A4B5C6D7E8F901234567890 /* AudioEngineRecoverySupportTests.swift in Sources */,

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -1,5 +1,34 @@
 import SwiftUI
 
+struct OverlayTranscriptPreviewState: Equatable {
+    let isRecording: Bool
+    let previewEnabled: Bool
+    let isRecorder: Bool
+    let externalStreamingDisplayCount: Int
+    let partialText: String
+    let textExpanded: Bool
+
+    var suppressStreamingText: Bool {
+        !isRecorder && externalStreamingDisplayCount > 0
+    }
+
+    var showTranscriptPreview: Bool {
+        previewEnabled && !suppressStreamingText
+    }
+
+    var hasTranscriptSection: Bool {
+        isRecording && showTranscriptPreview
+    }
+
+    var transcriptBodyVisible: Bool {
+        hasTranscriptSection && textExpanded
+    }
+
+    var shouldExpandForCurrentText: Bool {
+        hasTranscriptSection && !partialText.isEmpty && !textExpanded
+    }
+}
+
 /// Pill-shaped overlay indicator that appears centered on the screen.
 /// Supports top and bottom positioning.
 struct OverlayIndicatorView: View {
@@ -16,10 +45,6 @@ struct OverlayIndicatorView: View {
         IndicatorPresentationData.make(dictation: viewModel, recorder: recorder)
     }
 
-    private var suppressStreamingText: Bool {
-        !presentation.isRecorder && presentation.externalStreamingDisplayCount > 0
-    }
-
     private var hasActionFeedback: Bool {
         presentation.state == .inserting && presentation.actionFeedbackMessage != nil
     }
@@ -28,17 +53,32 @@ struct OverlayIndicatorView: View {
         presentation.state == .recording && presentation.recordingCancelWarningMessage != nil
     }
 
-    private var showTranscriptPreview: Bool {
-        viewModel.indicatorTranscriptPreviewEnabled && !suppressStreamingText
+    private var transcriptPreviewState: OverlayTranscriptPreviewState {
+        OverlayTranscriptPreviewState(
+            isRecording: presentation.state == .recording,
+            previewEnabled: viewModel.indicatorTranscriptPreviewEnabled,
+            isRecorder: presentation.isRecorder,
+            externalStreamingDisplayCount: presentation.externalStreamingDisplayCount,
+            partialText: presentation.partialText,
+            textExpanded: textExpanded
+        )
     }
 
-    private var isExpanded: Bool {
-        textExpanded || hasActionFeedback || hasRecordingCancelWarning
+    private var showTranscriptPreview: Bool {
+        transcriptPreviewState.showTranscriptPreview
+    }
+
+    private var hasTranscriptSection: Bool {
+        transcriptPreviewState.hasTranscriptSection
+    }
+
+    private var transcriptBodyVisible: Bool {
+        transcriptPreviewState.transcriptBodyVisible
     }
 
     private var currentWidth: CGFloat {
         if hasRecordingCancelWarning { return max(closedWidth, 340) }
-        if textExpanded { return max(closedWidth, 400) }
+        if transcriptBodyVisible { return max(closedWidth, 400) }
         if hasActionFeedback { return max(closedWidth, 340) }
         return closedWidth
     }
@@ -81,29 +121,33 @@ struct OverlayIndicatorView: View {
         .animation(.easeInOut(duration: 0.3), value: textExpanded)
         .animation(.easeInOut(duration: 0.2), value: presentation.state)
         .animation(.easeOut(duration: 0.08), value: presentation.audioLevel)
+        .onChange(of: presentation.partialText) {
+            expandTranscriptPreviewIfNeeded()
+        }
         .onChange(of: presentation.state) {
             if presentation.state == .recording {
                 withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
                     dotPulse = true
                 }
+                expandTranscriptPreviewIfNeeded()
             } else {
                 dotPulse = false
                 textExpanded = false
             }
         }
-        .onChange(of: suppressStreamingText) {
+        .onChange(of: transcriptPreviewState.suppressStreamingText) {
             if !showTranscriptPreview {
                 withAnimation(.easeInOut(duration: 0.3)) {
                     textExpanded = false
                 }
+            } else {
+                expandTranscriptPreviewIfNeeded()
             }
         }
         .onChange(of: viewModel.indicatorTranscriptPreviewEnabled) {
-            if showTranscriptPreview, presentation.state == .recording, !presentation.partialText.isEmpty {
-                withAnimation(.easeOut(duration: 0.25)) {
-                    textExpanded = true
-                }
-            } else if !showTranscriptPreview {
+            if showTranscriptPreview {
+                expandTranscriptPreviewIfNeeded()
+            } else {
                 withAnimation(.easeInOut(duration: 0.3)) {
                     textExpanded = false
                 }
@@ -112,6 +156,13 @@ struct OverlayIndicatorView: View {
         .animation(.easeInOut(duration: 1.0), value: dotPulse)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    private func expandTranscriptPreviewIfNeeded() {
+        guard transcriptPreviewState.shouldExpandForCurrentText else { return }
+        withAnimation(.easeOut(duration: 0.25)) {
+            textExpanded = true
+        }
     }
 
     private var accessibilityLabel: String {
@@ -154,7 +205,7 @@ struct OverlayIndicatorView: View {
             )
         } else if isTop {
             // Top position: text expands downward, action feedback below text
-            if presentation.state == .recording, showTranscriptPreview {
+            if hasTranscriptSection {
                 IndicatorExpandableText(
                     text: presentation.partialText,
                     fontSize: transcriptFontSize,
@@ -162,13 +213,6 @@ struct OverlayIndicatorView: View {
                     expanded: textExpanded,
                     contentPadding: contentPadding
                 )
-                .onChange(of: presentation.partialText) {
-                    if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
-                        withAnimation(.easeOut(duration: 0.25)) {
-                            textExpanded = true
-                        }
-                    }
-                }
             }
 
             if hasActionFeedback {
@@ -194,7 +238,7 @@ struct OverlayIndicatorView: View {
                 Divider().background(Color.white.opacity(0.1))
             }
 
-            if presentation.state == .recording, showTranscriptPreview {
+            if hasTranscriptSection {
                 IndicatorExpandableText(
                     text: presentation.partialText,
                     fontSize: transcriptFontSize,
@@ -202,13 +246,6 @@ struct OverlayIndicatorView: View {
                     expanded: textExpanded,
                     contentPadding: contentPadding
                 )
-                .onChange(of: presentation.partialText) {
-                    if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
-                        withAnimation(.easeOut(duration: 0.25)) {
-                            textExpanded = true
-                        }
-                    }
-                }
             }
         }
     }

--- a/TypeWhisperTests/IndicatorTranscriptPreviewSizingTests.swift
+++ b/TypeWhisperTests/IndicatorTranscriptPreviewSizingTests.swift
@@ -23,4 +23,49 @@ final class IndicatorTranscriptPreviewSizingTests: XCTestCase {
         XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .notch, offset: offset), 16)
         XCTAssertEqual(DictationViewModel.indicatorTranscriptPreviewFontSize(for: .overlay, offset: offset), 17)
     }
+
+    func testOverlayTranscriptPreviewExpandsForRecordingPartialText() {
+        let state = OverlayTranscriptPreviewState(
+            isRecording: true,
+            previewEnabled: true,
+            isRecorder: false,
+            externalStreamingDisplayCount: 0,
+            partialText: "Hello",
+            textExpanded: false
+        )
+
+        XCTAssertTrue(state.hasTranscriptSection)
+        XCTAssertTrue(state.shouldExpandForCurrentText)
+    }
+
+    func testOverlayTranscriptPreviewCollapsesWhenDisabled() {
+        let state = OverlayTranscriptPreviewState(
+            isRecording: true,
+            previewEnabled: false,
+            isRecorder: false,
+            externalStreamingDisplayCount: 0,
+            partialText: "Hello",
+            textExpanded: false
+        )
+
+        XCTAssertFalse(state.showTranscriptPreview)
+        XCTAssertFalse(state.hasTranscriptSection)
+        XCTAssertFalse(state.shouldExpandForCurrentText)
+    }
+
+    func testOverlayTranscriptPreviewSuppressesWhenExternalStreamingDisplayIsActive() {
+        let state = OverlayTranscriptPreviewState(
+            isRecording: true,
+            previewEnabled: true,
+            isRecorder: false,
+            externalStreamingDisplayCount: 1,
+            partialText: "Hello",
+            textExpanded: false
+        )
+
+        XCTAssertTrue(state.suppressStreamingText)
+        XCTAssertFalse(state.showTranscriptPreview)
+        XCTAssertFalse(state.hasTranscriptSection)
+        XCTAssertFalse(state.shouldExpandForCurrentText)
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes Overlay live transcript preview expansion by moving the partial-text expansion trigger to the stable parent view.
- Keeps external streaming display suppression, top/bottom layout, transcription, and panel placement behavior unchanged.
- Adds focused tests for Overlay preview expansion, disabled preview, and external streaming suppression.

## Issue context

Issue #620 reports that with Indicator set to Overlay and live transcript preview enabled, streaming text does not appear during recording and only flashes after releasing the activation key. Max later confirmed this happens in a normal window on a Mac mini M4 with two external monitors on Sequoia 15.7.7, including an older 2026-05-20 daily build.

Closes #620

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/IndicatorTranscriptPreviewSizingTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify transcript preview expansion behavior during recording.

* **Refactor**
  * Improved internal organization of transcript preview state management for better code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->