### PR TITLE
Localize plugin settings and dev sync

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		D20000000000000000000003 /* SupertonicPlaybackSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000003 /* SupertonicPlaybackSession.swift */; };
 		D20000000000000000000004 /* SupertonicRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000004 /* SupertonicRuntime.swift */; };
 		D20000000000000000000005 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000005 /* manifest.json */; };
+		D20000000000000000000008 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D20100000000000000000007 /* Localizable.xcstrings */; };
 		D20000000000000000000006 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = D20700000000000000000001 /* TypeWhisperPluginSDK */; };
 		D20000000000000000000007 /* onnxruntime in Frameworks */ = {isa = PBXBuildFile; productRef = D20700000000000000000002 /* onnxruntime */; };
 		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
@@ -333,6 +334,7 @@
 		AA00000000000000000236 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000030 /* MLXAudioCore */; };
 		AA00000000000000000237 /* CloudflareASRPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000225 /* CloudflareASRPlugin.swift */; };
 		AA00000000000000000238 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000226 /* manifest.json */; };
+		AA0000000000000000023A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000022A /* Localizable.xcstrings */; };
 		AA00000000000000000239 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000031 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000240 /* MemoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000228 /* MemoryService.swift */; };
 		AA00000000000000000241 /* FileMemoryPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000229 /* FileMemoryPlugin.swift */; };
@@ -423,6 +425,7 @@
 		AA00000000000000000278 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000038 /* TypeWhisperPluginSDK */; };
 		BF1DFDDFBF91D87134DA57E7 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1D584661B6B55F6329CB5FC4 /* manifest.json */; };
 		F1177F582D186041B081F9C5 /* GoogleCloudSTTPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */; };
+		F1177F582D186041B081F9C6 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 1D584661B6B55F6329CB5FC5 /* Localizable.xcstrings */; };
 		F774802B61AFC0DCA9E8E668 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 67BE633BCFA1507F72199015 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000300 /* LicenseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000286 /* LicenseService.swift */; };
 		AA00000000000000000301 /* LicenseSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000287 /* LicenseSettingsView.swift */; };
@@ -759,6 +762,7 @@
 		BB00000000000000000224 /* GranitePlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GranitePlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000225 /* CloudflareASRPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudflareASRPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000226 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		BB0000000000000000022A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000227 /* CloudflareASRPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CloudflareASRPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000228 /* MemoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryService.swift; sourceTree = "<group>"; };
 		BB00000000000000000229 /* FileMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMemoryPlugin.swift; sourceTree = "<group>"; };
@@ -772,6 +776,7 @@
 		D20100000000000000000003 /* SupertonicPlaybackSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicPlaybackSession.swift; sourceTree = "<group>"; };
 		D20100000000000000000004 /* SupertonicRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupertonicRuntime.swift; sourceTree = "<group>"; };
 		D20100000000000000000005 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		D20100000000000000000007 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		D20100000000000000000006 /* SupertonicPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SupertonicPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000232 /* OpenAIVectorMemoryPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIVectorMemoryPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000233 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -885,6 +890,7 @@
 		BB00000000000000000294 /* SpeechmaticsPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpeechmaticsPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCloudSTTPlugin.swift; sourceTree = "<group>"; };
 		1D584661B6B55F6329CB5FC4 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		1D584661B6B55F6329CB5FC5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		5CA4DB761B06383B5B8CF082 /* GoogleCloudSTTPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoogleCloudSTTPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000274 /* OpenRouterPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRouterPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000275 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1875,6 +1881,7 @@
 			children = (
 				BB00000000000000000225 /* CloudflareASRPlugin.swift */,
 				BB00000000000000000226 /* manifest.json */,
+				BB0000000000000000022A /* Localizable.xcstrings */,
 			);
 			name = CloudflareASRPlugin;
 			path = TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin;
@@ -1908,6 +1915,7 @@
 				D20100000000000000000003 /* SupertonicPlaybackSession.swift */,
 				D20100000000000000000004 /* SupertonicRuntime.swift */,
 				D20100000000000000000005 /* manifest.json */,
+				D20100000000000000000007 /* Localizable.xcstrings */,
 			);
 			name = SupertonicPlugin;
 			path = TypeWhisperPluginSDK/Plugins/SupertonicPlugin;
@@ -2050,6 +2058,7 @@
 			children = (
 				01D368E23E2A0AB2390B34EA /* GoogleCloudSTTPlugin.swift */,
 				1D584661B6B55F6329CB5FC4 /* manifest.json */,
+				1D584661B6B55F6329CB5FC5 /* Localizable.xcstrings */,
 			);
 			name = GoogleCloudSTTPlugin;
 			path = TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin;
