### PR TITLE
feat: add commercial Cloud Folder Sync

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -166,6 +166,13 @@
 		AA00000000000000000079 /* DictionaryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000079 /* DictionaryService.swift */; };
 		AA00000000000000000080 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000080 /* Snippet.swift */; };
 		AA00000000000000000081 /* SnippetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000081 /* SnippetService.swift */; };
+		C1F000000000000000000011 /* UserDataSyncIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000002 /* UserDataSyncIdentity.swift */; };
+		C1F000000000000000000012 /* TypeWhisperUserDataSyncStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000003 /* TypeWhisperUserDataSyncStore.swift */; };
+		C1F000000000000000000013 /* CloudFolderSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000004 /* CloudFolderSyncEngine.swift */; };
+		C1F000000000000000000014 /* CloudFolderSyncSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000005 /* CloudFolderSyncSettingsView.swift */; };
+		C1F000000000000000000015 /* CloudFolderSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000006 /* CloudFolderSyncTests.swift */; };
+		C1F000000000000000000016 /* UserDataSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000007 /* UserDataSync.swift */; };
+		C1F000000000000000000017 /* PremiumSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000008 /* PremiumSettingsView.swift */; };
 		AA00000000000000000082 /* DictionaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000082 /* DictionaryViewModel.swift */; };
 		AA00000000000000000083 /* DictionarySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000083 /* DictionarySettingsView.swift */; };
 		AA00000000000000000084 /* SnippetsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000084 /* SnippetsViewModel.swift */; };
@@ -586,6 +593,13 @@
 		BB00000000000000000079 /* DictionaryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryService.swift; sourceTree = "<group>"; };
 		BB00000000000000000080 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		BB00000000000000000081 /* SnippetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetService.swift; sourceTree = "<group>"; };
+		C1F000000000000000000002 /* UserDataSyncIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataSyncIdentity.swift; sourceTree = "<group>"; };
+		C1F000000000000000000003 /* TypeWhisperUserDataSyncStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeWhisperUserDataSyncStore.swift; sourceTree = "<group>"; };
+		C1F000000000000000000004 /* CloudFolderSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudFolderSyncEngine.swift; sourceTree = "<group>"; };
+		C1F000000000000000000005 /* CloudFolderSyncSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudFolderSyncSettingsView.swift; sourceTree = "<group>"; };
+		C1F000000000000000000006 /* CloudFolderSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudFolderSyncTests.swift; sourceTree = "<group>"; };
+		C1F000000000000000000007 /* UserDataSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataSync.swift; sourceTree = "<group>"; };
+		C1F000000000000000000008 /* PremiumSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PremiumSettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000082 /* DictionaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000083 /* DictionarySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000084 /* SnippetsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsViewModel.swift; sourceTree = "<group>"; };
@@ -1390,6 +1404,7 @@
 				BB00000000000000000079 /* DictionaryService.swift */,
 				BB00000000000000000271 /* DictionaryExporter.swift */,
 				BB00000000000000000081 /* SnippetService.swift */,
+				C1F000000000000000000001 /* Sync */,
 				BB00000000000000000086 /* SoundService.swift */,
 				BB00000000000000000102 /* AudioDeviceService.swift */,
 				BB00000000000000000320 /* AudioEngineRecoverySupport.swift */,
@@ -1437,6 +1452,18 @@
 			path = NumberNormalization;
 			sourceTree = "<group>";
 		};
