### PR TITLE
Add app-aware smart insertion

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -500,7 +500,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             UserDefaultsKeys.showMenuBarIcon: true,
             UserDefaultsKeys.dockIconBehaviorWhenMenuBarHidden: DockIconBehavior.keepVisible.rawValue,
             UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue,
-            UserDefaultsKeys.appFormattingEnabled: false,
+            UserDefaultsKeys.appFormattingEnabled: true,
             UserDefaultsKeys.transcriptionNumberNormalizationEnabled: true
         ])
     }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1916,18 +1916,18 @@
         }
       }
     },
-    "Automatically format transcribed text based on the target app. Configure the output format per workflow.": {
+    "Automatically format transcribed text based on the target app and use available cursor context for smarter insertion. Configure the output format per workflow.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transkribierten Text automatisch basierend auf der Ziel-App formatieren. Das Ausgabeformat kann pro Workflow konfiguriert werden."
+            "value": "Transkribierten Text automatisch basierend auf der Ziel-App formatieren und verfügbaren Cursor-Kontext für intelligenteres Einfügen nutzen. Das Ausgabeformat kann pro Workflow konfiguriert werden."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "対象アプリに基づいて文字起こしテキストを自動整形します。出力形式はワークフローごとに設定できます。"
+            "value": "対象アプリに基づいて文字起こしテキストを自動整形し、利用可能なカーソルの文脈を使ってよりスマートに挿入します。出力形式はワークフローごとに設定できます。"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1916,18 +1916,18 @@
         }
       }
     },
-    "Automatically format transcribed text based on the target app and use available cursor context for smarter insertion. Configure the output format per workflow.": {
+    "When enabled, TypeWhisper uses target-app rules and available cursor context for smarter insertion. Workflow output format settings still choose the inserted format for each workflow.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transkribierten Text automatisch basierend auf der Ziel-App formatieren und verfügbaren Cursor-Kontext für intelligenteres Einfügen nutzen. Das Ausgabeformat kann pro Workflow konfiguriert werden."
+            "value": "Wenn aktiviert, nutzt TypeWhisper Regeln der Ziel-App und verfügbaren Cursor-Kontext für intelligenteres Einfügen. Die Ausgabeformat-Einstellungen des Workflows bestimmen weiterhin das eingefügte Format für jeden Workflow."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "対象アプリに基づいて文字起こしテキストを自動整形し、利用可能なカーソルの文脈を使ってよりスマートに挿入します。出力形式はワークフローごとに設定できます。"
+            "value": "有効にすると、TypeWhisper は対象アプリのルールと利用可能なカーソルの文脈を使って、よりスマートに挿入します。ワークフローの出力形式設定は、各ワークフローで挿入する形式を引き続き決定します。"
           }
         }
       }

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -263,6 +263,14 @@ final class TextInsertionService {
         let element: AXUIElement
     }
 
+    struct InsertionContext: Equatable {
+        let value: String
+        let selectedRange: NSRange
+        let selectedText: String?
+        let previousCharacter: Character?
+        let nextCharacter: Character?
+    }
+
     typealias ClipboardItemSnapshot = [NSPasteboard.PasteboardType: Data]
     typealias ClipboardSnapshot = [ClipboardItemSnapshot]
 
