### PR TITLE
Fix Safari fullscreen indicator suppression fallback

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -233,7 +233,51 @@ final class IndicatorCoordinator {
     }
 }
 
+private enum SafariBundleIdentifiers {
+    private static let identifiers: Set<String> = [
+        "com.apple.Safari",
+        "com.apple.SafariTechnologyPreview",
+    ]
+
+    static func contains(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return identifiers.contains(bundleIdentifier)
+    }
+}
+
 enum IndicatorWindowFrameLookup {
+    @MainActor
+    static func safariWindowFrames(intersecting screenFrame: CGRect) -> [CGRect] {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return []
+        }
+
+        let screenFrame = screenFrame.standardized
+        return windowList.compactMap { windowInfo in
+            guard let rawBounds = windowInfo[kCGWindowBounds as String],
+                  let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+                  let application = NSRunningApplication(processIdentifier: ownerPID),
+                  isSafariWindowOwner(application.bundleIdentifier) else {
+                return nil
+            }
+
+            let boundsDictionary = rawBounds as! CFDictionary
+            guard let bounds = CGRect(dictionaryRepresentation: boundsDictionary),
+                  !bounds.isEmpty,
+                  bounds.standardized.intersects(screenFrame) else {
+                return nil
+            }
+
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
+            guard alpha > 0 else { return nil }
+
+            return bounds
+        }
+    }
+
     nonisolated static func frontmostWindowFrame(for processIdentifier: pid_t) -> CGRect? {
         guard let windowList = CGWindowListCopyWindowInfo(
             [.optionOnScreenOnly, .excludeDesktopElements],
@@ -365,6 +409,10 @@ enum IndicatorWindowFrameLookup {
         }
         return focusedWindow
     }
+
+    private static func isSafariWindowOwner(_ bundleIdentifier: String?) -> Bool {
+        SafariBundleIdentifiers.contains(bundleIdentifier)
+    }
 }
 
 /// Where an indicator panel renders relative to the display's notch safe area.
