### PR TITLE
Add configurable LLM request timeout to OpenAI Compatible plugin

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -61,6 +61,16 @@
         }
       }
     },
+    "LLM Request Timeout" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitlimit für LLM-Anfrage"
+          }
+        }
+      }
+    },
     "Model name" : {
       "localizations" : {
         "de" : {
@@ -137,6 +147,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sichern"
+          }
+        }
+      }
+    },
+    "Seconds" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sekunden"
+          }
+        }
+      }
+    },
+    "Seconds to wait for the LLM response. Increase for local servers (LM Studio, Ollama) that take a long time on large prompts. Higher values wait longer before failing. Default 30." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sekunden, die auf die LLM-Antwort gewartet wird. Erhöhen Sie den Wert für lokale Server (LM Studio, Ollama), die bei großen Prompts lange brauchen. Höhere Werte warten länger, bevor die Anfrage fehlschlägt. Standard 30."
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -366,6 +366,7 @@ final class OpenAICompatiblePlugin: NSObject,
     }
 
     func setChatRequestTimeout(_ seconds: Double, for profileId: String) {
+        guard seconds.isFinite else { return }
         let clamped = min(
             max(seconds.rounded(), OpenAICompatibleProfile.minChatRequestTimeout),
             OpenAICompatibleProfile.maxChatRequestTimeout

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -16,9 +16,11 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var llmTemperatureModeRaw: String
     var llmTemperatureValue: Double
     var fetchedModels: [FetchedModel]
-    var chatRequestTimeoutSeconds: Double?
+    var chatRequestTimeoutSeconds: TimeInterval?
 
     static let defaultChatRequestTimeout: TimeInterval = 30
+    static let minChatRequestTimeout: TimeInterval = 5
+    static let maxChatRequestTimeout: TimeInterval = 3600
 
     init(
         id: String,
@@ -29,7 +31,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
-        chatRequestTimeoutSeconds: Double? = nil
+        chatRequestTimeoutSeconds: TimeInterval? = nil
     ) {
         self.id = id
         self.name = name
@@ -45,7 +47,10 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var isDefault: Bool { id == Self.defaultId }
 
     var resolvedChatRequestTimeout: TimeInterval {
-        chatRequestTimeoutSeconds ?? Self.defaultChatRequestTimeout
+        guard let seconds = chatRequestTimeoutSeconds, seconds.isFinite else {
+            return Self.defaultChatRequestTimeout
+        }
+        return min(max(seconds, Self.minChatRequestTimeout), Self.maxChatRequestTimeout)
     }
 
     var displayName: String {
@@ -60,7 +65,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
-        chatRequestTimeoutSeconds: Double? = nil
+        chatRequestTimeoutSeconds: TimeInterval? = nil
     ) -> OpenAICompatibleProfile {
         OpenAICompatibleProfile(
             id: defaultId,
@@ -361,7 +366,10 @@ final class OpenAICompatiblePlugin: NSObject,
     }
 
     func setChatRequestTimeout(_ seconds: Double, for profileId: String) {
-        let clamped = min(max(seconds.rounded(), 5), 3600)
+        let clamped = min(
+            max(seconds.rounded(), OpenAICompatibleProfile.minChatRequestTimeout),
+            OpenAICompatibleProfile.maxChatRequestTimeout
+        )
         updateProfile(profileId) { profile in
             profile.chatRequestTimeoutSeconds = clamped
         }
@@ -1204,6 +1212,7 @@ private struct OpenAICompatibleSettingsView: View {
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 100)
                     .onSubmit(saveChatTimeout)
+                    .accessibilityLabel(Text("LLM Request Timeout", bundle: bundle))
 
                 Button(String(localized: "Save", bundle: bundle), action: saveChatTimeout)
                     .buttonStyle(.bordered)

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -16,6 +16,9 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var llmTemperatureModeRaw: String
     var llmTemperatureValue: Double
     var fetchedModels: [FetchedModel]
+    var chatRequestTimeoutSeconds: Double?
+
+    static let defaultChatRequestTimeout: TimeInterval = 30
 
     init(
         id: String,
@@ -25,7 +28,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         selectedLLMModelId: String = "",
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
         llmTemperatureValue: Double = 0.3,
-        fetchedModels: [FetchedModel] = []
+        fetchedModels: [FetchedModel] = [],
+        chatRequestTimeoutSeconds: Double? = nil
     ) {
         self.id = id
         self.name = name
@@ -35,9 +39,14 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.llmTemperatureModeRaw = llmTemperatureModeRaw
         self.llmTemperatureValue = llmTemperatureValue
         self.fetchedModels = fetchedModels
+        self.chatRequestTimeoutSeconds = chatRequestTimeoutSeconds
     }
 
     var isDefault: Bool { id == Self.defaultId }
+
+    var resolvedChatRequestTimeout: TimeInterval {
+        chatRequestTimeoutSeconds ?? Self.defaultChatRequestTimeout
+    }
 
     var displayName: String {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -50,7 +59,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         selectedLLMModelId: String = "",
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
         llmTemperatureValue: Double = 0.3,
-        fetchedModels: [FetchedModel] = []
+        fetchedModels: [FetchedModel] = [],
+        chatRequestTimeoutSeconds: Double? = nil
     ) -> OpenAICompatibleProfile {
         OpenAICompatibleProfile(
             id: defaultId,
@@ -60,7 +70,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             selectedLLMModelId: selectedLLMModelId,
             llmTemperatureModeRaw: llmTemperatureModeRaw,
             llmTemperatureValue: llmTemperatureValue,
-            fetchedModels: fetchedModels
+            fetchedModels: fetchedModels,
+            chatRequestTimeoutSeconds: chatRequestTimeoutSeconds
         )
     }
 }
@@ -349,6 +360,13 @@ final class OpenAICompatiblePlugin: NSObject,
         }
     }
 
+    func setChatRequestTimeout(_ seconds: Double, for profileId: String) {
+        let clamped = min(max(seconds.rounded(), 5), 3600)
+        updateProfile(profileId) { profile in
+            profile.chatRequestTimeoutSeconds = clamped
+        }
+    }
+
     // MARK: - Profile Runtime
 
     func displayName(for profileId: String) -> String {
@@ -442,7 +460,8 @@ final class OpenAICompatiblePlugin: NSObject,
             model: modelId,
             systemPrompt: systemPrompt,
             userText: userText,
-            temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective)
+            temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective),
+            requestTimeout: profile.resolvedChatRequestTimeout
         )
     }
 
