### PR TITLE
Enable SenseVoice plugin release workflow

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -118,6 +118,7 @@ jobs:
             supertonic) TARGET="SupertonicPlugin" ;;
             filler-words) TARGET="FillerWordsPlugin" ;;
             xai) TARGET="XAIPlugin" ;;
+            sensevoice) TARGET="SenseVoicePlugin" ;;
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin


### PR DESCRIPTION
## Summary
- Add the SenseVoice plugin slug to the plugin release workflow target resolver.
- Enables the official plugin-only release job for SenseVoicePlugin v0.1.0.

## Test Plan
- `git diff --check -- .github/workflows/plugin-release.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the `sensevoice` plugin in the release workflow pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->