### PR TITLE
Add generic transcription number normalization

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		24FFE19AC026C48AE32BCD7E /* DictationPunctuationProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C54 /* DictationPunctuationProfileStoreTests.swift */; };
 		24FFE19AC026C48AE32BCD7F /* PunctuationRulesLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C55 /* PunctuationRulesLoaderTests.swift */; };
 		24FFE19AC026C48AE32BCD80 /* PunctuationStrategyResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */; };
+		71F1DCAA4C8685360B145C0B /* NumberWordNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5E4923A4F803921C03DEDE /* NumberWordNormalizer.swift */; };
+		B346BF6B189F3E7C6CBA1410 /* TranscriptionNormalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */; };
+		540AE1FA22F41A63C78B89EC /* NumberWordNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */; };
+		E8FB3269B522A8923134AD9A /* TranscriptionNormalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */; };
 		D4A100000000000000000001 /* RecorderTranscriptionBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */; };
 		D4A100000000000000000003 /* RecorderTranscriptionBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */; };
 		F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000141 /* GeminiPlugin.swift */; };
@@ -772,6 +776,8 @@
 		BB00000000000000000254 /* FireworksPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FireworksPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000235 /* AppFormatterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFormatterService.swift; sourceTree = "<group>"; };
 		BB00000000000000000236 /* SpeechPunctuationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechPunctuationService.swift; sourceTree = "<group>"; };
+		8C5E4923A4F803921C03DEDE /* NumberWordNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberWordNormalizer.swift; sourceTree = "<group>"; };
+		206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionNormalizationService.swift; sourceTree = "<group>"; };
 		D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBuffer.swift; sourceTree = "<group>"; };
 		BB00000000000000000238 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		BB00000000000000000239 /* AudioRecorderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderViewModel.swift; sourceTree = "<group>"; };
@@ -788,6 +794,8 @@
 		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppFormatterServiceTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C53 /* SpeechPunctuationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpeechPunctuationServiceTests.swift; sourceTree = "<group>"; };
+		50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NumberWordNormalizerTests.swift; sourceTree = "<group>"; };
+		16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionNormalizationServiceTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C54 /* DictationPunctuationProfileStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationPunctuationProfileStoreTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C55 /* PunctuationRulesLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PunctuationRulesLoaderTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PunctuationStrategyResolverTests.swift; sourceTree = "<group>"; };
@@ -1418,6 +1426,8 @@
 				BB00000000000000000228 /* MemoryService.swift */,
 				BB00000000000000000235 /* AppFormatterService.swift */,
 				BB00000000000000000236 /* SpeechPunctuationService.swift */,
+				8C5E4923A4F803921C03DEDE /* NumberWordNormalizer.swift */,
+				206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */,
 				BB00000000000000000333 /* DictationPunctuationProfileStore.swift */,
 				BB00000000000000000334 /* PunctuationRulesLoader.swift */,
 				BB00000000000000000335 /* PunctuationStrategyResolver.swift */,
@@ -2083,6 +2093,8 @@
 				3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */,
 				CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */,
 				CE5852D6767C5FA955B84C53 /* SpeechPunctuationServiceTests.swift */,
+				50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */,
+				16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */,
 				CE5852D6767C5FA955B84C54 /* DictationPunctuationProfileStoreTests.swift */,
 				CE5852D6767C5FA955B84C55 /* PunctuationRulesLoaderTests.swift */,
 				CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */,
@@ -3564,6 +3576,8 @@
 				7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7D /* SpeechPunctuationServiceTests.swift in Sources */,
+				540AE1FA22F41A63C78B89EC /* NumberWordNormalizerTests.swift in Sources */,
+				E8FB3269B522A8923134AD9A /* TranscriptionNormalizationServiceTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7E /* DictationPunctuationProfileStoreTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7F /* PunctuationRulesLoaderTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD80 /* PunctuationStrategyResolverTests.swift in Sources */,
@@ -3777,6 +3791,8 @@
 				AA00000000000000000240 /* MemoryService.swift in Sources */,
 				AA00000000000000000247 /* AppFormatterService.swift in Sources */,
 				AA00000000000000000248 /* SpeechPunctuationService.swift in Sources */,
+				71F1DCAA4C8685360B145C0B /* NumberWordNormalizer.swift in Sources */,
+				B346BF6B189F3E7C6CBA1410 /* TranscriptionNormalizationService.swift in Sources */,
 				AA00000000000000000333 /* DictationPunctuationProfileStore.swift in Sources */,
 				AA00000000000000000334 /* PunctuationRulesLoader.swift in Sources */,
 				AA00000000000000000335 /* PunctuationStrategyResolver.swift in Sources */,

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -500,7 +500,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             UserDefaultsKeys.showMenuBarIcon: true,
             UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden: DockIconBehavior.keepVisible.rawValue,
             UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue,