@@ -3346,6 +3355,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000238 /* manifest.json in Resources */,
+				AA0000000000000000023A /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3370,6 +3380,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D20000000000000000000005 /* manifest.json in Resources */,
+				D20000000000000000000008 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3440,6 +3451,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF1DFDDFBF91D87134DA57E7 /* manifest.json in Resources */,
+				F1177F582D186041B081F9C6 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -564,7 +564,7 @@ final class TextInsertionService {
         case .verified:
             logger.info("insertText paste verified: bundle=\(bundleId ?? "nil", privacy: .public)")
         case .unverified(let reason):
-            logger.warning(
+            logger.info(
                 "insertText paste unverified: bundle=\(bundleId ?? "nil", privacy: .public), reason=\(reason.rawValue, privacy: .public)"
             )
         }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1339,7 +1339,7 @@ final class DictationViewModel: ObservableObject {
                         outputFormat: self.effectiveOutputFormat
                     )
                     if case .pasted(.unverified(let reason)) = insertionResult {
-                        logger.warning(
+                        logger.info(
                             "Text insertion paste could not be verified; continuing with clipboard paste fallback. reason=\(reason.rawValue, privacy: .public), app=\(activeApp.bundleId ?? "nil", privacy: .public)"
                         )
                     }

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -147,6 +147,7 @@ let package = Package(
             path: "Plugins/SupertonicPlugin",
             exclude: ["Tests"],
             resources: [
+                .process("Localizable.xcstrings"),
                 .process("manifest.json"),
             ]
         ),

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
@@ -375,6 +375,7 @@ private extension Data {
 
 private struct CloudflareASRSettingsView: View {
     let plugin: CloudflareASRPlugin
+    private let bundle = Bundle(for: CloudflareASRPlugin.self)
     @State private var baseURLInput = ""
     @State private var apiKeyInput = ""
     @State private var cfClientIdInput = ""
@@ -393,7 +394,7 @@ private struct CloudflareASRSettingsView: View {
         VStack(alignment: .leading, spacing: 16) {
             // Server URL
             VStack(alignment: .leading, spacing: 8) {
-                Text("Server URL")
+                Text("Server URL", bundle: bundle)
                     .font(.headline)
 
                 TextField("e.g. https://asr.example.com", text: $baseURLInput)
@@ -403,7 +404,7 @@ private struct CloudflareASRSettingsView: View {
 
             // Cloudflare Tunnel Auth
             VStack(alignment: .leading, spacing: 8) {
-                Text("Cloudflare Tunnel Auth")
+                Text("Cloudflare Tunnel Auth", bundle: bundle)
                     .font(.headline)
 
                 TextField("CF-Access-Client-Id", text: $cfClientIdInput)
@@ -428,23 +429,23 @@ private struct CloudflareASRSettingsView: View {
                     .buttonStyle(.borderless)
                 }
 
-                Text("Service token credentials for Cloudflare Access. Stored in macOS Keychain.")
+                Text("Service token credentials for Cloudflare Access. Stored in macOS Keychain.", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             // API Key (optional)
             VStack(alignment: .leading, spacing: 8) {
-                Text("API Key")
+                Text("API Key", bundle: bundle)
                     .font(.headline)
 
                 HStack(spacing: 8) {
                     if showApiKey {
-                        TextField("API Key", text: $apiKeyInput)
+                        TextField(String(localized: "API Key", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
                     } else {
-                        SecureField("API Key", text: $apiKeyInput)
+                        SecureField(String(localized: "API Key", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                     }
 
@@ -456,7 +457,7 @@ private struct CloudflareASRSettingsView: View {
                     .buttonStyle(.borderless)
                 }
 
-                Text("Optional Bearer token for the upstream API behind the tunnel.")
+                Text("Optional Bearer token for the upstream API behind the tunnel.", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -466,7 +467,7 @@ private struct CloudflareASRSettingsView: View {
                 Button {
                     testConnection()
                 } label: {
-                    Text("Test Connection")
+                    Text("Test Connection", bundle: bundle)
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
@@ -477,13 +478,13 @@ private struct CloudflareASRSettingsView: View {
 
                 if isTesting {
                     ProgressView().controlSize(.small)
-                    Text("Testing...")
+                    Text("Testing...", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else if let result = connectionResult {
                     Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
                         .foregroundStyle(result ? .green : .red)
-                    Text(result ? "Connected" : "Connection Failed")
+                    Text(result ? String(localized: "Connected", bundle: bundle) : String(localized: "Connection Failed", bundle: bundle))
                         .font(.caption)
                         .foregroundStyle(result ? .green : .red)
                 }
@@ -495,21 +496,21 @@ private struct CloudflareASRSettingsView: View {
                 // Model Selection
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
-                        Text("Model")
+                        Text("Model", bundle: bundle)
                             .font(.headline)
                         Spacer()
                         Button {
                             refreshModels()
                         } label: {
-                            Label("Refresh", systemImage: "arrow.clockwise")
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                     }
 
                     if hasModels {
-                        Picker("Transcription Model", selection: $selectedModel) {
-                            Text("None").tag("")
+                        Picker(String(localized: "Transcription Model", bundle: bundle), selection: $selectedModel) {
+                            Text("None", bundle: bundle).tag("")
                             ForEach(fetchedModels, id: \.id) { model in
                                 Text(model.id).tag(model.id)
                             }
@@ -519,17 +520,17 @@ private struct CloudflareASRSettingsView: View {
                             plugin.selectModel(selectedModel)
                         }
                     } else {
-                        Text("No models found. Enter model name manually.")
+                        Text("No models found. Enter model name manually.", bundle: bundle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
                         HStack(spacing: 8) {
-                            TextField("Model name", text: $manualModel)
+                            TextField(String(localized: "Model name", bundle: bundle), text: $manualModel)
                                 .textFieldStyle(.roundedBorder)
                                 .font(.system(.body, design: .monospaced))
                                 .onSubmit { saveManualModel() }
 
-                            Button("Save") { saveManualModel() }
+                            Button(String(localized: "Save", bundle: bundle)) { saveManualModel() }
                                 .buttonStyle(.bordered)
                                 .controlSize(.small)
                                 .disabled(manualModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -538,7 +539,7 @@ private struct CloudflareASRSettingsView: View {
                 }
             }
 
-            Text("All credentials are stored securely in the macOS Keychain.")
+            Text("All credentials are stored securely in the macOS Keychain.", bundle: bundle)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
@@ -375,7 +375,7 @@ private extension Data {
 
 private struct CloudflareASRSettingsView: View {
     let plugin: CloudflareASRPlugin
-    private let bundle = Bundle(for: CloudflareASRPlugin.self)
+    private let bundle = pluginModuleBundle
     @State private var baseURLInput = ""
     @State private var apiKeyInput = ""
     @State private var cfClientIdInput = ""
@@ -604,3 +604,11 @@ private struct CloudflareASRSettingsView: View {
         }
     }
 }
+
+private let pluginModuleBundle: Bundle = {
+#if SWIFT_PACKAGE
+    Bundle.module
+#else
+    Bundle(for: CloudflareASRPlugin.self)
+#endif
+}()

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/Localizable.xcstrings
@@ -1,0 +1,23 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "API Key": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "APIキー" } } } },
+    "All credentials are stored securely in the macOS Keychain.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "すべての認証情報はmacOSキーチェーンに安全に保存されます。" } } } },
+    "Cloudflare Tunnel Auth": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Cloudflare Tunnel認証" } } } },
+    "Connected": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "接続済み" } } } },
+    "Connection Failed": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "接続失敗" } } } },
+    "Model": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "モデル" } } } },
+    "Model name": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "モデル名" } } } },
+    "No models found. Enter model name manually.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "モデルが見つかりません。モデル名を手動で入力してください。" } } } },
+    "None": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "なし" } } } },
+    "Optional Bearer token for the upstream API behind the tunnel.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Tunnel背後の上流APIに渡す任意のBearerトークンです。" } } } },
+    "Refresh": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "更新" } } } },
+    "Save": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "保存" } } } },
+    "Server URL": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "サーバーURL" } } } },
+    "Service token credentials for Cloudflare Access. Stored in macOS Keychain.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Cloudflare Accessのサービストークン認証情報です。macOSキーチェーンに保存されます。" } } } },
+    "Test Connection": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "接続テスト" } } } },
+    "Testing...": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "テスト中..." } } } },
+    "Transcription Model": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "文字起こしモデル" } } } }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
@@ -789,7 +789,7 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
 
 private struct GoogleCloudSTTSettingsView: View {
     let plugin: GoogleCloudSTTPlugin
-    private let bundle = Bundle(for: GoogleCloudSTTPlugin.self)
+    private let bundle = pluginModuleBundle
 
     @State private var serviceAccountInput = ""
     @State private var isValidating = false
@@ -945,3 +945,11 @@ private struct GoogleCloudSTTSettingsView: View {
         }
     }
 }