@@ -386,6 +434,7 @@ enum IndicatorFullscreenSuppressionPolicy {
     private static let minimumHorizontalCoverage: CGFloat = 0.5
     private static let minimumVerticalCoverage: CGFloat = 0.5
     private static let minimumFullscreenDimensionCoverage: CGFloat = 0.98
+    private static let safariFullscreenEdgeTolerance: CGFloat = 4
     @MainActor private static var lastSuppression: IndicatorFullscreenSuppressionDiagnostics?
 
     @MainActor
@@ -403,35 +452,33 @@ enum IndicatorFullscreenSuppressionPolicy {
         focusedWindowFrameProvider: () -> CGRect? = IndicatorWindowFrameLookup.focusedWindowFrame,
         focusedWindowFullscreenProvider: () -> Bool? = IndicatorWindowFrameLookup.focusedWindowIsFullscreen,
         windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
+        safariWindowFramesProvider: @MainActor (CGRect) -> [CGRect] = IndicatorWindowFrameLookup.safariWindowFrames(intersecting:),
         appBundleIdentifier: String? = Bundle.main.bundleIdentifier
     ) -> Bool {
-        guard let application = frontmostApplicationProvider() else {
-            return false
+        let application = frontmostApplicationProvider()
+        let windowFrame: CGRect?
+        if let focusedWindowFrame = focusedWindowFrameProvider() {
+            windowFrame = focusedWindowFrame
+        } else if let application {
+            windowFrame = windowFrameProvider(application.processIdentifier)
+        } else {
+            windowFrame = nil
         }
-
-        guard application.processIdentifier != NSRunningApplication.current.processIdentifier else {
-            return false
-        }
-
-        guard placement == .notchStrip || isSafariBundleIdentifier(application.bundleIdentifier) else {
-            return false
-        }
-
-        let windowFrame = focusedWindowFrameProvider()
-            ?? windowFrameProvider(application.processIdentifier)
         let focusedWindowIsFullscreen = focusedWindowFullscreenProvider()
+        let safariWindowFrames = safariWindowFramesProvider(screen.frame)
 
         let shouldSuppress = shouldSuppressIndicator(
             screenFrame: screen.frame,
             safeAreaTopInset: screen.safeAreaInsets.top,
             windowFrame: windowFrame,
             focusedWindowIsFullscreen: focusedWindowIsFullscreen,
-            frontmostBundleIdentifier: application.bundleIdentifier,
+            frontmostBundleIdentifier: application?.bundleIdentifier,
             appBundleIdentifier: appBundleIdentifier,
-            placement: placement
+            placement: placement,
+            safariWindowFrames: safariWindowFrames
         )
 
-        if shouldSuppress {
+        if shouldSuppress, let application {
             recordSuppression(
                 screenFrame: screen.frame,
                 safeAreaTopInset: screen.safeAreaInsets.top,
@@ -451,28 +498,46 @@ enum IndicatorFullscreenSuppressionPolicy {
         focusedWindowIsFullscreen: Bool? = nil,
         frontmostBundleIdentifier: String?,
         appBundleIdentifier: String?,
-        placement: IndicatorPlacement = .notchStrip
+        placement: IndicatorPlacement = .notchStrip,
+        safariWindowFrames: [CGRect] = []
     ) -> Bool {
-        guard safeAreaTopInset > 0,
-              let candidateWindowFrame = windowFrame,
-              !screenFrame.isEmpty,
+        guard safeAreaTopInset > 0, !screenFrame.isEmpty else {
+            return false
+        }
+
+        let screenFrame = screenFrame.standardized
+
+        if safariWindowFrames.contains(where: {
+            isSafariFullscreenLikeWindow(
+                screenFrame: screenFrame,
+                safeAreaTopInset: safeAreaTopInset,
+                windowFrame: $0.standardized
+            )
+        }) {
+            return true
+        }
+
+        guard let candidateWindowFrame = windowFrame,
               !candidateWindowFrame.isEmpty,
               !isTypeWhisperBundleIdentifier(frontmostBundleIdentifier, appBundleIdentifier: appBundleIdentifier) else {
             return false
         }
 
-        let screenFrame = screenFrame.standardized
+        guard placement == .notchStrip || isSafariBundleIdentifier(frontmostBundleIdentifier) else {
+            return false
+        }
+
         let windowFrame = candidateWindowFrame.standardized
 
         // Safari's hidden fullscreen toolbar can be triggered by auxiliary panels
         // even when the indicator renders away from the notch strip.
         if isSafariBundleIdentifier(frontmostBundleIdentifier),
-           isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
-            return windowSubstantiallyOverlapsNotchStrip(
+           isSafariFullscreenLikeWindow(
                 screenFrame: screenFrame,
                 safeAreaTopInset: safeAreaTopInset,
                 windowFrame: windowFrame
-            )
+           ) {
+            return true
         }
 
         guard placement == .notchStrip else {
@@ -500,6 +565,30 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         return widthCoverage >= minimumFullscreenDimensionCoverage
             && heightCoverage >= minimumFullscreenDimensionCoverage
+    }
+
+    private static func isSafariFullscreenLikeWindow(
+        screenFrame: CGRect,
+        safeAreaTopInset: CGFloat,
+        windowFrame: CGRect
+    ) -> Bool {
+        if isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
+            return true
+        }
+
+        let contentHeight = screenFrame.height - safeAreaTopInset
+        guard contentHeight > 0 else { return false }
+
+        let widthCoverage = min(windowFrame.width / screenFrame.width, 1)
+        let contentHeightCoverage = min(windowFrame.height / contentHeight, 1)
+        // CGWindowList uses top-left-origin bounds, so maxY is the visual bottom edge.
+        let fillsToScreenBottom = abs(windowFrame.maxY - screenFrame.maxY) <= safariFullscreenEdgeTolerance
+        let visualTopStartsBelowNotch = abs(windowFrame.minY - (screenFrame.minY + safeAreaTopInset)) <= safariFullscreenEdgeTolerance
+
+        return widthCoverage >= minimumFullscreenDimensionCoverage
+            && contentHeightCoverage >= minimumFullscreenDimensionCoverage
+            && fillsToScreenBottom
+            && visualTopStartsBelowNotch
     }
 
     private static func windowSubstantiallyOverlapsNotchStrip(
@@ -541,8 +630,7 @@ enum IndicatorFullscreenSuppressionPolicy {
     }
 
     private static func isSafariBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
-        bundleIdentifier == "com.apple.Safari"
-            || bundleIdentifier == "com.apple.SafariTechnologyPreview"
+        SafariBundleIdentifiers.contains(bundleIdentifier)
     }
 
     @MainActor

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -326,6 +326,75 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testSuppressesSafariWindowScanWhenFrontmostLookupMissesSafari() {
+        let safariFullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: nil,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: nil,
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                safariWindowFrames: [safariFullscreenWindow]
+            )
+        )
+    }
+
+    func testSuppressesSafariWindowScanWhenTypeWhisperIsFrontmost() {
+        let safariFullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: nil,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.typewhisper.mac.dev",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                safariWindowFrames: [safariFullscreenWindow]
+            )
+        )
+    }
+
+    func testSuppressesSafariContentWindowThatStartsBelowNotchStrip() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let safariContentWindowBelowNotch = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: nil,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.typewhisper.mac.dev",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                safariWindowFrames: [safariContentWindowBelowNotch]
+            )
+        )
+    }
+
+    func testDoesNotSuppressSafariWindowScanForNormalWindowBelowNotchStrip() {
+        let safariWindowBelowMenuBar = CGRect(x: 7, y: 46, width: 3008, height: 1870)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: nil,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: nil,
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                safariWindowFrames: [safariWindowBelowMenuBar]
+            )
+        )
+    }
+
     func testDoesNotSuppressSafariWindowBelowNotchStripWhenAXReportsNotFullscreen() {
         let safariWindowBelowMenuBar = CGRect(x: 7, y: 46, width: 3008, height: 1870)
 


### PR DESCRIPTION
## Summary
- Add a Safari/STP visible-window fallback so indicator suppression still fires when the focused/frontmost lookup misses Safari during recording start.
- Treat Safari fullscreen content windows that start below the notch strip and fill the rest of the screen as fullscreen-like, covering the hidden-toolbar path seen with bottom Overlay indicators.
- Add regression coverage for Safari fallback scans, TypeWhisper-frontmost races, and normal non-fullscreen Safari windows.

## Issue context
Issue #665 reports that Safari fullscreen on notched MacBooks can show the hidden toolbar while TypeWhisper is running, even with Safari's "Always Show Toolbar in Full Screen" disabled. The reporter reproduced this on 1.5.0 (844) Daily with Overlay / Only during activity / Built-in Display / Bottom. Local dev smoke tests did not reproduce the visible toolbar, so this patch hardens the suppression path against the likely frontmost/focused window race shown by the reporter's screencast.

Closes #665

## Test plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests 2>&1 | tee /tmp/issue665-window-scan-reviewfix-xcodebuild.log`
- `bash scripts/check_first_party_warnings.sh /tmp/issue665-window-scan-reviewfix-xcodebuild.log`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/3d36/typewhisper-mac`
- Manual Safari fullscreen smoke test on Built-in Retina Display with Overlay / Only during activity / Built-in Display / Bottom: baseline and recording screenshots stayed clean with Safari's toolbar option unchecked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indicator suppression when Safari is fullscreen or showing content in edge-case window positions (better handling of Safari windows near the screen top/bottom).

* **Tests**
  * Added tests covering Safari window-detection and suppression scenarios, including fullscreen-like and notch-adjacent cases.

* **Refactor**
  * Consolidated and clarified Safari detection logic for more reliable suppression decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->