### PR TITLE
Add Dutch spoken-number normalization

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		9A645F000000000000000005 /* HanNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000105 /* HanNumberWordParser.swift */; };
 		9A645F000000000000000006 /* ChineseNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000106 /* ChineseNumberWordParser.swift */; };
 		9A645F000000000000000007 /* JapaneseNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000107 /* JapaneseNumberWordParser.swift */; };
+		9A645F000000000000000008 /* DutchNumberWordParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A645F000000000000000108 /* DutchNumberWordParser.swift */; };
 		B346BF6B189F3E7C6CBA1410 /* TranscriptionNormalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */; };
 		540AE1FA22F41A63C78B89EC /* NumberWordNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */; };
 		E8FB3269B522A8923134AD9A /* TranscriptionNormalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */; };
@@ -787,6 +788,7 @@
 		9A645F000000000000000105 /* HanNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HanNumberWordParser.swift; sourceTree = "<group>"; };
 		9A645F000000000000000106 /* ChineseNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChineseNumberWordParser.swift; sourceTree = "<group>"; };
 		9A645F000000000000000107 /* JapaneseNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JapaneseNumberWordParser.swift; sourceTree = "<group>"; };
+		9A645F000000000000000108 /* DutchNumberWordParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DutchNumberWordParser.swift; sourceTree = "<group>"; };
 		206526FD5E41E23B077E3499 /* TranscriptionNormalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionNormalizationService.swift; sourceTree = "<group>"; };
 		D4A100000000000000000002 /* RecorderTranscriptionBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderTranscriptionBuffer.swift; sourceTree = "<group>"; };
 		BB00000000000000000238 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
@@ -1446,6 +1448,7 @@
 			isa = PBXGroup;
 			children = (
 				9A645F000000000000000106 /* ChineseNumberWordParser.swift */,
+				9A645F000000000000000108 /* DutchNumberWordParser.swift */,
 				9A645F000000000000000101 /* EnglishNumberWordParser.swift */,
 				9A645F000000000000000103 /* FrenchNumberWordParser.swift */,
 				9A645F000000000000000102 /* GermanNumberWordParser.swift */,
@@ -3707,6 +3710,7 @@
 				9A645F000000000000000005 /* HanNumberWordParser.swift in Sources */,
 				9A645F000000000000000006 /* ChineseNumberWordParser.swift in Sources */,
 				9A645F000000000000000007 /* JapaneseNumberWordParser.swift in Sources */,
+				9A645F000000000000000008 /* DutchNumberWordParser.swift in Sources */,
 				B346BF6B189F3E7C6CBA1410 /* TranscriptionNormalizationService.swift in Sources */,
 				AA00000000000000000333 /* DictationPunctuationProfileStore.swift in Sources */,
 				AA00000000000000000334 /* PunctuationRulesLoader.swift in Sources */,

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1948,6 +1948,16 @@
         }
       }
     },
+    "Converts spoken numbers in supported languages into digits before insertion and export." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wandelt gesprochene Zahlen in unterstützten Sprachen vor dem Einfügen und Exportieren in Ziffern um."
+          }
+        }
+      }
+    },
     "Create profiles to use app-specific transcription settings." : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TypeWhisper/Services/NumberNormalization/DutchNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/DutchNumberWordParser.swift
