### PR TITLE
fix: treat Reson8 as single-language engine

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -311,6 +311,14 @@ let package = Package(
             path: "Plugins/AssemblyAIPlugin/Tests"
         ),
         .testTarget(
+            name: "Reson8PluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "Reson8Plugin",
+            ],
+            path: "Plugins/Reson8Plugin/Tests"
+        ),
+        .testTarget(
             name: "SmallestAIPluginTests",
             dependencies: [
                 "TypeWhisperPluginSDK",

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
@@ -302,7 +302,7 @@ struct Reson8CustomModel: Codable, Sendable {
 // MARK: - Plugin Entry Point
 
 @objc(Reson8Plugin)
-final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, LanguageHintTranscriptionEnginePlugin, @unchecked Sendable {
+final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.reson8"
     static let pluginName = "Reson8"
     private static let logger = Logger(subsystem: "com.typewhisper.reson8", category: "Plugin")
@@ -433,7 +433,7 @@ final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         )
     }
 
-    // MARK: - Transcription (LanguageHintTranscriptionEnginePlugin)
+    // MARK: - Transcription (selection helper)
 
     func transcribe(
         audio: AudioData,
@@ -481,14 +481,9 @@ final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         }
     }
 
-    /// Reson8 does not support a list of language hints — when more than one hint is
-    /// supplied (or no language at all), we omit the `language` query param and let
-    /// Reson8 auto-detect. A single explicit language is forwarded as-is.
-    private static func resolveLanguage(selection: PluginLanguageSelection) -> String? {
-        if selection.languageHints.count > 1 {
-            logger.info("Multiple language hints — falling back to Reson8 auto-detect")
-            return nil
-        }
+    /// Reson8 accepts one language query parameter, not an ordered hint list.
+    /// If multiple hints reach this helper, keep #627 semantics by using the first.
+    static func resolveLanguage(selection: PluginLanguageSelection) -> String? {
         if let req = selection.requestedLanguage, !req.isEmpty {
             return req
         }

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Tests/Reson8PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Tests/Reson8PluginTests.swift
@@ -1,0 +1,31 @@
+import TypeWhisperPluginSDK
+import XCTest
+@testable import Reson8Plugin
+
+final class Reson8PluginTests: XCTestCase {
+    func testDoesNotAdvertiseMultiLanguageHintCapability() {
+        let engine: any TranscriptionEnginePlugin = Reson8Plugin()
+
+        XCTAssertFalse(engine is LanguageHintTranscriptionEnginePlugin)
+    }
+
+    func testResolveLanguagePrefersRequestedLanguage() {
+        let selection = PluginLanguageSelection(
+            requestedLanguage: "nl",
+            languageHints: ["de", "en"]
+        )
+
+        XCTAssertEqual(Reson8Plugin.resolveLanguage(selection: selection), "nl")
+    }
+
+    func testResolveLanguageUsesFirstHintForMultipleHints() {
+        let selection = PluginLanguageSelection(languageHints: ["de", "en"])
+
+        XCTAssertEqual(Reson8Plugin.resolveLanguage(selection: selection), "de")
+    }
+
+    func testResolveLanguageFallsBackToAutoDetectWithoutUsableLanguage() {
+        XCTAssertNil(Reson8Plugin.resolveLanguage(selection: PluginLanguageSelection()))
+        XCTAssertNil(Reson8Plugin.resolveLanguage(selection: PluginLanguageSelection(languageHints: [""])))
+    }
+}


### PR DESCRIPTION
## Summary
- Follow-up to #627 and https://github.com/TypeWhisper/typewhisper-mac/issues/627#issuecomment-4572722262.
- Reson8 accepts one language parameter, not an ordered multi-language hint list, so it should not advertise `LanguageHintTranscriptionEnginePlugin` capability.
- Keep Reson8 aligned with the #627 fallback semantics by resolving any accidental multi-hint selection to the first selected language instead of auto-detect.

## Test Plan
- `git diff --check -- TypeWhisperPluginSDK/Package.swift TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift TypeWhisperPluginSDK/Plugins/Reson8Plugin/Tests/Reson8PluginTests.swift`
- `swift test --package-path TypeWhisperPluginSDK --filter Reson8PluginTests`
- `swift test --package-path TypeWhisperPluginSDK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite to verify Reson8Plugin language resolution behavior, language hint handling, and multi-language hint support detection capabilities.

* **Refactor**
  * Updated language resolution logic to use first-hint selection semantics when multiple language hints are provided to the plugin.
  * Removed multi-language hint support capability from the Reson8Plugin module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeWhisper/typewhisper-mac/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->