-            UserDefaultsKeys.appFormattingEnabled: false
+            UserDefaultsKeys.appFormattingEnabled: false,
+            UserDefaultsKeys.transcriptionNumberNormalizationEnabled: true
         ])
     }
 

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -95,6 +95,7 @@ enum UserDefaultsKeys {
 
     // MARK: - Formatting
     static let appFormattingEnabled = "appFormattingEnabled"
+    static let transcriptionNumberNormalizationEnabled = "transcriptionNumberNormalizationEnabled"
     static let dictationPunctuationProfiles = "dictationPunctuationProfiles"
 
     // MARK: - Accessibility

--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -330,15 +330,50 @@ struct WorkflowOutput: Codable, Equatable, Sendable {
     var format: String?
     var autoEnter: Bool
     var targetActionPluginId: String?
+    var numberNormalizationModeRaw: String?
 
     init(
         format: String? = nil,
         autoEnter: Bool = false,
-        targetActionPluginId: String? = nil
+        targetActionPluginId: String? = nil,
+        numberNormalizationModeRaw: String? = nil
     ) {
         self.format = format
         self.autoEnter = autoEnter
         self.targetActionPluginId = targetActionPluginId
+        self.numberNormalizationModeRaw = numberNormalizationModeRaw
+    }
+
+    var numberNormalizationMode: WorkflowNumberNormalizationMode {
+        get { WorkflowNumberNormalizationMode(rawValue: numberNormalizationModeRaw ?? "") ?? .inherit }
+        set { numberNormalizationModeRaw = newValue == .inherit ? nil : newValue.rawValue }
+    }
+}
+
+enum WorkflowNumberNormalizationMode: String, CaseIterable, Identifiable, Codable, Sendable {
+    case inherit
+    case enabled
+    case disabled
+
+    var id: String { rawValue }
+
+    var overrideValue: Bool? {
+        switch self {
+        case .inherit: nil
+        case .enabled: true
+        case .disabled: false
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .inherit:
+            localizedAppText("Use Global Default", de: "Globalen Standard verwenden")
+        case .enabled:
+            localizedAppText("On", de: "An")
+        case .disabled:
+            localizedAppText("Off", de: "Aus")
+        }
     }
 }
 

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -172,8 +172,12 @@ final class APIHandlers: @unchecked Sendable {
             }
 
             if let normalizePart = parts.first(where: { $0.name == "normalize_numbers" }),
-               let val = String(data: normalizePart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) {
-                options.normalizeNumbers = Self.parseBoolean(val)
+               let val = String(data: normalizePart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !val.isEmpty {
+                guard let parsed = Self.parseBoolean(val) else {
+                    return .error(status: 400, message: "Invalid 'normalize_numbers' value")
+                }
+                options.normalizeNumbers = parsed
             }
         } else if !request.body.isEmpty {
             audioData = request.body
@@ -204,7 +208,10 @@ final class APIHandlers: @unchecked Sendable {
             }
             if let normalizeNumbers = request.headers["x-normalize-numbers"]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !normalizeNumbers.isEmpty {
-                options.normalizeNumbers = Self.parseBoolean(normalizeNumbers)
+                guard let parsed = Self.parseBoolean(normalizeNumbers) else {
+                    return .error(status: 400, message: "Invalid 'x-normalize-numbers' value")
+                }
+                options.normalizeNumbers = parsed
             }
         } else {
             return .error(status: 400, message: "No audio data provided")

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -72,6 +72,7 @@ final class APIHandlers: @unchecked Sendable {
         var engineOverride: String? = nil
         var modelOverride: String? = nil
         var awaitDownload = false
+        var normalizeNumbers: Bool? = nil
     }
 
     private struct LocalFileTranscribeRequest: Decodable {
@@ -84,6 +85,7 @@ final class APIHandlers: @unchecked Sendable {
         let prompt: String?
         let engine: String?
         let model: String?
+        let normalizeNumbers: Bool?
 
         enum CodingKeys: String, CodingKey {
             case path
@@ -95,6 +97,7 @@ final class APIHandlers: @unchecked Sendable {
             case prompt
             case engine
             case model
+            case normalizeNumbers = "normalize_numbers"
         }
     }
 
@@ -167,6 +170,11 @@ final class APIHandlers: @unchecked Sendable {
                !val.isEmpty {
                 options.modelOverride = val
             }
+
+            if let normalizePart = parts.first(where: { $0.name == "normalize_numbers" }),
+               let val = String(data: normalizePart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) {
+                options.normalizeNumbers = Self.parseBoolean(val)
+            }
         } else if !request.body.isEmpty {
             audioData = request.body
             fileExtension = extensionFromMIME(contentType)
@@ -193,6 +201,10 @@ final class APIHandlers: @unchecked Sendable {
             if let model = request.headers["x-model"]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !model.isEmpty {
                 options.modelOverride = model
+            }
+            if let normalizeNumbers = request.headers["x-normalize-numbers"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !normalizeNumbers.isEmpty {
+                options.normalizeNumbers = Self.parseBoolean(normalizeNumbers)
             }
         } else {
             return .error(status: 400, message: "No audio data provided")
@@ -248,6 +260,7 @@ final class APIHandlers: @unchecked Sendable {
         options.requestPrompt = payload.prompt?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         options.engineOverride = payload.engine?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         options.modelOverride = payload.model?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        options.normalizeNumbers = payload.normalizeNumbers
 
         do {
             let samples = try await audioFileService.loadAudioSamples(from: fileURL)
@@ -306,7 +319,8 @@ final class APIHandlers: @unchecked Sendable {
                 task: options.task,
                 engineOverrideId: resolvedOverride.engineId,
                 cloudModelOverride: resolvedOverride.modelId,
-                prompt: prompt
+                prompt: prompt,
+                normalizeNumbers: options.normalizeNumbers
             )
 
             var finalText = result.text
@@ -534,6 +548,17 @@ final class APIHandlers: @unchecked Sendable {
             .filter { !$0.isEmpty }
         guard !components.isEmpty else { return nil }
         return components.joined(separator: "\n")
+    }
+
+    private static func parseBoolean(_ value: String) -> Bool? {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            true
+        case "0", "false", "no", "off":
+            false
+        default:
+            nil
+        }
     }
 
     // MARK: - GET /v1/status

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -372,7 +372,10 @@ final class ModelManagerService: ObservableObject {
 
     func finishLiveTranscriptionSession(
         _ handle: LiveTranscriptionSessionHandle,
-        bufferedDuration: Double
+        bufferedDuration: Double,
+        language: String? = nil,
+        task: TranscriptionTask = .transcribe,
+        normalizeNumbers: Bool? = nil
     ) async throws -> TranscriptionResult {
         let startTime = CFAbsoluteTimeGetCurrent()
         let result = try await handle.session.finish()
@@ -380,13 +383,16 @@ final class ModelManagerService: ObservableObject {
 
         scheduleAutoUnloadIfNeeded()
 
-        return TranscriptionResult(
+        return TranscriptionNormalizationService.normalizeResult(
             text: result.text,
             detectedLanguage: result.detectedLanguage,
+            configuredLanguage: language,
             duration: bufferedDuration,
             processingTime: processingTime,
             engineUsed: handle.providerId,
-            segments: Self.transcriptionSegments(from: result.segments)
+            segments: Self.transcriptionSegments(from: result.segments),
+            task: task,
+            normalizeNumbers: normalizeNumbers
         )
     }
 
@@ -396,7 +402,8 @@ final class ModelManagerService: ObservableObject {
         task: TranscriptionTask,
         engineOverrideId: String? = nil,
         cloudModelOverride: String? = nil,
-        prompt: String? = nil
+        prompt: String? = nil,
+        normalizeNumbers: Bool? = nil
     ) async throws -> TranscriptionResult {
         try await transcribe(
             audioSamples: audioSamples,
@@ -404,7 +411,8 @@ final class ModelManagerService: ObservableObject {
             task: task,
             engineOverrideId: engineOverrideId,
             cloudModelOverride: cloudModelOverride,
-            prompt: prompt
+            prompt: prompt,
+            normalizeNumbers: normalizeNumbers
         )
     }
 
@@ -414,7 +422,8 @@ final class ModelManagerService: ObservableObject {
         task: TranscriptionTask,
         engineOverrideId: String? = nil,
         cloudModelOverride: String? = nil,
-        prompt: String? = nil
+        prompt: String? = nil,
+        normalizeNumbers: Bool? = nil
     ) async throws -> TranscriptionResult {
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
@@ -441,11 +450,12 @@ final class ModelManagerService: ObservableObject {
 
         let startTime = CFAbsoluteTimeGetCurrent()
         let audio = await Self.makeAudioData(from: audioSamples)
+        let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
 
         let result = try await transcribeWithResolvedLanguageSelection(
             plugin: plugin,
             audio: audio,
-            languageSelection: runtimeLanguageSelection(for: languageSelection, plugin: plugin),
+            languageSelection: runtimeSelection,
             task: task,
             prompt: prompt
         )
@@ -454,13 +464,16 @@ final class ModelManagerService: ObservableObject {
 
         scheduleAutoUnloadIfNeeded()
 
-        return TranscriptionResult(
+        return TranscriptionNormalizationService.normalizeResult(
             text: result.text,
             detectedLanguage: result.detectedLanguage,
+            configuredLanguage: runtimeSelection.requestedLanguage,
             duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
-            segments: Self.transcriptionSegments(from: result.segments)
+            segments: Self.transcriptionSegments(from: result.segments),
+            task: task,
+            normalizeNumbers: normalizeNumbers
         )
     }
 
@@ -471,6 +484,7 @@ final class ModelManagerService: ObservableObject {
         engineOverrideId: String? = nil,
         cloudModelOverride: String? = nil,
         prompt: String? = nil,
+        normalizeNumbers: Bool? = nil,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> TranscriptionResult {
         try await transcribe(
@@ -480,6 +494,7 @@ final class ModelManagerService: ObservableObject {
             engineOverrideId: engineOverrideId,
             cloudModelOverride: cloudModelOverride,
             prompt: prompt,
+            normalizeNumbers: normalizeNumbers,
             onProgress: onProgress
         )
     }
@@ -491,6 +506,7 @@ final class ModelManagerService: ObservableObject {
         engineOverrideId: String? = nil,
         cloudModelOverride: String? = nil,
         prompt: String? = nil,
+        normalizeNumbers: Bool? = nil,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> TranscriptionResult {
         let providerId = engineOverrideId ?? selectedProviderId
@@ -518,11 +534,12 @@ final class ModelManagerService: ObservableObject {
 
         let startTime = CFAbsoluteTimeGetCurrent()
         let audio = await Self.makeAudioData(from: audioSamples)
+        let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
 
         let result = try await transcribeWithResolvedLanguageSelection(
             plugin: plugin,
             audio: audio,
-            languageSelection: runtimeLanguageSelection(for: languageSelection, plugin: plugin),
+            languageSelection: runtimeSelection,
             task: task,
             prompt: prompt,
             onProgress: onProgress
@@ -532,13 +549,16 @@ final class ModelManagerService: ObservableObject {
 
         scheduleAutoUnloadIfNeeded()
 
-        return TranscriptionResult(
+        return TranscriptionNormalizationService.normalizeResult(
             text: result.text,
             detectedLanguage: result.detectedLanguage,
+            configuredLanguage: runtimeSelection.requestedLanguage,
             duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
-            segments: Self.transcriptionSegments(from: result.segments)
+            segments: Self.transcriptionSegments(from: result.segments),
+            task: task,
+            normalizeNumbers: normalizeNumbers
         )
     }
 

--- a/TypeWhisper/Services/NumberWordNormalizer.swift
+++ b/TypeWhisper/Services/NumberWordNormalizer.swift
@@ -1,0 +1,474 @@
+import Foundation
+
+enum NumberWordNormalizer {
+    static func normalize(text: String, language: String?) -> String {
+        guard let languageCode = PunctuationLanguageNormalizer.normalize(language),
+              ["en", "de"].contains(languageCode),
+              !text.isEmpty else {
+            return text
+        }
+
+        let tokens = tokenize(text)
+        guard tokens.contains(where: \.isWord) else { return text }
+
+        var result = ""
+        var index = 0
+        while index < tokens.count {
+            if tokens[index].isWord,
+               let parsed = parseNumber(startingAt: index, in: tokens, languageCode: languageCode) {
+                result.append(parsed.replacement)
+                index = parsed.endIndex
+            } else {
+                result.append(tokens[index].text)
+                index += 1
+            }
+        }
+
+        return result
+    }
+
+    private struct Token {
+        let text: String
+        let isWord: Bool
+    }
+
+    private struct ParsedNumber {
+        let replacement: String
+        let endIndex: Int
+    }
+
+    private struct WordCandidate {
+        let tokenIndex: Int
+        let text: String
+    }
+
+    fileprivate struct ParsedWords {
+        let value: String
+        let consumedWords: Int
+    }
+
+    private static func parseNumber(startingAt index: Int, in tokens: [Token], languageCode: String) -> ParsedNumber? {
+        let words = wordCandidates(startingAt: index, in: tokens)
+        guard !words.isEmpty else { return nil }
+
+        let parsed: ParsedWords?
+        switch languageCode {
+        case "en":
+            parsed = EnglishNumberParser.parse(words.map(\.text))
+        case "de":
+            parsed = GermanNumberParser.parse(words.map(\.text))
+        default:
+            parsed = nil
+        }
+
+        guard let parsed, parsed.consumedWords > 0, parsed.consumedWords <= words.count else {
+            return nil
+        }
+
+        let finalTokenIndex = words[parsed.consumedWords - 1].tokenIndex
+        return ParsedNumber(replacement: parsed.value, endIndex: finalTokenIndex + 1)
+    }
+
+    private static func wordCandidates(startingAt index: Int, in tokens: [Token]) -> [WordCandidate] {
+        var words: [WordCandidate] = []
+        var current = index
+
+        while current < tokens.count, tokens[current].isWord {
+            words.append(WordCandidate(tokenIndex: current, text: tokens[current].text))
+
+            let separatorIndex = current + 1
+            let nextWordIndex = current + 2
+            guard separatorIndex < tokens.count,
+                  nextWordIndex < tokens.count,
+                  tokens[nextWordIndex].isWord,
+                  isWordConnector(tokens[separatorIndex].text) else {
+                break
+            }
+
+            current = nextWordIndex
+        }
+
+        return words
+    }
+
+    private static func tokenize(_ text: String) -> [Token] {
+        var tokens: [Token] = []
+        var current = ""
+        var currentIsWord: Bool?
+
+        for character in text {
+            let isWord = isWordCharacter(character)
+            if currentIsWord == isWord {
+                current.append(character)
+            } else {
+                if !current.isEmpty, let currentIsWord {
+                    tokens.append(Token(text: current, isWord: currentIsWord))
+                }
+                current = String(character)
+                currentIsWord = isWord
+            }
+        }
+
+        if !current.isEmpty, let currentIsWord {
+            tokens.append(Token(text: current, isWord: currentIsWord))
+        }
+
+        return tokens
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { CharacterSet.letters.contains($0) }
+    }
+
+    private static func isWordConnector(_ text: String) -> Bool {
+        !text.isEmpty && text.unicodeScalars.allSatisfy { scalar in
+            CharacterSet.whitespacesAndNewlines.contains(scalar) || scalar == "-" || scalar == "\u{2011}"
+        }
+    }
+}
+
+private enum EnglishNumberParser {
+    private static let unitValues: [String: Int] = [
+        "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4,
+        "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
+    ]
+
+    private static let teenValues: [String: Int] = [
+        "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
+        "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+    ]
+
+    private static let tensValues: [String: Int] = [
+        "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+        "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
+    ]
+
+    private static let scaleValues: [String: Int] = [
+        "thousand": 1_000,
+        "million": 1_000_000,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if ["minus", "negative"].contains(normalizedWords[index]) {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "point" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ".\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
+        guard var group = parseGroup(words, startingAt: startIndex) else { return nil }
+        var total = 0
+        var current = group.value
+        var index = group.nextIndex
+        var consumedScale = false
+
+        while index < words.count {
+            if words[index] == "and",
+               let nextGroup = parseGroup(words, startingAt: index + 1) {
+                group = nextGroup
+                current += group.value
+                index = group.nextIndex
+                continue
+            }
+
+            guard let scale = scaleValues[words[index]] else { break }
+            total += current * scale
+            current = 0
+            consumedScale = true
+            index += 1
+
+            if index < words.count, words[index] == "and" {
+                index += 1
+            }
+
+            if let nextGroup = parseGroup(words, startingAt: index) {
+                group = nextGroup
+                current = group.value
+                index = group.nextIndex
+            }
+        }
+
+        let value = consumedScale ? total + current : current
+        return (value, index)
+    }
+
+    private static func parseGroup(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var index = startIndex
+        var value = 0
+        var consumed = false
+
+        if let base = smallNumberValue(words[index]),
+           index + 1 < words.count,
+           words[index + 1] == "hundred" {
+            value = base * 100
+            index += 2
+            consumed = true
+
+            if index < words.count, words[index] == "and" {
+                index += 1
+            }
+        }
+
+        if index < words.count, let tens = tensValues[words[index]] {
+            value += tens
+            index += 1
+            consumed = true
+
+            if index < words.count, let unit = unitValues[words[index]], unit > 0 {
+                value += unit
+                index += 1
+            }
+        } else if index < words.count, let small = smallNumberValue(words[index]) {
+            value += small
+            index += 1
+            consumed = true
+        }
+
+        return consumed ? (value, index) : nil
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = unitValues[words[index]], digit >= 0, digit <= 9 {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func smallNumberValue(_ word: String) -> Int? {
+        unitValues[word] ?? teenValues[word]
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US"))
+            .lowercased()
+    }
+}
+
+private enum GermanNumberParser {
+    private static let units: [String: Int] = [
+        "null": 0, "eins": 1, "ein": 1, "eine": 1, "einen": 1, "einem": 1, "einer": 1,
+        "zwei": 2, "drei": 3, "vier": 4, "funf": 5, "fuenf": 5,
+        "sechs": 6, "sieben": 7, "acht": 8, "neun": 9,
+    ]
+
+    private static let teens: [String: Int] = [
+        "zehn": 10, "elf": 11, "zwolf": 12, "zwoelf": 12, "dreizehn": 13, "vierzehn": 14,
+        "funfzehn": 15, "fuenfzehn": 15, "sechzehn": 16, "siebzehn": 17,
+        "achtzehn": 18, "neunzehn": 19,
+    ]
+
+    private static let tens: [String: Int] = [
+        "zwanzig": 20, "dreissig": 30, "dreizig": 30, "vierzig": 40,
+        "funfzig": 50, "fuenfzig": 50, "sechzig": 60, "siebzig": 70,
+        "achtzig": 80, "neunzig": 90,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if normalizedWords[index] == "minus" {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "komma" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ",\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var total = 0
+        var current = 0
+        var index = startIndex
+        var consumed = false
+        var lastWasPlainSmallNumber = false
+
+        while index < words.count {
+            let word = words[index]
+
+            if word == "und",
+               current > 0,
+               current < 10,
+               index + 1 < words.count,
+               let tenValue = tens[words[index + 1]] {
+                current += tenValue
+                index += 2
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if word == "hundert" {
+                current = max(current, 1) * 100
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if ["tausend", "million", "millionen"].contains(word) {
+                let scale = word == "tausend" ? 1_000 : 1_000_000
+                total += max(current, 1) * scale
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            let allowsArticleOne = allowsArticleOne(at: index, in: words)
+            guard let value = parseCompound(word, allowArticleOne: allowsArticleOne) else { break }
+
+            if lastWasPlainSmallNumber, value < 10 {
+                break
+            }
+
+            current += value
+            index += 1
+            consumed = true
+            lastWasPlainSmallNumber = value < 10 && !allowsArticleOne
+        }
+
+        guard consumed else { return nil }
+        return (total + current, index)
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = digitValue(words[index]) {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func parseCompound(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return direct
+        }
+
+        if let range = word.range(of: "tausend") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            let prefixValue = prefix.isEmpty ? 1 : parseCompound(prefix, allowArticleOne: true)
+            guard let prefixValue else { return nil }
+            let suffixValue = suffix.isEmpty ? 0 : parseCompound(suffix, allowArticleOne: true)
+            guard let suffixValue else { return nil }
+            return prefixValue * 1_000 + suffixValue
+        }
+
+        if let range = word.range(of: "hundert") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            let prefixValue = prefix.isEmpty ? 1 : parseUnderHundred(prefix, allowArticleOne: true)
+            guard let prefixValue else { return nil }
+            let suffixValue = suffix.isEmpty ? 0 : parseUnderHundred(suffix, allowArticleOne: true)
+            guard let suffixValue else { return nil }
+            return prefixValue * 100 + suffixValue
+        }
+
+        return parseUnderHundred(word, allowArticleOne: allowArticleOne)
+    }
+
+    private static func parseUnderHundred(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return direct
+        }
+
+        if let range = word.range(of: "und") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            guard let unit = directUnitValue(prefix, allowArticleOne: true),
+                  unit > 0,
+                  unit < 10,
+                  let tenValue = tens[suffix] else {
+                return nil
+            }
+            return unit + tenValue
+        }
+
+        return nil
+    }
+
+    private static func directValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let unit = directUnitValue(word, allowArticleOne: allowArticleOne) {
+            return unit
+        }
+        return teens[word] ?? tens[word]
+    }
+
+    private static func directUnitValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        guard let value = units[word] else { return nil }
+        if value == 1, word != "eins", !allowArticleOne {
+            return nil
+        }
+        return value
+    }
+
+    private static func digitValue(_ word: String) -> Int? {
+        directUnitValue(word, allowArticleOne: false)
+    }
+
+    private static func allowsArticleOne(at index: Int, in words: [String]) -> Bool {
+        guard index + 1 < words.count else { return false }
+        return ["hundert", "tausend", "million", "millionen"].contains(words[index + 1])
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "de_DE"))
+            .lowercased()
+            .replacingOccurrences(of: "ß", with: "ss")
+    }
+}

--- a/TypeWhisper/Services/NumberWordNormalizer.swift
+++ b/TypeWhisper/Services/NumberWordNormalizer.swift
@@ -187,14 +187,6 @@ private enum EnglishNumberParser {
         var consumedScale = false
 
         while index < words.count {
-            if words[index] == "and",
-               let nextGroup = parseGroup(words, startingAt: index + 1) {
-                group = nextGroup
-                current += group.value
-                index = group.nextIndex
-                continue
-            }
-
             guard let scale = scaleValues[words[index]] else { break }
             total += current * scale
             current = 0

--- a/TypeWhisper/Services/PostProcessingPipeline.swift
+++ b/TypeWhisper/Services/PostProcessingPipeline.swift
@@ -37,14 +37,17 @@ final class PostProcessingPipeline {
         dictationContext: DictationRuntimeContext? = nil,
         llmHandler: ((String) async throws -> String)? = nil,
         outputFormat: String? = nil,
-        llmStepName: String? = nil
+        llmStepName: String? = nil,
+        normalizeNumbers: Bool? = nil
     ) async throws -> PostProcessingResult {
         // Collect plugin processors with their priorities
         let plugins = PluginManager.shared.postProcessors
 
         // Build priority-ordered step list: (priority, id)
-        // IDs: -1 = LLM, -2 = snippets, -3 = dictionary, -4 = app formatter, -5 = punctuation, 0+ = plugin index
+        // IDs: -1 = LLM, -2 = snippets, -3 = dictionary, -4 = app formatter, -5 = punctuation, -6 = normalization, 0+ = plugin index
         var steps: [(priority: Int, id: Int)] = []
+
+        steps.append((100, -6))
 
         // App formatter at priority 150 (before LLM at 300)
         let formattingEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.appFormattingEnabled)
@@ -69,6 +72,7 @@ final class PostProcessingPipeline {
 
         func stepName(for id: Int) -> String {
             switch id {
+            case -6: return "Number Normalization"
             case -4: return "Formatting"
             case -5: return "Speech Punctuation"
             case -1: return llmStepName ?? "Prompt"
@@ -84,6 +88,17 @@ final class PostProcessingPipeline {
             let stepStart = ContinuousClock.now
             do {
                 switch step.id {
+                case -6:
+                    let language = TranscriptionNormalizationService.normalizationLanguage(
+                        task: .transcribe,
+                        detectedLanguage: dictationContext?.detectedLanguage ?? context.language,
+                        configuredLanguage: dictationContext?.configuredLanguage ?? context.language
+                    )
+                    result = TranscriptionNormalizationService.normalizeText(
+                        result,
+                        language: language,
+                        normalizeNumbers: normalizeNumbers
+                    )
                 case -4:
                     result = appFormatterService!.format(
                         text: result,

--- a/TypeWhisper/Services/TranscriptionNormalizationService.swift
+++ b/TypeWhisper/Services/TranscriptionNormalizationService.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum TranscriptionNormalizationService {
+    static func numberNormalizationEnabled(
+        override: Bool? = nil,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if let override {
+            return override
+        }
+
+        if defaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) == nil {
+            return true
+        }
+
+        return defaults.bool(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+    }
+
+    static func normalizeText(
+        _ text: String,
+        language: String?,
+        normalizeNumbers: Bool? = nil,
+        defaults: UserDefaults = .standard
+    ) -> String {
+        guard numberNormalizationEnabled(override: normalizeNumbers, defaults: defaults) else {
+            return text
+        }
+
+        return NumberWordNormalizer.normalize(text: text, language: language)
+    }
+
+    static func normalizeResult(
+        text: String,
+        detectedLanguage: String?,
+        configuredLanguage: String?,
+        duration: TimeInterval,
+        processingTime: TimeInterval,
+        engineUsed: String,
+        segments: [TranscriptionSegment],
+        task: TranscriptionTask,
+        normalizeNumbers: Bool? = nil,
+        defaults: UserDefaults = .standard
+    ) -> TranscriptionResult {
+        let language = normalizationLanguage(
+            task: task,
+            detectedLanguage: detectedLanguage,
+            configuredLanguage: configuredLanguage
+        )
+        return TranscriptionResult(
+            text: normalizeText(text, language: language, normalizeNumbers: normalizeNumbers, defaults: defaults),
+            detectedLanguage: detectedLanguage,
+            duration: duration,
+            processingTime: processingTime,
+            engineUsed: engineUsed,
+            segments: segments.map {
+                TranscriptionSegment(
+                    text: normalizeText($0.text, language: language, normalizeNumbers: normalizeNumbers, defaults: defaults),
+                    start: $0.start,
+                    end: $0.end,
+                    speakerLabel: $0.speakerLabel,
+                    speakerConfidence: $0.speakerConfidence
+                )
+            }
+        )
+    }
+
+    static func normalizeResult(
+        _ result: TranscriptionResult,
+        configuredLanguage: String?,
+        task: TranscriptionTask,
+        normalizeNumbers: Bool? = nil,
+        defaults: UserDefaults = .standard
+    ) -> TranscriptionResult {
+        normalizeResult(
+            text: result.text,
+            detectedLanguage: result.detectedLanguage,
+            configuredLanguage: configuredLanguage,
+            duration: result.duration,
+            processingTime: result.processingTime,
+            engineUsed: result.engineUsed,
+            segments: result.segments,
+            task: task,
+            normalizeNumbers: normalizeNumbers,
+            defaults: defaults
+        )
+    }
+
+    static func normalizationLanguage(
+        task: TranscriptionTask,
+        detectedLanguage: String?,
+        configuredLanguage: String?
+    ) -> String? {
+        if task == .translate {
+            return "en"
+        }
+        return detectedLanguage ?? configuredLanguage
+    }
+}

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -238,6 +238,7 @@ final class DictationViewModel: ObservableObject {
         let languageSelection: LanguageSelection
         let task: TranscriptionTask
         let cloudModelOverride: String?
+        let normalizeNumbers: Bool?
     }
     private var lastStreamingParams: StreamingParamsSnapshot?
     private var isStopInFlight = false
@@ -1081,6 +1082,10 @@ final class DictationViewModel: ObservableObject {
         matchedWorkflow?.output.format
     }
 
+    private var effectiveNumberNormalizationOverride: Bool? {
+        matchedWorkflow?.output.numberNormalizationMode.overrideValue
+    }
+
     private var effectiveActionPluginId: String? {
         matchedWorkflow?.output.targetActionPluginId
     }
@@ -1225,7 +1230,8 @@ final class DictationViewModel: ObservableObject {
                         task: task,
                         engineOverrideId: engineOverride,
                         cloudModelOverride: cloudModelOverride,
-                        prompt: termsPrompt
+                        prompt: termsPrompt,
+                        normalizeNumbers: effectiveNumberNormalizationOverride
                     )
                 }
 
@@ -1289,7 +1295,8 @@ final class DictationViewModel: ObservableObject {
                 let ppResult = try await postProcessingPipeline.process(
                     text: text, context: ppContext, dictationContext: dictationContext, llmHandler: llmHandler,
                     outputFormat: self.effectiveOutputFormat,
-                    llmStepName: llmStepName
+                    llmStepName: llmStepName,
+                    normalizeNumbers: self.effectiveNumberNormalizationOverride
                 )
                 text = ppResult.text
                 let transcriptionID = sessionID ?? UUID()
@@ -1508,7 +1515,8 @@ final class DictationViewModel: ObservableObject {
             providerId: modelManager.selectedProviderId,
             languageSelection: effectiveLanguageSelection,
             task: effectiveTask,
-            cloudModelOverride: effectiveCloudModelOverride
+            cloudModelOverride: effectiveCloudModelOverride,
+            normalizeNumbers: effectiveNumberNormalizationOverride
         )
         lastStreamingParams = allowLiveTranscription ? params : nil
         streamingHandler.start(
@@ -1520,6 +1528,7 @@ final class DictationViewModel: ObservableObject {
             languageSelection: params.languageSelection,
             task: params.task,
             cloudModelOverride: params.cloudModelOverride,
+            normalizeNumbers: params.normalizeNumbers,
             allowLiveTranscription: allowLiveTranscription,
             stateCheck: { [weak self] in self?.state == .recording }
         )
@@ -1538,7 +1547,8 @@ final class DictationViewModel: ObservableObject {
             providerId: modelManager.selectedProviderId,
             languageSelection: effectiveLanguageSelection,
             task: effectiveTask,
-            cloudModelOverride: effectiveCloudModelOverride
+            cloudModelOverride: effectiveCloudModelOverride,
+            normalizeNumbers: effectiveNumberNormalizationOverride
         )
         guard newParams != previous else { return }
         logger.info("Streaming params changed after URL resolution, restarting live session")

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -7,6 +7,9 @@ final class StreamingHandler: @unchecked Sendable {
     private struct SharedState {
         var confirmedStreamingText = ""
         var liveSessionHandle: ModelManagerService.LiveTranscriptionSessionHandle?
+        var normalizeNumbers: Bool?
+        var configuredLanguage: String?
+        var task: TranscriptionTask = .transcribe
         var livePreviewAudioGate = LivePreviewAudioGate()
         var sampleCursor = 0
     }
@@ -92,6 +95,7 @@ final class StreamingHandler: @unchecked Sendable {
         languageSelection: LanguageSelection,
         task: TranscriptionTask,
         cloudModelOverride: String?,
+        normalizeNumbers: Bool? = nil,
         allowLiveTranscription: Bool,
         stateCheck: @escaping @MainActor @Sendable () -> Bool
     ) {
@@ -110,6 +114,11 @@ final class StreamingHandler: @unchecked Sendable {
         }
 
         resetStreamingState()
+        sharedState.withLock { state in
+            state.normalizeNumbers = normalizeNumbers
+            state.configuredLanguage = languageSelection.requestedLanguage
+            state.task = task
+        }
         onStreamingStateChange?(true)
 
         streamingTask = Task { [weak self] in
@@ -155,6 +164,7 @@ final class StreamingHandler: @unchecked Sendable {
                 languageSelection: languageSelection,
                 task: task,
                 cloudModelOverride: cloudModelOverride,
+                normalizeNumbers: normalizeNumbers,
                 stateCheck: stateCheck
             )
         }
@@ -178,7 +188,10 @@ final class StreamingHandler: @unchecked Sendable {
             }
             let result = try await modelManager.finishLiveTranscriptionSession(
                 handle,
-                bufferedDuration: bufferedDurationProvider()
+                bufferedDuration: bufferedDurationProvider(),
+                language: sharedState.withLock { $0.configuredLanguage },
+                task: sharedState.withLock { $0.task },
+                normalizeNumbers: sharedState.withLock { $0.normalizeNumbers }
             )
             clearStreamingState(notifyStreamingStopped: true)
 
@@ -239,6 +252,7 @@ final class StreamingHandler: @unchecked Sendable {
         languageSelection: LanguageSelection,
         task: TranscriptionTask,
         cloudModelOverride: String?,
+        normalizeNumbers: Bool?,
         stateCheck: @escaping @MainActor @Sendable () -> Bool
     ) async {
         try? await Task.sleep(for: Self.fallbackPollInterval)
@@ -258,6 +272,7 @@ final class StreamingHandler: @unchecked Sendable {
                         engineOverrideId: engineOverrideId,
                         cloudModelOverride: cloudModelOverride,
                         prompt: streamPrompt,
+                        normalizeNumbers: normalizeNumbers,
                         onProgress: { [weak self] text in
                             guard let self, !Task.isCancelled else { return false }
                             _ = self.processPreviewUpdate(text, audioGate: nil, persist: false)
@@ -285,6 +300,9 @@ final class StreamingHandler: @unchecked Sendable {
         sharedState.withLock { state in
             state.confirmedStreamingText = ""
             state.liveSessionHandle = nil
+            state.normalizeNumbers = nil
+            state.configuredLanguage = nil
+            state.task = .transcribe
             state.sampleCursor = 0
         }
         progressText.withLock { $0 = "" }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -578,6 +578,15 @@ struct RecordingSettingsView: View {
                 Text(String(localized: "Automatically format transcribed text based on the target app. Configure the output format per workflow."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                Toggle(String(localized: "Normalize spoken numbers to digits"), isOn: Binding(
+                    get: { TranscriptionNormalizationService.numberNormalizationEnabled() },
+                    set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) }
+                ))
+
+                Text(String(localized: "Converts spoken English and German numbers, such as twenty three or dreiundzwanzig, into digits before insertion and export."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section(String(localized: "Audio Ducking")) {

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -903,6 +903,10 @@ private struct WorkflowEditorPage: View {
                                 Divider()
                             }
 
+                            numberNormalizationSection
+
+                            Divider()
+
                             Toggle(localizedAppText("Press Enter after inserting", de: "Nach dem Einfügen Enter drücken"), isOn: $draft.autoEnter)
                         }
                         .padding(.top, 4)
@@ -1757,6 +1761,23 @@ private struct WorkflowEditorPage: View {
             }
         )
     }
+
+    private var numberNormalizationSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Picker(localizedAppText("Number formatting", de: "Zahlenformatierung"), selection: $draft.numberNormalizationMode) {
+                ForEach(WorkflowNumberNormalizationMode.allCases) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+
+            Text(localizedAppText(
+                "Controls whether spoken English and German numbers are converted to digits for this workflow.",
+                de: "Steuert, ob gesprochene englische und deutsche Zahlen in diesem Workflow zu Ziffern werden."
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
 }
 
 private struct WorkflowTemplateCard: View {
@@ -2141,6 +2162,7 @@ struct WorkflowDraft {
     var customInstruction: String
     var outputFormat: String
     var autoEnter: Bool
+    var numberNormalizationMode: WorkflowNumberNormalizationMode
     var transcriptionEngineId: String?
     var transcriptionModelId: String?
     var microphoneBoostOverride: Bool?
@@ -2173,6 +2195,7 @@ struct WorkflowDraft {
         self.customInstruction = ""
         self.outputFormat = ""
         self.autoEnter = false
+        self.numberNormalizationMode = .inherit
         self.transcriptionEngineId = nil
         self.transcriptionModelId = nil
         self.microphoneBoostOverride = nil
@@ -2204,6 +2227,7 @@ struct WorkflowDraft {
         self.customInstruction = behavior.settings["instruction"] ?? behavior.settings["goal"] ?? behavior.settings["prompt"] ?? ""
         self.outputFormat = output.format ?? ""
         self.autoEnter = output.autoEnter
+        self.numberNormalizationMode = output.numberNormalizationMode
         self.transcriptionEngineId = workflow.template == .dictation ? behavior.transcriptionEngineId : nil
         self.transcriptionModelId = workflow.template == .dictation ? behavior.transcriptionModelId : nil
         self.microphoneBoostOverride = behavior.microphoneBoostOverride
@@ -2551,7 +2575,8 @@ struct WorkflowDraft {
         return WorkflowOutput(
             format: usesLLMProcessing && !trimmedFormat.isEmpty ? trimmedFormat : nil,
             autoEnter: autoEnter,
-            targetActionPluginId: template == .dictation ? nil : targetActionPluginId
+            targetActionPluginId: template == .dictation ? nil : targetActionPluginId,
+            numberNormalizationModeRaw: numberNormalizationMode == .inherit ? nil : numberNormalizationMode.rawValue
         )
     }
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1269,6 +1269,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
 
         MockTranscriptionPlugin.reset()
+        defer { MockTranscriptionPlugin.reset() }
         MockTranscriptionPlugin.setResponseText("two")
         context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
@@ -1299,6 +1300,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
 
         MockTranscriptionPlugin.reset()
+        defer { MockTranscriptionPlugin.reset() }
         MockTranscriptionPlugin.setResponseText("two")
         context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
@@ -1322,6 +1324,78 @@ final class APIRouterAndHandlersTests: XCTestCase {
         ))
 
         XCTAssertEqual(response["text"] as? String, "two")
+    }
+
+    func testTranscribeEndpointRejectsInvalidNormalizeNumbersHeader() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let response = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-normalize-numbers": "maybe",
+                ],
+                body: WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 400)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Invalid 'x-normalize-numbers' value")
+    }
+
+    func testTranscribeEndpointRejectsInvalidMultipartNormalizeNumbers() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let boundary = "Boundary-\(UUID().uuidString)"
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"normalize_numbers\"\r\n\r\n".data(using: .utf8)!)
+        body.append("maybe\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        let response = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: body
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 400)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Invalid 'normalize_numbers' value")
     }
 
     func testTranscribeEndpointUsesOverrideEngineBudgetForDictionaryPrompt() async throws {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -276,6 +276,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         private static let promptLock = NSLock()
         nonisolated(unsafe) private static var _lastPrompt: String?
         nonisolated(unsafe) private static var _lastLanguageSelection = PluginLanguageSelection()
+        nonisolated(unsafe) private static var _responseText = "transcribed"
 
         static var lastPrompt: String? {
             promptLock.withLock { _lastPrompt }
@@ -289,6 +290,13 @@ final class APIRouterAndHandlersTests: XCTestCase {
             promptLock.withLock {
                 _lastPrompt = nil
                 _lastLanguageSelection = PluginLanguageSelection()
+                _responseText = "transcribed"
+            }
+        }
+
+        static func setResponseText(_ text: String) {
+            promptLock.withLock {
+                _responseText = text
             }
         }
 
@@ -313,7 +321,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 Self._lastPrompt = prompt
                 Self._lastLanguageSelection = PluginLanguageSelection(requestedLanguage: language)
             }
-            return PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+            return PluginTranscriptionResult(text: Self.promptLock.withLock { Self._responseText }, detectedLanguage: language)
         }
 
         func transcribe(
@@ -327,7 +335,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 Self._lastLanguageSelection = languageSelection
             }
             return PluginTranscriptionResult(
-                text: "transcribed",
+                text: Self.promptLock.withLock { Self._responseText },
                 detectedLanguage: languageSelection.requestedLanguage ?? languageSelection.languageHints.first
             )
         }
@@ -1250,6 +1258,70 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(response["text"] as? String, "transcribed")
         XCTAssertEqual(MockTranscriptionPlugin.lastPrompt, "TypeWhisper, WhisperKit")
+    }
+
+    func testTranscribeEndpointNormalizesNumbersByDefault() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setResponseText("two")
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+
+        let response = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "audio/wav", "x-language": "en"],
+                body: wavData
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "2")
+    }
+
+    func testTranscribeEndpointNormalizeNumbersFalsePreservesRawText() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setResponseText("two")
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+
+        let response = try Self.jsonObject(await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-language": "en",
+                    "x-normalize-numbers": "false",
+                ],
+                body: wavData
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "two")
     }
 
     func testTranscribeEndpointUsesOverrideEngineBudgetForDictionaryPrompt() async throws {

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -92,5 +92,6 @@ final class AppFormatterServiceTests: XCTestCase {
         AppDelegate.registerDefaultUserDefaults(defaults)
 
         XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.appFormattingEnabled) as? Bool, false)
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) as? Bool, true)
     }
 }

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -36,6 +36,25 @@ final class NumberWordNormalizerTests: XCTestCase {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus two point five", language: "en"), "-2.5")
     }
 
+    func testEnglishAndSeparatorDoesNotMergeIndependentNumbers() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "two and three", language: "en"), "2 and 3")
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "between two and three minutes", language: "en"),
+            "between 2 and 3 minutes"
+        )
+    }
+
+    func testEnglishHundredAndScaleAndStillNormalize() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "one hundred and twenty three", language: "en"),
+            "123"
+        )
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "one thousand and five", language: "en"),
+            "1005"
+        )
+    }
+
     func testGermanNegativeDecimalNormalizesToDigits() {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus zwei komma fünf", language: "de"), "-2,5")
     }

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import TypeWhisper
+
+final class NumberWordNormalizerTests: XCTestCase {
+    func testEnglishSimpleNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "I have two questions", language: "en"), "I have 2 questions")
+    }
+
+    func testGermanSimpleNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "ich habe zwei Fragen", language: "de"), "ich habe 2 Fragen")
+    }
+
+    func testEnglishCompoundNumberNormalizesToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty three files", language: "en"), "23 files")
+    }
+
+    func testGermanCompoundNumberNormalizesToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "dreiundzwanzig Dateien", language: "de"), "23 Dateien")
+    }
+
+    func testEnglishScaleNumberNormalizesToDigits() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "one thousand two hundred thirty four", language: "en"),
+            "1234"
+        )
+    }
+
+    func testGermanScaleNumberNormalizesToDigits() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "eintausendzweihundertvierunddreißig", language: "de"),
+            "1234"
+        )
+    }
+
+    func testEnglishNegativeDecimalNormalizesToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus two point five", language: "en"), "-2.5")
+    }
+
+    func testGermanNegativeDecimalNormalizesToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus zwei komma fünf", language: "de"), "-2,5")
+    }
+
+    func testUnsupportedLanguageIsNoOp() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty three", language: "fr"), "twenty three")
+    }
+
+    func testAlreadyDigitTextIsNoOp() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "I have 23 files", language: "en"), "I have 23 files")
+    }
+
+    func testGermanArticleOneIsPreservedOutsideClearNumberConstructs() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "ich habe ein Problem", language: "de"), "ich habe ein Problem")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "ein hundert Euro", language: "de"), "100 Euro")
+    }
+}