@@ -1,0 +1,307 @@
+import Foundation
+
+enum DutchNumberWordParser {
+    private static let unitValues: [String: Int] = [
+        "nul": 0, "een": 1, "twee": 2, "drie": 3, "vier": 4, "vijf": 5,
+        "zes": 6, "zeven": 7, "acht": 8, "negen": 9,
+    ]
+
+    private static let teenValues: [String: Int] = [
+        "tien": 10, "elf": 11, "twaalf": 12, "dertien": 13, "veertien": 14,
+        "vijftien": 15, "zestien": 16, "zeventien": 17, "achttien": 18,
+        "negentien": 19,
+    ]
+
+    private static let tensValues: [String: Int] = [
+        "twintig": 20, "dertig": 30, "veertig": 40, "vijftig": 50,
+        "zestig": 60, "zeventig": 70, "tachtig": 80, "negentig": 90,
+    ]
+
+    static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        guard !words.isEmpty else { return nil }
+        let normalizedWords = words.map(normalizeWord)
+        var index = 0
+        var isNegative = false
+
+        if ["min", "minus"].contains(normalizedWords[index]) {
+            isNegative = true
+            index += 1
+            guard index < normalizedWords.count else { return nil }
+        }
+
+        let allowLeadingArticleOne = isNegative || startsWithOneDecimal(at: index, in: normalizedWords)
+        guard let integer = parseInteger(
+            normalizedWords,
+            startingAt: index,
+            allowLeadingArticleOne: allowLeadingArticleOne
+        ) else {
+            return nil
+        }
+        index = integer.nextIndex
+        var replacement = "\(integer.value)"
+
+        if index < normalizedWords.count, normalizedWords[index] == "komma" {
+            let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
+            if !decimal.digits.isEmpty {
+                replacement += ",\(decimal.digits)"
+                index = decimal.nextIndex
+            }
+        }
+
+        if isNegative {
+            replacement = "-" + replacement
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+    }
+
+    private static func parseInteger(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowLeadingArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        var total = 0
+        var current = 0
+        var index = startIndex
+        var consumed = false
+        var lastWasPlainSmallNumber = false
+
+        while index < words.count {
+            let word = words[index]
+
+            if word == "en",
+               let remainder = parseOptionalAndRemainder(words, startingAt: index, current: current, total: total) {
+                current += remainder.value
+                index = remainder.nextIndex
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if ["miljoen", "miljoenen"].contains(word) {
+                total += max(current, 1) * 1_000_000
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if word == "duizend" {
+                total += max(current, 1) * 1_000
+                current = 0
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            if word == "honderd" {
+                current = max(current, 1) * 100
+                index += 1
+                consumed = true
+                lastWasPlainSmallNumber = false
+                continue
+            }
+
+            let allowArticleOne = allowsArticleOne(
+                at: index,
+                in: words,
+                startIndex: startIndex,
+                allowLeadingArticleOne: allowLeadingArticleOne,
+                current: current,
+                total: total
+            )
+            guard let segment = parseSegment(words, startingAt: index, allowArticleOne: allowArticleOne) else {
+                break
+            }
+
+            if lastWasPlainSmallNumber {
+                break
+            }
+
+            current += segment.value
+            index = segment.nextIndex
+            consumed = true
+            lastWasPlainSmallNumber = segment.value < 10 && !allowArticleOne
+        }
+
+        guard consumed else { return nil }
+        return (total + current, index)
+    }
+
+    private static func parseSegment(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        if let underHundred = parseUnderHundred(words, startingAt: startIndex, allowArticleOne: allowArticleOne) {
+            return underHundred
+        }
+
+        guard let compound = parseCompound(words[startIndex], allowArticleOne: allowArticleOne) else {
+            return nil
+        }
+        return (compound, startIndex + 1)
+    }
+
+    private static func parseUnderHundred(
+        _ words: [String],
+        startingAt startIndex: Int,
+        allowArticleOne: Bool
+    ) -> (value: Int, nextIndex: Int)? {
+        guard startIndex < words.count else { return nil }
+        let word = words[startIndex]
+
+        if let unit = unitValue(word, allowArticleOne: true),
+           unit > 0,
+           startIndex + 2 < words.count,
+           words[startIndex + 1] == "en",
+           let ten = tensValues[words[startIndex + 2]] {
+            return (unit + ten, startIndex + 3)
+        }
+
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return (direct, startIndex + 1)
+        }
+
+        return nil
+    }
+
+    private static func parseCompound(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return direct
+        }
+
+        if let range = word.range(of: "duizend") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            let prefixValue = prefix.isEmpty ? 1 : parseCompound(prefix, allowArticleOne: true)
+            guard let prefixValue,
+                  let suffixValue = compoundSuffixValue(suffix) else {
+                return nil
+            }
+            return prefixValue * 1_000 + suffixValue
+        }
+
+        if let range = word.range(of: "honderd") {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            let prefixValue = prefix.isEmpty ? 1 : parseUnderHundred(prefix, allowArticleOne: true)
+            guard let prefixValue,
+                  let suffixValue = compoundSuffixValue(suffix) else {
+                return nil
+            }
+            return prefixValue * 100 + suffixValue
+        }
+
+        return parseUnderHundred(word, allowArticleOne: allowArticleOne)
+    }
+
+    private static func parseUnderHundred(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let direct = directValue(word, allowArticleOne: allowArticleOne) {
+            return direct
+        }
+
+        var searchRange = word.startIndex..<word.endIndex
+        while let range = word.range(of: "en", range: searchRange) {
+            let prefix = String(word[..<range.lowerBound])
+            let suffix = String(word[range.upperBound...])
+            if let unit = unitValue(prefix, allowArticleOne: true),
+               unit > 0,
+               let ten = tensValues[suffix] {
+                return unit + ten
+            }
+            searchRange = range.upperBound..<word.endIndex
+        }
+
+        return nil
+    }
+
+    private static func compoundSuffixValue(_ suffix: String) -> Int? {
+        guard !suffix.isEmpty else { return 0 }
+
+        if suffix.hasPrefix("en") {
+            let remainder = String(suffix.dropFirst(2))
+            guard let value = parseCompound(remainder, allowArticleOne: true),
+                  value <= 12 else {
+                return nil
+            }
+            return value
+        }
+
+        return parseCompound(suffix, allowArticleOne: true)
+    }
+
+    private static func parseOptionalAndRemainder(
+        _ words: [String],
+        startingAt startIndex: Int,
+        current: Int,
+        total: Int
+    ) -> (value: Int, nextIndex: Int)? {
+        guard current > 0 || total > 0,
+              startIndex + 1 < words.count,
+              let remainder = parseSegment(words, startingAt: startIndex + 1, allowArticleOne: true),
+              remainder.value <= 12 else {
+            return nil
+        }
+        return remainder
+    }
+
+    private static func parseDecimalDigits(_ words: [String], startingAt startIndex: Int) -> (digits: String, nextIndex: Int) {
+        var digits = ""
+        var index = startIndex
+
+        while index < words.count, let digit = unitValue(words[index], allowArticleOne: true) {
+            digits += "\(digit)"
+            index += 1
+        }
+
+        return (digits, index)
+    }
+
+    private static func directValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        if let unit = unitValue(word, allowArticleOne: allowArticleOne) {
+            return unit
+        }
+        return teenValues[word] ?? tensValues[word]
+    }
+
+    private static func unitValue(_ word: String, allowArticleOne: Bool) -> Int? {
+        guard let value = unitValues[word] else { return nil }
+        if value == 1, !allowArticleOne {
+            return nil
+        }
+        return value
+    }
+
+    private static func allowsArticleOne(
+        at index: Int,
+        in words: [String],
+        startIndex: Int,
+        allowLeadingArticleOne: Bool,
+        current: Int,
+        total: Int
+    ) -> Bool {
+        if index == startIndex, allowLeadingArticleOne {
+            return true
+        }
+
+        if current >= 100 || total > 0 {
+            return true
+        }
+
+        guard index + 1 < words.count else { return false }
+        return ["honderd", "duizend", "miljoen", "miljoenen", "komma"].contains(words[index + 1])
+    }
+
+    private static func startsWithOneDecimal(at index: Int, in words: [String]) -> Bool {
+        index + 1 < words.count && words[index] == "een" && words[index + 1] == "komma"
+    }
+
+    private static func normalizeWord(_ word: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "nl_NL"))
+            .lowercased()
+    }
+}

