### PR TITLE
feat: order language hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ curl -X POST http://localhost:8978/v1/transcribe \
 
 Optional parameters:
 - `language` - ISO 639-1 code (e.g., `en`, `de`). Omit for full auto-detection.
-- `language_hint` - Repeatable language hint for restricted auto-detection. Do not combine with `language`.
+- `language_hint` - Repeatable, ordered language hint for restricted auto-detection. Hint-aware engines receive the full list; other engines use the first hint as the requested language. Do not combine with `language`.
 - `task` - `transcribe` (default) or `translate` (translates to English, WhisperKit only).
 - `target_language` - ISO 639-1 code for translation target language (e.g., `es`, `fr`). Uses Apple Translate.
 
@@ -455,7 +455,7 @@ typewhisper transcribe file.wav # Transcribe an audio file
 | `--port <N>` | Server port (default: auto-detect) |
 | `--json` | Output as JSON |
 | `--language <code>` | Source language (e.g. `en`, `de`) |
-| `--language-hint <code>` | Repeatable language hint for restricted auto-detection |
+| `--language-hint <code>` | Repeatable, ordered language hint for restricted auto-detection; engines without hint support use the first hint |
 | `--task <task>` | `transcribe` (default) or `translate` |
 | `--translate-to <code>` | Target language for translation |
 

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -25,6 +25,14 @@ enum TranscriptionEngineError: LocalizedError {
     }
 }
 