+		C1F000000000000000000001 /* Sync */ = {
+			isa = PBXGroup;
+			children = (
+				C1F000000000000000000007 /* UserDataSync.swift */,
+				C1F000000000000000000002 /* UserDataSyncIdentity.swift */,
+				C1F000000000000000000003 /* TypeWhisperUserDataSyncStore.swift */,
+				C1F000000000000000000004 /* CloudFolderSyncEngine.swift */,
+				C1F000000000000000000005 /* CloudFolderSyncSettingsView.swift */,
+			);
+			path = Sync;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000007 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -1476,6 +1503,7 @@
 				BB00000000000000000016 /* FileTranscriptionView.swift */,
 				533C00000000000000000003 /* DictationRecoveryView.swift */,
 				BB00000000000000000017 /* SettingsView.swift */,
+				C1F000000000000000000008 /* PremiumSettingsView.swift */,
 				BB00000000000000000359 /* WorkflowsSettingsView.swift */,
 				BB00000000000000000046 /* AdvancedSettingsView.swift */,
 				BB00000000000000000051 /* GeneralSettingsView.swift */,
@@ -2079,6 +2107,7 @@
 				CE5852D6767C5FA955B84C55 /* PunctuationRulesLoaderTests.swift */,
 				CE5852D6767C5FA955B84C56 /* PunctuationStrategyResolverTests.swift */,
 				FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */,
+				C1F000000000000000000006 /* CloudFolderSyncTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */,
 				2F4D6A8B0C1E3F5A7B9D2C51 /* IndicatorTranscriptPreviewSizingTests.swift */,
 					6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */,
@@ -3461,6 +3490,7 @@
 				24FFE19AC026C48AE32BCD7F /* PunctuationRulesLoaderTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD80 /* PunctuationStrategyResolverTests.swift in Sources */,
 				7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */,
+				C1F000000000000000000015 /* CloudFolderSyncTests.swift in Sources */,
 				A40500000000000000000101 /* CLIClient.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C4E /* DictationViewModelIndicatorSettingsTests.swift in Sources */,
 				2F4D6A8B0C1E3F5A7B9D2C50 /* IndicatorTranscriptPreviewSizingTests.swift in Sources */,
@@ -3607,6 +3637,12 @@
 				AA00000000000000000079 /* DictionaryService.swift in Sources */,
 				AA00000000000000000080 /* Snippet.swift in Sources */,
 				AA00000000000000000081 /* SnippetService.swift in Sources */,
+				C1F000000000000000000011 /* UserDataSyncIdentity.swift in Sources */,
+				C1F000000000000000000012 /* TypeWhisperUserDataSyncStore.swift in Sources */,
+				C1F000000000000000000013 /* CloudFolderSyncEngine.swift in Sources */,
+				C1F000000000000000000014 /* CloudFolderSyncSettingsView.swift in Sources */,
+				C1F000000000000000000016 /* UserDataSync.swift in Sources */,
+				C1F000000000000000000017 /* PremiumSettingsView.swift in Sources */,
 				AA00000000000000000082 /* DictionaryViewModel.swift in Sources */,
 				AA00000000000000000083 /* DictionarySettingsView.swift in Sources */,
 				AA00000000000000000084 /* SnippetsViewModel.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -21,6 +21,8 @@ final class ServiceContainer: ObservableObject {
     let mediaPlaybackService: MediaPlaybackService
     let dictionaryService: DictionaryService
     let snippetService: SnippetService
+    let userDataSyncStore: TypeWhisperUserDataSyncStore
+    let cloudFolderSyncController: CloudFolderSyncController
     let soundService: SoundService
     let audioDeviceService: AudioDeviceService
     let promptActionService: PromptActionService
@@ -90,6 +92,10 @@ final class ServiceContainer: ObservableObject {
         mediaPlaybackService = MediaPlaybackService()
         dictionaryService = DictionaryService()
         snippetService = SnippetService()
+        userDataSyncStore = TypeWhisperUserDataSyncStore(
+            dictionaryService: dictionaryService,
+            snippetService: snippetService
+        )
         soundService = SoundService()
         audioDeviceService = AudioDeviceService(
             inputActivationGuard: inputActivationGuard
@@ -114,6 +120,10 @@ final class ServiceContainer: ObservableObject {
         errorLogService = ErrorLogService()
         licenseService = LicenseService()
         supporterDiscordService = SupporterDiscordService(licenseService: licenseService)
+        cloudFolderSyncController = CloudFolderSyncController(
+            licenseService: licenseService,
+            syncStore: userDataSyncStore
+        )
 
         // ViewModels (created before HTTP API so DictationViewModel is available)
         fileTranscriptionViewModel = FileTranscriptionViewModel(

--- a/TypeWhisper/Models/DictionaryEntry.swift
+++ b/TypeWhisper/Models/DictionaryEntry.swift
@@ -29,6 +29,7 @@ final class DictionaryEntry {
     var caseSensitive: Bool
     var isEnabled: Bool
     var createdAt: Date
+    var updatedAt: Date?
     var usageCount: Int
 
     var type: DictionaryEntryType {
@@ -44,6 +45,7 @@ final class DictionaryEntry {
         caseSensitive: Bool = false,
         isEnabled: Bool = true,
         createdAt: Date = Date(),
+        updatedAt: Date? = nil,
         usageCount: Int = 0
     ) {
         self.id = id
@@ -53,7 +55,12 @@ final class DictionaryEntry {
         self.caseSensitive = caseSensitive
         self.isEnabled = isEnabled
         self.createdAt = createdAt
+        self.updatedAt = updatedAt ?? createdAt
         self.usageCount = usageCount
+    }
+
+    var effectiveUpdatedAt: Date {
+        updatedAt ?? createdAt
     }
 
     var displayText: String {

--- a/TypeWhisper/Models/Snippet.swift
+++ b/TypeWhisper/Models/Snippet.swift
@@ -10,6 +10,7 @@ final class Snippet {
     var caseSensitive: Bool
     var isEnabled: Bool
     var createdAt: Date
+    var updatedAt: Date?
     var usageCount: Int
 
     init(
@@ -19,6 +20,7 @@ final class Snippet {
         caseSensitive: Bool = false,
         isEnabled: Bool = true,
         createdAt: Date = Date(),
+        updatedAt: Date? = nil,
         usageCount: Int = 0
     ) {
         self.id = id
@@ -27,7 +29,12 @@ final class Snippet {
         self.caseSensitive = caseSensitive
         self.isEnabled = isEnabled
         self.createdAt = createdAt
+        self.updatedAt = updatedAt ?? createdAt
         self.usageCount = usageCount
+    }
+
+    var effectiveUpdatedAt: Date {
+        updatedAt ?? createdAt
     }
 
     /// Process replacement text, expanding placeholders like {{DATE}}, {{TIME}}, {{CLIPBOARD}}
@@ -67,10 +74,40 @@ final class Snippet {
             return formatter.string(from: Date())
         }
 
+        result = processBracePlaceholder(in: result, placeholder: "date") { format in
+            let formatter = DateFormatter()
+            formatter.dateFormat = format ?? "yyyy-MM-dd"
+            return formatter.string(from: Date())
+        }
+
+        result = processBracePlaceholder(in: result, placeholder: "time") { format in
+            let formatter = DateFormatter()
+            formatter.dateFormat = format ?? "HH:mm"
+            return formatter.string(from: Date())
+        }
+
+        result = processBracePlaceholder(in: result, placeholder: "datetime") { format in
+            let formatter = DateFormatter()
+            formatter.dateFormat = format ?? "yyyy-MM-dd HH:mm"
+            return formatter.string(from: Date())
+        }
+
+        let now = Date()
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "EEEE"
+        result = result.replacingOccurrences(of: "{day}", with: dayFormatter.string(from: now))
+        result = result.replacingOccurrences(of: "{year}", with: Calendar.current.component(.year, from: now).description)
+
         if result.contains("{{CLIPBOARD}}") {
             let pasteboard = NSPasteboard.general
             let clipboardContent = pasteboard.string(forType: .string) ?? ""
             result = result.replacingOccurrences(of: "{{CLIPBOARD}}", with: clipboardContent)
+        }
+
+        if result.contains("{clipboard}") {
+            let pasteboard = NSPasteboard.general
+            let clipboardContent = pasteboard.string(forType: .string) ?? ""
+            result = result.replacingOccurrences(of: "{clipboard}", with: clipboardContent)
         }
 
         return result
@@ -84,6 +121,36 @@ final class Snippet {
         var result = text
 
         let pattern = "\\{\\{\(placeholder)(?::([^}]+))?\\}\\}"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return result
+        }
+
+        let range = NSRange(result.startIndex..., in: result)
+        let matches = regex.matches(in: result, range: range).reversed()
+
+        for match in matches {
+            let fullRange = Range(match.range, in: result)!
+            var format: String? = nil
+
+            if match.numberOfRanges > 1, let formatRange = Range(match.range(at: 1), in: result) {
+                format = String(result[formatRange])
+            }
+
+            let replacement = handler(format)
+            result.replaceSubrange(fullRange, with: replacement)
+        }
+
+        return result
+    }
+
+    private func processBracePlaceholder(
+        in text: String,
+        placeholder: String,
+        handler: (String?) -> String
+    ) -> String {
+        var result = text
+
+        let pattern = "\\{\(placeholder)(?::([^}]+))?\\}"
         guard let regex = try? NSRegularExpression(pattern: pattern) else {
             return result
         }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9017,7 +9017,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Commercial-Lizenz kaufen"
+            "value" : "Kommerzielle Lizenz kaufen"
           }
         }
       }
@@ -9077,7 +9077,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cloud-Ordner-Sync ist mit einer Commercial-Lizenz verfügbar. Synchronisiere Wörterbücher und Snippets über dein eigenes iCloud Drive, Dropbox, OneDrive, Syncthing oder einen benutzerdefinierten Ordner."
+            "value" : "Cloud-Ordner-Sync ist mit einer kommerziellen Lizenz verfügbar. Synchronisiere Wörterbücher und Snippets über dein eigenes iCloud Drive, Dropbox, OneDrive, Syncthing oder einen benutzerdefinierten Ordner."
           }
         }
       }
@@ -9087,7 +9087,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cloud-Ordner-Sync erfordert eine aktive Commercial-Lizenz."
+            "value" : "Cloud-Ordner-Sync erfordert eine aktive kommerzielle Lizenz."
           }
         }
       }
@@ -9097,7 +9097,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Commercial-Lizenz aktiv"
+            "value" : "Kommerzielle Lizenz aktiv"
           }
         }
       }
@@ -9107,7 +9107,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Commercial-Lizenz erforderlich"
+            "value" : "Kommerzielle Lizenz erforderlich"
           }
         }
       }
@@ -9197,7 +9197,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Supporter-Status ist aktiv. Premium-Features erfordern eine Commercial-Lizenz."
+            "value" : "Supporter-Status ist aktiv. Premium-Features erfordern eine kommerzielle Lizenz."
           }
         }
       }
@@ -9215,9 +9215,39 @@
     "Synced %lld changes." : {
       "localizations" : {
         "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Änderungen synchronisiert."
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "1 Änderung synchronisiert."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld Änderungen synchronisiert."
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Synced 1 change."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Synced %lld changes."
+                }
+              }
+            }
           }
         }
       }
@@ -9227,7 +9257,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronisiert"
+            "value" : "Wird synchronisiert"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9001,6 +9001,256 @@
           }
         }
       }
+    },
+    "Activate or buy a license to start writing sync files." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiviere oder kaufe eine Lizenz, damit Sync-Dateien geschrieben werden können."
+          }
+        }
+      }
+    },
+    "Buy Commercial License" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commercial-Lizenz kaufen"
+          }
+        }
+      }
+    },
+    "Choose a cloud-synced folder for TypeWhisper." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle einen Cloud-synchronisierten Ordner für TypeWhisper."
+          }
+        }
+      }
+    },
+    "Choose a sync folder first." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle zuerst einen Sync-Ordner."
+          }
+        }
+      }
+    },
+    "Choose Folder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordner wählen"
+          }
+        }
+      }
+    },
+    "Clear" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leeren"
+          }
+        }
+      }
+    },
+    "Cloud Folder Sync" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud-Ordner-Sync"
+          }
+        }
+      }
+    },
+    "Cloud Folder Sync is available with a Commercial license. Sync dictionaries and snippets through your own iCloud Drive, Dropbox, OneDrive, Syncthing, or custom folder." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud-Ordner-Sync ist mit einer Commercial-Lizenz verfügbar. Synchronisiere Wörterbücher und Snippets über dein eigenes iCloud Drive, Dropbox, OneDrive, Syncthing oder einen benutzerdefinierten Ordner."
+          }
+        }
+      }
+    },
+    "Cloud Folder Sync requires an active Commercial license." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud-Ordner-Sync erfordert eine aktive Commercial-Lizenz."
+          }
+        }
+      }
+    },
+    "Commercial license active" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commercial-Lizenz aktiv"
+          }
+        }
+      }
+    },
+    "Commercial license required" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commercial-Lizenz erforderlich"
+          }
+        }
+      }
+    },
+    "Custom Folder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdefinierter Ordner"
+          }
+        }
+      }
+    },
+    "Dictionary and snippets" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wörterbuch und Snippets"
+          }
+        }
+      }
+    },
+    "Enter License Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenzschlüssel eingeben"
+          }
+        }
+      }
+    },
+    "Folder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordner"
+          }
+        }
+      }
+    },
+    "Last Sync" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzter Sync"
+          }
+        }
+      }
+    },
+    "No folder selected" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Ordner ausgewählt"
+          }
+        }
+      }
+    },
+    "Open License" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lizenz öffnen"
+          }
+        }
+      }
+    },
+    "Premium" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premium"
+          }
+        }
+      }
+    },
+    "Supporter status is active. Premium features require a Commercial license." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supporter-Status ist aktiv. Premium-Features erfordern eine Commercial-Lizenz."
+          }
+        }
+      }
+    },
+    "Sync Now" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt synchronisieren"
+          }
+        }
+      }
+    },
+    "Synced %lld changes." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Änderungen synchronisiert."
+          }
+        }
+      }
+    },
+    "Syncing" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisiert"
+          }
+        }
+      }
+    },
+    "TypeWhisper user data is unavailable." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper-Benutzerdaten sind nicht verfügbar."
+          }
+        }
+      }
+    },
+    "Unlock Premium features" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premium-Features freischalten"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -112,11 +112,14 @@ final class DictionaryService: ObservableObject {
             return
         }
 
+        let now = Date()
         let entry = DictionaryEntry(
             type: type,
             original: original,
             replacement: replacement,
-            caseSensitive: caseSensitive
+            caseSensitive: caseSensitive,
+            createdAt: now,
+            updatedAt: now
         )
 
         context.insert(entry)
@@ -140,6 +143,7 @@ final class DictionaryService: ObservableObject {
         entry.original = original
         entry.replacement = replacement
         entry.caseSensitive = caseSensitive
+        entry.updatedAt = Date()
 
         do {
             try context.save()
@@ -166,6 +170,7 @@ final class DictionaryService: ObservableObject {
         guard let context = modelContext else { return }
 
         entry.isEnabled.toggle()
+        entry.updatedAt = Date()
 
         do {
             try context.save()
@@ -189,7 +194,8 @@ final class DictionaryService: ObservableObject {
                 type: item.type,
                 original: item.original,
                 replacement: item.replacement,
-                caseSensitive: item.caseSensitive
+                caseSensitive: item.caseSensitive,
+                updatedAt: Date()
             )
             context.insert(entry)
         }
@@ -217,7 +223,8 @@ final class DictionaryService: ObservableObject {
                 original: item.original,
                 replacement: item.replacement,
                 caseSensitive: item.caseSensitive,
-                isEnabled: item.isEnabled
+                isEnabled: item.isEnabled,
+                updatedAt: Date()
             )
             context.insert(entry)
             existingOriginals.insert(key)
@@ -278,6 +285,7 @@ final class DictionaryService: ObservableObject {
             if let desiredTerm = normalizedByKey[key] {
                 entry.original = desiredTerm
                 entry.isEnabled = true
+                entry.updatedAt = Date()
             } else if replaceExisting {
                 context.delete(entry)
             }
@@ -288,7 +296,8 @@ final class DictionaryService: ObservableObject {
         })
 
         for term in normalized where !existingKeys.contains(term.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)) {
-            context.insert(DictionaryEntry(type: .term, original: term, replacement: nil, caseSensitive: false, isEnabled: true))
+            let now = Date()
+            context.insert(DictionaryEntry(type: .term, original: term, replacement: nil, caseSensitive: false, isEnabled: true, createdAt: now, updatedAt: now))
         }
 
         if replaceExisting || !desiredKeys.isEmpty {
@@ -417,13 +426,17 @@ final class DictionaryService: ObservableObject {
             entry.replacement = replacement
             entry.caseSensitive = caseSensitive
             entry.isEnabled = true
+            entry.updatedAt = Date()
         } else {
+            let now = Date()
             let entry = DictionaryEntry(
                 type: .correction,
                 original: original,
                 replacement: replacement,
                 caseSensitive: caseSensitive,
-                isEnabled: true
+                isEnabled: true,
+                createdAt: now,
+                updatedAt: now
             )
             context.insert(entry)
         }
@@ -459,6 +472,94 @@ final class DictionaryService: ObservableObject {
             logger.error("Failed to delete correction: \(error.localizedDescription)")
             throw DictionaryServiceMutationError.saveFailed(error)
         }
+    }
+
+    func userDataSyncEntries(
+        excludingTermItemIDs: Set<String> = [],
+        excludingCorrectionItemIDs: Set<String> = []
+    ) -> [UserDataSyncDictionaryEntry] {
+        entries.compactMap { entry in
+            let itemID = UserDataSyncIdentity.dictionaryItemID(entryType: entry.type, original: entry.original)
+            if entry.type == .term, excludingTermItemIDs.contains(itemID) {
+                return nil
+            }
+            if entry.type == .correction, excludingCorrectionItemIDs.contains(itemID) {
+                return nil
+            }
+
+            return UserDataSyncDictionaryEntry(
+                entryType: UserDataSyncDictionaryEntryType(entry.type),
+                original: entry.original,
+                replacement: entry.type == .correction ? (entry.replacement ?? "") : nil,
+                caseSensitive: entry.caseSensitive,
+                isEnabled: entry.isEnabled,
+                createdAt: entry.createdAt,
+                updatedAt: entry.effectiveUpdatedAt
+            )
+        }
+    }
+
+    func applyUserDataSyncMutations(_ mutations: [UserDataSyncMutation]) throws {
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
+        guard !mutations.isEmpty else { return }
+
+        for mutation in mutations {
+            switch mutation {
+            case .upsertDictionary(let synced):
+                upsertSyncedDictionaryEntry(synced, context: context)
+            case .deleteDictionary(let itemID):
+                deleteSyncedDictionaryEntry(itemID: itemID, context: context)
+            case .upsertSnippet, .deleteSnippet:
+                continue
+            }
+        }
+
+        do {
+            try context.save()
+            loadEntries()
+        } catch {
+            logger.error("Failed to apply dictionary sync mutations: \(error.localizedDescription)")
+            throw DictionaryServiceMutationError.saveFailed(error)
+        }
+    }
+
+    private func upsertSyncedDictionaryEntry(_ synced: UserDataSyncDictionaryEntry, context: ModelContext) {
+        let targetType = DictionaryEntryType(synced.entryType)
+        let targetID = UserDataSyncIdentity.dictionaryItemID(entryType: synced.entryType, original: synced.original)
+        let replacement = targetType == .correction ? (synced.replacement ?? "") : nil
+
+        if let entry = entries.first(where: {
+            $0.type == targetType &&
+            UserDataSyncIdentity.dictionaryItemID(entryType: $0.type, original: $0.original) == targetID
+        }) {
+            entry.original = synced.original
+            entry.replacement = replacement
+            entry.caseSensitive = synced.caseSensitive
+            entry.isEnabled = synced.isEnabled
+            entry.updatedAt = synced.updatedAt
+            return
+        }
+
+        context.insert(DictionaryEntry(
+            type: targetType,
+            original: synced.original,
+            replacement: replacement,
+            caseSensitive: synced.caseSensitive,
+            isEnabled: synced.isEnabled,
+            createdAt: synced.createdAt,
+            updatedAt: synced.updatedAt
+        ))
+    }
+
+    private func deleteSyncedDictionaryEntry(itemID: String, context: ModelContext) {
+        guard let entry = entries.first(where: {
+            UserDataSyncIdentity.dictionaryItemID(entryType: $0.type, original: $0.original) == itemID
+        }) else {
+            return
+        }
+        context.delete(entry)
     }
 
     private func incrementUsageCount(for entry: DictionaryEntry) {

--- a/TypeWhisper/Services/SnippetService.swift
+++ b/TypeWhisper/Services/SnippetService.swift
@@ -69,10 +69,13 @@ final class SnippetService: ObservableObject {
             return
         }
 
+        let now = Date()
         let snippet = Snippet(
             trigger: trigger,
             replacement: replacement,
-            caseSensitive: caseSensitive
+            caseSensitive: caseSensitive,
+            createdAt: now,
+            updatedAt: now
         )
 
         context.insert(snippet)
@@ -91,6 +94,7 @@ final class SnippetService: ObservableObject {
         snippet.trigger = trigger
         snippet.replacement = replacement
         snippet.caseSensitive = caseSensitive
+        snippet.updatedAt = Date()
 
         do {
             try context.save()
@@ -117,6 +121,7 @@ final class SnippetService: ObservableObject {
         guard let context = modelContext else { return }
 
         snippet.isEnabled.toggle()
+        snippet.updatedAt = Date()
 
         do {
             try context.save()
@@ -164,5 +169,74 @@ final class SnippetService: ObservableObject {
         } catch {
             logger.error("Failed to update usage count: \(error.localizedDescription)")
         }
+    }
+
+    func userDataSyncSnippets() -> [UserDataSyncSnippet] {
+        snippets.map { snippet in
+            UserDataSyncSnippet(
+                trigger: snippet.trigger,
+                replacement: snippet.replacement,
+                caseSensitive: snippet.caseSensitive,
+                isEnabled: snippet.isEnabled,
+                createdAt: snippet.createdAt,
+                updatedAt: snippet.effectiveUpdatedAt
+            )
+        }
+    }
+
+    func applyUserDataSyncMutations(_ mutations: [UserDataSyncMutation]) throws {
+        guard let context = modelContext else { return }
+        guard !mutations.isEmpty else { return }
+
+        for mutation in mutations {
+            switch mutation {
+            case .upsertSnippet(let synced):
+                upsertSyncedSnippet(synced, context: context)
+            case .deleteSnippet(let itemID):
+                deleteSyncedSnippet(itemID: itemID, context: context)
+            case .upsertDictionary, .deleteDictionary:
+                continue
+            }
+        }
+
+        do {
+            try context.save()
+            loadSnippets()
+        } catch {
+            logger.error("Failed to apply snippet sync mutations: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    private func upsertSyncedSnippet(_ synced: UserDataSyncSnippet, context: ModelContext) {
+        let targetID = UserDataSyncIdentity.snippetItemID(trigger: synced.trigger)
+        if let snippet = snippets.first(where: {
+            UserDataSyncIdentity.snippetItemID(trigger: $0.trigger) == targetID
+        }) {
+            snippet.trigger = synced.trigger
+            snippet.replacement = synced.replacement
+            snippet.caseSensitive = synced.caseSensitive
+            snippet.isEnabled = synced.isEnabled
+            snippet.updatedAt = synced.updatedAt
+            return
+        }
+
+        context.insert(Snippet(
+            trigger: synced.trigger,
+            replacement: synced.replacement,
+            caseSensitive: synced.caseSensitive,
+            isEnabled: synced.isEnabled,
+            createdAt: synced.createdAt,
+            updatedAt: synced.updatedAt
+        ))
+    }
+
+    private func deleteSyncedSnippet(itemID: String, context: ModelContext) {
+        guard let snippet = snippets.first(where: {
+            UserDataSyncIdentity.snippetItemID(trigger: $0.trigger) == itemID
+        }) else {
+            return
+        }
+        context.delete(snippet)
     }
 }

--- a/TypeWhisper/Services/Sync/CloudFolderSyncEngine.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncEngine.swift
@@ -244,27 +244,84 @@ enum CloudFolderSyncEngine {
         var records: [String: CloudFolderSyncRecord] = [:]
         for entry in snapshot.dictionaryEntries {
             let itemID = UserDataSyncIdentity.dictionaryItemID(entryType: entry.entryType, original: entry.original)
-            records[itemID] = CloudFolderSyncRecord(
-                collection: .dictionary,
-                itemID: itemID,
-                updatedAt: entry.updatedAt,
-                version: versionString(for: entry.updatedAt),
-                dictionary: entry,
-                snippet: nil
+            merge(
+                CloudFolderSyncRecord(
+                    collection: .dictionary,
+                    itemID: itemID,
+                    updatedAt: entry.updatedAt,
+                    version: versionString(for: entry.updatedAt),
+                    dictionary: entry,
+                    snippet: nil
+                ),
+                into: &records
             )
         }
         for snippet in snapshot.snippets {
             let itemID = UserDataSyncIdentity.snippetItemID(trigger: snippet.trigger)
-            records[itemID] = CloudFolderSyncRecord(
-                collection: .snippets,
-                itemID: itemID,
-                updatedAt: snippet.updatedAt,
-                version: versionString(for: snippet.updatedAt),
-                dictionary: nil,
-                snippet: snippet
+            merge(
+                CloudFolderSyncRecord(
+                    collection: .snippets,
+                    itemID: itemID,
+                    updatedAt: snippet.updatedAt,
+                    version: versionString(for: snippet.updatedAt),
+                    dictionary: nil,
+                    snippet: snippet
+                ),
+                into: &records
             )
         }
         return records
+    }
+
+    private static func merge(
+        _ candidate: CloudFolderSyncRecord,
+        into records: inout [String: CloudFolderSyncRecord]
+    ) {
+        guard let existing = records[candidate.itemID] else {
+            records[candidate.itemID] = candidate
+            return
+        }
+
+        // Legacy local data can contain duplicates that collapse to one natural sync ID.
+        // Keep the newest deterministic record instead of depending on array order.
+        if prefers(candidate, over: existing) {
+            records[candidate.itemID] = candidate
+        }
+    }
+
+    private static func prefers(_ candidate: CloudFolderSyncRecord, over existing: CloudFolderSyncRecord) -> Bool {
+        if candidate.updatedAt != existing.updatedAt {
+            return candidate.updatedAt > existing.updatedAt
+        }
+        return recordTieBreaker(candidate) > recordTieBreaker(existing)
+    }
+
+    private static func recordTieBreaker(_ record: CloudFolderSyncRecord) -> String {
+        if let dictionary = record.dictionary {
+            return [
+                record.collection.rawValue,
+                dictionary.entryType.rawValue,
+                dictionary.original,
+                dictionary.replacement ?? "",
+                String(dictionary.caseSensitive),
+                String(dictionary.isEnabled),
+                versionString(for: dictionary.createdAt)
+            ].joined(separator: "|")
+        }
+
+        if let snippet = record.snippet {
+            return [
+                record.collection.rawValue,
+                snippet.trigger,
+                snippet.replacement,
+                String(snippet.caseSensitive),
+                String(snippet.isEnabled),
+                snippet.tags.joined(separator: ","),
+                versionString(for: snippet.createdAt)
+            ].joined(separator: "|")
+        }
+
+        return record.itemID
     }
 
     static func winningOperations(from operations: [CloudFolderSyncOperation]) -> [String: CloudFolderSyncOperation] {
@@ -445,21 +502,50 @@ enum CloudFolderSyncEngine {
     }
 
     private static func versionString(for date: Date) -> String {
+        iso8601String(from: date)
+    }
+
+    private static func iso8601String(from date: Date) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter.string(from: date)
     }
 
+    private static func iso8601Date(from string: String) -> Date? {
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractionalFormatter.date(from: string) {
+            return date
+        }
+
+        let wholeSecondFormatter = ISO8601DateFormatter()
+        wholeSecondFormatter.formatOptions = [.withInternetDateTime]
+        return wholeSecondFormatter.date(from: string)
+    }
+
     private static let encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(iso8601String(from: date))
+        }
         return encoder
     }()
 
     private static let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let value = try container.decode(String.self)
+            if let date = iso8601Date(from: value) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ISO-8601 date: \(value)"
+            )
+        }
         return decoder
     }()
 

--- a/TypeWhisper/Services/Sync/CloudFolderSyncEngine.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncEngine.swift
@@ -1,0 +1,475 @@
+import Foundation
+
+enum CloudFolderSyncProvider: String, Equatable, Sendable {
+    case iCloudDrive = "iCloud Drive"
+    case oneDrive = "OneDrive"
+    case dropbox = "Dropbox"
+    case custom = "Custom Folder"
+
+    var displayName: String {
+        switch self {
+        case .iCloudDrive:
+            String(localized: "iCloud Drive")
+        case .oneDrive:
+            String(localized: "OneDrive")
+        case .dropbox:
+            String(localized: "Dropbox")
+        case .custom:
+            String(localized: "Custom Folder")
+        }
+    }
+
+    static func detect(folderURL: URL) -> CloudFolderSyncProvider {
+        let path = folderURL.path.lowercased()
+        if path.contains("mobile documents") || path.contains("icloud drive") {
+            return .iCloudDrive
+        }
+        if path.contains("onedrive") {
+            return .oneDrive
+        }
+        if path.contains("dropbox") {
+            return .dropbox
+        }
+        return .custom
+    }
+}
+
+struct CloudFolderSyncState: Codable, Equatable, Sendable {
+    var deviceId: String
+    var knownLocalItemIDs: Set<String>
+    var exportedItemVersions: [String: String]
+    var appliedOperationIDs: Set<String>
+    var lastSyncAt: Date?
+
+    init(
+        deviceId: String = UUID().uuidString,
+        knownLocalItemIDs: Set<String> = [],
+        exportedItemVersions: [String: String] = [:],
+        appliedOperationIDs: Set<String> = [],
+        lastSyncAt: Date? = nil
+    ) {
+        self.deviceId = deviceId
+        self.knownLocalItemIDs = knownLocalItemIDs
+        self.exportedItemVersions = exportedItemVersions
+        self.appliedOperationIDs = appliedOperationIDs
+        self.lastSyncAt = lastSyncAt
+    }
+}
+
+struct CloudFolderSyncResult: Equatable, Sendable {
+    let operationsRead: Int
+    let operationsWritten: Int
+    let mutationsApplied: Int
+    let syncedAt: Date
+}
+
+struct CloudFolderSyncManifest: Codable, Equatable, Sendable {
+    let schemaVersion: Int
+    let createdBy: String
+    let updatedAt: Date
+}
+
+struct CloudFolderSyncDeviceRecord: Codable, Equatable, Sendable {
+    let deviceId: String
+    let platform: String
+    let appVersion: String
+    let updatedAt: Date
+}
+
+struct CloudFolderSyncOperation: Codable, Equatable, Sendable {
+    enum Kind: String, Codable, Sendable {
+        case upsert
+        case delete
+    }
+
+    let schemaVersion: Int
+    let operationId: String
+    let deviceId: String
+    let collection: UserDataSyncCollection
+    let itemId: String
+    let kind: Kind
+    let updatedAt: Date
+    let deletedAt: Date?
+    let dictionary: UserDataSyncDictionaryEntry?
+    let snippet: UserDataSyncSnippet?
+
+    static func upsertDictionary(
+        _ entry: UserDataSyncDictionaryEntry,
+        itemID: String,
+        deviceId: String,
+        operationId: String = UUID().uuidString
+    ) -> CloudFolderSyncOperation {
+        CloudFolderSyncOperation(
+            schemaVersion: 1,
+            operationId: operationId,
+            deviceId: deviceId,
+            collection: .dictionary,
+            itemId: itemID,
+            kind: .upsert,
+            updatedAt: entry.updatedAt,
+            deletedAt: nil,
+            dictionary: entry,
+            snippet: nil
+        )
+    }
+
+    static func upsertSnippet(
+        _ snippet: UserDataSyncSnippet,
+        itemID: String,
+        deviceId: String,
+        operationId: String = UUID().uuidString
+    ) -> CloudFolderSyncOperation {
+        CloudFolderSyncOperation(
+            schemaVersion: 1,
+            operationId: operationId,
+            deviceId: deviceId,
+            collection: .snippets,
+            itemId: itemID,
+            kind: .upsert,
+            updatedAt: snippet.updatedAt,
+            deletedAt: nil,
+            dictionary: nil,
+            snippet: snippet
+        )
+    }
+
+    static func delete(
+        collection: UserDataSyncCollection,
+        itemID: String,
+        deviceId: String,
+        deletedAt: Date,
+        operationId: String = UUID().uuidString
+    ) -> CloudFolderSyncOperation {
+        CloudFolderSyncOperation(
+            schemaVersion: 1,
+            operationId: operationId,
+            deviceId: deviceId,
+            collection: collection,
+            itemId: itemID,
+            kind: .delete,
+            updatedAt: deletedAt,
+            deletedAt: deletedAt,
+            dictionary: nil,
+            snippet: nil
+        )
+    }
+}
+
+enum CloudFolderSyncError: LocalizedError {
+    case missingStore
+    case notEntitled
+
+    var errorDescription: String? {
+        switch self {
+        case .missingStore:
+            String(localized: "TypeWhisper user data is unavailable.")
+        case .notEntitled:
+            String(localized: "Cloud Folder Sync requires an active Commercial license.")
+        }
+    }
+}
+
+enum CloudFolderSyncEngine {
+    private static let packageDirectoryName = "typewhisper-sync"
+    private static let manifestFileName = "manifest.json"
+    private static let devicesDirectoryName = "devices"
+    private static let operationsDirectoryName = "ops"
+    private static let tombstoneRetentionInterval: TimeInterval = 90 * 24 * 60 * 60
+
+    static func packageURL(for folderURL: URL) -> URL {
+        folderURL.appendingPathComponent(packageDirectoryName, isDirectory: true)
+    }
+
+    static func sync(
+        folderURL: URL,
+        store: (any UserDataSyncStore)?,
+        state: inout CloudFolderSyncState,
+        entitlements: PaidEntitlements,
+        now: Date = Date()
+    ) async throws -> CloudFolderSyncResult {
+        guard entitlements.canUseCloudFolderSync else {
+            throw CloudFolderSyncError.notEntitled
+        }
+        guard let store else {
+            throw CloudFolderSyncError.missingStore
+        }
+
+        let packageURL = packageURL(for: folderURL)
+        let operationsURL = packageURL
+            .appendingPathComponent(operationsDirectoryName, isDirectory: true)
+        let deviceOperationsURL = operationsURL
+            .appendingPathComponent(state.deviceId, isDirectory: true)
+        let devicesURL = packageURL
+            .appendingPathComponent(devicesDirectoryName, isDirectory: true)
+
+        try FileManager.default.createDirectory(at: deviceOperationsURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: devicesURL, withIntermediateDirectories: true)
+        try writePackageMetadata(packageURL: packageURL, devicesURL: devicesURL, deviceId: state.deviceId, now: now)
+
+        let initialSnapshot = await store.snapshot()
+        let initialRecords = records(from: initialSnapshot)
+        let localOperations = makeLocalOperations(records: initialRecords, state: state, now: now)
+        try write(localOperations, to: deviceOperationsURL, now: now)
+        pruneExpiredTombstones(in: deviceOperationsURL, now: now)
+
+        let operations = readOperations(from: operationsURL)
+        let winners = winningOperations(from: operations)
+        let mutations = makeMutations(
+            from: winners,
+            localRecords: initialRecords,
+            localDeviceId: state.deviceId,
+            appliedOperationIDs: state.appliedOperationIDs
+        )
+
+        if !mutations.isEmpty {
+            try await store.apply(mutations)
+        }
+
+        let finalSnapshot = await store.snapshot()
+        let finalRecords = records(from: finalSnapshot)
+        state.knownLocalItemIDs = Set(finalRecords.keys)
+        state.exportedItemVersions = finalRecords.mapValues(\.version)
+        state.appliedOperationIDs.formUnion(operations.map(\.operationId))
+        state.lastSyncAt = now
+
+        return CloudFolderSyncResult(
+            operationsRead: operations.count,
+            operationsWritten: localOperations.count,
+            mutationsApplied: mutations.count,
+            syncedAt: now
+        )
+    }
+
+    static func records(from snapshot: UserDataSyncSnapshot) -> [String: CloudFolderSyncRecord] {
+        var records: [String: CloudFolderSyncRecord] = [:]
+        for entry in snapshot.dictionaryEntries {
+            let itemID = UserDataSyncIdentity.dictionaryItemID(entryType: entry.entryType, original: entry.original)
+            records[itemID] = CloudFolderSyncRecord(
+                collection: .dictionary,
+                itemID: itemID,
+                updatedAt: entry.updatedAt,
+                version: versionString(for: entry.updatedAt),
+                dictionary: entry,
+                snippet: nil
+            )
+        }
+        for snippet in snapshot.snippets {
+            let itemID = UserDataSyncIdentity.snippetItemID(trigger: snippet.trigger)
+            records[itemID] = CloudFolderSyncRecord(
+                collection: .snippets,
+                itemID: itemID,
+                updatedAt: snippet.updatedAt,
+                version: versionString(for: snippet.updatedAt),
+                dictionary: nil,
+                snippet: snippet
+            )
+        }
+        return records
+    }
+
+    static func winningOperations(from operations: [CloudFolderSyncOperation]) -> [String: CloudFolderSyncOperation] {
+        operations.reduce(into: [:]) { result, operation in
+            guard operation.schemaVersion == 1 else { return }
+            guard operation.kind == .delete || operation.dictionary != nil || operation.snippet != nil else { return }
+            if let existing = result[operation.itemId] {
+                if prefers(operation, over: existing) {
+                    result[operation.itemId] = operation
+                }
+            } else {
+                result[operation.itemId] = operation
+            }
+        }
+    }
+
+    private static func makeLocalOperations(
+        records: [String: CloudFolderSyncRecord],
+        state: CloudFolderSyncState,
+        now: Date
+    ) -> [CloudFolderSyncOperation] {
+        var operations: [CloudFolderSyncOperation] = []
+
+        for record in records.values.sorted(by: { $0.itemID < $1.itemID }) {
+            guard state.exportedItemVersions[record.itemID] != record.version else { continue }
+            if let dictionary = record.dictionary {
+                operations.append(.upsertDictionary(dictionary, itemID: record.itemID, deviceId: state.deviceId))
+            } else if let snippet = record.snippet {
+                operations.append(.upsertSnippet(snippet, itemID: record.itemID, deviceId: state.deviceId))
+            }
+        }
+
+        let deletedItemIDs = state.knownLocalItemIDs.subtracting(records.keys)
+        for itemID in deletedItemIDs.sorted() {
+            let collection: UserDataSyncCollection = itemID.hasPrefix("snippet:") ? .snippets : .dictionary
+            operations.append(.delete(collection: collection, itemID: itemID, deviceId: state.deviceId, deletedAt: now))
+        }
+
+        return operations
+    }
+
+    private static func makeMutations(
+        from winners: [String: CloudFolderSyncOperation],
+        localRecords: [String: CloudFolderSyncRecord],
+        localDeviceId: String,
+        appliedOperationIDs: Set<String> = []
+    ) -> [UserDataSyncMutation] {
+        var mutations: [UserDataSyncMutation] = []
+
+        for operation in winners.values.sorted(by: { $0.itemId < $1.itemId }) {
+            guard !appliedOperationIDs.contains(operation.operationId) else { continue }
+            let local = localRecords[operation.itemId]
+            guard shouldApply(operation, over: local, localDeviceId: localDeviceId) else { continue }
+
+            switch (operation.kind, operation.collection) {
+            case (.delete, .dictionary):
+                mutations.append(.deleteDictionary(itemID: operation.itemId))
+            case (.delete, .snippets):
+                mutations.append(.deleteSnippet(itemID: operation.itemId))
+            case (.upsert, .dictionary):
+                if let dictionary = operation.dictionary {
+                    mutations.append(.upsertDictionary(dictionary))
+                }
+            case (.upsert, .snippets):
+                if let snippet = operation.snippet {
+                    mutations.append(.upsertSnippet(snippet))
+                }
+            }
+        }
+
+        return mutations
+    }
+
+    private static func shouldApply(
+        _ operation: CloudFolderSyncOperation,
+        over local: CloudFolderSyncRecord?,
+        localDeviceId: String
+    ) -> Bool {
+        guard let local else { return operation.kind == .upsert }
+        if operation.updatedAt > local.updatedAt {
+            return true
+        }
+        if operation.updatedAt == local.updatedAt && operation.deviceId > localDeviceId {
+            return true
+        }
+        return false
+    }
+
+    private static func prefers(_ candidate: CloudFolderSyncOperation, over existing: CloudFolderSyncOperation) -> Bool {
+        if candidate.updatedAt != existing.updatedAt {
+            return candidate.updatedAt > existing.updatedAt
+        }
+        if candidate.deviceId != existing.deviceId {
+            return candidate.deviceId > existing.deviceId
+        }
+        return candidate.operationId > existing.operationId
+    }
+
+    private static func writePackageMetadata(packageURL: URL, devicesURL: URL, deviceId: String, now: Date) throws {
+        let manifest = CloudFolderSyncManifest(
+            schemaVersion: 1,
+            createdBy: "TypeWhisper",
+            updatedAt: now
+        )
+        try writeJSON(manifest, to: packageURL.appendingPathComponent(manifestFileName))
+
+        let device = CloudFolderSyncDeviceRecord(
+            deviceId: deviceId,
+            platform: "macOS",
+            appVersion: AppConstants.currentReleaseFingerprint,
+            updatedAt: now
+        )
+        try writeJSON(device, to: devicesURL.appendingPathComponent("\(deviceId).json"))
+    }
+
+    private static func write(_ operations: [CloudFolderSyncOperation], to directory: URL, now: Date) throws {
+        for operation in operations {
+            let fileName = "\(operationTimestamp(now))-\(operation.operationId).json"
+            try writeJSON(operation, to: directory.appendingPathComponent(fileName))
+        }
+    }
+
+    private static func readOperations(from operationsURL: URL) -> [CloudFolderSyncOperation] {
+        guard let deviceDirectories = try? FileManager.default.contentsOfDirectory(
+            at: operationsURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return deviceDirectories.flatMap { deviceDirectory -> [CloudFolderSyncOperation] in
+            guard (try? deviceDirectory.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true,
+                  let files = try? FileManager.default.contentsOfDirectory(
+                    at: deviceDirectory,
+                    includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                  ) else {
+                return []
+            }
+
+            return files.compactMap { file in
+                guard file.pathExtension == "json",
+                      let data = try? Data(contentsOf: file) else { return nil }
+                return try? decoder.decode(CloudFolderSyncOperation.self, from: data)
+            }
+        }
+    }
+
+    private static func pruneExpiredTombstones(in deviceOperationsURL: URL, now: Date) {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: deviceOperationsURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for file in files where file.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: file),
+                  let operation = try? decoder.decode(CloudFolderSyncOperation.self, from: data),
+                  operation.kind == .delete,
+                  let deletedAt = operation.deletedAt,
+                  now.timeIntervalSince(deletedAt) > tombstoneRetentionInterval else {
+                continue
+            }
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    private static func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {
+        let data = try encoder.encode(value)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    private static func operationTimestamp(_ date: Date) -> String {
+        String(Int(date.timeIntervalSince1970 * 1000))
+    }
+
+    private static func versionString(for date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+}
+
+struct CloudFolderSyncRecord: Equatable, Sendable {
+    let collection: UserDataSyncCollection
+    let itemID: String
+    let updatedAt: Date
+    let version: String
+    let dictionary: UserDataSyncDictionaryEntry?
+    let snippet: UserDataSyncSnippet?
+}

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -75,8 +75,10 @@ final class CloudFolderSyncController: ObservableObject {
     }
 
     func clearFolder() {
+        scheduledSyncTask?.cancel()
         selectedFolderURL = nil
         provider = .custom
+        resetSyncState()
         removeDefault(forKey: Keys.folderBookmark, legacyKey: Keys.legacyFolderBookmark)
         pendingChanges = 0
         statusMessage = nil
@@ -116,13 +118,23 @@ final class CloudFolderSyncController: ObservableObject {
             saveState()
             lastSyncDate = result.syncedAt
             pendingChanges = 0
-            statusMessage = String(localized: "Synced \(result.operationsRead) changes.")
+            statusMessage = String.localizedStringWithFormat(
+                String(localized: "Synced %lld changes."),
+                Int64(result.operationsRead)
+            )
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
     private func setFolder(_ url: URL) {
+        if selectedFolderURL != url {
+            scheduledSyncTask?.cancel()
+            resetSyncState()
+            pendingChanges = 0
+            statusMessage = nil
+            errorMessage = nil
+        }
         selectedFolderURL = url
         provider = CloudFolderSyncProvider.detect(folderURL: url)
         do {
@@ -166,9 +178,22 @@ final class CloudFolderSyncController: ObservableObject {
         pendingChanges += 1
         scheduledSyncTask?.cancel()
         scheduledSyncTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(2))
-            await self?.syncNow()
+            do {
+                try await Task.sleep(for: .seconds(2))
+                try Task.checkCancellation()
+                await self?.syncNow()
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
         }
+    }
+
+    private func resetSyncState() {
+        state = CloudFolderSyncState()
+        lastSyncDate = nil
+        removeDefault(forKey: Keys.syncState, legacyKey: Keys.legacySyncState)
     }
 
     private func saveState() {

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -1,0 +1,343 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+@MainActor
+final class CloudFolderSyncController: ObservableObject {
+    private enum Keys {
+        static let folderBookmark = "cloudFolderSync.folderBookmark"
+        static let syncState = "cloudFolderSync.syncState"
+        static let legacyFolderBookmark = "plugin.com.typewhisper.cloud-folder-sync.folderBookmark"
+        static let legacySyncState = "plugin.com.typewhisper.cloud-folder-sync.syncState"
+    }
+
+    private let licenseService: LicenseService
+    private let syncStore: TypeWhisperUserDataSyncStore
+    private let defaults: UserDefaults
+    private var state: CloudFolderSyncState
+    private var localChangeObserverId: UUID?
+    private var scheduledSyncTask: Task<Void, Never>?
+
+    @Published private(set) var selectedFolderURL: URL?
+    @Published private(set) var provider: CloudFolderSyncProvider = .custom
+    @Published private(set) var lastSyncDate: Date?
+    @Published private(set) var pendingChanges = 0
+    @Published private(set) var isSyncing = false
+    @Published var errorMessage: String?
+    @Published var statusMessage: String?
+
+    var canUseSync: Bool {
+        licenseService.hasCommercialLicense
+    }
+
+    var selectedFolderDisplayName: String {
+        selectedFolderURL?.path(percentEncoded: false) ?? String(localized: "No folder selected")
+    }
+
+    init(
+        licenseService: LicenseService,
+        syncStore: TypeWhisperUserDataSyncStore,
+        defaults: UserDefaults = .standard
+    ) {
+        self.licenseService = licenseService
+        self.syncStore = syncStore
+        self.defaults = defaults
+        self.state = Self.loadState(from: defaults)
+        self.lastSyncDate = state.lastSyncAt
+
+        restoreSelectedFolder()
+        installLocalChangeObserver()
+    }
+
+    deinit {
+        scheduledSyncTask?.cancel()
+    }
+
+    func deactivate() {
+        scheduledSyncTask?.cancel()
+        if let localChangeObserverId {
+            syncStore.removeLocalChangeObserver(localChangeObserverId)
+            self.localChangeObserverId = nil
+        }
+    }
+
+    func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.message = String(localized: "Choose a cloud-synced folder for TypeWhisper.")
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        setFolder(url)
+        Task { await syncNow() }
+    }
+
+    func clearFolder() {
+        selectedFolderURL = nil
+        provider = .custom
+        removeDefault(forKey: Keys.folderBookmark, legacyKey: Keys.legacyFolderBookmark)
+        pendingChanges = 0
+        statusMessage = nil
+        errorMessage = nil
+    }
+
+    func syncNow() async {
+        guard let selectedFolderURL else {
+            errorMessage = String(localized: "Choose a sync folder first.")
+            return
+        }
+        guard canUseSync else {
+            errorMessage = CloudFolderSyncError.notEntitled.localizedDescription
+            return
+        }
+        guard !isSyncing else { return }
+
+        errorMessage = nil
+        isSyncing = true
+        let accessed = selectedFolderURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                selectedFolderURL.stopAccessingSecurityScopedResource()
+            }
+            isSyncing = false
+        }
+
+        do {
+            var syncState = state
+            let result = try await CloudFolderSyncEngine.sync(
+                folderURL: selectedFolderURL,
+                store: syncStore,
+                state: &syncState,
+                entitlements: PaidEntitlements(canUseCloudFolderSync: canUseSync)
+            )
+            state = syncState
+            saveState()
+            lastSyncDate = result.syncedAt
+            pendingChanges = 0
+            statusMessage = String(localized: "Synced \(result.operationsRead) changes.")
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func setFolder(_ url: URL) {
+        selectedFolderURL = url
+        provider = CloudFolderSyncProvider.detect(folderURL: url)
+        do {
+            let bookmark = try url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
+            saveDefault(bookmark, forKey: Keys.folderBookmark, legacyKey: Keys.legacyFolderBookmark)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func restoreSelectedFolder() {
+        guard let data = migratedData(forKey: Keys.folderBookmark, legacyKey: Keys.legacyFolderBookmark) else { return }
+        var isStale = false
+        do {
+            let url = try URL(
+                resolvingBookmarkData: data,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+            selectedFolderURL = url
+            provider = CloudFolderSyncProvider.detect(folderURL: url)
+            if isStale {
+                setFolder(url)
+            } else if defaults.object(forKey: Keys.folderBookmark) == nil {
+                saveDefault(data, forKey: Keys.folderBookmark, legacyKey: Keys.legacyFolderBookmark)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func installLocalChangeObserver() {
+        localChangeObserverId = syncStore.observeLocalChanges { [weak self] in
+            self?.scheduleSyncAfterLocalChange()
+        }
+    }
+
+    private func scheduleSyncAfterLocalChange() {
+        guard selectedFolderURL != nil, canUseSync else { return }
+        pendingChanges += 1
+        scheduledSyncTask?.cancel()
+        scheduledSyncTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            await self?.syncNow()
+        }
+    }
+
+    private func saveState() {
+        guard let data = try? Self.encoder.encode(state) else { return }
+        saveDefault(data, forKey: Keys.syncState, legacyKey: Keys.legacySyncState)
+    }
+
+    private func migratedData(forKey key: String, legacyKey: String) -> Data? {
+        if let data = defaults.data(forKey: key) {
+            return data
+        }
+        return defaults.data(forKey: legacyKey)
+    }
+
+    private func saveDefault(_ value: Any, forKey key: String, legacyKey: String) {
+        defaults.set(value, forKey: key)
+        defaults.removeObject(forKey: legacyKey)
+    }
+
+    private func removeDefault(forKey key: String, legacyKey: String) {
+        defaults.removeObject(forKey: key)
+        defaults.removeObject(forKey: legacyKey)
+    }
+
+    private static func loadState(from defaults: UserDefaults) -> CloudFolderSyncState {
+        let data = defaults.data(forKey: Keys.syncState) ?? defaults.data(forKey: Keys.legacySyncState)
+        guard let data,
+              let state = try? decoder.decode(CloudFolderSyncState.self, from: data) else {
+            return CloudFolderSyncState()
+        }
+        return state
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
+
+struct CloudFolderSyncSettingsView: View {
+    @ObservedObject var controller: CloudFolderSyncController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+
+            if !controller.canUseSync {
+                lockedPanel
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                statusRow(title: String(localized: "Provider"), value: controller.provider.displayName, systemImage: "cloud")
+                statusRow(title: String(localized: "Folder"), value: controller.selectedFolderDisplayName, systemImage: "folder")
+                statusRow(title: String(localized: "Last Sync"), value: lastSyncText, systemImage: "clock")
+                statusRow(title: String(localized: "Pending"), value: "\(controller.pendingChanges)", systemImage: "arrow.triangle.2.circlepath")
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    controller.chooseFolder()
+                } label: {
+                    Label(String(localized: "Choose Folder"), systemImage: "folder.badge.plus")
+                }
+
+                Button {
+                    Task { await controller.syncNow() }
+                } label: {
+                    if controller.isSyncing {
+                        Label(String(localized: "Syncing"), systemImage: "arrow.triangle.2.circlepath")
+                    } else {
+                        Label(String(localized: "Sync Now"), systemImage: "arrow.triangle.2.circlepath")
+                    }
+                }
+                .disabled(!controller.canUseSync || controller.selectedFolderURL == nil || controller.isSyncing)
+
+                Button {
+                    controller.clearFolder()
+                } label: {
+                    Label(String(localized: "Clear"), systemImage: "xmark.circle")
+                }
+                .disabled(controller.selectedFolderURL == nil)
+            }
+
+            if let status = controller.statusMessage {
+                Label(status, systemImage: "checkmark.circle")
+                    .foregroundStyle(.secondary)
+            }
+
+            if let error = controller.errorMessage {
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(.secondary.opacity(0.07)))
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "cloud")
+                .font(.title2)
+                .foregroundStyle(.blue)
+                .frame(width: 36, height: 36)
+                .background(RoundedRectangle(cornerRadius: 8).fill(.blue.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "Cloud Folder Sync"))
+                    .font(.headline)
+                Text(String(localized: "Dictionary and snippets"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var lockedPanel: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "lock.fill")
+                .foregroundStyle(.yellow)
+                .frame(width: 28, height: 28)
+                .background(RoundedRectangle(cornerRadius: 8).fill(.yellow.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(String(localized: "Commercial license required"))
+                    .font(.subheadline.weight(.semibold))
+                Text(String(localized: "Activate or buy a license to start writing sync files."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 12)
+
+            Button {
+                SettingsNavigationCoordinator.shared.navigateToLicense(target: .activationKey)
+            } label: {
+                Label(String(localized: "Open License"), systemImage: "key")
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(.yellow.opacity(0.08)))
+    }
+
+    private func statusRow(title: String, value: String, systemImage: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: systemImage)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 74, alignment: .leading)
+            Text(value)
+                .lineLimit(2)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var lastSyncText: String {
+        guard let date = controller.lastSyncDate else {
+            return String(localized: "Never")
+        }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+}

--- a/TypeWhisper/Services/Sync/TypeWhisperUserDataSyncStore.swift
+++ b/TypeWhisper/Services/Sync/TypeWhisperUserDataSyncStore.swift
@@ -1,0 +1,95 @@
+import Combine
+import Foundation
+
+@MainActor
+final class TypeWhisperUserDataSyncStore: UserDataSyncStore, @unchecked Sendable {
+    private let dictionaryService: DictionaryService
+    private let snippetService: SnippetService
+    private let defaults: UserDefaults
+    private var cancellables = Set<AnyCancellable>()
+    private var observers: [UUID: @MainActor @Sendable () -> Void] = [:]
+    private var isApplyingRemoteChanges = false
+
+    init(
+        dictionaryService: DictionaryService,
+        snippetService: SnippetService,
+        defaults: UserDefaults = .standard
+    ) {
+        self.dictionaryService = dictionaryService
+        self.snippetService = snippetService
+        self.defaults = defaults
+
+        dictionaryService.$entries
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.notifyLocalChange()
+            }
+            .store(in: &cancellables)
+
+        snippetService.$snippets
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.notifyLocalChange()
+            }
+            .store(in: &cancellables)
+    }
+
+    func snapshot() -> UserDataSyncSnapshot {
+        let excluded = managedDictionaryItemIDs()
+        return UserDataSyncSnapshot(
+            dictionaryEntries: dictionaryService.userDataSyncEntries(
+                excludingTermItemIDs: excluded.terms,
+                excludingCorrectionItemIDs: excluded.corrections
+            ),
+            snippets: snippetService.userDataSyncSnippets()
+        )
+    }
+
+    func apply(_ mutations: [UserDataSyncMutation]) throws {
+        guard !mutations.isEmpty else { return }
+        isApplyingRemoteChanges = true
+        defer { isApplyingRemoteChanges = false }
+
+        try dictionaryService.applyUserDataSyncMutations(mutations)
+        try snippetService.applyUserDataSyncMutations(mutations)
+    }
+
+    @discardableResult
+    func observeLocalChanges(_ handler: @escaping @MainActor @Sendable () -> Void) -> UUID {
+        let id = UUID()
+        observers[id] = handler
+        return id
+    }
+
+    func removeLocalChangeObserver(_ id: UUID) {
+        observers.removeValue(forKey: id)
+    }
+
+    private func notifyLocalChange() {
+        guard !isApplyingRemoteChanges else { return }
+        for handler in observers.values {
+            handler()
+        }
+    }
+
+    private func managedDictionaryItemIDs() -> (terms: Set<String>, corrections: Set<String>) {
+        guard let data = defaults.data(forKey: UserDefaultsKeys.activatedTermPackStates),
+              let states = try? JSONDecoder().decode([ActivatedTermPackState].self, from: data) else {
+            return ([], [])
+        }
+
+        var termIDs = Set<String>()
+        var correctionIDs = Set<String>()
+
+        for state in states {
+            for term in state.installedTerms {
+                termIDs.insert(UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: term))
+            }
+            for correction in state.installedCorrections {
+                correctionIDs.insert(UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.correction, original: correction.original))
+            }
+        }
+
+        return (termIDs, correctionIDs)
+    }
+}

--- a/TypeWhisper/Services/Sync/TypeWhisperUserDataSyncStore.swift
+++ b/TypeWhisper/Services/Sync/TypeWhisperUserDataSyncStore.swift
@@ -67,7 +67,8 @@ final class TypeWhisperUserDataSyncStore: UserDataSyncStore, @unchecked Sendable
 
     private func notifyLocalChange() {
         guard !isApplyingRemoteChanges else { return }
-        for handler in observers.values {
+        let handlers = Array(observers.values)
+        for handler in handlers {
             handler()
         }
     }

--- a/TypeWhisper/Services/Sync/UserDataSync.swift
+++ b/TypeWhisper/Services/Sync/UserDataSync.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct PaidEntitlements: Sendable, Equatable {
+    let canUseCloudFolderSync: Bool
+
+    init(canUseCloudFolderSync: Bool = false) {
+        self.canUseCloudFolderSync = canUseCloudFolderSync
+    }
+}
+
+enum UserDataSyncCollection: String, Codable, Sendable {
+    case dictionary
+    case snippets
+}
+
+enum UserDataSyncDictionaryEntryType: String, Codable, Sendable {
+    case term
+    case correction
+}
+
+struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
+    let entryType: UserDataSyncDictionaryEntryType
+    let original: String
+    let replacement: String?
+    let caseSensitive: Bool
+    let isEnabled: Bool
+    let createdAt: Date
+    let updatedAt: Date
+
+    init(
+        entryType: UserDataSyncDictionaryEntryType,
+        original: String,
+        replacement: String?,
+        caseSensitive: Bool,
+        isEnabled: Bool,
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.entryType = entryType
+        self.original = original
+        self.replacement = replacement
+        self.caseSensitive = caseSensitive
+        self.isEnabled = isEnabled
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+struct UserDataSyncSnippet: Codable, Equatable, Sendable {
+    let trigger: String
+    let replacement: String
+    let caseSensitive: Bool
+    let isEnabled: Bool
+    let tags: [String]
+    let createdAt: Date
+    let updatedAt: Date
+
+    init(
+        trigger: String,
+        replacement: String,
+        caseSensitive: Bool,
+        isEnabled: Bool,
+        tags: [String] = [],
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.trigger = trigger
+        self.replacement = replacement
+        self.caseSensitive = caseSensitive
+        self.isEnabled = isEnabled
+        self.tags = tags
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+struct UserDataSyncSnapshot: Codable, Equatable, Sendable {
+    let dictionaryEntries: [UserDataSyncDictionaryEntry]
+    let snippets: [UserDataSyncSnippet]
+
+    init(
+        dictionaryEntries: [UserDataSyncDictionaryEntry] = [],
+        snippets: [UserDataSyncSnippet] = []
+    ) {
+        self.dictionaryEntries = dictionaryEntries
+        self.snippets = snippets
+    }
+}
+
+enum UserDataSyncMutation: Equatable, Sendable {
+    case upsertDictionary(UserDataSyncDictionaryEntry)
+    case deleteDictionary(itemID: String)
+    case upsertSnippet(UserDataSyncSnippet)
+    case deleteSnippet(itemID: String)
+}
+
+@MainActor
+protocol UserDataSyncStore: AnyObject, Sendable {
+    func snapshot() -> UserDataSyncSnapshot
+    func apply(_ mutations: [UserDataSyncMutation]) throws
+    @discardableResult
+    func observeLocalChanges(_ handler: @escaping @MainActor @Sendable () -> Void) -> UUID
+    func removeLocalChangeObserver(_ id: UUID)
+}

--- a/TypeWhisper/Services/Sync/UserDataSyncIdentity.swift
+++ b/TypeWhisper/Services/Sync/UserDataSyncIdentity.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum UserDataSyncIdentity {
+    static func dictionaryItemID(entryType: UserDataSyncDictionaryEntryType, original: String) -> String {
+        "dictionary:\(entryType.rawValue):\(encodedKey(normalizedKey(original)))"
+    }
+
+    static func dictionaryItemID(entryType: DictionaryEntryType, original: String) -> String {
+        dictionaryItemID(entryType: UserDataSyncDictionaryEntryType(entryType), original: original)
+    }
+
+    static func snippetItemID(trigger: String) -> String {
+        "snippet:\(encodedKey(normalizedKey(trigger)))"
+    }
+
+    static func normalizedKey(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .precomposedStringWithCanonicalMapping
+    }
+
+    private static func encodedKey(_ value: String) -> String {
+        Data(value.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+extension UserDataSyncDictionaryEntryType {
+    init(_ type: DictionaryEntryType) {
+        switch type {
+        case .term:
+            self = .term
+        case .correction:
+            self = .correction
+        }
+    }
+}
+
+extension DictionaryEntryType {
+    init(_ type: UserDataSyncDictionaryEntryType) {
+        switch type {
+        case .term:
+            self = .term
+        case .correction:
+            self = .correction
+        }
+    }
+}

--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+@MainActor
+struct PremiumSettingsView: View {
+    @Environment(\.openURL) private var openURL
+
+    @ObservedObject private var license: LicenseService
+    @ObservedObject private var syncController: CloudFolderSyncController
+
+    private let settingsNavigation: SettingsNavigationCoordinator
+
+    init(
+        licenseService: LicenseService = LicenseService.shared,
+        syncController: CloudFolderSyncController = ServiceContainer.shared.cloudFolderSyncController,
+        settingsNavigation: SettingsNavigationCoordinator = .shared
+    ) {
+        self.license = licenseService
+        self.syncController = syncController
+        self.settingsNavigation = settingsNavigation
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                premiumHeader
+                if !license.hasCommercialLicense {
+                    premiumUpsell
+                } else {
+                    CloudFolderSyncSettingsView(controller: syncController)
+                }
+            }
+            .padding(22)
+            .frame(maxWidth: 760, alignment: .topLeading)
+        }
+        .frame(minWidth: 560, minHeight: 360, alignment: .topLeading)
+    }
+
+    private var premiumHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: "sparkles")
+                    .font(.title2)
+                    .foregroundStyle(.yellow)
+                    .frame(width: 40, height: 40)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(.yellow.opacity(0.14)))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(String(localized: "Premium"))
+                        .font(.title2.weight(.semibold))
+
+                    premiumStatus
+                }
+
+                Spacer(minLength: 16)
+            }
+
+            if license.isSupporter && !license.hasCommercialLicense {
+                Label(String(localized: "Supporter status is active. Premium features require a Commercial license."), systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var premiumUpsell: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "lock.open.fill")
+                .font(.title2)
+                .foregroundStyle(.yellow)
+                .frame(width: 44, height: 44)
+                .background(RoundedRectangle(cornerRadius: 8).fill(.yellow.opacity(0.14)))
+
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "Unlock Premium features"))
+                        .font(.headline)
+
+                    Text(String(localized: "Cloud Folder Sync is available with a Commercial license. Sync dictionaries and snippets through your own iCloud Drive, Dropbox, OneDrive, Syncthing, or custom folder."))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: 8) {
+                    Button {
+                        openURL(AppConstants.Website.pricingURL)
+                    } label: {
+                        Label(String(localized: "Buy Commercial License"), systemImage: "cart")
+                    }
+                    .controlSize(.large)
+                    .buttonStyle(.borderedProminent)
+
+                    Button {
+                        settingsNavigation.navigateToLicense(target: .activationKey)
+                    } label: {
+                        Label(String(localized: "Enter License Key"), systemImage: "key")
+                    }
+                    .controlSize(.large)
+                }
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(.yellow.opacity(0.08)))
+    }
+
+    @ViewBuilder
+    private var premiumStatus: some View {
+        if license.hasCommercialLicense {
+            Label(String(localized: "Commercial license active"), systemImage: "checkmark.seal.fill")
+                .font(.caption)
+                .foregroundStyle(.green)
+        } else {
+            Label(String(localized: "Commercial license required"), systemImage: "lock.fill")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -4,7 +4,7 @@ import TypeWhisperPluginSDK
 
 enum SettingsTab: Hashable {
     case home, general, recording, hotkeys, recorder
-    case dictationRecovery, fileTranscription, history, dictionary, snippets, workflows, profiles, prompts, integrations, advanced, license, about
+    case dictationRecovery, fileTranscription, history, dictionary, snippets, workflows, profiles, prompts, premium, integrations, advanced, license, about
 }
 
 private struct SettingsDestination: Identifiable, Hashable {
@@ -58,6 +58,12 @@ struct SettingsView: View {
                 tab: .workflows,
                 title: localizedAppText("Workflows", de: "Workflows"),
                 systemImage: "point.3.connected.trianglepath.dotted",
+                badge: nil
+            ),
+            SettingsDestination(
+                tab: .premium,
+                title: localizedAppText("Premium", de: "Premium"),
+                systemImage: "sparkles",
                 badge: nil
             ),
             SettingsDestination(
@@ -172,6 +178,8 @@ struct SettingsView: View {
             WorkflowsSettingsView()
         case .prompts:
             WorkflowsSettingsView()
+        case .premium:
+            PremiumSettingsView()
         case .integrations:
             PluginSettingsView()
         case .advanced:
@@ -272,7 +280,8 @@ private func settingsDestinationSections(_ destinations: [SettingsDestination]) 
         settingsDestination(destinations, .history),
         settingsDestination(destinations, .dictionary),
         settingsDestination(destinations, .snippets),
-        settingsDestination(destinations, .workflows)
+        settingsDestination(destinations, .workflows),
+        settingsDestination(destinations, .premium)
     ]
 
     workspaceDestinations.append(settingsDestination(destinations, .integrations))

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -1,0 +1,438 @@
+import XCTest
+@testable import TypeWhisper
+
+@MainActor
+private final class InMemoryUserDataSyncStore: UserDataSyncStore, @unchecked Sendable {
+    var dictionaryEntries: [UserDataSyncDictionaryEntry]
+    var snippets: [UserDataSyncSnippet]
+    var appliedMutations: [UserDataSyncMutation] = []
+    private var observers: [UUID: @MainActor @Sendable () -> Void] = [:]
+
+    init(
+        dictionaryEntries: [UserDataSyncDictionaryEntry] = [],
+        snippets: [UserDataSyncSnippet] = []
+    ) {
+        self.dictionaryEntries = dictionaryEntries
+        self.snippets = snippets
+    }
+
+    func snapshot() -> UserDataSyncSnapshot {
+        UserDataSyncSnapshot(dictionaryEntries: dictionaryEntries, snippets: snippets)
+    }
+
+    func apply(_ mutations: [UserDataSyncMutation]) throws {
+        appliedMutations.append(contentsOf: mutations)
+
+        for mutation in mutations {
+            switch mutation {
+            case .upsertDictionary(let entry):
+                let itemID = UserDataSyncIdentity.dictionaryItemID(entryType: entry.entryType, original: entry.original)
+                dictionaryEntries.removeAll {
+                    UserDataSyncIdentity.dictionaryItemID(entryType: $0.entryType, original: $0.original) == itemID
+                }
+                dictionaryEntries.append(entry)
+            case .deleteDictionary(let itemID):
+                dictionaryEntries.removeAll {
+                    UserDataSyncIdentity.dictionaryItemID(entryType: $0.entryType, original: $0.original) == itemID
+                }
+            case .upsertSnippet(let snippet):
+                let itemID = UserDataSyncIdentity.snippetItemID(trigger: snippet.trigger)
+                snippets.removeAll {
+                    UserDataSyncIdentity.snippetItemID(trigger: $0.trigger) == itemID
+                }
+                snippets.append(snippet)
+            case .deleteSnippet(let itemID):
+                snippets.removeAll {
+                    UserDataSyncIdentity.snippetItemID(trigger: $0.trigger) == itemID
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    func observeLocalChanges(_ handler: @escaping @MainActor @Sendable () -> Void) -> UUID {
+        let id = UUID()
+        observers[id] = handler
+        return id
+    }
+
+    func removeLocalChangeObserver(_ id: UUID) {
+        observers.removeValue(forKey: id)
+    }
+}
+
+final class CloudFolderSyncTests: XCTestCase {
+    @MainActor
+    func testDeterministicItemIDsUseNaturalKeys() {
+        XCTAssertEqual(
+            UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: " TypeWhisper "),
+            UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: "typewhisper")
+        )
+        XCTAssertEqual(
+            UserDataSyncIdentity.snippetItemID(trigger: "Résumé"),
+            UserDataSyncIdentity.snippetItemID(trigger: "resume")
+        )
+        XCTAssertNotEqual(
+            UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: "same"),
+            UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.correction, original: "same")
+        )
+    }
+
+    @MainActor
+    func testProviderDetectionFromFolderPath() {
+        XCTAssertEqual(
+            CloudFolderSyncProvider.detect(folderURL: URL(fileURLWithPath: "/Users/marco/Library/Mobile Documents/com~apple~CloudDocs")),
+            .iCloudDrive
+        )
+        XCTAssertEqual(
+            CloudFolderSyncProvider.detect(folderURL: URL(fileURLWithPath: "/Users/marco/OneDrive - Example")),
+            .oneDrive
+        )
+        XCTAssertEqual(
+            CloudFolderSyncProvider.detect(folderURL: URL(fileURLWithPath: "/Users/marco/Dropbox/TypeWhisper")),
+            .dropbox
+        )
+        XCTAssertEqual(
+            CloudFolderSyncProvider.detect(folderURL: URL(fileURLWithPath: "/Volumes/Sync")),
+            .custom
+        )
+    }
+
+    @MainActor
+    func testSnippetPlaceholderCompatibilityKeepsBothDialects() {
+        let currentYear = Calendar.current.component(.year, from: Date()).description
+        let snippet = Snippet(
+            trigger: ";date",
+            replacement: "{{DATE:yyyy}}|{date:yyyy}|{year}|{day}"
+        )
+
+        let output = snippet.processedReplacement()
+        let parts = output.split(separator: "|").map(String.init)
+
+        XCTAssertEqual(parts[0], currentYear)
+        XCTAssertEqual(parts[1], currentYear)
+        XCTAssertEqual(parts[2], currentYear)
+        XCTAssertFalse(output.contains("{{DATE"))
+        XCTAssertFalse(output.contains("{date"))
+        XCTAssertFalse(output.contains("{day}"))
+    }
+
+    @MainActor
+    func testUnpaidSyncDoesNotCreateFiles() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncUnpaid")
+        defer { TestSupport.remove(folder) }
+
+        let store = InMemoryUserDataSyncStore(dictionaryEntries: [
+            Self.dictionaryEntry(original: "TypeWhisper", updatedAt: Self.date(10))
+        ])
+        var state = CloudFolderSyncState(deviceId: "mac-a")
+
+        do {
+            _ = try await CloudFolderSyncEngine.sync(
+                folderURL: folder,
+                store: store,
+                state: &state,
+                entitlements: PaidEntitlements(canUseCloudFolderSync: false),
+                now: Self.date(20)
+            )
+            XCTFail("Expected unpaid sync to throw")
+        } catch CloudFolderSyncError.notEntitled {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: CloudFolderSyncEngine.packageURL(for: folder).path))
+        }
+    }
+
+    @MainActor
+    func testTwoSimulatedDevicesShareAppendOnlyOperations() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncTwoDevices")
+        defer { TestSupport.remove(folder) }
+
+        let firstEntry = Self.dictionaryEntry(original: "TypeWhisper", updatedAt: Self.date(10))
+        let deviceAStore = InMemoryUserDataSyncStore(dictionaryEntries: [firstEntry])
+        let deviceBStore = InMemoryUserDataSyncStore()
+        var deviceAState = CloudFolderSyncState(deviceId: "mac-a")
+        var deviceBState = CloudFolderSyncState(deviceId: "mac-b")
+
+        let firstResult = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceAStore,
+            state: &deviceAState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(20)
+        )
+        let secondResult = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceBStore,
+            state: &deviceBState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(30)
+        )
+
+        XCTAssertEqual(firstResult.operationsWritten, 1)
+        XCTAssertEqual(secondResult.mutationsApplied, 1)
+        XCTAssertEqual(deviceBStore.dictionaryEntries.map(\.original), ["TypeWhisper"])
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: CloudFolderSyncEngine.packageURL(for: folder)
+                    .appendingPathComponent("ops/mac-a", isDirectory: true)
+                    .path
+            )
+        )
+    }
+
+    @MainActor
+    func testDeleteTombstoneWinsOverOlderLocalItem() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncDelete")
+        defer { TestSupport.remove(folder) }
+
+        let snippet = Self.snippet(trigger: ";sig", replacement: "Regards", updatedAt: Self.date(10))
+        let deviceAStore = InMemoryUserDataSyncStore(snippets: [snippet])
+        var deviceAState = CloudFolderSyncState(deviceId: "mac-a")
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceAStore,
+            state: &deviceAState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(20)
+        )
+
+        deviceAStore.snippets = []
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceAStore,
+            state: &deviceAState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(30)
+        )
+
+        let deviceBStore = InMemoryUserDataSyncStore(snippets: [snippet])
+        var deviceBState = CloudFolderSyncState(deviceId: "mac-b")
+        let result = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceBStore,
+            state: &deviceBState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(40)
+        )
+
+        XCTAssertEqual(result.mutationsApplied, 1)
+        XCTAssertTrue(deviceBStore.snippets.isEmpty)
+    }
+
+    @MainActor
+    func testAlreadyAppliedRemoteOperationIsNotAppliedAgain() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncApplied")
+        defer { TestSupport.remove(folder) }
+
+        let entry = Self.dictionaryEntry(original: "TypeWhisper", updatedAt: Self.date(10))
+        let deviceAStore = InMemoryUserDataSyncStore(dictionaryEntries: [entry])
+        let deviceBStore = InMemoryUserDataSyncStore()
+        var deviceAState = CloudFolderSyncState(deviceId: "mac-z")
+        var deviceBState = CloudFolderSyncState(deviceId: "mac-b")
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceAStore,
+            state: &deviceAState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(20)
+        )
+
+        let firstResult = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceBStore,
+            state: &deviceBState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(30)
+        )
+        let secondResult = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceBStore,
+            state: &deviceBState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(40)
+        )
+
+        XCTAssertEqual(firstResult.mutationsApplied, 1)
+        XCTAssertEqual(secondResult.mutationsApplied, 0)
+        XCTAssertEqual(deviceBStore.appliedMutations.count, 1)
+    }
+
+    @MainActor
+    func testExpiredLocalTombstonesArePrunedAfterRetentionWindow() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncTombstoneRetention")
+        defer { TestSupport.remove(folder) }
+
+        let itemID = UserDataSyncIdentity.snippetItemID(trigger: ";sig")
+        let store = InMemoryUserDataSyncStore()
+        var state = CloudFolderSyncState(deviceId: "mac-a", knownLocalItemIDs: [itemID])
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: store,
+            state: &state,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(10)
+        )
+        XCTAssertEqual(Self.operationFiles(folder: folder, deviceId: "mac-a").count, 1)
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: store,
+            state: &state,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(10 + 91 * 24 * 60 * 60)
+        )
+
+        XCTAssertTrue(Self.operationFiles(folder: folder, deviceId: "mac-a").isEmpty)
+    }
+
+    @MainActor
+    func testConflictTieBreakerUsesUpdatedAtThenDeviceId() {
+        let older = CloudFolderSyncOperation.upsertDictionary(
+            Self.dictionaryEntry(original: "TypeWhisper", updatedAt: Self.date(10)),
+            itemID: UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: "TypeWhisper"),
+            deviceId: "mac-z",
+            operationId: "older"
+        )
+        let newer = CloudFolderSyncOperation.upsertDictionary(
+            Self.dictionaryEntry(original: "TypeWhisper", updatedAt: Self.date(20)),
+            itemID: UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: "TypeWhisper"),
+            deviceId: "mac-a",
+            operationId: "newer"
+        )
+        let sameTimeHigherDevice = CloudFolderSyncOperation.upsertDictionary(
+            Self.dictionaryEntry(original: "TypeWhisper", updatedAt: Self.date(20)),
+            itemID: UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: "TypeWhisper"),
+            deviceId: "mac-z",
+            operationId: "tie"
+        )
+
+        let winner = CloudFolderSyncEngine.winningOperations(from: [older, newer, sameTimeHigherDevice]).values.first
+        XCTAssertEqual(winner?.operationId, "tie")
+    }
+
+    @MainActor
+    func testHostStoreExcludesManagedEntriesAndPreservesUserAuthoredData() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncHostStore")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let suiteName = "CloudFolderSyncHostStore-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        dictionaryService.addEntry(type: .term, original: "ManualTerm")
+        dictionaryService.addEntry(type: .term, original: "ManagedTerm")
+        dictionaryService.addEntry(type: .correction, original: "filler", replacement: "")
+        snippetService.addSnippet(trigger: ";sig", replacement: "{date:yyyy}")
+        _ = dictionaryService.applyCorrections(to: "filler")
+        _ = snippetService.applySnippets(to: ";sig")
+
+        let state = ActivatedTermPackState(
+            packID: "managed-pack",
+            source: "test",
+            installedVersion: "1",
+            installedTerms: ["ManagedTerm"],
+            installedCorrections: [],
+            requiresCommercialLicense: false
+        )
+        defaults.set(try JSONEncoder().encode([state]), forKey: UserDefaultsKeys.activatedTermPackStates)
+
+        let store = TypeWhisperUserDataSyncStore(
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            defaults: defaults
+        )
+        let snapshot = store.snapshot()
+
+        XCTAssertEqual(snapshot.dictionaryEntries.filter { $0.original == "ManualTerm" }.count, 1)
+        XCTAssertFalse(snapshot.dictionaryEntries.contains { $0.original == "ManagedTerm" })
+        XCTAssertEqual(snapshot.dictionaryEntries.first { $0.original == "filler" }?.replacement, "")
+        XCTAssertEqual(snapshot.snippets.first?.replacement, "{date:yyyy}")
+    }
+
+    @MainActor
+    func testHostApplyMergesDuplicateNaturalKeys() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncMerge")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        snippetService.addSnippet(trigger: ";sig", replacement: "Old")
+
+        let store = TypeWhisperUserDataSyncStore(
+            dictionaryService: dictionaryService,
+            snippetService: snippetService
+        )
+
+        try store.apply([
+            .upsertDictionary(Self.dictionaryEntry(original: " typewhisper ", updatedAt: Self.date(30))),
+            .upsertSnippet(Self.snippet(trigger: ";SIG", replacement: "New", updatedAt: Self.date(30)))
+        ])
+
+        let dictionaryMatches = dictionaryService.entries.filter {
+            UserDataSyncIdentity.dictionaryItemID(entryType: $0.type, original: $0.original)
+                == UserDataSyncIdentity.dictionaryItemID(entryType: UserDataSyncDictionaryEntryType.term, original: "typewhisper")
+        }
+        let snippetMatches = snippetService.snippets.filter {
+            UserDataSyncIdentity.snippetItemID(trigger: $0.trigger)
+                == UserDataSyncIdentity.snippetItemID(trigger: ";sig")
+        }
+
+        XCTAssertEqual(dictionaryMatches.count, 1)
+        XCTAssertEqual(dictionaryMatches.first?.original, " typewhisper ")
+        XCTAssertEqual(snippetMatches.count, 1)
+        XCTAssertEqual(snippetMatches.first?.replacement, "New")
+    }
+
+    private static func dictionaryEntry(
+        entryType: UserDataSyncDictionaryEntryType = .term,
+        original: String,
+        replacement: String? = nil,
+        updatedAt: Date
+    ) -> UserDataSyncDictionaryEntry {
+        UserDataSyncDictionaryEntry(
+            entryType: entryType,
+            original: original,
+            replacement: replacement,
+            caseSensitive: false,
+            isEnabled: true,
+            createdAt: date(1),
+            updatedAt: updatedAt
+        )
+    }
+
+    private static func snippet(
+        trigger: String,
+        replacement: String,
+        updatedAt: Date
+    ) -> UserDataSyncSnippet {
+        UserDataSyncSnippet(
+            trigger: trigger,
+            replacement: replacement,
+            caseSensitive: false,
+            isEnabled: true,
+            createdAt: date(1),
+            updatedAt: updatedAt
+        )
+    }
+
+    private static func date(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: 1_700_000_000 + seconds)
+    }
+
+    private static func operationFiles(folder: URL, deviceId: String) -> [URL] {
+        let directory = CloudFolderSyncEngine.packageURL(for: folder)
+            .appendingPathComponent("ops", isDirectory: true)
+            .appendingPathComponent(deviceId, isDirectory: true)
+
+        return (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+    }
+}

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -2,6 +2,9 @@ import XCTest
 @testable import TypeWhisper
 
 @MainActor
+// @unchecked Sendable is safe here because @MainActor serializes all access in tests,
+// so there are no concurrent cross-thread mutations. Revisit this if the store
+// gains nonisolated mutable state or loses MainActor isolation.
 private final class InMemoryUserDataSyncStore: UserDataSyncStore, @unchecked Sendable {
     var dictionaryEntries: [UserDataSyncDictionaryEntry]
     var snippets: [UserDataSyncSnippet]
@@ -139,6 +142,80 @@ final class CloudFolderSyncTests: XCTestCase {
         } catch CloudFolderSyncError.notEntitled {
             XCTAssertFalse(FileManager.default.fileExists(atPath: CloudFolderSyncEngine.packageURL(for: folder).path))
         }
+    }
+
+    @MainActor
+    func testExportCollapsesDuplicateNaturalKeysToNewestRecord() {
+        let older = Self.snippet(trigger: ";SIG", replacement: "Old", updatedAt: Self.date(10))
+        let newer = Self.snippet(trigger: ";sig", replacement: "New", updatedAt: Self.date(20))
+
+        let records = CloudFolderSyncEngine.records(
+            from: UserDataSyncSnapshot(snippets: [older, newer])
+        )
+
+        let itemID = UserDataSyncIdentity.snippetItemID(trigger: ";sig")
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[itemID]?.snippet?.replacement, "New")
+    }
+
+    @MainActor
+    func testOperationEncodingPreservesFractionalSeconds() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncFractional")
+        defer { TestSupport.remove(folder) }
+
+        let updatedAt = Date(timeIntervalSince1970: 1_700_000_010.456)
+        let deviceAStore = InMemoryUserDataSyncStore(dictionaryEntries: [
+            Self.dictionaryEntry(original: "TypeWhisper", updatedAt: updatedAt)
+        ])
+        let deviceBStore = InMemoryUserDataSyncStore()
+        var deviceAState = CloudFolderSyncState(deviceId: "mac-a")
+        var deviceBState = CloudFolderSyncState(deviceId: "mac-b")
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceAStore,
+            state: &deviceAState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(20)
+        )
+        let operationFile = try XCTUnwrap(Self.operationFiles(folder: folder, deviceId: "mac-a").first)
+        let operationJSON = try String(contentsOf: operationFile, encoding: .utf8)
+        XCTAssertTrue(operationJSON.contains(".456"))
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: deviceBStore,
+            state: &deviceBState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(30)
+        )
+
+        let syncedUpdatedAt = try XCTUnwrap(deviceBStore.dictionaryEntries.first?.updatedAt)
+        XCTAssertEqual(syncedUpdatedAt.timeIntervalSince1970, updatedAt.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testMalformedOperationFileIsSkipped() async throws {
+        let folder = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncMalformed")
+        defer { TestSupport.remove(folder) }
+
+        let remoteDirectory = CloudFolderSyncEngine.packageURL(for: folder)
+            .appendingPathComponent("ops/remote-device", isDirectory: true)
+        try FileManager.default.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(to: remoteDirectory.appendingPathComponent("bad.json"))
+
+        let store = InMemoryUserDataSyncStore()
+        var state = CloudFolderSyncState(deviceId: "mac-a")
+
+        let result = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: store,
+            state: &state,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(20)
+        )
+
+        XCTAssertEqual(result.mutationsApplied, 0)
     }
 
     @MainActor
@@ -310,6 +387,39 @@ final class CloudFolderSyncTests: XCTestCase {
 
         let winner = CloudFolderSyncEngine.winningOperations(from: [older, newer, sameTimeHigherDevice]).values.first
         XCTAssertEqual(winner?.operationId, "tie")
+    }
+
+    @MainActor
+    func testHostStoreSnapshotsObserversBeforeNotifying() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncObservers")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        let store = TypeWhisperUserDataSyncStore(
+            dictionaryService: dictionaryService,
+            snippetService: snippetService
+        )
+
+        var firstObserverID: UUID?
+        var firstCalls = 0
+        var secondCalls = 0
+
+        firstObserverID = store.observeLocalChanges {
+            firstCalls += 1
+            if let firstObserverID {
+                store.removeLocalChangeObserver(firstObserverID)
+            }
+        }
+        store.observeLocalChanges {
+            secondCalls += 1
+        }
+
+        dictionaryService.addEntry(type: .term, original: "First")
+        dictionaryService.addEntry(type: .term, original: "Second")
+
+        XCTAssertEqual(firstCalls, 1)
+        XCTAssertEqual(secondCalls, 2)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- Add a first-party Premium settings surface for Cloud Folder Sync, gated by active Commercial licenses only.
- Add provider-neutral folder sync for user-authored dictionary entries and snippets using per-device append-only operation files, deterministic natural-key item IDs, last-write-wins conflict handling, tombstones, already-applied operation tracking, and 90-day local tombstone pruning.
- Add host export/apply plumbing for dictionary and snippet sync, excluding managed term-pack entries, ignoring usage counts, preserving empty correction replacements, and keeping Mac/iOS plus Windows snippet placeholder dialects as-entered.
- Add German localization for the new Premium upsell and Cloud Folder Sync settings strings.

## Test plan

- [x] `plutil -lint TypeWhisper.xcodeproj/project.pbxproj`
- [x] `jq empty TypeWhisper/Resources/Localizable.xcstrings`
- [x] `git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Passed before the final German-localization and review-fix changes: 823 tests, 0 failures.
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/CloudFolderSyncTests -only-testing:TypeWhisperTests/DictionaryServiceTests -only-testing:TypeWhisperTests/SnippetServiceTests -quiet`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/40f2/typewhisper-mac`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/.codex/worktrees/40f2/typewhisper-mac`

## Local runner note

After the final localization/review-fix changes, the relevant focused tests and dev build passed. A subsequent full-suite rerun in this local session became unusable because the app testhost repeatedly hung in existing non-sync tests (`APIRouterAndHandlersTests/testAPIHandlersExposeStatusHistoryAndRules`, then `AudioRecorderViewModelTests/testDefaultEngineModelOverrideClearsWhenGlobalProviderChanges`). Those runs were interrupted and are not counted as failures for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud folder sync (iCloud/OneDrive/Dropbox) with UI to choose folder, run sync, and view status.
  * Premium settings tab exposing sync configuration and upsell/activation flows.

* **Behavior Changes**
  * Snippet placeholders now use single-brace forms: {date}, {time}, {datetime}, {day}, {year}, {clipboard}.
  * Entries and snippets record updated timestamps for accurate sync/ordering.

* **Tests**
  * Added comprehensive cloud sync test coverage.

* **Localization**
  * German translations for sync and premium screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->