### PR TITLE
Add English ordinal number normalization

### DIFF
--- a/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
@@ -21,6 +21,26 @@ enum EnglishNumberWordParser {
         "million": 1_000_000,
     ]
 
+    // Unit ordinals 1–9. Used only as the tail of a compound such as
+    // "twenty" + "eighth" -> 28th, where the numeric context is unambiguous.
+    private static let ordinalUnitValues: [String: Int] = [
+        "first": 1, "second": 2, "third": 3, "fourth": 4, "fifth": 5,
+        "sixth": 6, "seventh": 7, "eighth": 8, "ninth": 9,
+    ]
+
+    // Ordinals safe to convert on their own. Bare "first" / "second" / "third"
+    // are deliberately excluded — in dictation they are too often non-numeric
+    // ("first, let's...", "wait a second"). They still convert inside a
+    // compound ("twenty first" -> 21st), just not standalone.
+    private static let standaloneOrdinalValues: [String: Int] = [
+        "fourth": 4, "fifth": 5, "sixth": 6, "seventh": 7, "eighth": 8, "ninth": 9,
+        "tenth": 10, "eleventh": 11, "twelfth": 12, "thirteenth": 13, "fourteenth": 14,
+        "fifteenth": 15, "sixteenth": 16, "seventeenth": 17, "eighteenth": 18, "nineteenth": 19,
+        "twentieth": 20, "thirtieth": 30, "fortieth": 40, "fiftieth": 50,
+        "sixtieth": 60, "seventieth": 70, "eightieth": 80, "ninetieth": 90,
+        "hundredth": 100, "thousandth": 1_000,
+    ]
+
     static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
         guard !words.isEmpty else { return nil }
         let normalizedWords = words.map(normalizeWord)
@@ -33,23 +53,64 @@ enum EnglishNumberWordParser {
             guard index < normalizedWords.count else { return nil }
         }
 
-        guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
-        index = integer.nextIndex
-        var replacement = "\(integer.value)"
+        if let integer = parseInteger(normalizedWords, startingAt: index) {
+            index = integer.nextIndex
 
-        if index < normalizedWords.count, normalizedWords[index] == "point" {
-            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
-            if !decimal.digits.isEmpty {
-                replacement += ".\(decimal.digits)"
-                index = decimal.nextIndex
+            // "twenty" + "eighth" -> 28th, "thirty" + "first" -> 31st.
+            if integer.value > 0, integer.value % 10 == 0,
+               index < normalizedWords.count,
+               let unit = ordinalUnitValues[normalizedWords[index]] {
+                index += 1
+                return makeResult(integer.value + unit, ordinal: true, isNegative: isNegative, consumedWords: index)
             }
+
+            var replacement = "\(integer.value)"
+
+            if index < normalizedWords.count, normalizedWords[index] == "point" {
+                let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+                if !decimal.digits.isEmpty {
+                    replacement += ".\(decimal.digits)"
+                    index = decimal.nextIndex
+                }
+            }
+
+            if isNegative {
+                replacement = "-" + replacement
+            }
+
+            return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
         }
 
+        // Standalone ordinal word ("eighth", "twelfth", "twentieth", ...),
+        // excluding the ambiguous bare "first" / "second" / "third".
+        if let ordinal = standaloneOrdinalValues[normalizedWords[index]] {
+            index += 1
+            return makeResult(ordinal, ordinal: true, isNegative: isNegative, consumedWords: index)
+        }
+
+        return nil
+    }
+
+    private static func makeResult(_ value: Int, ordinal: Bool, isNegative: Bool, consumedWords: Int) -> NumberWordNormalizer.ParsedWords {
+        var replacement = "\(value)"
+        if ordinal {
+            replacement += ordinalSuffix(value)
+        }
         if isNegative {
             replacement = "-" + replacement
         }
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: consumedWords)
+    }
 
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    private static func ordinalSuffix(_ value: Int) -> String {
+        let magnitude = abs(value)
+        if (11...13).contains(magnitude % 100) { return "th" }
+        switch magnitude % 10 {
+        case 1: return "st"
+        case 2: return "nd"
+        case 3: return "rd"
+        default: return "th"
+        }
     }
 
     private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -60,6 +60,9 @@ final class NumberWordNormalizerTests: XCTestCase {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "thirty first", language: "en"), "31st")
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "forty second", language: "en"), "42nd")
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty third", language: "en"), "23rd")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty-third", language: "en"), "23rd")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "one hundred first", language: "en"), "101st")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "one hundred twenty first", language: "en"), "121st")
     }
 
     func testEnglishStandaloneOrdinalNormalizesToDigits() {

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -55,6 +55,55 @@ final class NumberWordNormalizerTests: XCTestCase {
         )
     }
 
