### PR TITLE
Add English digit-sequence number normalization

### DIFF
--- a/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
@@ -21,6 +21,17 @@ enum EnglishNumberWordParser {
         "million": 1_000_000,
     ]
 
+    // Spoken zeros inside a digit sequence ("four oh two" -> the "oh" is 0).
+    // Only read as 0 when flanked by real digits; never starts or ends a run,
+    // so a bare interjection "oh" is left alone.
+    private static let sequenceZeroWords: Set<String> = ["oh", "o"]
+
+    // Minimum length, in digit positions, before a run of bare single digits is
+    // read as one sequence ("one nine eight four" -> 1984) instead of spaced
+    // individual digits. Kept high so dictated counting like "one two three"
+    // stays split — the false-positive risk lives in the short runs.
+    private static let minDigitSequenceLength = 4
+
     // Unit ordinals 1–9. Used only as the tail of a compound such as
     // "twenty" + "eighth" -> 28th, where the numeric context is unambiguous.
     private static let ordinalUnitValues: [String: Int] = [
@@ -44,6 +55,14 @@ enum EnglishNumberWordParser {
     static func parse(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
         guard !words.isEmpty else { return nil }
         let normalizedWords = words.map(normalizeWord)
+
+        // A long run of bare single digits is a sequence ("one nine eight four"
+        // -> 1984), not a cardinal. Checked first because the cardinal path
+        // would otherwise emit the same digits spaced apart.
+        if let sequence = parseDigitSequence(normalizedWords) {
+            return sequence
+        }
+
         var index = 0
         var isNegative = false
 
@@ -89,6 +108,41 @@ enum EnglishNumberWordParser {
         }
 
         return nil
+    }
+
+    // Reads a leading run of bare single-digit words as one joined sequence,
+    // e.g. ["one","nine","eight","four"] -> "1984". An "oh"/"o" inside the run
+    // counts as 0. The run must start and end on a real digit, and reach
+    // `minDigitSequenceLength` positions, or this returns nil and the caller
+    // falls back to the cardinal reading.
+    private static func parseDigitSequence(_ words: [String]) -> NumberWordNormalizer.ParsedWords? {
+        // Must start on a real digit so a leading "oh" is never swallowed as 0.
+        guard let first = words.first, unitValues[first] != nil else { return nil }
+
+        var index = 0
+        var lastRealDigitIndex = -1
+        while index < words.count {
+            let word = words[index]
+            if unitValues[word] != nil {
+                lastRealDigitIndex = index
+            } else if !sequenceZeroWords.contains(word) {
+                break
+            }
+            index += 1
+        }
+
+        // End on a real digit: a trailing "oh"/"o" is not consumed.
+        let positions = lastRealDigitIndex + 1
+        guard positions >= minDigitSequenceLength else { return nil }
+
+        var sequence = ""
+        for position in 0..<positions {
+            // Within the run, anything that is not a unit digit is a flanked
+            // "oh"/"o", which reads as 0.
+            sequence += "\(unitValues[words[position]] ?? 0)"
+        }
+
+        return NumberWordNormalizer.ParsedWords(value: sequence, consumedWords: positions)
     }
 
     private static func makeResult(_ value: Int, ordinal: Bool, isNegative: Bool, consumedWords: Int) -> NumberWordNormalizer.ParsedWords {

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -107,6 +107,52 @@ final class NumberWordNormalizerTests: XCTestCase {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "the 31st of May", language: "en"), "the 31st of May")
     }
 
+    func testEnglishDigitSequenceJoinsBareSingleDigits() {
+        // A run of four or more bare single digits is read as one sequence
+        // (phone numbers, PINs, codes, digit-by-digit years) instead of the
+        // spaced individual digits the cardinal path would emit.
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "one nine eight four", language: "en"), "1984")
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "my pin is one two three four", language: "en"),
+            "my pin is 1234"
+        )
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "call five five five one two one two now", language: "en"),
+            "call 5551212 now"
+        )
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "one two three four dogs", language: "en"), "1234 dogs")
+    }
+
+    func testEnglishDigitSequenceReadsOhAsZeroWhenFlanked() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "five five five oh one two three", language: "en"),
+            "5550123"
+        )
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "four oh oh two", language: "en"), "4002")
+        // A leading zero is preserved because the run is emitted as written.
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "zero one two three", language: "en"), "0123")
+    }
+
+    func testEnglishShortDigitRunsStaySplit() {
+        // Below the four-digit threshold, dictated counting must not collapse.
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "one two three", language: "en"), "1 2 3")
+        // "oh" is only zero when flanked by digits inside a qualifying run;
+        // a short run leaves it as an interjection.
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "four oh two", language: "en"), "4 oh 2")
+    }
+
+    func testEnglishDigitSequenceDoesNotDisturbCardinalsOrOrdinals() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "one hundred", language: "en"), "100")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "two thousand", language: "en"), "2000")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "twenty third", language: "en"), "23rd")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "two point five", language: "en"), "2.5")
+    }
+
+    func testEnglishDigitSequenceOutputIsIdempotent() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "1984", language: "en"), "1984")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "5550123", language: "en"), "5550123")
+    }
+
     func testGermanNegativeDecimalNormalizesToDigits() {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "minus zwei komma fünf", language: "de"), "-2,5")
     }