--- a/TypeWhisper/Services/NumberWordNormalizer.swift
+++ b/TypeWhisper/Services/NumberWordNormalizer.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NumberWordNormalizer {
-    private static let supportedLanguageCodes: Set<String> = ["en", "de", "fr", "es", "zh", "ja"]
+    private static let supportedLanguageCodes: Set<String> = ["en", "de", "fr", "es", "nl", "zh", "ja"]
     private static let cjkNumberCharacters = Set("零〇一二两兩三四五六七八九十百千万萬亿億点點負负".map { $0 })
 
     static func normalize(text: String, language: String?) -> String {
@@ -82,6 +82,8 @@ enum NumberWordNormalizer {
             parsed = FrenchNumberWordParser.parse(wordTexts)
         case "es":
             parsed = SpanishNumberWordParser.parse(wordTexts)
+        case "nl":
+            parsed = DutchNumberWordParser.parse(wordTexts)
         case "zh":
             parsed = ChineseNumberWordParser.parse(wordTexts)
         case "ja":

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -593,7 +593,7 @@ struct RecordingSettingsView: View {
                     set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) }
                 ))
 
-                Text(String(localized: "Converts spoken English and German numbers, such as twenty three or dreiundzwanzig, into digits before insertion and export."))
+                Text(String(localized: "Converts spoken numbers in supported languages into digits before insertion and export."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -1771,8 +1771,8 @@ private struct WorkflowEditorPage: View {
             }
 
             Text(localizedAppText(
-                "Controls whether spoken English and German numbers are converted to digits for this workflow.",
-                de: "Steuert, ob gesprochene englische und deutsche Zahlen in diesem Workflow zu Ziffern werden."
+                "Controls whether spoken numbers in supported languages are converted to digits for this workflow.",
+                de: "Steuert, ob gesprochene Zahlen in unterstützten Sprachen in diesem Workflow zu Ziffern werden."
             ))
             .font(.caption)
             .foregroundStyle(.secondary)

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -136,6 +136,22 @@ final class NumberWordNormalizerTests: XCTestCase {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "un millón de filas", language: "es"), "1000000 de filas")
     }
 
