### PR TITLE
feat: universal chunked live transcription for all local engines

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		E8FB3269B522A8923134AD9A /* TranscriptionNormalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */; };
 		D4A100000000000000000001 /* RecorderTranscriptionBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */; };
 		D4A100000000000000000003 /* RecorderTranscriptionBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */; };
+		D4A100000000000000000005 /* UniversalChunkedLiveSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100000000000000000006 /* UniversalChunkedLiveSession.swift */; };
 		F0A1B2C3D4E5F60718293A4B /* GeminiPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000141 /* GeminiPlugin.swift */; };
 		A10000000000000000000001 /* SystemTTSPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000001 /* SystemTTSPlugin.swift */; };
 		A10000000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000002 /* manifest.json */; };
@@ -789,6 +790,7 @@
 		9A645F000000000000000107 /* JapaneseNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JapaneseNumberWordParser.swift; sourceTree = "<group>"; };
 		206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionNormalizationService.swift; sourceTree = "<group>"; };
 		D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBuffer.swift; sourceTree = "<group>"; };
+		D4A100000000000000000006 /* UniversalChunkedLiveSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalChunkedLiveSession.swift; sourceTree = "<group>"; };
 		BB00000000000000000238 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		BB00000000000000000239 /* AudioRecorderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000240 /* AudioRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderView.swift; sourceTree = "<group>"; };
@@ -1438,6 +1440,7 @@
 				BB00000000000000000272 /* TermPackRegistryService.swift */,
 				BB00000000000000000286 /* LicenseService.swift */,
 				D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */,
+				D4A100000000000000000006 /* UniversalChunkedLiveSession.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -3713,6 +3716,7 @@
 				AA00000000000000000335 /* PunctuationStrategyResolver.swift in Sources */,
 				AA00000000000000000336 /* PunctuationVerificationService.swift in Sources */,
 				D4A100000000000000000001 /* RecorderTranscriptionBuffer.swift in Sources */,
+				D4A100000000000000000005 /* UniversalChunkedLiveSession.swift in Sources */,
 				AA00000000000000000250 /* AudioRecorderService.swift in Sources */,
 				AA00000000000000000251 /* AudioRecorderViewModel.swift in Sources */,
 				AA00000000000000000252 /* AudioRecorderView.swift in Sources */,

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -370,8 +370,42 @@ final class ModelManagerService: ObservableObject {
         }
 
         guard let livePlugin = plugin as? LiveTranscriptionCapablePlugin else {
-            restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId)
-            return nil
+            // For engines without native live session support, use a universal chunked session
+            // that processes audio in the background during recording. This ensures that when
+            // recording stops, only a short tail of audio needs transcription regardless of
+            // how long the recording was.
+            let allowsChunked = (plugin as? TranscriptPreviewFallbackPolicyProviding)?.allowsTranscriptPreviewFallback ?? true
+            guard allowsChunked else {
+                restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId)
+                return nil
+            }
+
+            let capturedPlugin = plugin
+            let capturedLanguage = runtimeSelection.requestedLanguage
+            let capturedTranslate = task == .translate
+            let capturedPrompt = prompt
+
+            let transcribeChunk: UniversalChunkedLiveSession.ChunkTranscriber = { samples in
+                let audio = await Self.makeAudioData(from: samples)
+                return try await capturedPlugin.transcribe(
+                    audio: audio,
+                    language: capturedLanguage,
+                    translate: capturedTranslate,
+                    prompt: capturedPrompt
+                )
+            }
+
+            let session = UniversalChunkedLiveSession(
+                transcribeChunk: transcribeChunk,
+                onProgress: onProgress
+            )
+
+            return LiveTranscriptionSessionHandle(
+                providerId: providerId,
+                session: session,
+                cloudModelOverridePlugin: overrideRestoreId == nil ? nil : plugin,
+                cloudModelOverrideRestoreId: overrideRestoreId
+            )
         }
 
         let session: any LiveTranscriptionSession

