### PR TITLE
Add recent transcriptions to the workflow palette

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -338,6 +338,8 @@ final class DictationViewModel: ObservableObject {
         self.promptPaletteHandler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
             promptProcessingService: promptProcessingService,
             workflowTextProcessingService: self.workflowTextProcessingService,
             soundService: soundService,

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -84,6 +84,16 @@ final class PromptPaletteHandler {
         let recentEntries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.records)
         guard !workflows.isEmpty || !recentEntries.isEmpty else { return }
 
+        if workflows.isEmpty {
+            showPalette(
+                context: nil,
+                workflows: [],
+                recentEntries: recentEntries,
+                soundFeedbackEnabled: soundFeedbackEnabled
+            )
+            return
+        }
+
         let activeApp = textInsertionService.captureActiveApp()
         let browserInfoTask = makeBrowserInfoTask(activeApp: activeApp)
 

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -27,6 +27,8 @@ final class PromptPaletteHandler {
     private let promptPaletteController: any PromptPaletteControlling
     private let textInsertionService: TextInsertionService
     private let workflowService: WorkflowService
+    private let historyService: HistoryService
+    private let recentTranscriptionStore: RecentTranscriptionStore
     private let workflowTextProcessingService: WorkflowTextProcessingService
     private let soundService: SoundService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
@@ -43,6 +45,8 @@ final class PromptPaletteHandler {
     init(
         textInsertionService: TextInsertionService,
         workflowService: WorkflowService,
+        historyService: HistoryService,
+        recentTranscriptionStore: RecentTranscriptionStore,
         promptProcessingService: PromptProcessingService,
         workflowTextProcessingService: WorkflowTextProcessingService? = nil,
         soundService: SoundService,
@@ -52,6 +56,8 @@ final class PromptPaletteHandler {
         self.promptPaletteController = promptPaletteController
         self.textInsertionService = textInsertionService
         self.workflowService = workflowService
+        self.historyService = historyService
+        self.recentTranscriptionStore = recentTranscriptionStore
         self.workflowTextProcessingService = workflowTextProcessingService
             ?? WorkflowTextProcessingService(
                 promptProcessingService: promptProcessingService,
@@ -75,7 +81,8 @@ final class PromptPaletteHandler {
         guard currentState == .idle else { return }
 
         let workflows = workflowService.workflows.filter { $0.isEnabled && $0.isManuallyRunnable }
-        guard !workflows.isEmpty else { return }
+        let recentEntries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.records)
+        guard !workflows.isEmpty || !recentEntries.isEmpty else { return }
 
         let activeApp = textInsertionService.captureActiveApp()
         let browserInfoTask = makeBrowserInfoTask(activeApp: activeApp)
@@ -83,11 +90,24 @@ final class PromptPaletteHandler {
         resolveTextContext(
             activeApp: activeApp,
             browserInfoTask: browserInfoTask,
-            soundFeedbackEnabled: soundFeedbackEnabled
+            onUnavailable: { [weak self] in
+                guard let self else { return }
+                guard !recentEntries.isEmpty else {
+                    self.showMissingTextFeedback(soundFeedbackEnabled: soundFeedbackEnabled)
+                    return
+                }
+                self.showPalette(
+                    context: nil,
+                    workflows: [],
+                    recentEntries: recentEntries,
+                    soundFeedbackEnabled: soundFeedbackEnabled
+                )
+            }
         ) { [weak self] context in
             self?.showPalette(
                 context: context,
                 workflows: workflows,
+                recentEntries: recentEntries,
                 soundFeedbackEnabled: soundFeedbackEnabled
             )
         }
@@ -110,7 +130,9 @@ final class PromptPaletteHandler {
         resolveTextContext(
             activeApp: activeApp,
             browserInfoTask: browserInfoTask,
-            soundFeedbackEnabled: soundFeedbackEnabled
+            onUnavailable: { [weak self] in
+                self?.showMissingTextFeedback(soundFeedbackEnabled: soundFeedbackEnabled)
+            }
         ) { [weak self] context in
             self?.processStandaloneWorkflow(
                 workflow: workflow,
@@ -133,7 +155,7 @@ final class PromptPaletteHandler {
     private func resolveTextContext(
         activeApp: (name: String?, bundleId: String?, url: String?),
         browserInfoTask: Task<(url: String?, title: String?), Never>?,
-        soundFeedbackEnabled: Bool,
+        onUnavailable: @escaping () -> Void,
         completion: @escaping (PaletteContext) -> Void
     ) {
         if let sel = textInsertionService.getTextSelection() {
@@ -171,27 +193,48 @@ final class PromptPaletteHandler {
                         selectionViaCopy: false
                     ))
                 } else {
-                    logger.info("[PromptPalette] No text available, aborting")
-                    let message = "Please select or copy some text first."
-                    soundService.play(.error, enabled: soundFeedbackEnabled)
-                    self.accessibilityAnnouncementService.announceError(message)
-                    self.onShowNotchFeedback?(message, "xmark.circle.fill", 2.5, true, "workflow")
-                    self.onShowError?(message)
+                    logger.info("[PromptPalette] No text available")
+                    onUnavailable()
                 }
             }
         }
     }
 
     private func showPalette(
-        context: PaletteContext,
+        context: PaletteContext?,
         workflows: [Workflow],
+        recentEntries: [RecentTranscriptionStore.Entry],
         soundFeedbackEnabled: Bool
     ) {
         paletteContext = context
 
-        promptPaletteController.show(workflows: workflows, sourceText: context.text) { [weak self] workflow in
-            self?.processStandaloneWorkflow(workflow: workflow, soundFeedbackEnabled: soundFeedbackEnabled)
+        var entries: [PromptPaletteEntry] = []
+        if context != nil {
+            entries.append(contentsOf: workflows.map { .workflow($0) })
         }
+        entries.append(contentsOf: recentEntries.map { .recentTranscription($0) })
+        guard !entries.isEmpty else { return }
+
+        promptPaletteController.show(entries: entries, sourceText: context?.text) { [weak self] entry in
+            guard let self else { return }
+            switch entry {
+            case .workflow(let workflow):
+                self.processStandaloneWorkflow(workflow: workflow, soundFeedbackEnabled: soundFeedbackEnabled)
+            case .recentTranscription(let recentEntry):
+                self.paletteContext = nil
+                Task { @MainActor in
+                    await self.insertRecentTranscription(recentEntry)
+                }
+            }
+        }
+    }
+
+    private func showMissingTextFeedback(soundFeedbackEnabled: Bool) {
+        let message = "Please select or copy some text first."
+        soundService.play(.error, enabled: soundFeedbackEnabled)
+        accessibilityAnnouncementService.announceError(message)
+        onShowNotchFeedback?(message, "xmark.circle.fill", 2.5, true, "workflow")
+        onShowError?(message)
     }
 
     private func processStandaloneWorkflow(workflow: Workflow, soundFeedbackEnabled: Bool) {
@@ -203,6 +246,19 @@ final class PromptPaletteHandler {
             context: ctx,
             soundFeedbackEnabled: soundFeedbackEnabled
         )
+    }
+
+    private func insertRecentTranscription(_ entry: RecentTranscriptionStore.Entry) async {
+        do {
+            _ = try await textInsertionService.insertText(
+                entry.finalText,
+                preserveClipboard: getPreserveClipboard?() ?? false,
+                autoEnter: false
+            )
+            onShowNotchFeedback?(String(localized: "Text inserted"), "checkmark.circle.fill", 2.5, false, nil)
+        } catch {
+            onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "recentTranscriptions")
+        }
     }
 
     private func processStandaloneWorkflow(

--- a/TypeWhisper/Views/PromptPalettePanel.swift
+++ b/TypeWhisper/Views/PromptPalettePanel.swift
@@ -2,55 +2,107 @@ import AppKit
 import SwiftUI
 
 @MainActor
+enum PromptPaletteEntry {
+    case workflow(Workflow)
+    case recentTranscription(RecentTranscriptionStore.Entry)
+}
+
+@MainActor
 protocol PromptPaletteControlling: AnyObject {
     var isVisible: Bool { get }
-    func show(workflows: [Workflow], sourceText: String, onSelect: @escaping (Workflow) -> Void)
+    func show(entries: [PromptPaletteEntry], sourceText: String?, onSelect: @escaping (PromptPaletteEntry) -> Void)
     func hide()
 }
 
 @MainActor
 final class PromptPaletteController: PromptPaletteControlling {
     private let paletteController: any SelectionPaletteControlling
+    private let relativeDateFormatter = RelativeDateTimeFormatter()
 
     init(paletteController: any SelectionPaletteControlling = SelectionPaletteController()) {
         self.paletteController = paletteController
+        relativeDateFormatter.unitsStyle = .short
     }
 
     var isVisible: Bool { paletteController.isVisible }
 
-    func show(workflows: [Workflow], sourceText: String, onSelect: @escaping (Workflow) -> Void) {
-        let enabledWorkflows = workflows.filter(\.isEnabled)
-        guard !enabledWorkflows.isEmpty else { return }
-
-        let items = enabledWorkflows.map {
-            SelectionPaletteItem(
-                id: $0.id,
-                title: $0.name,
-                subtitle: workflowPaletteSubtitle(for: $0),
-                iconSystemName: $0.definition.systemImage,
-                searchTokens: workflowPaletteSearchTokens(for: $0)
-            )
+    func show(entries: [PromptPaletteEntry], sourceText _: String?, onSelect: @escaping (PromptPaletteEntry) -> Void) {
+        let visibleEntries = entries.filter { entry in
+            switch entry {
+            case .workflow(let workflow):
+                return workflow.isEnabled
+            case .recentTranscription:
+                return true
+            }
         }
-        let workflowsByID = Dictionary(uniqueKeysWithValues: enabledWorkflows.map { ($0.id, $0) })
+        guard !visibleEntries.isEmpty else { return }
+
+        let itemPairs = visibleEntries.map { entry in
+            (paletteItem(for: entry), entry)
+        }
+        let entriesByID = Dictionary(uniqueKeysWithValues: itemPairs.map { ($0.0.id, $0.1) })
+        let containsRecentTranscriptions = visibleEntries.contains { entry in
+            if case .recentTranscription = entry {
+                return true
+            }
+            return false
+        }
 
         paletteController.show(
             configuration: SelectionPaletteConfiguration(
-                panelWidth: 380,
-                panelHeight: 344,
+                panelWidth: containsRecentTranscriptions ? 520 : 380,
+                panelHeight: containsRecentTranscriptions ? 380 : 344,
                 previewText: nil,
                 previewLineLimit: 3,
-                searchPrompt: localizedAppText("Search workflows...", de: "Workflows suchen..."),
-                emptyStateTitle: localizedAppText("No matching workflows", de: "Keine passenden Workflows")
+                titleLineLimit: containsRecentTranscriptions ? 2 : 1,
+                searchPrompt: searchPrompt(containsRecentTranscriptions: containsRecentTranscriptions),
+                emptyStateTitle: emptyStateTitle(containsRecentTranscriptions: containsRecentTranscriptions)
             ),
-            items: items
+            items: itemPairs.map { $0.0 }
         ) { item in
-            guard let workflow = workflowsByID[item.id] else { return }
-            onSelect(workflow)
+            guard let entry = entriesByID[item.id] else { return }
+            onSelect(entry)
         }
     }
 
     func hide() {
         paletteController.hide()
+    }
+
+    private func paletteItem(for entry: PromptPaletteEntry) -> SelectionPaletteItem {
+        switch entry {
+        case .workflow(let workflow):
+            SelectionPaletteItem(
+                id: UUID(),
+                title: workflow.name,
+                subtitle: workflowPaletteSubtitle(for: workflow),
+                iconSystemName: workflow.definition.systemImage,
+                searchTokens: workflowPaletteSearchTokens(for: workflow)
+            )
+        case .recentTranscription(let recentEntry):
+            SelectionPaletteItem(
+                id: UUID(),
+                title: recentEntry.finalText,
+                subtitle: recentTranscriptionSubtitle(for: recentEntry),
+                iconSystemName: "clock.arrow.circlepath",
+                searchTokens: recentTranscriptionSearchTokens(for: recentEntry)
+            )
+        }
+    }
+
+    private func searchPrompt(containsRecentTranscriptions: Bool) -> String {
+        containsRecentTranscriptions
+            ? localizedAppText(
+                "Search workflows and recent transcriptions...",
+                de: "Workflows und letzte Transkriptionen suchen..."
+            )
+            : localizedAppText("Search workflows...", de: "Workflows suchen...")
+    }
+
+    private func emptyStateTitle(containsRecentTranscriptions: Bool) -> String {
+        containsRecentTranscriptions
+            ? localizedAppText("No matching results", de: "Keine passenden Ergebnisse")
+            : localizedAppText("No matching workflows", de: "Keine passenden Workflows")
     }
 
     private func workflowPaletteSubtitle(for workflow: Workflow) -> String? {
@@ -123,5 +175,24 @@ final class PromptPaletteController: PromptPaletteControlling {
         return bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? bundle.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
             ?? bundleIdentifier
+    }
+
+    private func recentTranscriptionSubtitle(for entry: RecentTranscriptionStore.Entry) -> String {
+        let relativeTimestamp = relativeDateFormatter.localizedString(for: entry.timestamp, relativeTo: Date())
+        let appName = entry.appName?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let appName, !appName.isEmpty {
+            return "\(appName) • \(relativeTimestamp)"
+        }
+        return relativeTimestamp
+    }
+
+    private func recentTranscriptionSearchTokens(for entry: RecentTranscriptionStore.Entry) -> [String] {
+        [
+            localizedAppText("Recent Transcription", de: "Letzte Transkription"),
+            localizedAppText("Recent Transcriptions", de: "Letzte Transkriptionen"),
+            entry.appName,
+            entry.appBundleIdentifier,
+        ].compactMap { $0 }
     }
 }

--- a/TypeWhisper/Views/SelectionPalettePanel.swift
+++ b/TypeWhisper/Views/SelectionPalettePanel.swift
@@ -138,7 +138,8 @@ final class SelectionPaletteInteractionModel: ObservableObject {
 
     private func moveSelection(by offset: Int) {
         guard !filteredItems.isEmpty else { return }
-        selectedIndex = min(max(selectedIndex + offset, 0), filteredItems.count - 1)
+        let itemCount = filteredItems.count
+        selectedIndex = (selectedIndex + offset + itemCount) % itemCount
     }
 
     private func acceptSelection() {

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -460,21 +460,15 @@ final class PromptPaletteHandlerTests: XCTestCase {
 
         let textInsertionService = TextInsertionService()
         textInsertionService.accessibilityGrantedOverride = true
-        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        var didCaptureActiveApp = false
+        textInsertionService.captureActiveAppOverride = {
+            didCaptureActiveApp = true
+            return ("Notes", "com.apple.Notes", nil)
+        }
         textInsertionService.textSelectionOverride = { nil }
         textInsertionService.textSelectionViaCopyOverride = { nil }
 
-        let pasteboard = NSPasteboard.general
-        let savedClipboard = textInsertionService.saveClipboard(from: pasteboard)
-        defer { textInsertionService.restoreClipboard(savedClipboard, to: pasteboard) }
-        pasteboard.clearContents()
-
         let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
-        _ = workflowService.addWorkflow(
-            name: "Manual Summary",
-            template: .summary,
-            trigger: .manual()
-        )
 
         let recentTranscriptionStore = RecentTranscriptionStore()
         recentTranscriptionStore.recordTranscription(
@@ -502,12 +496,11 @@ final class PromptPaletteHandlerTests: XCTestCase {
 
         handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
 
-        try await Task.sleep(for: .milliseconds(50))
-
         XCTAssertTrue(controller.isVisible)
         XCTAssertEqual(controller.lastEntryDescriptions, ["recent:Recovered field text"])
         XCTAssertNil(controller.lastSourceText)
         XCTAssertNil(shownError)
+        XCTAssertFalse(didCaptureActiveApp)
     }
 
     func testWorkflowPaletteRecentSelectionInsertsWithoutAutoEnter() async throws {

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -164,11 +164,21 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
             template: .summary,
             trigger: .manual()
         )
+        let recentTranscriptionStore = RecentTranscriptionStore()
+        recentTranscriptionStore.recordTranscription(
+            id: UUID(),
+            finalText: "Recovered field text",
+            timestamp: Date(),
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes"
+        )
 
         let controller = PromptPaletteControllerSpy()
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: recentTranscriptionStore,
             promptProcessingService: PromptProcessingService(),
             soundService: SoundService(),
             accessibilityAnnouncementService: AccessibilityAnnouncementService(),
@@ -178,7 +188,7 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
         handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
 
         XCTAssertTrue(controller.isVisible)
-        XCTAssertEqual(controller.lastWorkflows?.map(\.name), ["Manual Summary"])
+        XCTAssertEqual(controller.lastEntryDescriptions, ["workflow:Manual Summary", "recent:Recovered field text"])
         XCTAssertEqual(controller.lastSourceText, "Selected text")
     }
 }
@@ -215,6 +225,8 @@ final class PromptPaletteHandlerTests: XCTestCase {
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
             promptProcessingService: PromptProcessingService(),
             workflowTextProcessingService: WorkflowTextProcessingService(
                 promptProcessor: { _, _, _, _, _ in "Processed: Selected source" },
@@ -286,6 +298,8 @@ final class PromptPaletteHandlerTests: XCTestCase {
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
             promptProcessingService: PromptProcessingService(),
             workflowTextProcessingService: WorkflowTextProcessingService(
                 promptProcessor: { _, _, _, _, _ in "Processed: Selected source" },
@@ -352,6 +366,8 @@ final class PromptPaletteHandlerTests: XCTestCase {
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
             promptProcessingService: PromptProcessingService(),
             workflowTextProcessingService: WorkflowTextProcessingService(
                 promptProcessor: { _, _, _, _, _ in "Processed: Clipboard source" },
@@ -401,6 +417,8 @@ final class PromptPaletteHandlerTests: XCTestCase {
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
             promptProcessingService: PromptProcessingService(),
             workflowTextProcessingService: WorkflowTextProcessingService(
                 promptProcessor: { _, text, _, _, _ in
@@ -436,6 +454,170 @@ final class PromptPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(errorMessage, "Please select or copy some text first.")
     }
 
+    func testWorkflowPaletteShowsRecentTranscriptionsWhenNoTextContextExists() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        textInsertionService.textSelectionOverride = { nil }
+        textInsertionService.textSelectionViaCopyOverride = { nil }
+
+        let pasteboard = NSPasteboard.general
+        let savedClipboard = textInsertionService.saveClipboard(from: pasteboard)
+        defer { textInsertionService.restoreClipboard(savedClipboard, to: pasteboard) }
+        pasteboard.clearContents()
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = workflowService.addWorkflow(
+            name: "Manual Summary",
+            template: .summary,
+            trigger: .manual()
+        )
+
+        let recentTranscriptionStore = RecentTranscriptionStore()
+        recentTranscriptionStore.recordTranscription(
+            id: UUID(),
+            finalText: "Recovered field text",
+            timestamp: Date(),
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes"
+        )
+
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: recentTranscriptionStore,
+            promptProcessingService: PromptProcessingService(),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller
+        )
+
+        var shownError: String?
+        handler.onShowError = { shownError = $0 }
+
+        handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertTrue(controller.isVisible)
+        XCTAssertEqual(controller.lastEntryDescriptions, ["recent:Recovered field text"])
+        XCTAssertNil(controller.lastSourceText)
+        XCTAssertNil(shownError)
+    }
+
+    func testWorkflowPaletteRecentSelectionInsertsWithoutAutoEnter() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Messages", "com.apple.MobileSMS", nil) }
+        textInsertionService.textSelectionOverride = { nil }
+        textInsertionService.textSelectionViaCopyOverride = { nil }
+
+        let generalPasteboard = NSPasteboard.general
+        let savedClipboard = textInsertionService.saveClipboard(from: generalPasteboard)
+        defer { textInsertionService.restoreClipboard(savedClipboard, to: generalPasteboard) }
+        generalPasteboard.clearContents()
+
+        let insertionPasteboard = NSPasteboard.withUniqueName()
+        textInsertionService.pasteboardProvider = { insertionPasteboard }
+
+        var pasteCount = 0
+        var returnCount = 0
+        textInsertionService.pasteSimulatorOverride = { pasteCount += 1 }
+        textInsertionService.returnSimulatorOverride = { returnCount += 1 }
+
+        let recentTranscriptionStore = RecentTranscriptionStore()
+        let recentID = UUID()
+        recentTranscriptionStore.recordTranscription(
+            id: recentID,
+            finalText: "Insert recovered text",
+            timestamp: Date(),
+            appName: "Messages",
+            appBundleIdentifier: "com.apple.MobileSMS"
+        )
+
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: WorkflowService(appSupportDirectory: appSupportDirectory),
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: recentTranscriptionStore,
+            promptProcessingService: PromptProcessingService(),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller
+        )
+
+        handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
+        try await Task.sleep(for: .milliseconds(50))
+        controller.selectRecent(id: recentID)
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(returnCount, 0)
+        XCTAssertEqual(insertionPasteboard.string(forType: .string), "Insert recovered text")
+    }
+
+    func testWorkflowPaletteWorkflowSelectionProcessesOriginalTextContext() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        let selectedElement = AXUIElementCreateSystemWide()
+        textInsertionService.textSelectionOverride = {
+            TextInsertionService.TextSelection(text: "Selected source", element: selectedElement)
+        }
+
+        var insertedText: String?
+        textInsertionService.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        _ = workflowService.addWorkflow(
+            name: "Palette Cleanup",
+            template: .cleanedText,
+            trigger: .manual()
+        )
+
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
+            promptProcessingService: PromptProcessingService(),
+            workflowTextProcessingService: WorkflowTextProcessingService(
+                promptProcessor: { _, _, _, _, _ in "Processed: Selected source" },
+                appleTranslator: nil
+            ),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller
+        )
+
+        handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
+
+        XCTAssertTrue(controller.isVisible)
+        XCTAssertEqual(controller.lastEntryDescriptions, ["workflow:Palette Cleanup"])
+        controller.selectWorkflow(named: "Palette Cleanup")
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(insertedText, "Processed: Selected source")
+    }
+
     func testTriggerSelectionStillOpensPaletteWhenCurrentProviderIsNotReady() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -468,6 +650,8 @@ final class PromptPaletteHandlerTests: XCTestCase {
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
             workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
             promptProcessingService: promptProcessingService,
             soundService: SoundService(),
             accessibilityAnnouncementService: AccessibilityAnnouncementService(),
@@ -480,7 +664,7 @@ final class PromptPaletteHandlerTests: XCTestCase {
         handler.triggerSelection(currentState: .idle, soundFeedbackEnabled: false)
 
         XCTAssertTrue(controller.isVisible)
-        XCTAssertEqual(controller.lastWorkflows?.map(\.name), ["Translate"])
+        XCTAssertEqual(controller.lastEntryDescriptions, ["workflow:Translate"])
         XCTAssertEqual(controller.lastSourceText, "Selected text")
         XCTAssertNil(shownError)
     }
@@ -528,6 +712,26 @@ final class SelectionPaletteInteractionModelTests: XCTestCase {
 
         XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 36, characters: "\r")))
         XCTAssertEqual(selectedID, items[1].id)
+    }
+
+    func testArrowKeysWrapSelectionAtListEdges() throws {
+        let items = [
+            SelectionPaletteItem(id: UUID(), title: "First"),
+            SelectionPaletteItem(id: UUID(), title: "Second"),
+            SelectionPaletteItem(id: UUID(), title: "Third"),
+        ]
+        let model = SelectionPaletteInteractionModel(
+            configuration: SelectionPaletteConfiguration(emptyStateTitle: "Empty"),
+            items: items,
+            onSelect: { _ in },
+            onDismiss: {}
+        )
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 126, characters: "")))
+        XCTAssertEqual(model.selectedIndex, 2)
+
+        XCTAssertTrue(model.handleKeyDown(try keyEvent(keyCode: 125, characters: "")))
+        XCTAssertEqual(model.selectedIndex, 0)
     }
 
     func testTypingAndDeleteUpdateSearchTextAndFilteredItems() throws {
@@ -594,19 +798,50 @@ final class SelectionPaletteInteractionModelTests: XCTestCase {
 @MainActor
 private final class PromptPaletteControllerSpy: PromptPaletteControlling {
     private(set) var isVisible = false
-    private(set) var lastWorkflows: [Workflow]?
+    private(set) var lastEntries: [PromptPaletteEntry]?
     private(set) var lastSourceText: String?
-    private var onSelect: ((Workflow) -> Void)?
+    private var onSelect: ((PromptPaletteEntry) -> Void)?
 
-    func show(workflows: [Workflow], sourceText: String, onSelect: @escaping (Workflow) -> Void) {
+    var lastEntryDescriptions: [String] {
+        lastEntries?.map { entry in
+            switch entry {
+            case .workflow(let workflow):
+                return "workflow:\(workflow.name)"
+            case .recentTranscription(let recentEntry):
+                return "recent:\(recentEntry.finalText)"
+            }
+        } ?? []
+    }
+
+    func show(entries: [PromptPaletteEntry], sourceText: String?, onSelect: @escaping (PromptPaletteEntry) -> Void) {
         isVisible = true
-        lastWorkflows = workflows
+        lastEntries = entries
         lastSourceText = sourceText
         self.onSelect = onSelect
     }
 
     func hide() {
         isVisible = false
+    }
+
+    func selectWorkflow(named name: String) {
+        guard let entry = lastEntries?.first(where: { entry in
+            if case .workflow(let workflow) = entry {
+                return workflow.name == name
+            }
+            return false
+        }) else { return }
+        onSelect?(entry)
+    }
+
+    func selectRecent(id: UUID) {
+        guard let entry = lastEntries?.first(where: { entry in
+            if case .recentTranscription(let recentEntry) = entry {
+                return recentEntry.id == id
+            }
+            return false
+        }) else { return }
+        onSelect?(entry)
     }
 }
 


### PR DESCRIPTION
## Summary
- add recent transcriptions as selectable entries in the workflow palette
- fall back to recent transcriptions when no text context is available
- wrap selection palette arrow-key navigation at list edges

## Issue context
This implements the workflow palette recovery path requested in #668 so users can recover recent dictations from the same hotkey they already use for workflows, while keeping the dedicated Recent Transcriptions palette intact.

Closes #668

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PromptPaletteHandlerTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/SelectionPaletteInteractionModelTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/268c/typewhisper-mac`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent transcriptions now appear in the prompt palette and can be inserted directly without triggering auto-enter.
* **Improvements**
  * Palette layout, titles and search text adapt based on available entry types.
  * Navigation wraps around at list edges for seamless circular movement.
* **Bug Fixes**
  * Missing-text situations now show appropriate feedback and still surface recent entries.
* **Tests**
  * Added tests for recent transcription display, selection, insertion, and wrap-around navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->