### PR TITLE
Apply Dictionary Corrections to API and CLI transcriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Optional parameters:
 - `language_hint` - Repeatable, ordered language hint for restricted auto-detection. Hint-aware engines receive the full list; other engines use the first hint as the requested language. Do not combine with `language`.
 - `task` - `transcribe` (default) or `translate` (translates to English, WhisperKit only).
 - `target_language` - ISO 639-1 code for translation target language (e.g., `es`, `fr`). Uses Apple Translate.
+- `apply_corrections` - Boolean, default `true`. Set to `false` to return raw transcription text without Dictionary Corrections. For raw body uploads, send `x-apply-corrections: false`.
 
 Uploads to `/v1/transcribe` are limited to 256 MiB, including stdin uploads from the CLI. Requests above that size return `413 Payload Too Large`. Local CLI file paths use a direct handoff to the running TypeWhisper app instead of uploading the file bytes.
 
@@ -458,6 +459,7 @@ typewhisper transcribe file.wav # Transcribe an audio file
 | `--language-hint <code>` | Repeatable, ordered language hint for restricted auto-detection; engines without hint support use the first hint |
 | `--task <task>` | `transcribe` (default) or `translate` |
 | `--translate-to <code>` | Target language for translation |
+| `--no-corrections` | Return raw transcription text without Dictionary Corrections |
 
 ### Examples
 
