### PR TITLE
Fix middle mouse pass-through for hotkeys

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -479,27 +479,50 @@ final class HotkeyService: ObservableObject {
 
     private func setupMonitor() {
         tearDownMonitor()
+        let includeMouse = needsMouseEventMonitoring
 
         guard accessibilityTrustedProvider() else {
             logger.info("Accessibility permission not granted, installing local hotkey monitor only")
-            installLocalEventMonitor()
+            installLocalEventMonitor(includeMouse: includeMouse)
             return
         }
 
         // Try CGEventTap first - it can suppress hotkey events from reaching other apps
-        if setupEventTap() {
+        if setupEventTap(includeMouse: needsSuppressingMouseEventTap) {
             logger.info("Using tail-appended CGEventTap for hotkey monitoring with NSEvent compatibility fallback")
-            installEventMonitors(includeMouse: false)
+            installEventMonitors(includeMouse: includeMouse)
             return
         }
 
         // Fallback: NSEvent monitors (no event suppression)
         logger.info("CGEventTap unavailable, falling back to NSEvent monitors (hotkey events will pass through)")
-        installEventMonitors(includeMouse: true)
+        installEventMonitors(includeMouse: includeMouse)
     }
 
-    private func installLocalEventMonitor() {
-        let mask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .keyUp]
+    private var needsMouseEventMonitoring: Bool {
+        slots.values.contains { states in
+            states.contains { $0.hotkey?.mouseButton != nil }
+        } || workflowSlots.values.contains { states in
+            states.contains { $0.hotkey.mouseButton != nil }
+        }
+    }
+
+    private var needsSuppressingMouseEventTap: Bool {
+        slots.values.contains { states in
+            states.contains { state in
+                guard let button = state.hotkey?.mouseButton else { return false }
+                return Self.shouldSuppressMouseButtonHotkey(button)
+            }
+        } || workflowSlots.values.contains { states in
+            states.contains { state in
+                guard let button = state.hotkey.mouseButton else { return false }
+                return Self.shouldSuppressMouseButtonHotkey(button)
+            }
+        }
+    }
+
+    private func installLocalEventMonitor(includeMouse: Bool) {
+        let mask = eventMonitorMask(includeMouse: includeMouse)
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
             _ = self?.handleEvent(event, source: .monitor)
             return event
@@ -507,11 +530,7 @@ final class HotkeyService: ObservableObject {
     }
 
     private func installEventMonitors(includeMouse: Bool) {
-        var mask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .keyUp]
-        if includeMouse {
-            mask.insert(.otherMouseDown)
-            mask.insert(.otherMouseUp)
-        }
+        let mask = eventMonitorMask(includeMouse: includeMouse)
 
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { [weak self] event in
             _ = self?.handleEvent(event, source: .monitor)
@@ -521,6 +540,15 @@ final class HotkeyService: ObservableObject {
             _ = self?.handleEvent(event, source: .monitor)
             return event
         }
+    }
+
+    private func eventMonitorMask(includeMouse: Bool) -> NSEvent.EventTypeMask {
+        var mask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .keyUp]
+        if includeMouse {
+            mask.insert(.otherMouseDown)
+            mask.insert(.otherMouseUp)
+        }
+        return mask
     }
 
     private func tearDownMonitor() {
@@ -556,13 +584,7 @@ final class HotkeyService: ObservableObject {
 
     /// Creates a CGEventTap to intercept and suppress hotkey events before they reach other apps.
     /// Requires Accessibility permission. Returns true if the tap was successfully created.
-    private func setupEventTap() -> Bool {
-        let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
-            | (1 << CGEventType.keyUp.rawValue)
-            | (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.otherMouseDown.rawValue)
-            | (1 << CGEventType.otherMouseUp.rawValue)
-
+    private func setupEventTap(includeMouse: Bool) -> Bool {
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
 
         // @convention(c) callback - must not capture context. Uses userInfo to access HotkeyService.
@@ -590,7 +612,7 @@ final class HotkeyService: ObservableObject {
             tap: .cgSessionEventTap,
             place: .tailAppendEventTap,
             options: .defaultTap,
-            eventsOfInterest: eventMask,
+            eventsOfInterest: Self.suppressingEventTapMask(includeMouse: includeMouse),
             callback: callback,
             userInfo: selfPtr
         ) else {
@@ -603,6 +625,24 @@ final class HotkeyService: ObservableObject {
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         return true
+    }
+
+    private nonisolated static func suppressingEventTapMask(includeMouse: Bool) -> CGEventMask {
+        var mask: CGEventMask =
+            (CGEventMask(1) << CGEventType.keyDown.rawValue)
+            | (CGEventMask(1) << CGEventType.keyUp.rawValue)
+            | (CGEventMask(1) << CGEventType.flagsChanged.rawValue)
+
+        if includeMouse {
+            mask |= (CGEventMask(1) << CGEventType.otherMouseDown.rawValue)
+            mask |= (CGEventMask(1) << CGEventType.otherMouseUp.rawValue)
+        }
+
+        return mask
+    }
+
+    private nonisolated static func shouldSuppressMouseButtonHotkey(_ button: UInt16) -> Bool {
+        button != 2
     }
 
     private func reenableEventTapAfterSystemDisable() {
@@ -943,6 +983,18 @@ final class HotkeyService: ObservableObject {
     func processEventForTesting(_ event: NSEvent, source: HotkeyEventSource) -> Bool {
         handleEvent(event, source: source)
     }
+
+    func needsMouseEventMonitoringForTesting() -> Bool {
+        needsMouseEventMonitoring
+    }
+
+    func needsSuppressingMouseEventTapForTesting() -> Bool {
+        needsSuppressingMouseEventTap
+    }
+
+    static func suppressingEventTapMaskForTesting(includeMouse: Bool = false) -> CGEventMask {
+        suppressingEventTapMask(includeMouse: includeMouse)
+    }
 #endif
 
     private enum KeyEventResult {
@@ -967,37 +1019,38 @@ final class HotkeyService: ObservableObject {
             guard let button = hotkey.mouseButton, event.buttonNumber == Int(button) else {
                 return (false, false, false)
             }
+            let shouldSuppress = Self.shouldSuppressMouseButtonHotkey(button)
 
             let isDown = event.type == .otherMouseDown
             let wasDown = state.mouseButtonWasDown
 
             if isDown && !wasDown {
                 state.mouseButtonWasDown = true
-                guard hotkey.isDoubleTap else { return (true, false, true) }
+                guard hotkey.isDoubleTap else { return (true, false, shouldSuppress) }
                 if state.tapCount == 1,
                    let lastUp = state.lastTapUpTime,
                    Date().timeIntervalSince(lastUp) < Self.doubleTapThreshold {
                     state.tapCount = 2
                     state.lastTapUpTime = nil
-                    return (true, false, true)
+                    return (true, false, shouldSuppress)
                 } else {
                     state.tapCount = 0
                     state.lastTapUpTime = nil
-                    return (false, false, true)
+                    return (false, false, shouldSuppress)
                 }
             } else if !isDown && wasDown {
                 state.mouseButtonWasDown = false
-                guard hotkey.isDoubleTap else { return (false, true, true) }
+                guard hotkey.isDoubleTap else { return (false, true, shouldSuppress) }
                 if state.tapCount == 2 {
                     state.tapCount = 0
-                    return (false, true, true)
+                    return (false, true, shouldSuppress)
                 } else {
                     state.tapCount = 1
                     state.lastTapUpTime = Date()
-                    return (false, false, true)
+                    return (false, false, shouldSuppress)
                 }
             }
-            return (false, false, false)
+            return (false, false, shouldSuppress)
         }
 
         // Fn hotkeys can run in two modes:

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -5566,6 +5566,127 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testSuppressingEventTapMaskOnlyIncludesMouseEventsWhenRequested() {
+        let keyboardOnlyMask = HotkeyService.suppressingEventTapMaskForTesting(includeMouse: false)
+
+        XCTAssertNotEqual(keyboardOnlyMask & eventMask(for: .keyDown), 0)
+        XCTAssertNotEqual(keyboardOnlyMask & eventMask(for: .keyUp), 0)
+        XCTAssertNotEqual(keyboardOnlyMask & eventMask(for: .flagsChanged), 0)
+        XCTAssertEqual(keyboardOnlyMask & eventMask(for: .otherMouseDown), 0)
+        XCTAssertEqual(keyboardOnlyMask & eventMask(for: .otherMouseUp), 0)
+
+        let mouseAwareMask = HotkeyService.suppressingEventTapMaskForTesting(includeMouse: true)
+
+        XCTAssertNotEqual(mouseAwareMask & eventMask(for: .keyDown), 0)
+        XCTAssertNotEqual(mouseAwareMask & eventMask(for: .keyUp), 0)
+        XCTAssertNotEqual(mouseAwareMask & eventMask(for: .flagsChanged), 0)
+        XCTAssertNotEqual(mouseAwareMask & eventMask(for: .otherMouseDown), 0)
+        XCTAssertNotEqual(mouseAwareMask & eventMask(for: .otherMouseUp), 0)
+    }
+
+    @MainActor
+    func testMiddleMousePassesThroughWhenNoMouseHotkeyIsBound() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let middleMouseDown = try makeOtherMouseEvent(buttonNumber: 2, isDown: true)
+
+        XCTAssertFalse(service.needsMouseEventMonitoringForTesting())
+        XCTAssertFalse(service.needsSuppressingMouseEventTapForTesting())
+        XCTAssertFalse(service.processEventForTesting(middleMouseDown, source: .eventTap))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testMiddleMousePassesThroughWhenDifferentMouseHotkeyIsBound() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.setHotkeyForTesting(UnifiedHotkey(mouseButton: 3), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let middleMouseDown = try makeOtherMouseEvent(buttonNumber: 2, isDown: true)
+
+        XCTAssertTrue(service.needsMouseEventMonitoringForTesting())
+        XCTAssertTrue(service.needsSuppressingMouseEventTapForTesting())
+        XCTAssertFalse(service.processEventForTesting(middleMouseDown, source: .eventTap))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    @MainActor
+    func testMatchingMiddleMouseHotkeyDispatchesWithoutSuppressingClick() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.setHotkeyForTesting(UnifiedHotkey(mouseButton: 2), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let middleMouseDown = try makeOtherMouseEvent(buttonNumber: 2, isDown: true)
+        let middleMouseUp = try makeOtherMouseEvent(buttonNumber: 2, isDown: false)
+
+        XCTAssertTrue(service.needsMouseEventMonitoringForTesting())
+        XCTAssertFalse(service.needsSuppressingMouseEventTapForTesting())
+        XCTAssertFalse(service.processEventForTesting(middleMouseDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertFalse(service.processEventForTesting(middleMouseUp, source: .monitor))
+    }
+
+    @MainActor
+    func testMiddleMouseHotkeyPassesThroughEvenWhenSideMouseHotkeyUsesSuppressingTap() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.setHotkeysForTesting([
+            UnifiedHotkey(mouseButton: 2),
+            UnifiedHotkey(mouseButton: 3)
+        ], for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let middleMouseDown = try makeOtherMouseEvent(buttonNumber: 2, isDown: true)
+
+        XCTAssertTrue(service.needsMouseEventMonitoringForTesting())
+        XCTAssertTrue(service.needsSuppressingMouseEventTapForTesting())
+        XCTAssertFalse(service.processEventForTesting(middleMouseDown, source: .eventTap))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testMatchingSideMouseHotkeyDispatchesAndSuppressesClick() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.setHotkeyForTesting(UnifiedHotkey(mouseButton: 3), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let sideMouseDown = try makeOtherMouseEvent(buttonNumber: 3, isDown: true)
+        let sideMouseUp = try makeOtherMouseEvent(buttonNumber: 3, isDown: false)
+
+        XCTAssertTrue(service.needsMouseEventMonitoringForTesting())
+        XCTAssertTrue(service.needsSuppressingMouseEventTapForTesting())
+        XCTAssertTrue(service.processEventForTesting(sideMouseDown, source: .eventTap))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertTrue(service.processEventForTesting(sideMouseUp, source: .eventTap))
+    }
+
+    @MainActor
     func testPushToTalkStartCallbackIncludesRequestTimestamp() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -6703,6 +6824,24 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
         event.flags = flags
         return try XCTUnwrap(NSEvent(cgEvent: event))
+    }
+
+    private func makeOtherMouseEvent(buttonNumber: UInt32, isDown: Bool) throws -> NSEvent {
+        let eventType: CGEventType = isDown ? .otherMouseDown : .otherMouseUp
+        let button = try XCTUnwrap(CGMouseButton(rawValue: buttonNumber))
+        let event = try XCTUnwrap(
+            CGEvent(
+                mouseEventSource: nil,
+                mouseType: eventType,
+                mouseCursorPosition: .zero,
+                mouseButton: button
+            )
+        )
+        return try XCTUnwrap(NSEvent(cgEvent: event))
+    }
+
+    private func eventMask(for type: CGEventType) -> CGEventMask {
+        CGEventMask(1) << type.rawValue
     }
 
     private func makeFlagsChangedEvent(


### PR DESCRIPTION
## Issue context

Issue #623 reports that when TypeWhisper 1.4.0 (803) is open on macOS 26.1 Tahoe, middle mouse clicks stop reaching the system even when no TypeWhisper shortcut is bound to the middle mouse button.

Closes #623

## Summary

- Keep the suppressing `CGEventTap` keyboard-only when no suppressible mouse-button hotkeys are configured.
- Keep middle-click (`mouseButton: 2`) pass-through even when it is assigned as a TypeWhisper hotkey, so browser tab/open/close behavior keeps working.
- Use the suppressing tap for side-button mouse hotkeys, so buttons like Mouse Button 4 can trigger TypeWhisper without also reaching the foreground app.
- Keep `NSEvent` mouse monitors conditional on active mouse-button hotkeys and preserve `HotkeyRecorderView` recording behavior.
- Added focused regression coverage for no mouse hotkeys, different mouse hotkeys, matching middle-click pass-through, side-button suppression, and the mixed middle+side-button configuration.

## Test plan

- [x] `git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Result: `Executed 56 tests, with 0 failures`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/bb11/typewhisper-mac`
  - Result: built and launched `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app` as `com.typewhisper.mac.dev`, signed with Apple Development team `2D8ALY3LCL`
- [x] Local process sanity check
  - Result: only the dev app `com.typewhisper.mac.dev` is running; the installed `com.typewhisper.mac` 1.4.0 (803) app was quit to avoid its old event tap affecting the smoke test.
- [ ] Manual physical mouse smoke: verify middle-click opens/closes browser tabs while TypeWhisper Dev is running, verify Mouse Button 4 triggers TypeWhisper while being consumed by the suppressing tap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined mouse hotkey handling and suppression so local and system-level event monitoring consistently include or exclude mouse events and preserve suppression eligibility for mouse-button hotkeys.

* **Tests**
  * Added tests for middle- and side-mouse scenarios, event-tap suppression behavior across input paths, and debug-only helpers to synthesize events and inspect masks for reliable verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
