### PR TITLE
Add multilingual number word normalization

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -23,6 +23,13 @@
 		24FFE19AC026C48AE32BCD7F /* PunctuationRulesLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C55 /* PunctuationRulesLoaderTests.swift */; };
 		24FFE19AC026C48AE32BCD80 /* PunctuationStrategyResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */; };
 		71F1DCAA4C8685360B145C0B /* NumberWordNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5E4923A4F803921C03DEDE /* NumberWordNormalizer.swift */; };
+		9A645F000000000000000001 /* EnglishNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000101 /* EnglishNumberWordParser.swift */; };
+		9A645F000000000000000002 /* GermanNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000102 /* GermanNumberWordParser.swift */; };
+		9A645F000000000000000003 /* FrenchNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000103 /* FrenchNumberWordParser.swift */; };
+		9A645F000000000000000004 /* SpanishNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000104 /* SpanishNumberWordParser.swift */; };
+		9A645F000000000000000005 /* HanNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000105 /* HanNumberWordParser.swift */; };
+		9A645F000000000000000006 /* ChineseNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000106 /* ChineseNumberWordParser.swift */; };
+		9A645F000000000000000007 /* JapaneseNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000107 /* JapaneseNumberWordParser.swift */; };
 		B346BF6B189F3E7C6CBA1410 /* TranscriptionNormalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */; };
 		540AE1FA22F41A63C78B89EC /* NumberWordNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */; };
 		E8FB3269B522A8923134AD9A /* TranscriptionNormalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */; };
@@ -777,6 +784,13 @@
 		BB00000000000000000235 /* AppFormatterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFormatterService.swift; sourceTree = "<group>"; };
 		BB00000000000000000236 /* SpeechPunctuationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechPunctuationService.swift; sourceTree = "<group>"; };
 		8C5E4923A4F803921C03DEDE /* NumberWordNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberWordNormalizer.swift; sourceTree = "<group>"; };
+		9A645F000000000000000101 /* EnglishNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnglishNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000102 /* GermanNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GermanNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000103 /* FrenchNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrenchNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000104 /* SpanishNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanishNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000105 /* HanNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HanNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000106 /* ChineseNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChineseNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000107 /* JapaneseNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JapaneseNumberWordParser.swift; sourceTree = "<group>"; };
 		206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionNormalizationService.swift; sourceTree = "<group>"; };
 		D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBuffer.swift; sourceTree = "<group>"; };
 		BB00000000000000000238 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
@@ -1427,6 +1441,7 @@
 				BB00000000000000000235 /* AppFormatterService.swift */,
 				BB00000000000000000236 /* SpeechPunctuationService.swift */,
 				8C5E4923A4F803921C03DEDE /* NumberWordNormalizer.swift */,
+				9A645F000000000000000201 /* NumberNormalization */,
 				206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */,
 				BB00000000000000000333 /* DictationPunctuationProfileStore.swift */,
 				BB00000000000000000334 /* PunctuationRulesLoader.swift */,
