### PR TITLE
Add experimental SenseVoice transcription plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ DerivedData/
 .build/
 .swiftpm/
 Package.resolved
+TypeWhisperPluginSDK/Vendor/SherpaONNX/
 
 # macOS
 .DS_Store

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -759,7 +759,6 @@
 		5E5100000000000000000012 /* SenseVoiceModelAssetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SenseVoiceModelAssetManager.swift; sourceTree = "<group>"; };
 		5E5100000000000000000013 /* SenseVoiceRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SenseVoiceRuntime.swift; sourceTree = "<group>"; };
 		5E5100000000000000000014 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
-		5E5100000000000000000015 /* SenseVoicePlugin-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SenseVoicePlugin-Bridging-Header.h"; sourceTree = "<group>"; };
 		5E5100000000000000000016 /* SenseVoicePlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SenseVoicePlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E5100000000000000000017 /* libsherpa-onnx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libsherpa-onnx.a"; path = TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/libsherpa-onnx.a; sourceTree = "<group>"; };
 		5E5100000000000000000018 /* SenseVoicePluginTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SenseVoicePluginTests.swift; sourceTree = "<group>"; };
@@ -1879,7 +1878,6 @@
 				5E5100000000000000000011 /* SenseVoicePlugin.swift */,
 				5E5100000000000000000012 /* SenseVoiceModelAssetManager.swift */,
 				5E5100000000000000000013 /* SenseVoiceRuntime.swift */,
-				5E5100000000000000000015 /* SenseVoicePlugin-Bridging-Header.h */,
 				5E5100000000000000000014 /* manifest.json */,
 			);
 			name = SenseVoicePlugin;
@@ -4182,8 +4180,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.TypeWhisperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
-				SWIFT_VERSION = 6.0;
+					SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TypeWhisper.app/Contents/MacOS/TypeWhisper";
 				TEST_TARGET_NAME = TypeWhisper;
 			};
@@ -4223,8 +4220,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.TypeWhisperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
-				SWIFT_VERSION = 6.0;
+					SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TypeWhisper.app/Contents/MacOS/TypeWhisper";
 				TEST_TARGET_NAME = TypeWhisper;
 			};
@@ -5765,8 +5761,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)";
-				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
-				SWIFT_VERSION = 6.0;
+					SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -5815,8 +5810,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)";
-				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
-				SWIFT_VERSION = 6.0;
+					SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -35,6 +35,20 @@
 		D20000000000000000000005 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000005 /* manifest.json */; };
 		D20000000000000000000006 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = D20700000000000000000001 /* TypeWhisperPluginSDK */; };
 		D20000000000000000000007 /* onnxruntime in Frameworks */ = {isa = PBXBuildFile; productRef = D20700000000000000000002 /* onnxruntime */; };
+		5E5100000000000000000001 /* SenseVoicePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000011 /* SenseVoicePlugin.swift */; };
+		5E5100000000000000000002 /* SenseVoiceModelAssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000012 /* SenseVoiceModelAssetManager.swift */; };
+		5E5100000000000000000003 /* SenseVoiceRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000013 /* SenseVoiceRuntime.swift */; };
+		5E5100000000000000000004 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000014 /* manifest.json */; };
+		5E5100000000000000000005 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5E5100000000000000000034 /* TypeWhisperPluginSDK */; };
+		5E5100000000000000000006 /* libsherpa-onnx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000017 /* libsherpa-onnx.a */; };
+		5E510000000000000000000D /* onnxruntime in Frameworks */ = {isa = PBXBuildFile; productRef = 5E5100000000000000000035 /* onnxruntime */; };
+		5E5100000000000000000007 /* SenseVoicePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000018 /* SenseVoicePluginTests.swift */; };
+		5E5100000000000000000008 /* SenseVoiceRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000019 /* SenseVoiceRuntimeTests.swift */; };
+		5E5100000000000000000009 /* SenseVoicePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000011 /* SenseVoicePlugin.swift */; };
+		5E510000000000000000000A /* SenseVoiceModelAssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000012 /* SenseVoiceModelAssetManager.swift */; };
+		5E510000000000000000000B /* SenseVoiceRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000013 /* SenseVoiceRuntime.swift */; };
+		5E510000000000000000000C /* libsherpa-onnx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5100000000000000000017 /* libsherpa-onnx.a */; };
+		5E510000000000000000000E /* onnxruntime in Frameworks */ = {isa = PBXBuildFile; productRef = 5E5100000000000000000036 /* onnxruntime */; };
 		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
 		A10000000000000000000006 /* WorkflowServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000005 /* WorkflowServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
@@ -741,6 +755,15 @@
 		D20100000000000000000004 /* SupertonicRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicRuntime.swift; sourceTree = "<group>"; };
 		D20100000000000000000005 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		D20100000000000000000006 /* SupertonicPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SupertonicPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E5100000000000000000011 /* SenseVoicePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SenseVoicePlugin.swift; sourceTree = "<group>"; };
+		5E5100000000000000000012 /* SenseVoiceModelAssetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SenseVoiceModelAssetManager.swift; sourceTree = "<group>"; };
+		5E5100000000000000000013 /* SenseVoiceRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SenseVoiceRuntime.swift; sourceTree = "<group>"; };
+		5E5100000000000000000014 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		5E5100000000000000000015 /* SenseVoicePlugin-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SenseVoicePlugin-Bridging-Header.h"; sourceTree = "<group>"; };
+		5E5100000000000000000016 /* SenseVoicePlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SenseVoicePlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E5100000000000000000017 /* libsherpa-onnx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libsherpa-onnx.a"; path = TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/libsherpa-onnx.a; sourceTree = "<group>"; };
+		5E5100000000000000000018 /* SenseVoicePluginTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SenseVoicePluginTests.swift; sourceTree = "<group>"; };
+		5E5100000000000000000019 /* SenseVoiceRuntimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SenseVoiceRuntimeTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000232 /* OpenAIVectorMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIVectorMemoryPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000233 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenAIVectorMemoryPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -859,6 +882,8 @@
 			files = (
 				1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */,
 				928A1F1B7A0D4C62A2B90761 /* TypeWhisperPluginSDK in Frameworks */,
+				5E510000000000000000000C /* libsherpa-onnx.a in Frameworks */,
+				5E510000000000000000000E /* onnxruntime in Frameworks */,
 				C23000000000000000000005 /* MLXVLM in Frameworks */,
 				C23000000000000000000006 /* MLXLMCommon in Frameworks */,
 				C23000000000000000000007 /* Transformers in Frameworks */,
@@ -1110,6 +1135,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5E5100000000000000000022 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E5100000000000000000005 /* TypeWhisperPluginSDK in Frameworks */,
+				5E5100000000000000000006 /* libsherpa-onnx.a in Frameworks */,
+				5E510000000000000000000D /* onnxruntime in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000120 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1224,6 +1259,7 @@
 			isa = PBXGroup;
 			children = (
 				4E2BF06351BDA040CC87C5D5 /* OS X */,
+				5E5100000000000000000017 /* libsherpa-onnx.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1268,6 +1304,7 @@
 				CC00000000000000000035 /* FileMemoryPlugin */,
 				C10000000000000000000001 /* SystemTTSPlugin */,
 				D20200000000000000000001 /* SupertonicPlugin */,
+				5E5100000000000000000020 /* SenseVoicePlugin */,
 				CC00000000000000000036 /* OpenAIVectorMemoryPlugin */,
 				CC00000000000000000037 /* FireworksPlugin */,
 				CC00000000000000000038 /* CerebrasPlugin */,