@@ -395,6 +403,30 @@ final class TextInsertionService {
 
     func capturePasteVerificationState() -> PasteVerificationState {
         PasteVerificationState(focusedTextState: captureFocusedTextState())
+    }
+
+    func captureInsertionContext() -> InsertionContext? {
+        guard let state = captureFocusedTextState(),
+              let value = state.value,
+              let selectedRange = state.selectedRange,
+              let stringRange = Range(selectedRange, in: value) else {
+            return nil
+        }
+
+        let previousCharacter = stringRange.lowerBound > value.startIndex
+            ? value[value.index(before: stringRange.lowerBound)]
+            : nil
+        let nextCharacter = stringRange.upperBound < value.endIndex
+            ? value[stringRange.upperBound]
+            : nil
+
+        return InsertionContext(
+            value: value,
+            selectedRange: selectedRange,
+            selectedText: state.selectedText,
+            previousCharacter: previousCharacter,
+            nextCharacter: nextCharacter
+        )
     }
 
     func canRestoreClipboard(afterPasteUsing state: PasteVerificationState) -> Bool {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1323,7 +1323,15 @@ final class DictationViewModel: ObservableObject {
                         activeApp: activeApp, language: language, originalText: result.text
                     )
                 } else {
-                    let insertionText = DictationInsertionTextFormatter.textForInsertion(text)
+                    let contextualInsertionEnabled = DictationInsertionTextFormatter.contextualInsertionEnabled()
+                    let insertionContext = contextualInsertionEnabled
+                        ? textInsertionService.captureInsertionContext()
+                        : nil
+                    let insertionText = DictationInsertionTextFormatter.textForInsertion(
+                        text,
+                        insertionContext: insertionContext,
+                        contextualInsertionEnabled: contextualInsertionEnabled
+                    )
                     let insertionResult = try await textInsertionService.insertText(
                         insertionText,
                         preserveClipboard: preserveClipboard,
@@ -1891,10 +1899,170 @@ func hasConfirmedTranscriptionResultText(_ result: TranscriptionResult?) -> Bool
 }
 
 enum DictationInsertionTextFormatter {
-    static func textForInsertion(_ text: String) -> String {
+    static func contextualInsertionEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: UserDefaultsKeys.appFormattingEnabled)
+    }
+
+    static func textForInsertion(
+        _ text: String,
+        insertionContext: TextInsertionService.InsertionContext? = nil,
+        contextualInsertionEnabled: Bool = true
+    ) -> String {
+        guard contextualInsertionEnabled, let insertionContext else {
+            return textWithTrailingSpaceIfNeeded(text)
+        }
+
+        var result = text
+        if isHighConfidenceMidSentenceInsertion(insertionContext) {
+            result = lowercasingFirstWordIfSafe(result)
+        }
+        if shouldStripFinalPeriod(insertionContext) {
+            result = strippingSingleFinalPeriod(result)
+        }
+
+        if let previous = insertionContext.previousCharacter,
+           let first = result.first,
+           shouldInsertSpace(between: previous, and: first) {
+            result = " " + result
+        }
+
+        if let next = insertionContext.nextCharacter {
+            if let last = result.last,
+               shouldInsertSpace(between: last, and: next) {
+                result += " "
+            }
+        } else {
+            result = textWithTrailingSpaceIfNeeded(result)
+        }
+
+        return result
+    }
+
+    private static func textWithTrailingSpaceIfNeeded(_ text: String) -> String {
         guard let lastScalar = text.unicodeScalars.last else { return text }
         guard !CharacterSet.whitespacesAndNewlines.contains(lastScalar) else { return text }
         return text + " "
+    }
+
+    private static func isHighConfidenceMidSentenceInsertion(
+        _ context: TextInsertionService.InsertionContext
+    ) -> Bool {
+        guard let previous = context.previousCharacter else { return false }
+        return isWordLike(previous)
+    }
+
+    private static func shouldStripFinalPeriod(_ context: TextInsertionService.InsertionContext) -> Bool {
+        guard isHighConfidenceMidSentenceInsertion(context),
+              let next = context.nextCharacter else {
+            return false
+        }
+        return isWordLike(next)
+    }
+
+    private static func lowercasingFirstWordIfSafe(_ text: String) -> String {
+        var result = text
+        guard let wordRange = firstWordRange(in: result),
+              shouldLowercaseFirstWord(String(result[wordRange])) else {
+            return result
+        }
+
+        let firstIndex = wordRange.lowerBound
+        let nextIndex = result.index(after: firstIndex)
+        result.replaceSubrange(firstIndex..<nextIndex, with: String(result[firstIndex]).lowercased())
+        return result
+    }
+
+    private static func firstWordRange(in text: String) -> Range<String.Index>? {
+        var start = text.startIndex
+        while start < text.endIndex, isWhitespace(text[start]) {
+            start = text.index(after: start)
+        }
+        guard start < text.endIndex, isWordLike(text[start]) else {
+            return nil
+        }
+
+        var end = text.index(after: start)
+        while end < text.endIndex, isWordLike(text[end]) {
+            end = text.index(after: end)
+        }
+        return start..<end
+    }
+
+    private static func shouldLowercaseFirstWord(_ word: String) -> Bool {
+        guard word.count > 1,
+              let first = word.first,
+              isUppercaseLetter(first) else {
+            return false
+        }
+
+        let remainder = word.dropFirst()
+        guard remainder.contains(where: isLowercaseLetter) else {
+            return false
+        }
+        return !remainder.contains(where: isUppercaseLetter)
+    }
+
+    private static func strippingSingleFinalPeriod(_ text: String) -> String {
+        var result = text
+        var currentIndex = result.endIndex
+
+        while currentIndex > result.startIndex {
+            let previousIndex = result.index(before: currentIndex)
+            if isWhitespace(result[previousIndex]) {
+                currentIndex = previousIndex
+                continue
+            }
+
+            guard result[previousIndex] == "." else {
+                return result
+            }
+            if previousIndex > result.startIndex {
+                let beforePeriod = result.index(before: previousIndex)
+                guard result[beforePeriod] != "." else {
+                    return result
+                }
+            }
+            result.removeSubrange(previousIndex..<currentIndex)
+            return result
+        }
+
+        return result
+    }
+
+    private static func shouldInsertSpace(between left: Character, and right: Character) -> Bool {
+        if isWhitespace(left) || isWhitespace(right) {
+            return false
+        }
+        if closingPunctuation.contains(right) || openingPunctuation.contains(left) {
+            return false
+        }
+        if isWordLike(left) && isWordLike(right) {
+            return true
+        }
+        if isWordLike(right) && punctuationThatTakesFollowingSpace.contains(left) {
+            return true
+        }
+        return false
+    }
+
+    private static let openingPunctuation: Set<Character> = ["(", "[", "{", "\"", "'", "“", "‘"]
+    private static let closingPunctuation: Set<Character> = [".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "”", "’"]
+    private static let punctuationThatTakesFollowingSpace: Set<Character> = [".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "”", "’"]
+
+    private static func isWordLike(_ character: Character) -> Bool {
+        character.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
+    }
+
+    private static func isWhitespace(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
+    }
+
+    private static func isUppercaseLetter(_ character: Character) -> Bool {
+        character.unicodeScalars.contains { CharacterSet.uppercaseLetters.contains($0) }
+    }
+
+    private static func isLowercaseLetter(_ character: Character) -> Bool {
+        character.unicodeScalars.contains { CharacterSet.lowercaseLetters.contains($0) }
     }
 }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -584,7 +584,7 @@ struct RecordingSettingsView: View {
                     set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.appFormattingEnabled) }
                 ))
 
