### PR TITLE
Update Soniox async model to v5

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -70,6 +70,7 @@ private actor TranscriptCollector {
 final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.soniox"
     static let pluginName = "Soniox"
+    static let asyncModelId = "stt-async-v5"
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -149,7 +150,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
             throw PluginTranscriptionError.notConfigured
         }
 
-        let effectiveHints = resolvedLanguageHints(
+        let effectiveHints = Self.resolvedLanguageHints(
             requestedLanguage: languageSelection.requestedLanguage,
             languageHints: languageSelection.languageHints
         )
@@ -249,7 +250,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
             throw PluginTranscriptionError.noModelSelected
         }
 
-        let effectiveHints = resolvedLanguageHints(
+        let effectiveHints = Self.resolvedLanguageHints(
             requestedLanguage: languageSelection.requestedLanguage,
             languageHints: languageSelection.languageHints
         )
@@ -309,7 +310,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
             "enable_endpoint_detection": true,
         ]
 
-        let effectiveHints = resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
+        let effectiveHints = Self.resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
         if !effectiveHints.isEmpty {
             config["language_hints"] = effectiveHints
         }
@@ -556,36 +557,14 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         apiKey: String,
         prompt: String?
     ) async throws -> String {
-        guard let url = URL(string: "https://api.soniox.com/v1/transcriptions") else {
-            throw PluginTranscriptionError.apiError("Invalid transcriptions URL")
-        }
-
-        var body: [String: Any] = [
-            "file_id": fileId,
-            "model": "stt-async-v4",
-        ]
-
-        let effectiveHints = resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
-        if !effectiveHints.isEmpty {
-            body["language_hints"] = effectiveHints
-        }
-
-        if translate {
-            body["translation"] = [
-                "type": "one_way",
-                "target_language": "en",
-            ]
-        }
-        if let context = Self.contextPayload(prompt: prompt) {
-            body["context"] = context
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        request.timeoutInterval = 30
+        let request = try Self.makeCreateTranscriptionRequest(
+            fileId: fileId,
+            language: language,
+            languageHints: languageHints,
+            translate: translate,
+            apiKey: apiKey,
+            prompt: prompt
+        )
 
         let (data, response) = try await PluginHTTPClient.data(for: request)
 
@@ -610,13 +589,54 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         return id
     }
 
+    static func makeCreateTranscriptionRequest(
+        fileId: String,
+        language: String?,
+        languageHints: [String] = [],
+        translate: Bool,
+        apiKey: String,
+        prompt: String?
+    ) throws -> URLRequest {
+        guard let url = URL(string: "https://api.soniox.com/v1/transcriptions") else {
+            throw PluginTranscriptionError.apiError("Invalid transcriptions URL")
+        }
+
+        var body: [String: Any] = [
+            "file_id": fileId,
+            "model": Self.asyncModelId,
+        ]
+
+        let effectiveHints = Self.resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
+        if !effectiveHints.isEmpty {
+            body["language_hints"] = effectiveHints
+        }
+
+        if translate {
+            body["translation"] = [
+                "type": "one_way",
+                "target_language": "en",
+            ]
+        }
+        if let context = Self.contextPayload(prompt: prompt) {
+            body["context"] = context
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 30
+        return request
+    }
+
     private static func contextPayload(prompt: String?) -> [String: Any]? {
         let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
         guard !terms.isEmpty else { return nil }
         return ["terms": terms]
     }
 
-    private func resolvedLanguageHints(requestedLanguage: String?, languageHints: [String]) -> [String] {
+    private static func resolvedLanguageHints(requestedLanguage: String?, languageHints: [String]) -> [String] {
         if !languageHints.isEmpty {
             return languageHints
         }

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -1,8 +1,35 @@
+import Foundation
 import XCTest
 import TypeWhisperPluginSDK
 @testable import SonioxPlugin
 
 final class SonioxPluginTests: XCTestCase {
+    func testCreateTranscriptionRequestUsesAsyncV5Model() throws {
+        let request = try SonioxPlugin.makeCreateTranscriptionRequest(
+            fileId: "file_123",
+            language: "de",
+            languageHints: ["en", "de"],
+            translate: true,
+            apiKey: "soniox-key",
+            prompt: nil
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.soniox.com/v1/transcriptions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 30)
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["file_id"] as? String, "file_123")
+        XCTAssertEqual(body["model"] as? String, "stt-async-v5")
+        XCTAssertEqual(body["language_hints"] as? [String], ["en", "de"])
+
+        let translation = try XCTUnwrap(body["translation"] as? [String: Any])
+        XCTAssertEqual(translation["type"] as? String, "one_way")
+        XCTAssertEqual(translation["target_language"] as? String, "en")
+    }
+
     func testSourceProgressUsesFinalOriginalTokenTiming() {
         let progress = SonioxPlugin.sourceProgress(
             fromTokens: [
@@ -40,5 +67,10 @@ final class SonioxPluginTests: XCTestCase {
             ],
             totalDuration: 0
         ))
+    }
+
+    private static func jsonBody(from request: URLRequest) throws -> [String: Any] {
+        let data = try XCTUnwrap(request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 }


### PR DESCRIPTION
## Summary

- Update the Soniox Async REST transcription request to use `stt-async-v5`.
- Extract the Soniox Async create-transcription request into a testable builder.
- Add a regression test that verifies the request body sends `model: stt-async-v5`.

This does not release the Soniox plugin or bump the plugin manifest version. It only prepares the repo change so a later plugin release picks up the new Async model.

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests`
- `xcodebuild -list -project TypeWhisper.xcodeproj`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme SonioxPlugin -configuration Debug build CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the Soniox plugin's transcription request handling for improved maintainability and consistency.

* **Tests**
  * Added comprehensive test coverage for transcription request construction, validating proper headers, timeouts, and request payload formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->