### PR TITLE
Harden media pause and resume confirmation

### DIFF
--- a/TypeWhisper/Services/MediaPlaybackService.swift
+++ b/TypeWhisper/Services/MediaPlaybackService.swift
@@ -7,17 +7,87 @@ import os.log
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "MediaPlaybackService")
 
 #if !APPSTORE
+struct MediaPlaybackSnapshot: Equatable {
+    let isApplicationPlaying: Bool?
+    let playbackRate: Double?
+    let bundleIdentifier: String?
+    let trackIdentifier: String?
+
+    init(
+        isApplicationPlaying: Bool?,
+        playbackRate: Double?,
+        bundleIdentifier: String?,
+        trackIdentifier: String?
+    ) {
+        self.isApplicationPlaying = isApplicationPlaying
+        self.playbackRate = playbackRate
+        self.bundleIdentifier = bundleIdentifier
+        self.trackIdentifier = trackIdentifier
+    }
+
+    init(
+        isApplicationPlaying: Bool?,
+        playbackRate: Double?,
+        bundleIdentifier: String?,
+        title: String?,
+        artist: String?,
+        album: String?
+    ) {
+        self.init(
+            isApplicationPlaying: isApplicationPlaying,
+            playbackRate: playbackRate,
+            bundleIdentifier: bundleIdentifier,
+            trackIdentifier: Self.trackIdentifier(title: title, artist: artist, album: album)
+        )
+    }
+
+    var isActivelyPlaying: Bool {
+        guard isApplicationPlaying == true else { return false }
+        guard let playbackRate else { return true }
+        return playbackRate > 0
+    }
+
+    var logDescription: String {
+        let playingDescription = isApplicationPlaying.map { String(describing: $0) } ?? "nil"
+        let playbackRateDescription = playbackRate.map { String(format: "%.3f", $0) } ?? "nil"
+        return "bundle=\(bundleIdentifier ?? "unknown"), track=\(trackIdentifier ?? "unknown"), isPlaying=\(playingDescription), playbackRate=\(playbackRateDescription)"
+    }
+
+    func matchesMediaContext(of other: MediaPlaybackSnapshot) -> Bool {
+        guard bundleIdentifier == other.bundleIdentifier else { return false }
+        return trackIdentifier == other.trackIdentifier
+    }
+
+    private static func trackIdentifier(title: String?, artist: String?, album: String?) -> String? {
+        let parts = [title, artist, album].map { $0?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "" }
+        guard parts.contains(where: { !$0.isEmpty }) else { return nil }
+        return parts.joined(separator: "||")
+    }
+}
+
 protocol MediaPlaybackControlling: AnyObject {
-    func getPlaybackSnapshot(_ onReceive: @escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void)
+    func getPlaybackSnapshot(_ onReceive: @escaping (_ snapshot: MediaPlaybackSnapshot?) -> Void)
     func play()
     func pause()
+    func togglePlayPause()
 }
 
 extension MediaController: MediaPlaybackControlling {
-    func getPlaybackSnapshot(_ onReceive: @escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void) {
+    func getPlaybackSnapshot(_ onReceive: @escaping (_ snapshot: MediaPlaybackSnapshot?) -> Void) {
         getTrackInfo { trackInfo in
-            let playing = (trackInfo?.payload.isPlaying ?? false) || ((trackInfo?.payload.playbackRate ?? 0) > 0)
-            onReceive(playing, trackInfo?.payload.bundleIdentifier)
+            guard let payload = trackInfo?.payload else {
+                onReceive(nil)
+                return
+            }
+
+            onReceive(MediaPlaybackSnapshot(
+                isApplicationPlaying: payload.isPlaying,
+                playbackRate: payload.playbackRate,
+                bundleIdentifier: payload.bundleIdentifier,
+                title: payload.title,
+                artist: payload.artist,
+                album: payload.album
+            ))
         }
     }
 }
@@ -32,9 +102,12 @@ class MediaPlaybackService {
 
     private let controllerFactory: () -> MediaPlaybackControlling
     private let resumeDelay: TimeInterval
+    private let pauseConfirmDelay: TimeInterval
+    private let resumeConfirmDelay: TimeInterval
     private let resumeScheduler: ResumeScheduler
     private lazy var mediaController: MediaPlaybackControlling = controllerFactory()
     private var nowPlayingBundleID: String?
+    private var pausedSnapshot: MediaPlaybackSnapshot?
     private var trackInfoRequestGeneration = 0
     private var resumeGeneration = 0
 
@@ -44,21 +117,27 @@ class MediaPlaybackService {
     ) {
         self.controllerFactory = controllerFactory
         self.resumeDelay = 0.6
+        self.pauseConfirmDelay = 0.15
+        self.resumeConfirmDelay = 0.25
         self.resumeScheduler = Self.defaultResumeScheduler
     }
 
     init(
         startListening _: Bool = true,
         resumeDelay: TimeInterval,
+        pauseConfirmDelay: TimeInterval = 0.15,
+        resumeConfirmDelay: TimeInterval = 0.25,
         resumeScheduler: @escaping ResumeScheduler,
         controllerFactory: @escaping () -> MediaPlaybackControlling = { MediaController() }
     ) {
         self.controllerFactory = controllerFactory
         self.resumeDelay = resumeDelay
+        self.pauseConfirmDelay = pauseConfirmDelay
+        self.resumeConfirmDelay = resumeConfirmDelay
         self.resumeScheduler = resumeScheduler
     }
 
-    /// Uses a one-shot status probe to avoid keeping MediaRemote listener processes
+    /// Uses short status probes to avoid keeping MediaRemote listener processes
     /// alive while TypeWhisper is idle in the menu bar.
     func pauseIfPlaying() {
         cancelPendingResume()
@@ -66,18 +145,37 @@ class MediaPlaybackService {
         trackInfoRequestGeneration += 1
         let generation = trackInfoRequestGeneration
 
-        mediaController.getPlaybackSnapshot { [weak self] isPlaying, bundleIdentifier in
+        mediaController.getPlaybackSnapshot { [weak self] initialSnapshot in
             guard let self else { return }
             guard generation == self.trackInfoRequestGeneration else { return }
-            guard isPlaying else {
-                logger.info("No media playing, skipping pause")
+            guard let initialSnapshot, initialSnapshot.isActivelyPlaying else {
+                self.logSkippedPause(stage: "initial", snapshot: initialSnapshot)
                 return
             }
 
-            self.nowPlayingBundleID = bundleIdentifier
-            self.mediaController.pause()
-            self.didPause = true
-            logger.info("Media paused (nowPlaying: \(self.nowPlayingBundleID ?? "unknown"))")
+            self.resumeScheduler(self.pauseConfirmDelay) { [weak self] in
+                guard let self else { return }
+                guard generation == self.trackInfoRequestGeneration else { return }
+                guard !self.didPause else { return }
+
+                self.mediaController.getPlaybackSnapshot { [weak self] confirmedSnapshot in
+                    guard let self else { return }
+                    guard generation == self.trackInfoRequestGeneration else { return }
+                    guard !self.didPause else { return }
+                    guard let confirmedSnapshot,
+                          confirmedSnapshot.isActivelyPlaying,
+                          confirmedSnapshot.matchesMediaContext(of: initialSnapshot) else {
+                        self.logSkippedPause(stage: "confirm", snapshot: confirmedSnapshot)
+                        return
+                    }
+
+                    self.nowPlayingBundleID = confirmedSnapshot.bundleIdentifier
+                    self.pausedSnapshot = confirmedSnapshot
+                    self.mediaController.pause()
+                    self.didPause = true
+                    logger.info("Media paused after confirmation (\(confirmedSnapshot.logDescription, privacy: .public))")
+                }
+            }
         }
     }
 
@@ -87,6 +185,7 @@ class MediaPlaybackService {
         guard didPause else { return }
         cancelPendingResume()
         let generation = resumeGeneration
+        let snapshotToResume = pausedSnapshot
 
         resumeScheduler(resumeDelay) { [weak self] in
             guard let self else { return }
@@ -94,8 +193,36 @@ class MediaPlaybackService {
             guard self.didPause else { return }
 
             self.mediaController.play()
-            self.didPause = false
             logger.info("Media playback resumed")
+
+            guard let snapshotToResume else {
+                self.didPause = false
+                self.pausedSnapshot = nil
+                return
+            }
+            self.resumeScheduler(self.resumeConfirmDelay) { [weak self] in
+                guard let self else { return }
+                guard generation == self.resumeGeneration else { return }
+
+                self.mediaController.getPlaybackSnapshot { [weak self] resumedSnapshot in
+                    guard let self else { return }
+                    guard generation == self.resumeGeneration else { return }
+
+                    defer {
+                        self.didPause = false
+                        self.pausedSnapshot = nil
+                    }
+
+                    guard let resumedSnapshot,
+                          resumedSnapshot.matchesMediaContext(of: snapshotToResume),
+                          !resumedSnapshot.isActivelyPlaying else {
+                        return
+                    }
+
+                    self.mediaController.togglePlayPause()
+                    logger.info("Media resume fallback toggled playback (\(resumedSnapshot.logDescription, privacy: .public))")
+                }
+            }
         }
 
         logger.info("Scheduled media playback resume in \(self.resumeDelay, privacy: .public)s")
@@ -103,6 +230,10 @@ class MediaPlaybackService {
 
     private func cancelPendingResume() {
         resumeGeneration += 1
+    }
+
+    private func logSkippedPause(stage: String, snapshot: MediaPlaybackSnapshot?) {
+        logger.info("Media pause skipped at \(stage, privacy: .public) probe (\(snapshot?.logDescription ?? "nil", privacy: .public))")
     }
 
     private static let defaultResumeScheduler: ResumeScheduler = { delay, action in

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -825,13 +825,14 @@ final class APIRouterAndHandlersTests: XCTestCase {
             isPlaying: Bool?,
             playbackRate: Double?,
             bundleIdentifier: String? = "com.apple.Music",
-            trackIdentifier: String? = "Song||Artist||Album"
+            trackIdentifier: String? = nil
         ) -> MediaPlaybackSnapshot {
-            MediaPlaybackSnapshot(
+            let resolvedTrackIdentifier = bundleIdentifier == nil ? nil : (trackIdentifier ?? "Song||Artist||Album")
+            return MediaPlaybackSnapshot(
                 isApplicationPlaying: isPlaying,
                 playbackRate: playbackRate,
                 bundleIdentifier: bundleIdentifier,
-                trackIdentifier: trackIdentifier
+                trackIdentifier: resolvedTrackIdentifier
             )
         }
     }
@@ -3972,6 +3973,11 @@ final class APIRouterAndHandlersTests: XCTestCase {
         scheduler.runNextAction()
 
         XCTAssertEqual(controller.playCalls, 1)
+        XCTAssertEqual(scheduler.scheduledDelays, [0.15, 0.6, 0.25])
+
+        scheduler.runNextAction()
+
+        XCTAssertEqual(controller.togglePlayPauseCalls, 0)
     }
 
     @MainActor
@@ -4035,6 +4041,11 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(controller.pauseCalls, 1)
         XCTAssertEqual(controller.playCalls, 1)
+        XCTAssertEqual(scheduler.scheduledDelays, [0.15, 0.6, 0.25])
+
+        scheduler.runNextAction()
+
+        XCTAssertEqual(controller.togglePlayPauseCalls, 0)
     }
 
     @MainActor

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -784,17 +784,29 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
     #if !APPSTORE
     private final class FakeMediaPlaybackController: MediaPlaybackControlling {
-        var returnedSnapshot: (isPlaying: Bool, bundleIdentifier: String?) = (false, nil)
-        var onGetPlaybackSnapshot: ((@escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void) -> Void)?
+        var returnedSnapshot: MediaPlaybackSnapshot? = FakeMediaPlaybackController.snapshot(
+            isPlaying: false,
+            playbackRate: nil,
+            bundleIdentifier: nil
+        )
+        var snapshotQueue: [MediaPlaybackSnapshot?] = []
+        var onGetPlaybackSnapshot: ((@escaping (_ snapshot: MediaPlaybackSnapshot?) -> Void) -> Void)?
         private(set) var pauseCalls = 0
         private(set) var playCalls = 0
+        private(set) var togglePlayPauseCalls = 0
 
-        func getPlaybackSnapshot(_ onReceive: @escaping (_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void) {
+        func getPlaybackSnapshot(_ onReceive: @escaping (_ snapshot: MediaPlaybackSnapshot?) -> Void) {
             if let onGetPlaybackSnapshot {
                 onGetPlaybackSnapshot(onReceive)
                 return
             }
-            onReceive(returnedSnapshot.isPlaying, returnedSnapshot.bundleIdentifier)
+
+            if !snapshotQueue.isEmpty {
+                onReceive(snapshotQueue.removeFirst())
+                return
+            }
+
+            onReceive(returnedSnapshot)
         }
 
         func play() {
@@ -803,6 +815,24 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         func pause() {
             pauseCalls += 1
+        }
+
+        func togglePlayPause() {
+            togglePlayPauseCalls += 1
+        }
+
+        static func snapshot(
+            isPlaying: Bool?,
+            playbackRate: Double?,
+            bundleIdentifier: String? = "com.apple.Music",
+            trackIdentifier: String? = "Song||Artist||Album"
+        ) -> MediaPlaybackSnapshot {
+            MediaPlaybackSnapshot(
+                isApplicationPlaying: isPlaying,
+                playbackRate: playbackRate,
+                bundleIdentifier: bundleIdentifier,
+                trackIdentifier: trackIdentifier
+            )
         }
     }
 
@@ -816,11 +846,15 @@ final class APIRouterAndHandlersTests: XCTestCase {
             actions.append(action)
         }
 
+        func runNextAction() {
+            guard !actions.isEmpty else { return }
+            let action = actions.removeFirst()
+            action()
+        }
+
         func runPendingActions() {
-            let pendingActions = actions
-            actions.removeAll()
-            for action in pendingActions {
-                action()
+            while !actions.isEmpty {
+                runNextAction()
             }
         }
     }
@@ -3375,7 +3409,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testDictationDirectInsertionAddsTrailingSpaceWithoutMutatingStoredTranscription() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let historyEnabledKey = UserDefaultsKeys.historyEnabled
+        let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
         let originalHistoryEnabled = UserDefaults.standard.object(forKey: historyEnabledKey)
+        let originalPreserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardKey)
         var dictationContext: DictationContext?
         defer {
             dictationContext = nil
@@ -3384,13 +3420,20 @@ final class APIRouterAndHandlersTests: XCTestCase {
             } else {
                 UserDefaults.standard.removeObject(forKey: historyEnabledKey)
             }
+            if let originalPreserveClipboard {
+                UserDefaults.standard.set(originalPreserveClipboard, forKey: preserveClipboardKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: preserveClipboardKey)
+            }
             TestSupport.remove(appSupportDirectory)
         }
 
         UserDefaults.standard.set(true, forKey: historyEnabledKey)
+        UserDefaults.standard.set(false, forKey: preserveClipboardKey)
 
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.preserveClipboard = false
         let pasteboard = NSPasteboard.withUniqueName()
         context.textInsertionService.pasteboardProvider = { pasteboard }
         context.textInsertionService.captureActiveAppOverride = {
@@ -3901,10 +3944,10 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
     #if !APPSTORE
     @MainActor
-    func testMediaPlaybackServicePausesAndResumesFromOneShotTrackInfo() {
+    func testMediaPlaybackServicePausesAndResumesFromConfirmedTrackInfo() {
         let controller = FakeMediaPlaybackController()
         let scheduler = TestMediaPlaybackResumeScheduler()
-        controller.returnedSnapshot = (true, "com.apple.Music")
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 1)
         let service = MediaPlaybackService(
             startListening: false,
             resumeDelay: 0.6,
@@ -3912,13 +3955,21 @@ final class APIRouterAndHandlersTests: XCTestCase {
         ) { controller }
 
         service.pauseIfPlaying()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(scheduler.scheduledDelays, [0.15])
+
+        scheduler.runNextAction()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+
         service.resumeIfWePaused()
 
         XCTAssertEqual(controller.pauseCalls, 1)
         XCTAssertEqual(controller.playCalls, 0)
-        XCTAssertEqual(scheduler.scheduledDelays, [0.6])
+        XCTAssertEqual(scheduler.scheduledDelays, [0.15, 0.6])
 
-        scheduler.runPendingActions()
+        scheduler.runNextAction()
 
         XCTAssertEqual(controller.playCalls, 1)
     }
@@ -3926,7 +3977,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     @MainActor
     func testMediaPlaybackServiceSkipsPauseWhenPlaybackIsAlreadyStopped() {
         let controller = FakeMediaPlaybackController()
-        controller.returnedSnapshot = (false, nil)
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: false, playbackRate: nil, bundleIdentifier: nil)
         let service = MediaPlaybackService(startListening: false) { controller }
 
         service.pauseIfPlaying()
@@ -3937,10 +3988,220 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testMediaPlaybackServiceSkipsPauseForSpotifyPausedSnapshot() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(
+            isPlaying: false,
+            playbackRate: nil,
+            bundleIdentifier: "com.spotify.client",
+            trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+        )
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+        XCTAssertTrue(scheduler.scheduledDelays.isEmpty)
+    }
+
+    @MainActor
+    func testMediaPlaybackServicePausesAndResumesForSpotifyPlayingSnapshot() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(
+            isPlaying: true,
+            playbackRate: 1,
+            bundleIdentifier: "com.spotify.client",
+            trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+        )
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        scheduler.runNextAction()
+        service.resumeIfWePaused()
+        scheduler.runNextAction()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+        XCTAssertEqual(controller.playCalls, 1)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceFallsBackToToggleWhenResumePlayDoesNotRestartConfirmedMedia() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.snapshotQueue = [
+            FakeMediaPlaybackController.snapshot(
+                isPlaying: true,
+                playbackRate: 1,
+                bundleIdentifier: "com.spotify.client",
+                trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+            ),
+            FakeMediaPlaybackController.snapshot(
+                isPlaying: true,
+                playbackRate: 1,
+                bundleIdentifier: "com.spotify.client",
+                trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+            ),
+            FakeMediaPlaybackController.snapshot(
+                isPlaying: false,
+                playbackRate: nil,
+                bundleIdentifier: "com.spotify.client",
+                trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+            )
+        ]
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        scheduler.runNextAction()
+        service.resumeIfWePaused()
+        scheduler.runNextAction()
+        scheduler.runNextAction()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+        XCTAssertEqual(controller.playCalls, 1)
+        XCTAssertEqual(controller.togglePlayPauseCalls, 1)
+        XCTAssertEqual(scheduler.scheduledDelays, [0.15, 0.6, 0.25])
+
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.playCalls, 1)
+        XCTAssertEqual(controller.togglePlayPauseCalls, 1)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceSkipsTransientStalePlaybackStateWhenConfirmReportsPaused() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.snapshotQueue = [
+            FakeMediaPlaybackController.snapshot(
+                isPlaying: true,
+                playbackRate: 1,
+                bundleIdentifier: "com.spotify.client",
+                trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+            ),
+            FakeMediaPlaybackController.snapshot(
+                isPlaying: false,
+                playbackRate: nil,
+                bundleIdentifier: "com.spotify.client",
+                trackIdentifier: "Wildberry Lillet||Nina Chuba||Glas"
+            )
+        ]
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        scheduler.runNextAction()
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceSkipsPauseWhenPlaybackRateIsActiveButApplicationIsNotPlaying() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: false, playbackRate: 1)
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+        XCTAssertTrue(scheduler.scheduledDelays.isEmpty)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceSkipsPauseWhenPlaybackRateIsZero() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 0)
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+        XCTAssertTrue(scheduler.scheduledDelays.isEmpty)
+    }
+
+    @MainActor
+    func testMediaPlaybackServicePausesWhenApplicationIsPlayingAndPlaybackRateIsMissing() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: nil)
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        scheduler.runNextAction()
+
+        XCTAssertEqual(controller.pauseCalls, 1)
+    }
+
+    @MainActor
+    func testMediaPlaybackServiceStopBeforePauseConfirmInvalidatesPendingPause() {
+        let controller = FakeMediaPlaybackController()
+        let scheduler = TestMediaPlaybackResumeScheduler()
+        controller.snapshotQueue = [
+            FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 1),
+            FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 1)
+        ]
+        let service = MediaPlaybackService(
+            startListening: false,
+            resumeDelay: 0.6,
+            resumeScheduler: scheduler.schedule(after:action:)
+        ) { controller }
+
+        service.pauseIfPlaying()
+        service.resumeIfWePaused()
+        scheduler.runPendingActions()
+
+        XCTAssertEqual(controller.pauseCalls, 0)
+        XCTAssertEqual(controller.playCalls, 0)
+    }
+
+    @MainActor
     func testMediaPlaybackServiceIgnoresStalePauseProbeAfterResume() {
         let controller = FakeMediaPlaybackController()
         let scheduler = TestMediaPlaybackResumeScheduler()
-        var deferredCallback: ((_ isPlaying: Bool, _ bundleIdentifier: String?) -> Void)?
+        var deferredCallback: ((_ snapshot: MediaPlaybackSnapshot?) -> Void)?
         controller.onGetPlaybackSnapshot = { callback in
             deferredCallback = callback
         }
@@ -3952,7 +4213,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         service.pauseIfPlaying()
         service.resumeIfWePaused()
-        deferredCallback?(true, "com.apple.Music")
+        deferredCallback?(FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 1))
 
         XCTAssertEqual(controller.pauseCalls, 0)
         XCTAssertEqual(controller.playCalls, 0)
@@ -3967,7 +4228,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testMediaPlaybackServiceCancelsPendingResumeWhenRecordingRestartsBeforeDelayElapses() {
         let controller = FakeMediaPlaybackController()
         let scheduler = TestMediaPlaybackResumeScheduler()
-        controller.returnedSnapshot = (true, "com.apple.Music")
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 1)
         let service = MediaPlaybackService(
             startListening: false,
             resumeDelay: 0.6,
@@ -3975,6 +4236,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         ) { controller }
 
         service.pauseIfPlaying()
+        scheduler.runNextAction()
         service.resumeIfWePaused()
         service.pauseIfPlaying()
 
@@ -3993,7 +4255,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testMediaPlaybackServiceCoalescesDuplicateResumeRequestsIntoSinglePlay() {
         let controller = FakeMediaPlaybackController()
         let scheduler = TestMediaPlaybackResumeScheduler()
-        controller.returnedSnapshot = (true, "com.apple.Music")
+        controller.returnedSnapshot = FakeMediaPlaybackController.snapshot(isPlaying: true, playbackRate: 1)
         let service = MediaPlaybackService(
             startListening: false,
             resumeDelay: 0.6,
@@ -4001,6 +4263,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         ) { controller }
 
         service.pauseIfPlaying()
+        scheduler.runNextAction()
         service.resumeIfWePaused()
         service.resumeIfWePaused()
 


### PR DESCRIPTION
## Summary
- Add `MediaPlaybackSnapshot` so pause decisions use `isApplicationPlaying`, `playbackRate`, bundle ID, and a stable track identifier.
- Require a second matching playback snapshot before sending a pause command, which filters out stale Spotify-like paused states.
- Keep the confirmed paused media context through resume and send one targeted `togglePlayPause()` fallback when `play()` does not restart that same context.

## Issue context
#686 reports that Spotify music can start automatically after recording even though it was already paused before the transcription. The fix avoids marking TypeWhisper as the owner of a pause unless playback is confirmed as active across two matching snapshots, so a stable paused Spotify state remains untouched.

During local Spotify testing, active playback still pauses and resumes correctly. After the follow-up regression check, the resume path now also handles Spotify cases where the normal play command does not restart the same confirmed track.

Closes #686

## Test plan
- Local Spotify smoke test with TypeWhisper dev app: paused Spotify stays paused, active Spotify pauses and resumes.
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable pause/resume behavior with two-stage confirmation to avoid false pauses and incorrect resumes.
  * Improved matching of media context to prevent resuming the wrong track and to skip stale/transient states.
  * Coalesced duplicate resume attempts and better cancellation of pending actions when state changes.

* **Refactor**
  * Media playback state handling unified into a richer snapshot model for safer decision-making.

* **Tests**
  * Expanded test coverage for pause/resume edge cases and scheduler determinism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->