### PR TITLE
fix: improve long file transcription progress and Groq uploads

### DIFF
--- a/TypeWhisper/Services/AudioFileService.swift
+++ b/TypeWhisper/Services/AudioFileService.swift
@@ -1,8 +1,15 @@
 import Foundation
 import AVFoundation
 
+struct AudioFileLoadProgress: Sendable, Equatable {
+    let fraction: Double?
+    let currentTime: TimeInterval?
+    let duration: TimeInterval?
+}
+
 /// Converts audio/video files to 16kHz mono Float32 PCM samples for transcription.
 final class AudioFileService: Sendable {
+    typealias ProgressHandler = @Sendable (AudioFileLoadProgress) async -> Bool
 
     enum AudioFileError: LocalizedError {
         case fileNotFound
@@ -24,7 +31,10 @@ final class AudioFileService: Sendable {
     ]
 
     /// Extracts audio from a file and returns 16kHz mono Float32 samples.
-    func loadAudioSamples(from url: URL) async throws -> [Float] {
+    func loadAudioSamples(
+        from url: URL,
+        onProgress: ProgressHandler? = nil
+    ) async throws -> [Float] {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw AudioFileError.fileNotFound
         }
@@ -34,12 +44,17 @@ final class AudioFileService: Sendable {
             throw AudioFileError.unsupportedFormat
         }
 
-        return try await extractSamples(from: url)
+        return try await extractSamples(from: url, onProgress: onProgress)
     }
 
-    private func extractSamples(from url: URL) async throws -> [Float] {
+    private func extractSamples(
+        from url: URL,
+        onProgress: ProgressHandler?
+    ) async throws -> [Float] {
         let asset = AVURLAsset(url: url)
 
+        let assetDuration = try? await asset.load(.duration)
+        let duration = assetDuration?.seconds
         let tracks = try await asset.load(.tracks)
         guard let audioTrack = tracks.first(where: { $0.mediaType == .audio }) else {
             throw AudioFileError.conversionFailed("No audio track found")
@@ -68,8 +83,25 @@ final class AudioFileService: Sendable {
         }
 
         var allSamples: [Float] = []
+        var lastProgress = 0.0
 
         while let sampleBuffer = output.copyNextSampleBuffer() {
+            try Task.checkCancellation()
+            if let onProgress {
+                let currentTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+                let fraction = Self.progressFraction(currentTime: currentTime, duration: duration)
+                if fraction - lastProgress >= 0.01 {
+                    lastProgress = fraction
+                    guard await onProgress(AudioFileLoadProgress(
+                        fraction: fraction,
+                        currentTime: currentTime.isFinite ? currentTime : nil,
+                        duration: duration
+                    )) else {
+                        throw CancellationError()
+                    }
+                }
+            }
+
             guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { continue }
 
             let length = CMBlockBufferGetDataLength(blockBuffer)
@@ -91,6 +123,26 @@ final class AudioFileService: Sendable {
             throw AudioFileError.conversionFailed(reader.error?.localizedDescription ?? "Reading incomplete")
         }
 
+        if let onProgress {
+            guard await onProgress(AudioFileLoadProgress(
+                fraction: 1.0,
+                currentTime: duration,
+                duration: duration
+            )) else {
+                throw CancellationError()
+            }
+        }
+
         return allSamples
+    }
+
+    private static func progressFraction(currentTime: TimeInterval, duration: TimeInterval?) -> Double {
+        guard currentTime.isFinite,
+              let duration,
+              duration.isFinite,
+              duration > 0 else {
+            return 0
+        }
+        return min(max(currentTime / duration, 0), 1)
     }
 }

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -1,18 +1,28 @@
 import Foundation
 import Combine
 import AppKit
+import os
 import UniformTypeIdentifiers
 import TypeWhisperPluginSDK
 
 @MainActor
 final class FileTranscriptionViewModel: ObservableObject {
-    typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
+    typealias AudioProgressHandler = @MainActor @Sendable (AudioFileLoadProgress) -> Bool
+    typealias TranscriptionProgressHandler = @MainActor @Sendable (String) -> Bool
+    typealias CancellationChecker = @Sendable () -> Bool
+    typealias AudioSamplesLoader = @MainActor (
+        URL,
+        @escaping AudioProgressHandler,
+        @escaping CancellationChecker
+    ) async throws -> [Float]
     typealias TranscriptionRunner = @MainActor (
         [Float],
         LanguageSelection,
         TranscriptionTask,
         String?,
-        String?
+        String?,
+        @escaping TranscriptionProgressHandler,
+        @escaping CancellationChecker
     ) async throws -> TranscriptionResult
     typealias EngineReadinessChecker = @MainActor (String?) -> Bool
 
@@ -30,6 +40,11 @@ final class FileTranscriptionViewModel: ObservableObject {
         var state: FileItemState = .pending
         var result: TranscriptionResult?
         var errorMessage: String?
+        var phaseDescription: String?
+        var progressFraction: Double?
+        var progressText: String?
+        var startedAt: Date?
+        var finishedAt: Date?
 
         var fileName: String { url.lastPathComponent }
     }
@@ -40,18 +55,33 @@ final class FileTranscriptionViewModel: ObservableObject {
         case transcribing
         case done
         case error
+        case cancelled
     }
 
     enum BatchState: Equatable {
         case idle
         case processing
         case done
+        case cancelled
+    }
+
+    private final class CancellationFlag: @unchecked Sendable {
+        private let lock = OSAllocatedUnfairLock(initialState: false)
+
+        func cancel() {
+            lock.withLock { $0 = true }
+        }
+
+        var isCancelled: Bool {
+            lock.withLock { $0 }
+        }
     }
 
     @Published var files: [FileItem] = []
     @Published var showFilePickerFromMenu = false
     @Published var batchState: BatchState = .idle
     @Published var currentIndex: Int = 0
+    @Published private var elapsedRefreshDate = Date()
     @Published var languageSelection: LanguageSelection = .auto {
         didSet {
             defaults.set(
@@ -81,6 +111,9 @@ final class FileTranscriptionViewModel: ObservableObject {
     private let engineReadinessChecker: EngineReadinessChecker?
     private var cancellables = Set<AnyCancellable>()
     private var isInitialized = false
+    private var activeBatchTask: Task<Void, Never>?
+    private var activeCancellationFlag: CancellationFlag?
+    private var elapsedTimerTask: Task<Void, Never>?
 
     static let allowedContentTypes: [UTType] = [
         .wav, .mp3, .mpeg4Audio, .aiff, .audio,
@@ -98,16 +131,26 @@ final class FileTranscriptionViewModel: ObservableObject {
         self.modelManager = modelManager
         self.audioFileService = audioFileService
         self.defaults = defaults
-        self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
-            try await audioFileService.loadAudioSamples(from: url)
+        self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url, onProgress, isCancelled in
+            try await audioFileService.loadAudioSamples(from: url) { progress in
+                guard !isCancelled() else { return false }
+                return await onProgress(progress)
+            }
         }
-        self.transcriptionRunner = transcriptionRunner ?? { [modelManager] samples, languageSelection, task, engineOverrideId, cloudModelOverride in
+        self.transcriptionRunner = transcriptionRunner ?? { [modelManager] samples, languageSelection, task, engineOverrideId, cloudModelOverride, onProgress, isCancelled in
             try await modelManager.transcribe(
                 audioSamples: samples,
                 languageSelection: languageSelection,
                 task: task,
                 engineOverrideId: engineOverrideId,
-                cloudModelOverride: cloudModelOverride
+                cloudModelOverride: cloudModelOverride,
+                onProgress: { text in
+                    guard !isCancelled() else { return false }
+                    Task { @MainActor in
+                        _ = onProgress(text)
+                    }
+                    return !isCancelled()
+                }
             )
         }
         self.engineReadinessChecker = engineReadinessChecker
@@ -196,8 +239,14 @@ final class FileTranscriptionViewModel: ObservableObject {
     func transcribeAll() {
         guard canTranscribe else { return }
 
+        activeBatchTask?.cancel()
+        activeCancellationFlag?.cancel()
+
+        let cancellationFlag = CancellationFlag()
+        activeCancellationFlag = cancellationFlag
         batchState = .processing
         currentIndex = 0
+        startElapsedTimer()
 
         // Reset pending/error items
         for i in files.indices {
@@ -205,42 +254,122 @@ final class FileTranscriptionViewModel: ObservableObject {
                 files[i].state = .pending
                 files[i].result = nil
                 files[i].errorMessage = nil
+                files[i].phaseDescription = nil
+                files[i].progressFraction = nil
+                files[i].progressText = nil
+                files[i].startedAt = nil
+                files[i].finishedAt = nil
             }
         }
 
-        Task {
+        activeBatchTask = Task { [weak self] in
+            guard let self else { return }
             for i in files.indices {
-                guard batchState == .processing else { break }
+                guard batchState == .processing, !cancellationFlag.isCancelled else { break }
                 guard files[i].state != .done else { continue }
 
                 currentIndex = i
-                await transcribeFile(at: i)
+                await transcribeFile(at: i, cancellationFlag: cancellationFlag)
             }
-            batchState = .done
+
+            if cancellationFlag.isCancelled {
+                batchState = .cancelled
+            } else {
+                batchState = .done
+            }
+            stopElapsedTimer()
+            activeBatchTask = nil
+            activeCancellationFlag = nil
         }
     }
 
-    private func transcribeFile(at index: Int) async {
+    func cancelTranscription() {
+        guard batchState == .processing else { return }
+        activeCancellationFlag?.cancel()
+        activeBatchTask?.cancel()
+        if files.indices.contains(currentIndex),
+           files[currentIndex].state == .loading || files[currentIndex].state == .transcribing {
+            files[currentIndex].state = .cancelled
+            files[currentIndex].phaseDescription = String(localized: "Cancelled")
+            files[currentIndex].progressFraction = nil
+            files[currentIndex].finishedAt = Date()
+        }
+    }
+
+    private func transcribeFile(at index: Int, cancellationFlag: CancellationFlag) async {
         files[index].state = .loading
+        files[index].phaseDescription = String(localized: "Loading audio")
+        files[index].progressFraction = nil
+        files[index].progressText = nil
+        files[index].startedAt = Date()
+        files[index].finishedAt = nil
 
         do {
-            let samples = try await audioSamplesLoader(files[index].url)
+            let samples = try await audioSamplesLoader(
+                files[index].url,
+                { [weak self] progress in
+                    guard let self,
+                          !cancellationFlag.isCancelled,
+                          self.files.indices.contains(index),
+                          self.files[index].state == .loading else {
+                        return false
+                    }
+                    self.files[index].phaseDescription = Self.loadingPhaseDescription(for: progress)
+                    self.files[index].progressFraction = progress.fraction
+                    return true
+                },
+                { cancellationFlag.isCancelled }
+            )
+
+            try Task.checkCancellation()
+            guard !cancellationFlag.isCancelled else {
+                throw CancellationError()
+            }
 
             files[index].state = .transcribing
+            files[index].phaseDescription = String(localized: "Transcribing")
+            files[index].progressFraction = nil
 
             let result = try await transcriptionRunner(
                 samples,
                 languageSelection,
                 selectedTask,
                 selectedEngine,
-                selectedModel
+                selectedModel,
+                { [weak self] text in
+                    guard let self,
+                          !cancellationFlag.isCancelled,
+                          self.files.indices.contains(index),
+                          self.files[index].state == .transcribing else {
+                        return false
+                    }
+                    self.files[index].phaseDescription = String(localized: "Transcribing")
+                    self.files[index].progressText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return true
+                },
+                { cancellationFlag.isCancelled }
             )
+
+            guard !cancellationFlag.isCancelled else {
+                throw CancellationError()
+            }
 
             files[index].result = result
             files[index].state = .done
+            files[index].phaseDescription = String(localized: "Done")
+            files[index].progressFraction = 1.0
+            files[index].finishedAt = Date()
+        } catch is CancellationError {
+            files[index].state = .cancelled
+            files[index].phaseDescription = String(localized: "Cancelled")
+            files[index].progressFraction = nil
+            files[index].finishedAt = Date()
         } catch {
             files[index].state = .error
             files[index].errorMessage = error.localizedDescription
+            files[index].phaseDescription = String(localized: "Error")
+            files[index].progressFraction = nil
+            files[index].finishedAt = Date()
         }
     }
 
@@ -308,9 +437,19 @@ final class FileTranscriptionViewModel: ObservableObject {
     }
 
     func reset() {
+        cancelTranscription()
         files = []
         batchState = .idle
         currentIndex = 0
+        activeBatchTask = nil
+        activeCancellationFlag = nil
+        stopElapsedTimer()
+    }
+
+    func elapsedTime(for item: FileItem) -> TimeInterval? {
+        guard let startedAt = item.startedAt else { return nil }
+        let end = item.finishedAt ?? elapsedRefreshDate
+        return end.timeIntervalSince(startedAt)
     }
 
     private var selectedEngineIsReady: Bool {
@@ -338,5 +477,32 @@ final class FileTranscriptionViewModel: ObservableObject {
         if normalized != languageSelection {
             languageSelection = normalized
         }
+    }
+
+    private static func loadingPhaseDescription(for progress: AudioFileLoadProgress) -> String {
+        guard let fraction = progress.fraction else {
+            return String(localized: "Loading audio")
+        }
+        let percent = Int((fraction * 100).rounded())
+        return String(localized: "Loading audio \(percent)%")
+    }
+
+    private func startElapsedTimer() {
+        elapsedTimerTask?.cancel()
+        elapsedTimerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { break }
+                await MainActor.run {
+                    self?.elapsedRefreshDate = Date()
+                }
+            }
+        }
+    }
+
+    private func stopElapsedTimer() {
+        elapsedTimerTask?.cancel()
+        elapsedTimerTask = nil
+        elapsedRefreshDate = Date()
     }
 }

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -198,6 +198,10 @@ final class FileTranscriptionViewModel: ObservableObject {
         files.filter { $0.state == .done }.count
     }
 
+    var processedFiles: Int {
+        files.filter { $0.state == .done || $0.state == .error || $0.state == .cancelled }.count
+    }
+
     func observePluginManager() {
         guard let pluginManager = PluginManager.shared else { return }
         pluginManager.objectWillChange
@@ -297,6 +301,8 @@ final class FileTranscriptionViewModel: ObservableObject {
     }
 
     private func transcribeFile(at index: Int, cancellationFlag: CancellationFlag) async {
+        guard files.indices.contains(index) else { return }
+
         files[index].state = .loading
         files[index].phaseDescription = String(localized: "Loading audio")
         files[index].progressFraction = nil
@@ -322,6 +328,7 @@ final class FileTranscriptionViewModel: ObservableObject {
             )
 
             try Task.checkCancellation()
+            guard files.indices.contains(index) else { return }
             guard !cancellationFlag.isCancelled else {
                 throw CancellationError()
             }
@@ -350,6 +357,7 @@ final class FileTranscriptionViewModel: ObservableObject {
                 { cancellationFlag.isCancelled }
             )
 
+            guard files.indices.contains(index) else { return }
             guard !cancellationFlag.isCancelled else {
                 throw CancellationError()
             }
@@ -360,11 +368,13 @@ final class FileTranscriptionViewModel: ObservableObject {
             files[index].progressFraction = 1.0
             files[index].finishedAt = Date()
         } catch is CancellationError {
+            guard files.indices.contains(index) else { return }
             files[index].state = .cancelled
             files[index].phaseDescription = String(localized: "Cancelled")
             files[index].progressFraction = nil
             files[index].finishedAt = Date()
         } catch {
+            guard files.indices.contains(index) else { return }
             files[index].state = .error
             files[index].errorMessage = error.localizedDescription
             files[index].phaseDescription = String(localized: "Error")

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -290,6 +290,10 @@ struct FileTranscriptionView: View {
                         Text(String(localized: "\(String(format: "%.1f", result.duration))s - \(String(format: "%.1f", result.processingTime))s processing"))
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                    } else if let phase = item.phaseDescription {
+                        Text(statusSummary(for: item, phase: phase))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
 
@@ -328,6 +332,8 @@ struct FileTranscriptionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 10)
                     .padding(.bottom, 10)
+            } else if item.state == .loading || item.state == .transcribing {
+                activeFileDetails(item)
             }
         }
         .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
@@ -356,7 +362,31 @@ struct FileTranscriptionView: View {
             Image(systemName: "exclamationmark.circle.fill")
                 .foregroundStyle(.red)
                 .accessibilityLabel(String(localized: "Error"))
+        case .cancelled:
+            Image(systemName: "stop.circle.fill")
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(String(localized: "Cancelled"))
         }
+    }
+
+    @ViewBuilder
+    private func activeFileDetails(_ item: FileTranscriptionViewModel.FileItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let progress = item.progressFraction {
+                ProgressView(value: progress)
+                    .controlSize(.small)
+            }
+
+            if let progressText = item.progressText, !progressText.isEmpty {
+                Text(progressText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.bottom, 10)
     }
 
     @ViewBuilder
@@ -380,6 +410,7 @@ struct FileTranscriptionView: View {
                 }
                 .buttonStyle(.plain)
                 .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
                 .frame(width: 20)
                 .help(String(localized: "Export Subtitles"))
             }
@@ -417,7 +448,7 @@ struct FileTranscriptionView: View {
                     .controlSize(.small)
                 }
 
-                Spacer()
+                Spacer(minLength: 12)
 
                 if viewModel.hasResults {
                     Menu(String(localized: "Export All")) {
@@ -427,15 +458,21 @@ struct FileTranscriptionView: View {
                         Button(String(localized: "Export All as VTT")) { viewModel.exportAllSubtitles(format: .vtt) }
                     }
                     .controlSize(.small)
+                    .fixedSize(horizontal: true, vertical: false)
                 }
 
                 if viewModel.batchState == .processing {
-                    HStack(spacing: 6) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
-                            .font(.caption)
-                            .monospacedDigit()
+                    HStack(spacing: 10) {
+                        processingSummary
+
+                        Button(role: .destructive) {
+                            viewModel.cancelTranscription()
+                        } label: {
+                            Label(String(localized: "Stop"), systemImage: "stop.fill")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .fixedSize(horizontal: true, vertical: false)
                     }
                 } else {
                     Button {
@@ -445,6 +482,7 @@ struct FileTranscriptionView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
+                    .fixedSize(horizontal: true, vertical: false)
                     .disabled(!viewModel.canTranscribe)
                 }
 
@@ -455,10 +493,38 @@ struct FileTranscriptionView: View {
                         .foregroundStyle(.red)
                 }
                 .buttonStyle(.plain)
+                .frame(width: 22, height: 22)
                 .disabled(viewModel.batchState == .processing)
                 .help(String(localized: "Clear All"))
                 .accessibilityLabel(String(localized: "Clear All"))
             }
+        }
+    }
+
+    @ViewBuilder
+    private var processingSummary: some View {
+        if viewModel.files.indices.contains(viewModel.currentIndex) {
+            let item = viewModel.files[viewModel.currentIndex]
+            HStack(spacing: 4) {
+                Text(statusSummary(for: item, phase: item.phaseDescription ?? String(localized: "Processing...")))
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text("·")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .layoutPriority(1)
+        } else {
+            Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
+                .font(.caption)
+                .monospacedDigit()
+                .fixedSize(horizontal: true, vertical: false)
         }
     }
 
@@ -537,5 +603,20 @@ struct FileTranscriptionView: View {
             handled = true
         }
         return handled
+    }
+
+    private func statusSummary(for item: FileTranscriptionViewModel.FileItem, phase: String) -> String {
+        guard let elapsed = viewModel.elapsedTime(for: item) else { return phase }
+        return "\(phase) - \(formattedElapsed(elapsed))"
+    }
+
+    private func formattedElapsed(_ elapsed: TimeInterval) -> String {
+        let seconds = max(Int(elapsed.rounded()), 0)
+        let minutes = seconds / 60
+        let remainder = seconds % 60
+        if minutes > 0 {
+            return String(format: "%d:%02d", minutes, remainder)
+        }
+        return "\(remainder)s"
     }
 }

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -513,7 +513,7 @@ struct FileTranscriptionView: View {
                 Text("·")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
+                Text(String(localized: "\(viewModel.processedFiles)/\(viewModel.totalFiles)"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
@@ -521,7 +521,7 @@ struct FileTranscriptionView: View {
             .fixedSize(horizontal: true, vertical: false)
             .layoutPriority(1)
         } else {
-            Text(String(localized: "\(viewModel.completedFiles)/\(viewModel.totalFiles)"))
+            Text(String(localized: "\(viewModel.processedFiles)/\(viewModel.totalFiles)"))
                 .font(.caption)
                 .monospacedDigit()
                 .fixedSize(horizontal: true, vertical: false)

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -53,6 +53,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "GroqPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/GroqPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "Qwen3Plugin",
             dependencies: [
                 "TypeWhisperPluginSDK",
@@ -230,6 +240,15 @@ let package = Package(
                 "OpenRouterPlugin",
             ],
             path: "Plugins/OpenRouterPlugin/Tests"
+        ),
+        .testTarget(
+            name: "GroqPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "GroqPlugin",
+            ],
+            path: "Plugins/GroqPlugin/Tests"
         ),
         .testTarget(
             name: "Qwen3PluginTests",

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/GroqPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/GroqPlugin.swift
@@ -8,6 +8,7 @@ import TypeWhisperPluginSDK
 final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, LLMProviderPlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.groq"
     static let pluginName = "Groq"
+    private static let transcriptionRequestTimeout: TimeInterval = 600
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -102,13 +103,14 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
             throw PluginTranscriptionError.noModelSelected
         }
 
-        return try await transcriptionHelper.transcribe(
+        return try await transcriptionHelper.transcribeCompressedAudio(
             audio: audio,
             apiKey: apiKey,
             modelName: modelId,
             language: language,
             translate: translate,
-            prompt: prompt
+            prompt: prompt,
+            requestTimeout: Self.transcriptionRequestTimeout
         )
     }
 

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/Tests/GroqPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/Tests/GroqPluginTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XCTest
+import TypeWhisperPluginSDK
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import GroqPlugin
+
+final class GroqPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testTranscribeUsesLongTimeoutForLargerAudioUploads() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "whisper-large-v3"],
+            secrets: ["api-key": "groq-key"]
+        )
+        let plugin = GroqPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"hello","language":"en"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.groq.com/openai/v1/audio/transcriptions",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let audio = AudioData(samples: [0, 0, 0], wavData: Data("wav".utf8), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: nil, translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "hello")
+        XCTAssertEqual(store.sessions[0].requestedPaths, ["/openai/v1/audio/transcriptions"])
+        let request = try XCTUnwrap(store.sessions[0].requestedRequests.first)
+        XCTAssertEqual(request.timeoutInterval, 600)
+
+        let body = try XCTUnwrap(request.httpBody)
+        let bodyText = String(decoding: body.prefix(1_024), as: UTF8.self)
+        XCTAssertTrue(bodyText.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(bodyText.contains("Content-Type: audio/mp4"))
+        XCTAssertFalse(bodyText.contains(#"filename="audio.wav""#))
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.groq",
     "name": "Groq",
-    "version": "1.0.15",
-    "minHostVersion": "0.9.0",
+    "version": "1.0.16",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -408,7 +408,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
                 case .prewarming:
                     self?.modelState = .loading(phase: "prewarming")
                 case .loaded, .prewarmed:
-                    self?.modelState = .ready(self?.loadedModelId ?? modelDef.id)
+                    self?.modelState = .loading(phase: "prewarming")
                 case .unloaded:
                     self?.modelState = .notLoaded
                 default:

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -407,6 +407,10 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
                     self?.modelState = .loading(phase: "loading")
                 case .prewarming:
                     self?.modelState = .loading(phase: "prewarming")
+                case .loaded, .prewarmed:
+                    self?.modelState = .ready(self?.loadedModelId ?? modelDef.id)
+                case .unloaded:
+                    self?.modelState = .notLoaded
                 default:
                     break
                 }
@@ -450,6 +454,13 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
         }
         host?.notifyCapabilitiesChanged()
     }
+
+    #if DEBUG
+    func setModelStateForTesting(_ state: WhisperModelState, loadedModelId: String? = nil) {
+        self.loadedModelId = loadedModelId
+        modelState = state
+    }
+    #endif
 
     fileprivate func deleteModelFiles(_ modelDef: WhisperModelDef) throws {
         let modelPath = resolvedModelPath(for: modelDef)
@@ -658,6 +669,7 @@ final class WhisperKitPlugin: NSObject, TranscriptionEnginePlugin, Transcription
                 progress: downloadProgress
             )
         case .loading(let phase):
+            guard loadedModelId == nil else { return nil }
             let message: String
             switch phase {
             case "prewarming":

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -414,6 +414,16 @@ let result = try await helper.transcribe(
 )
 ```
 
+For large file transcription paths, use the compressed upload variant. It normalizes the audio for upload, encodes it as M4A before sending the OpenAI-compatible multipart request, and keeps the same response parsing behavior:
+
+```swift
+let result = try await helper.transcribeCompressedAudio(
+    audio: audio, apiKey: apiKey, modelName: "whisper-large-v3",
+    language: nil, translate: false, prompt: nil,
+    requestTimeout: 600
+)
+```
+
 ### PluginAudioUtils
 
 Helpers for short-clip handling:

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import os
 
@@ -282,6 +283,13 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
     private static let defaultRequestTimeout: TimeInterval = 30
     static let minimumUploadDuration: TimeInterval = 1.0
     static let uploadSampleRate = 16000
+    private static let compressedUploadChunkFrames = 16_000 * 30
+
+    private struct UploadFile {
+        let data: Data
+        let filename: String
+        let contentType: String
+    }
 
     public init(baseURL: String, responseFormat: String = "verbose_json") {
         self.baseURL = baseURL
@@ -348,6 +356,43 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         )
     }
 
+    public func transcribeCompressedAudio(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil
+    ) async throws -> PluginTranscriptionResult {
+        let uploadAudio = normalizedAudioForUpload(audio)
+        let compressedData: Data
+        do {
+            compressedData = try Self.makeCompressedM4AData(from: uploadAudio.samples)
+        } catch {
+            throw PluginTranscriptionError.apiError(
+                "Failed to encode compressed upload: \(error.localizedDescription)"
+            )
+        }
+
+        return try await performTranscribe(
+            audio: uploadAudio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            requestTimeout: requestTimeout,
+            uploadFile: UploadFile(
+                data: compressedData,
+                filename: "audio.m4a",
+                contentType: "audio/mp4"
+            )
+        )
+    }
+
     private func performTranscribe(
         audio: AudioData,
         apiKey: String,
@@ -356,7 +401,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         translate: Bool,
         prompt: String?,
         responseFormat: String?,
-        requestTimeout: TimeInterval
+        requestTimeout: TimeInterval,
+        uploadFile: UploadFile? = nil
     ) async throws -> PluginTranscriptionResult {
         let endpoint: String
         if translate {
@@ -376,14 +422,19 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = requestTimeout
 
-        let uploadAudio = normalizedAudioForUpload(audio)
+        let uploadAudio = uploadFile == nil ? normalizedAudioForUpload(audio) : audio
+        let uploadFile = uploadFile ?? UploadFile(
+            data: uploadAudio.wavData,
+            filename: "audio.wav",
+            contentType: "audio/wav"
+        )
         var body = Data()
 
         // file field
         body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
-        body.append(uploadAudio.wavData)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+        body.append(uploadFile.data)
         body.append("\r\n".data(using: .utf8)!)
 
         // model field
@@ -427,6 +478,58 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         }
 
         return try parseResponse(responseData)
+    }
+
+    private static func makeCompressedM4AData(from samples: [Float]) throws -> Data {
+        guard !samples.isEmpty else {
+            throw PluginTranscriptionError.apiError("Cannot encode empty audio upload")
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typewhisper-upload-\(UUID().uuidString).m4a")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: Double(uploadSampleRate),
+            AVNumberOfChannelsKey: 1,
+        ]
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(uploadSampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw PluginTranscriptionError.apiError("Failed to create compressed upload format")
+        }
+
+        do {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: settings,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+
+            var offset = 0
+            while offset < samples.count {
+                let count = min(compressedUploadChunkFrames, samples.count - offset)
+                guard let buffer = AVAudioPCMBuffer(
+                    pcmFormat: format,
+                    frameCapacity: AVAudioFrameCount(count)
+                ) else {
+                    throw PluginTranscriptionError.apiError("Failed to create compressed upload buffer")
+                }
+                buffer.frameLength = AVAudioFrameCount(count)
+                samples.withUnsafeBufferPointer { pointer in
+                    buffer.floatChannelData?[0].update(from: pointer.baseAddress! + offset, count: count)
+                }
+                try file.write(from: buffer)
+                offset += count
+            }
+        }
+
+        return try Data(contentsOf: url)
     }
 
     public func validateApiKey(_ apiKey: String) async -> Bool {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -124,6 +124,33 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         XCTAssertEqual(result.text, "ok")
         XCTAssertEqual(store.sessions.first?.requestedRequests.first?.timeoutInterval, 600)
     }
+
+    func testTranscribeCompressedAudioRejectsEmptySamplesBeforeUpload() async throws {
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession()
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let audio = AudioData(samples: [], wavData: Data(), duration: 1.0)
+
+        do {
+            _ = try await helper.transcribeCompressedAudio(
+                audio: audio,
+                apiKey: "test-key",
+                modelName: "whisper-1",
+                language: nil,
+                translate: false,
+                prompt: nil,
+                requestTimeout: 600
+            )
+            XCTFail("Expected empty compressed audio upload to fail")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertTrue(message.contains("empty audio upload"))
+        }
+
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
 }
 
 private final class OpenAITranscriptionMockSessionStore: @unchecked Sendable {

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -57,11 +57,11 @@ final class FileTranscriptionViewModelTests: XCTestCase {
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
             defaults: defaults,
-            audioSamplesLoader: { url in
+            audioSamplesLoader: { url, _, _ in
                 XCTAssertEqual(url, fileURL)
                 return [0.1, -0.1]
             },
-            transcriptionRunner: { samples, languageSelection, task, engineOverrideId, cloudModelOverride in
+            transcriptionRunner: { samples, languageSelection, task, engineOverrideId, cloudModelOverride, _, _ in
                 XCTAssertEqual(samples, [0.1, -0.1])
                 capturedLanguageSelection = languageSelection
                 capturedTask = task
@@ -96,6 +96,186 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(capturedModelOverrideId, "parakeet-large")
         XCTAssertEqual(viewModel.files.first?.state, .done)
         XCTAssertEqual(viewModel.files.first?.result?.text, "Recovered text")
+    }
+
+    func testTranscribeAllExposesLoadingProgressAndElapsedTime() async throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "long-video.mp4")
+        let progressReported = AsyncGate()
+        let finishLoading = AsyncGate()
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { url, onProgress, _ in
+                XCTAssertEqual(url, fileURL)
+                XCTAssertTrue(onProgress(AudioFileLoadProgress(
+                    fraction: 0.25,
+                    currentTime: 60,
+                    duration: 240
+                )))
+                await progressReported.open()
+                await finishLoading.wait()
+                return [0.1, -0.1]
+            },
+            transcriptionRunner: { _, _, _, engineOverrideId, _, _, _ in
+                TranscriptionResult(
+                    text: "Done",
+                    detectedLanguage: "en",
+                    duration: 1,
+                    processingTime: 0.1,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { _ in true }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.selectedEngine = "whisper"
+
+        viewModel.transcribeAll()
+        await progressReported.wait()
+
+        let item = try XCTUnwrap(viewModel.files.first)
+        XCTAssertEqual(item.phaseDescription, "Loading audio 25%")
+        XCTAssertNotNil(viewModel.elapsedTime(for: item))
+
+        await finishLoading.open()
+        try await waitForBatchToFinish(viewModel)
+    }
+
+    func testCancelTranscriptionMarksActiveFileCancelledAndStopsBatch() async throws {
+        let defaults = try makeDefaults()
+        let firstURL = makeTemporaryFile(named: "large-video.mp4")
+        let secondURL = makeTemporaryFile(named: "queued-video.mp4")
+        let started = AsyncGate()
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { _, _, isCancelled in
+                await started.open()
+                while !isCancelled() {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                throw CancellationError()
+            },
+            transcriptionRunner: { _, _, _, engineOverrideId, _, _, _ in
+                TranscriptionResult(
+                    text: "Should not complete",
+                    detectedLanguage: "en",
+                    duration: 1,
+                    processingTime: 0.1,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { _ in true }
+        )
+
+        viewModel.addFiles([firstURL, secondURL])
+        viewModel.selectedEngine = "whisper"
+
+        viewModel.transcribeAll()
+        await started.wait()
+        viewModel.cancelTranscription()
+        try await waitUntil {
+            viewModel.batchState == .cancelled
+        }
+
+        XCTAssertEqual(viewModel.files.first?.state, .cancelled)
+        XCTAssertEqual(viewModel.files.dropFirst().first?.state, .pending)
+        XCTAssertTrue(viewModel.canTranscribe)
+    }
+
+    func testRunnerProgressUpdatesActiveFileStatus() async throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "progress-video.mp4")
+        let progressReported = AsyncGate()
+        let finishRunner = AsyncGate()
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { _, _, _ in [0.1, -0.1] },
+            transcriptionRunner: { _, _, _, engineOverrideId, _, onProgress, _ in
+                XCTAssertTrue(onProgress("Partial transcript"))
+                await progressReported.open()
+                await finishRunner.wait()
+                return TranscriptionResult(
+                    text: "Final transcript",
+                    detectedLanguage: "en",
+                    duration: 1,
+                    processingTime: 0.1,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { _ in true }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.selectedEngine = "whisper"
+
+        viewModel.transcribeAll()
+        await progressReported.wait()
+
+        XCTAssertEqual(viewModel.files.first?.phaseDescription, "Transcribing")
+        XCTAssertEqual(viewModel.files.first?.progressText, "Partial transcript")
+        await finishRunner.open()
+        try await waitForBatchToFinish(viewModel)
+    }
+
+    func testCancellationDuringAudioLoadingIsNotReportedAsError() async throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "cancel-loading.mp4")
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { _, onProgress, isCancelled in
+                while !isCancelled() {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                XCTAssertFalse(onProgress(AudioFileLoadProgress(
+                    fraction: 0.5,
+                    currentTime: 30,
+                    duration: 60
+                )))
+                throw CancellationError()
+            },
+            transcriptionRunner: { _, _, _, engineOverrideId, _, _, _ in
+                TranscriptionResult(
+                    text: "Should not complete",
+                    detectedLanguage: "en",
+                    duration: 1,
+                    processingTime: 0.1,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { _ in true }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.selectedEngine = "whisper"
+
+        viewModel.transcribeAll()
+        try await waitUntil {
+            viewModel.files.first?.state == .loading
+        }
+        viewModel.cancelTranscription()
+        try await waitUntil {
+            viewModel.batchState == .cancelled
+        }
+
+        XCTAssertEqual(viewModel.files.first?.state, .cancelled)
+        XCTAssertNil(viewModel.files.first?.errorMessage)
     }
 
     func testRecoveryTranscribeUsesRecoveryEngineAndModelOverrides() async throws {
@@ -260,6 +440,33 @@ final class FileTranscriptionViewModelTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(20))
         }
         XCTFail("Recovery transcription was not saved to history")
+    }
+
+    private func waitUntil(
+        timeoutAttempts: Int = 100,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        for _ in 0..<timeoutAttempts {
+            if condition() {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("Condition was not met")
+    }
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+
+    func open() {
+        isOpen = true
+    }
+
+    func wait() async {
+        while !isOpen {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
     }
 }
 

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -116,7 +116,8 @@ final class FileTranscriptionViewModelTests: XCTestCase {
                     duration: 240
                 )))
                 await progressReported.open()
-                await finishLoading.wait()
+                let didFinishLoading = await finishLoading.wait()
+                XCTAssertTrue(didFinishLoading, "Timed out waiting for loading gate")
                 return [0.1, -0.1]
             },
             transcriptionRunner: { _, _, _, engineOverrideId, _, _, _ in
@@ -136,7 +137,8 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         viewModel.selectedEngine = "whisper"
 
         viewModel.transcribeAll()
-        await progressReported.wait()
+        let didReportProgress = await progressReported.wait()
+        XCTAssertTrue(didReportProgress, "Timed out waiting for loading progress callback")
 
         let item = try XCTUnwrap(viewModel.files.first)
         XCTAssertEqual(item.phaseDescription, "Loading audio 25%")
@@ -180,7 +182,8 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         viewModel.selectedEngine = "whisper"
 
         viewModel.transcribeAll()
-        await started.wait()
+        let didStart = await started.wait()
+        XCTAssertTrue(didStart, "Timed out waiting for cancellation loader start")
         viewModel.cancelTranscription()
         try await waitUntil {
             viewModel.batchState == .cancelled
@@ -205,7 +208,8 @@ final class FileTranscriptionViewModelTests: XCTestCase {
             transcriptionRunner: { _, _, _, engineOverrideId, _, onProgress, _ in
                 XCTAssertTrue(onProgress("Partial transcript"))
                 await progressReported.open()
-                await finishRunner.wait()
+                let didFinishRunner = await finishRunner.wait()
+                XCTAssertTrue(didFinishRunner, "Timed out waiting for runner gate")
                 return TranscriptionResult(
                     text: "Final transcript",
                     detectedLanguage: "en",
@@ -222,7 +226,8 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         viewModel.selectedEngine = "whisper"
 
         viewModel.transcribeAll()
-        await progressReported.wait()
+        let didReportProgress = await progressReported.wait()
+        XCTAssertTrue(didReportProgress, "Timed out waiting for transcription progress callback")
 
         XCTAssertEqual(viewModel.files.first?.phaseDescription, "Transcribing")
         XCTAssertEqual(viewModel.files.first?.progressText, "Partial transcript")
@@ -463,10 +468,12 @@ private actor AsyncGate {
         isOpen = true
     }
 
-    func wait() async {
-        while !isOpen {
+    func wait(timeoutAttempts: Int = 300) async -> Bool {
+        for _ in 0..<timeoutAttempts {
+            if isOpen { return true }
             try? await Task.sleep(for: .milliseconds(10))
         }
+        return isOpen
     }
 }
 

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -117,6 +117,16 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.resolvedCategoryIdentifiers, ["transcription", "llm", "tts"])
     }
 
+    func testGroqPluginReleaseRequiresHost15() throws {
+        let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json")
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.version, "1.0.16")
+        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
+    }
+
     func testQwen3UnsupportedLanguageSelectionFallsBackToAuto() {
         XCTAssertEqual(
             LanguageSelection.exact("uk").normalizedForSupportedLanguages(Qwen3Plugin.qwenSupportedLanguageCodes),

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -115,13 +115,24 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(plugin.currentSettingsActivity?.message, "Loading model")
 
         plugin.setModelStateForTesting(
-            .loading(phase: "loading"),
+            .ready("openai_whisper-large-v3_turbo"),
             loadedModelId: "openai_whisper-large-v3_turbo"
         )
         XCTAssertNil(plugin.currentSettingsActivity)
+    }
+
+    func testLoadedModelSuppressesLoadingSettingsActivity() throws {
+        let host = try makeHost(defaults: [
+            "selectedModel": "openai_whisper-large-v3_turbo",
+            "loadedModel": "openai_whisper-large-v3_turbo",
+        ])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
 
         plugin.setModelStateForTesting(
-            .ready("openai_whisper-large-v3_turbo"),
+            .loading(phase: "loading"),
             loadedModelId: "openai_whisper-large-v3_turbo"
         )
         XCTAssertNil(plugin.currentSettingsActivity)

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -101,6 +101,32 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
     }
 
+    func testReadyModelStateClearsLoadingSettingsActivity() throws {
+        let host = try makeHost(defaults: [
+            "selectedModel": "openai_whisper-large-v3_turbo",
+            "loadedModel": "openai_whisper-large-v3_turbo",
+        ])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        plugin.setModelStateForTesting(.loading(phase: "loading"))
+        XCTAssertEqual(plugin.currentSettingsActivity?.message, "Loading model")
+
+        plugin.setModelStateForTesting(
+            .loading(phase: "loading"),
+            loadedModelId: "openai_whisper-large-v3_turbo"
+        )
+        XCTAssertNil(plugin.currentSettingsActivity)
+
+        plugin.setModelStateForTesting(
+            .ready("openai_whisper-large-v3_turbo"),
+            loadedModelId: "openai_whisper-large-v3_turbo"
+        )
+        XCTAssertNil(plugin.currentSettingsActivity)
+    }
+
     func testActivationDoesNotMarkPluginConfiguredBeforeRestoreSucceeds() async throws {
         let host = try makeHost(defaults: [
             "selectedModel": "openai_whisper-tiny",


### PR DESCRIPTION
## Summary
This PR fixes issue #672 by making long file transcription jobs visible, cancellable, and safer for large cloud uploads.

**File Transcription progress and cancellation**
- Adds an active batch task, cancellation flag, and `cancelTranscription()` path for File Transcription.
- Shows active phase metadata per file: loading progress, elapsed time, transcription phase, and live transcript preview text when available.
- Replaces the processing-only spinner area with an explicit Stop button and tightens the File Transcription row/control layout.
- Adds cancellable AVAssetReader audio-loading progress based on media timestamps.

**Groq large-file upload path**
- Routes Groq file transcription through a compressed M4A upload path instead of re-uploading large decoded WAV payloads.
- Raises the Groq transcription request timeout to 600 seconds.
- Adds a Groq plugin SwiftPM target/test target so the upload behavior is covered by SDK tests.
- Releases Groq plugin metadata as `1.0.16` with `minHostVersion` `1.5.0`, so older apps do not install a bundle that depends on the new SDK helper.

**WhisperKit activity state**
- Clears stale `Loading model` activity when WhisperKit reports `.loaded` or `.prewarmed`, and avoids showing loading activity when `loadedModelId` is already present.

Closes #672

## Test Coverage
All new code paths are covered with focused XCTest/SwiftPM tests:
- `FileTranscriptionViewModelTests` covers active task progress, cancellation, runner progress text, and cancellation during audio loading.
- `OpenAITranscriptionHelperTests` covers custom timeout and compressed-upload empty-sample rejection.
- `GroqPluginTests` covers compressed M4A multipart upload and the 600-second request timeout.
- `PluginManifestValidationTests` covers Groq `1.0.16` / `minHostVersion` `1.5.0` compatibility metadata.
- `WhisperKitPluginLifecycleTests` covers stale loading activity clearing.

## Pre-Landing Review
One informational issue was auto-fixed before final verification:
- The compressed M4A helper now rejects empty sample uploads before encoding, with a regression test.

## Design Review
No web design review was run. This is a macOS SwiftUI settings surface change; the visible File Transcription layout was checked locally while iterating.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
No plan file detected. The implementation follows the issue #672 plan from the triage thread.

## Verification Results
Fresh verification was rerun after the review fix and after merging `origin/main` into the branch.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Passed: 873 tests, 0 failures.
- [x] `swift test --package-path TypeWhisperPluginSDK`
  - Passed: 208 tests, 0 failures.
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh GroqPlugin "$(pwd)"`
  - Passed: GroqPlugin build/install succeeded.
- [x] `git diff --check`
  - Passed.
- [x] Local API smoke test before final metadata/guard polish: Groq transcribed `/Users/marco/Downloads/test2/60f6cbbd-f625-493e-8924-981da1987220.wav` in ~9.9s with `error: null`, `language: English`, and non-empty transcript output.
- [x] Local API smoke test before final metadata/guard polish: Reson8 transcribed `/Users/marco/Downloads/test2/c63a7536-5d69-4122-bde9-ff490da6e4a8.mp4` in ~9.8s with `error: null` and non-empty transcript output.


## Documentation
- Updated `TypeWhisperPluginSDK/README.md` with the new `PluginOpenAITranscriptionHelper.transcribeCompressedAudio(...)` helper for large OpenAI-compatible transcription uploads.
- Audited the public website docs. No website docs PR was opened from this worktree because `/Users/marco/Projects/typewhisper.com` already has unrelated local changes (`.astro/settings.json`, `src/data/social-stats.json`) and the stable public macOS docs still describe the 1.4 release line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress-reporting and cancelable callbacks for audio loading and transcription; per-file elapsed time tracking.
  * Compressed (M4A) audio upload support with configurable request timeout and Groq plugin support for large files.
* **UI**
  * Per-file and batch UI show progress bars, phase summaries, elapsed time, and cancelled states; improved batch controls.
* **Documentation**
  * Docs for compressed upload usage.
* **Tests**
  * New tests for compressed uploads, progress/cancellation, and plugin manifest/version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