@@ -1836,6 +1873,19 @@
 			path = TypeWhisperPluginSDK/Plugins/SupertonicPlugin;
 			sourceTree = "<group>";
 		};
+		5E5100000000000000000020 /* SenseVoicePlugin */ = {
+			isa = PBXGroup;
+			children = (
+				5E5100000000000000000011 /* SenseVoicePlugin.swift */,
+				5E5100000000000000000012 /* SenseVoiceModelAssetManager.swift */,
+				5E5100000000000000000013 /* SenseVoiceRuntime.swift */,
+				5E5100000000000000000015 /* SenseVoicePlugin-Bridging-Header.h */,
+				5E5100000000000000000014 /* manifest.json */,
+			);
+			name = SenseVoicePlugin;
+			path = TypeWhisperPluginSDK/Plugins/SenseVoicePlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000036 /* OpenAIVectorMemoryPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2007,6 +2057,7 @@
 				BB00000000000000000231 /* FileMemoryPlugin.bundle */,
 				B10000000000000000000003 /* SystemTTSPlugin.bundle */,
 				D20100000000000000000006 /* SupertonicPlugin.bundle */,
+				5E5100000000000000000016 /* SenseVoicePlugin.bundle */,
 				BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */,
 				BB00000000000000000254 /* FireworksPlugin.bundle */,
 				BB00000000000000000257 /* CerebrasPlugin.bundle */,
@@ -2070,6 +2121,8 @@
 				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
 				9A584149706C7567496E0101 /* XAIPluginTests.swift */,
 				4D980A5CFE1A4217A10C2102 /* WhisperKitPluginLifecycleTests.swift */,
+				5E5100000000000000000018 /* SenseVoicePluginTests.swift */,
+				5E5100000000000000000019 /* SenseVoiceRuntimeTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
 				05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */,
 			);
@@ -2084,9 +2137,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 52E9F6F513650CA6EC4DDCA3 /* Build configuration list for PBXNativeTarget "TypeWhisperTests" */;
 			buildPhases = (
+				5E5100000000000000000025 /* Bootstrap Sherpa-ONNX */,
 				D7199BC8CB6EE00511EFCC10 /* Sources */,
 				A5DCBFE5A7ECF9AFC7B5EA6D /* Frameworks */,
 				247A5DE2C113AA399A91B4AD /* Resources */,
+				5E5100000000000000000026 /* Write SenseVoice Runtime Test Flag */,
 			);
 			buildRules = (
 			);
@@ -2103,6 +2158,7 @@
 				PP00000000000000000013 /* MLXAudioCore */,
 				PP00000000000000000015 /* WhisperKit */,
 				PP00000000000000000017 /* FluidAudio */,
+				5E5100000000000000000036 /* onnxruntime */,
 			);
 			productName = TypeWhisperTests;
 			productReference = E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */;
@@ -2679,6 +2735,28 @@
 			productReference = D20100000000000000000006 /* SupertonicPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		5E5100000000000000000030 /* SenseVoicePlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5E5100000000000000000033 /* Build configuration list for PBXNativeTarget "SenseVoicePlugin" */;
+			buildPhases = (
+				5E5100000000000000000024 /* Bootstrap Sherpa-ONNX */,
+				5E5100000000000000000021 /* Sources */,
+				5E5100000000000000000022 /* Frameworks */,
+				5E5100000000000000000023 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SenseVoicePlugin;
+			packageProductDependencies = (
+				5E5100000000000000000034 /* TypeWhisperPluginSDK */,
+				5E5100000000000000000035 /* onnxruntime */,
+			);
+			productName = SenseVoicePlugin;
+			productReference = 5E5100000000000000000016 /* SenseVoicePlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000024 /* OpenAIVectorMemoryPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000122 /* Build configuration list for PBXNativeTarget "OpenAIVectorMemoryPlugin" */;
@@ -3017,6 +3095,7 @@
 				DD00000000000000000023 /* FileMemoryPlugin */,
 				D10000000000000000000001 /* SystemTTSPlugin */,
 				D20300000000000000000001 /* SupertonicPlugin */,
+				5E5100000000000000000030 /* SenseVoicePlugin */,
 				DD00000000000000000024 /* OpenAIVectorMemoryPlugin */,
 				DD00000000000000000025 /* FireworksPlugin */,
 				DD00000000000000000026 /* CerebrasPlugin */,
@@ -3289,6 +3368,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5E5100000000000000000023 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E5100000000000000000004 /* manifest.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000121 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3406,6 +3493,71 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		5E5100000000000000000024 /* Bootstrap Sherpa-ONNX */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/scripts/bootstrap_sherpa_onnx.sh",
+			);
+			name = "Bootstrap Sherpa-ONNX";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/libsherpa-onnx.a",
+				"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/.version",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/bootstrap_sherpa_onnx.sh\"\n";
+		};
+		5E5100000000000000000025 /* Bootstrap Sherpa-ONNX */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/scripts/bootstrap_sherpa_onnx.sh",
+			);
+			name = "Bootstrap Sherpa-ONNX";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/libsherpa-onnx.a",
+				"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/.version",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/bootstrap_sherpa_onnx.sh\"\n";
+		};
+		5E5100000000000000000026 /* Write SenseVoice Runtime Test Flag */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Write SenseVoice Runtime Test Flag";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/SenseVoiceRuntimeTestFlag",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "flag_path=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/SenseVoiceRuntimeTestFlag\"\nmkdir -p \"$(dirname \"$flag_path\")\"\nif [ \"${TYPEWHISPER_RUN_SENSEVOICE_RUNTIME_TESTS:-}\" = \"1\" ]; then\n  printf '1\\n' > \"$flag_path\"\nelse\n  printf '0\\n' > \"$flag_path\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		D7199BC8CB6EE00511EFCC10 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -3469,6 +3621,11 @@
 				204C804898EAE1127B62EC98 /* TestSupport.swift in Sources */,
 				76858B5B28A121356A5D9599 /* TextDiffServiceTests.swift in Sources */,
 				4D980A5CFE1A4217A10C2101 /* WhisperKitPluginLifecycleTests.swift in Sources */,
+				5E5100000000000000000007 /* SenseVoicePluginTests.swift in Sources */,
+				5E5100000000000000000008 /* SenseVoiceRuntimeTests.swift in Sources */,
+				5E5100000000000000000009 /* SenseVoicePlugin.swift in Sources */,
+				5E510000000000000000000A /* SenseVoiceModelAssetManager.swift in Sources */,
+				5E510000000000000000000B /* SenseVoiceRuntime.swift in Sources */,
 				E2DA879FDEFA04FBD013E837 /* OutputFormatter.swift in Sources */,
 				BA68B1E282D5D714132FEA24 /* PortDiscovery.swift in Sources */,
 			);
@@ -3490,6 +3647,16 @@
 				D20000000000000000000002 /* SupertonicModelAssetManager.swift in Sources */,
 				D20000000000000000000003 /* SupertonicPlaybackSession.swift in Sources */,
 				D20000000000000000000004 /* SupertonicRuntime.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5E5100000000000000000021 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E5100000000000000000001 /* SenseVoicePlugin.swift in Sources */,
