### PR TITLE
Fix terminal clipboard restore race after verified paste

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -39,6 +39,7 @@ final class TextInsertionService {
     var pasteVerificationPollingDelay: Duration = .milliseconds(50)
     var defaultPasteFallbackRestoreDelay: Duration = .milliseconds(350)
     var terminalPasteFallbackRestoreDelay: Duration = .milliseconds(900)
+    var verifiedRestoreGraceDelay: Duration = .milliseconds(150)
 
     enum InsertionResult: Equatable {
         case insertedViaAccessibility
@@ -478,13 +479,21 @@ final class TextInsertionService {
         logPasteVerification(verification, bundleId: bundleId)
 
         if preserveClipboard {
+            let restoreDelay: Duration
+            if isTerminalApp {
+                restoreDelay = terminalPasteFallbackRestoreDelay
+            } else if verification == .verified {
+                restoreDelay = verifiedRestoreGraceDelay
+            } else {
+                restoreDelay = defaultPasteFallbackRestoreDelay
+            }
+
             if verification != .verified {
-                let restoreDelay = isTerminalApp ? terminalPasteFallbackRestoreDelay : defaultPasteFallbackRestoreDelay
                 logger.warning(
                     "insertText delaying clipboard restore after unverified paste: bundle=\(bundleId ?? "nil", privacy: .public), delay=\(String(describing: restoreDelay), privacy: .public)"
                 )
-                try? await Task.sleep(for: restoreDelay)
             }
+            try? await Task.sleep(for: restoreDelay)
             restoreClipboard(savedItems, to: pasteboard)
             logger.info(
                 "insertText restored clipboard: bundle=\(bundleId ?? "nil", privacy: .public), changeCountAfterRestore=\(pasteboard.changeCount, privacy: .public)"

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2791,6 +2791,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.focusedTextElementOverride = { element }
         service.captureActiveAppOverride = { ("Terminal", "com.apple.Terminal", nil) }
         service.terminalPasteFallbackRestoreDelay = .milliseconds(80)
+        service.verifiedRestoreGraceDelay = .milliseconds(1)
 
         let pasteStarted = expectation(description: "terminal synthetic paste started")
         var pasteCount = 0
@@ -2832,6 +2833,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.pasteboardProvider = { pasteboard }
         service.focusedTextElementOverride = { element }
         service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        service.defaultPasteFallbackRestoreDelay = .milliseconds(1)
         service.verifiedRestoreGraceDelay = .milliseconds(80)
 
         let pasteStarted = expectation(description: "non-terminal synthetic paste started")

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2751,6 +2751,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.pasteboardProvider = { pasteboard }
         service.focusedTextElementOverride = { element }
         service.captureActiveAppOverride = { ("iTerm2", "com.googlecode.iterm2", nil) }
+        service.terminalPasteFallbackRestoreDelay = .milliseconds(1)
 
         var pasteCount = 0
         service.pasteSimulatorOverride = {
@@ -2776,6 +2777,90 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertFalse(didAttemptDirectAXInsertion)
         XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(result, .pasted(verification: .verified))
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
+    @MainActor
+    func testVerifiedTerminalPasteKeepsGeneratedTextUntilTerminalRestoreDelay() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { element }
+        service.captureActiveAppOverride = { ("Terminal", "com.apple.Terminal", nil) }
+        service.terminalPasteFallbackRestoreDelay = .milliseconds(80)
+
+        let pasteStarted = expectation(description: "terminal synthetic paste started")
+        var pasteCount = 0
+        service.pasteSimulatorOverride = {
+            pasteCount += 1
+            pasteStarted.fulfill()
+        }
+        service.focusedTextStateOverride = { _ in
+            if pasteCount == 0 {
+                return (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+            }
+            return (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+
+        let insertionTask = Task {
+            try await service.insertText("Hello", preserveClipboard: true)
+        }
+
+        await fulfillment(of: [pasteStarted], timeout: 1.0)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+
+        let result = try await insertionTask.value
+        XCTAssertEqual(result, .pasted(verification: .verified))
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
+    @MainActor
+    func testVerifiedNonTerminalSyntheticPasteUsesGraceDelayBeforeClipboardRestore() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { element }
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        service.verifiedRestoreGraceDelay = .milliseconds(80)
+
+        let pasteStarted = expectation(description: "non-terminal synthetic paste started")
+        var pasteCount = 0
+        service.pasteSimulatorOverride = {
+            pasteCount += 1
+            pasteStarted.fulfill()
+        }
+        service.focusedTextStateOverride = { _ in
+            if pasteCount == 0 {
+                return (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+            }
+            return (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+
+        let insertionTask = Task {
+            try await service.insertText("**Hello**", preserveClipboard: true, outputFormat: "rtf")
+        }
+
+        await fulfillment(of: [pasteStarted], timeout: 1.0)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
+
+        let result = try await insertionTask.value
         XCTAssertEqual(result, .pasted(verification: .verified))
         XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
     }


### PR DESCRIPTION
## Summary
- Keep generated pasteboard content available briefly before restoring the saved clipboard after verified synthetic paste.
- Always use the terminal restore delay for terminal bundle IDs, because AX focused-text verification can fire before the target has finished reading `NSPasteboard`.
- Add regression coverage for verified terminal paste and verified non-terminal synthetic paste restore timing.

## Issue context
Closes #677.

This follows the restore-race analysis reported in #677: focused-text verification can show that the target changed, but it does not prove that the target app has already consumed the pasteboard for the synthetic Cmd+V. The reporter's analysis called out the zero-delay `.verified` restore path; this PR implements that timing guard and covers it with tests.

## Test plan
```bash
set -o pipefail && xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests | tee /tmp/typewhisper-issue-677-xcodebuild.log
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-issue-677-xcodebuild.log
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/3f7a/typewhisper-mac
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard restoration now uses configurable, context-aware delays—distinguishing terminal vs non-terminal apps and whether a paste was verified—to better preserve generated text during synthetic paste operations.

* **Tests**
  * Added tests validating verified-paste timing in terminal and non-terminal scenarios to ensure clipboard content remains available for the intended grace period before restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->