### PR TITLE
为 ChineseNumberWordParser 添加 Swift 文档注释

### DIFF
--- a/TypeWhisper/Services/NumberNormalization/ChineseNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/ChineseNumberWordParser.swift
@@ -1,6 +1,13 @@
 import Foundation
 
+/// 解析中文数字词的解析器
+///
+/// 提供将中文数字词转换为标准数字格式的功能，作为数字规范化服务的一部分。
 enum ChineseNumberWordParser {
+    /// 解析中文数字词数组为标准化的数字格式
+    ///
+    /// - Parameter words: 包含中文数字词的字符串数组，例如 `["一", "十", "百"]`
+    /// - Returns: 解析成功返回标准化的数字表示，解析失败返回 `nil`
     static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
         HanNumberWordParser.parse(words)
     }


### PR DESCRIPTION
## 问题背景
代码中的公共枚举 `ChineseNumberWordParser` 和其静态函数 `parse` 缺少文档注释，这降低了代码的可读性和可维护性。开发者在阅读或维护代码时，难以快速理解这些组件的功能和用法。

## 修改内容
- 为枚举 `ChineseNumberWordParser` 添加了 Swift 文档注释，说明其作为中文数字词解析器的用途，并简要描述其在数字规范化服务中的作用。
- 为静态函数 `parse` 添加了详细的 Swift 文档注释，包括函数描述、参数说明（`words` 数组，例如 `["一", "十", "百"]`）和返回值解释（成功返回标准化数字表示，失败返回 `nil`）。

## 验证方式
- 由于此更改仅涉及添加文档注释，不改变代码逻辑或外部行为，因此无需功能测试。
- 可通过代码审查确认注释的准确性、完整性和与现有代码风格的一致性。
- 确保现有单元测试和集成测试仍然通过，以排除任何意外影响。