+
+private let pluginModuleBundle: Bundle = {
+#if SWIFT_PACKAGE
+    Bundle.module
+#else
+    Bundle(for: GoogleCloudSTTPlugin.self)
+#endif
+}()

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
@@ -109,6 +109,10 @@ private struct GoogleWordInfo: Decodable {
 private struct GoogleCredentialValidationResult {
     let isValid: Bool
     let message: String
+
+    func localizedMessage(bundle: Bundle) -> String {
+        String(localized: String.LocalizationValue(message), bundle: bundle)
+    }
 }
 
 @objc(GoogleCloudSTTPlugin)
@@ -785,6 +789,7 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
 
 private struct GoogleCloudSTTSettingsView: View {
     let plugin: GoogleCloudSTTPlugin
+    private let bundle = Bundle(for: GoogleCloudSTTPlugin.self)
 
     @State private var serviceAccountInput = ""
     @State private var isValidating = false
@@ -799,7 +804,7 @@ private struct GoogleCloudSTTSettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Service Account JSON")
+                Text("Service Account JSON", bundle: bundle)
                     .font(.headline)
 
                 TextEditor(text: $serviceAccountInput)
@@ -810,25 +815,27 @@ private struct GoogleCloudSTTSettingsView: View {
                             .stroke(.quaternary, lineWidth: 1)
                     }
 
-                Text("Google Speech-to-Text does not accept simple API keys. Paste a Google Cloud service-account JSON key here. Credentials are stored in the macOS Keychain.")
+                Text("Google Speech-to-Text does not accept simple API keys. Paste a Google Cloud service-account JSON key here. Credentials are stored in the macOS Keychain.", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 if plugin.isConfigured && trimmedServiceAccountInput.isEmpty {
-                    Text("Stored credentials are active. Paste a new JSON key above to replace them.")
+                    Text("Stored credentials are active. Paste a new JSON key above to replace them.", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
 
                 HStack(spacing: 8) {
-                    Button(plugin.isConfigured ? "Replace Credentials" : "Save Credentials") {
+                    Button(plugin.isConfigured
+                        ? String(localized: "Replace Credentials", bundle: bundle)
+                        : String(localized: "Save Credentials", bundle: bundle)) {
                         saveCredentials()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
                     .disabled(trimmedServiceAccountInput.isEmpty)
 
-                    Button("Test Stored Credentials") {
+                    Button(String(localized: "Test Stored Credentials", bundle: bundle)) {
                         testStoredCredentials()
                     }
                     .buttonStyle(.bordered)
@@ -836,7 +843,7 @@ private struct GoogleCloudSTTSettingsView: View {
                     .disabled(!plugin.isConfigured || isValidating)
 
                     if plugin.isConfigured {
-                        Button("Remove") {
+                        Button(String(localized: "Remove", bundle: bundle)) {
                             serviceAccountInput = ""
                             validationResult = nil
                             plugin.removeServiceAccountJSON()
@@ -850,7 +857,7 @@ private struct GoogleCloudSTTSettingsView: View {
                 if isValidating {
                     HStack(spacing: 4) {
                         ProgressView().controlSize(.small)
-                        Text("Validating...")
+                        Text("Validating...", bundle: bundle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -858,7 +865,7 @@ private struct GoogleCloudSTTSettingsView: View {
                     HStack(spacing: 4) {
                         Image(systemName: validationResult.isValid ? "checkmark.circle.fill" : "xmark.circle.fill")
                             .foregroundStyle(validationResult.isValid ? .green : .red)
-                        Text(validationResult.message)
+                        Text(validationResult.localizedMessage(bundle: bundle))
                             .font(.caption)
                             .foregroundStyle(validationResult.isValid ? .green : .red)
                     }
@@ -868,10 +875,10 @@ private struct GoogleCloudSTTSettingsView: View {
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Model")
+                Text("Model", bundle: bundle)
                     .font(.headline)
 
-                Picker("Model", selection: $selectedModel) {
+                Picker(String(localized: "Model", bundle: bundle), selection: $selectedModel) {
                     ForEach(plugin.transcriptionModels, id: \.id) { model in
                         Text(model.displayName).tag(model.id)
                     }
@@ -881,13 +888,13 @@ private struct GoogleCloudSTTSettingsView: View {
                     plugin.selectModel(selectedModel)
                 }
 
-                Text("Use `default` or `command_and_search` for the broadest language coverage. The newer `latest_*` models can be more restrictive depending on language support.")
+                Text("Use `default` or `command_and_search` for the broadest language coverage. The newer `latest_*` models can be more restrictive depending on language support.", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Default Language")
+                Text("Default Language", bundle: bundle)
                     .font(.headline)
 
                 TextField("e.g. gu-IN, kn-IN, pa-Guru-IN, en-US", text: $defaultLanguageCode)
@@ -897,7 +904,7 @@ private struct GoogleCloudSTTSettingsView: View {
                         plugin.setDefaultLanguageCode(defaultLanguageCode)
                     }
 
-                Text("If TypeWhisper already passes a spoken language, that value wins. Otherwise this BCP-47 code is used for Google recognition requests.")
+                Text("If TypeWhisper already passes a spoken language, that value wins. Otherwise this BCP-47 code is used for Google recognition requests.", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/Localizable.xcstrings
@@ -1,0 +1,29 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "Cloud Speech-to-Text API is not enabled for this Google Cloud project. Enable speech.googleapis.com in Google Cloud, wait a few minutes, and retry.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "このGoogle CloudプロジェクトでCloud Speech-to-Text APIが有効になっていません。Google Cloudでspeech.googleapis.comを有効化し、数分待ってから再試行してください。" } } } },
+    "Credentials look valid and Speech-to-Text is reachable.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "認証情報は有効で、Speech-to-Textに接続できます。" } } } },
+    "Default Language": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "既定の言語" } } } },
+    "Google Cloud billing is not enabled for this project. Enable billing for the project and retry.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "このプロジェクトでGoogle Cloudの請求が有効になっていません。プロジェクトの請求を有効化してから再試行してください。" } } } },
+    "Google Cloud rate-limited the request. Please wait a moment and retry.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Google Cloudによりリクエストがレート制限されました。少し待ってから再試行してください。" } } } },
+    "Google denied access to Speech-to-Text. Make sure the API is enabled and the service account has the Cloud Speech Client role.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "GoogleがSpeech-to-Textへのアクセスを拒否しました。APIが有効で、サービスアカウントにCloud Speech Clientロールがあることを確認してください。" } } } },
+    "Google rejected the service-account credentials.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Googleがサービスアカウント認証情報を拒否しました。" } } } },
+    "Google rejected the service-account credentials. Check that you pasted the full JSON key file for the correct project.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Googleがサービスアカウント認証情報を拒否しました。正しいプロジェクトのJSONキーファイル全体を貼り付けたか確認してください。" } } } },
+    "Google Speech-to-Text does not accept simple API keys. Paste a Google Cloud service-account JSON key here. Credentials are stored in the macOS Keychain.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Google Speech-to-Textでは単純なAPIキーは使えません。Google CloudのサービスアカウントJSONキー全体をここに貼り付けてください。認証情報はmacOSキーチェーンに保存されます。" } } } },
+    "If TypeWhisper already passes a spoken language, that value wins. Otherwise this BCP-47 code is used for Google recognition requests.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "TypeWhisperから発話言語が渡される場合は、その値が優先されます。それ以外の場合、このBCP-47コードがGoogle認識リクエストに使われます。" } } } },
+    "Model": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "モデル" } } } },
+    "No Google recognition model is selected.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Google認識モデルが選択されていません。" } } } },
+    "No service-account JSON is configured yet.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "サービスアカウントJSONがまだ設定されていません。" } } } },
+    "Remove": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "削除" } } } },
+    "Replace Credentials": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "認証情報を置き換え" } } } },
+    "Save Credentials": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "認証情報を保存" } } } },
+    "Service Account JSON": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "サービスアカウントJSON" } } } },
+    "Stored credentials are active. Paste a new JSON key above to replace them.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "保存済みの認証情報が有効です。置き換えるには上に新しいJSONキーを貼り付けてください。" } } } },
+    "Test Stored Credentials": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "保存済み認証情報をテスト" } } } },
+    "The JSON could not be parsed. Paste the full Google service-account JSON file.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "JSONを解析できませんでした。GoogleサービスアカウントJSONファイル全体を貼り付けてください。" } } } },
+    "The verification audio was rejected as too large.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "検証用音声が大きすぎるため拒否されました。" } } } },
+    "Use `default` or `command_and_search` for the broadest language coverage. The newer `latest_*` models can be more restrictive depending on language support.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "最も広い言語対応には `default` または `command_and_search` を使ってください。新しい `latest_*` モデルは、言語サポートによって制限が強い場合があります。" } } } },
+    "Validating...": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "検証中..." } } } }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings
@@ -113,6 +113,26 @@
         }
       }
     },