+				5E5100000000000000000002 /* SenseVoiceModelAssetManager.swift in Sources */,
+				5E5100000000000000000003 /* SenseVoiceRuntime.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3988,16 +4155,34 @@
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_IDENTITY = "-";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/Headers",
+				);
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.TypeWhisperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TypeWhisper.app/Contents/MacOS/TypeWhisper";
 				TEST_TARGET_NAME = TypeWhisper;
@@ -4011,16 +4196,34 @@
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_IDENTITY = "-";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/Headers",
+				);
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.TypeWhisperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TypeWhisper.app/Contents/MacOS/TypeWhisper";
 				TEST_TARGET_NAME = TypeWhisper;
@@ -5518,6 +5721,106 @@
 			};
 			name = Release;
 		};
+		5E5100000000000000000031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/Headers",
+				);
+				INFOPLIST_KEY_CFBundleDisplayName = "SenseVoice (Experimental)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = SenseVoicePlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.sensevoice;
+				PRODUCT_NAME = SenseVoicePlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)";
+				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		5E5100000000000000000032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64/Headers",
+				);
+				INFOPLIST_KEY_CFBundleDisplayName = "SenseVoice (Experimental)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = SenseVoicePlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/Vendor/SherpaONNX/sherpa-onnx.xcframework/macos-arm64_x86_64",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.sensevoice;
+				PRODUCT_NAME = SenseVoicePlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)";
+				SWIFT_OBJC_BRIDGING_HEADER = "TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h";
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		XX00000000000000000097 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6376,6 +6679,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		5E5100000000000000000033 /* Build configuration list for PBXNativeTarget "SenseVoicePlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5E5100000000000000000031 /* Debug */,
+				5E5100000000000000000032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000122 /* Build configuration list for PBXNativeTarget "OpenAIVectorMemoryPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6782,6 +7094,20 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		D20700000000000000000002 /* onnxruntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */;
+			productName = onnxruntime;
+		};
+		5E5100000000000000000034 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		5E5100000000000000000035 /* onnxruntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */;
+			productName = onnxruntime;
+		};
+		5E5100000000000000000036 /* onnxruntime */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */;
 			productName = onnxruntime;