@@ -806,6 +825,7 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var manualLLMModel = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
+    @State private var chatTimeoutInput = ""
 
     private let bundle = pluginModuleBundle
 
@@ -907,6 +927,7 @@ private struct OpenAICompatibleSettingsView: View {
                     serverSection
                     modelSection
                     temperatureSection
+                    timeoutSection
 
                     Text("API keys are stored securely in the Keychain", bundle: bundle)
                         .font(.caption)
@@ -1171,6 +1192,30 @@ private struct OpenAICompatibleSettingsView: View {
         }
     }
 
+    private var timeoutSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+
+            Text("LLM Request Timeout", bundle: bundle)
+                .font(.headline)
+
+            HStack(spacing: 8) {
+                TextField(String(localized: "Seconds", bundle: bundle), text: $chatTimeoutInput)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 100)
+                    .onSubmit(saveChatTimeout)
+
+                Button(String(localized: "Save", bundle: bundle), action: saveChatTimeout)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+
+            Text("Seconds to wait for the LLM response. Increase for local servers (LM Studio, Ollama) that take a long time on large prompts. Higher values wait longer before failing. Default 30.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
     private func reloadProfiles(selecting profileId: String? = nil, preserveInputs: Bool = false) {
         profiles = plugin.profileSnapshots
         if let profileId,
@@ -1197,7 +1242,22 @@ private struct OpenAICompatibleSettingsView: View {
         manualLLMModel = profile.selectedLLMModelId
         llmTemperatureMode = PluginLLMTemperatureMode(rawValue: profile.llmTemperatureModeRaw) ?? .providerDefault
         llmTemperatureValue = profile.llmTemperatureValue
+        chatTimeoutInput = String(Int(profile.resolvedChatRequestTimeout))
         connectionResult = nil
+    }
+
+    private func saveChatTimeout() {
+        guard let selectedProfile else { return }
+        let trimmed = chatTimeoutInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let seconds = Double(trimmed) else {
+            chatTimeoutInput = String(Int(selectedProfile.resolvedChatRequestTimeout))
+            return
+        }
+        plugin.setChatRequestTimeout(seconds, for: selectedProfile.id)
+        reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+        if let updated = plugin.profileSnapshot(for: selectedProfile.id) {
+            chatTimeoutInput = String(Int(updated.resolvedChatRequestTimeout))
+        }
     }
 
     private func saveProfileName() {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -293,6 +293,23 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
     }
 
+    func testSetChatRequestTimeoutIgnoresNonFiniteValues() throws {
+        let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        plugin.setChatRequestTimeout(600, for: plugin.providerId)
+        XCTAssertEqual(plugin.profileSnapshot(for: plugin.providerId)?.chatRequestTimeoutSeconds, 600)
+
+        plugin.setChatRequestTimeout(.nan, for: plugin.providerId)
+        plugin.setChatRequestTimeout(.infinity, for: plugin.providerId)
+
+        let stored = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+        XCTAssertEqual(stored.chatRequestTimeoutSeconds, 600)
+        XCTAssertTrue(stored.resolvedChatRequestTimeout.isFinite)
+        XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
+    }
+
     func testProcessFailsWithoutSelectedModel() async throws {
         let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
         let plugin = OpenAICompatiblePlugin()

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -68,6 +68,26 @@ public enum PluginHTTPClient {
         try await data(for: request, allowsRetry: true)
     }
 
+    public static func data(
+        for request: URLRequest,
+        resourceTimeout: TimeInterval?
+    ) async throws -> (Data, URLResponse) {
+        guard let resourceTimeout, resourceTimeout > longRunningResourceTimeout else {
+            return try await data(for: request, allowsRetry: true)
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = resourceTimeout
+        config.timeoutIntervalForResource = resourceTimeout
+        let session = sessionFactory(config)
+        defer { session.finishTasksAndInvalidate() }
+
+        let method = request.httpMethod ?? "GET"
+        let url = request.url?.absoluteString ?? "unknown"
+        logger.info("\(method) \(url) (dedicated session, resourceTimeout=\(resourceTimeout))")
+        return try await session.data(for: request)
+    }
+
     public static func resetSharedSession(reason: String? = nil) {
         let session = lock.withLock {
             let existing = sharedSession
@@ -539,7 +559,8 @@ public struct PluginOpenAIChatHelper: Sendable {
         maxOutputTokens: Int? = 4096,
         maxOutputTokenParameter: String = "max_tokens",
         reasoningEffort: String? = nil,
-        temperature: Double?
+        temperature: Double?,
+        requestTimeout: TimeInterval = 30
     ) async throws -> String {
         let endpoint = "\(baseURL)\(chatEndpoint)"
         guard let url = URL(string: endpoint) else {
@@ -560,10 +581,10 @@ public struct PluginOpenAIChatHelper: Sendable {
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 30
+        request.timeoutInterval = requestTimeout
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await PluginHTTPClient.data(for: request)
+        let (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: requestTimeout)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PluginChatError.networkError("Invalid response")
@@ -623,7 +644,8 @@ public struct PluginOpenAIChatHelper: Sendable {
         userText: String,
         maxOutputTokens: Int? = 4096,
         maxOutputTokenParameter: String = "max_tokens",
-        temperature: Double?
+        temperature: Double?,
+        requestTimeout: TimeInterval = 30
     ) async throws -> String {
         try await process(
             apiKey: apiKey,
@@ -633,7 +655,8 @@ public struct PluginOpenAIChatHelper: Sendable {
             maxOutputTokens: maxOutputTokens,
             maxOutputTokenParameter: maxOutputTokenParameter,
             reasoningEffort: nil,
-            temperature: temperature
+            temperature: temperature,
+            requestTimeout: requestTimeout
         )
     }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -551,6 +551,31 @@ public struct PluginOpenAIChatHelper: Sendable {
         )
     }
 
+    // Keep the pre-requestTimeout symbols available so already-installed plugin
+    // bundles continue to load after the helper grew the timeout parameter.
+    public func process(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        maxOutputTokens: Int? = 4096,
+        maxOutputTokenParameter: String = "max_tokens",
+        reasoningEffort: String? = nil,
+        temperature: Double?
+    ) async throws -> String {
+        try await process(
+            apiKey: apiKey,
+            model: model,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            maxOutputTokens: maxOutputTokens,
+            maxOutputTokenParameter: maxOutputTokenParameter,
+            reasoningEffort: reasoningEffort,
+            temperature: temperature,
+            requestTimeout: 30
+        )
+    }
+
     public func process(
         apiKey: String,
         model: String,
@@ -560,7 +585,7 @@ public struct PluginOpenAIChatHelper: Sendable {
         maxOutputTokenParameter: String = "max_tokens",
         reasoningEffort: String? = nil,
         temperature: Double?,
-        requestTimeout: TimeInterval = 30
+        requestTimeout: TimeInterval
     ) async throws -> String {
         let endpoint = "\(baseURL)\(chatEndpoint)"
         guard let url = URL(string: endpoint) else {
@@ -644,8 +669,30 @@ public struct PluginOpenAIChatHelper: Sendable {
         userText: String,
         maxOutputTokens: Int? = 4096,
         maxOutputTokenParameter: String = "max_tokens",
+        temperature: Double?
+    ) async throws -> String {
+        try await process(
+            apiKey: apiKey,
+            model: model,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            maxOutputTokens: maxOutputTokens,
+            maxOutputTokenParameter: maxOutputTokenParameter,
+            reasoningEffort: nil,
+            temperature: temperature,
+            requestTimeout: 30
+        )
+    }
+
+    public func process(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        maxOutputTokens: Int? = 4096,
+        maxOutputTokenParameter: String = "max_tokens",
         temperature: Double?,
-        requestTimeout: TimeInterval = 30
+        requestTimeout: TimeInterval
     ) async throws -> String {
         try await process(
             apiKey: apiKey,


### PR DESCRIPTION
## Summary
The OpenAI Compatible plugin hardcoded chat completions to a 30s request timeout (PluginOpenAIChatHelper), so long prompts against local LLM servers (LM Studio, Ollama, vLLM) were cut off mid-processing. This adds a per-profile **LLM Request Timeout** setting (default 30s) so users of slow local models can wait longer.
- New optional `chatRequestTimeoutSeconds` per OpenAI Compatible profile (defaults to 30s; Codable-backward-compatible).
- `PluginOpenAIChatHelper.process(...)` gains an additive `requestTimeout` parameter (default 30) — other plugins sharing the helper are unaffected.
- `PluginHTTPClient.data(for:resourceTimeout:)` overload uses a dedicated session only when the timeout exceeds the shared 600s resource cap, so large values aren't silently truncated. Shared defaults are unchanged.
- New UI strings localized (en + de).
  
## Test Plan
- [x] Built and ran locally (OpenAICompatiblePlugin scheme)
- [x] Set timeout to 600s+ against a local LM Studio server with a large prompt; the chat completion now completes instead of failing at ~31s.
- [x] Verified other profiles/providers keep the 30s default.
- [x] swift test --package-path TypeWhisperPluginSDK → 184 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile configurable LLM request timeout (5–3600 seconds, default 30s).
  * Settings UI: new "LLM Request Timeout" section with seconds field; saving validates and applies timeout to LLM requests.

* **Localization**
  * Added German translations for the timeout label, unit ("Seconds"), and explanatory text.

* **Tests**
  * Added unit test ensuring timeout persistence and ignoring non-finite inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->