+    "Hugging Face Token": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hugging Faceトークン"
+          }
+        }
+      }
+    },
+    "Invalid Hugging Face Token": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なHugging Faceトークン"
+          }
+        }
+      }
+    },
     "Model Version": {
       "localizations": {
         "de": {
@@ -161,6 +181,16 @@
         }
       }
     },
+    "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意です。ダウンロードのレート制限を緩和できます。huggingface.co/settings/tokens で無料作成できます"
+          }
+        }
+      }
+    },
     "Ready - %lld terms loaded": {
       "localizations": {
         "de": {
@@ -193,6 +223,16 @@
         }
       }
     },
+    "Remove": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
     "Retry": {
       "localizations": {
         "de": {
@@ -209,6 +249,16 @@
         }
       }
     },
+    "Save": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
     "Unload": {
       "localizations": {
         "de": {
@@ -221,6 +271,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "無効化"
+          }
+        }
+      }
+    },
+    "Valid Hugging Face Token": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なHugging Faceトークン"
+          }
+        }
+      }
+    },
+    "Validating token...": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トークンを検証中..."
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings
@@ -115,6 +115,12 @@
     },
     "Hugging Face Token": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hugging Face Token"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -125,6 +131,12 @@
     },
     "Invalid Hugging Face Token": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger Hugging Face Token"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -183,6 +195,12 @@
     },
     "Optional. Increases download rate limits. Free at huggingface.co/settings/tokens": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. Erhöht die Download-Rate-Limits. Kostenlos unter huggingface.co/settings/tokens"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -225,6 +243,12 @@
     },
     "Remove": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -251,6 +275,12 @@
     },
     "Save": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -277,6 +307,12 @@
     },
     "Valid Hugging Face Token": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültiger Hugging Face Token"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -287,6 +323,12 @@
     },
     "Validating token...": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Token wird geprüft..."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Localizable.xcstrings