--- a/TypeWhisper.xcodeproj/xcshareddata/xcschemes/SenseVoicePlugin.xcscheme
+++ b/TypeWhisper.xcodeproj/xcshareddata/xcschemes/SenseVoicePlugin.xcscheme
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E5100000000000000000030"
+               BuildableName = "SenseVoicePlugin.bundle"
+               BlueprintName = "SenseVoicePlugin"
+               ReferencedContainer = "container:TypeWhisper.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoiceModelAssetManager.swift
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoiceModelAssetManager.swift
@@ -1,0 +1,228 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+enum SenseVoiceModelLicense {
+    static let id = "FunAudioLLM/SenseVoiceSmall"
+    static let revision = "model-license-2024-07-17"
+    static let licenseName = "SenseVoiceSmall model license"
+    static let url = URL(string: "https://huggingface.co/FunAudioLLM/SenseVoiceSmall/blob/main/model-license")!
+}
+
+enum SenseVoicePluginError: LocalizedError, Equatable {
+    case notConfigured
+    case licenseNotAccepted
+    case runtimeUnavailable
+    case incompleteModelAssets
+    case invalidDownloadResponse
+    case invalidArchive
+    case unsupportedTranslation
+    case transcriptionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            "SenseVoice model assets are not downloaded."
+        case .licenseNotAccepted:
+            "Accept the SenseVoiceSmall model license before downloading model assets."
+        case .runtimeUnavailable:
+            "Sherpa-ONNX runtime is not available for SenseVoice."
+        case .incompleteModelAssets:
+            "The downloaded SenseVoice model cache is incomplete."
+        case .invalidDownloadResponse:
+            "SenseVoice model download returned an invalid response."
+        case .invalidArchive:
+            "SenseVoice model archive could not be extracted."
+        case .unsupportedTranslation:
+            "SenseVoice does not support translation."
+        case .transcriptionFailed(let detail):
+            "SenseVoice transcription failed: \(detail)"
+        }
+    }
+}
+
+struct SenseVoiceLanguageResolver {
+    static let supportedLanguageCodes = ["zh", "en", "ja", "ko", "yue"]
+
+    static func runtimeLanguage(for language: String?) -> String {
+        guard let language else { return "auto" }
+        let normalized = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(whereSeparator: { $0 == "-" || $0 == "_" })
+            .first
+            .map(String.init)
+
+        guard let normalized else { return "auto" }
+        return supportedLanguageCodes.contains(normalized) ? normalized : "auto"
+    }
+}
+
+struct SenseVoiceModelAssetManager: Sendable {
+    static let modelId = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17"
+    static let displayName = "SenseVoice Small int8"
+    static let sizeDescription = "~155 MB"
+    static let releaseURL = URL(
+        string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\(modelId).tar.bz2"
+    )!
+
+    static let modelSubdirectory = "models/sensevoice/\(modelId)"
+    static let requiredRelativePaths = [
+        "model.int8.onnx",
+        "tokens.txt",
+    ]
+
+    let rootDirectory: URL
+
+    var modelDirectory: URL {
+        rootDirectory.appendingPathComponent(Self.modelSubdirectory, isDirectory: true)
+    }
+
+    var archiveName: String {
+        Self.modelId + ".tar.bz2"
+    }
+
+    func hasDownloadedModel() -> Bool {
+        Self.requiredRelativePaths.allSatisfy { relativePath in
+            FileManager.default.fileExists(atPath: modelDirectory.appendingPathComponent(relativePath).path)
+        }
+    }
+
+    func deleteModelFiles() throws {
+        if FileManager.default.fileExists(atPath: modelDirectory.path) {
+            try FileManager.default.removeItem(at: modelDirectory)
+        }
+    }
+
+    func install(files: [String: Data], licenseAccepted: Bool) throws {
+        guard licenseAccepted else { throw SenseVoicePluginError.licenseNotAccepted }
+        guard Self.requiredRelativePaths.allSatisfy({ files[$0] != nil }) else {
+            throw SenseVoicePluginError.incompleteModelAssets
+        }
+
+        let stagingDirectory = rootDirectory.appendingPathComponent(
+            ".sensevoice-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+
+        do {
+            for (relativePath, data) in files {
+                guard Self.isSafeRelativePath(relativePath) else {
+                    throw SenseVoicePluginError.invalidDownloadResponse
+                }
+                let destination = stagingDirectory.appendingPathComponent(relativePath)
+                try FileManager.default.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: destination, options: .atomic)
+            }
+
+            guard Self.requiredRelativePaths.allSatisfy({
+                FileManager.default.fileExists(atPath: stagingDirectory.appendingPathComponent($0).path)
+            }) else {
+                throw SenseVoicePluginError.incompleteModelAssets
+            }
+
+            try replaceModelDirectory(with: stagingDirectory)
+        } catch {
+            try? FileManager.default.removeItem(at: stagingDirectory)
+            throw error
+        }
+    }
+
+    func download(
+        licenseAccepted: Bool,
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        guard licenseAccepted else { throw SenseVoicePluginError.licenseNotAccepted }
+        try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+
+        let temporaryDirectory = rootDirectory.appendingPathComponent(
+            ".sensevoice-download-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let archiveURL = try await downloadArchive(to: temporaryDirectory, progress: progress)
+        progress(0.75)
+
+        let extractedDirectory = try extractArchive(archiveURL, into: temporaryDirectory)
+        progress(0.90)
+
+        guard Self.requiredRelativePaths.allSatisfy({
+            FileManager.default.fileExists(atPath: extractedDirectory.appendingPathComponent($0).path)
+        }) else {
+            throw SenseVoicePluginError.incompleteModelAssets
+        }
+
+        try replaceModelDirectory(with: extractedDirectory)
+        progress(1.0)
+    }
+
+    private func downloadArchive(
+        to temporaryDirectory: URL,
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws -> URL {
+        var request = URLRequest(url: Self.releaseURL)
+        request.timeoutInterval = 600
+
+        progress(0.05)
+        let (temporaryFile, response) = try await URLSession.shared.download(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw SenseVoicePluginError.invalidDownloadResponse
+        }
+
+        let archiveURL = temporaryDirectory.appendingPathComponent(archiveName)
+        if FileManager.default.fileExists(atPath: archiveURL.path) {
+            try FileManager.default.removeItem(at: archiveURL)
+        }
+        try FileManager.default.moveItem(at: temporaryFile, to: archiveURL)
+        progress(0.70)
+        return archiveURL
+    }
+
+    private func extractArchive(_ archiveURL: URL, into temporaryDirectory: URL) throws -> URL {
+        let extractionDirectory = temporaryDirectory.appendingPathComponent("extract", isDirectory: true)
+        try FileManager.default.createDirectory(at: extractionDirectory, withIntermediateDirectories: true)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["xjf", archiveURL.path, "-C", extractionDirectory.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw SenseVoicePluginError.invalidArchive
+        }
+
+        let extractedRoot = extractionDirectory.appendingPathComponent(Self.modelId, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: extractedRoot.path) else {
+            throw SenseVoicePluginError.invalidArchive
+        }
+        return extractedRoot
+    }
+
+    private func replaceModelDirectory(with stagingDirectory: URL) throws {
+        let destination = modelDirectory
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: stagingDirectory, to: destination)
+    }
+
+    static func isSafeRelativePath(_ path: String) -> Bool {
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.contains("..") else {
+            return false
+        }
+        return path.split(separator: "/").allSatisfy { !$0.isEmpty }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h
@@ -1,6 +1,0 @@
-#ifndef SENSEVOICE_PLUGIN_BRIDGING_HEADER_H
-#define SENSEVOICE_PLUGIN_BRIDGING_HEADER_H
-
-#import "sherpa-onnx/c-api/c-api.h"
-
-#endif

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin-Bridging-Header.h
@@ -1,0 +1,6 @@
+#ifndef SENSEVOICE_PLUGIN_BRIDGING_HEADER_H
+#define SENSEVOICE_PLUGIN_BRIDGING_HEADER_H
+
+#import "sherpa-onnx/c-api/c-api.h"
+
+#endif

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoicePlugin.swift
@@ -1,0 +1,390 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+import os
+
+enum SenseVoiceDefaultsKey {
+    static let selectedModel = "selectedModel"
+    static let loadedModel = "loadedModel"
+    static let acceptedModelLicenseId = "acceptedModelLicenseId"
+    static let acceptedModelLicenseRevision = "acceptedModelLicenseRevision"
+    static let acceptedModelLicenseAt = "acceptedModelLicenseAt"
+}
+
+enum SenseVoiceModelState: Equatable, Sendable {
+    case notDownloaded
+    case downloading
+    case ready
+    case error(String)
+}
+
+protocol SenseVoiceRecognizing: AnyObject, Sendable {
+    func transcribe(samples: [Float], sampleRate: Int) throws -> String
+}
+
+typealias SenseVoiceRecognizerFactory = @Sendable (URL, String) throws -> any SenseVoiceRecognizing
+
+@objc(SenseVoicePlugin)
+final class SenseVoicePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.sensevoice"
+    static let pluginName = "SenseVoice (Experimental)"
+
+    private let logger = Logger(subsystem: "com.typewhisper.plugin.sensevoice", category: "Transcription")
+    private var host: HostServices?
+    private var downloadProgress = 0.0
+    private(set) var modelState: SenseVoiceModelState = .notDownloaded
+    private let recognizerLock = NSLock()
+    private var recognizerLanguage: String?
+    private var recognizer: (any SenseVoiceRecognizing)?
+    private var recognizerFactory: SenseVoiceRecognizerFactory = { modelDirectory, language in
+        try SenseVoiceONNXRecognizer(modelDirectory: modelDirectory, language: language)
+    }
+
+    required override init() {
+        super.init()
+    }
+
+    init(recognizerFactory: @escaping SenseVoiceRecognizerFactory) {
+        self.recognizerFactory = recognizerFactory
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        if host.userDefault(forKey: SenseVoiceDefaultsKey.selectedModel) as? String == nil {
+            host.setUserDefault(SenseVoiceModelAssetManager.modelId, forKey: SenseVoiceDefaultsKey.selectedModel)
+        }
+        modelState = modelAssetManager.hasDownloadedModel() ? .ready : .notDownloaded
+        if modelAssetManager.hasDownloadedModel() {
+            host.setUserDefault(SenseVoiceModelAssetManager.modelId, forKey: SenseVoiceDefaultsKey.loadedModel)
+        }
+    }
+
+    func deactivate() {
+        clearRecognizerCache()
+        host = nil
+        downloadProgress = 0
+        modelState = .notDownloaded
+    }
+
+    var providerId: String { "sensevoice" }
+    var providerDisplayName: String { "SenseVoice (Experimental)" }
+    var isConfigured: Bool { modelAssetManager.hasDownloadedModel() }
+
+    var transcriptionModels: [PluginModelInfo] { availableModels }
+
+    var availableModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(
+                id: SenseVoiceModelAssetManager.modelId,
+                displayName: SenseVoiceModelAssetManager.displayName,
+                sizeDescription: SenseVoiceModelAssetManager.sizeDescription,
+                languageCount: supportedLanguages.count,
+                downloaded: modelAssetManager.hasDownloadedModel(),
+                loaded: modelState == .ready
+            )
+        ]
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        guard modelAssetManager.hasDownloadedModel() else { return [] }
+        return availableModels
+    }
+
+    var selectedModelId: String? {
+        (host?.userDefault(forKey: SenseVoiceDefaultsKey.selectedModel) as? String) ?? SenseVoiceModelAssetManager.modelId
+    }
+
+    func selectModel(_ modelId: String) {
+        guard modelId == SenseVoiceModelAssetManager.modelId else { return }
+        host?.setUserDefault(modelId, forKey: SenseVoiceDefaultsKey.selectedModel)
+    }
+
+    var supportsTranslation: Bool { false }
+    var supportsStreaming: Bool { false }
+    var supportedLanguages: [String] { SenseVoiceLanguageResolver.supportedLanguageCodes }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notDownloaded, .ready:
+            return nil
+        case .downloading:
+            return PluginSettingsActivity(message: "Downloading SenseVoice model", progress: downloadProgress)
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
+
+    @MainActor
+    var settingsView: AnyView? {
+        AnyView(SenseVoiceSettingsView(plugin: self))
+    }
+
+    var hasAcceptedCurrentModelLicense: Bool {
+        guard let host else { return false }
+        return host.userDefault(forKey: SenseVoiceDefaultsKey.acceptedModelLicenseId) as? String == SenseVoiceModelLicense.id
+            && host.userDefault(forKey: SenseVoiceDefaultsKey.acceptedModelLicenseRevision) as? String == SenseVoiceModelLicense.revision
+    }
+
+    var canDownloadModel: Bool {
+        hasAcceptedCurrentModelLicense
+    }
+
+    var modelDownloadProgress: Double {
+        downloadProgress
+    }
+
+    func acceptCurrentModelLicense(now: Date = Date()) {
+        host?.setUserDefault(SenseVoiceModelLicense.id, forKey: SenseVoiceDefaultsKey.acceptedModelLicenseId)
+        host?.setUserDefault(SenseVoiceModelLicense.revision, forKey: SenseVoiceDefaultsKey.acceptedModelLicenseRevision)
+        host?.setUserDefault(Self.isoDateString(from: now), forKey: SenseVoiceDefaultsKey.acceptedModelLicenseAt)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func downloadModel() async {
+        guard canDownloadModel else {
+            modelState = .error(SenseVoicePluginError.licenseNotAccepted.localizedDescription)
+            host?.notifyCapabilitiesChanged()
+            return
+        }
+
+        downloadProgress = 0
+        modelState = .downloading
+        host?.notifyCapabilitiesChanged()
+
+        do {
+            try await modelAssetManager.download(licenseAccepted: true) { [weak self] progress in
+                Task { @MainActor in
+                    self?.downloadProgress = progress
+                    self?.host?.notifyCapabilitiesChanged()
+                }
+            }
+            clearRecognizerCache()
+            downloadProgress = 1
+            modelState = .ready
+            host?.setUserDefault(SenseVoiceModelAssetManager.modelId, forKey: SenseVoiceDefaultsKey.selectedModel)
+            host?.setUserDefault(SenseVoiceModelAssetManager.modelId, forKey: SenseVoiceDefaultsKey.loadedModel)
+            host?.notifyCapabilitiesChanged()
+        } catch {
+            logger.error("SenseVoice model download failed: \(error.localizedDescription)")
+            downloadProgress = 0
+            modelState = .error(error.localizedDescription)
+            host?.notifyCapabilitiesChanged()
+        }
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard modelId == SenseVoiceModelAssetManager.modelId else { return }
+        try deleteCachedModel()
+    }
+
+    func deleteCachedModel() throws {
+        clearRecognizerCache()
+        try modelAssetManager.deleteModelFiles()
+        downloadProgress = 0
+        modelState = .notDownloaded
+        host?.setUserDefault(nil, forKey: SenseVoiceDefaultsKey.loadedModel)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard !translate else { throw SenseVoicePluginError.unsupportedTranslation }
+        guard modelAssetManager.hasDownloadedModel() else { throw SenseVoicePluginError.notConfigured }
+
+        let runtimeLanguage = SenseVoiceLanguageResolver.runtimeLanguage(for: language)
+        let modelDirectory = modelAssetManager.modelDirectory
+        let text = try await Task.detached(priority: .userInitiated) { [self] in
+            try recognizer(for: runtimeLanguage, modelDirectory: modelDirectory)
+                .transcribe(samples: audio.samples, sampleRate: 16_000)
+        }.value
+
+        return PluginTranscriptionResult(
+            text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+            detectedLanguage: runtimeLanguage == "auto" ? nil : runtimeLanguage,
+            segments: []
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        let result = try await transcribe(audio: audio, language: language, translate: translate, prompt: prompt)
+        _ = onProgress(result.text)
+        return result
+    }
+
+    fileprivate var modelAssetManager: SenseVoiceModelAssetManager {
+        SenseVoiceModelAssetManager(
+            rootDirectory: host?.pluginDataDirectory
+                ?? FileManager.default.temporaryDirectory.appendingPathComponent("SenseVoicePlugin", isDirectory: true)
+        )
+    }
+
+    private func recognizer(for language: String, modelDirectory: URL) throws -> any SenseVoiceRecognizing {
+        recognizerLock.lock()
+        defer { recognizerLock.unlock() }
+
+        if let recognizer, recognizerLanguage == language {
+            return recognizer
+        }
+
+        let recognizer = try recognizerFactory(modelDirectory, language)
+        self.recognizer = recognizer
+        recognizerLanguage = language
+        return recognizer
+    }
+
+    private func clearRecognizerCache() {
+        recognizerLock.lock()
+        recognizer = nil
+        recognizerLanguage = nil
+        recognizerLock.unlock()
+    }
+
+    private static func isoDateString(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+}
+
+private struct SenseVoiceSettingsView: View {
+    let plugin: SenseVoicePlugin
+
+    @State private var acceptedLicense = false
+    @State private var modelState: SenseVoiceModelState = .notDownloaded
+    @State private var progress = 0.0
+    @State private var isDownloading = false
+
+    private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("SenseVoice (Experimental)")
+                .font(.headline)
+
+            Text("Local speech recognition through SenseVoice Small and Sherpa-ONNX. This experimental engine is limited to Chinese, English, Japanese, Korean, and Cantonese.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            licenseSection
+
+            Divider()
+
+            modelSection
+        }
+        .padding()
+        .frame(minWidth: 480)
+        .onAppear {
+            refreshFromPlugin()
+        }
+        .onReceive(pollTimer) { _ in
+            refreshTransientState()
+        }
+    }
+
+    private var licenseSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Model License")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Text("SenseVoiceSmall model assets are downloaded only after you accept the model license. Review the license before downloading.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Link("Open SenseVoiceSmall model license", destination: SenseVoiceModelLicense.url)
+                .font(.caption)
+
+            Toggle(isOn: $acceptedLicense) {
+                Text("I have read and accept the SenseVoiceSmall model license terms")
+            }
+            .onChange(of: acceptedLicense) { _, newValue in
+                if newValue {
+                    plugin.acceptCurrentModelLicense()
+                }
+            }
+        }
+    }
+
+    private var modelSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Model")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Text("\(SenseVoiceModelAssetManager.displayName) - \(SenseVoiceModelAssetManager.sizeDescription)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            switch modelState {
+            case .ready:
+                HStack {
+                    Label("Ready", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Spacer()
+                    Button("Delete cached model") {
+                        try? plugin.deleteCachedModel()
+                        refreshFromPlugin()
+                    }
+                    .controlSize(.small)
+                }
+            case .downloading:
+                HStack(spacing: 8) {
+                    ProgressView(value: progress)
+                        .frame(width: 160)
+                    Text("\(Int(progress * 100))%")
+                        .font(.caption)
+                        .monospacedDigit()
+                }
+            case .error(let message):
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                downloadButton
+            case .notDownloaded:
+                downloadButton
+            }
+        }
+    }
+
+    private var downloadButton: some View {
+        Button {
+            isDownloading = true
+            Task {
+                await plugin.downloadModel()
+                await MainActor.run {
+                    isDownloading = false
+                    refreshFromPlugin()
+                }
+            }
+        } label: {
+            Label("Download & Load", systemImage: "arrow.down.circle")
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!acceptedLicense || isDownloading || modelState == .downloading)
+    }
+
+    private func refreshFromPlugin() {
+        acceptedLicense = plugin.hasAcceptedCurrentModelLicense
+        modelState = plugin.modelState
+        progress = plugin.modelDownloadProgress
+    }
+
+    private func refreshTransientState() {
+        modelState = plugin.modelState
+        progress = plugin.modelDownloadProgress
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoiceRuntime.swift
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoiceRuntime.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SherpaOnnxC
 
 final class SenseVoiceONNXRecognizer: SenseVoiceRecognizing, @unchecked Sendable {
     private let recognizer: OpaquePointer

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoiceRuntime.swift
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/SenseVoiceRuntime.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+final class SenseVoiceONNXRecognizer: SenseVoiceRecognizing, @unchecked Sendable {
+    private let recognizer: OpaquePointer
+    private let inferenceLock = NSLock()
+
+    init(modelDirectory: URL, language: String) throws {
+        let modelPath = modelDirectory.appendingPathComponent("model.int8.onnx").path
+        let tokensPath = modelDirectory.appendingPathComponent("tokens.txt").path
+        guard FileManager.default.fileExists(atPath: modelPath),
+              FileManager.default.fileExists(atPath: tokensPath) else {
+            throw SenseVoicePluginError.incompleteModelAssets
+        }
+
+        var createdRecognizer: OpaquePointer?
+        modelPath.withCString { modelCString in
+            tokensPath.withCString { tokensCString in
+                language.withCString { languageCString in
+                    "cpu".withCString { providerCString in
+                        "greedy_search".withCString { decodingCString in
+                            var config = SherpaOnnxOfflineRecognizerConfig()
+                            config.feat_config.sample_rate = 16_000
+                            config.feat_config.feature_dim = 80
+                            config.model_config.tokens = tokensCString
+                            config.model_config.num_threads = 4
+                            config.model_config.provider = providerCString
+                            config.model_config.sense_voice.model = modelCString
+                            config.model_config.sense_voice.language = languageCString
+                            config.model_config.sense_voice.use_itn = 1
+                            config.decoding_method = decodingCString
+                            createdRecognizer = SherpaOnnxCreateOfflineRecognizer(&config)
+                        }
+                    }
+                }
+            }
+        }
+
+        guard let createdRecognizer else {
+            throw SenseVoicePluginError.runtimeUnavailable
+        }
+        self.recognizer = createdRecognizer
+    }
+
+    deinit {
+        SherpaOnnxDestroyOfflineRecognizer(recognizer)
+    }
+
+    func transcribe(samples: [Float], sampleRate: Int) throws -> String {
+        inferenceLock.lock()
+        defer { inferenceLock.unlock() }
+
+        guard let stream = SherpaOnnxCreateOfflineStream(recognizer) else {
+            throw SenseVoicePluginError.transcriptionFailed("Failed to create offline stream.")
+        }
+        defer { SherpaOnnxDestroyOfflineStream(stream) }
+
+        samples.withUnsafeBufferPointer { buffer in
+            SherpaOnnxAcceptWaveformOffline(
+                stream,
+                Int32(sampleRate),
+                buffer.baseAddress,
+                Int32(buffer.count)
+            )
+        }
+
+        SherpaOnnxDecodeOfflineStream(recognizer, stream)
+
+        guard let result = SherpaOnnxGetOfflineStreamResult(stream) else {
+            throw SenseVoicePluginError.transcriptionFailed("Failed to read recognizer result.")
+        }
+        defer { SherpaOnnxDestroyOfflineRecognizerResult(result) }
+
+        guard let text = result.pointee.text else {
+            return ""
+        }
+        return String(cString: text)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/manifest.json
@@ -1,0 +1,22 @@
+{
+    "id": "com.typewhisper.sensevoice",
+    "name": "SenseVoice (Experimental)",
+    "version": "0.1.0",
+    "minHostVersion": "1.4.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "supportedArchitectures": [
+        "arm64"
+    ],
+    "author": "TypeWhisper",
+    "description": "Experimental local speech-to-text powered by SenseVoice Small through Sherpa-ONNX. Supports zh, en, ja, ko, and yue.",
+    "descriptions": {
+        "de": "Experimentelle lokale Spracherkennung mit SenseVoice Small via Sherpa-ONNX. Unterstützt zh, en, ja, ko und yue."
+    },
+    "requiresAPIKey": false,
+    "hosting": "local",
+    "category": "transcription",
+    "iconSystemName": "waveform.badge.magnifyingglass",
+    "principalClass": "SenseVoicePlugin",
+    "detailsURL": "https://github.com/FunAudioLLM/SenseVoice"
+}

--- a/TypeWhisperTests/SenseVoicePluginTests.swift
+++ b/TypeWhisperTests/SenseVoicePluginTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import TypeWhisperPluginSDK
+import XCTest
+@testable import TypeWhisper
+
+final class SenseVoicePluginTests: XCTestCase {
+    private final class MockEventBus: EventBusProtocol {
+        @discardableResult
+        func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID { UUID() }
+        func unsubscribe(id: UUID) {}
+    }
+
+    private final class MockHostServices: HostServices, @unchecked Sendable {
+        private var defaults: [String: Any]
+        private var secrets: [String: String] = [:]
+
+        let pluginDataDirectory: URL
+        let eventBus: EventBusProtocol = MockEventBus()
+        var activeAppBundleId: String?
+        var activeAppName: String?
+        var availableRuleNames: [String] = []
+        private(set) var capabilitiesChangedCount = 0
+
+        init(pluginDataDirectory: URL, defaults: [String: Any] = [:]) {
+            self.pluginDataDirectory = pluginDataDirectory
+            self.defaults = defaults
+        }
+
+        func storeSecret(key: String, value: String) throws { secrets[key] = value }
+        func loadSecret(key: String) -> String? { secrets[key] }
+        func userDefault(forKey key: String) -> Any? { defaults[key] }
+        func setUserDefault(_ value: Any?, forKey key: String) { defaults[key] = value }
+        func notifyCapabilitiesChanged() { capabilitiesChangedCount += 1 }
+        func setStreamingDisplayActive(_ active: Bool) {}
+    }
+
+    private final class StubRecognizer: SenseVoiceRecognizing, @unchecked Sendable {
+        let text: String
+
+        init(text: String) {
+            self.text = text
+        }
+
+        func transcribe(samples: [Float], sampleRate: Int) throws -> String {
+            text
+        }
+    }
+
+    private func makeHost(defaults: [String: Any] = [:]) throws -> MockHostServices {
+        let directory = try TestSupport.makeTemporaryDirectory(prefix: "SenseVoicePluginTests")
+        return MockHostServices(pluginDataDirectory: directory, defaults: defaults)
+    }
+
+    func testManifestDeclaresExperimentalLocalTranscriptionPlugin() throws {
+        let manifestURL = TestSupport.repoRoot
+            .appendingPathComponent("TypeWhisperPluginSDK/Plugins/SenseVoicePlugin/manifest.json")
+
+        let manifest = try JSONDecoder().decode(
+            PluginManifest.self,
+            from: try Data(contentsOf: manifestURL)
+        )
+
+        XCTAssertEqual(manifest.id, "com.typewhisper.sensevoice")
+        XCTAssertEqual(manifest.name, "SenseVoice (Experimental)")
+        XCTAssertEqual(manifest.category, "transcription")
+        XCTAssertEqual(manifest.hosting, .local)
+        XCTAssertEqual(manifest.requiresAPIKey, false)
+        XCTAssertEqual(manifest.minHostVersion, "1.4.0")
+        XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
+        XCTAssertEqual(manifest.principalClass, "SenseVoicePlugin")
+    }
+
+    func testDownloadRequiresCurrentModelLicenseAcceptance() throws {
+        let host = try makeHost()
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let plugin = SenseVoicePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.hasAcceptedCurrentModelLicense)
+        XCTAssertFalse(plugin.canDownloadModel)
+
+        plugin.acceptCurrentModelLicense(now: Date(timeIntervalSince1970: 1_716_000_000))
+
+        XCTAssertTrue(plugin.hasAcceptedCurrentModelLicense)
+        XCTAssertTrue(plugin.canDownloadModel)
+        XCTAssertEqual(host.userDefault(forKey: "acceptedModelLicenseId") as? String, SenseVoiceModelLicense.id)
+        XCTAssertEqual(host.userDefault(forKey: "acceptedModelLicenseRevision") as? String, SenseVoiceModelLicense.revision)
+        XCTAssertEqual(host.userDefault(forKey: "acceptedModelLicenseAt") as? String, "2024-05-18T02:40:00Z")
+    }
+
+    func testChangedModelLicenseRevisionInvalidatesPriorAcceptance() throws {
+        let host = try makeHost(defaults: [
+            "acceptedModelLicenseId": SenseVoiceModelLicense.id,
+            "acceptedModelLicenseRevision": "old-revision",
+            "acceptedModelLicenseAt": "2024-05-18T08:00:00Z",
+        ])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let plugin = SenseVoicePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.hasAcceptedCurrentModelLicense)
+        XCTAssertFalse(plugin.canDownloadModel)
+    }
+
+    func testDownloadWithoutAcceptedLicenseDoesNotCreateModelDirectory() async throws {
+        let host = try makeHost()
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let plugin = SenseVoicePlugin()
+        plugin.activate(host: host)
+
+        await plugin.downloadModel()
+
+        XCTAssertEqual(plugin.modelState, .error(SenseVoicePluginError.licenseNotAccepted.localizedDescription))
+        let modelDirectory = SenseVoiceModelAssetManager(rootDirectory: host.pluginDataDirectory).modelDirectory
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+    }
+
+    func testPluginAdvertisesLimitedExperimentalCapabilities() throws {
+        let plugin = SenseVoicePlugin()
+
+        XCTAssertEqual(plugin.providerId, "sensevoice")
+        XCTAssertEqual(plugin.providerDisplayName, "SenseVoice (Experimental)")
+        XCTAssertFalse(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .unsupported)
+        XCTAssertEqual(plugin.supportedLanguages, ["zh", "en", "ja", "ko", "yue"])
+        XCTAssertEqual(plugin.availableModels.first?.id, SenseVoiceModelAssetManager.modelId)
+        XCTAssertEqual(plugin.availableModels.first?.languageCount, 5)
+    }
+
+    func testLanguageResolverUsesSupportedPrimaryLanguageOrAuto() {
+        XCTAssertEqual(SenseVoiceLanguageResolver.runtimeLanguage(for: "en-US"), "en")
+        XCTAssertEqual(SenseVoiceLanguageResolver.runtimeLanguage(for: "zh-Hans"), "zh")
+        XCTAssertEqual(SenseVoiceLanguageResolver.runtimeLanguage(for: "yue"), "yue")
+        XCTAssertEqual(SenseVoiceLanguageResolver.runtimeLanguage(for: "de-DE"), "auto")
+        XCTAssertEqual(SenseVoiceLanguageResolver.runtimeLanguage(for: nil), "auto")
+    }
+
+    func testModelInstallerRequiresSafeCompleteAssetSet() throws {
+        let root = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: FileManager.default.temporaryDirectory,
+            create: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let installer = SenseVoiceModelAssetManager(rootDirectory: root)
+        let files = [
+            "model.int8.onnx": Data("model".utf8),
+            "tokens.txt": Data("tokens".utf8),
+        ]
+
+        try installer.install(files: files, licenseAccepted: true)
+
+        XCTAssertTrue(installer.hasDownloadedModel())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installer.modelDirectory.appendingPathComponent("model.int8.onnx").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installer.modelDirectory.appendingPathComponent("tokens.txt").path))
+    }
+
+    func testModelInstallerDoesNotWriteFinalDirectoryWhenRequiredFileIsMissing() throws {
+        let root = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: FileManager.default.temporaryDirectory,
+            create: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let installer = SenseVoiceModelAssetManager(rootDirectory: root)
+        let files = [
+            "model.int8.onnx": Data("model".utf8),
+        ]
+
+        XCTAssertThrowsError(try installer.install(files: files, licenseAccepted: true)) { error in
+            XCTAssertEqual(error as? SenseVoicePluginError, .incompleteModelAssets)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installer.modelDirectory.path))
+    }
+
+    func testSafeRelativePathRejectsTraversalAndAbsolutePaths() {
+        XCTAssertTrue(SenseVoiceModelAssetManager.isSafeRelativePath("model.int8.onnx"))
+        XCTAssertTrue(SenseVoiceModelAssetManager.isSafeRelativePath("nested/file.txt"))
+        XCTAssertFalse(SenseVoiceModelAssetManager.isSafeRelativePath("/tmp/model.onnx"))
+        XCTAssertFalse(SenseVoiceModelAssetManager.isSafeRelativePath("../model.onnx"))
+        XCTAssertFalse(SenseVoiceModelAssetManager.isSafeRelativePath("nested/../model.onnx"))
+        XCTAssertFalse(SenseVoiceModelAssetManager.isSafeRelativePath(""))
+    }
+
+    func testTranscribeUsesInjectedRuntimeAndRejectsTranslation() async throws {
+        let host = try makeHost()
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let installer = SenseVoiceModelAssetManager(rootDirectory: host.pluginDataDirectory)
+        try installer.install(files: [
+            "model.int8.onnx": Data("model".utf8),
+            "tokens.txt": Data("tokens".utf8),
+        ], licenseAccepted: true)
+
+        let plugin = SenseVoicePlugin { _, language in
+            XCTAssertEqual(language, "en")
+            return StubRecognizer(text: "Recovered text")
+        }
+        plugin.activate(host: host)
+
+        let audio = AudioData(samples: [0, 0, 0], wavData: Data(), duration: 0.0001875)
+        let result = try await plugin.transcribe(audio: audio, language: "en-US", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "Recovered text")
+        XCTAssertEqual(result.detectedLanguage, "en")
+
+        do {
+            _ = try await plugin.transcribe(audio: audio, language: "en", translate: true, prompt: nil)
+            XCTFail("Expected translation to fail")
+        } catch {
+            XCTAssertEqual(error as? SenseVoicePluginError, .unsupportedTranslation)
+        }
+    }
+}