@@ -1442,6 +1457,20 @@
 				D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		9A645F000000000000000201 /* NumberNormalization */ = {
+			isa = PBXGroup;
+			children = (
+				9A645F000000000000000106 /* ChineseNumberWordParser.swift */,
+				9A645F000000000000000101 /* EnglishNumberWordParser.swift */,
+				9A645F000000000000000103 /* FrenchNumberWordParser.swift */,
+				9A645F000000000000000102 /* GermanNumberWordParser.swift */,
+				9A645F000000000000000105 /* HanNumberWordParser.swift */,
+				9A645F000000000000000107 /* JapaneseNumberWordParser.swift */,
+				9A645F000000000000000104 /* SpanishNumberWordParser.swift */,
+			);
+			path = NumberNormalization;
 			sourceTree = "<group>";
 		};
 		CC00000000000000000007 /* ViewModels */ = {
@@ -3792,6 +3821,13 @@
 				AA00000000000000000247 /* AppFormatterService.swift in Sources */,
 				AA00000000000000000248 /* SpeechPunctuationService.swift in Sources */,
 				71F1DCAA4C8685360B145C0B /* NumberWordNormalizer.swift in Sources */,
+				9A645F000000000000000001 /* EnglishNumberWordParser.swift in Sources */,
+				9A645F000000000000000002 /* GermanNumberWordParser.swift in Sources */,
+				9A645F000000000000000003 /* FrenchNumberWordParser.swift in Sources */,
+				9A645F000000000000000004 /* SpanishNumberWordParser.swift in Sources */,
+				9A645F000000000000000005 /* HanNumberWordParser.swift in Sources */,
+				9A645F000000000000000006 /* ChineseNumberWordParser.swift in Sources */,
+				9A645F000000000000000007 /* JapaneseNumberWordParser.swift in Sources */,
 				B346BF6B189F3E7C6CBA1410 /* TranscriptionNormalizationService.swift in Sources */,
 				AA00000000000000000333 /* DictationPunctuationProfileStore.swift in Sources */,
 				AA00000000000000000334 /* PunctuationRulesLoader.swift in Sources */,

--- a/TypeWhisper/Models/DictationRuntimeContext.swift
+++ b/TypeWhisper/Models/DictationRuntimeContext.swift
@@ -4,5 +4,20 @@ struct DictationRuntimeContext {
     let engineId: String?
     let modelId: String?
     let configuredLanguage: String?
+    let configuredLanguageCandidates: [String]
     let detectedLanguage: String?
+
+    init(
+        engineId: String?,
+        modelId: String?,
+        configuredLanguage: String?,
+        configuredLanguageCandidates: [String] = [],
+        detectedLanguage: String?
+    ) {
+        self.engineId = engineId
+        self.modelId = modelId
+        self.configuredLanguage = configuredLanguage
+        self.configuredLanguageCandidates = configuredLanguageCandidates
+        self.detectedLanguage = detectedLanguage
+    }
 }

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -374,6 +374,7 @@ final class ModelManagerService: ObservableObject {
         _ handle: LiveTranscriptionSessionHandle,
         bufferedDuration: Double,
         language: String? = nil,
+        languageCandidates: [String] = [],
         task: TranscriptionTask = .transcribe,
         normalizeNumbers: Bool? = nil
     ) async throws -> TranscriptionResult {
@@ -387,6 +388,7 @@ final class ModelManagerService: ObservableObject {
             text: result.text,
             detectedLanguage: result.detectedLanguage,
             configuredLanguage: language,
+            configuredLanguageCandidates: languageCandidates,
             duration: bufferedDuration,
             processingTime: processingTime,
             engineUsed: handle.providerId,
@@ -451,6 +453,10 @@ final class ModelManagerService: ObservableObject {
         let startTime = CFAbsoluteTimeGetCurrent()
         let audio = await Self.makeAudioData(from: audioSamples)
         let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
+        let normalizationLanguageCandidates = normalizationLanguageCandidates(
+            for: languageSelection,
+            plugin: plugin
+        )
 
         let result = try await transcribeWithResolvedLanguageSelection(
             plugin: plugin,
@@ -468,6 +474,7 @@ final class ModelManagerService: ObservableObject {
             text: result.text,
             detectedLanguage: result.detectedLanguage,
             configuredLanguage: runtimeSelection.requestedLanguage,
+            configuredLanguageCandidates: normalizationLanguageCandidates,
             duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
@@ -535,6 +542,10 @@ final class ModelManagerService: ObservableObject {
         let startTime = CFAbsoluteTimeGetCurrent()
         let audio = await Self.makeAudioData(from: audioSamples)
         let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
+        let normalizationLanguageCandidates = normalizationLanguageCandidates(
+            for: languageSelection,
+            plugin: plugin
+        )
 
         let result = try await transcribeWithResolvedLanguageSelection(
             plugin: plugin,
@@ -553,6 +564,7 @@ final class ModelManagerService: ObservableObject {
             text: result.text,
             detectedLanguage: result.detectedLanguage,
             configuredLanguage: runtimeSelection.requestedLanguage,
+            configuredLanguageCandidates: normalizationLanguageCandidates,
             duration: audio.duration,
             processingTime: processingTime,
             engineUsed: providerId,
@@ -633,6 +645,15 @@ final class ModelManagerService: ObservableObject {
         case .inheritGlobal, .auto:
             return PluginLanguageSelection()
         }
+    }
+
+    private func normalizationLanguageCandidates(
+        for languageSelection: LanguageSelection,
+        plugin: TranscriptionEnginePlugin
+    ) -> [String] {
+        languageSelection
+            .normalizedForSupportedLanguages(plugin.supportedLanguages)
+            .selectedCodes
     }
 
     private func transcribeWithResolvedLanguageSelection(

--- a/TypeWhisper/Services/NumberNormalization/ChineseNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/ChineseNumberWordParser.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ChineseNumberWordParser {
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        HanNumberWordParser.parse(words)
+    }
+}

--- a/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+enum EnglishNumberWordParser {
+    private static let unitValues: [String: Int] = [
+        "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4,
+        "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
+    ]
+
+    private static let teenValues: [String: Int] = [
+        "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
+        "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+    ]
+
+    private static let tensValues: [String: Int] = [
+        "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+        "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
+    ]
+
+    private static let scaleValues: [String: Int] = [
+        "thousand": 1_000,
+        "million": 1_000_000,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if ["minus", "negative"].contains(normalizedWords[index]) {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "point" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ".\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
+        guard var group = parseGroup(words, startingAt: startIndex) else { return nil }
+        var total = 0
+        var current = group.value
+        var index = group.nextIndex
+        var consumedScale = false
+
+        while index < words.count {
+            guard let scale = scaleValues[words[index]] else { break }
+            total += current * scale
+            current = 0
+            consumedScale = true
+            index += 1
+
+            if index < words.count, words[index] == "and" {
+                index += 1
+            }
+
+            if let nextGroup = parseGroup(words, startingAt: index) {
+                group = nextGroup
+                current = group.value
+                index = group.nextIndex
+            }
+        }
+
+        let value = consumedScale ? total + current : current
+        return (value, index)
+    }
+
+    private static func parseGroup(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var index = startIndex
+        var value = 0
+        var consumed = false
+
+        if let base = smallNumberValue(words[index]),
+           index + 1 < words.count,
+           words[index + 1] == "hundred" {
+            value = base * 100
+            index += 2
+            consumed = true
+
+            if index < words.count, words[index] == "and" {
+                index += 1
+            }
+        }
+
+        if index < words.count, let tens = tensValues[words[index]] {
+            value += tens
+            index += 1
+            consumed = true
+
+            if index < words.count, let unit = unitValues[words[index]], unit > 0 {
+                value += unit
+                index += 1
+            }
+        } else if index < words.count, let small = smallNumberValue(words[index]) {
+            value += small
+            index += 1
+            consumed = true
+        }
+
+        return consumed ? (value, index) : nil
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = unitValues[words[index]], digit >= 0, digit <= 9 {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func smallNumberValue(_ word: String) -> Int? {
+        unitValues[word] ?? teenValues[word]
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US"))
+            .lowercased()
+    }
+}

--- a/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+enum FrenchNumberWordParser {
+    private static let unitValues: [String: Int] = [
+        "zero": 0, "un": 1, "une": 1, "deux": 2, "trois": 3, "quatre": 4,
+        "cinq": 5, "six": 6, "sept": 7, "huit": 8, "neuf": 9,
+    ]
+
+    private static let teenValues: [String: Int] = [
+        "dix": 10, "onze": 11, "douze": 12, "treize": 13, "quatorze": 14,
+        "quinze": 15, "seize": 16,
+    ]
+
+    private static let tensValues: [String: Int] = [
+        "vingt": 20, "trente": 30, "quarante": 40,
+        "cinquante": 50, "soixante": 60,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if normalizedWords[index] == "moins" {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        guard let integer = parseInteger(normalizedWords, startingAt: index, allowLeadingArticleOne: isNegative) else {
+            return nil
+        }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "virgule" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ",\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowLeadingArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var total = 0
+        var current = 0
+        var index = startIndex
+        var consumed = false
+        var lastWasPlainSmallNumber = false
+
+        while index < words.count {
+            let word = words[index]
+
+            if ["million", "millions"].contains(word) {
+                total += max(current, 1) * 1_000_000
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if word == "mille" {
+                total += max(current, 1) * 1_000
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if ["cent", "cents"].contains(word) {
+                current = max(current, 1) * 100
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            let allowArticleOne = allowsArticleOne(
+                at: index,
+                in: words,
+                startIndex: startIndex,
+                allowLeadingArticleOne: allowLeadingArticleOne,
+                current: current,
+                total: total
+            )
+            guard let segment = parseUnderHundred(words, startingAt: index, allowArticleOne: allowArticleOne) else {
+                break
+            }
+
+            if lastWasPlainSmallNumber, segment.value < 10 {
+                break
+            }
+
+            current += segment.value
+            index = segment.nextIndex
+            consumed = true
+            lastWasPlainSmallNumber = segment.value < 10 && !allowArticleOne
+        }
+
+        guard consumed else { return nil }
+        return (total + current, index)
+    }
+
+    private static func parseUnderHundred(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+
+        let word = words[startIndex]
+        if word == "quatre",
+           startIndex + 1 < words.count,
+           ["vingt", "vingts"].contains(words[startIndex + 1]) {
+            return appendFrenchRemainder(base: 80, words: words, startingAt: startIndex + 2)
+        }
+
+        if word == "dix",
+           startIndex + 1 < words.count,
+           let unit = unitValue(words[startIndex + 1], allowArticleOne: true),
+           unit >= 7 {
+            return (10 + unit, startIndex + 2)
+        }
+
+        if let ten = tensValues[word] {
+            return appendFrenchRemainder(base: ten, words: words, startingAt: startIndex + 1)
+        }
+
+        if let teen = teenValues[word] {
+            return (teen, startIndex + 1)
+        }
+
+        if let unit = unitValue(word, allowArticleOne: allowArticleOne) {
+            return (unit, startIndex + 1)
+        }
+
+        return nil
+    }
+
+    private static func appendFrenchRemainder(
+        base: Int,
+        words: [String],
+        startingAt startIndex: Int
+    ) -> (value: Int, nextIndex: Int) {
+        var index = startIndex
+
+        if index < words.count, words[index] == "et" {
+            let afterEt = index + 1
+            if afterEt < words.count {
+                if let unit = unitValue(words[afterEt], allowArticleOne: true), unit == 1 {
+                    return (base + unit, afterEt + 1)
+                }
+                if base == 60, let teen = teenValues[words[afterEt]], teen == 11 {
+                    return (base + teen, afterEt + 1)
+                }
+            }
+            return (base, startIndex)
+        }
+
+        if base == 60, index < words.count, let teen = teenValues[words[index]] {
+            return (base + teen, index + 1)
+        }
+
+        if base == 80, index < words.count {
+            if words[index] == "dix",
+               index + 1 < words.count,
+               let unit = unitValue(words[index + 1], allowArticleOne: true),
+               unit >= 7 {
+                return (90 + unit, index + 2)
+            }
+
+            if let teen = teenValues[words[index]] {
+                return (base + teen, index + 1)
+            }
+        }
+
+        if index < words.count,
+           let unit = unitValue(words[index], allowArticleOne: true),
+           unit > 0 {
+            return (base + unit, index + 1)
+        }
+
+        return (base, startIndex)
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = unitValue(words[index], allowArticleOne: true) {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func unitValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        guard let value = unitValues[word] else { return nil }
+        if value == 1, !allowArticleOne {
+            return nil
+        }
+        return value
+    }
+
+    private static func allowsArticleOne(
+        at index: Int,
+        in words: [String],
+        startIndex: Int,
+        allowLeadingArticleOne: Bool,
+        current: Int,
+        total: Int
+    ) -> Bool {
+        if index == startIndex, allowLeadingArticleOne {
+            return true
+        }
+
+        if current >= 100 || total > 0 {
+            return true
+        }
+
+        guard index + 1 < words.count else { return false }
+        return ["cent", "cents", "mille", "million", "millions"].contains(words[index + 1])
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "fr_FR"))
+            .lowercased()
+    }
+}

--- a/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
@@ -157,7 +157,7 @@ enum FrenchNumberWordParser {
         words: [String],
         startingAt startIndex: Int
     ) -> (value: Int, nextIndex: Int) {
-        var index = startIndex
+        let index = startIndex
 
         if index < words.count, words[index] == "et" {
             let afterEt = index + 1

--- a/TypeWhisper/Services/NumberNormalization/GermanNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/GermanNumberWordParser.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+enum GermanNumberWordParser {
+    private static let units: [String: Int] = [
+        "null": 0, "eins": 1, "ein": 1, "eine": 1, "einen": 1, "einem": 1, "einer": 1,
+        "zwei": 2, "drei": 3, "vier": 4, "funf": 5, "fuenf": 5,
+        "sechs": 6, "sieben": 7, "acht": 8, "neun": 9,
+    ]
+
+    private static let teens: [String: Int] = [
+        "zehn": 10, "elf": 11, "zwolf": 12, "zwoelf": 12, "dreizehn": 13, "vierzehn": 14,
+        "funfzehn": 15, "fuenfzehn": 15, "sechzehn": 16, "siebzehn": 17,
+        "achtzehn": 18, "neunzehn": 19,
+    ]
+
+    private static let tens: [String: Int] = [
+        "zwanzig": 20, "dreissig": 30, "dreizig": 30, "vierzig": 40,
+        "funfzig": 50, "fuenfzig": 50, "sechzig": 60, "siebzig": 70,
+        "achtzig": 80, "neunzig": 90,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if normalizedWords[index] == "minus" {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "komma" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ",\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var total = 0
+        var current = 0
+        var index = startIndex
+        var consumed = false
+        var lastWasPlainSmallNumber = false
+
+        while index < words.count {
+            let word = words[index]
+
+            if word == "und",
+               current > 0,
+               current < 10,
+               index + 1 < words.count,
+               let tenValue = tens[words[index + 1]] {
+                current += tenValue
+                index += 2
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if word == "hundert" {
+                current = max(current, 1) * 100
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if ["tausend", "million", "millionen"].contains(word) {
+                let scale = word == "tausend" ? 1_000 : 1_000_000
+                total += max(current, 1) * scale
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            let allowsArticleOne = allowsArticleOne(at: index, in: words)
+            guard let value = parseCompound(word, allowArticleOne: allowsArticleOne) else { break }
+
+            if lastWasPlainSmallNumber, value < 10 {
+                break
+            }
+
+            current += value
+            index += 1
+            consumed = true
+            lastWasPlainSmallNumber = value < 10 && !allowsArticleOne
+        }
+
+        guard consumed else { return nil }
+        return (total + current, index)
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = digitValue(words[index]) {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func parseCompound(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return direct
+        }
+
+        if let range = word.range(of: "tausend") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            let prefixValue = prefix.isEmpty ? 1 : parseCompound(prefix, allowArticleOne: true)
+            guard let prefixValue else { return nil }
+            let suffixValue = suffix.isEmpty ? 0 : parseCompound(suffix, allowArticleOne: true)
+            guard let suffixValue else { return nil }
+            return prefixValue * 1_000 + suffixValue
+        }
+
+        if let range = word.range(of: "hundert") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            let prefixValue = prefix.isEmpty ? 1 : parseUnderHundred(prefix, allowArticleOne: true)
+            guard let prefixValue else { return nil }
+            let suffixValue = suffix.isEmpty ? 0 : parseUnderHundred(suffix, allowArticleOne: true)
+            guard let suffixValue else { return nil }
+            return prefixValue * 100 + suffixValue
+        }
+
+        return parseUnderHundred(word, allowArticleOne: allowArticleOne)
+    }
+
+    private static func parseUnderHundred(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return direct
+        }
+
+        if let range = word.range(of: "und") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            guard let unit = directUnitValue(prefix, allowArticleOne: true),
+                  unit > 0,
+                  unit < 10,
+                  let tenValue = tens[suffix] else {
+                return nil
+            }
+            return unit + tenValue
+        }
+
+        return nil
+    }
+
+    private static func directValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let unit = directUnitValue(word, allowArticleOne: allowArticleOne) {
+            return unit
+        }
+        return teens[word] ?? tens[word]
+    }
+
+    private static func directUnitValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        guard let value = units[word] else { return nil }
+        if value == 1, word != "eins", !allowArticleOne {
+            return nil
+        }
+        return value
+    }
+
+    private static func digitValue(_ word: String) -> Int? {
+        directUnitValue(word, allowArticleOne: false)
+    }
+
+    private static func allowsArticleOne(at index: Int, in words: [String]) -> Bool {
+        guard index + 1 < words.count else { return false }
+        return ["hundert", "tausend", "million", "millionen"].contains(words[index + 1])
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "de_DE"))
+            .lowercased()
+            .replacingOccurrences(of: "ß", with: "ss")
+    }
+}

--- a/TypeWhisper/Services/NumberNormalization/GermanNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/GermanNumberWordParser.swift
@@ -13,6 +13,7 @@ enum GermanNumberWordParser {
         "achtzehn": 18, "neunzehn": 19,
     ]
 
+    // Include common ASR spelling variants for spoken-number cleanup.
     private static let tens: [String: Int] = [
         "zwanzig": 20, "dreissig": 30, "dreizig": 30, "vierzig": 40,
         "funfzig": 50, "fuenfzig": 50, "sechzig": 60, "siebzig": 70,

--- a/TypeWhisper/Services/NumberNormalization/HanNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/HanNumberWordParser.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+enum HanNumberWordParser {
+    private static let digitValues: [Character: Int] = [
+        "零": 0, "〇": 0, "一": 1, "二": 2, "两": 2, "兩": 2, "三": 3,
+        "四": 4, "五": 5, "六": 6, "七": 7, "八": 8, "九": 9,
+    ]
+
+    private static let unitValues: [Character: Int] = [
+        "十": 10, "百": 100, "千": 1_000,
+    ]
+
+    private static let largeUnitValues: [Character: Int] = [
+        "万": 10_000, "萬": 10_000, "亿": 100_000_000, "億": 100_000_000,
+    ]
+
+    private static let decimalMarkers: Set<Character> = ["点", "點"]
+    private static let negativeMarkers: Set<Character> = ["负", "負"]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+
+        var consumedWords = 0
+        var pieces: [String] = []
+
+        if words[0] == "マイナス" {
+            pieces.append("負")
+            consumedWords = 1
+        }
+
+        while consumedWords < words.count, isHanNumberWord(words[consumedWords]) {
+            pieces.append(words[consumedWords])
+            consumedWords += 1
+        }
+
+        guard !pieces.isEmpty else { return nil }
+
+        let numberText = pieces.joined()
+        guard containsNumberMarker(numberText) else { return nil }
+        guard let parsed = parseNumberText(numberText) else { return nil }
+        return NumberWordNormalizer.ParsedWords(value: parsed, consumedWords: consumedWords)
+    }
+
+    private static func parseNumberText(_ text: String) -> String? {
+        var characters = Array(text)
+        var isNegative = false
+
+        if let first = characters.first, negativeMarkers.contains(first) {
+            isNegative = true
+            characters.removeFirst()
+            guard !characters.isEmpty else { return nil }
+        }
+
+        let parts = splitDecimal(characters)
+        guard let integer = parseInteger(parts.integer), parts.integerHadNumber else { return nil }
+
+        var replacement = "\(integer)"
+        if let decimal = parts.decimal {
+            let decimalDigits = decimal.compactMap { digitValues[$0] }
+            guard decimalDigits.count == decimal.count, !decimalDigits.isEmpty else { return nil }
+            replacement += "." + decimalDigits.map { String($0) }.joined()
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+        return replacement
+    }
+
+    private static func splitDecimal(_ characters: [Character]) -> (integer: [Character], integerHadNumber: Bool, decimal: [Character]?) {
+        guard let decimalIndex = characters.firstIndex(where: { decimalMarkers.contains($0) }) else {
+            return (characters, characters.contains(where: isNumericCharacter), nil)
+        }
+
+        let integer = Array(characters[..<decimalIndex])
+        let decimal = Array(characters[characters.index(after: decimalIndex)...])
+        return (integer, integer.contains(where: isNumericCharacter), decimal)
+    }
+
+    private static func parseInteger(_ characters: [Character]) -> Int? {
+        guard !characters.isEmpty else { return nil }
+
+        var total = 0
+        var section = 0
+        var number = 0
+
+        for character in characters {
+            if let digit = digitValues[character] {
+                number = digit
+                continue
+            }
+
+            if let unit = unitValues[character] {
+                section += (number == 0 ? 1 : number) * unit
+                number = 0
+                continue
+            }
+
+            if let largeUnit = largeUnitValues[character] {
+                section += number
+                total += max(section, 1) * largeUnit
+                section = 0
+                number = 0
+                continue
+            }
+
+            return nil
+        }
+
+        return total + section + number
+    }
+
+    private static func isHanNumberWord(_ word: String) -> Bool {
+        !word.isEmpty && word.allSatisfy { isNumericCharacter($0) || negativeMarkers.contains($0) }
+    }
+
+    private static func isNumericCharacter(_ character: Character) -> Bool {
+        digitValues[character] != nil ||
+            unitValues[character] != nil ||
+            largeUnitValues[character] != nil ||
+            decimalMarkers.contains(character)
+    }
+
+    private static func containsNumberMarker(_ text: String) -> Bool {
+        text.contains { character in
+            negativeMarkers.contains(character) ||
+                decimalMarkers.contains(character) ||
+                unitValues[character] != nil ||
+                largeUnitValues[character] != nil
+        }
+    }
+}

--- a/TypeWhisper/Services/NumberNormalization/JapaneseNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/JapaneseNumberWordParser.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum JapaneseNumberWordParser {
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        HanNumberWordParser.parse(words)
+    }
+}

--- a/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
@@ -167,7 +167,7 @@ enum SpanishNumberWordParser {
         startingAt startIndex: Int,
         allowWithoutY: Bool
     ) -> (value: Int, nextIndex: Int) {
-        var index = startIndex
+        let index = startIndex
 
         if index < words.count, words[index] == "y" {
             let afterY = index + 1

--- a/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
@@ -139,6 +139,7 @@ enum SpanishNumberWordParser {
         let word = words[startIndex]
 
         if word == "veinte" {
+            // Keep ASR tolerance for split "veintiuno" forms like "veinte uno".
             return appendSpanishUnit(base: 20, words: words, startingAt: startIndex + 1, allowWithoutY: true)
         }
 

--- a/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+enum SpanishNumberWordParser {
+    private static let unitValues: [String: Int] = [
+        "cero": 0, "uno": 1, "un": 1, "una": 1, "dos": 2, "tres": 3,
+        "cuatro": 4, "cinco": 5, "seis": 6, "siete": 7, "ocho": 8, "nueve": 9,
+    ]
+
+    private static let teenValues: [String: Int] = [
+        "diez": 10, "once": 11, "doce": 12, "trece": 13, "catorce": 14,
+        "quince": 15, "dieciseis": 16, "diecisiete": 17, "dieciocho": 18, "diecinueve": 19,
+    ]
+
+    private static let twentyValues: [String: Int] = [
+        "veinte": 20, "veintiuno": 21, "veintiun": 21, "veintiuna": 21,
+        "veintidos": 22, "veintitres": 23, "veinticuatro": 24, "veinticinco": 25,
+        "veintiseis": 26, "veintisiete": 27, "veintiocho": 28, "veintinueve": 29,
+    ]
+
+    private static let tensValues: [String: Int] = [
+        "treinta": 30, "cuarenta": 40, "cincuenta": 50,
+        "sesenta": 60, "setenta": 70, "ochenta": 80, "noventa": 90,
+    ]
+
+    private static let hundredValues: [String: Int] = [
+        "cien": 100, "ciento": 100, "doscientos": 200, "doscientas": 200,
+        "trescientos": 300, "trescientas": 300, "cuatrocientos": 400, "cuatrocientas": 400,
+        "quinientos": 500, "quinientas": 500, "seiscientos": 600, "seiscientas": 600,
+        "setecientos": 700, "setecientas": 700, "ochocientos": 800, "ochocientas": 800,
+        "novecientos": 900, "novecientas": 900,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if normalizedWords[index] == "menos" {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        guard let integer = parseInteger(normalizedWords, startingAt: index, allowLeadingArticleOne: isNegative) else {
+            return nil
+        }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "coma" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ",\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowLeadingArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var total = 0
+        var current = 0
+        var index = startIndex
+        var consumed = false
+        var lastWasPlainSmallNumber = false
+
+        while index < words.count {
+            let word = words[index]
+
+            if ["millon", "millones"].contains(word) {
+                total += max(current, 1) * 1_000_000
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if word == "mil" {
+                total += max(current, 1) * 1_000
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if let hundred = hundredValues[word] {
+                current += hundred
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            let allowArticleOne = allowsArticleOne(
+                at: index,
+                in: words,
+                startIndex: startIndex,
+                allowLeadingArticleOne: allowLeadingArticleOne,
+                current: current,
+                total: total
+            )
+            guard let segment = parseUnderHundred(words, startingAt: index, allowArticleOne: allowArticleOne) else {
+                break
+            }
+
+            if lastWasPlainSmallNumber, segment.value < 10 {
+                break
+            }
+
+            current += segment.value
+            index = segment.nextIndex
+            consumed = true
+            lastWasPlainSmallNumber = segment.value < 10 && !allowArticleOne
+        }
+
+        guard consumed else { return nil }
+        return (total + current, index)
+    }
+
+    private static func parseUnderHundred(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        let word = words[startIndex]
+
+        if word == "veinte" {
+            return appendSpanishUnit(base: 20, words: words, startingAt: startIndex + 1, allowWithoutY: true)
+        }
+
+        if let twenty = twentyValues[word] {
+            return (twenty, startIndex + 1)
+        }
+
+        if let ten = tensValues[word] {
+            return appendSpanishUnit(base: ten, words: words, startingAt: startIndex + 1, allowWithoutY: false)
+        }
+
+        if let teen = teenValues[word] {
+            return (teen, startIndex + 1)
+        }
+
+        if let unit = unitValue(word, allowArticleOne: allowArticleOne) {
+            return (unit, startIndex + 1)
+        }
+
+        return nil
+    }
+
+    private static func appendSpanishUnit(
+        base: Int,
+        words: [String],
+        startingAt startIndex: Int,
+        allowWithoutY: Bool
+    ) -> (value: Int, nextIndex: Int) {
+        var index = startIndex
+
+        if index < words.count, words[index] == "y" {
+            let afterY = index + 1
+            if afterY < words.count,
+               let unit = unitValue(words[afterY], allowArticleOne: true),
+               unit > 0 {
+                return (base + unit, afterY + 1)
+            }
+            return (base, startIndex)
+        }
+
+        if allowWithoutY,
+           index < words.count,
+           let unit = unitValue(words[index], allowArticleOne: true),
+           unit > 0 {
+            return (base + unit, index + 1)
+        }
+
+        return (base, startIndex)
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = unitValue(words[index], allowArticleOne: true) {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func unitValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        guard let value = unitValues[word] else { return nil }
+        if value == 1, !allowArticleOne {
+            return nil
+        }
+        return value
+    }
+
+    private static func allowsArticleOne(
+        at index: Int,
+        in words: [String],
+        startIndex: Int,
+        allowLeadingArticleOne: Bool,
+        current: Int,
+        total: Int
+    ) -> Bool {
+        if index == startIndex, allowLeadingArticleOne {
+            return true
+        }
+
+        if current >= 100 || total > 0 {
+            return true
+        }
+
+        guard index + 1 < words.count else { return false }
+        return ["mil", "millon", "millones"].contains(words[index + 1])
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "es_ES"))
+            .lowercased()
+    }
+}

--- a/TypeWhisper/Services/NumberWordNormalizer.swift
+++ b/TypeWhisper/Services/NumberWordNormalizer.swift
@@ -1,9 +1,12 @@
 import Foundation
 
 enum NumberWordNormalizer {
+    private static let supportedLanguageCodes: Set<String> = ["en", "de", "fr", "es", "zh", "ja"]
+    private static let cjkNumberCharacters = Set("零〇一二两兩三四五六七八九十百千万萬亿億点點負负".map { $0 })
+
     static func normalize(text: String, language: String?) -> String {
         guard let languageCode = PunctuationLanguageNormalizer.normalize(language),
-              ["en", "de"].contains(languageCode),
+              supportedLanguageCodes.contains(languageCode),
               !text.isEmpty else {
             return text
         }
@@ -27,9 +30,31 @@ enum NumberWordNormalizer {
         return result
     }
 
+    struct ParsedWords {
+        let value: String
+        let consumedWords: Int
+    }
+
+    private enum TokenKind {
+        case word
+        case cjkNumber
+        case other
+
+        var isWord: Bool {
+            switch self {
+            case .word, .cjkNumber:
+                return true
+            case .other:
+                return false
+            }
+        }
+    }
+
     private struct Token {
         let text: String
-        let isWord: Bool
+        let kind: TokenKind
+
+        var isWord: Bool { kind.isWord }
     }
 
     private struct ParsedNumber {
@@ -42,21 +67,25 @@ enum NumberWordNormalizer {
         let text: String
     }
 
-    fileprivate struct ParsedWords {
-        let value: String
-        let consumedWords: Int
-    }
-
     private static func parseNumber(startingAt index: Int, in tokens: [Token], languageCode: String) -> ParsedNumber? {
         let words = wordCandidates(startingAt: index, in: tokens)
         guard !words.isEmpty else { return nil }
 
+        let wordTexts = words.map(\.text)
         let parsed: ParsedWords?
         switch languageCode {
         case "en":
-            parsed = EnglishNumberParser.parse(words.map(\.text))
+            parsed = EnglishNumberWordParser.parse(wordTexts)
         case "de":
-            parsed = GermanNumberParser.parse(words.map(\.text))
+            parsed = GermanNumberWordParser.parse(wordTexts)
+        case "fr":
+            parsed = FrenchNumberWordParser.parse(wordTexts)
+        case "es":
+            parsed = SpanishNumberWordParser.parse(wordTexts)
+        case "zh":
+            parsed = ChineseNumberWordParser.parse(wordTexts)
+        case "ja":
+            parsed = JapaneseNumberWordParser.parse(wordTexts)
         default:
             parsed = nil
         }
@@ -94,26 +123,38 @@ enum NumberWordNormalizer {
     private static func tokenize(_ text: String) -> [Token] {
         var tokens: [Token] = []
         var current = ""
-        var currentIsWord: Bool?
+        var currentKind: TokenKind?
 
         for character in text {
-            let isWord = isWordCharacter(character)
-            if currentIsWord == isWord {
+            let kind = tokenKind(for: character)
+            if currentKind == kind {
                 current.append(character)
             } else {
-                if !current.isEmpty, let currentIsWord {
-                    tokens.append(Token(text: current, isWord: currentIsWord))
+                if !current.isEmpty, let currentKind {
+                    tokens.append(Token(text: current, kind: currentKind))
                 }
                 current = String(character)
-                currentIsWord = isWord
+                currentKind = kind
             }
         }
 
-        if !current.isEmpty, let currentIsWord {
-            tokens.append(Token(text: current, isWord: currentIsWord))
+        if !current.isEmpty, let currentKind {
+            tokens.append(Token(text: current, kind: currentKind))
         }
 
         return tokens
+    }
+
+    private static func tokenKind(for character: Character) -> TokenKind {
+        if cjkNumberCharacters.contains(character) {
+            return .cjkNumber
+        }
+
+        if isWordCharacter(character) {
+            return .word
+        }
+
+        return .other
     }
 
     private static func isWordCharacter(_ character: Character) -> Bool {
@@ -124,343 +165,5 @@ enum NumberWordNormalizer {
         !text.isEmpty && text.unicodeScalars.allSatisfy { scalar in
             CharacterSet.whitespacesAndNewlines.contains(scalar) || scalar == "-" || scalar == "\u{2011}"
         }
-    }
-}
-
-private enum EnglishNumberParser {
-    private static let unitValues: [String: Int] = [
-        "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4,
-        "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
-    ]
-
-    private static let teenValues: [String: Int] = [
-        "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
-        "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
-    ]
-
-    private static let tensValues: [String: Int] = [
-        "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
-        "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
-    ]
-
-    private static let scaleValues: [String: Int] = [
-        "thousand": 1_000,
-        "million": 1_000_000,
-    ]
-
-    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
-        guard !words.isEmpty else { return nil }
-        let normalizedWords = words.map(normalizeWord)
-        var index = 0
-        var isNegative = false
-
-        if ["minus", "negative"].contains(normalizedWords[index]) {
-            isNegative = true
-            index += 1
-            guard index < normalizedWords.count else { return nil }
-        }
-
-        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
-        index = integer.nextIndex
-        var replacement = "\(integer.value)"
-
-        if index < normalizedWords.count, normalizedWords[index] == "point" {
-            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
-            if !decimal.digits.isEmpty {
-                replacement += ".\(decimal.digits)"
-                index = decimal.nextIndex
-            }
-        }
-
-        if isNegative {
-            replacement = "-" + replacement
-        }
-
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
-    }
-
-    private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
-        guard var group = parseGroup(words, startingAt: startIndex) else { return nil }
-        var total = 0
-        var current = group.value
-        var index = group.nextIndex
-        var consumedScale = false
-
-        while index < words.count {
-            guard let scale = scaleValues[words[index]] else { break }
-            total += current * scale
-            current = 0
-            consumedScale = true
-            index += 1
-
-            if index < words.count, words[index] == "and" {
-                index += 1
-            }
-
-            if let nextGroup = parseGroup(words, startingAt: index) {
-                group = nextGroup
-                current = group.value
-                index = group.nextIndex
-            }
-        }
-
-        let value = consumedScale ? total + current : current
-        return (value, index)
-    }
-
-    private static func parseGroup(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
-        guard startIndex < words.count else { return nil }
-        var index = startIndex
-        var value = 0
-        var consumed = false
-
-        if let base = smallNumberValue(words[index]),
-           index + 1 < words.count,
-           words[index + 1] == "hundred" {
-            value = base * 100
-            index += 2
-            consumed = true
-
-            if index < words.count, words[index] == "and" {
-                index += 1
-            }
-        }
-
-        if index < words.count, let tens = tensValues[words[index]] {
-            value += tens
-            index += 1
-            consumed = true
-
-            if index < words.count, let unit = unitValues[words[index]], unit > 0 {
-                value += unit
-                index += 1
-            }
-        } else if index < words.count, let small = smallNumberValue(words[index]) {
-            value += small
-            index += 1
-            consumed = true
-        }
-
-        return consumed ? (value, index) : nil
-    }
-
-    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
-        var digits = ""
-        var index = startIndex
-
-        while index < words.count, let digit = unitValues[words[index]], digit >= 0, digit <= 9 {
-            digits += "\(digit)"
-            index += 1
-        }
-
-        return (digits, index)
-    }
-
-    private static func smallNumberValue(_ word: String) -> Int? {
-        unitValues[word] ?? teenValues[word]
-    }
-
-    private static func normalizeWord(_ word: String) -> String {
-        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US"))
-            .lowercased()
-    }
-}
-
-private enum GermanNumberParser {
-    private static let units: [String: Int] = [
-        "null": 0, "eins": 1, "ein": 1, "eine": 1, "einen": 1, "einem": 1, "einer": 1,
-        "zwei": 2, "drei": 3, "vier": 4, "funf": 5, "fuenf": 5,
-        "sechs": 6, "sieben": 7, "acht": 8, "neun": 9,
-    ]
-
-    private static let teens: [String: Int] = [
-        "zehn": 10, "elf": 11, "zwolf": 12, "zwoelf": 12, "dreizehn": 13, "vierzehn": 14,
-        "funfzehn": 15, "fuenfzehn": 15, "sechzehn": 16, "siebzehn": 17,
-        "achtzehn": 18, "neunzehn": 19,
-    ]
-
-    private static let tens: [String: Int] = [
-        "zwanzig": 20, "dreissig": 30, "dreizig": 30, "vierzig": 40,
-        "funfzig": 50, "fuenfzig": 50, "sechzig": 60, "siebzig": 70,
-        "achtzig": 80, "neunzig": 90,
-    ]
-
-    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
-        guard !words.isEmpty else { return nil }
-        let normalizedWords = words.map(normalizeWord)
-        var index = 0
-        var isNegative = false
-
-        if normalizedWords[index] == "minus" {
-            isNegative = true
-            index += 1
-            guard index < normalizedWords.count else { return nil }
-        }
-
-        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
-        index = integer.nextIndex
-        var replacement = "\(integer.value)"
-
-        if index < normalizedWords.count, normalizedWords[index] == "komma" {
-            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
-            if !decimal.digits.isEmpty {
-                replacement += ",\(decimal.digits)"
-                index = decimal.nextIndex
-            }
-        }
-
-        if isNegative {
-            replacement = "-" + replacement
-        }
-
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
-    }
-
-    private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {
-        guard startIndex < words.count else { return nil }
-        var total = 0
-        var current = 0
-        var index = startIndex
-        var consumed = false
-        var lastWasPlainSmallNumber = false
-
-        while index < words.count {
-            let word = words[index]
-
-            if word == "und",
-               current > 0,
-               current < 10,
-               index + 1 < words.count,
-               let tenValue = tens[words[index + 1]] {
-                current += tenValue
-                index += 2
-                consumed = true
-                lastWasPlainSmallNumber = false
-                continue
-            }
-
-            if word == "hundert" {
-                current = max(current, 1) * 100
-                index += 1
-                consumed = true
-                lastWasPlainSmallNumber = false
-                continue
-            }
-
-            if ["tausend", "million", "millionen"].contains(word) {
-                let scale = word == "tausend" ? 1_000 : 1_000_000
-                total += max(current, 1) * scale
-                current = 0
-                index += 1
-                consumed = true
-                lastWasPlainSmallNumber = false
-                continue
-            }
-
-            let allowsArticleOne = allowsArticleOne(at: index, in: words)
-            guard let value = parseCompound(word, allowArticleOne: allowsArticleOne) else { break }
-
-            if lastWasPlainSmallNumber, value < 10 {
-                break
-            }
-
-            current += value
-            index += 1
-            consumed = true
-            lastWasPlainSmallNumber = value < 10 && !allowsArticleOne
-        }
-
-        guard consumed else { return nil }
-        return (total + current, index)
-    }
-
-    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
-        var digits = ""
-        var index = startIndex
-
-        while index < words.count, let digit = digitValue(words[index]) {
-            digits += "\(digit)"
-            index += 1
-        }
-
-        return (digits, index)
-    }
-
-    private static func parseCompound(_ word: String, allowArticleOne: Bool) -> Int? {
-        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
-            return direct
-        }
-
-        if let range = word.range(of: "tausend") {
-            let prefix = String(word[..<range.lowerBound])
-            let suffix = String(word[range.upperBound...])
-            let prefixValue = prefix.isEmpty ? 1 : parseCompound(prefix, allowArticleOne: true)
-            guard let prefixValue else { return nil }
-            let suffixValue = suffix.isEmpty ? 0 : parseCompound(suffix, allowArticleOne: true)
-            guard let suffixValue else { return nil }
-            return prefixValue * 1_000 + suffixValue
-        }
-
-        if let range = word.range(of: "hundert") {
-            let prefix = String(word[..<range.lowerBound])
-            let suffix = String(word[range.upperBound...])
-            let prefixValue = prefix.isEmpty ? 1 : parseUnderHundred(prefix, allowArticleOne: true)
-            guard let prefixValue else { return nil }
-            let suffixValue = suffix.isEmpty ? 0 : parseUnderHundred(suffix, allowArticleOne: true)
-            guard let suffixValue else { return nil }
-            return prefixValue * 100 + suffixValue
-        }
-
-        return parseUnderHundred(word, allowArticleOne: allowArticleOne)
-    }
-
-    private static func parseUnderHundred(_ word: String, allowArticleOne: Bool) -> Int? {
-        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
-            return direct
-        }
-
-        if let range = word.range(of: "und") {
-            let prefix = String(word[..<range.lowerBound])
-            let suffix = String(word[range.upperBound...])
-            guard let unit = directUnitValue(prefix, allowArticleOne: true),
-                  unit > 0,
-                  unit < 10,
-                  let tenValue = tens[suffix] else {
-                return nil
-            }
-            return unit + tenValue
-        }
-
-        return nil
-    }
-
-    private static func directValue(_ word: String, allowArticleOne: Bool) -> Int? {
-        if let unit = directUnitValue(word, allowArticleOne: allowArticleOne) {
-            return unit
-        }
-        return teens[word] ?? tens[word]
-    }
-
-    private static func directUnitValue(_ word: String, allowArticleOne: Bool) -> Int? {
-        guard let value = units[word] else { return nil }
-        if value == 1, word != "eins", !allowArticleOne {
-            return nil
-        }
-        return value
-    }
-
-    private static func digitValue(_ word: String) -> Int? {
-        directUnitValue(word, allowArticleOne: false)
-    }
-
-    private static func allowsArticleOne(at index: Int, in words: [String]) -> Bool {
-        guard index + 1 < words.count else { return false }
-        return ["hundert", "tausend", "million", "millionen"].contains(words[index + 1])
-    }
-
-    private static func normalizeWord(_ word: String) -> String {
-        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "de_DE"))
-            .lowercased()
-            .replacingOccurrences(of: "ß", with: "ss")
     }
 }

--- a/TypeWhisper/Services/PostProcessingPipeline.swift
+++ b/TypeWhisper/Services/PostProcessingPipeline.swift
@@ -89,14 +89,15 @@ final class PostProcessingPipeline {
             do {
                 switch step.id {
                 case -6:
-                    let language = TranscriptionNormalizationService.normalizationLanguage(
+                    let languages = TranscriptionNormalizationService.normalizationLanguages(
                         task: .transcribe,
                         detectedLanguage: dictationContext?.detectedLanguage ?? context.language,
-                        configuredLanguage: dictationContext?.configuredLanguage ?? context.language
+                        configuredLanguage: dictationContext?.configuredLanguage ?? context.language,
+                        configuredLanguageCandidates: dictationContext?.configuredLanguageCandidates ?? []
                     )
                     result = TranscriptionNormalizationService.normalizeText(
                         result,
-                        language: language,
+                        languages: languages,
                         normalizeNumbers: normalizeNumbers
                     )
                 case -4:

--- a/TypeWhisper/Services/TranscriptionNormalizationService.swift
+++ b/TypeWhisper/Services/TranscriptionNormalizationService.swift
@@ -19,6 +19,7 @@ enum TranscriptionNormalizationService {
     static func normalizeText(
         _ text: String,
         language: String?,
+        languageCandidates: [String] = [],
         normalizeNumbers: Bool? = nil,
         defaults: UserDefaults = .standard
     ) -> String {
@@ -26,13 +27,39 @@ enum TranscriptionNormalizationService {
             return text
         }
 
-        return NumberWordNormalizer.normalize(text: text, language: language)
+        return normalizeText(
+            text,
+            languages: prioritizedLanguages(primary: language, candidates: languageCandidates),
+            normalizeNumbers: normalizeNumbers,
+            defaults: defaults
+        )
+    }
+
+    static func normalizeText(
+        _ text: String,
+        languages: [String],
+        normalizeNumbers: Bool? = nil,
+        defaults: UserDefaults = .standard
+    ) -> String {
+        guard numberNormalizationEnabled(override: normalizeNumbers, defaults: defaults) else {
+            return text
+        }
+
+        for language in prioritizedLanguages(primary: nil, candidates: languages) {
+            let normalized = NumberWordNormalizer.normalize(text: text, language: language)
+            if normalized != text {
+                return normalized
+            }
+        }
+
+        return text
     }
 
     static func normalizeResult(
         text: String,
         detectedLanguage: String?,
         configuredLanguage: String?,
+        configuredLanguageCandidates: [String] = [],
         duration: TimeInterval,
         processingTime: TimeInterval,
         engineUsed: String,
@@ -41,20 +68,21 @@ enum TranscriptionNormalizationService {
         normalizeNumbers: Bool? = nil,
         defaults: UserDefaults = .standard
     ) -> TranscriptionResult {
-        let language = normalizationLanguage(
+        let languages = normalizationLanguages(
             task: task,
             detectedLanguage: detectedLanguage,
-            configuredLanguage: configuredLanguage
+            configuredLanguage: configuredLanguage,
+            configuredLanguageCandidates: configuredLanguageCandidates
         )
         return TranscriptionResult(
-            text: normalizeText(text, language: language, normalizeNumbers: normalizeNumbers, defaults: defaults),
+            text: normalizeText(text, languages: languages, normalizeNumbers: normalizeNumbers, defaults: defaults),
             detectedLanguage: detectedLanguage,
             duration: duration,
             processingTime: processingTime,
             engineUsed: engineUsed,
             segments: segments.map {
                 TranscriptionSegment(
-                    text: normalizeText($0.text, language: language, normalizeNumbers: normalizeNumbers, defaults: defaults),
+                    text: normalizeText($0.text, languages: languages, normalizeNumbers: normalizeNumbers, defaults: defaults),
                     start: $0.start,
                     end: $0.end,
                     speakerLabel: $0.speakerLabel,
@@ -67,6 +95,7 @@ enum TranscriptionNormalizationService {
     static func normalizeResult(
         _ result: TranscriptionResult,
         configuredLanguage: String?,
+        configuredLanguageCandidates: [String] = [],
         task: TranscriptionTask,
         normalizeNumbers: Bool? = nil,
         defaults: UserDefaults = .standard
@@ -75,6 +104,7 @@ enum TranscriptionNormalizationService {
             text: result.text,
             detectedLanguage: result.detectedLanguage,
             configuredLanguage: configuredLanguage,
+            configuredLanguageCandidates: configuredLanguageCandidates,
             duration: result.duration,
             processingTime: result.processingTime,
             engineUsed: result.engineUsed,
@@ -94,5 +124,36 @@ enum TranscriptionNormalizationService {
             return "en"
         }
         return detectedLanguage ?? configuredLanguage
+    }
+
+    static func normalizationLanguages(
+        task: TranscriptionTask,
+        detectedLanguage: String?,
+        configuredLanguage: String?,
+        configuredLanguageCandidates: [String] = []
+    ) -> [String] {
+        if task == .translate {
+            return ["en"]
+        }
+
+        return prioritizedLanguages(
+            primary: detectedLanguage,
+            candidates: [configuredLanguage].compactMap { $0 } + configuredLanguageCandidates
+        )
+    }
+
+    private static func prioritizedLanguages(primary: String?, candidates: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+
+        for rawLanguage in [primary].compactMap({ $0 }) + candidates {
+            guard let normalized = PunctuationLanguageNormalizer.normalize(rawLanguage),
+                  seen.insert(normalized).inserted else {
+                continue
+            }
+            result.append(normalized)
+        }
+
+        return result
     }
 }

--- a/TypeWhisper/Services/TranscriptionNormalizationService.swift
+++ b/TypeWhisper/Services/TranscriptionNormalizationService.swift
@@ -115,17 +115,6 @@ enum TranscriptionNormalizationService {
         )
     }
 
-    static func normalizationLanguage(
-        task: TranscriptionTask,
-        detectedLanguage: String?,
-        configuredLanguage: String?
-    ) -> String? {
-        if task == .translate {
-            return "en"
-        }
-        return detectedLanguage ?? configuredLanguage
-    }
-
     static func normalizationLanguages(
         task: TranscriptionTask,
         detectedLanguage: String?,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1213,6 +1213,7 @@ final class DictationViewModel: ObservableObject {
                 let activeApp = capturedActiveApp ?? textInsertionService.captureActiveApp()
                 let languageSelection = effectiveLanguageSelection
                 let language = languageSelection.requestedLanguage
+                let languageCandidates = languageSelection.selectedCodes
                 let task = effectiveTask
                 let engineOverride = effectiveEngineOverrideId
                 let cloudModelOverride = effectiveCloudModelOverride
@@ -1290,6 +1291,7 @@ final class DictationViewModel: ObservableObject {
                         cloudModelOverride: cloudModelOverride
                     ),
                     configuredLanguage: language,
+                    configuredLanguageCandidates: languageCandidates,
                     detectedLanguage: result.detectedLanguage
                 )
                 let ppResult = try await postProcessingPipeline.process(

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -9,6 +9,7 @@ final class StreamingHandler: @unchecked Sendable {
         var liveSessionHandle: ModelManagerService.LiveTranscriptionSessionHandle?
         var normalizeNumbers: Bool?
         var configuredLanguage: String?
+        var configuredLanguageCandidates: [String] = []
         var task: TranscriptionTask = .transcribe
         var livePreviewAudioGate = LivePreviewAudioGate()
         var sampleCursor = 0
@@ -117,6 +118,7 @@ final class StreamingHandler: @unchecked Sendable {
         sharedState.withLock { state in
             state.normalizeNumbers = normalizeNumbers
             state.configuredLanguage = languageSelection.requestedLanguage
+            state.configuredLanguageCandidates = languageSelection.selectedCodes
             state.task = task
         }
         onStreamingStateChange?(true)
@@ -190,6 +192,7 @@ final class StreamingHandler: @unchecked Sendable {
                 handle,
                 bufferedDuration: bufferedDurationProvider(),
                 language: sharedState.withLock { $0.configuredLanguage },
+                languageCandidates: sharedState.withLock { $0.configuredLanguageCandidates },
                 task: sharedState.withLock { $0.task },
                 normalizeNumbers: sharedState.withLock { $0.normalizeNumbers }
             )
@@ -302,6 +305,7 @@ final class StreamingHandler: @unchecked Sendable {
             state.liveSessionHandle = nil
             state.normalizeNumbers = nil
             state.configuredLanguage = nil
+            state.configuredLanguageCandidates = []
             state.task = .transcribe
             state.sampleCursor = 0
         }

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -59,8 +59,49 @@ final class NumberWordNormalizerTests: XCTestCase {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus zwei komma fünf", language: "de"), "-2,5")
     }
 
+    func testFrenchNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "J'ai deux questions", language: "fr"), "J'ai 2 questions")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "vingt trois fichiers", language: "fr"), "23 fichiers")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "mille deux cent trente quatre", language: "fr"), "1234")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "moins deux virgule cinq", language: "fr"), "-2,5")
+    }
+
+    func testFrenchArticleOneIsPreservedOutsideClearNumberConstructs() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "j'ai un problème", language: "fr"), "j'ai un problème")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "un million de lignes", language: "fr"), "1000000 de lignes")
+    }
+
+    func testSpanishNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "tengo dos preguntas", language: "es"), "tengo 2 preguntas")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "veintitrés archivos", language: "es"), "23 archivos")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "veinte y tres archivos", language: "es"), "23 archivos")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "mil doscientos treinta y cuatro", language: "es"), "1234")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "menos dos coma cinco", language: "es"), "-2,5")
+    }
+
+    func testSpanishArticleOneIsPreservedOutsideClearNumberConstructs() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "tengo un problema", language: "es"), "tengo un problema")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "un millón de filas", language: "es"), "1000000 de filas")
+    }
+
+    func testChineseHanNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "我有二十三个文件", language: "zh"), "我有23个文件")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "一千二百三十四", language: "zh"), "1234")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "负二点五", language: "zh"), "-2.5")
+    }
+
+    func testJapaneseHanNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "二十三個のファイル", language: "ja"), "23個のファイル")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "千二百三十四", language: "ja"), "1234")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "負二点五", language: "ja"), "-2.5")
+    }
+
+    func testJapaneseSingleKanjiInWordsIsPreserved() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "一緒に行く", language: "ja"), "一緒に行く")
+    }
+
     func testUnsupportedLanguageIsNoOp() {
-        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty three", language: "fr"), "twenty three")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty three", language: "it"), "twenty three")
     }
 
     func testAlreadyDigitTextIsNoOp() {

--- a/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
+++ b/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
@@ -50,4 +50,45 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
 
         XCTAssertEqual(result, "I have two questions")
     }
