### PR TITLE
Fix Safari fullscreen toolbar indicator suppression

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -405,15 +405,15 @@ enum IndicatorFullscreenSuppressionPolicy {
         windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
         appBundleIdentifier: String? = Bundle.main.bundleIdentifier
     ) -> Bool {
-        guard placement == .notchStrip else {
-            return false
-        }
-
         guard let application = frontmostApplicationProvider() else {
             return false
         }
 
         guard application.processIdentifier != NSRunningApplication.current.processIdentifier else {
+            return false
+        }
+
+        guard placement == .notchStrip || isSafariBundleIdentifier(application.bundleIdentifier) else {
             return false
         }
 
@@ -453,10 +453,6 @@ enum IndicatorFullscreenSuppressionPolicy {
         appBundleIdentifier: String?,
         placement: IndicatorPlacement = .notchStrip
     ) -> Bool {
-        guard placement == .notchStrip else {
-            return false
-        }
-
         guard safeAreaTopInset > 0,
               let candidateWindowFrame = windowFrame,
               !screenFrame.isEmpty,
@@ -468,12 +464,49 @@ enum IndicatorFullscreenSuppressionPolicy {
         let screenFrame = screenFrame.standardized
         let windowFrame = candidateWindowFrame.standardized
 
+        // Safari's hidden fullscreen toolbar can be triggered by auxiliary panels
+        // even when the indicator renders away from the notch strip.
+        if isSafariBundleIdentifier(frontmostBundleIdentifier),
+           isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
+            return windowSubstantiallyOverlapsNotchStrip(
+                screenFrame: screenFrame,
+                safeAreaTopInset: safeAreaTopInset,
+                windowFrame: windowFrame
+            )
+        }
+
+        guard placement == .notchStrip else {
+            return false
+        }
+
         if let focusedWindowIsFullscreen {
             guard focusedWindowIsFullscreen else { return false }
         } else if !isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
             return false
         }
 
+        return windowSubstantiallyOverlapsNotchStrip(
+            screenFrame: screenFrame,
+            safeAreaTopInset: safeAreaTopInset,
+            windowFrame: windowFrame
+        )
+    }
+
+    private static func isFullscreenLikeWindow(screenFrame: CGRect, windowFrame: CGRect) -> Bool {
+        guard screenFrame.width > 0, screenFrame.height > 0 else { return false }
+
+        let widthCoverage = min(windowFrame.width / screenFrame.width, 1)
+        let heightCoverage = min(windowFrame.height / screenFrame.height, 1)
+
+        return widthCoverage >= minimumFullscreenDimensionCoverage
+            && heightCoverage >= minimumFullscreenDimensionCoverage
+    }
+
+    private static func windowSubstantiallyOverlapsNotchStrip(
+        screenFrame: CGRect,
+        safeAreaTopInset: CGFloat,
+        windowFrame: CGRect
+    ) -> Bool {
         let notchStripHeight = min(safeAreaTopInset, screenFrame.height)
         let notchStrip = CGRect(
             x: screenFrame.minX,
@@ -494,16 +527,6 @@ enum IndicatorFullscreenSuppressionPolicy {
             && verticalCoverage >= minimumVerticalCoverage
     }
 
-    private static func isFullscreenLikeWindow(screenFrame: CGRect, windowFrame: CGRect) -> Bool {
-        guard screenFrame.width > 0, screenFrame.height > 0 else { return false }
-
-        let widthCoverage = min(windowFrame.width / screenFrame.width, 1)
-        let heightCoverage = min(windowFrame.height / screenFrame.height, 1)
-
-        return widthCoverage >= minimumFullscreenDimensionCoverage
-            && heightCoverage >= minimumFullscreenDimensionCoverage
-    }
-
     private static func isTypeWhisperBundleIdentifier(
         _ bundleIdentifier: String?,
         appBundleIdentifier: String?
@@ -515,6 +538,11 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         return bundleIdentifier == "com.typewhisper.mac"
             || bundleIdentifier == "com.typewhisper.mac.dev"
+    }
+
+    private static func isSafariBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        bundleIdentifier == "com.apple.Safari"
+            || bundleIdentifier == "com.apple.SafariTechnologyPreview"
     }
 
     @MainActor

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -280,6 +280,67 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testSuppressesSafariFullscreenLikeWindowWhenAXReportsNotFullscreen() {
+        let safariFullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: safariFullscreenWindow,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.apple.Safari",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
+    func testSuppressesSafariTechnologyPreviewFullscreenLikeWindow() {
+        let safariFullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: safariFullscreenWindow,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.apple.SafariTechnologyPreview",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
+    func testSuppressesSafariFullscreenLikeWindowForNonNotchPlacement() {
+        let safariFullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: safariFullscreenWindow,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.apple.Safari",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea
+            )
+        )
+    }
+
+    func testDoesNotSuppressSafariWindowBelowNotchStripWhenAXReportsNotFullscreen() {
+        let safariWindowBelowMenuBar = CGRect(x: 7, y: 46, width: 3008, height: 1870)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: safariWindowBelowMenuBar,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.apple.Safari",
+                appBundleIdentifier: "com.typewhisper.mac.dev"
+            )
+        )
+    }
+
     func testDoesNotSuppressForeignMaximizedWindowWhenAXFullscreenIsUnavailable() {
         let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
         let maximizedWindowBelowMenuBar = CGRect(x: 7, y: 46, width: 1497, height: 929)


### PR DESCRIPTION
## Summary
- Suppress TypeWhisper indicator panels for Safari and Safari Technology Preview fullscreen-like windows on notched displays so Safari's hidden fullscreen toolbar is not forced visible.
- Keep the existing notch-strip suppression behavior for other fullscreen apps, and preserve non-notch indicator visibility outside the Safari-specific fullscreen case.
- Add regression coverage for Safari AX fullscreen misreporting, Safari Technology Preview, non-notch placement, and normal Safari windows below the notch strip.

## Issue context
Issue #665 reports that on notched MacBooks, Safari fullscreen with `View -> Always Show Toolbar in Full Screen` disabled shows a broken toolbar while TypeWhisper is running. Safari can expose hidden fullscreen toolbar chrome when an auxiliary fullscreen panel joins the Space, even when `AXFullScreen` reports `false`.

Closes #665

## Test plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests 2>&1 | tee /tmp/issue665-xcodebuild.log`
- `bash scripts/check_first_party_warnings.sh /tmp/issue665-xcodebuild.log`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/ship_typewhisper_tests.txt`
- `bash scripts/check_first_party_warnings.sh /tmp/ship_typewhisper_tests.txt`

## Manual verification
- Not run: I do not have a notched MacBook Safari fullscreen environment in this runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indicator placement logic in Safari to prevent indicators from overlapping with the notch area when fullscreen-like windows are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->