--- a/TypeWhisperTests/SenseVoiceRuntimeTests.swift
+++ b/TypeWhisperTests/SenseVoiceRuntimeTests.swift
@@ -1,0 +1,125 @@
+@preconcurrency import AVFoundation
+import Foundation
+import XCTest
+@testable import TypeWhisper
+
+final class SenseVoiceRuntimeTests: XCTestCase {
+    func testRuntimeSmokeTranscribesEnglishFixtureWhenEnabled() throws {
+        guard Self.runtimeSmokeTestsEnabled else {
+            throw XCTSkip("Set TYPEWHISPER_RUN_SENSEVOICE_RUNTIME_TESTS=1 to run the SenseVoice runtime smoke test.")
+        }
+
+        let modelDirectory = URL(fileURLWithPath: "/tmp/typewhisper-sensevoice-bench")
+            .appendingPathComponent(SenseVoiceModelAssetManager.modelId, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: modelDirectory.appendingPathComponent("model.int8.onnx").path),
+              FileManager.default.fileExists(atPath: modelDirectory.appendingPathComponent("tokens.txt").path) else {
+            throw XCTSkip("SenseVoice smoke model is not downloaded at \(modelDirectory.path).")
+        }
+
+        let recognizer = try SenseVoiceONNXRecognizer(modelDirectory: modelDirectory, language: "en")
+        let fixture = try Self.makeEnglishFixtureSamples()
+
+        let text = try recognizer.transcribe(samples: fixture.samples, sampleRate: fixture.sampleRate)
+
+        XCTAssertFalse(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private static var runtimeSmokeTestsEnabled: Bool {
+        if ProcessInfo.processInfo.environment["TYPEWHISPER_RUN_SENSEVOICE_RUNTIME_TESTS"] == "1" {
+            return true
+        }
+
+        guard let flagURL = Bundle(for: SenseVoiceRuntimeTests.self).url(
+            forResource: "SenseVoiceRuntimeTestFlag",
+            withExtension: nil
+        ),
+              let flag = try? String(contentsOf: flagURL, encoding: .utf8) else {
+            return false
+        }
+
+        return flag.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+    }
+
+    private static func makeEnglishFixtureSamples() throws -> (samples: [Float], sampleRate: Int) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typewhisper-sensevoice-runtime-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioURL = directory.appendingPathComponent("english-fixture.aiff")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        process.arguments = ["-o", audioURL.path, "hello from type whisper"]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw XCTSkip("Unable to generate the local English speech fixture with /usr/bin/say.")
+        }
+
+        let audioFile = try AVAudioFile(forReading: audioURL)
+        guard let inputBuffer = AVAudioPCMBuffer(
+            pcmFormat: audioFile.processingFormat,
+            frameCapacity: AVAudioFrameCount(audioFile.length)
+        ) else {
+            throw SenseVoicePluginError.transcriptionFailed("Failed to allocate the input fixture buffer.")
+        }
+        try audioFile.read(into: inputBuffer)
+
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ),
+              let converter = AVAudioConverter(from: audioFile.processingFormat, to: outputFormat) else {
+            throw SenseVoicePluginError.transcriptionFailed("Failed to create the fixture audio converter.")
+        }
+
+        let capacity = AVAudioFrameCount(
+            ceil(Double(inputBuffer.frameLength) * outputFormat.sampleRate / audioFile.processingFormat.sampleRate)
+        ) + 512
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: capacity) else {
+            throw SenseVoicePluginError.transcriptionFailed("Failed to allocate the output fixture buffer.")
+        }
+
+        var conversionError: NSError?
+        let inputProvider = SenseVoiceFixtureInputProvider(buffer: inputBuffer)
+        let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+            inputProvider.nextBuffer(status: outStatus)
+        }
+
+        if status == .error {
+            throw conversionError ?? SenseVoicePluginError.transcriptionFailed("Failed to convert the fixture audio.")
+        }
+
+        guard let channel = outputBuffer.floatChannelData?[0] else {
+            throw SenseVoicePluginError.transcriptionFailed("Converted fixture audio has no float channel.")
+        }
+        let samples = Array(UnsafeBufferPointer(start: channel, count: Int(outputBuffer.frameLength)))
+        return (samples, 16_000)
+    }
+}
+
+private final class SenseVoiceFixtureInputProvider: @unchecked Sendable {
+    private let buffer: AVAudioPCMBuffer
+    private let lock = NSLock()
+    private var didProvideInput = false
+
+    init(buffer: AVAudioPCMBuffer) {
+        self.buffer = buffer
+    }
+
+    func nextBuffer(status: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if didProvideInput {
+            status.pointee = .endOfStream
+            return nil
+        }
+
+        didProvideInput = true
+        status.pointee = .haveData
+        return buffer
+    }
+}