-                Text(String(localized: "Automatically format transcribed text based on the target app and use available cursor context for smarter insertion. Configure the output format per workflow."))
+                Text(String(localized: "When enabled, TypeWhisper uses target-app rules and available cursor context for smarter insertion. Workflow output format settings still choose the inserted format for each workflow."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -584,7 +584,7 @@ struct RecordingSettingsView: View {
                     set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.appFormattingEnabled) }
                 ))
 
-                Text(String(localized: "Automatically format transcribed text based on the target app. Configure the output format per workflow."))
+                Text(String(localized: "Automatically format transcribed text based on the target app and use available cursor context for smarter insertion. Configure the output format per workflow."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2728,6 +2728,38 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testCaptureInsertionContextIncludesCharactersAroundSelectionRange() throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.focusedTextElementOverride = { element }
+        service.focusedTextStateOverride = { _ in
+            (value: "coffeemachine", selectedText: nil, selectedRange: NSRange(location: 6, length: 0))
+        }
+
+        let context = try XCTUnwrap(service.captureInsertionContext())
+
+        XCTAssertEqual(context.value, "coffeemachine")
+        XCTAssertEqual(context.selectedRange, NSRange(location: 6, length: 0))
+        XCTAssertNil(context.selectedText)
+        XCTAssertEqual(context.previousCharacter, "e")
+        XCTAssertEqual(context.nextCharacter, "m")
+    }
+
+    @MainActor
+    func testCaptureInsertionContextReturnsNilWhenFocusedTextStateIsIncomplete() {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.focusedTextElementOverride = { element }
+        service.focusedTextStateOverride = { _ in
+            (value: "coffee", selectedText: nil, selectedRange: nil)
+        }
+
+        XCTAssertNil(service.captureInsertionContext())
+    }
+
+    @MainActor
     func testSyntheticPasteReturnsUnverifiedWhenFocusedTextStateIsUnavailable() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()
@@ -3469,6 +3501,84 @@ final class APIRouterAndHandlersTests: XCTestCase {
             context.recentTranscriptionStore.latestEntry(historyRecords: context.historyService.records)?.finalText,
             "transcribed"
         )
+    }
+
+    @MainActor
+    func testDictationDirectInsertionUsesContextWhenAppAwareFormattingIsEnabled() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let historyEnabledKey = UserDefaultsKeys.historyEnabled
+        let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
+        let appFormattingKey = UserDefaultsKeys.appFormattingEnabled
+        let originalHistoryEnabled = UserDefaults.standard.object(forKey: historyEnabledKey)
+        let originalPreserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardKey)
+        let originalAppFormatting = UserDefaults.standard.object(forKey: appFormattingKey)
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            MockTranscriptionPlugin.reset()
+            if let originalHistoryEnabled {
+                UserDefaults.standard.set(originalHistoryEnabled, forKey: historyEnabledKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: historyEnabledKey)
+            }
+            if let originalPreserveClipboard {
+                UserDefaults.standard.set(originalPreserveClipboard, forKey: preserveClipboardKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: preserveClipboardKey)
+            }
+            if let originalAppFormatting {
+                UserDefaults.standard.set(originalAppFormatting, forKey: appFormattingKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: appFormattingKey)
+            }
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        UserDefaults.standard.set(true, forKey: historyEnabledKey)
+        UserDefaults.standard.set(false, forKey: preserveClipboardKey)
+        UserDefaults.standard.set(true, forKey: appFormattingKey)
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setResponseText("Strong.")
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.preserveClipboard = false
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        context.textInsertionService.pasteboardProvider = { pasteboard }
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Notes", "com.apple.Notes", nil)
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.focusedTextElementOverride = { element }
+        context.textInsertionService.focusedTextStateOverride = { _ in
+            (value: "coffeemachine", selectedText: nil, selectedRange: NSRange(location: 6, length: 0))
+        }
+        context.textInsertionService.pasteVerificationAttempts = 0
+        context.textInsertionService.pasteSimulatorOverride = {}
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<40 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        let session = try XCTUnwrap(context.dictationViewModel.apiDictationSession(id: sessionID))
+        XCTAssertEqual(session.status, .completed)
+        XCTAssertEqual(pasteboard.string(forType: .string), " strong ")
+        XCTAssertEqual(session.transcription?.text, "Strong.")
+        XCTAssertEqual(context.historyService.records.first?.finalText, "Strong.")
     }
 
     @MainActor

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -91,7 +91,7 @@ final class AppFormatterServiceTests: XCTestCase {
 
         AppDelegate.registerDefaultUserDefaults(defaults)
 
-        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.appFormattingEnabled) as? Bool, false)
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.appFormattingEnabled) as? Bool, true)
         XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) as? Bool, true)
     }
 }

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -242,4 +242,158 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
     func testLeavesEmptyTextUntouched() {
         XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion(""), "")
     }