+extension TranscriptionEnginePlugin {
+    var acceptsLanguageHints: Bool {
+        self is LanguageHintTranscriptionEnginePlugin
+            || self is StructuredLanguageHintTranscriptionEnginePlugin
+            || self is LiveLanguageHintTranscriptionCapablePlugin
+    }
+}
+
 @MainActor
 final class ModelManagerService: ObservableObject {
     struct LiveTranscriptionSessionHandle: Sendable {
@@ -593,27 +601,18 @@ final class ModelManagerService: ObservableObject {
         for languageSelection: LanguageSelection,
         plugin: TranscriptionEnginePlugin
     ) -> PluginLanguageSelection {
-        if case .hints(let requestedCodes) = languageSelection,
-           requestedCodes.count > 1,
-           !pluginSupportsLanguageHints(plugin) {
-            return PluginLanguageSelection()
-        }
-
         let normalizedSelection = languageSelection.normalizedForSupportedLanguages(plugin.supportedLanguages)
         switch normalizedSelection {
         case .exact(let code):
             return PluginLanguageSelection(requestedLanguage: code)
         case .hints(let codes):
-            return PluginLanguageSelection(languageHints: codes)
+            if plugin.acceptsLanguageHints {
+                return PluginLanguageSelection(languageHints: codes)
+            }
+            return PluginLanguageSelection(requestedLanguage: codes.first)
         case .inheritGlobal, .auto:
             return PluginLanguageSelection()
         }
-    }
-
-    private func pluginSupportsLanguageHints(_ plugin: TranscriptionEnginePlugin) -> Bool {
-        plugin is LanguageHintTranscriptionEnginePlugin
-            || plugin is StructuredLanguageHintTranscriptionEnginePlugin
-            || plugin is LiveLanguageHintTranscriptionCapablePlugin
     }
 
     private func transcribeWithResolvedLanguageSelection(

--- a/TypeWhisper/ViewModels/SettingsViewModel.swift
+++ b/TypeWhisper/ViewModels/SettingsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import TypeWhisperPluginSDK
 
 enum LanguageSelectionNilBehavior: Sendable {
     case inheritGlobal
@@ -132,6 +133,42 @@ enum LanguageSelection: Equatable, Sendable {
         }
     }
 
+    func withSelectedCodeMoved(
+        _ code: String,
+        by offset: Int,
+        nilBehavior: LanguageSelectionNilBehavior
+    ) -> LanguageSelection {
+        var codes = selectedCodes
+        guard let currentIndex = codes.firstIndex(of: code) else { return self }
+        let targetIndex = currentIndex + offset
+        guard codes.indices.contains(targetIndex) else { return self }
+
+        codes.swapAt(currentIndex, targetIndex)
+        return withSelectedCodes(codes, nilBehavior: nilBehavior)
+    }
+
+    func withSelectedCodeMoved(
+        _ code: String,
+        droppedOn targetCode: String,
+        nilBehavior: LanguageSelectionNilBehavior
+    ) -> LanguageSelection {
+        guard code != targetCode else { return self }
+        var codes = selectedCodes
+        guard let fromIndex = codes.firstIndex(of: code),
+              let toIndex = codes.firstIndex(of: targetCode) else {
+            return self
+        }
+
+        let movedCode = codes.remove(at: fromIndex)
+        let insertionIndex = toIndex
+        guard insertionIndex >= codes.startIndex, insertionIndex <= codes.endIndex else {
+            return self
+        }
+
+        codes.insert(movedCode, at: insertionIndex)
+        return withSelectedCodes(codes, nilBehavior: nilBehavior)
+    }
+
     func normalizedForSupportedLanguages(_ supportedLanguages: [String]) -> LanguageSelection {
         let supportedSet = Set(supportedLanguages)
         guard !supportedSet.isEmpty else {
@@ -219,6 +256,11 @@ final class SettingsViewModel: ObservableObject {
 
     var selectedLanguage: String? {
         languageSelection.requestedLanguage
+    }
+
+    var activeTranscriptionEngine: TranscriptionEnginePlugin? {
+        guard let providerId = modelManager.selectedProviderId else { return nil }
+        return PluginManager.shared.transcriptionEngine(for: providerId)
     }
 
     func observePluginManager() {

--- a/TypeWhisper/ViewModels/SettingsViewModel.swift
+++ b/TypeWhisper/ViewModels/SettingsViewModel.swift
@@ -160,7 +160,7 @@ enum LanguageSelection: Equatable, Sendable {
         }
 
         let movedCode = codes.remove(at: fromIndex)
-        let insertionIndex = toIndex
+        let insertionIndex = fromIndex < toIndex ? toIndex - 1 : toIndex
         guard insertionIndex >= codes.startIndex, insertionIndex <= codes.endIndex else {
             return self
         }

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -223,7 +223,8 @@ struct AudioRecorderView: View {
 
                     LanguageSelectionEditor(
                         selection: $viewModel.languageSelection,
-                        availableLanguages: languageOptions
+                        availableLanguages: languageOptions,
+                        hintBehavior: LanguageSelectionHintBehavior(engine: viewModel.resolvedEngine)
                     )
                     .disabled(isEditingLocked)
 

--- a/TypeWhisper/Views/DictationRecoveryView.swift
+++ b/TypeWhisper/Views/DictationRecoveryView.swift
@@ -106,7 +106,8 @@ struct DictationRecoveryView: View {
 
                     LanguageSelectionEditor(
                         selection: $viewModel.languageSelection,
-                        availableLanguages: recoveryLanguageOptions
+                        availableLanguages: recoveryLanguageOptions,
+                        hintBehavior: LanguageSelectionHintBehavior(engine: viewModel.resolvedEngine)
                     )
                     .disabled(viewModel.isProcessing)
                 }

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -115,7 +115,8 @@ struct FileTranscriptionView: View {
                         selection: $watchFolder.languageSelection,
                         availableLanguages: localizedAppLanguageOptions(for: watchFolder.selectedEngineSupportedLanguages)
                             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                            .map { (code: $0.code, name: $0.name) }
+                            .map { (code: $0.code, name: $0.name) },
+                        hintBehavior: LanguageSelectionHintBehavior(engine: watchFolder.resolvedEngine)
                     )
                 }
 
@@ -394,7 +395,8 @@ struct FileTranscriptionView: View {
 
             LanguageSelectionEditor(
                 selection: $viewModel.languageSelection,
-                availableLanguages: fileTranscriptionLanguageOptions
+                availableLanguages: fileTranscriptionLanguageOptions,
+                hintBehavior: LanguageSelectionHintBehavior(engine: viewModel.resolvedEngine)
             )
 
             HStack {

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -85,7 +85,8 @@ struct GeneralSettingsView: View {
             Section(String(localized: "Spoken Language")) {
                 LanguageSelectionEditor(
                     selection: $settings.languageSelection,
-                    availableLanguages: settings.availableLanguages
+                    availableLanguages: settings.availableLanguages,
+                    hintBehavior: LanguageSelectionHintBehavior(engine: settings.activeTranscriptionEngine)
                 )
 
                 Text(String(localized: "The language being spoken. Setting this explicitly improves accuracy."))

--- a/TypeWhisper/Views/LanguageSelectionEditor.swift
+++ b/TypeWhisper/Views/LanguageSelectionEditor.swift
@@ -1,4 +1,19 @@
 import SwiftUI
+import TypeWhisperPluginSDK
+
+enum LanguageSelectionHintBehavior: Equatable {
+    case unknown
+    case acceptsHints
+    case firstSelectedFallback
+
+    init(engine: TranscriptionEnginePlugin?) {
+        guard let engine else {
+            self = .unknown
+            return
+        }
+        self = engine.acceptsLanguageHints ? .acceptsHints : .firstSelectedFallback
+    }
+}
 
 struct LanguageSelectionEditor: View {
     private enum SelectionMode: Hashable {
@@ -13,10 +28,12 @@ struct LanguageSelectionEditor: View {
     var inheritTitle: String? = nil
     var autoTitle: String = "Auto-detect all languages"
     var restrictedTitle: String = "Restrict detection to selected languages"
+    var hintBehavior: LanguageSelectionHintBehavior = .unknown
 
     @State private var isPickerPresented = false
     @State private var searchQuery = ""
     @State private var pendingRestrictedSelection = false
+    @State private var dropTargetedCode: String?
 
     private var mode: SelectionMode {
         if pendingRestrictedSelection {
@@ -66,6 +83,19 @@ struct LanguageSelectionEditor: View {
         selection.selectedCodes
     }
 
+    private var restrictedHelpText: String? {
+        guard selectedCodes.count > 1 else { return nil }
+
+        switch hintBehavior {
+        case .acceptsHints:
+            return "This engine uses the ordered list as language hints."
+        case .firstSelectedFallback:
+            return "This engine does not support multiple language hints. It will use #1 as the spoken language."
+        case .unknown:
+            return "Engines that support language hints use this ordered list. Other engines use #1 as the spoken language."
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             if let inheritTitle {
@@ -103,14 +133,12 @@ struct LanguageSelectionEditor: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
-                    FlowLayout(spacing: 2) {
-                        ForEach(selectedCodes, id: \.self) { code in
-                            LanguageChip(
-                                code: code,
-                                title: localizedAppLanguageName(for: code),
-                                removeAction: { removeCode(code) }
-                            )
-                        }
+                    selectedLanguageChips
+
+                    if let restrictedHelpText {
+                        Text(restrictedHelpText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -164,6 +192,28 @@ struct LanguageSelectionEditor: View {
         .buttonStyle(.plain)
     }
 
+    private var selectedLanguageChips: some View {
+        FlowLayout(spacing: 4) {
+            ForEach(Array(selectedCodes.enumerated()), id: \.element) { index, code in
+                LanguageChip(
+                    priority: index + 1,
+                    code: code,
+                    title: localizedAppLanguageName(for: code),
+                    isDropTargeted: dropTargetedCode == code,
+                    canMoveEarlier: index > 0,
+                    canMoveLater: index < selectedCodes.count - 1,
+                    moveEarlierAction: { moveCode(code, by: -1) },
+                    moveLaterAction: { moveCode(code, by: 1) },
+                    removeAction: { removeCode(code) },
+                    dropAction: { droppedCode in moveDroppedCode(droppedCode, onto: code) },
+                    dropTargetAction: { isTargeted in
+                        dropTargetedCode = isTargeted ? code : (dropTargetedCode == code ? nil : dropTargetedCode)
+                    }
+                )
+            }
+        }
+    }
+
     private func setMode(_ newMode: SelectionMode) {
         switch newMode {
         case .inheritGlobal:
@@ -197,14 +247,25 @@ struct LanguageSelectionEditor: View {
         applySelection(for: selectedCodes.filter { $0 != code })
     }
 
+    private func moveCode(_ code: String, by offset: Int) {
+        selection = selection.withSelectedCodeMoved(code, by: offset, nilBehavior: nilBehavior)
+    }
+
+    private func moveDroppedCode(_ code: String, onto targetCode: String) -> Bool {
+        let moved = selection.withSelectedCodeMoved(code, droppedOn: targetCode, nilBehavior: nilBehavior)
+        guard moved != selection else { return false }
+        selection = moved
+        return true
+    }
+
     private func applySelection(for codes: [String]) {
         guard !codes.isEmpty else {
             pendingRestrictedSelection = true
-            selection = .auto
+            selection = nilBehavior == .inheritGlobal ? .inheritGlobal : .auto
             return
         }
         pendingRestrictedSelection = false
-        selection = selection.withSelectedCodes(codes, nilBehavior: .auto)
+        selection = selection.withSelectedCodes(codes, nilBehavior: nilBehavior)
     }
 
     private func languageRow(_ language: (code: String, name: String)) -> some View {
@@ -236,21 +297,58 @@ struct LanguageSelectionEditor: View {
 }
 
 struct LanguageChip: View {
+    let priority: Int
     let code: String
     let title: String
+    let isDropTargeted: Bool
+    let canMoveEarlier: Bool
+    let canMoveLater: Bool
+    let moveEarlierAction: () -> Void
+    let moveLaterAction: () -> Void
     let removeAction: () -> Void
+    let dropAction: (String) -> Bool
+    let dropTargetAction: (Bool) -> Void
 
     var body: some View {
         HStack(spacing: 6) {
+            Text("\(priority)")
+                .font(.caption2.weight(.bold))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(width: 18, height: 18)
+                .background {
+                    Circle()
+                        .fill(Color.primary.opacity(0.06))
+                }
             LanguageCodeBadge(code: code)
             Text(title)
                 .font(.subheadline.weight(.medium))
                 .lineLimit(1)
+            Button(action: moveEarlierAction) {
+                Image(systemName: "chevron.left")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canMoveEarlier)
+            .help("Move earlier")
+            .accessibilityLabel("Move \(title) earlier")
+
+            Button(action: moveLaterAction) {
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canMoveLater)
+            .help("Move later")
+            .accessibilityLabel("Move \(title) later")
+
             Button(action: removeAction) {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
+            .help("Remove")
+            .accessibilityLabel("Remove \(title)")
         }
         .padding(.leading, 7)
         .padding(.trailing, 9)
@@ -261,7 +359,14 @@ struct LanguageChip: View {
         }
         .overlay {
             RoundedRectangle(cornerRadius: 11, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                .strokeBorder(isDropTargeted ? Color.accentColor.opacity(0.7) : Color.primary.opacity(0.08), lineWidth: 1)
+        }
+        .draggable(code)
+        .dropDestination(for: String.self) { droppedCodes, _ in
+            guard let droppedCode = droppedCodes.first else { return false }
+            return dropAction(droppedCode)
+        } isTargeted: { targeted in
+            dropTargetAction(targeted)
         }
     }
 }

--- a/TypeWhisper/Views/ProfilesSettingsView.swift
+++ b/TypeWhisper/Views/ProfilesSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TypeWhisperPluginSDK
 
 struct ProfilesSettingsView: View {
     @ObservedObject private var viewModel = ProfilesViewModel.shared
@@ -939,7 +940,8 @@ private struct RuleBehaviorStep: View {
                             ),
                             availableLanguages: viewModel.settingsViewModel.availableLanguages,
                             nilBehavior: .inheritGlobal,
-                            inheritTitle: localizedAppText("Global Setting", de: "Globale Einstellung")
+                            inheritTitle: localizedAppText("Global Setting", de: "Globale Einstellung"),
+                            hintBehavior: LanguageSelectionHintBehavior(engine: profileLanguageEngine)
                         )
                     }
 
@@ -1093,6 +1095,14 @@ private struct RuleBehaviorStep: View {
                 }
             }
         }
+    }
+
+    private var profileLanguageEngine: TranscriptionEnginePlugin? {
+        if let override = viewModel.editorEngineOverride,
+           let engine = PluginManager.shared.transcriptionEngine(for: override) {
+            return engine
+        }
+        return viewModel.settingsViewModel.activeTranscriptionEngine
     }
 }
 

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1089,9 +1089,18 @@ private struct WorkflowEditorPage: View {
                 selection: $draft.inputLanguageSelection,
                 availableLanguages: settingsViewModel.availableLanguages,
                 nilBehavior: .inheritGlobal,
-                inheritTitle: localizedAppText("Global Setting", de: "Globale Einstellung")
+                inheritTitle: localizedAppText("Global Setting", de: "Globale Einstellung"),
+                hintBehavior: LanguageSelectionHintBehavior(engine: workflowLanguageEngine)
             )
         }
+    }
+
+    private var workflowLanguageEngine: TranscriptionEnginePlugin? {
+        if let engineId = draft.transcriptionEngineId,
+           let engine = pluginManager.transcriptionEngine(for: engineId) {
+            return engine
+        }
+        return settingsViewModel.activeTranscriptionEngine
     }
 
     @ViewBuilder

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3812,7 +3812,11 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
         XCTAssertEqual(
             selection.withSelectedCodeMoved("de", droppedOn: "nl", nilBehavior: .auto),
-            .hints(["en", "nl", "de"])
+            .hints(["en", "de", "nl"])
+        )
+        XCTAssertEqual(
+            selection.withSelectedCodeMoved("nl", droppedOn: "de", nilBehavior: .auto),
+            .hints(["nl", "de", "en"])
         )
     }
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1521,6 +1521,59 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
     }
 
+    func testTranscribeLocalFileEndpointUsesFirstHintForLegacyEngine() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory)
+        }
+        let plugin = StructuredTranscriptionPlugin()
+        await MainActor.run {
+            PluginManager.shared.loadedPlugins.append(
+                LoadedPlugin(
+                    manifest: PluginManifest(
+                        id: "com.typewhisper.mock.structured-transcription",
+                        name: "Structured Mock Transcription",
+                        version: "1.0.0",
+                        principalClass: "APIRouterStructuredTranscriptionPlugin"
+                    ),
+                    instance: plugin,
+                    bundle: Bundle.main,
+                    sourceURL: appSupportDirectory,
+                    isEnabled: true
+                )
+            )
+        }
+
+        let fileURL = audioDirectory.appendingPathComponent("legacy-hinted.wav")
+        try WavEncoder.encode(Array(repeating: Float(0), count: 1600)).write(to: fileURL)
+
+        let body: [String: Any] = [
+            "path": fileURL.path,
+            "language_hints": ["de", "en"],
+            "engine": "structured-mock"
+        ]
+        let response = try Self.jsonObject(await XCTUnwrap(context?.router).route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: body)
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "Speaker A: Hello\nSpeaker B: Hi")
+        XCTAssertEqual(response["language"] as? String, "de")
+    }
+
     func testTranscribeLocalFileEndpointRejectsMissingAndUnsupportedFiles() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let audioDirectory = try TestSupport.makeTemporaryDirectory()
@@ -3748,6 +3801,19 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(profile.inputLanguage, #"["de","en"]"#)
         XCTAssertEqual(profile.inputLanguageSelection, .hints(["de", "en"]))
+    }
+
+    func testLanguageSelectionMovesSelectedCodesInStoredOrder() {
+        let selection = LanguageSelection.hints(["de", "en", "nl"])
+
+        XCTAssertEqual(
+            selection.withSelectedCodeMoved("nl", by: -1, nilBehavior: .auto),
+            .hints(["de", "nl", "en"])
+        )
+        XCTAssertEqual(
+            selection.withSelectedCodeMoved("de", droppedOn: "nl", nilBehavior: .auto),
+            .hints(["en", "nl", "de"])
+        )
     }
 
     func testLanguageSelectionNormalizesAgainstSupportedLanguages() {

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -16,7 +16,8 @@ final class StreamingHandlerTests: XCTestCase {
         var selectedModelId: String? { nil }
         var supportsTranslation: Bool { false }
         var supportsStreaming: Bool { false }
-        var supportedLanguages: [String] { ["en"] }
+        var languages = ["en"]
+        var supportedLanguages: [String] { languages }
         private(set) var transcribeCallCount = 0
         private(set) var lastPrompt: String?
 
@@ -1051,11 +1052,12 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertNil(plugin.lastSelection.requestedLanguage)
     }
 
-    func testModelManagerFallsBackToAutoDetectForLegacyPluginsWithMultipleHints() async throws {
+    func testModelManagerUsesFirstSelectedHintForLegacyPluginsWithMultipleHints() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
         let plugin = MockBatchPlugin()
+        plugin.languages = ["de", "en"]
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
         PluginManager.shared.loadedPlugins = [
             LoadedPlugin(
@@ -1081,7 +1083,41 @@ final class StreamingHandlerTests: XCTestCase {
             task: .transcribe
         )
 
-        XCTAssertNil(result.detectedLanguage)
+        XCTAssertEqual(result.detectedLanguage, "de")
+    }
+
+    func testModelManagerFiltersUnsupportedHintsBeforeLegacyFallback() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockBatchPlugin()
+        plugin.languages = ["en"]
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.batch",
+                    name: "Mock Batch",
+                    version: "1.0.0",
+                    principalClass: "MockBatchPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: Array(repeating: 0.25, count: 16_000),
+            languageSelection: .hints(["de", "en"]),
+            task: .transcribe
+        )
+
+        XCTAssertEqual(result.detectedLanguage, "en")
     }
 
     func testStreamingHandlerUsesHintAwareLiveSessionWhenAvailable() async throws {

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -76,8 +76,9 @@
   - HTTP API: send `engine`/`model` in the `/v1/transcribe` request and verify the returned metadata
   - CLI: `typewhisper transcribe --engine <id> --model <id>` against a running local server
 - Multilingual language hints
-  - Open the language picker, search, select multiple languages, verify the selected count
-  - Run a dictation and confirm the hints reach the engine
+  - Open the language picker, search, select multiple languages, verify the selected order and count
+  - Reorder the selected languages and confirm hint-aware engines receive the ordered list
+  - Confirm engines without language-hint support use the first selected language
 - Verify CLI and HTTP API locally
 - Upgrade from `1.2.2` with 1.4 Workflows available and no Legacy settings page
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -102,7 +102,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Sound feedback settings and sound switching
 - Spoken feedback (TTS) enable/disable, voice and speed selection, scope limited to transcription readback
 - Per-request engine/model selection through the HTTP API and CLI
-- Multilingual language hints: picker, search, multi-select, selected count, dictation verification
+- Multilingual language hints: picker, search, ordered multi-select, selected count, first-hint fallback verification
 - Fn hotkey in press-and-release and press-and-hold strategies
 - CLI against a running local server, including `--engine` and `--model`
 - HTTP API `status`, `models`, `transcribe`

--- a/typewhisper-cli/main.swift
+++ b/typewhisper-cli/main.swift
@@ -178,7 +178,7 @@ func printUsage() {
 
         Transcribe options:
           --language <code>    Source language (e.g. en, de)
-          --language-hint <code>  Repeatable language hint for auto-detection
+          --language-hint <code>  Repeatable ordered language hint; non-hint engines use the first
           --task <task>        transcribe (default) or translate
           --translate-to <code>  Target language for translation
           --engine <id>        Override the engine for this request (e.g. groq, qwen3)


### PR DESCRIPTION
## Summary
- Treat multi-language selections as an ordered priority list in `LanguageSelectionEditor`, with visible priority numbers, remove controls, drag/drop reordering, and accessible move-earlier/move-later buttons.
- Show engine-aware copy so hint-capable engines explain that all selected languages are passed as hints, while non-hint engines explain that the first selected language is used as the spoken-language fallback.
- Update runtime language resolution so hint-aware plugins receive the full ordered `languageHints` list, while legacy/non-hint plugins receive `requestedLanguage` set to the first supported selected code.
- Update README, CLI help, and release verification docs to describe ordered hint semantics and first-hint fallback behavior.

## Issue Context
Issue #627 reports that selecting multiple spoken languages currently falls back to unrestricted auto-detect for engines that do not support language hints, without making that behavior clear to users. This PR makes the selected-language order explicit and uses that order as the fallback priority for engines without multi-language hint support.

Closes #627

## Test Coverage
- Added runtime coverage for hint-aware plugins receiving `["de", "en"]` as `languageHints`.
- Added runtime/API coverage for legacy plugins receiving `requestedLanguage == "de"` and no `languageHints` when multiple hints are selected.
- Added coverage that unsupported selected codes are filtered before legacy fallback selection.
- Added coverage for preserving/reordering `LanguageSelection.hints` order.

## Pre-Landing Review
No issues found.

## Scope Drift
Scope Check: CLEAN

## Verification Results
- Local dev app build/run passed and launched `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.
- Documentation companion check found no live TypeWhisper website docs that need a separate update for `language_hints`; matching references were archived release-note data only.

## Test plan
- [x] `git diff --check`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorderable language-hint UI with drag-and-drop and move controls; editor shows contextual hint behavior per selected engine.
  * Engines that accept hints receive the ordered list.

* **Bug Fixes**
  * Engines without hint support now reliably fall back to the first chosen hint.

* **Documentation**
  * README and CLI updated to clarify repeatable, ordered language-hint semantics; release checklists updated to verify ordering and fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->