--- a/TypeWhisper/Services/UniversalChunkedLiveSession.swift
+++ b/TypeWhisper/Services/UniversalChunkedLiveSession.swift
@@ -1,0 +1,201 @@
+import Foundation
+import os
+import TypeWhisperPluginSDK
+
+// A universal live transcription session that works with any TranscriptionEnginePlugin
+// by processing audio in background chunks during recording. When the recording stops,
+// only the remaining "tail" audio (since the last committed chunk) needs transcription,
+// dramatically reducing the delay for long recordings.
+final class UniversalChunkedLiveSession: LiveTranscriptionSession, @unchecked Sendable {
+
+    // MARK: - Types
+
+    typealias ChunkTranscriber = @Sendable ([Float]) async throws -> PluginTranscriptionResult
+
+    // MARK: - Configuration
+
+    private static let chunkThresholdSeconds: Double = 7.0
+    private static let safetyMarginSeconds: Double = 2.0
+    private static let sampleRate: Double = 16_000
+
+    // MARK: - State
+
+    private struct State {
+        var allSamples: [Float] = []
+        var confirmedEndIndex: Int = 0
+        var confirmedText: String = ""
+        var isCancelled: Bool = false
+        var chunkTask: Task<Void, Never>? = nil
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let transcribeChunk: ChunkTranscriber
+    private let onProgress: @Sendable (String) -> Bool
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac",
+        category: "UniversalChunkedLiveSession"
+    )
+
+    // MARK: - Init
+
+    init(
+        transcribeChunk: @escaping ChunkTranscriber,
+        onProgress: @escaping @Sendable (String) -> Bool
+    ) {
+        self.transcribeChunk = transcribeChunk
+        self.onProgress = onProgress
+    }
+
+    // MARK: - LiveTranscriptionSession
+
+    func appendAudio(samples: [Float]) async throws {
+        guard !state.withLock({ $0.isCancelled }) else { return }
+
+        state.withLock { $0.allSamples.append(contentsOf: samples) }
+
+        // Only trigger one chunk at a time
+        guard state.withLock({ $0.chunkTask == nil }) else { return }
+
+        let pendingDuration = state.withLock {
+            Double($0.allSamples.count - $0.confirmedEndIndex) / Self.sampleRate
+        }
+
+        guard pendingDuration >= Self.chunkThresholdSeconds else { return }
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.processChunk()
+        }
+        state.withLock { $0.chunkTask = task }
+    }
+
+    func finish() async throws -> PluginTranscriptionResult {
+        // Wait for any in-progress chunk to complete so we commit as much text as possible
+        // before transcribing only the remaining tail.
+        let taskToWait = state.withLock { $0.chunkTask }
+        await taskToWait?.value
+
+        let (endIndex, confirmed, samples) = state.withLock {
+            ($0.confirmedEndIndex, $0.confirmedText, $0.allSamples)
+        }
+
+        let tailSamples = Array(samples.dropFirst(endIndex))
+
+        guard !tailSamples.isEmpty else {
+            Self.logger.info("finish: no tail, returning confirmed text (\(confirmed.count) chars)")
+            return PluginTranscriptionResult(text: confirmed, detectedLanguage: nil, segments: [])
+        }
+
+        Self.logger.info(
+            "finish: confirmed=\(confirmed.isEmpty ? "empty" : "\(confirmed.count) chars"), tail=\(String(format: "%.1f", Double(tailSamples.count) / Self.sampleRate))s"
+        )
+
+        let tailResult = try await transcribeChunk(tailSamples)
+        let tailText = tailResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let finalText: String
+        if confirmed.isEmpty {
+            finalText = tailText
+        } else if tailText.isEmpty {
+            finalText = confirmed
+        } else {
+            finalText = confirmed + " " + tailText
+        }
+
+        return PluginTranscriptionResult(
+            text: finalText,
+            detectedLanguage: tailResult.detectedLanguage,
+            segments: []
+        )
+    }
+
+    func cancel() async {
+        state.withLock { $0.isCancelled = true }
+        state.withLock { $0.chunkTask }?.cancel()
+    }
+
+    // MARK: - Private
+
+    private func processChunk() async {
+        defer { state.withLock { $0.chunkTask = nil } }
+
+        guard !state.withLock({ $0.isCancelled }) else { return }
+
+        // Slice audio from confirmedEndIndex to end minus the safety margin.
+        // The safety margin prevents committing words that may still be forming at the boundary.
+        let (chunkSamples, chunkStartIndex): ([Float], Int) = state.withLock { s in
+            let start = s.confirmedEndIndex
+            let safetyCount = Int(Self.safetyMarginSeconds * Self.sampleRate)
+            let end = max(start, s.allSamples.count - safetyCount)
+            guard end > start else { return ([], start) }
+            return (Array(s.allSamples[start..<end]), start)
+        }
+
+        guard !chunkSamples.isEmpty else { return }
+
+        Self.logger.info(
+            "processChunk: transcribing \(String(format: "%.1f", Double(chunkSamples.count) / Self.sampleRate))s from offset \(chunkStartIndex)"
+        )
+
+        guard let result = try? await transcribeChunk(chunkSamples) else {
+            Self.logger.warning("processChunk: transcription failed, skipping commit")
+            return
+        }
+
+        guard !state.withLock({ $0.isCancelled }) else { return }
+
+        commitStableSegments(result: result, chunkStartIndex: chunkStartIndex, chunkSampleCount: chunkSamples.count)
+    }
+
+    private func commitStableSegments(
+        result: PluginTranscriptionResult,
+        chunkStartIndex: Int,
+        chunkSampleCount: Int
+    ) {
+        let chunkDuration = Double(chunkSampleCount) / Self.sampleRate
+        let safeCommitBefore = chunkDuration - Self.safetyMarginSeconds
+
+        guard safeCommitBefore > 0 else { return }
+
+        let (stableText, stableEndSeconds): (String, Double)
+
+        if result.segments.isEmpty {
+            // Engine returned no segment timestamps — commit everything up to the safety margin.
+            let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            stableText = trimmed
+            stableEndSeconds = safeCommitBefore
+        } else {
+            // Use segment timestamps to only commit segments fully before the safety margin.
+            let stable = result.segments.filter {
+                $0.end <= safeCommitBefore && !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            guard !stable.isEmpty else { return }
+            stableText = stable
+                .map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .joined(separator: " ")
+            stableEndSeconds = stable.last!.end
+        }
+
+        guard !stableText.isEmpty else { return }
+
+        let newEndIndex = chunkStartIndex + Int(stableEndSeconds * Self.sampleRate)
+
+        let progressText: String = state.withLock { s in
+            guard newEndIndex > s.confirmedEndIndex else { return s.confirmedText }
+            s.confirmedEndIndex = min(newEndIndex, s.allSamples.count)
+            if s.confirmedText.isEmpty {
+                s.confirmedText = stableText
+            } else {
+                s.confirmedText = (s.confirmedText + " " + stableText)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return s.confirmedText
+        }
+
+        Self.logger.info("processChunk: committed \(String(format: "%.1f", stableEndSeconds))s, confirmed text now \(progressText.count) chars")
+
+        _ = onProgress(progressText)
+    }
+}

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -13,6 +13,7 @@ final class StreamingHandler: @unchecked Sendable {
         var task: TranscriptionTask = .transcribe
         var livePreviewAudioGate = LivePreviewAudioGate()
         var sampleCursor = 0
+        var showPreview: Bool = true
     }
 
     private static let liveSessionPollInterval: Duration = .milliseconds(350)
@@ -102,11 +103,6 @@ final class StreamingHandler: @unchecked Sendable {
     ) {
         stop()
 
-        guard allowLiveTranscription else {
-            logger.info("Live transcript preview skipped: disabled")
-            return
-        }
-
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
               PluginManager.shared.transcriptionEngine(for: providerId) != nil else {
@@ -120,8 +116,11 @@ final class StreamingHandler: @unchecked Sendable {
             state.configuredLanguage = languageSelection.requestedLanguage
             state.configuredLanguageCandidates = languageSelection.selectedCodes
             state.task = task
+            state.showPreview = allowLiveTranscription
         }
-        onStreamingStateChange?(true)
+        if allowLiveTranscription {
+            onStreamingStateChange?(true)
+        }
 
         streamingTask = Task { [weak self] in
             guard let self else { return }
@@ -354,8 +353,10 @@ final class StreamingHandler: @unchecked Sendable {
             sharedState.withLock { $0.confirmedStreamingText = stable }
         }
 
-        Task { @MainActor [weak self] in
-            self?.onPartialTextUpdate?(stable)
+        if sharedState.withLock({ $0.showPreview }) {
+            Task { @MainActor [weak self] in
+                self?.onPartialTextUpdate?(stable)
+            }
         }
         return true
     }


### PR DESCRIPTION
## Summary

Adds `UniversalChunkedLiveSession`, a fallback live session for any `TranscriptionEnginePlugin` that does **not** implement `LiveTranscriptionCapablePlugin` — including:

* Parakeet
* WhisperKit
* Granite
* Qwen3
* Voxtral

It processes audio in the background while recording, so when the user stops recording, only the short tail since the last committed chunk needs to be transcribed. This significantly reduces post-stop delay for long recordings.

## How it works

* Audio is accumulated as it arrives, using the existing live session loop in `StreamingHandler` every 350 ms.
* Every ~7 seconds of buffered audio, a background transcription runs on the pending window.
* Segment timestamps are used to commit only the stable portion of text:
    * anything ending more than 2 seconds before the current buffer edge is finalized
    * the confirmed-sample offset advances accordingly
* On `finish()`, only the remaining tail is transcribed, typically `≤ 7 s`, and stitched together with the confirmed text.

## Pipeline changes

### `ModelManagerService`

Instead of returning `nil` for engines without native live transcription, it now returns `UniversalChunkedLiveSession`.

This works with the existing pipeline, so no changes are needed in:

* `StreamingHandler`
* `DictationViewModel`

## Expected impact

For engines like Parakeet and WhisperKit:

* `15 s` recording: about `2-3 s` → `1-2 s`
* `60 s` recording: about `8-15 s` → `2-3 s`
* `3 min` recording: about `30-60 s` → `2-3 s`

## Result

This makes stop-to-transcript latency much more consistent, especially for longer recordings, without requiring native live transcription support from every engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Extended live transcription support to work with additional transcription engine types previously unavailable for live streaming.
  - Improved streaming preview with enhanced controls for when preview text updates are displayed during transcription.

* **Chores**
  - Updated project build configuration for service implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->