+    func testDutchNumbersNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "ik heb twee vragen", language: "nl"), "ik heb 2 vragen")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "drieëntwintig bestanden", language: "nl"), "23 bestanden")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twee en twintig bestanden", language: "nl"), "22 bestanden")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "duizend tweehonderd vierendertig", language: "nl"), "1234")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "driehonderdvijfendertig", language: "nl"), "335")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "min twee komma vijf", language: "nl"), "-2,5")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus een komma vijf", language: "nl"), "-1,5")
+    }
+
+    func testDutchArticleOneIsPreservedOutsideClearNumberConstructs() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "ik heb een probleem", language: "nl"), "ik heb een probleem")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "een miljoen regels", language: "nl"), "1000000 regels")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "een komma vijf seconden", language: "nl"), "1,5 seconden")
+    }
+
     func testChineseHanNumbersNormalizeToDigits() {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "我有二十三个文件", language: "zh"), "我有23个文件")
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "一千二百三十四", language: "zh"), "1234")

--- a/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
+++ b/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
@@ -19,6 +19,21 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testDutchLocaleNormalizesBeforePostProcessing() async throws {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeText(
+            "ik heb twee vragen",
+            language: "nl-NL",
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result, "ik heb 2 vragen")
+    }
+
+    @MainActor
     func testGlobalOffSkipsNormalization() async throws {
         let defaults = UserDefaults(suiteName: #function)!
         defaults.removePersistentDomain(forName: #function)


### PR DESCRIPTION
## Summary
- Adds a Dutch spoken-number parser and wires `nl` / `nl-*` into the existing number normalization path.
- Covers Dutch cardinal numbers, split ASR forms such as `twee en twintig`, scale words through `miljoen(en)`, `min` / `minus`, and `komma` decimals.
- Updates number-normalization help text so the UI no longer claims support is limited to English and German.

## Issue context
Issue #666 requested a Dutch-language number parser based on the existing parser family and noted that the UI copy still mentions only English and German.

Closes #666

## Test plan
- `jq empty TypeWhisper/Resources/Localizable.xcstrings`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/NumberWordNormalizerTests -only-testing:TypeWhisperTests/TranscriptionNormalizationServiceTests`
- `bash scripts/check_first_party_warnings.sh /tmp/typewhisper-dutch-number-parser-test.log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dutch language support for spoken number normalization, allowing automatic conversion of Dutch spoken numbers to digit equivalents during transcription and export.

* **Documentation**
  * Updated application settings to clarify that number normalization now supports converting spoken numbers from multiple languages into digits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->