### PR TITLE
Add OpenRouter speech-to-text support

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -43,6 +43,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "OpenRouterPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/OpenRouterPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "Qwen3Plugin",
             dependencies: [
                 "TypeWhisperPluginSDK",
@@ -211,6 +221,15 @@ let package = Package(
                 "OpenAIPlugin",
             ],
             path: "Plugins/OpenAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "OpenRouterPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "OpenRouterPlugin",
+            ],
+            path: "Plugins/OpenRouterPlugin/Tests"
         ),
         .testTarget(
             name: "Qwen3PluginTests",

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Localizable.xcstrings
@@ -111,6 +111,16 @@
         }
       }
     },
+    "Transcription Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transkriptionsmodell"
+          }
+        }
+      }
+    },
     "Using default models. Press Refresh to fetch all available models." : {
       "localizations" : {
         "de" : {

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -5,20 +5,40 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(OpenRouterPlugin)
-final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unchecked Sendable {
+final class OpenRouterPlugin: NSObject,
+    TranscriptionEnginePlugin,
+    DictionaryTermsCapabilityProviding,
+    LLMProviderPlugin,
+    LLMModelSelectable,
+    @unchecked Sendable
+{
     static let pluginId = "com.typewhisper.openrouter"
     static let pluginName = "OpenRouter"
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
+    fileprivate var _selectedModelId: String?
     fileprivate var _selectedLLMModelId: String?
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.3
-    fileprivate var _fetchedModels: [OpenRouterFetchedModel] = []
+    fileprivate var _fetchedLLMModels: [OpenRouterFetchedModel] = []
+    fileprivate var _fetchedTranscriptionModels: [OpenRouterFetchedModel] = []
 
     private let chatHelper = PluginOpenAIChatHelper(
         baseURL: "https://openrouter.ai/api"
     )
+
+    private static let transcriptionRequestTimeout: TimeInterval = 120
+
+    private enum StorageKeys {
+        static let apiKey = "api-key"
+        static let selectedModel = "selectedModel"
+        static let selectedLLMModel = "selectedLLMModel"
+        static let llmTemperatureMode = "llmTemperatureMode"
+        static let llmTemperatureValue = "llmTemperatureValue"
+        static let fetchedModels = "fetchedModels"
+        static let fetchedTranscriptionModels = "fetchedTranscriptionModels"
+    }
 
     required override init() {
         super.init()
@@ -26,16 +46,22 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
 
     func activate(host: HostServices) {
         self.host = host
-        _apiKey = host.loadSecret(key: "api-key")
-        if let data = host.userDefault(forKey: "fetchedModels") as? Data,
+        _apiKey = host.loadSecret(key: Self.StorageKeys.apiKey)
+        if let data = host.userDefault(forKey: Self.StorageKeys.fetchedModels) as? Data,
            let models = try? JSONDecoder().decode([OpenRouterFetchedModel].self, from: data) {
-            _fetchedModels = models
+            _fetchedLLMModels = models
         }
-        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+        if let data = host.userDefault(forKey: Self.StorageKeys.fetchedTranscriptionModels) as? Data,
+           let models = try? JSONDecoder().decode([OpenRouterFetchedModel].self, from: data) {
+            _fetchedTranscriptionModels = models
+        }
+        _selectedModelId = host.userDefault(forKey: Self.StorageKeys.selectedModel) as? String
+            ?? transcriptionModels.first?.id
+        _selectedLLMModelId = host.userDefault(forKey: Self.StorageKeys.selectedLLMModel) as? String
             ?? supportedModels.first?.id
-        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+        _llmTemperatureModeRaw = host.userDefault(forKey: Self.StorageKeys.llmTemperatureMode) as? String
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
-        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+        _llmTemperatureValue = host.userDefault(forKey: Self.StorageKeys.llmTemperatureValue) as? Double
             ?? 0.3
     }
 
@@ -43,27 +69,164 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
         host = nil
     }
 
-    // MARK: - LLMProviderPlugin
+    // MARK: - TranscriptionEnginePlugin
 
-    var providerName: String { "OpenRouter" }
+    var providerId: String { "openrouter" }
+    var providerDisplayName: String { "OpenRouter" }
 
-    var isAvailable: Bool {
+    var isConfigured: Bool {
         guard let key = _apiKey else { return false }
         return !key.isEmpty
     }
 
-    private static let fallbackModels: [PluginModelInfo] = [
-        PluginModelInfo(id: "openai/gpt-4o", displayName: "OpenAI: GPT-4o"),
-        PluginModelInfo(id: "anthropic/claude-sonnet-4", displayName: "Anthropic: Claude Sonnet 4"),
-        PluginModelInfo(id: "google/gemini-2.5-flash-preview", displayName: "Google: Gemini 2.5 Flash"),
-        PluginModelInfo(id: "meta-llama/llama-3.3-70b-instruct", displayName: "Meta: Llama 3.3 70B"),
+    fileprivate static let fallbackTranscriptionModels: [OpenRouterFetchedModel] = [
+        OpenRouterFetchedModel(id: "openai/whisper-1", name: "OpenAI: Whisper 1", promptPrice: "0", completionPrice: "0"),
+        OpenRouterFetchedModel(id: "openai/gpt-4o-mini-transcribe", name: "OpenAI: GPT-4o Mini Transcribe", promptPrice: "0", completionPrice: "0"),
+        OpenRouterFetchedModel(id: "openai/gpt-4o-transcribe", name: "OpenAI: GPT-4o Transcribe", promptPrice: "0", completionPrice: "0"),
+        OpenRouterFetchedModel(id: "openai/whisper-large-v3", name: "OpenAI: Whisper Large V3", promptPrice: "0", completionPrice: "0"),
+    ]
+
+    var transcriptionModels: [PluginModelInfo] {
+        let models = _fetchedTranscriptionModels.isEmpty
+            ? Self.fallbackTranscriptionModels
+            : _fetchedTranscriptionModels
+        return models.map {
+            PluginModelInfo(id: $0.id, displayName: $0.name)
+        }
+    }
+
+    var selectedModelId: String? { _selectedModelId }
+
+    func selectModel(_ modelId: String) {
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: Self.StorageKeys.selectedModel)
+    }
+
+    var supportsTranslation: Bool { false }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelId.isEmpty else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("OpenRouter speech-to-text does not support translation.")
+        }
+
+        let request = try Self.makeTranscriptionRequest(
+            audio: audio,
+            apiKey: apiKey,
+            modelId: modelId,
+            language: language,
+            timeout: Self.transcriptionRequestTimeout
+        )
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        try Self.validateTranscriptionResponse(data: data, response: response)
+        return try Self.parseTranscriptionResponse(data)
+    }
+
+    static func makeTranscriptionRequest(
+        audio: AudioData,
+        apiKey: String,
+        modelId: String,
+        language: String?,
+        timeout: TimeInterval
+    ) throws -> URLRequest {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/audio/transcriptions") else {
+            throw PluginTranscriptionError.apiError("Invalid OpenRouter transcription URL.")
+        }
+
+        var body: [String: Any] = [
+            "model": modelId,
+            "input_audio": [
+                "data": audio.wavData.base64EncodedString(),
+                "format": "wav",
+            ],
+        ]
+        let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedLanguage, !trimmedLanguage.isEmpty {
+            body["language"] = trimmedLanguage
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = timeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func validateTranscriptionResponse(data: Data, response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return
+        case 401:
+            throw PluginTranscriptionError.invalidApiKey
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        default:
+            let errorMessage = Self.apiErrorMessage(from: data)
+            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
+        }
+    }
+
+    static func parseTranscriptionResponse(_ data: Data) throws -> PluginTranscriptionResult {
+        struct Response: Decodable {
+            let text: String
+        }
+
+        do {
+            let response = try JSONDecoder().decode(Response.self, from: data)
+            return PluginTranscriptionResult(text: response.text)
+        } catch {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let text = json["text"] as? String {
+                return PluginTranscriptionResult(text: text)
+            }
+            throw PluginTranscriptionError.apiError("Failed to parse transcription response")
+        }
+    }
+
+    private static func apiErrorMessage(from data: Data) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let error = json["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                return message
+            }
+            if let message = json["message"] as? String {
+                return message
+            }
+        }
+        return String(data: data, encoding: .utf8) ?? "Unknown error"
+    }
+
+    // MARK: - LLMProviderPlugin
+
+    var providerName: String { "OpenRouter" }
+
+    var isAvailable: Bool { isConfigured }
+
+    fileprivate static let fallbackLLMModels: [OpenRouterFetchedModel] = [
+        OpenRouterFetchedModel(id: "openai/gpt-4o", name: "OpenAI: GPT-4o", promptPrice: "0", completionPrice: "0"),
+        OpenRouterFetchedModel(id: "anthropic/claude-sonnet-4", name: "Anthropic: Claude Sonnet 4", promptPrice: "0", completionPrice: "0"),
+        OpenRouterFetchedModel(id: "google/gemini-2.5-flash-preview", name: "Google: Gemini 2.5 Flash", promptPrice: "0", completionPrice: "0"),
+        OpenRouterFetchedModel(id: "meta-llama/llama-3.3-70b-instruct", name: "Meta: Llama 3.3 70B", promptPrice: "0", completionPrice: "0"),
     ]
 
     var supportedModels: [PluginModelInfo] {
-        if _fetchedModels.isEmpty {
-            return Self.fallbackModels
-        }
-        return _fetchedModels.map {
+        let models = _fetchedLLMModels.isEmpty ? Self.fallbackLLMModels : _fetchedLLMModels
+        return models.map {
             PluginModelInfo(id: $0.id, displayName: $0.name)
         }
     }
@@ -98,7 +261,7 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
 
     func selectLLMModel(_ modelId: String) {
         _selectedLLMModelId = modelId
-        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+        host?.setUserDefault(modelId, forKey: Self.StorageKeys.selectedLLMModel)
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
@@ -113,13 +276,13 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
 
     func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
         _llmTemperatureModeRaw = mode.rawValue
-        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+        host?.setUserDefault(mode.rawValue, forKey: Self.StorageKeys.llmTemperatureMode)
     }
 
     func setLLMTemperatureValue(_ value: Double) {
         let clamped = min(max(value, 0.0), 2.0)
         _llmTemperatureValue = clamped
-        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+        host?.setUserDefault(clamped, forKey: Self.StorageKeys.llmTemperatureValue)
     }
 
     // MARK: - Settings View
@@ -134,7 +297,7 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
         _apiKey = key
         if let host {
             do {
-                try host.storeSecret(key: "api-key", value: key)
+                try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
             } catch {
                 print("[OpenRouterPlugin] Failed to store API key: \(error)")
             }
@@ -146,7 +309,7 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
         _apiKey = nil
         if let host {
             do {
-                try host.storeSecret(key: "api-key", value: "")
+                try host.storeSecret(key: Self.StorageKeys.apiKey, value: "")
             } catch {
                 print("[OpenRouterPlugin] Failed to delete API key: \(error)")
             }
@@ -173,15 +336,23 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
 
     // MARK: - Model Fetching
 
-    fileprivate func setFetchedModels(_ models: [OpenRouterFetchedModel]) {
-        _fetchedModels = models
+    func setFetchedLLMModels(_ models: [OpenRouterFetchedModel]) {
+        _fetchedLLMModels = models
         if let data = try? JSONEncoder().encode(models) {
-            host?.setUserDefault(data, forKey: "fetchedModels")
+            host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedModels)
         }
         host?.notifyCapabilitiesChanged()
     }
 
-    fileprivate func fetchModels() async -> [OpenRouterFetchedModel] {
+    func setFetchedTranscriptionModels(_ models: [OpenRouterFetchedModel]) {
+        _fetchedTranscriptionModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedTranscriptionModels)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func fetchLLMModels() async -> [OpenRouterFetchedModel] {
         guard let url = URL(string: "https://openrouter.ai/api/v1/models") else { return [] }
 
         var request = URLRequest(url: url)
@@ -198,6 +369,36 @@ final class OpenRouterPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @
             let decoded = try JSONDecoder().decode(OpenRouterModelsResponse.self, from: data)
             return decoded.data
                 .filter { Self.isTextLLM($0) }
+                .map { model in
+                    OpenRouterFetchedModel(
+                        id: model.id,
+                        name: model.name,
+                        promptPrice: model.pricing?.prompt ?? "0",
+                        completionPrice: model.pricing?.completion ?? "0"
+                    )
+                }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            return []
+        }
+    }
+
+    func fetchTranscriptionModels() async -> [OpenRouterFetchedModel] {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/models?output_modalities=transcription") else { return [] }
+
+        var request = URLRequest(url: url)
+        if let apiKey = _apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+
+            let decoded = try JSONDecoder().decode(OpenRouterModelsResponse.self, from: data)
+            return decoded.data
                 .map { model in
                     OpenRouterFetchedModel(
                         id: model.id,
@@ -303,18 +504,39 @@ private struct OpenRouterSettingsView: View {
     @State private var isValidating = false
     @State private var validationResult: Bool?
     @State private var showApiKey = false
-    @State private var selectedModel: String = ""
+    @State private var selectedLLMModel = ""
+    @State private var selectedTranscriptionModel = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
-    @State private var fetchedModels: [OpenRouterFetchedModel] = []
-    @State private var searchText = ""
+    @State private var fetchedLLMModels: [OpenRouterFetchedModel] = []
+    @State private var fetchedTranscriptionModels: [OpenRouterFetchedModel] = []
+    @State private var llmSearchText = ""
+    @State private var transcriptionSearchText = ""
     @State private var remainingCredits: Double?
     private let bundle = Bundle(for: OpenRouterPlugin.self)
 
-    private var filteredModels: [OpenRouterFetchedModel] {
-        if searchText.isEmpty { return fetchedModels }
+    private var llmModels: [OpenRouterFetchedModel] {
+        fetchedLLMModels.isEmpty ? OpenRouterPlugin.fallbackLLMModels : fetchedLLMModels
+    }
+
+    private var transcriptionModels: [OpenRouterFetchedModel] {
+        fetchedTranscriptionModels.isEmpty
+            ? OpenRouterPlugin.fallbackTranscriptionModels
+            : fetchedTranscriptionModels
+    }
+
+    private var filteredLLMModels: [OpenRouterFetchedModel] {
+        filtered(models: llmModels, searchText: llmSearchText)
+    }
+
+    private var filteredTranscriptionModels: [OpenRouterFetchedModel] {
+        filtered(models: transcriptionModels, searchText: transcriptionSearchText)
+    }
+
+    private func filtered(models: [OpenRouterFetchedModel], searchText: String) -> [OpenRouterFetchedModel] {
+        if searchText.isEmpty { return models }
         let query = searchText.lowercased()
-        return fetchedModels.filter {
+        return models.filter {
             $0.name.lowercased().contains(query) || $0.id.lowercased().contains(query)
         }
     }
@@ -398,7 +620,46 @@ private struct OpenRouterSettingsView: View {
             if plugin.isAvailable {
                 Divider()
 
-                // LLM Model Selection
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Transcription Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshTranscriptionModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    TextField(String(localized: "Search models...", bundle: bundle), text: $transcriptionSearchText)
+                        .textFieldStyle(.roundedBorder)
+
+                    let models = filteredTranscriptionModels
+                    Picker("Transcription Model", selection: $selectedTranscriptionModel) {
+                        ForEach(models, id: \.id) { model in
+                            Text(model.name).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedTranscriptionModel) {
+                        guard !selectedTranscriptionModel.isEmpty else { return }
+                        plugin.selectModel(selectedTranscriptionModel)
+                    }
+
+                    if fetchedTranscriptionModels.isEmpty {
+                        Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
                         Text("LLM Model", bundle: bundle)
@@ -407,7 +668,7 @@ private struct OpenRouterSettingsView: View {
                         Spacer()
 
                         Button {
-                            refreshModels()
+                            refreshLLMModels()
                         } label: {
                             Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
                         }
@@ -415,21 +676,22 @@ private struct OpenRouterSettingsView: View {
                         .controlSize(.small)
                     }
 
-                    TextField(String(localized: "Search models...", bundle: bundle), text: $searchText)
+                    TextField(String(localized: "Search models...", bundle: bundle), text: $llmSearchText)
                         .textFieldStyle(.roundedBorder)
 
-                    let models = filteredModels
-                    Picker("LLM Model", selection: $selectedModel) {
+                    let models = filteredLLMModels
+                    Picker("LLM Model", selection: $selectedLLMModel) {
                         ForEach(models, id: \.id) { model in
                             Text("\(model.name) - \(model.formattedPricing)").tag(model.id)
                         }
                     }
                     .labelsHidden()
-                    .onChange(of: selectedModel) {
-                        plugin.selectLLMModel(selectedModel)
+                    .onChange(of: selectedLLMModel) {
+                        guard !selectedLLMModel.isEmpty else { return }
+                        plugin.selectLLMModel(selectedLLMModel)
                     }
 
-                    if fetchedModels.isEmpty {
+                    if fetchedLLMModels.isEmpty {
                         Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -478,8 +740,10 @@ private struct OpenRouterSettingsView: View {
             if let key = plugin._apiKey, !key.isEmpty {
                 apiKeyInput = key
             }
-            fetchedModels = plugin._fetchedModels
-            selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            fetchedLLMModels = plugin._fetchedLLMModels
+            fetchedTranscriptionModels = plugin._fetchedTranscriptionModels
+            selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            selectedTranscriptionModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
 
@@ -506,17 +770,20 @@ private struct OpenRouterSettingsView: View {
         Task {
             let isValid = await plugin.validateApiKey(trimmedKey)
             if isValid {
-                async let modelsTask = plugin.fetchModels()
+                async let llmModelsTask = plugin.fetchLLMModels()
+                async let transcriptionModelsTask = plugin.fetchTranscriptionModels()
                 async let creditsTask = plugin.fetchCredits()
-                let (models, credits) = await (modelsTask, creditsTask)
+                let (llmModels, transcriptionModels, credits) = await (
+                    llmModelsTask,
+                    transcriptionModelsTask,
+                    creditsTask
+                )
                 await MainActor.run {
                     isValidating = false
                     validationResult = true
                     remainingCredits = credits
-                    if !models.isEmpty {
-                        fetchedModels = models
-                        plugin.setFetchedModels(models)
-                    }
+                    applyLLMModels(llmModels)
+                    applyTranscriptionModels(transcriptionModels)
                 }
             } else {
                 await MainActor.run {
@@ -527,20 +794,43 @@ private struct OpenRouterSettingsView: View {
         }
     }
 
-    private func refreshModels() {
+    private func refreshLLMModels() {
         Task {
-            let models = await plugin.fetchModels()
+            let models = await plugin.fetchLLMModels()
             await MainActor.run {
-                if !models.isEmpty {
-                    fetchedModels = models
-                    plugin.setFetchedModels(models)
-                    if !models.contains(where: { $0.id == selectedModel }),
-                       let first = models.first {
-                        selectedModel = first.id
-                        plugin.selectLLMModel(first.id)
-                    }
-                }
+                applyLLMModels(models)
             }
+        }
+    }
+
+    private func refreshTranscriptionModels() {
+        Task {
+            let models = await plugin.fetchTranscriptionModels()
+            await MainActor.run {
+                applyTranscriptionModels(models)
+            }
+        }
+    }
+
+    private func applyLLMModels(_ models: [OpenRouterFetchedModel]) {
+        guard !models.isEmpty else { return }
+        fetchedLLMModels = models
+        plugin.setFetchedLLMModels(models)
+        if !models.contains(where: { $0.id == selectedLLMModel }),
+           let first = models.first {
+            selectedLLMModel = first.id
+            plugin.selectLLMModel(first.id)
+        }
+    }
+
+    private func applyTranscriptionModels(_ models: [OpenRouterFetchedModel]) {
+        guard !models.isEmpty else { return }
+        fetchedTranscriptionModels = models
+        plugin.setFetchedTranscriptionModels(models)
+        if !models.contains(where: { $0.id == selectedTranscriptionModel }),
+           let first = models.first {
+            selectedTranscriptionModel = first.id
+            plugin.selectModel(first.id)
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -55,14 +55,40 @@ final class OpenRouterPlugin: NSObject,
            let models = try? JSONDecoder().decode([OpenRouterFetchedModel].self, from: data) {
             _fetchedTranscriptionModels = models
         }
-        _selectedModelId = host.userDefault(forKey: Self.StorageKeys.selectedModel) as? String
-            ?? transcriptionModels.first?.id
-        _selectedLLMModelId = host.userDefault(forKey: Self.StorageKeys.selectedLLMModel) as? String
-            ?? supportedModels.first?.id
+        _selectedModelId = Self.resolvedStoredModelId(
+            host.userDefault(forKey: Self.StorageKeys.selectedModel) as? String,
+            availableModels: transcriptionModels,
+            storageKey: Self.StorageKeys.selectedModel,
+            host: host
+        )
+        _selectedLLMModelId = Self.resolvedStoredModelId(
+            host.userDefault(forKey: Self.StorageKeys.selectedLLMModel) as? String,
+            availableModels: supportedModels,
+            storageKey: Self.StorageKeys.selectedLLMModel,
+            host: host
+        )
         _llmTemperatureModeRaw = host.userDefault(forKey: Self.StorageKeys.llmTemperatureMode) as? String
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
         _llmTemperatureValue = host.userDefault(forKey: Self.StorageKeys.llmTemperatureValue) as? Double
             ?? 0.3
+    }
+
+    private static func resolvedStoredModelId(
+        _ storedModelId: String?,
+        availableModels: [PluginModelInfo],
+        storageKey: String,
+        host: HostServices
+    ) -> String? {
+        let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let selectedModelId = trimmedModelId.flatMap { modelId in
+            availableModels.contains(where: { $0.id == modelId }) ? modelId : nil
+        } ?? availableModels.first?.id
+
+        if selectedModelId != storedModelId {
+            host.setUserDefault(selectedModelId, forKey: storageKey)
+        }
+
+        return selectedModelId
     }
 
     func deactivate() {

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -48,6 +48,21 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(reloaded.selectedModelId, "openai/gpt-4o-transcribe")
     }
 
+    func testInvalidPersistedModelSelectionsFallbackAndPersistValidDefaults() throws {
+        let host = try PluginTestHostServices(defaults: [
+            "selectedModel": " retired-stt-model ",
+            "selectedLLMModel": "retired-llm-model",
+        ])
+        let plugin = OpenRouterPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "openai/whisper-1")
+        XCTAssertEqual(plugin.selectedLLMModelId, "openai/gpt-4o")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai/whisper-1")
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "openai/gpt-4o")
+    }
+
     func testLLMAndTranscriptionModelFetchesUseSeparateEndpointsAndCaches() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
         let plugin = OpenRouterPlugin()

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -1,0 +1,294 @@
+import Foundation
+import TypeWhisperPluginSDK
+import XCTest
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import OpenRouterPlugin
+
+final class OpenRouterPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testTranscriptionCapabilitiesAndFallbackModels() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OpenRouterPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.providerId, "openrouter")
+        XCTAssertEqual(plugin.providerDisplayName, "OpenRouter")
+        XCTAssertFalse(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .unsupported)
+        XCTAssertEqual(plugin.selectedModelId, "openai/whisper-1")
+        XCTAssertEqual(
+            plugin.transcriptionModels.map(\.id),
+            [
+                "openai/whisper-1",
+                "openai/gpt-4o-mini-transcribe",
+                "openai/gpt-4o-transcribe",
+                "openai/whisper-large-v3",
+            ]
+        )
+    }
+
+    func testSelectedTranscriptionModelPersistsAcrossActivation() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectModel("openai/gpt-4o-transcribe")
+        plugin.deactivate()
+
+        let reloaded = OpenRouterPlugin()
+        reloaded.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai/gpt-4o-transcribe")
+        XCTAssertEqual(reloaded.selectedModelId, "openai/gpt-4o-transcribe")
+    }
+
+    func testLLMAndTranscriptionModelFetchesUseSeparateEndpointsAndCaches() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "data": [
+                            {
+                              "id": "openai/whisper-1",
+                              "name": "OpenAI: Whisper 1",
+                              "architecture": { "modality": "audio->transcription" }
+                            },
+                            {
+                              "id": "openai/gpt-4o",
+                              "name": "OpenAI: GPT-4o",
+                              "pricing": { "prompt": "0.0000025", "completion": "0.00001" },
+                              "architecture": { "modality": "text->text" }
+                            }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/models", statusCode: 200)
+                ),
+                .success(
+                    Data(
+                        """
+                        {
+                          "data": [
+                            {
+                              "id": "z-provider/z-stt",
+                              "name": "Zulu STT",
+                              "pricing": { "prompt": "0.40", "completion": "0" },
+                              "architecture": { "modality": "audio->transcription" }
+                            },
+                            {
+                              "id": "a-provider/a-stt",
+                              "name": "Alpha STT",
+                              "pricing": { "prompt": "0.20", "completion": "0" },
+                              "architecture": { "modality": "audio->transcription" }
+                            }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/models?output_modalities=transcription", statusCode: 200)
+                ),
+            ])
+        }
+
+        let llmModels = await plugin.fetchLLMModels()
+        let transcriptionModels = await plugin.fetchTranscriptionModels()
+        plugin.setFetchedLLMModels(llmModels)
+        plugin.setFetchedTranscriptionModels(transcriptionModels)
+
+        XCTAssertEqual(llmModels.map(\.id), ["openai/gpt-4o"])
+        XCTAssertEqual(transcriptionModels.map(\.id), ["a-provider/a-stt", "z-provider/z-stt"])
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["openai/gpt-4o"])
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["a-provider/a-stt", "z-provider/z-stt"])
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, ["/api/v1/models", "/api/v1/models"])
+        XCTAssertEqual(requests.map { $0.url?.query }, [nil, "output_modalities=transcription"])
+        XCTAssertEqual(requests.map { $0.value(forHTTPHeaderField: "Authorization") }, [
+            "Bearer openrouter-key",
+            "Bearer openrouter-key",
+        ])
+        XCTAssertNotNil(host.userDefault(forKey: "fetchedModels") as? Data)
+        XCTAssertNotNil(host.userDefault(forKey: "fetchedTranscriptionModels") as? Data)
+    }
+
+    func testTranscribeFailsWithoutAPIKey() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: Self.audio(),
+                language: nil,
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected notConfigured")
+        } catch let error as PluginTranscriptionError {
+            guard case .notConfigured = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testTranscribeRejectsTranslateRequests() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: Self.audio(),
+                language: nil,
+                translate: true,
+                prompt: nil
+            )
+            XCTFail("Expected apiError")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "OpenRouter speech-to-text does not support translation.")
+        }
+    }
+
+    func testTranscriptionRequestUsesJSONBase64AndLanguage() throws {
+        let request = try OpenRouterPlugin.makeTranscriptionRequest(
+            audio: Self.audio(),
+            apiKey: "openrouter-key",
+            modelId: "openai/whisper-1",
+            language: " de ",
+            timeout: 120
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://openrouter.ai/api/v1/audio/transcriptions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer openrouter-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 120)
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "openai/whisper-1")
+        XCTAssertEqual(body["language"] as? String, "de")
+
+        let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
+        XCTAssertEqual(inputAudio["format"] as? String, "wav")
+        XCTAssertEqual(inputAudio["data"] as? String, Data("wav".utf8).base64EncodedString())
+    }
+
+    func testTranscriptionRequestOmitsEmptyLanguageAndPrompt() throws {
+        let request = try OpenRouterPlugin.makeTranscriptionRequest(
+            audio: Self.audio(),
+            apiKey: "openrouter-key",
+            modelId: "openai/whisper-1",
+            language: " ",
+            timeout: 120
+        )
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertNil(body["language"])
+        XCTAssertNil(body["prompt"])
+    }
+
+    func testTranscribeSendsJSONRequestAndParsesText() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "openai/whisper-1"],
+            secrets: ["api-key": "openrouter-key"]
+        )
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"hello from openrouter","usage":{"cost":0.01}}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.audio(),
+            language: "de",
+            translate: false,
+            prompt: "ignored dictionary terms"
+        )
+
+        XCTAssertEqual(result.text, "hello from openrouter")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/api/v1/audio/transcriptions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "openai/whisper-1")
+        XCTAssertEqual(body["language"] as? String, "de")
+        XCTAssertNil(body["prompt"])
+    }
+
+    func testTranscriptionHTTPErrorMapping() {
+        XCTAssertThrowsError(try OpenRouterPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"bad key"}}"#.utf8),
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 401)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .invalidApiKey = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try OpenRouterPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"slow down"}}"#.utf8),
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 429)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .rateLimited = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try OpenRouterPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"server failed"}}"#.utf8),
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 500)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "HTTP 500: server failed")
+        }
+    }
+
+    private static func audio() -> AudioData {
+        AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1)
+    }
+
+    private static func jsonBody(from request: URLRequest) throws -> [String: Any] {
+        let data = try XCTUnwrap(request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -1,16 +1,17 @@
 {
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
-    "description": "Access 300+ LLMs from OpenAI, Anthropic, Meta, Google and more via OpenRouter. Shows model pricing and account balance. Requires API key.",
+    "description": "Access OpenRouter speech-to-text models and 300+ LLMs from OpenAI, Anthropic, Meta, Google and more. Shows model pricing and account balance. Requires API key.",
     "descriptions": {
-        "de": "Zugriff auf über 300 LLMs von OpenAI, Anthropic, Meta, Google und mehr über OpenRouter. Zeigt Modellpreise und Kontoguthaben. Erfordert API-Key."
+        "de": "Zugriff auf OpenRouter-Spracherkennungsmodelle und über 300 LLMs von OpenAI, Anthropic, Meta, Google und mehr. Zeigt Modellpreise und Kontoguthaben. Erfordert API-Key."
     },
-    "category": "llm",
+    "category": "transcription",
+    "categories": ["transcription", "llm"],
     "iconSystemName": "globe",
     "iconURL": "https://www.typewhisper.com/brand-logos/openrouter/logo-light.svg",
     "iconDarkURL": "https://www.typewhisper.com/brand-logos/openrouter/logo-dark.svg",


### PR DESCRIPTION
## Issue context

Issue #660 asks for speech-to-text support in the existing OpenRouter plugin, not a new plugin. This PR makes OpenRouter selectable as a transcription provider while keeping its LLM provider behavior intact.

Closes #660

## Summary

- Extends `OpenRouterPlugin` to implement `TranscriptionEnginePlugin` with provider id `openrouter`, no translation support, no streaming support, and dictionary terms reported as unsupported for this first slice.
- Adds separate OpenRouter STT model state, fallback models, persisted selection, and fetched-model cache, separate from the existing LLM model state.
- Fetches transcription-capable models from `models?output_modalities=transcription` while keeping the existing LLM model discovery on `/api/v1/models`.
- Adds the OpenRouter STT JSON/base64 request path for `POST /api/v1/audio/transcriptions`, including optional non-empty `language` and no multipart OpenAI transcription helper reuse.
- Updates the OpenRouter settings UI with separate Transcription Model and LLM Model sections and refresh actions.
- Updates the OpenRouter manifest to `1.1.0`, primary `transcription` category, and categories `transcription` + `llm`.
- Adds `OpenRouterPlugin` and `OpenRouterPluginTests` to `TypeWhisperPluginSDK/Package.swift`.

## Test Coverage

OpenRouter plugin tests cover configuration errors, selected STT model persistence, separate LLM/STT model fetches and cache keys, JSON/base64 request shape, optional language handling, prompt omission, successful `{ "text": ... }` responses, and HTTP error mapping for 401, 429, and generic API errors.

## Pre-Landing Review

No issues found.

## Scope Drift

Scope check: CLEAN. This is code + tests only for the OpenRouter plugin slice. No plugin release, registry update, or marketplace copy is included.

## Test plan

- [x] `git diff --check`
- [x] `jq empty TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Localizable.xcstrings`
- [x] `swift test --package-path TypeWhisperPluginSDK --filter OpenRouterPluginTests`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme OpenRouterPlugin -configuration Debug build CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcription model support in OpenRouter plugin with in-app selection and dedicated settings UI.

* **Improvements**
  * Manifest updated to v1.1.0 with expanded descriptions for multi-provider transcription and LLMs.
  * German localization updated.
  * Separate handling and persistence for LLM vs transcription model selections; API key flows now refresh both model lists and UI.

* **Tests**
  * Added end-to-end tests covering transcription flows, model selection persistence, and error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->