+    func testEnglishCompoundOrdinalNormalizesToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty eighth", language: "en"), "28th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "thirty first", language: "en"), "31st")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "forty second", language: "en"), "42nd")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty third", language: "en"), "23rd")
+    }
+
+    func testEnglishStandaloneOrdinalNormalizesToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "eighth", language: "en"), "8th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twelfth", language: "en"), "12th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twentieth", language: "en"), "20th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "thirtieth", language: "en"), "30th")
+    }
+
+    func testEnglishOrdinalSuffixSelection() {
+        // st/nd/rd come from compounds; the th-exception (11–13) from teen ordinals.
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty first", language: "en"), "21st")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty second", language: "en"), "22nd")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty third", language: "en"), "23rd")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "fourth", language: "en"), "4th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "eleventh", language: "en"), "11th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twelfth", language: "en"), "12th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "thirteenth", language: "en"), "13th")
+    }
+
+    func testEnglishBareFirstSecondThirdAreLeftUnchanged() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "first", language: "en"), "first")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "second", language: "en"), "second")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "third", language: "en"), "third")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "first, let's start", language: "en"), "first, let's start")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "wait a second", language: "en"), "wait a second")
+    }
+
+    func testEnglishOrdinalWithinSentenceNormalizesToDigits() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "the thirty first of May", language: "en"),
+            "the 31st of May"
+        )
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "every twenty fourth hour", language: "en"),
+            "every 24th hour"
+        )
+    }
+
+    func testEnglishOrdinalDigitOutputIsIdempotent() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "28th", language: "en"), "28th")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "the 31st of May", language: "en"), "the 31st of May")
+    }
+
     func testGermanNegativeDecimalNormalizesToDigits() {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus zwei komma fünf", language: "de"), "-2,5")
     }


### PR DESCRIPTION
## Summary

Adds English ordinal number normalization to `EnglishNumberWordParser`, implementing the clear-context policy agreed in #599.

Spoken ordinals → digit + suffix:
- **Compounds:** "twenty eighth" → `28th`, "thirty first" → `31st`, "forty second" → `42nd`
- **Unambiguous standalone:** "eighth" → `8th`, "twelfth" → `12th`, "twentieth" → `20th`, "eleventh" → `11th`
- Suffix selection handles the 11–13 exception ("eleventh" → `11th`, not `11st`)
- **Bare `first` / `second` / `third` are intentionally left unchanged** to avoid dictation false positives ("first, let's…", "wait a second"). They still convert inside a compound ("twenty first" → `21st`).
- Output is **idempotent** (`28th` and already-formatted text pass through unchanged), so it's safe under the double-application in dictation post-processing.

Implementation extends the existing cardinal path and rides the existing `transcriptionNumberNormalizationEnabled` flag — no new pipeline wiring. Scope is English-only; date-specific formatting and digit sequences remain separate follow-ups per #599.

Addresses the ordinal slice of #599.

## Test Plan

- [x] Added unit tests in `NumberWordNormalizerTests.swift`: compounds, unambiguous standalone, suffix-exception (11/12/13th), in-sentence placement, idempotency, and bare `first`/`second`/`third` left unchanged.
- [x] Verified the parser in isolation by compiling the real `NumberNormalization` sources with the Swift CLI — 30/30 assertions green, no warnings.
- [x] No regressions to existing cardinal normalization (cardinal cases re-verified; existing tests unchanged).
- [ ] Full `xcodebuild test -only-testing:TypeWhisperTests/NumberWordNormalizerTests` — no local Xcode available, relying on CI for the hosted run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * English ordinal word conversion: converts compound and standalone ordinals (e.g., "twenty eighth", "eighth") to numeric ordinals ("28th", "8th").
  * Correct ordinal suffix rules with st/nd/rd/th handling, including 11–13 → "th" teen exception.
  * Ordinals normalized when appearing within running text.

* **Tests**
  * Expanded test coverage verifying conversions, suffix selection, idempotence, and in-text normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->