+
+    func testDisabledContextualInsertionKeepsTrailingSpaceOnlyBehavior() {
+        let context = TextInsertionService.InsertionContext(
+            value: "coffeemachine",
+            selectedRange: NSRange(location: 6, length: 0),
+            selectedText: nil,
+            previousCharacter: "e",
+            nextCharacter: "m"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion(
+                "Strong.",
+                insertionContext: context,
+                contextualInsertionEnabled: false
+            ),
+            "Strong. "
+        )
+    }
+
+    func testSmartInsertionAddsMissingLeadingAndTrailingSpacesBetweenWords() {
+        let context = TextInsertionService.InsertionContext(
+            value: "coffeemachine",
+            selectedRange: NSRange(location: 6, length: 0),
+            selectedText: nil,
+            previousCharacter: "e",
+            nextCharacter: "m"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("strong", insertionContext: context),
+            " strong "
+        )
+    }
+
+    func testSmartInsertionAvoidsDuplicateLeadingSpace() {
+        let context = TextInsertionService.InsertionContext(
+            value: "coffee machine",
+            selectedRange: NSRange(location: 7, length: 0),
+            selectedText: nil,
+            previousCharacter: " ",
+            nextCharacter: "m"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("strong", insertionContext: context),
+            "strong "
+        )
+    }
+
+    func testSmartInsertionDoesNotAddSpaceBeforePunctuation() {
+        let context = TextInsertionService.InsertionContext(
+            value: "Hello,",
+            selectedRange: NSRange(location: 5, length: 0),
+            selectedText: nil,
+            previousCharacter: "o",
+            nextCharacter: ","
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("friend", insertionContext: context),
+            " friend"
+        )
+    }
+
+    func testSmartInsertionDoesNotLowercaseAfterSentenceEndingPunctuation() {
+        let context = TextInsertionService.InsertionContext(
+            value: "Done.Next",
+            selectedRange: NSRange(location: 5, length: 0),
+            selectedText: nil,
+            previousCharacter: ".",
+            nextCharacter: "N"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("Another item", insertionContext: context),
+            " Another item "
+        )
+    }
+
+    func testSmartInsertionLowercasesTitlecaseFirstWordInMidSentence() {
+        let context = TextInsertionService.InsertionContext(
+            value: "The presentation will bemachine",
+            selectedRange: NSRange(location: 24, length: 0),
+            selectedText: nil,
+            previousCharacter: "e",
+            nextCharacter: "m"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("Presented tomorrow", insertionContext: context),
+            " presented tomorrow "
+        )
+    }
+
+    func testSmartInsertionPreservesAllCapsFirstWord() {
+        let context = TextInsertionService.InsertionContext(
+            value: "we use",
+            selectedRange: NSRange(location: 6, length: 0),
+            selectedText: nil,
+            previousCharacter: "e",
+            nextCharacter: nil
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("NASA tools.", insertionContext: context),
+            " NASA tools. "
+        )
+    }
+
+    func testSmartInsertionPreservesCamelCaseFirstWord() {
+        let context = TextInsertionService.InsertionContext(
+            value: "about",
+            selectedRange: NSRange(location: 5, length: 0),
+            selectedText: nil,
+            previousCharacter: "t",
+            nextCharacter: nil
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("TypeWhisper", insertionContext: context),
+            " TypeWhisper "
+        )
+    }
+
+    func testSmartInsertionStripsSingleFinalPeriodBeforeExistingWord() {
+        let context = TextInsertionService.InsertionContext(
+            value: "coffeemachine",
+            selectedRange: NSRange(location: 6, length: 0),
+            selectedText: nil,
+            previousCharacter: "e",
+            nextCharacter: "m"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("Strong.", insertionContext: context),
+            " strong "
+        )
+    }
+
+    func testSmartInsertionPreservesQuestionPunctuation() {
+        let context = TextInsertionService.InsertionContext(
+            value: "coffeemachine",
+            selectedRange: NSRange(location: 6, length: 0),
+            selectedText: nil,
+            previousCharacter: "e",
+            nextCharacter: "m"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("Really?", insertionContext: context),
+            " really? "
+        )
+    }
 }