--- a/scripts/bootstrap_sherpa_onnx.sh
+++ b/scripts/bootstrap_sherpa_onnx.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+VERSION="v1.13.2"
+ARCHIVE_NAME="sherpa-onnx-${VERSION}-macos-xcframework-static.tar.bz2"
+DOWNLOAD_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/${VERSION}/${ARCHIVE_NAME}"
+VENDOR_ROOT="$PROJECT_DIR/TypeWhisperPluginSDK/Vendor/SherpaONNX"
+XCFRAMEWORK_PATH="$VENDOR_ROOT/sherpa-onnx.xcframework"
+STAMP_PATH="$VENDOR_ROOT/.version"
+
+if [ -d "$XCFRAMEWORK_PATH" ] && [ -f "$STAMP_PATH" ] && [ "$(cat "$STAMP_PATH")" = "$VERSION" ]; then
+  exit 0
+fi
+
+mkdir -p "$VENDOR_ROOT"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/typewhisper-sherpa-onnx.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Bootstrapping Sherpa-ONNX ${VERSION}..."
+curl -L --fail --retry 3 -o "$TMP_DIR/$ARCHIVE_NAME" "$DOWNLOAD_URL"
+tar xjf "$TMP_DIR/$ARCHIVE_NAME" -C "$TMP_DIR"
+
+EXTRACTED="$TMP_DIR/sherpa-onnx-${VERSION}-macos-xcframework-static/sherpa-onnx.xcframework"
+if [ ! -d "$EXTRACTED" ]; then
+  echo "ERROR: Sherpa-ONNX XCFramework was not found in archive" >&2
+  exit 1
+fi
+
+rm -rf "$XCFRAMEWORK_PATH"
+cp -R "$EXTRACTED" "$XCFRAMEWORK_PATH"
+echo "$VERSION" > "$STAMP_PATH"
+echo "Sherpa-ONNX ready at $XCFRAMEWORK_PATH"