+
+    @MainActor
+    func testLaterLanguageCandidateNormalizesWhenConfiguredLanguageDoesNotMatch() async throws {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeText(
+            "Set the value to twenty three",
+            language: "de",
+            languageCandidates: ["de", "en"],
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result, "Set the value to 23")
+    }
+
+    @MainActor
+    func testNormalizeResultUsesLaterConfiguredLanguageCandidate() async throws {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeResult(
+            text: "Set the value to twenty three",
+            detectedLanguage: nil,
+            configuredLanguage: "de",
+            configuredLanguageCandidates: ["de", "en"],
+            duration: 1,
+            processingTime: 0.1,
+            engineUsed: "test",
+            segments: [
+                TranscriptionSegment(text: "twenty three", start: 0, end: 1)
+            ],
+            task: .transcribe,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result.text, "Set the value to 23")
+        XCTAssertEqual(result.segments.first?.text, "23")
+    }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #645 after a French user asked for number normalization beyond English and German.
- Refactors the number normalizer into a small router/tokenizer plus language-specific parser files.
- Adds cardinal number normalization for French, Spanish, Chinese Han numerals, and Japanese Han numerals while preserving the existing English and German behavior.
- Keeps v1 scope intentionally narrow: no ordinals, dates, phone numbers, currencies, or custom prompt-driven formatting.

Refs #645

## Test Plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/NumberWordNormalizerTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added number-word normalization for French, Spanish, Chinese (Han), and Japanese, expanding multilingual support to six languages.
  * Improved tokenization/parsing for language-specific number formats and decimals.
  * Normalization now accepts and prioritizes multiple configured language candidates across transcription and post-processing.

* **Tests**
  * Expanded tests for French, Spanish, Chinese, and Japanese normalization, including negative and decimal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->