--- a/TypeWhisperTests/SpeechPunctuationServiceTests.swift
+++ b/TypeWhisperTests/SpeechPunctuationServiceTests.swift
@@ -157,4 +157,86 @@ final class SpeechPunctuationServiceTests: XCTestCase {
         XCTAssertEqual(result.text, "ciao [mondo]")
         XCTAssertEqual(result.appliedSteps, ["Speech Punctuation", "Corrections"])
     }
+
+    @MainActor
+    func testPipelineNormalizesNumbersBeforeLaterPostProcessing() async throws {
+        let previousDefault = UserDefaults.standard.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        defer {
+            if let previousDefault {
+                UserDefaults.standard.set(previousDefault, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            }
+        }
+
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
+
+        let pipeline = makePipeline(appSupportDirectory: appSupportDirectory)
+
+        let result = try await pipeline.process(
+            text: "twenty three",
+            context: PostProcessingContext(language: "en"),
+            dictationContext: DictationRuntimeContext(
+                engineId: "mock",
+                modelId: "tiny",
+                configuredLanguage: "en",
+                detectedLanguage: nil
+            )
+        )
+
+        XCTAssertEqual(result.text, "23")
+        XCTAssertEqual(result.appliedSteps, ["Number Normalization"])
+    }
+
+    @MainActor
+    func testPipelineNumberNormalizationOverrideOffWinsOverGlobalOn() async throws {
+        let previousDefault = UserDefaults.standard.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        UserDefaults.standard.set(true, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        defer {
+            if let previousDefault {
+                UserDefaults.standard.set(previousDefault, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            }
+        }
+
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
+
+        let pipeline = makePipeline(appSupportDirectory: appSupportDirectory)
+
+        let result = try await pipeline.process(
+            text: "twenty three",
+            context: PostProcessingContext(language: "en"),
+            dictationContext: DictationRuntimeContext(
+                engineId: "mock",
+                modelId: "tiny",
+                configuredLanguage: "en",
+                detectedLanguage: nil
+            ),
+            normalizeNumbers: false
+        )
+
+        XCTAssertEqual(result.text, "twenty three")
+        XCTAssertFalse(result.appliedSteps.contains("Number Normalization"))
+    }
+
+    @MainActor
+    private func makePipeline(appSupportDirectory: URL) -> PostProcessingPipeline {
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        let profileStore = DictationPunctuationProfileStore(defaults: UserDefaults(suiteName: #function)!, storageKey: #function)
+        return PostProcessingPipeline(
+            snippetService: SnippetService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
+            appFormatterService: nil,
+            speechPunctuationService: SpeechPunctuationService(rulesLoader: makeRulesLoader()),
+            punctuationStrategyResolver: PunctuationStrategyResolver(profileStore: profileStore)
+        )
+    }
 }

--- a/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
+++ b/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import TypeWhisperPluginSDK
+@testable import TypeWhisper
+
+final class TranscriptionNormalizationServiceTests: XCTestCase {
+    @MainActor
+    func testDefaultOnNormalizesBeforePostProcessing() async throws {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeText(
+            "I have two questions",
+            language: "en",
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result, "I have 2 questions")
+    }
+
+    @MainActor
+    func testGlobalOffSkipsNormalization() async throws {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(false, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeText(
+            "I have two questions",
+            language: "en",
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result, "I have two questions")
+    }
+
+    @MainActor
+    func testWorkflowOverrideOffWinsOverGlobalOn() async throws {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(true, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeText(
+            "I have two questions",
+            language: "en",
+            normalizeNumbers: false,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result, "I have two questions")
+    }
+}


### PR DESCRIPTION
## Issue context

Issue #645 reports that Qwen3 ASR transcribes spoken numbers as words, forcing users to run a second Gemma/LLM post-processing step just to convert values like `twenty three` into `23`. That adds latency to a common dictation path.

This PR implements the fix as a generic post-ASR text normalization layer instead of a Qwen-only custom prompt field, so dictation, file/API transcription, live sessions, and workflows can share the same behavior.

Closes #645

## Changes

- Adds `NumberWordNormalizer` and `TranscriptionNormalizationService` for English and German cardinal number normalization.
- Enables number normalization by default through `transcriptionNumberNormalizationEnabled`.
- Adds a global Recording > Output Formatting toggle.
- Adds workflow-level `Number formatting` overrides: Use Global Default, On, Off.
- Applies normalization centrally in `ModelManagerService` and idempotently in dictation post-processing.
- Adds API support for `normalize_numbers` and `x-normalize-numbers`.
- Adds unit and pipeline coverage for EN/DE parsing, global defaults, workflow override behavior, and API option plumbing.

## Test plan

- [x] `git diff --cached --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/NumberWordNormalizerTests -only-testing:TypeWhisperTests/TranscriptionNormalizationServiceTests -only-testing:TypeWhisperTests/SpeechPunctuationServiceTests/testPipelineNormalizesNumbersBeforeLaterPostProcessing -only-testing:TypeWhisperTests/SpeechPunctuationServiceTests/testPipelineNumberNormalizationOverrideOffWinsOverGlobalOn -only-testing:TypeWhisperTests/AppFormatterServiceTests/testRegisterDefaultUserDefaultsIncludesAppFormattingFlag CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- [x] Manual dev-app smoke: German spoken number phrases produced expected digit output, including `zwei`, `dreiundzwanzig`, `ein hundert`, and `null komma sieben`.
- [ ] Full suite command for CI/local verification: `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Note: the full suite was not completed locally because focused `/v1/transcribe` API tests in `APIRouterAndHandlersTests` hung in the local app-hosted test process. A pre-existing API test showed the same hang, so this PR keeps the API coverage changes in place and leaves full-suite validation to CI or a clean test host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Number normalization: converts spoken numbers to digits in English and German transcriptions.
  * Global toggle in Output Formatting to enable/disable number normalization.
  * Per-workflow and per-request controls to override number normalization behavior.
  * API accepts request-level number-normalization option.

* **Tests**
  * Added unit and integration tests covering normalization logic, pipeline ordering, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->