### PR DESCRIPTION
## Summary

This implements the first pass for issue #688 as an app-aware dictation insertion improvement.

The feature reuses the existing App-aware formatting setting instead of adding a second checkbox. When that setting is enabled and macOS exposes a focused text value plus selection range, TypeWhisper captures a small insertion-context snapshot and uses it to avoid double spaces, add missing spaces around inserted words, lowercase safe mid-sentence insertions, and strip one final period before existing mid-sentence text.

When the target app does not expose enough AX cursor context, TypeWhisper keeps the existing trailing-space insertion behavior instead of guessing.

App-aware formatting is now registered on by default for new users, while existing stored user choices are preserved.

Closes #688

## Test Plan

```zsh
git diff --check
jq empty TypeWhisper/Resources/Localizable.xcstrings
set -o pipefail && xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationInsertionTextFormatterTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests -only-testing:TypeWhisperTests/AppFormatterServiceTests 2>&1 | tee /tmp/typewhisper-smart-insertion-focused.log
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-smart-insertion-focused.log
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/260e/typewhisper-mac
```

Manual smoke test: verified the dev app locally with App-aware formatting enabled in native text fields for mid-word insertion, duplicate whitespace avoidance, punctuation boundaries, safe mid-sentence lowercasing, final-period stripping, and fallback behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcribed text now intelligently adapts spacing, casing, and punctuation handling using cursor/context-aware insertion.

* **Chores**
  * App-aware formatting is enabled by default.

* **Documentation**
  * Updated setting text to clarify use of cursor context and workflow-specific formatting.

* **Tests**
  * Added tests validating contextual insertion behavior and the new default formatting setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->