### PR TITLE
Fix smart insertion mid-sentence edge cases

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1912,21 +1912,22 @@ enum DictationInsertionTextFormatter {
             return textWithTrailingSpaceIfNeeded(text)
         }
 
-        var result = text
-        if isHighConfidenceMidSentenceInsertion(insertionContext) {
+        let boundaries = insertionBoundaries(for: insertionContext)
+        var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isHighConfidenceMidSentenceInsertion(boundaries) {
             result = lowercasingFirstWordIfSafe(result)
         }
-        if shouldStripFinalPeriod(insertionContext) {
+        if shouldStripFinalPeriod(boundaries) {
             result = strippingSingleFinalPeriod(result)
         }
 
-        if let previous = insertionContext.previousCharacter,
+        if let previous = boundaries.previousCharacter,
            let first = result.first,
            shouldInsertSpace(between: previous, and: first) {
             result = " " + result
         }
 
-        if let next = insertionContext.nextCharacter {
+        if let next = boundaries.nextCharacter {
             if let last = result.last,
                shouldInsertSpace(between: last, and: next) {
                 result += " "
@@ -1944,19 +1945,95 @@ enum DictationInsertionTextFormatter {
         return text + " "
     }
 
+    private struct InsertionBoundaries {
+        let previousCharacter: Character?
+        let nextCharacter: Character?
+        let previousNonWhitespaceCharacter: Character?
+        let nextNonWhitespaceCharacter: Character?
+    }
+
+    private static func insertionBoundaries(
+        for context: TextInsertionService.InsertionContext
+    ) -> InsertionBoundaries {
+        guard let selectedRange = Range(context.selectedRange, in: context.value) else {
+            return InsertionBoundaries(
+                previousCharacter: context.previousCharacter,
+                nextCharacter: context.nextCharacter,
+                previousNonWhitespaceCharacter: nonWhitespaceCharacter(context.previousCharacter),
+                nextNonWhitespaceCharacter: nonWhitespaceCharacter(context.nextCharacter)
+            )
+        }
+
+        let previousCharacter = selectedRange.lowerBound > context.value.startIndex
+            ? context.value[context.value.index(before: selectedRange.lowerBound)]
+            : nil
+        let nextCharacter = selectedRange.upperBound < context.value.endIndex
+            ? context.value[selectedRange.upperBound]
+            : nil
+
+        return InsertionBoundaries(
+            previousCharacter: previousCharacter,
+            nextCharacter: nextCharacter,
+            previousNonWhitespaceCharacter: previousNonWhitespaceCharacter(
+                before: selectedRange.lowerBound,
+                in: context.value
+            ),
+            nextNonWhitespaceCharacter: nextNonWhitespaceCharacter(
+                after: selectedRange.upperBound,
+                in: context.value
+            )
+        )
+    }
+
+    private static func previousNonWhitespaceCharacter(
+        before index: String.Index,
+        in value: String
+    ) -> Character? {
+        var currentIndex = index
+        while currentIndex > value.startIndex {
+            let previousIndex = value.index(before: currentIndex)
+            let character = value[previousIndex]
+            if !isWhitespace(character) {
+                return character
+            }
+            currentIndex = previousIndex
+        }
+        return nil
+    }
+
+    private static func nextNonWhitespaceCharacter(
+        after index: String.Index,
+        in value: String
+    ) -> Character? {
+        var currentIndex = index
+        while currentIndex < value.endIndex {
+            let character = value[currentIndex]
+            if !isWhitespace(character) {
+                return character
+            }
+            currentIndex = value.index(after: currentIndex)
+        }
+        return nil
+    }
+
+    private static func nonWhitespaceCharacter(_ character: Character?) -> Character? {
+        guard let character, !isWhitespace(character) else { return nil }
+        return character
+    }
+
     private static func isHighConfidenceMidSentenceInsertion(
-        _ context: TextInsertionService.InsertionContext
+        _ boundaries: InsertionBoundaries
     ) -> Bool {
-        guard let previous = context.previousCharacter else { return false }
+        guard let previous = boundaries.previousNonWhitespaceCharacter else { return false }
         return isWordLike(previous)
     }
 
-    private static func shouldStripFinalPeriod(_ context: TextInsertionService.InsertionContext) -> Bool {
-        guard isHighConfidenceMidSentenceInsertion(context),
-              let next = context.nextCharacter else {
+    private static func shouldStripFinalPeriod(_ boundaries: InsertionBoundaries) -> Bool {
+        guard isHighConfidenceMidSentenceInsertion(boundaries),
+              let next = boundaries.nextNonWhitespaceCharacter else {
             return false
         }
-        return isWordLike(next)
+        return isWordLike(next) || closingPunctuation.contains(next)
     }
 
     private static func lowercasingFirstWordIfSafe(_ text: String) -> String {

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -262,6 +262,13 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
         )
     }
 
+    func testMissingContextKeepsTrailingSpaceOnlyBehavior() {
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("Strong."),
+            "Strong. "
+        )
+    }
+
     func testSmartInsertionAddsMissingLeadingAndTrailingSpacesBetweenWords() {
         let context = TextInsertionService.InsertionContext(
             value: "coffeemachine",
@@ -307,6 +314,39 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
         )
     }
 
+    func testSmartInsertionStripsFinalPeriodBeforeExistingComma() {
+        let context = TextInsertionService.InsertionContext(
+            value: "start, I will begin",
+            selectedRange: NSRange(location: 5, length: 0),
+            selectedText: nil,
+            previousCharacter: "t",
+            nextCharacter: ","
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion(
+                "Dictation in the middle of a sentence before the comma.",
+                insertionContext: context
+            ),
+            " dictation in the middle of a sentence before the comma"
+        )
+    }
+
+    func testSmartInsertionStripsFinalPeriodBeforeExistingPeriod() {
+        let context = TextInsertionService.InsertionContext(
+            value: "dictating.",
+            selectedRange: NSRange(location: 9, length: 0),
+            selectedText: nil,
+            previousCharacter: "g",
+            nextCharacter: "."
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("my first sentence.", insertionContext: context),
+            " my first sentence"
+        )
+    }
+
     func testSmartInsertionDoesNotLowercaseAfterSentenceEndingPunctuation() {
         let context = TextInsertionService.InsertionContext(
             value: "Done.Next",
@@ -334,6 +374,36 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
         XCTAssertEqual(
             DictationInsertionTextFormatter.textForInsertion("Presented tomorrow", insertionContext: context),
             " presented tomorrow "
+        )
+    }
+
+    func testSmartInsertionLowercasesAndStripsPeriodAfterExistingWordSeparatedBySpace() {
+        let context = TextInsertionService.InsertionContext(
+            value: "will begin",
+            selectedRange: NSRange(location: 5, length: 0),
+            selectedText: nil,
+            previousCharacter: " ",
+            nextCharacter: "b"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("Immediately.", insertionContext: context),
+            "immediately "
+        )
+    }
+
+    func testSmartInsertionTrimsDictatedBoundaryWhitespaceBeforePunctuation() {
+        let context = TextInsertionService.InsertionContext(
+            value: "dictating.",
+            selectedRange: NSRange(location: 9, length: 0),
+            selectedText: nil,
+            previousCharacter: "g",
+            nextCharacter: "."
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion(" my first sentence ", insertionContext: context),
+            " my first sentence"
         )
     }
 


### PR DESCRIPTION
## Summary

This fixes the remaining smart insertion formatter edge cases reported in #695 after the app-aware insertion work from #691.

When target-app cursor context is available, TypeWhisper now trims dictated boundary whitespace before applying smart insertion rules, detects mid-sentence insertions through adjacent whitespace, and strips one trailing dictated period before existing words or closing punctuation. This keeps the existing fallback behavior unchanged when cursor context is unavailable.

Closes #695

## Test Plan

```zsh
git diff --check
set -o pipefail && xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationInsertionTextFormatterTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testDictationDirectInsertionUsesContextWhenAppAwareFormattingIsEnabled -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testCaptureInsertionContextIncludesCharactersAroundSelectionRange -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testCaptureInsertionContextReturnsNilWhenFocusedTextStateIsIncomplete 2>&1 | tee /tmp/typewhisper-issue-695-smart-insertion.log
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-issue-695-smart-insertion.log
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/036e/typewhisper-mac
```

Manual smoke test: verified browser/GitHub text fields and Obsidian with insertions before commas, before periods, and between words. No double punctuation or extra boundary spaces were observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dictation text insertion to intelligently handle spacing, punctuation, and capitalization based on surrounding context.

* **Tests**
  * Added comprehensive test coverage for text insertion edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->