### PR TITLE
Disable dictionary term prompts for Qwen3 ASR

### DIFF
--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -360,8 +360,15 @@ final class DictionaryService: ObservableObject {
         guard !terms.isEmpty else { return nil }
 
         guard let providerId,
-              let plugin = PluginManager.shared?.transcriptionEngine(for: providerId),
-              let budget = (plugin as? any DictionaryTermsBudgetProviding)?.dictionaryTermsBudget else {
+              let plugin = PluginManager.shared?.transcriptionEngine(for: providerId) else {
+            return PluginDictionaryTerms.prompt(from: terms)
+        }
+
+        if (plugin as? any DictionaryTermsCapabilityProviding)?.dictionaryTermsSupport == .unsupported {
+            return nil
+        }
+
+        guard let budget = (plugin as? any DictionaryTermsBudgetProviding)?.dictionaryTermsBudget else {
             return PluginDictionaryTerms.prompt(from: terms)
         }
 

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 
@@ -129,8 +129,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     }
 
     var supportsTranslation: Bool { false }
-    var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
-    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTotalChars: 10_000) }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
 
     func transcribe(
         audio: AudioData,

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -34,11 +34,11 @@ final class Qwen3PluginTests: XCTestCase {
         XCTAssertEqual(Qwen3Plugin.resolveLanguageName("tl"), "Filipino")
     }
 
-    func testContextFormatterAddsAntiHallucinationInstructionAndDictionaryTerms() {
-        let context = Qwen3Plugin.contextBiasString(from: " TypeWhisper, MLX, TypeWhisper ")
+    func testContextFormatterIncludesExplicitPromptContext() {
+        let context = Qwen3Plugin.contextBiasString(from: " Use TypeWhisper and MLX spelling. ")
 
         XCTAssertTrue(context.contains(Qwen3ContextBiasFormatter.baseInstruction))
-        XCTAssertTrue(context.contains("Technical terms: TypeWhisper, MLX."))
+        XCTAssertTrue(context.contains("Use TypeWhisper and MLX spelling."))
     }
 
     func testContextFormatterIncludesBaseInstructionWithoutDictionaryTerms() {
@@ -46,6 +46,10 @@ final class Qwen3PluginTests: XCTestCase {
             Qwen3Plugin.contextBiasString(from: nil),
             Qwen3ContextBiasFormatter.baseInstruction
         )
+    }
+
+    func testDictionaryTermsAreNotAdvertisedForQwen3Prompting() {
+        XCTAssertEqual(Qwen3Plugin().dictionaryTermsSupport, .unsupported)
     }
 
     func testFrenchTrailingOuiArtifactIsRemovedOnlyAfterSentencePunctuation() {

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -50,6 +50,30 @@ private final class LegacyDictionaryEnginePlugin: NSObject, TranscriptionEngineP
     }
 }
 
+private final class UnsupportedDictionaryEnginePlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.tests.unsupported-dictionary-engine"
+    static let pluginName = "Unsupported Dictionary Engine"
+    var providerIdValue = "unsupported"
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    var providerId: String { providerIdValue }
+    var providerDisplayName: String { "Unsupported Mock" }
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] { [] }
+    var selectedModelId: String? { nil }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "ok", detectedLanguage: language)
+    }
+}
+
 final class DictionaryServiceTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -196,6 +220,20 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(service.getTermsForPrompt(providerId: plugin.providerId), expectedFallback)
         XCTAssertEqual(service.getTermsForPrompt(providerId: "missing"), expectedFallback)
         XCTAssertLessThanOrEqual(expectedFallback?.count ?? 0, 600)
+    }
+
+    @MainActor
+    func testGetTermsForPromptReturnsNilForUnsupportedEngines() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.setTerms(["Alpha", "Beta"], replaceExisting: true)
+
+        let plugin = UnsupportedDictionaryEnginePlugin()
+        installPlugins([plugin], appSupportDirectory: appSupportDirectory)
+
+        XCTAssertNil(service.getTermsForPrompt(providerId: plugin.providerId))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Mark Qwen3 ASR as not supporting dictionary-term prompting
- Stop `DictionaryService` from passing global dictionary terms to engines that advertise unsupported dictionary terms
- Preserve explicit caller-provided transcription prompts for Qwen3

## Motivation
Qwen3 receives context as prompt text rather than a dedicated hotword-bias channel. Long dictionary-term prompts can leak into transcripts, especially on longer recordings. This change removes the global dictionary terms from Qwen3's ASR context while keeping explicit request prompts intact.

## Verification
- `swift test --filter Qwen3PluginTests` from `TypeWhisperPluginSDK`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -only-testing:TypeWhisperTests/DictionaryServiceTests test`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme Qwen3Plugin -configuration Debug build`
- `~/.openclaw/skills/autoreview/scripts/autoreview --mode branch --base origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transcription engines that don't support dictionary terms, preventing unnecessary prompt generation.

* **Tests**
  * Updated test coverage for dictionary term capability checks and plugin support verification.

**Note:** Qwen3 transcription engine no longer supports custom dictionary terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->