@@ -1,0 +1,28 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "Balanced": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "バランス" } } } },
+    "Delete cached model": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "キャッシュ済みモデルを削除" } } } },
+    "Download & Load": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "ダウンロードして読み込む" } } } },
+    "Fast": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "高速" } } } },
+    "High": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "高品質" } } } },
+    "Hugging Face Token": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Hugging Faceトークン" } } } },
+    "I have read and accept the Supertonic 3 model license terms": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Supertonic 3モデルのライセンス条項を読み、同意します" } } } },
+    "Invalid Hugging Face token": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "無効なHugging Faceトークン" } } } },
+    "Local text-to-speech powered by Supertonic 3 ONNX models. Model assets are downloaded only after you accept the model license.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Supertonic 3 ONNXモデルによるローカル音声合成です。モデルアセットは、モデルライセンスに同意した後にのみダウンロードされます。" } } } },
+    "Model": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "モデル" } } } },
+    "Model License": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "モデルライセンス" } } } },
+    "Open Supertonic 3 OpenRAIL-M license": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Supertonic 3 OpenRAIL-Mライセンスを開く" } } } },
+    "Optional. It can increase download rate limits for the model download.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "任意です。モデルダウンロード時のレート制限を緩和できる場合があります。" } } } },
+    "Quality": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "品質" } } } },
+    "Ready": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "準備完了" } } } },
+    "Remove": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "削除" } } } },
+    "Save": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "保存" } } } },
+    "Speed": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "速度" } } } },
+    "Supertonic (Experimental)": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Supertonic（実験的）" } } } },
+    "Supertonic 3 model assets are licensed under OpenRAIL-M and include use restrictions. Review the full license before downloading the model.": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "Supertonic 3のモデルアセットはOpenRAIL-Mライセンスで提供され、利用制限があります。モデルをダウンロードする前にライセンス全文を確認してください。" } } } },
+    "Valid Hugging Face token": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "有効なHugging Faceトークン" } } } },
+    "Voice": { "localizations": { "ja": { "stringUnit": { "state": "translated", "value": "音声" } } } }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicPlugin.swift
@@ -300,6 +300,7 @@ final class SupertonicPlugin: NSObject, TTSProviderPlugin, PluginSettingsActivit
 
 private struct SupertonicSettingsView: View {
     let plugin: SupertonicPlugin
+    private let bundle = pluginModuleBundle
 
     @State private var acceptedLicense = false
     @State private var selectedVoiceId = "M1"
@@ -316,10 +317,10 @@ private struct SupertonicSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Supertonic (Experimental)")
+            Text("Supertonic (Experimental)", bundle: bundle)
                 .font(.headline)
 
-            Text("Local text-to-speech powered by Supertonic 3 ONNX models. Model assets are downloaded only after you accept the model license.")
+            Text("Local text-to-speech powered by Supertonic 3 ONNX models. Model assets are downloaded only after you accept the model license.", bundle: bundle)
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
@@ -351,19 +352,19 @@ private struct SupertonicSettingsView: View {
 
     private var licenseSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Model License")
+            Text("Model License", bundle: bundle)
                 .font(.subheadline)
                 .fontWeight(.medium)
 
-            Text("Supertonic 3 model assets are licensed under OpenRAIL-M and include use restrictions. Review the full license before downloading the model.")
+            Text("Supertonic 3 model assets are licensed under OpenRAIL-M and include use restrictions. Review the full license before downloading the model.", bundle: bundle)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            Link("Open Supertonic 3 OpenRAIL-M license", destination: SupertonicModelLicense.url)
+            Link(String(localized: "Open Supertonic 3 OpenRAIL-M license", bundle: bundle), destination: SupertonicModelLicense.url)
                 .font(.caption)
 
             Toggle(isOn: $acceptedLicense) {
-                Text("I have read and accept the Supertonic 3 model license terms")
+                Text("I have read and accept the Supertonic 3 model license terms", bundle: bundle)
             }
             .onChange(of: acceptedLicense) { _, newValue in
                 if newValue {
@@ -375,17 +376,17 @@ private struct SupertonicSettingsView: View {
 
     private var modelSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Model")
+            Text("Model", bundle: bundle)
                 .font(.subheadline)
                 .fontWeight(.medium)
 
             switch modelState {
             case .ready:
                 HStack {
-                    Label("Ready", systemImage: "checkmark.circle.fill")
+                    Label(String(localized: "Ready", bundle: bundle), systemImage: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                     Spacer()
-                    Button("Delete cached model") {
+                    Button(String(localized: "Delete cached model", bundle: bundle)) {
                         try? plugin.deleteCachedModel()
                         refreshFromPlugin()
                     }
@@ -421,7 +422,7 @@ private struct SupertonicSettingsView: View {
                 }
             }
         } label: {
-            Label("Download & Load", systemImage: "arrow.down.circle")
+            Label(String(localized: "Download & Load", bundle: bundle), systemImage: "arrow.down.circle")
         }
         .buttonStyle(.borderedProminent)
         .disabled(!acceptedLicense || isDownloading || modelState == .downloading)
@@ -429,11 +430,11 @@ private struct SupertonicSettingsView: View {
 
     private var voiceSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Voice")
+            Text("Voice", bundle: bundle)
                 .font(.subheadline)
                 .fontWeight(.medium)
 
-            Picker("Voice", selection: $selectedVoiceId) {
+            Picker(String(localized: "Voice", bundle: bundle), selection: $selectedVoiceId) {
                 ForEach(plugin.availableVoices, id: \.id) { voice in
                     Text(voice.displayName).tag(voice.id)
                 }
@@ -443,7 +444,7 @@ private struct SupertonicSettingsView: View {
             }
 
             HStack {
-                Text("Speed")
+                Text("Speed", bundle: bundle)
                 Spacer()
                 Text(speed, format: .number.precision(.fractionLength(2)))
                     .monospacedDigit()
@@ -456,9 +457,9 @@ private struct SupertonicSettingsView: View {
                     plugin.setSpeed(newValue)
                 }
 
-            Picker("Quality", selection: $quality) {
+            Picker(String(localized: "Quality", bundle: bundle), selection: $quality) {
                 ForEach(SupertonicQuality.allCases, id: \.self) { quality in
-                    Text(quality.displayName).tag(quality)
+                    Text(String(localized: String.LocalizationValue(quality.displayName), bundle: bundle)).tag(quality)
                 }
             }
             .onChange(of: quality) { _, newValue in
@@ -469,11 +470,11 @@ private struct SupertonicSettingsView: View {
 
     private var tokenSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Hugging Face Token")
+            Text("Hugging Face Token", bundle: bundle)
                 .font(.subheadline)
                 .fontWeight(.medium)
 
-            Text("Optional. It can increase download rate limits for the model download.")
+            Text("Optional. It can increase download rate limits for the model download.", bundle: bundle)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -481,14 +482,14 @@ private struct SupertonicSettingsView: View {
                 SecureField("hf_...", text: $hfTokenInput)
                     .textFieldStyle(.roundedBorder)
 
-                Button("Save") {
+                Button(String(localized: "Save", bundle: bundle)) {
                     validateAndSaveHuggingFaceToken()
                 }
                 .controlSize(.small)
                 .disabled(hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isValidatingToken)
 
                 if plugin.huggingFaceToken != nil {
-                    Button("Remove") {
+                    Button(String(localized: "Remove", bundle: bundle)) {
                         hfTokenInput = ""
                         tokenValidationResult = nil
                         plugin.clearHuggingFaceToken()
@@ -502,7 +503,9 @@ private struct SupertonicSettingsView: View {
                     .controlSize(.small)
             } else if let tokenValidationResult {
                 Label(
-                    tokenValidationResult ? "Valid Hugging Face token" : "Invalid Hugging Face token",
+                    tokenValidationResult
+                        ? String(localized: "Valid Hugging Face token", bundle: bundle)
+                        : String(localized: "Invalid Hugging Face token", bundle: bundle),
                     systemImage: tokenValidationResult ? "checkmark.circle.fill" : "xmark.circle.fill"
                 )
                 .font(.caption)
@@ -543,3 +546,11 @@ private struct SupertonicSettingsView: View {
         progress = plugin.modelDownloadProgress
     }
 }
+
+private let pluginModuleBundle: Bundle = {
+#if SWIFT_PACKAGE
+    Bundle.module
+#else
+    Bundle(for: SupertonicPlugin.self)
+#endif
+}()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2765,6 +2765,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let pasteboard = NSPasteboard.withUniqueName()
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { nil }
 
         var pasteCount = 0
         service.pasteSimulatorOverride = {
@@ -2784,6 +2785,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let pasteboard = NSPasteboard.withUniqueName()
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { nil }
         service.defaultPasteFallbackRestoreDelay = .milliseconds(80)
 
         let pasteStarted = expectation(description: "synthetic paste started")

--- a/scripts/build-dev-local.sh
+++ b/scripts/build-dev-local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+xcodebuild build \
+  -project "$repo_root/TypeWhisper.xcodeproj" \
+  -scheme TypeWhisper \
+  -destination 'platform=macOS,arch=arm64' \
+  CODE_SIGN_IDENTITY='-' \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO
+
+"$repo_root/scripts/sync-dev-data-local.sh"
+
+app_path="$HOME/Library/Developer/Xcode/DerivedData/TypeWhisper-blctgsqwodthsydjmlajcmlwqoin/Build/Products/Debug/TypeWhisper.app"
+if [[ -d "$app_path" ]]; then
+  printf '[typewhisper-dev-build] app: %s\n' "$app_path"
+else
+  found_app="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path '*/Build/Products/Debug/TypeWhisper.app' -type d -print -quit 2>/dev/null || true)"
+  if [[ -n "$found_app" ]]; then
+    printf '[typewhisper-dev-build] app: %s\n' "$found_app"
+  fi
+fi

--- a/scripts/sync-dev-data-local.sh
+++ b/scripts/sync-dev-data-local.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEV_SUPPORT="${DEV_SUPPORT:-$HOME/Library/Application Support/TypeWhisper-Dev}"
+SEED_SUPPORT="${SEED_SUPPORT:-$HOME/Library/Application Support/TypeWhisper-Dev-Seed}"
+SEED_DEFAULTS_PLIST="${SEED_DEFAULTS_PLIST:-$SEED_SUPPORT/defaults/com.typewhisper.mac.dev.plist}"
+DEV_DEFAULTS="${DEV_DEFAULTS:-com.typewhisper.mac.dev}"
+BACKUP_ROOT="${BACKUP_ROOT:-$HOME/Library/Application Support/TypeWhisper-Dev-Backups}"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+backup_dir="$BACKUP_ROOT/$timestamp"
+
+log() {
+  printf '[typewhisper-dev-sync] %s\n' "$*"
+}
+
+table_for_store() {
+  case "$1" in
+    dictionary.store) printf 'ZDICTIONARYENTRY' ;;
+    snippets.store) printf 'ZSNIPPET' ;;
+    profiles.store) printf 'ZPROFILE' ;;
+    prompt-actions.store) printf 'ZPROMPTACTION' ;;
+    workflows.store) printf 'ZWORKFLOW' ;;
+    history.store) printf 'ZTRANSCRIPTIONRECORD' ;;
+    *) printf '' ;;
+  esac
+}
+
+store_count() {
+  local store="$1"
+  local table="$2"
+  if [[ ! -f "$store" ]]; then
+    printf '0'
+    return
+  fi
+  if [[ -z "$table" ]]; then
+    printf '0'
+    return
+  fi
+  sqlite3 "$store" "select count(*) from $table;"
+}
+
+backup_path() {
+  local path="$1"
+  local rel="${path#$DEV_SUPPORT/}"
+  mkdir -p "$backup_dir/$(dirname "$rel")"
+  if [[ -e "$path" ]]; then
+    cp -a "$path" "$backup_dir/$rel"
+  fi
+}
+
+copy_store_if_dev_empty() {
+  local name="$1"
+  local source_base="$SEED_SUPPORT/$name"
+  local dev_base="$DEV_SUPPORT/$name"
+  local table
+  table="$(table_for_store "$name")"
+
+  if [[ ! -f "$source_base" ]]; then
+    log "skip $name: source missing"
+    return
+  fi
+
+  local source_count dev_count
+  if ! source_count="$(store_count "$source_base" "$table" 2>/dev/null)"; then
+    log "skip $name: source store could not be read"
+    return
+  fi
+  if ! dev_count="$(store_count "$dev_base" "$table" 2>/dev/null)"; then
+    log "skip $name: dev store could not be read"
+    return
+  fi
+
+  if [[ "$source_count" == "0" ]]; then
+    log "skip $name: source has no entries"
+    return
+  fi
+
+  if [[ "$dev_count" != "0" ]]; then
+    log "keep $name: dev already has $dev_count entries"
+    return
+  fi
+
+  mkdir -p "$DEV_SUPPORT"
+  mkdir -p "$backup_dir"
+  for suffix in "" "-shm" "-wal"; do
+    backup_path "$dev_base$suffix"
+    if [[ -e "$source_base$suffix" ]]; then
+      cp -a "$source_base$suffix" "$dev_base$suffix"
+    else
+      rm -f "$dev_base$suffix"
+    fi
+  done
+  log "copied $name: source entries=$source_count"
+}
+
+copy_dir_if_dev_missing() {
+  local rel="$1"
+  local source_dir="$SEED_SUPPORT/$rel"
+  local dev_dir="$DEV_SUPPORT/$rel"
+
+  if [[ ! -d "$source_dir" ]]; then
+    log "skip $rel: source missing"
+    return
+  fi
+
+  if [[ -d "$dev_dir" ]] && [[ -n "$(find "$dev_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+    log "keep $rel: dev already populated"
+    return
+  fi
+
+  mkdir -p "$(dirname "$dev_dir")"
+  mkdir -p "$backup_dir"
+  backup_path "$dev_dir"
+  rm -rf "$dev_dir"
+  cp -a "$source_dir" "$dev_dir"
+  log "copied $rel"
+}
+
+copy_default_if_dev_missing() {
+  local key="$1"
+  if [[ ! -f "$SEED_DEFAULTS_PLIST" ]]; then
+    return
+  fi
+  if defaults read "$DEV_DEFAULTS" "$key" >/dev/null 2>&1; then
+    return
+  fi
+
+  local value_xml
+  value_xml="$(/usr/libexec/PlistBuddy -x -c "Print :$key" "$SEED_DEFAULTS_PLIST" 2>/dev/null || true)"
+  if [[ -z "$value_xml" ]]; then
+    return
+  fi
+
+  case "$value_xml" in
+    *"<true/>"*)
+      defaults write "$DEV_DEFAULTS" "$key" -bool true
+      ;;
+    *"<false/>"*)
+      defaults write "$DEV_DEFAULTS" "$key" -bool false
+      ;;
+    *"<integer>"*)
+      local int_value
+      int_value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$SEED_DEFAULTS_PLIST")"
+      defaults write "$DEV_DEFAULTS" "$key" -int "$int_value"
+      ;;
+    *"<real>"*)
+      local float_value
+      float_value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$SEED_DEFAULTS_PLIST")"
+      defaults write "$DEV_DEFAULTS" "$key" -float "$float_value"
+      ;;
+    *"<data>"*)
+      local data_hex
+      data_hex="$(
+        printf '%s\n' "$value_xml" \
+          | sed -n '/<data>/,/<\/data>/p' \
+          | sed -e 's/<[^>]*>//g' -e 's/[[:space:]]//g' \
+          | tr -d '\n' \
+          | base64 --decode \
+          | xxd -p -c 256 \
+          | tr -d '\n'
+      )"
+      if [[ -z "$data_hex" ]]; then
+        log "skip default $key: empty data"
+        return
+      fi
+      defaults write "$DEV_DEFAULTS" "$key" -data "$data_hex"
+      ;;
+    *"<string>"*)
+      local string_value
+      string_value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$SEED_DEFAULTS_PLIST")"
+      defaults write "$DEV_DEFAULTS" "$key" -string "$string_value"
+      ;;
+    *)
+      log "skip default $key: unsupported type"
+      return
+      ;;
+  esac
+  log "copied default $key"
+}
+
+create_seed_if_missing() {
+  if [[ -d "$SEED_SUPPORT" ]] && [[ -n "$(find "$SEED_SUPPORT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+    return
+  fi
+
+  if [[ ! -d "$DEV_SUPPORT" ]] || [[ -z "$(find "$DEV_SUPPORT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+    log "seed missing and dev support is empty; nothing to seed"
+    return
+  fi
+
+  mkdir -p "$SEED_SUPPORT/defaults"
+  cp -a "$DEV_SUPPORT/." "$SEED_SUPPORT/"
+  if defaults export "$DEV_DEFAULTS" "$SEED_DEFAULTS_PLIST" >/dev/null 2>&1; then
+    log "created seed from current dev data: $SEED_SUPPORT"
+  else
+    log "created seed from current dev data without defaults export: $SEED_SUPPORT"
+  fi
+}
+
+ensure_dev_defaults() {
+  defaults write "$DEV_DEFAULTS" selectedEngine qwen3
+  defaults write "$DEV_DEFAULTS" "plugin.com.typewhisper.qwen3.enabled" -bool true
+
+  if ! defaults read "$DEV_DEFAULTS" "plugin.com.typewhisper.qwen3.selectedModel" >/dev/null 2>&1; then
+    copy_default_if_dev_missing "plugin.com.typewhisper.qwen3.selectedModel"
+  fi
+  if ! defaults read "$DEV_DEFAULTS" "plugin.com.typewhisper.qwen3.loadedModel" >/dev/null 2>&1; then
+    copy_default_if_dev_missing "plugin.com.typewhisper.qwen3.loadedModel"
+  fi
+
+  copy_default_if_dev_missing selectedLanguage
+  copy_default_if_dev_missing preferredAppLanguage
+  copy_default_if_dev_missing pttHotkey
+  copy_default_if_dev_missing pttHotkeys
+  copy_default_if_dev_missing toggleHotkey
+  copy_default_if_dev_missing toggleHotkeys
+  copy_default_if_dev_missing setupWizardCompleted
+  copy_default_if_dev_missing workUsagePromptDismissed
+}
+
+mkdir -p "$DEV_SUPPORT"
+create_seed_if_missing
+
+copy_store_if_dev_empty dictionary.store
+copy_store_if_dev_empty snippets.store
+copy_store_if_dev_empty profiles.store
+copy_store_if_dev_empty prompt-actions.store
+copy_store_if_dev_empty workflows.store
+
+copy_dir_if_dev_missing "PluginData/com.typewhisper.qwen3"
+copy_dir_if_dev_missing "Plugins/Qwen3Plugin.bundle"
+
+ensure_dev_defaults
+
+dev_dictionary_count="$(store_count "$DEV_SUPPORT/dictionary.store" "$(table_for_store dictionary.store)" 2>/dev/null || printf 'unreadable')"
+dev_model="$(defaults read "$DEV_DEFAULTS" "plugin.com.typewhisper.qwen3.selectedModel" 2>/dev/null || true)"
+
+log "done: dev dictionary entries=$dev_dictionary_count, qwen3 selectedModel=${dev_model:-unset}"
+if [[ -d "$backup_dir" ]]; then
+  log "backup: $backup_dir"
+fi


### PR DESCRIPTION
## Summary

- Localize Supertonic, GoogleCloudSTT, and CloudflareASR settings surfaces through plugin bundle resources.
- Add missing Parakeet Japanese catalog entries and wire Supertonic xcstrings into SwiftPM resources.
- Downgrade unverified paste fallback logs from warning to info and stabilize focused paste fallback tests.
- Add local TypeWhisper Dev build/sync scripts that preserve TypeWhisper-Dev data and seed Qwen3 settings without using the normal TypeWhisper app data.

## Verification

- `git diff --check origin/main...HEAD`
- `jq empty TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Localizable.xcstrings`
- localized key scan for SupertonicPlugin / GoogleCloudSTTPlugin / CloudflareASRPlugin / Qwen3Plugin / ParakeetPlugin: all ok
- `swift test --package-path TypeWhisperPluginSDK --filter SupertonicPluginTests`
- `xcodebuild test -scheme TypeWhisper -configuration Debug -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testSyntheticPasteReturnsUnverifiedWhenFocusedTextStateIsUnavailable -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardKeepsGeneratedTextUntilFallbackRestoreWhenPasteIsUnverified -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardAvoidsPasteboardWhenVerifiedAccessibilityInsertionSucceeds -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardFallsBackToPasteboardWhenVerifiedAccessibilityInsertionFails`
- `scripts/build-dev-local.sh`
- `/Users/koipod/.openclaw/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean

## Notes

- Manifest description Japanese fallback remains separate from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Japanese localizations and bundled localization resources for multiple plugins; plugin settings UIs now use localized strings.

* **Bug Fixes**
  * Downgraded “unverified paste” log from warning to info to reduce noise during fallback paste.

* **Tests**
  * Updated two tests to explicitly clear a paste-related override for deterministic behavior.

* **Chores**
  * Added developer scripts to build the app locally and to sync seed dev-data into a local dev environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->