--- a/scripts/bootstrap_sherpa_onnx.sh
+++ b/scripts/bootstrap_sherpa_onnx.sh
@@ -9,9 +9,22 @@ ARCHIVE_NAME="sherpa-onnx-${VERSION}-macos-xcframework-static.tar.bz2"
 DOWNLOAD_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/${VERSION}/${ARCHIVE_NAME}"
 VENDOR_ROOT="$PROJECT_DIR/TypeWhisperPluginSDK/Vendor/SherpaONNX"
 XCFRAMEWORK_PATH="$VENDOR_ROOT/sherpa-onnx.xcframework"
+HEADERS_PATH="$XCFRAMEWORK_PATH/macos-arm64_x86_64/Headers"
+MODULEMAP_PATH="$HEADERS_PATH/module.modulemap"
 STAMP_PATH="$VENDOR_ROOT/.version"
 
+write_modulemap() {
+  mkdir -p "$HEADERS_PATH"
+  cat > "$MODULEMAP_PATH" <<'MODULEMAP'
+module SherpaOnnxC {
+  header "sherpa-onnx/c-api/c-api.h"
+  export *
+}
+MODULEMAP
+}
+
 if [ -d "$XCFRAMEWORK_PATH" ] && [ -f "$STAMP_PATH" ] && [ "$(cat "$STAMP_PATH")" = "$VERSION" ]; then