@@ -476,6 +478,8 @@ typewhisper transcribe meeting.m4a --json | jq -r '.text'
 ```
 
 The CLI requires the API server to be running (Settings > Advanced) and follows the documented command and flag surface for the current stable release.
+
+Dictionary Corrections apply to CLI transcriptions by default. Use `--no-corrections` when a script needs the raw engine output.
 
 Local file paths are handed to the running TypeWhisper app directly, so large files do not need to fit inside an HTTP upload body. Stdin usage (`typewhisper transcribe -`) still uses the regular `/v1/transcribe` upload endpoint and is limited to 256 MiB.
 

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -73,6 +73,7 @@ final class APIHandlers: @unchecked Sendable {
         var modelOverride: String? = nil
         var awaitDownload = false
         var normalizeNumbers: Bool? = nil
+        var applyCorrections = true
     }
 
     private struct LocalFileTranscribeRequest: Decodable {
@@ -86,6 +87,7 @@ final class APIHandlers: @unchecked Sendable {
         let engine: String?
         let model: String?
         let normalizeNumbers: Bool?
+        let applyCorrections: Bool?
 
         enum CodingKeys: String, CodingKey {
             case path
@@ -98,6 +100,7 @@ final class APIHandlers: @unchecked Sendable {
             case engine
             case model
             case normalizeNumbers = "normalize_numbers"
+            case applyCorrections = "apply_corrections"
         }
     }
 
@@ -179,6 +182,15 @@ final class APIHandlers: @unchecked Sendable {
                 }
                 options.normalizeNumbers = parsed
             }
+
+            if let correctionsPart = parts.first(where: { $0.name == "apply_corrections" }),
+               let val = String(data: correctionsPart.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !val.isEmpty {
+                guard let parsed = Self.parseBoolean(val) else {
+                    return .error(status: 400, message: "Invalid 'apply_corrections' value")
+                }
+                options.applyCorrections = parsed
+            }
         } else if !request.body.isEmpty {
             audioData = request.body
             fileExtension = extensionFromMIME(contentType)
@@ -213,6 +225,13 @@ final class APIHandlers: @unchecked Sendable {
                 }
                 options.normalizeNumbers = parsed
             }
+            if let applyCorrections = request.headers["x-apply-corrections"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !applyCorrections.isEmpty {
+                guard let parsed = Self.parseBoolean(applyCorrections) else {
+                    return .error(status: 400, message: "Invalid 'x-apply-corrections' value")
+                }
+                options.applyCorrections = parsed
+            }
         } else {
             return .error(status: 400, message: "No audio data provided")
         }
@@ -242,6 +261,9 @@ final class APIHandlers: @unchecked Sendable {
         do {
             payload = try JSONDecoder().decode(LocalFileTranscribeRequest.self, from: request.body)
         } catch {
+            if Self.hasInvalidJSONBooleanField("apply_corrections", in: request.body) {
+                return .error(status: 400, message: "Invalid 'apply_corrections' value")
+            }
             return .error(status: 400, message: "Invalid JSON body")
         }
 
@@ -268,6 +290,7 @@ final class APIHandlers: @unchecked Sendable {
         options.engineOverride = payload.engine?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         options.modelOverride = payload.model?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         options.normalizeNumbers = payload.normalizeNumbers
+        options.applyCorrections = payload.applyCorrections ?? true
 
         do {
             let samples = try await audioFileService.loadAudioSamples(from: fileURL)
@@ -365,6 +388,12 @@ final class APIHandlers: @unchecked Sendable {
                 #else
                 return .error(status: 501, message: "Translation requires macOS 15 or later")
                 #endif
+            }
+
+            if options.applyCorrections {
+                finalText = await MainActor.run {
+                    dictionaryService.applyCorrections(to: finalText)
+                }
             }
 
             let modelId = await resolveResponseModelId(
@@ -566,6 +595,15 @@ final class APIHandlers: @unchecked Sendable {
         default:
             nil
         }
+    }
+
+    private static func hasInvalidJSONBooleanField(_ field: String, in body: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let value = object[field] else {
+            return false
+        }
+
+        return !(value is Bool) && !(value is NSNull)
     }
 
     // MARK: - GET /v1/status

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1337,10 +1337,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
         MockTranscriptionPlugin.reset()
         defer { MockTranscriptionPlugin.reset() }
         MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
-        let apiContext = await MainActor.run {
+        context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
         }
-        context = apiContext
+        let apiContext = try XCTUnwrap(context)
         try await MainActor.run {
             try apiContext.dictionaryService.upsertAPICorrection(
                 original: "teh",
@@ -1377,10 +1377,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
         MockTranscriptionPlugin.reset()
         defer { MockTranscriptionPlugin.reset() }
         MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
-        let apiContext = await MainActor.run {
+        context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
         }
-        context = apiContext
+        let apiContext = try XCTUnwrap(context)
         try await MainActor.run {
             try apiContext.dictionaryService.upsertAPICorrection(
                 original: "teh",
@@ -1791,10 +1791,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
         MockTranscriptionPlugin.reset()
         defer { MockTranscriptionPlugin.reset() }
         MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
-        let apiContext = await MainActor.run {
+        context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
         }
-        context = apiContext
+        let apiContext = try XCTUnwrap(context)
         try await MainActor.run {
             try apiContext.dictionaryService.upsertAPICorrection(
                 original: "teh",
@@ -1836,10 +1836,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
         MockTranscriptionPlugin.reset()
         defer { MockTranscriptionPlugin.reset() }
         MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
-        let apiContext = await MainActor.run {
+        context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
         }
-        context = apiContext
+        let apiContext = try XCTUnwrap(context)
         try await MainActor.run {
             try apiContext.dictionaryService.upsertAPICorrection(
                 original: "teh",

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1326,6 +1326,159 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(response["text"] as? String, "two")
     }
 
+    func testTranscribeEndpointAppliesDictionaryCorrectionsByDefault() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        defer { MockTranscriptionPlugin.reset() }
+        MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
+        let apiContext = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        context = apiContext
+        try await MainActor.run {
+            try apiContext.dictionaryService.upsertAPICorrection(
+                original: "teh",
+                replacement: "the",
+                caseSensitive: false
+            )
+        }
+
+        let response = try Self.jsonObject(await apiContext.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "audio/wav", "x-language": "en"],
+                body: WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "the TypeWhisper")
+        let usageCount = await MainActor.run {
+            apiContext.dictionaryService.corrections.first?.usageCount
+        }
+        XCTAssertEqual(usageCount, 1)
+    }
+
+    func testTranscribeEndpointApplyCorrectionsFalsePreservesRawText() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        defer { MockTranscriptionPlugin.reset() }
+        MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
+        let apiContext = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        context = apiContext
+        try await MainActor.run {
+            try apiContext.dictionaryService.upsertAPICorrection(
+                original: "teh",
+                replacement: "the",
+                caseSensitive: false
+            )
+        }
+
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+        let rawResponse = try Self.jsonObject(await apiContext.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-language": "en",
+                    "x-apply-corrections": "false",
+                ],
+                body: wavData
+            )
+        ))
+
+        XCTAssertEqual(rawResponse["text"] as? String, "teh TypeWhisper")
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        let multipartResponse = try Self.jsonObject(await apiContext.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: Self.multipartTranscribeBody(
+                    wavData: wavData,
+                    boundary: boundary,
+                    fields: [("apply_corrections", "false")]
+                )
+            )
+        ))
+
+        XCTAssertEqual(multipartResponse["text"] as? String, "teh TypeWhisper")
+        let usageCount = await MainActor.run {
+            apiContext.dictionaryService.corrections.first?.usageCount
+        }
+        XCTAssertEqual(usageCount, 0)
+    }
+
+    func testTranscribeEndpointRejectsInvalidApplyCorrectionsValues() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        let router = try XCTUnwrap(context?.router)
+        let wavData = WavEncoder.encode(Array(repeating: Float(0), count: 1600))
+
+        let rawResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: [
+                    "content-type": "audio/wav",
+                    "x-apply-corrections": "maybe",
+                ],
+                body: wavData
+            )
+        )
+        let rawJSON = try Self.jsonObject(rawResponse)
+
+        XCTAssertEqual(rawResponse.status, 400)
+        XCTAssertEqual((rawJSON["error"] as? [String: Any])?["message"] as? String, "Invalid 'x-apply-corrections' value")
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        let multipartResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe",
+                queryParams: [:],
+                headers: ["content-type": "multipart/form-data; boundary=\(boundary)"],
+                body: Self.multipartTranscribeBody(
+                    wavData: wavData,
+                    boundary: boundary,
+                    fields: [("apply_corrections", "maybe")]
+                )
+            )
+        )
+        let multipartJSON = try Self.jsonObject(multipartResponse)
+
+        XCTAssertEqual(multipartResponse.status, 400)
+        XCTAssertEqual((multipartJSON["error"] as? [String: Any])?["message"] as? String, "Invalid 'apply_corrections' value")
+    }
+
     func testTranscribeEndpointRejectsInvalidNormalizeNumbersHeader() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?
@@ -1623,6 +1776,134 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(response["text"] as? String, "transcribed")
         XCTAssertEqual(MockTranscriptionPlugin.lastLanguageSelection.languageHints, [])
         XCTAssertNil(MockTranscriptionPlugin.lastLanguageSelection.requestedLanguage)
+    }
+
+    func testTranscribeLocalFileEndpointAppliesDictionaryCorrectionsByDefault() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        defer { MockTranscriptionPlugin.reset() }
+        MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
+        let apiContext = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        context = apiContext
+        try await MainActor.run {
+            try apiContext.dictionaryService.upsertAPICorrection(
+                original: "teh",
+                replacement: "the",
+                caseSensitive: false
+            )
+        }
+
+        let fileURL = audioDirectory.appendingPathComponent("corrected.wav")
+        try WavEncoder.encode(Array(repeating: Float(0), count: 1600)).write(to: fileURL)
+
+        let response = try Self.jsonObject(await apiContext.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["path": fileURL.path])
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "the TypeWhisper")
+        let usageCount = await MainActor.run {
+            apiContext.dictionaryService.corrections.first?.usageCount
+        }
+        XCTAssertEqual(usageCount, 1)
+    }
+
+    func testTranscribeLocalFileEndpointApplyCorrectionsFalsePreservesRawText() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        defer { MockTranscriptionPlugin.reset() }
+        MockTranscriptionPlugin.setResponseText("teh TypeWhisper")
+        let apiContext = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        context = apiContext
+        try await MainActor.run {
+            try apiContext.dictionaryService.upsertAPICorrection(
+                original: "teh",
+                replacement: "the",
+                caseSensitive: false
+            )
+        }
+
+        let fileURL = audioDirectory.appendingPathComponent("raw.wav")
+        try WavEncoder.encode(Array(repeating: Float(0), count: 1600)).write(to: fileURL)
+
+        let response = try Self.jsonObject(await apiContext.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: [
+                    "path": fileURL.path,
+                    "apply_corrections": false,
+                ])
+            )
+        ))
+
+        XCTAssertEqual(response["text"] as? String, "teh TypeWhisper")
+        let usageCount = await MainActor.run {
+            apiContext.dictionaryService.corrections.first?.usageCount
+        }
+        XCTAssertEqual(usageCount, 0)
+    }
+
+    func testTranscribeLocalFileEndpointRejectsInvalidApplyCorrectionsValue() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let audioDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(audioDirectory)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+        }
+        let fileURL = audioDirectory.appendingPathComponent("invalid-corrections.wav")
+        try WavEncoder.encode(Array(repeating: Float(0), count: 1600)).write(to: fileURL)
+
+        let router = try XCTUnwrap(context?.router)
+        let response = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/transcribe/local-file",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: [
+                    "path": fileURL.path,
+                    "apply_corrections": "maybe",
+                ])
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 400)
+        XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, "Invalid 'apply_corrections' value")
     }
 
     func testTranscribeLocalFileEndpointUsesLanguageHintsAndEngineModelOverrides() async throws {
@@ -4471,6 +4752,33 @@ final class APIRouterAndHandlersTests: XCTestCase {
         } else {
             UserDefaults.standard.removeObject(forKey: key)
         }
+    }
+
+    private static func multipartTranscribeBody(
+        wavData: Data,
+        boundary: String,
+        fields: [(name: String, value: String)] = []
+    ) -> Data {
+        var body = Data()
+
+        func append(_ string: String) {
+            body.append(Data(string.utf8))
+        }
+
+        append("--\(boundary)\r\n")
+        append("Content-Disposition: form-data; name=\"file\"; filename=\"test.wav\"\r\n")
+        append("Content-Type: audio/wav\r\n\r\n")
+        body.append(wavData)
+        append("\r\n")
+
+        for field in fields {
+            append("--\(boundary)\r\n")
+            append("Content-Disposition: form-data; name=\"\(field.name)\"\r\n\r\n")
+            append("\(field.value)\r\n")
+        }
+
+        append("--\(boundary)--\r\n")
+        return body
     }
 
     private static func jsonObject(_ response: HTTPResponse) throws -> [String: Any] {

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -107,7 +107,41 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(body["task"] as? String, "transcribe")
         XCTAssertEqual(body["engine"] as? String, "mock")
         XCTAssertEqual(body["model"] as? String, "tiny")
+        XCTAssertNil(body["apply_corrections"])
         XCTAssertFalse(String(data: bodyData, encoding: .utf8)?.contains("distinctive-video-bytes") == true)
+    }
+
+    func testCLIClientTranscribeLocalFileSendsApplyCorrectionsFalseWhenRequested() async throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(directory) }
+        let fileURL = directory.appendingPathComponent("raw.wav")
+        try Data("audio-bytes".utf8).write(to: fileURL)
+
+        let recorder = RequestRecorder()
+        let client = CLIClient(
+            port: 9876,
+            transport: { request in
+                recorder.record(request)
+                let body = #"{"text":"ok","language":null,"duration":1,"processing_time":0.1,"engine":"mock","model":"tiny"}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            }
+        )
+
+        _ = try await client.transcribe(
+            fileURL: fileURL,
+            language: nil,
+            languageHints: [],
+            task: "transcribe",
+            targetLanguage: nil,
+            applyCorrections: false
+        )
+
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.url?.path, "/v1/transcribe/local-file")
+        let bodyData = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        XCTAssertEqual(body["path"] as? String, fileURL.path)
+        XCTAssertEqual(body["apply_corrections"] as? Bool, false)
     }
 
     func testCLIClientSendsBearerTokenWhenConfigured() async throws {
@@ -160,6 +194,37 @@ final class CLISupportTests: XCTestCase {
         let bodyText = String(data: try XCTUnwrap(request.httpBody), encoding: .utf8)
         XCTAssertTrue(bodyText?.contains("stdin-audio-bytes") == true)
         XCTAssertTrue(bodyText?.contains("name=\"language\"") == true)
+        XCTAssertFalse(bodyText?.contains("name=\"apply_corrections\"") == true)
+    }
+
+    func testCLIClientTranscribeStdinSendsApplyCorrectionsFalseWhenRequested() async throws {
+        let recorder = RequestRecorder()
+        let client = CLIClient(
+            port: 9876,
+            transport: { request in
+                recorder.record(request)
+                let body = #"{"text":"ok","language":null,"duration":1,"processing_time":0.1,"engine":"mock","model":"tiny"}"#
+                return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
+            },
+            stdinReader: {
+                Data("stdin-audio-bytes".utf8)
+            }
+        )
+
+        _ = try await client.transcribe(
+            fileURL: nil,
+            language: nil,
+            languageHints: [],
+            task: "transcribe",
+            targetLanguage: nil,
+            applyCorrections: false
+        )
+
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.url?.path, "/v1/transcribe")
+        let bodyText = String(data: try XCTUnwrap(request.httpBody), encoding: .utf8)
+        XCTAssertTrue(bodyText?.contains("name=\"apply_corrections\"") == true)
+        XCTAssertTrue(bodyText?.contains("\r\nfalse\r\n") == true)
     }
 
     @MainActor

--- a/typewhisper-cli/CLIClient.swift
+++ b/typewhisper-cli/CLIClient.swift
@@ -93,7 +93,8 @@ struct CLIClient {
         targetLanguage: String?,
         engine: String? = nil,
         model: String? = nil,
-        awaitDownload: Bool = false
+        awaitDownload: Bool = false,
+        applyCorrections: Bool = true
     ) async throws -> Data {
         if let fileURL {
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
@@ -107,7 +108,8 @@ struct CLIClient {
                 targetLanguage: targetLanguage,
                 engine: engine,
                 model: model,
-                awaitDownload: awaitDownload
+                awaitDownload: awaitDownload,
+                applyCorrections: applyCorrections
             )
         }
 
@@ -145,6 +147,9 @@ struct CLIClient {
         if let model {
             body.appendFormField("model", value: model, boundary: boundary)
         }
+        if !applyCorrections {
+            body.appendFormField("apply_corrections", value: "false", boundary: boundary)
+        }
 
         body.append("--\(boundary)--\r\n")
 
@@ -172,7 +177,8 @@ struct CLIClient {
         targetLanguage: String?,
         engine: String?,
         model: String?,
-        awaitDownload: Bool
+        awaitDownload: Bool,
+        applyCorrections: Bool
     ) async throws -> Data {
         var payload: [String: Any] = [
             "path": fileURL.path
@@ -194,6 +200,9 @@ struct CLIClient {
         }
         if let model {
             payload["model"] = model
+        }
+        if !applyCorrections {
+            payload["apply_corrections"] = false
         }
 
         var transcribePath = "/v1/transcribe/local-file"

--- a/typewhisper-cli/main.swift
+++ b/typewhisper-cli/main.swift
@@ -16,6 +16,7 @@ var translateTo: String?
 var engineOverride: String?
 var modelOverride: String?
 var awaitDownload = false
+var applyCorrections = true
 
 var argIterator = args.makeIterator()
 while let arg = argIterator.next() {
@@ -80,6 +81,8 @@ while let arg = argIterator.next() {
         modelOverride = next
     case "--await-download":
         awaitDownload = true
+    case "--no-corrections":
+        applyCorrections = false
     default:
         // Ignore Apple/Xcode internal flags (e.g. -NSDocumentRevisionsDebugMode)
         if arg.hasPrefix("-NS") || arg.hasPrefix("-Apple") {
@@ -138,7 +141,8 @@ do {
             targetLanguage: translateTo,
             engine: engineOverride,
             model: modelOverride,
-            awaitDownload: awaitDownload
+            awaitDownload: awaitDownload,
+            applyCorrections: applyCorrections
         )
         print(OutputFormatter.formatTranscription(data, json: jsonOutput))
 
@@ -184,6 +188,7 @@ func printUsage() {
           --engine <id>        Override the engine for this request (e.g. groq, qwen3)
           --model <id>         Override the model for this request (e.g. whisper-large-v3-turbo)
           --await-download     Wait for an engine to restore/download its model instead of failing with 409
+          --no-corrections     Return raw transcription text without Dictionary Corrections
 
         Examples:
           typewhisper status


### PR DESCRIPTION
## Summary
Thanks to Yuri for the clear report in #656. The issue pointed out that the normal dictation path applies Dictionary Corrections after transcription, while `/v1/transcribe`, `/v1/transcribe/local-file`, and the CLI could return uncorrected output even for engines shown as “Corrections only” in Settings.

This PR:
- applies Dictionary Corrections to HTTP API and CLI transcription output by default
- adds `apply_corrections=false` / `x-apply-corrections: false` for raw API output
- adds `typewhisper transcribe --no-corrections` for raw CLI output
- documents the new behavior and covers default/opt-out paths in tests

Closes #656

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/CLISupportTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcription endpoints now accept an optional apply_corrections parameter (enabled by default) to control dictionary corrections.
  * CLI gains a --no-corrections flag to request raw (uncorrected) transcription output.

* **Documentation**
  * README updated with HTTP/CLI docs showing how to return raw transcription output and header override for raw uploads; CLI help clarifies when to use --no-corrections.

* **Tests**
  * Added/updated tests verifying correction behavior, disablement, and invalid-value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->