### PR DESCRIPTION
Addresses the **digit-sequence** slice of #599 (the spoken-number ITN follow-ups). Builds on the cardinal (#647/#648) and ordinal (#655) work already on `main`.

## What it does

A run of **four or more** bare single-digit words is now read as one joined number instead of the spaced individual digits the cardinal path emits:

| Spoken | Before | After |
|---|---|---|
| `one nine eight four` | `1 9 8 4` | `1984` |
| `my pin is one two three four` | `my pin is 1 2 3 4` | `my pin is 1234` |
| `call five five five one two one two now` | `5 5 5 1 2 1 2` | `5551212` |

An `"oh"`/`"o"` inside such a run reads as `0`, but **only when flanked by real digits**, so a bare interjection is left alone:

| Spoken | After |
|---|---|
| `five five five oh one two three` | `5550123` |
| `four oh oh two` | `4002` |
| `zero one two three` | `0123` (leading zero preserved) |

## Why the four-digit threshold

This is the false-positive-prone slice, so the policy is deliberately conservative:

- Sub-threshold runs stay split — `one two three` → `1 2 3`, `four oh two` → `4 oh 2` (unchanged from today). Dictated counting and short asides don't collapse.
- Every cardinal/ordinal/decimal construct contains a non-digit word (`hundred`, `thousand`, `point`, a tens-word, an ordinal suffix) that ends the run before it reaches four positions, so `one hundred` → `100`, `two thousand` → `2000`, `twenty third` → `23rd`, `two point five` → `2.5` are all untouched.
- A run must **start and end on a real digit**, so leading/trailing `"oh"` is never swallowed as zero.
- Output is idempotent (`1984` → `1984`); already-numeric tokens aren't words, so they pass through.

English-only, riding the existing `transcriptionNumberNormalizationEnabled` path — no new settings or pipeline wiring. Implemented as a single leading check in `EnglishNumberWordParser.parse()` that runs before the cardinal reading.

## Scope / follow-ups

Per #599, this PR intentionally leaves **dates** (`July twenty eighth`) and other ITN cases as separate follow-ups. `"oh"`-as-zero is included only inside qualifying digit runs.

## Tests

Adds five cases to `NumberWordNormalizerTests` covering joins, flanked `oh`→0, leading-zero preservation, sub-threshold non-joins, cardinal/ordinal/decimal non-regression, and idempotency.

Supported by Claude Opus 4.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition for digit sequences spoken as individual words (e.g., years, PIN codes, phone numbers)
  * Enhanced handling of "oh" as zero when spoken within digit sequences

* **Tests**
  * Added comprehensive tests for digit sequence recognition and normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->