+  write_modulemap
   exit 0
 fi
 
@@ -31,5 +44,6 @@ fi
 
 rm -rf "$XCFRAMEWORK_PATH"
 cp -R "$EXTRACTED" "$XCFRAMEWORK_PATH"
+write_modulemap
 echo "$VERSION" > "$STAMP_PATH"
 echo "Sherpa-ONNX ready at $XCFRAMEWORK_PATH"

--- a/scripts/build-release-local.sh
+++ b/scripts/build-release-local.sh
@@ -30,6 +30,9 @@ xcodebuild -resolvePackageDependencies \
   -project "$PROJECT_DIR/$PROJECT" \
   -scheme "$SCHEME"
 
+echo "--- Bootstrapping Sherpa-ONNX runtime ---"
+"$PROJECT_DIR/scripts/bootstrap_sherpa_onnx.sh"
+
 # Build
 echo "--- Building Release ---"
 set -o pipefail


### PR DESCRIPTION
## Summary
- Adds SenseVoice (Experimental) as an opt-in local transcription plugin backed by Sherpa-ONNX.
- Targets `sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2024-07-17` and limits the advertised scope to `zh`, `en`, `ja`, `ko`, and `yue`.
- Keeps SenseVoice out of the default path: no translation, no streaming, and no dictionary-term support for the first experimental version.
- Adds a reproducible Sherpa-ONNX bootstrap into an ignored vendor path; model weights are downloaded only after explicit model-license acceptance.

## Issue Context
Issue #640 proposed SenseVoice as a faster local STT option for TypeWhisper. This PR adds it as an experimental, user-selected local plugin rather than replacing WhisperKit or Parakeet. The implementation intentionally avoids broader 50+ language, translation, streaming, emotion, and audio-event claims until we have product-grade validation for those paths.

Closes #640

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/SenseVoicePluginTests -only-testing:TypeWhisperTests/SenseVoiceRuntimeTests`
- `TYPEWHISPER_RUN_SENSEVOICE_RUNTIME_TESTS=1 xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/SenseVoiceRuntimeTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run SenseVoicePlugin /Users/marco/Projects/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added SenseVoice plugin for local, offline speech-to-text transcription
- Includes built-in model download and management capabilities
- Supports multiple languages with automatic language detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->