### PR TITLE
Add Sber SaluteSpeech transcription plugin

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -111,6 +111,7 @@ jobs:
             cerebras) TARGET="CerebrasPlugin" ;;
             openrouter) TARGET="OpenRouterPlugin" ;;
             soniox) TARGET="SonioxPlugin" ;;
+            sber-salutespeech) TARGET="SaluteSpeechPlugin" ;;
             reson8) TARGET="Reson8Plugin" ;;
             cohere) TARGET="CoherePlugin" ;;
             speechmatics) TARGET="SpeechmaticsPlugin" ;;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -313,6 +313,9 @@
 		5A1100000000000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 5A1100000000000000000012 /* Localizable.xcstrings */; };
 		5A1100000000000000000004 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5A1100000000000000000030 /* TypeWhisperPluginSDK */; };
 		5A1100000000000000000005 /* smallest.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5A1100000000000000000014 /* smallest.svg */; };
+		5B2200000000000000000001 /* SaluteSpeechPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2200000000000000000010 /* SaluteSpeechPlugin.swift */; };
+		5B2200000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B2200000000000000000011 /* manifest.json */; };
+		5B2200000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5B2200000000000000000030 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000207 /* IndicatorPreviewView.swift */; };
 		AA00000000000000000218 /* ObsidianPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000208 /* ObsidianPlugin.swift */; };
 		AA00000000000000000219 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000209 /* manifest.json */; };
@@ -740,6 +743,9 @@
 		5A1100000000000000000012 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		5A1100000000000000000013 /* SmallestAIPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SmallestAIPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A1100000000000000000014 /* smallest.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = smallest.svg; sourceTree = "<group>"; };
+		5B2200000000000000000010 /* SaluteSpeechPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaluteSpeechPlugin.swift; sourceTree = "<group>"; };
+		5B2200000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		5B2200000000000000000012 /* SaluteSpeechPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SaluteSpeechPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000207 /* IndicatorPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorPreviewView.swift; sourceTree = "<group>"; };
 		BB00000000000000000208 /* ObsidianPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000209 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1079,6 +1085,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5B2200000000000000000051 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2200000000000000000003 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000096 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1310,6 +1324,7 @@
 				CC00000000000000000029 /* AssemblyAIPlugin */,
 				RESG00000000000000001 /* Reson8Plugin */,
 				5A1100000000000000000020 /* SmallestAIPlugin */,
+				5B2200000000000000000020 /* SaluteSpeechPlugin */,
 				CC00000000000000000030 /* ObsidianPlugin */,
 				CC00000000000000000031 /* ScriptPlugin */,
 				F18A00000000000000000020 /* FillerWordsPlugin */,
@@ -1814,6 +1829,16 @@
 			path = TypeWhisperPluginSDK/Plugins/SmallestAIPlugin;
 			sourceTree = "<group>";
 		};
+		5B2200000000000000000020 /* SaluteSpeechPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				5B2200000000000000000010 /* SaluteSpeechPlugin.swift */,
+				5B2200000000000000000011 /* manifest.json */,
+			);
+			name = SaluteSpeechPlugin;
+			path = TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000030 /* ObsidianPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2085,6 +2110,7 @@
 				BB00000000000000000199 /* DeepgramPlugin.bundle */,
 				BB00000000000000000203 /* AssemblyAIPlugin.bundle */,
 				5A1100000000000000000013 /* SmallestAIPlugin.bundle */,
+				5B2200000000000000000012 /* SaluteSpeechPlugin.bundle */,
 				BB00000000000000000211 /* ObsidianPlugin.bundle */,
 				BB00000000000000000215 /* ScriptPlugin.bundle */,
 				F18A00000000000000000012 /* FillerWordsPlugin.bundle */,
@@ -2568,6 +2594,26 @@
 			);
 			productName = SmallestAIPlugin;
 			productReference = 5A1100000000000000000013 /* SmallestAIPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		5B2200000000000000000040 /* SaluteSpeechPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B2200000000000000000062 /* Build configuration list for PBXNativeTarget "SaluteSpeechPlugin" */;
+			buildPhases = (
+				5B2200000000000000000050 /* Sources */,
+				5B2200000000000000000051 /* Frameworks */,
+				5B2200000000000000000052 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SaluteSpeechPlugin;
+			packageProductDependencies = (
+				5B2200000000000000000030 /* TypeWhisperPluginSDK */,
+			);
+			productName = SaluteSpeechPlugin;
+			productReference = 5B2200000000000000000012 /* SaluteSpeechPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		DD00000000000000000018 /* ObsidianPlugin */ = {
@@ -3102,6 +3148,7 @@
 				DD00000000000000000016 /* DeepgramPlugin */,
 				DD00000000000000000017 /* AssemblyAIPlugin */,
 				5A1100000000000000000040 /* SmallestAIPlugin */,
+				5B2200000000000000000040 /* SaluteSpeechPlugin */,
 				DD00000000000000000018 /* ObsidianPlugin */,
 				DD00000000000000000019 /* ScriptPlugin */,
 				F18A00000000000000000030 /* FillerWordsPlugin */,
@@ -3298,6 +3345,14 @@
 				5A1100000000000000000002 /* manifest.json in Resources */,
 				5A1100000000000000000003 /* Localizable.xcstrings in Resources */,
 				5A1100000000000000000005 /* smallest.svg in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B2200000000000000000052 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2200000000000000000002 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3903,6 +3958,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				5A1100000000000000000001 /* SmallestAIPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B2200000000000000000050 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B2200000000000000000001 /* SaluteSpeechPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5144,6 +5207,78 @@
 				PRODUCT_NAME = SmallestAIPlugin;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		5B2200000000000000000060 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Sber SaluteSpeech";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = SaluteSpeechPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					/usr/lib/swift,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.sber-salutespeech";
+				PRODUCT_NAME = SaluteSpeechPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
+				);
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		5B2200000000000000000061 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Sber SaluteSpeech";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = SaluteSpeechPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					/usr/lib/swift,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.sber-salutespeech";
+				PRODUCT_NAME = SaluteSpeechPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
+				);
 				SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
 			};
@@ -6407,6 +6542,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		5B2200000000000000000062 /* Build configuration list for PBXNativeTarget "SaluteSpeechPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B2200000000000000000060 /* Debug */,
+				5B2200000000000000000061 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000098 /* Build configuration list for PBXNativeTarget "ObsidianPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6783,6 +6927,11 @@
 		};
 		5A1100000000000000000030 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		5B2200000000000000000030 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = RR00000000000000000005 /* XCLocalSwiftPackageReference "TypeWhisperPluginSDK" */;
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000025 /* TypeWhisperPluginSDK */ = {

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -252,6 +252,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "SaluteSpeechPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/SaluteSpeechPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "WebhookPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/WebhookPlugin",
@@ -467,6 +476,15 @@ let package = Package(
                 "SmallestAIPlugin",
             ],
             path: "Plugins/SmallestAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "SaluteSpeechPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "SaluteSpeechPlugin",
+            ],
+            path: "Plugins/SaluteSpeechPlugin/Tests"
         ),
         .testTarget(
             name: "WebhookPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -1012,6 +1012,7 @@ private struct SaluteSpeechSettingsView: View {
     @State private var balanceRemainingInput = ""
     @State private var hasBalanceValidUntil = false
     @State private var balanceValidUntilDate = Date()
+    @State private var showBalanceDatePicker = false
     @State private var usageErrorMessage: String?
 
     var body: some View {
@@ -1238,14 +1239,32 @@ private struct SaluteSpeechSettingsView: View {
                     .toggleStyle(.checkbox)
                     .frame(width: 126, alignment: .leading)
 
-                DatePicker(
-                    "",
-                    selection: $balanceValidUntilDate,
-                    displayedComponents: .date
-                )
-                .labelsHidden()
+                Button {
+                    showBalanceDatePicker = true
+                } label: {
+                    Label(Self.formatDateInput(balanceValidUntilDate), systemImage: "calendar")
+                        .frame(width: 132, alignment: .leading)
+                }
+                .buttonStyle(.bordered)
                 .disabled(!hasBalanceValidUntil)
                 .opacity(hasBalanceValidUntil ? 1 : 0.55)
+                .popover(isPresented: $showBalanceDatePicker, arrowEdge: .bottom) {
+                    VStack(alignment: .trailing, spacing: 10) {
+                        DatePicker(
+                            "",
+                            selection: $balanceValidUntilDate,
+                            displayedComponents: .date
+                        )
+                        .datePickerStyle(.graphical)
+                        .labelsHidden()
+
+                        Button("Done") {
+                            showBalanceDatePicker = false
+                        }
+                        .keyboardShortcut(.defaultAction)
+                    }
+                    .padding(12)
+                }
             }
 
             HStack(spacing: 8) {
@@ -1357,7 +1376,9 @@ private struct SaluteSpeechSettingsView: View {
         do {
             try plugin.setUsageBalanceCorrection(
                 remainingMinutes: remainingMinutes,
-                validUntil: hasBalanceValidUntil ? balanceValidUntilDate : nil
+                validUntil: hasBalanceValidUntil
+                    ? Calendar.current.startOfDay(for: balanceValidUntilDate)
+                    : nil
             )
             refreshUsage()
         } catch {

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -1,0 +1,1038 @@
+import Foundation
+import SwiftUI
+import os
+import TypeWhisperPluginSDK
+
+@objc(SaluteSpeechPlugin)
+final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthRoleStatusProviding, TranscriptPreviewFallbackPolicyProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.sber-salutespeech"
+    static let pluginName = "Sber SaluteSpeech"
+
+    static let personalScope = "SALUTE_SPEECH_PERS"
+    static let corporateScope = "SALUTE_SPEECH_CORP"
+
+    private static let authorizationKeySecret = "authorization-key"
+    private static let selectedModelDefault = "selectedModel"
+    private static let scopeDefault = "scope"
+    private static let defaultModelId = "general"
+
+    private let state = SaluteSpeechPluginState()
+    private let tokenCache = SaluteSpeechTokenCache()
+    private let logger = Logger(subsystem: "com.typewhisper.sber-salutespeech", category: "Plugin")
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        state.activate(
+            host: host,
+            authorizationKey: Self.normalizedAuthorizationKey(
+                host.loadSecret(key: Self.authorizationKeySecret) ?? ""
+            ).nilIfEmpty,
+            scope: Self.resolvedScope(host.userDefault(forKey: Self.scopeDefault) as? String),
+            selectedModelId: host.userDefault(forKey: Self.selectedModelDefault) as? String
+                ?? Self.defaultModelId
+        )
+    }
+
+    func deactivate() {
+        state.deactivate()
+        Task { await tokenCache.clear() }
+    }
+
+    var providerId: String { "sber-salutespeech" }
+    var providerDisplayName: String { "Sber SaluteSpeech" }
+
+    var isConfigured: Bool {
+        guard let key = state.snapshot().authorizationKey else { return false }
+        return !key.isEmpty
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: Self.defaultModelId, displayName: "General"),
+        ]
+    }
+
+    var selectedModelId: String? {
+        state.snapshot().selectedModelId ?? Self.defaultModelId
+    }
+
+    func selectModel(_ modelId: String) {
+        state.currentHost()?.setUserDefault(modelId, forKey: Self.selectedModelDefault)
+        state.updateSelectedModelId(modelId)
+    }
+
+    var supportsTranslation: Bool { false }
+
+    var allowsTranscriptPreviewFallback: Bool { false }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("Sber SaluteSpeech does not support translation.")
+        }
+
+        let snapshot = state.snapshot()
+        guard let authorizationKey = snapshot.authorizationKey, !authorizationKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let pcmData = Self.makePCM16LEData(samples: audio.samples)
+        guard !pcmData.isEmpty else {
+            throw PluginTranscriptionError.apiError("Sber SaluteSpeech requires non-empty PCM audio samples.")
+        }
+
+        let token = try await accessToken(
+            authorizationKey: authorizationKey,
+            scope: snapshot.scope
+        )
+        let modelId = snapshot.selectedModelId ?? Self.defaultModelId
+
+        if pcmData.count <= Self.syncMaxBytes, audio.duration <= Self.syncMaxDuration {
+            return try await recognizeSync(
+                pcmData: pcmData,
+                token: token,
+                modelId: modelId
+            )
+        }
+
+        return try await recognizeAsync(
+            pcmData: pcmData,
+            token: token,
+            modelId: modelId,
+            duration: audio.duration
+        )
+    }
+
+    @MainActor
+    var settingsView: AnyView? {
+        AnyView(SaluteSpeechSettingsView(plugin: self))
+    }
+
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        guard role == .transcription else { return .available }
+        return PluginAuthRoleStatus.legacyFallback(
+            isConfigured: isConfigured,
+            unavailableReason: "Sber SaluteSpeech Authorization Key is missing.",
+            requiredCredentialLabel: "Authorization Key"
+        )
+    }
+
+    var authorizationKeyForSettings: String? {
+        state.snapshot().authorizationKey
+    }
+
+    var scopeForSettings: String {
+        state.snapshot().scope
+    }
+
+    func setAuthorizationKey(_ key: String) throws {
+        guard let host = state.currentHost() else {
+            throw SaluteSpeechPluginConfigurationError.missingHost
+        }
+
+        let normalized = Self.normalizedAuthorizationKey(key)
+        guard !normalized.isEmpty else {
+            throw SaluteSpeechPluginConfigurationError.emptyAuthorizationKey
+        }
+
+        do {
+            try host.storeSecret(key: Self.authorizationKeySecret, value: normalized)
+            state.updateAuthorizationKey(normalized)
+            Task { await tokenCache.clear() }
+            host.notifyCapabilitiesChanged()
+        } catch {
+            logger.error("Failed to store Sber SaluteSpeech Authorization Key: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    func removeAuthorizationKey() throws {
+        guard let host = state.currentHost() else {
+            throw SaluteSpeechPluginConfigurationError.missingHost
+        }
+
+        do {
+            try host.storeSecret(key: Self.authorizationKeySecret, value: "")
+            state.updateAuthorizationKey(nil)
+            Task { await tokenCache.clear() }
+            host.notifyCapabilitiesChanged()
+        } catch {
+            logger.error("Failed to delete Sber SaluteSpeech Authorization Key: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    func setScope(_ scope: String) {
+        let resolvedScope = Self.resolvedScope(scope)
+        state.currentHost()?.setUserDefault(resolvedScope, forKey: Self.scopeDefault)
+        state.updateScope(resolvedScope)
+        Task { await tokenCache.clear() }
+    }
+
+    func validateAuthorizationKey(_ key: String, scope: String) async -> AuthorizationKeyValidationResult {
+        let normalized = Self.normalizedAuthorizationKey(key)
+        guard !normalized.isEmpty else { return .invalidKey }
+
+        do {
+            _ = try await requestAccessToken(
+                authorizationKey: normalized,
+                scope: Self.resolvedScope(scope)
+            )
+            return .valid
+        } catch let error as PluginTranscriptionError {
+            switch error {
+            case .invalidApiKey:
+                return .invalidKey
+            default:
+                return .transientError
+            }
+        } catch {
+            return .transientError
+        }
+    }
+
+    enum AuthorizationKeyValidationResult: Equatable {
+        case valid
+        case invalidKey
+        case transientError
+    }
+}
+
+private struct SaluteSpeechPluginStateSnapshot: Sendable {
+    let authorizationKey: String?
+    let scope: String
+    let selectedModelId: String?
+}
+
+private final class SaluteSpeechPluginState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var host: HostServices?
+    private var authorizationKey: String?
+    private var scope = SaluteSpeechPlugin.personalScope
+    private var selectedModelId: String?
+
+    func activate(
+        host: HostServices,
+        authorizationKey: String?,
+        scope: String,
+        selectedModelId: String?
+    ) {
+        lock.withLock {
+            self.host = host
+            self.authorizationKey = authorizationKey
+            self.scope = scope
+            self.selectedModelId = selectedModelId
+        }
+    }
+
+    func deactivate() {
+        lock.withLock {
+            host = nil
+        }
+    }
+
+    func currentHost() -> HostServices? {
+        lock.withLock { host }
+    }
+
+    func snapshot() -> SaluteSpeechPluginStateSnapshot {
+        lock.withLock {
+            SaluteSpeechPluginStateSnapshot(
+                authorizationKey: authorizationKey,
+                scope: scope,
+                selectedModelId: selectedModelId
+            )
+        }
+    }
+
+    func updateAuthorizationKey(_ authorizationKey: String?) {
+        lock.withLock {
+            self.authorizationKey = authorizationKey
+        }
+    }
+
+    func updateScope(_ scope: String) {
+        lock.withLock {
+            self.scope = scope
+        }
+    }
+
+    func updateSelectedModelId(_ selectedModelId: String) {
+        lock.withLock {
+            self.selectedModelId = selectedModelId
+        }
+    }
+}
+
+private actor SaluteSpeechTokenCache {
+    private var token: String?
+    private var expiresAt: Date?
+
+    func cachedToken(now: Date = Date()) -> String? {
+        guard let token, let expiresAt else { return nil }
+        guard expiresAt.timeIntervalSince(now) > 60 else { return nil }
+        return token
+    }
+
+    func store(token: String, expiresAtMilliseconds: Int64?) {
+        self.token = token
+
+        guard let expiresAtMilliseconds else {
+            expiresAt = Date().addingTimeInterval(29 * 60)
+            return
+        }
+
+        let rawTimestamp = Double(expiresAtMilliseconds)
+        let seconds = rawTimestamp > 20_000_000_000 ? rawTimestamp / 1_000 : rawTimestamp
+        expiresAt = Date(timeIntervalSince1970: seconds)
+    }
+
+    func clear() {
+        token = nil
+        expiresAt = nil
+    }
+}
+
+private enum SaluteSpeechPluginConfigurationError: LocalizedError {
+    case missingHost
+    case emptyAuthorizationKey
+
+    var errorDescription: String? {
+        switch self {
+        case .missingHost:
+            "Sber SaluteSpeech is not connected to TypeWhisper."
+        case .emptyAuthorizationKey:
+            "Sber SaluteSpeech Authorization Key is empty."
+        }
+    }
+}
+
+extension SaluteSpeechPlugin {
+    static let tokenEndpoint = "https://ngw.devices.sberbank.ru:9443/api/v2/oauth"
+    static let restBaseURL = "https://smartspeech.sber.ru/rest/v1"
+    static let sampleRate = 16_000
+    static let syncMaxBytes = 2 * 1024 * 1024
+    static let syncMaxDuration: TimeInterval = 60
+    static let pcmContentType = "audio/x-pcm;bit=16;rate=16000"
+
+    static func normalizedAuthorizationKey(_ key: String) -> String {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.lowercased().hasPrefix("basic ") {
+            return String(trimmed.dropFirst(6)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return trimmed
+    }
+
+    static func resolvedScope(_ scope: String?) -> String {
+        let trimmed = scope?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        switch trimmed {
+        case personalScope, corporateScope:
+            return trimmed
+        default:
+            return personalScope
+        }
+    }
+
+    static func makePCM16LEData(samples: [Float]) -> Data {
+        var data = Data(capacity: samples.count * 2)
+        for sample in samples {
+            let clamped = max(-1, min(1, sample))
+            let intValue: Int16
+            if clamped <= -1 {
+                intValue = Int16.min
+            } else {
+                intValue = Int16(clamped * Float(Int16.max))
+            }
+            let raw = UInt16(bitPattern: intValue).littleEndian
+            data.append(UInt8(raw & 0xff))
+            data.append(UInt8((raw >> 8) & 0xff))
+        }
+        return data
+    }
+
+    static func makeTokenRequest(
+        authorizationKey: String,
+        scope: String
+    ) throws -> URLRequest {
+        guard let url = URL(string: tokenEndpoint) else {
+            throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech token URL")
+        }
+
+        var components = URLComponents()
+        components.queryItems = [URLQueryItem(name: "scope", value: resolvedScope(scope))]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Basic \(normalizedAuthorizationKey(authorizationKey))", forHTTPHeaderField: "Authorization")
+        request.setValue(UUID().uuidString, forHTTPHeaderField: "RqUID")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = components.percentEncodedQuery?.data(using: .utf8)
+        request.timeoutInterval = 30
+        return request
+    }
+
+    static func makeSyncRecognitionRequest(
+        pcmData: Data,
+        token: String,
+        modelId: String
+    ) throws -> URLRequest {
+        var components = URLComponents(string: "\(restBaseURL)/speech:recognize")
+        components?.queryItems = [URLQueryItem(name: "model", value: modelId)]
+        guard let url = components?.url else {
+            throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech recognition URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(pcmContentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = pcmData
+        request.timeoutInterval = 120
+        return request
+    }
+
+    static func makeUploadRequest(
+        pcmData: Data,
+        token: String
+    ) throws -> URLRequest {
+        guard let url = URL(string: "\(restBaseURL)/data:upload") else {
+            throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech upload URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(pcmContentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = pcmData
+        request.timeoutInterval = 120
+        return request
+    }
+
+    static func makeStartAsyncRecognitionRequest(
+        requestFileId: String,
+        token: String,
+        modelId: String
+    ) throws -> URLRequest {
+        guard let url = URL(string: "\(restBaseURL)/speech:async_recognize") else {
+            throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech async recognition URL")
+        }
+
+        let body = AsyncRecognitionRequest(
+            options: AsyncRecognitionOptions(
+                model: modelId,
+                audioEncoding: "PCM_S16LE",
+                sampleRate: sampleRate,
+                channelsCount: 1
+            ),
+            requestFileId: requestFileId
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        request.timeoutInterval = 30
+        return request
+    }
+
+    static func makeTaskStatusRequest(taskId: String, token: String) throws -> URLRequest {
+        var components = URLComponents(string: "\(restBaseURL)/task:get")
+        components?.queryItems = [URLQueryItem(name: "id", value: taskId)]
+        guard let url = components?.url else {
+            throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech task status URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 30
+        return request
+    }
+
+    static func makeDownloadRequest(responseFileId: String, token: String) throws -> URLRequest {
+        var components = URLComponents(string: "\(restBaseURL)/data:download")
+        components?.queryItems = [URLQueryItem(name: "response_file_id", value: responseFileId)]
+        guard let url = components?.url else {
+            throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech result download URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 120
+        return request
+    }
+
+    static func validateHTTPResponse(
+        data: Data,
+        response: URLResponse,
+        successStatusCodes: Range<Int> = 200..<300,
+        mapBadRequestToInvalidKey: Bool = false
+    ) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        guard !successStatusCodes.contains(httpResponse.statusCode) else { return }
+
+        switch httpResponse.statusCode {
+        case 400 where mapBadRequestToInvalidKey:
+            throw PluginTranscriptionError.invalidApiKey
+        case 401, 403:
+            throw PluginTranscriptionError.invalidApiKey
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        default:
+            throw PluginTranscriptionError.apiError(
+                "Sber SaluteSpeech HTTP \(httpResponse.statusCode): \(responseBodyMessage(data: data))"
+            )
+        }
+    }
+
+    static func responseBodyMessage(data: Data) -> String {
+        if let object = try? JSONSerialization.jsonObject(with: data) {
+            if let message = firstStringValue(
+                in: object,
+                keys: ["message", "error_description", "error", "detail"]
+            ) {
+                return message
+            }
+        }
+
+        let body = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return body?.nilIfEmpty ?? "Unknown error"
+    }
+
+    static func parseTokenResponse(_ data: Data) throws -> TokenResponse {
+        do {
+            return try JSONDecoder().decode(TokenResponse.self, from: data)
+        } catch {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Sber SaluteSpeech token response: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    static func parseRequestFileId(_ data: Data) throws -> String {
+        let object = try jsonObject(from: data, context: "upload response")
+        guard let id = firstStringValue(in: object, keys: ["request_file_id"]) else {
+            throw PluginTranscriptionError.apiError("Sber SaluteSpeech upload response did not include request_file_id")
+        }
+        return id
+    }
+
+    static func parseTaskId(_ data: Data) throws -> String {
+        let object = try jsonObject(from: data, context: "async recognition response")
+        guard let id = firstStringValue(in: object, keys: ["id"]) else {
+            throw PluginTranscriptionError.apiError("Sber SaluteSpeech async recognition response did not include task id")
+        }
+        return id
+    }
+
+    static func parseTaskStatus(_ data: Data) throws -> AsyncTaskStatus {
+        let object = try jsonObject(from: data, context: "task status response")
+        guard let status = firstStringValue(in: object, keys: ["status"]) else {
+            throw PluginTranscriptionError.apiError("Sber SaluteSpeech task status response did not include status")
+        }
+
+        return AsyncTaskStatus(
+            status: status,
+            responseFileId: firstStringValue(in: object, keys: ["response_file_id"]),
+            errorMessage: firstStringValue(
+                in: object,
+                keys: ["error_description", "error", "message", "detail"]
+            )
+        )
+    }
+
+    static func parseTranscriptionResult(_ data: Data) throws -> PluginTranscriptionResult {
+        if let object = try? JSONSerialization.jsonObject(with: data) {
+            let text = collectTranscriptionTexts(from: object, allowBareString: true)
+                .joined(separator: " ")
+                .normalizedWhitespace
+            if !text.isEmpty {
+                return PluginTranscriptionResult(text: text)
+            }
+        }
+
+        if let body = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !body.isEmpty,
+           !body.hasPrefix("{"),
+           !body.hasPrefix("[") {
+            return PluginTranscriptionResult(text: body)
+        }
+
+        throw PluginTranscriptionError.apiError("Sber SaluteSpeech response did not include transcription text")
+    }
+
+    static func collectTranscriptionTexts(from value: Any, allowBareString: Bool = false) -> [String] {
+        if let string = value as? String {
+            guard allowBareString else { return [] }
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? [] : [trimmed]
+        }
+
+        if let array = value as? [Any] {
+            return array.flatMap { collectTranscriptionTexts(from: $0, allowBareString: allowBareString) }
+        }
+
+        guard let dictionary = value as? [String: Any] else {
+            return []
+        }
+
+        if let text = directTranscriptionText(in: dictionary) {
+            return [text]
+        }
+
+        let preferredKeys = ["results", "result", "response", "items", "chunks"]
+        let preferred = preferredKeys.flatMap { key -> [String] in
+            guard let nested = dictionary[key] else { return [] }
+            return collectTranscriptionTexts(from: nested, allowBareString: true)
+        }
+        if !preferred.isEmpty || preferredKeys.contains(where: { dictionary[$0] != nil }) {
+            return preferred
+        }
+
+        return []
+    }
+
+    static func directTranscriptionText(in dictionary: [String: Any]) -> String? {
+        for key in ["normalized_text", "normalizedText", "text"] {
+            if let text = dictionary[key] as? String {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        return nil
+    }
+
+    static func jsonObject(from data: Data, context: String) throws -> Any {
+        do {
+            return try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Sber SaluteSpeech \(context): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    static func firstStringValue(in value: Any, keys: [String]) -> String? {
+        if let dictionary = value as? [String: Any] {
+            for key in keys {
+                if let string = dictionary[key] as? String {
+                    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty { return trimmed }
+                }
+            }
+
+            for nested in dictionary.values {
+                if let string = firstStringValue(in: nested, keys: keys) {
+                    return string
+                }
+            }
+        } else if let array = value as? [Any] {
+            for item in array {
+                if let string = firstStringValue(in: item, keys: keys) {
+                    return string
+                }
+            }
+        }
+
+        return nil
+    }
+
+    struct TokenResponse: Decodable, Sendable {
+        let accessToken: String
+        let expiresAtMilliseconds: Int64?
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case expiresAt = "expires_at"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            accessToken = try container.decode(String.self, forKey: .accessToken)
+
+            if let intValue = try? container.decode(Int64.self, forKey: .expiresAt) {
+                expiresAtMilliseconds = intValue
+            } else if let doubleValue = try? container.decode(Double.self, forKey: .expiresAt) {
+                expiresAtMilliseconds = Int64(doubleValue)
+            } else if let stringValue = try? container.decode(String.self, forKey: .expiresAt),
+                      let intValue = Int64(stringValue) {
+                expiresAtMilliseconds = intValue
+            } else {
+                expiresAtMilliseconds = nil
+            }
+        }
+    }
+
+    struct AsyncTaskStatus: Sendable {
+        let status: String
+        let responseFileId: String?
+        let errorMessage: String?
+
+        var normalizedStatus: String {
+            status.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        }
+
+        var isFinished: Bool {
+            ["DONE", "SUCCESS", "COMPLETED"].contains(normalizedStatus)
+        }
+
+        var isFailed: Bool {
+            ["ERROR", "FAILED", "FAIL", "CANCELED", "CANCELLED"].contains(normalizedStatus)
+        }
+    }
+
+    struct AsyncRecognitionOptions: Encodable {
+        let model: String
+        let audioEncoding: String
+        let sampleRate: Int
+        let channelsCount: Int
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case audioEncoding = "audio_encoding"
+            case sampleRate = "sample_rate"
+            case channelsCount = "channels_count"
+        }
+    }
+
+    struct AsyncRecognitionRequest: Encodable {
+        let options: AsyncRecognitionOptions
+        let requestFileId: String
+
+        enum CodingKeys: String, CodingKey {
+            case options
+            case requestFileId = "request_file_id"
+        }
+    }
+}
+
+private extension SaluteSpeechPlugin {
+    func accessToken(authorizationKey: String, scope: String) async throws -> String {
+        if let cached = await tokenCache.cachedToken() {
+            return cached
+        }
+
+        let response = try await requestAccessToken(
+            authorizationKey: authorizationKey,
+            scope: scope
+        )
+        await tokenCache.store(
+            token: response.accessToken,
+            expiresAtMilliseconds: response.expiresAtMilliseconds
+        )
+        return response.accessToken
+    }
+
+    func requestAccessToken(
+        authorizationKey: String,
+        scope: String
+    ) async throws -> TokenResponse {
+        let request = try Self.makeTokenRequest(
+            authorizationKey: authorizationKey,
+            scope: scope
+        )
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        try Self.validateHTTPResponse(
+            data: data,
+            response: response,
+            mapBadRequestToInvalidKey: true
+        )
+        return try Self.parseTokenResponse(data)
+    }
+
+    func recognizeSync(
+        pcmData: Data,
+        token: String,
+        modelId: String
+    ) async throws -> PluginTranscriptionResult {
+        let request = try Self.makeSyncRecognitionRequest(
+            pcmData: pcmData,
+            token: token,
+            modelId: modelId
+        )
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        try Self.validateHTTPResponse(data: data, response: response)
+        return try Self.parseTranscriptionResult(data)
+    }
+
+    func recognizeAsync(
+        pcmData: Data,
+        token: String,
+        modelId: String,
+        duration: TimeInterval
+    ) async throws -> PluginTranscriptionResult {
+        let uploadRequest = try Self.makeUploadRequest(pcmData: pcmData, token: token)
+        let (uploadData, uploadResponse) = try await PluginHTTPClient.data(for: uploadRequest)
+        try Self.validateHTTPResponse(data: uploadData, response: uploadResponse)
+        let requestFileId = try Self.parseRequestFileId(uploadData)
+
+        let startRequest = try Self.makeStartAsyncRecognitionRequest(
+            requestFileId: requestFileId,
+            token: token,
+            modelId: modelId
+        )
+        let (startData, startResponse) = try await PluginHTTPClient.data(for: startRequest)
+        try Self.validateHTTPResponse(data: startData, response: startResponse)
+        let taskId = try Self.parseTaskId(startData)
+
+        let responseFileId = try await waitForAsyncResultFileId(
+            taskId: taskId,
+            token: token,
+            duration: duration
+        )
+        let downloadRequest = try Self.makeDownloadRequest(
+            responseFileId: responseFileId,
+            token: token
+        )
+        let (downloadData, downloadResponse) = try await PluginHTTPClient.data(
+            for: downloadRequest,
+            resourceTimeout: 600
+        )
+        try Self.validateHTTPResponse(data: downloadData, response: downloadResponse)
+        return try Self.parseTranscriptionResult(downloadData)
+    }
+
+    func waitForAsyncResultFileId(
+        taskId: String,
+        token: String,
+        duration: TimeInterval
+    ) async throws -> String {
+        let maxWait = min(max(duration * 2 + 60, 120), 1_800)
+        let deadline = Date().addingTimeInterval(maxWait)
+
+        while Date() < deadline {
+            let request = try Self.makeTaskStatusRequest(taskId: taskId, token: token)
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            try Self.validateHTTPResponse(data: data, response: response)
+            let status = try Self.parseTaskStatus(data)
+
+            if status.isFinished {
+                guard let responseFileId = status.responseFileId else {
+                    throw PluginTranscriptionError.apiError(
+                        "Sber SaluteSpeech task finished without response_file_id."
+                    )
+                }
+                return responseFileId
+            }
+
+            if status.isFailed {
+                throw PluginTranscriptionError.apiError(
+                    status.errorMessage ?? "Sber SaluteSpeech async recognition failed with status \(status.status)."
+                )
+            }
+
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        throw PluginTranscriptionError.apiError("Sber SaluteSpeech async recognition timed out.")
+    }
+}
+
+private struct SaluteSpeechSettingsView: View {
+    let plugin: SaluteSpeechPlugin
+
+    @State private var authorizationKeyInput = ""
+    @State private var showAuthorizationKey = false
+    @State private var selectedScope = SaluteSpeechPlugin.personalScope
+    @State private var selectedModel = ""
+    @State private var isValidating = false
+    @State private var validationResult: SaluteSpeechPlugin.AuthorizationKeyValidationResult?
+    @State private var settingsErrorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Authorization Key")
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showAuthorizationKey {
+                        TextField("Base64 ClientID:ClientSecret", text: $authorizationKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("Base64 ClientID:ClientSecret", text: $authorizationKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showAuthorizationKey.toggle()
+                    } label: {
+                        Image(systemName: showAuthorizationKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isConfigured {
+                        Button("Remove") {
+                            removeAuthorizationKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button("Save") {
+                            saveAuthorizationKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(authorizationKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let settingsErrorMessage {
+                    HStack(spacing: 4) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.red)
+                        Text(settingsErrorMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                } else if let validationResult {
+                    let feedback = validationFeedback(for: validationResult)
+                    HStack(spacing: 4) {
+                        Image(systemName: feedback.systemName)
+                            .foregroundStyle(feedback.color)
+                        Text(feedback.message)
+                            .font(.caption)
+                            .foregroundStyle(feedback.color)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("OAuth Scope")
+                    .font(.headline)
+
+                Picker("OAuth Scope", selection: $selectedScope) {
+                    Text("Personal").tag(SaluteSpeechPlugin.personalScope)
+                    Text("Corporate").tag(SaluteSpeechPlugin.corporateScope)
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: selectedScope) {
+                    plugin.setScope(selectedScope)
+                    validationResult = nil
+                    settingsErrorMessage = nil
+                }
+            }
+
+            if plugin.isConfigured {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Model")
+                        .font(.headline)
+
+                    Picker("Model", selection: $selectedModel) {
+                        ForEach(plugin.transcriptionModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedModel) {
+                        plugin.selectModel(selectedModel)
+                    }
+                }
+            }
+
+            Text("Authorization Key is stored securely in the Keychain. If validation fails with a certificate error, install the SaluteSpeech certificate trusted by macOS.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin.authorizationKeyForSettings, !key.isEmpty {
+                authorizationKeyInput = key
+            }
+            selectedScope = plugin.scopeForSettings
+            selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+        }
+    }
+
+    private func saveAuthorizationKey() {
+        let trimmedKey = SaluteSpeechPlugin.normalizedAuthorizationKey(authorizationKeyInput)
+        guard !trimmedKey.isEmpty else { return }
+
+        isValidating = true
+        validationResult = nil
+        settingsErrorMessage = nil
+
+        Task {
+            let result = await plugin.validateAuthorizationKey(trimmedKey, scope: selectedScope)
+            await MainActor.run {
+                isValidating = false
+                validationResult = result
+                guard result == .valid else { return }
+
+                do {
+                    try plugin.setAuthorizationKey(trimmedKey)
+                } catch {
+                    validationResult = nil
+                    settingsErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func removeAuthorizationKey() {
+        do {
+            try plugin.removeAuthorizationKey()
+            authorizationKeyInput = ""
+            validationResult = nil
+            settingsErrorMessage = nil
+        } catch {
+            settingsErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func validationFeedback(
+        for result: SaluteSpeechPlugin.AuthorizationKeyValidationResult
+    ) -> (systemName: String, message: String, color: Color) {
+        switch result {
+        case .valid:
+            return ("checkmark.circle.fill", "Valid Authorization Key", .green)
+        case .invalidKey:
+            return ("xmark.circle.fill", "Invalid Authorization Key", .red)
+        case .transientError:
+            return (
+                "exclamationmark.triangle.fill",
+                "Could not validate Authorization Key. Check the key, scope, certificate, and network connection.",
+                .orange
+            )
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+
+    var normalizedWhitespace: String {
+        components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -1010,7 +1010,8 @@ private struct SaluteSpeechSettingsView: View {
     @State private var settingsErrorMessage: String?
     @State private var usageSnapshot = SaluteSpeechUsageSnapshot.empty
     @State private var balanceRemainingInput = ""
-    @State private var balanceValidUntilInput = ""
+    @State private var hasBalanceValidUntil = false
+    @State private var balanceValidUntilDate = Date()
     @State private var usageErrorMessage: String?
 
     var body: some View {
@@ -1190,30 +1191,7 @@ private struct SaluteSpeechSettingsView: View {
                 }
             }
 
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                TextField("Studio remaining minutes", text: $balanceRemainingInput)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 180)
-
-                TextField("Valid until YYYY-MM-DD", text: $balanceValidUntilInput)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 170)
-
-                Button("Save") {
-                    saveUsageBalanceCorrection()
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .disabled(balanceRemainingInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                if usageSnapshot.balanceRemainingSeconds != nil {
-                    Button("Clear") {
-                        clearUsageBalanceCorrection()
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-            }
+            usageCorrectionControls
 
             HStack(spacing: 8) {
                 Button("Reset tracked usage") {
@@ -1235,6 +1213,55 @@ private struct SaluteSpeechSettingsView: View {
                     Text(usageErrorMessage)
                         .font(.caption)
                         .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+
+    private var usageCorrectionControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Studio remaining")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 126, alignment: .leading)
+
+                TextField("Minutes", text: $balanceRemainingInput)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 120)
+
+                Text("min")
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Toggle("Valid until", isOn: $hasBalanceValidUntil)
+                    .toggleStyle(.checkbox)
+                    .frame(width: 126, alignment: .leading)
+
+                DatePicker(
+                    "",
+                    selection: $balanceValidUntilDate,
+                    displayedComponents: .date
+                )
+                .labelsHidden()
+                .disabled(!hasBalanceValidUntil)
+                .opacity(hasBalanceValidUntil ? 1 : 0.55)
+            }
+
+            HStack(spacing: 8) {
+                Button("Save balance") {
+                    saveUsageBalanceCorrection()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(balanceRemainingInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                if usageSnapshot.balanceRemainingSeconds != nil {
+                    Button("Clear balance") {
+                        clearUsageBalanceCorrection()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
             }
         }
@@ -1309,9 +1336,13 @@ private struct SaluteSpeechSettingsView: View {
         balanceRemainingInput = usageSnapshot.balanceRemainingSeconds
             .map { Self.formatEditableMinutes(seconds: $0) }
             ?? ""
-        balanceValidUntilInput = usageSnapshot.balanceValidUntil
-            .map { Self.formatDateInput($0) }
-            ?? ""
+        if let balanceValidUntil = usageSnapshot.balanceValidUntil {
+            hasBalanceValidUntil = true
+            balanceValidUntilDate = balanceValidUntil
+        } else {
+            hasBalanceValidUntil = false
+            balanceValidUntilDate = Date()
+        }
         usageErrorMessage = nil
     }
 
@@ -1323,21 +1354,10 @@ private struct SaluteSpeechSettingsView: View {
             return
         }
 
-        let validUntilText = balanceValidUntilInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        let validUntil: Date?
-        if validUntilText.isEmpty {
-            validUntil = nil
-        } else if let parsedDate = Self.parseDateInput(validUntilText) {
-            validUntil = parsedDate
-        } else {
-            usageErrorMessage = "Use date format YYYY-MM-DD."
-            return
-        }
-
         do {
             try plugin.setUsageBalanceCorrection(
                 remainingMinutes: remainingMinutes,
-                validUntil: validUntil
+                validUntil: hasBalanceValidUntil ? balanceValidUntilDate : nil
             )
             refreshUsage()
         } catch {
@@ -1367,14 +1387,6 @@ private struct SaluteSpeechSettingsView: View {
         let normalized = text.replacingOccurrences(of: ",", with: ".")
         guard let value = Double(normalized), value >= 0 else { return nil }
         return value
-    }
-
-    private static func parseDateInput(_ text: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.date(from: text)
     }
 
     private static func formatDateInput(_ date: Date) -> String {

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -18,6 +18,7 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
 
     private let state = SaluteSpeechPluginState()
     private let tokenCache = SaluteSpeechTokenCache()
+    private let usageStore = SaluteSpeechUsageStore()
     private let logger = Logger(subsystem: "com.typewhisper.sber-salutespeech", category: "Plugin")
 
     required override init() {
@@ -25,6 +26,7 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
     }
 
     func activate(host: HostServices) {
+        usageStore.configure(dataDirectory: host.pluginDataDirectory)
         state.activate(
             host: host,
             authorizationKey: Self.normalizedAuthorizationKey(
@@ -94,20 +96,24 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
         )
         let modelId = snapshot.selectedModelId ?? Self.defaultModelId
 
+        let result: PluginTranscriptionResult
         if pcmData.count <= Self.syncMaxBytes, audio.duration <= Self.syncMaxDuration {
-            return try await recognizeSync(
+            result = try await recognizeSync(
                 pcmData: pcmData,
                 token: token,
                 modelId: modelId
             )
+        } else {
+            result = try await recognizeAsync(
+                pcmData: pcmData,
+                token: token,
+                modelId: modelId,
+                duration: audio.duration
+            )
         }
 
-        return try await recognizeAsync(
-            pcmData: pcmData,
-            token: token,
-            modelId: modelId,
-            duration: audio.duration
-        )
+        usageStore.recordSuccessfulRecognition(duration: audio.duration)
+        return result
     }
 
     @MainActor
@@ -196,6 +202,22 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
         } catch {
             return .transientError
         }
+    }
+
+    var usageSnapshotForSettings: SaluteSpeechUsageSnapshot {
+        usageStore.snapshot()
+    }
+
+    func setUsageBalanceCorrection(remainingMinutes: Double?, validUntil: Date?) throws {
+        try usageStore.setBalanceCorrection(remainingMinutes: remainingMinutes, validUntil: validUntil)
+    }
+
+    func clearUsageBalanceCorrection() throws {
+        try usageStore.clearBalanceCorrection()
+    }
+
+    func resetRecognitionUsage() throws {
+        try usageStore.resetTrackedUsage()
     }
 
     enum AuthorizationKeyValidationResult: Equatable {
@@ -297,6 +319,138 @@ private actor SaluteSpeechTokenCache {
     func clear() {
         token = nil
         expiresAt = nil
+    }
+}
+
+struct SaluteSpeechUsageSnapshot: Equatable, Sendable {
+    let trackedSeconds: TimeInterval
+    let lastTranscriptionAt: Date?
+    let balanceRemainingSeconds: TimeInterval?
+    let balanceRecordedTrackedSeconds: TimeInterval?
+    let balanceUpdatedAt: Date?
+    let balanceValidUntil: Date?
+
+    static let empty = SaluteSpeechUsageSnapshot(
+        trackedSeconds: 0,
+        lastTranscriptionAt: nil,
+        balanceRemainingSeconds: nil,
+        balanceRecordedTrackedSeconds: nil,
+        balanceUpdatedAt: nil,
+        balanceValidUntil: nil
+    )
+
+    var spentSinceBalanceCorrectionSeconds: TimeInterval {
+        guard let balanceRecordedTrackedSeconds else { return 0 }
+        return max(0, trackedSeconds - balanceRecordedTrackedSeconds)
+    }
+
+    var estimatedRemainingSeconds: TimeInterval? {
+        guard let balanceRemainingSeconds else { return nil }
+        return max(0, balanceRemainingSeconds - spentSinceBalanceCorrectionSeconds)
+    }
+}
+
+private struct SaluteSpeechUsageState: Codable, Sendable {
+    var trackedSeconds: TimeInterval = 0
+    var lastTranscriptionAt: Date?
+    var balanceRemainingSeconds: TimeInterval?
+    var balanceRecordedTrackedSeconds: TimeInterval?
+    var balanceUpdatedAt: Date?
+    var balanceValidUntil: Date?
+
+    var snapshot: SaluteSpeechUsageSnapshot {
+        SaluteSpeechUsageSnapshot(
+            trackedSeconds: trackedSeconds,
+            lastTranscriptionAt: lastTranscriptionAt,
+            balanceRemainingSeconds: balanceRemainingSeconds,
+            balanceRecordedTrackedSeconds: balanceRecordedTrackedSeconds,
+            balanceUpdatedAt: balanceUpdatedAt,
+            balanceValidUntil: balanceValidUntil
+        )
+    }
+}
+
+private final class SaluteSpeechUsageStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private let fileName = "recognition-usage.json"
+    private var fileURL: URL?
+    private var state = SaluteSpeechUsageState()
+
+    func configure(dataDirectory: URL) {
+        lock.withLock {
+            fileURL = dataDirectory.appendingPathComponent(fileName)
+            state = Self.loadState(from: fileURL) ?? SaluteSpeechUsageState()
+        }
+    }
+
+    func snapshot() -> SaluteSpeechUsageSnapshot {
+        lock.withLock { state.snapshot }
+    }
+
+    func recordSuccessfulRecognition(duration: TimeInterval) {
+        let seconds = max(0, duration)
+        guard seconds > 0 else { return }
+
+        lock.withLock {
+            state.trackedSeconds += seconds
+            state.lastTranscriptionAt = Date()
+            try? persistLocked()
+        }
+    }
+
+    func setBalanceCorrection(remainingMinutes: Double?, validUntil: Date?) throws {
+        try lock.withLock {
+            if let remainingMinutes {
+                state.balanceRemainingSeconds = max(0, remainingMinutes) * 60
+                state.balanceRecordedTrackedSeconds = state.trackedSeconds
+                state.balanceUpdatedAt = Date()
+            } else {
+                state.balanceRemainingSeconds = nil
+                state.balanceRecordedTrackedSeconds = nil
+                state.balanceUpdatedAt = nil
+            }
+            state.balanceValidUntil = validUntil
+            try persistLocked()
+        }
+    }
+
+    func clearBalanceCorrection() throws {
+        try lock.withLock {
+            state.balanceRemainingSeconds = nil
+            state.balanceRecordedTrackedSeconds = nil
+            state.balanceUpdatedAt = nil
+            state.balanceValidUntil = nil
+            try persistLocked()
+        }
+    }
+
+    func resetTrackedUsage() throws {
+        try lock.withLock {
+            state.trackedSeconds = 0
+            state.lastTranscriptionAt = nil
+            if state.balanceRemainingSeconds != nil {
+                state.balanceRecordedTrackedSeconds = 0
+            }
+            try persistLocked()
+        }
+    }
+
+    private static func loadState(from url: URL?) -> SaluteSpeechUsageState? {
+        guard let url,
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(SaluteSpeechUsageState.self, from: data)
+    }
+
+    private func persistLocked() throws {
+        guard let fileURL else { return }
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONEncoder().encode(state)
+        try data.write(to: fileURL, options: .atomic)
     }
 }
 
@@ -854,6 +1008,10 @@ private struct SaluteSpeechSettingsView: View {
     @State private var isValidating = false
     @State private var validationResult: SaluteSpeechPlugin.AuthorizationKeyValidationResult?
     @State private var settingsErrorMessage: String?
+    @State private var usageSnapshot = SaluteSpeechUsageSnapshot.empty
+    @State private var balanceRemainingInput = ""
+    @State private var balanceValidUntilInput = ""
+    @State private var usageErrorMessage: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -955,6 +1113,10 @@ private struct SaluteSpeechSettingsView: View {
                         plugin.selectModel(selectedModel)
                     }
                 }
+
+                Divider()
+
+                usageSection
             }
 
             Text("Authorization Key is stored securely in the Keychain. If validation fails with a certificate error, install the SaluteSpeech certificate trusted by macOS.")
@@ -968,6 +1130,124 @@ private struct SaluteSpeechSettingsView: View {
             }
             selectedScope = plugin.scopeForSettings
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+            refreshUsage()
+        }
+    }
+
+    private var usageSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text("Recognition Usage")
+                    .font(.headline)
+
+                Spacer()
+
+                Button {
+                    refreshUsage()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .help("Refresh")
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                usageMetricRow(
+                    title: "Tracked spent",
+                    value: Self.formatMinutes(seconds: usageSnapshot.trackedSeconds)
+                )
+
+                if let estimatedRemainingSeconds = usageSnapshot.estimatedRemainingSeconds {
+                    usageMetricRow(
+                        title: "Estimated remaining",
+                        value: Self.formatMinutes(seconds: estimatedRemainingSeconds)
+                    )
+                    usageMetricRow(
+                        title: "Spent since balance update",
+                        value: Self.formatMinutes(seconds: usageSnapshot.spentSinceBalanceCorrectionSeconds)
+                    )
+                }
+
+                if let balanceUpdatedAt = usageSnapshot.balanceUpdatedAt {
+                    usageMetricRow(
+                        title: "Balance updated",
+                        value: Self.formatDisplayDate(balanceUpdatedAt)
+                    )
+                }
+
+                if let balanceValidUntil = usageSnapshot.balanceValidUntil {
+                    usageMetricRow(
+                        title: "Valid until",
+                        value: Self.formatDateInput(balanceValidUntil)
+                    )
+                }
+
+                if let lastTranscriptionAt = usageSnapshot.lastTranscriptionAt {
+                    usageMetricRow(
+                        title: "Last recognition",
+                        value: Self.formatDisplayDate(lastTranscriptionAt)
+                    )
+                }
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                TextField("Studio remaining minutes", text: $balanceRemainingInput)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 180)
+
+                TextField("Valid until YYYY-MM-DD", text: $balanceValidUntilInput)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 170)
+
+                Button("Save") {
+                    saveUsageBalanceCorrection()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(balanceRemainingInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                if usageSnapshot.balanceRemainingSeconds != nil {
+                    Button("Clear") {
+                        clearUsageBalanceCorrection()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button("Reset tracked usage") {
+                    resetRecognitionUsage()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .foregroundStyle(.red)
+
+                Text("Local estimate. Update it from SaluteSpeech Studio.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let usageErrorMessage {
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                    Text(usageErrorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+
+    private func usageMetricRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(.body, design: .rounded))
+                .monospacedDigit()
         }
     }
 
@@ -1022,6 +1302,106 @@ private struct SaluteSpeechSettingsView: View {
                 .orange
             )
         }
+    }
+
+    private func refreshUsage() {
+        usageSnapshot = plugin.usageSnapshotForSettings
+        balanceRemainingInput = usageSnapshot.balanceRemainingSeconds
+            .map { Self.formatEditableMinutes(seconds: $0) }
+            ?? ""
+        balanceValidUntilInput = usageSnapshot.balanceValidUntil
+            .map { Self.formatDateInput($0) }
+            ?? ""
+        usageErrorMessage = nil
+    }
+
+    private func saveUsageBalanceCorrection() {
+        usageErrorMessage = nil
+        let remainingText = balanceRemainingInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let remainingMinutes = Self.parseMinutes(remainingText) else {
+            usageErrorMessage = "Enter remaining minutes as a number."
+            return
+        }
+
+        let validUntilText = balanceValidUntilInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let validUntil: Date?
+        if validUntilText.isEmpty {
+            validUntil = nil
+        } else if let parsedDate = Self.parseDateInput(validUntilText) {
+            validUntil = parsedDate
+        } else {
+            usageErrorMessage = "Use date format YYYY-MM-DD."
+            return
+        }
+
+        do {
+            try plugin.setUsageBalanceCorrection(
+                remainingMinutes: remainingMinutes,
+                validUntil: validUntil
+            )
+            refreshUsage()
+        } catch {
+            usageErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func clearUsageBalanceCorrection() {
+        do {
+            try plugin.clearUsageBalanceCorrection()
+            refreshUsage()
+        } catch {
+            usageErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func resetRecognitionUsage() {
+        do {
+            try plugin.resetRecognitionUsage()
+            refreshUsage()
+        } catch {
+            usageErrorMessage = error.localizedDescription
+        }
+    }
+
+    private static func parseMinutes(_ text: String) -> Double? {
+        let normalized = text.replacingOccurrences(of: ",", with: ".")
+        guard let value = Double(normalized), value >= 0 else { return nil }
+        return value
+    }
+
+    private static func parseDateInput(_ text: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: text)
+    }
+
+    private static func formatDateInput(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    private static func formatDisplayDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private static func formatEditableMinutes(seconds: TimeInterval) -> String {
+        let minutes = max(0, seconds / 60)
+        if minutes.rounded() == minutes {
+            return String(format: "%.0f", minutes)
+        }
+        return String(format: "%.1f", minutes)
+    }
+
+    private static func formatMinutes(seconds: TimeInterval) -> String {
+        "\(formatEditableMinutes(seconds: seconds)) min"
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -15,6 +15,7 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
     private static let selectedModelDefault = "selectedModel"
     private static let scopeDefault = "scope"
     private static let defaultModelId = "general"
+    private static let defaultRecognitionLanguage = "ru-RU"
 
     private let state = SaluteSpeechPluginState()
     private let tokenCache = SaluteSpeechTokenCache()
@@ -68,6 +69,10 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
 
     var supportsTranslation: Bool { false }
 
+    var supportedLanguages: [String] {
+        ["ru", "ru-RU", "en", "en-US"]
+    }
+
     var allowsTranscriptPreviewFallback: Bool { false }
 
     func transcribe(
@@ -95,19 +100,22 @@ final class SaluteSpeechPlugin: NSObject, TranscriptionEnginePlugin, PluginAuthR
             scope: snapshot.scope
         )
         let modelId = snapshot.selectedModelId ?? Self.defaultModelId
+        let recognitionLanguage = Self.resolvedRecognitionLanguage(language)
 
         let result: PluginTranscriptionResult
         if pcmData.count <= Self.syncMaxBytes, audio.duration <= Self.syncMaxDuration {
             result = try await recognizeSync(
                 pcmData: pcmData,
                 token: token,
-                modelId: modelId
+                modelId: modelId,
+                language: recognitionLanguage
             )
         } else {
             result = try await recognizeAsync(
                 pcmData: pcmData,
                 token: token,
                 modelId: modelId,
+                language: recognitionLanguage,
                 duration: audio.duration
             )
         }
@@ -514,6 +522,26 @@ extension SaluteSpeechPlugin {
         }
     }
 
+    static func resolvedRecognitionLanguage(_ language: String?) -> String {
+        let normalized = language?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+
+        guard let normalized, !normalized.isEmpty else {
+            return defaultRecognitionLanguage
+        }
+
+        if normalized == "en" || normalized.hasPrefix("en-") {
+            return "en-US"
+        }
+        if normalized == "ru" || normalized.hasPrefix("ru-") {
+            return "ru-RU"
+        }
+
+        return defaultRecognitionLanguage
+    }
+
     static func makePCM16LEData(samples: [Float]) -> Data {
         var data = Data(capacity: samples.count * 2)
         for sample in samples {
@@ -555,10 +583,14 @@ extension SaluteSpeechPlugin {
     static func makeSyncRecognitionRequest(
         pcmData: Data,
         token: String,
-        modelId: String
+        modelId: String,
+        language: String
     ) throws -> URLRequest {
         var components = URLComponents(string: "\(restBaseURL)/speech:recognize")
-        components?.queryItems = [URLQueryItem(name: "model", value: modelId)]
+        components?.queryItems = [
+            URLQueryItem(name: "model", value: modelId),
+            URLQueryItem(name: "language", value: language),
+        ]
         guard let url = components?.url else {
             throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech recognition URL")
         }
@@ -592,7 +624,8 @@ extension SaluteSpeechPlugin {
     static func makeStartAsyncRecognitionRequest(
         requestFileId: String,
         token: String,
-        modelId: String
+        modelId: String,
+        language: String
     ) throws -> URLRequest {
         guard let url = URL(string: "\(restBaseURL)/speech:async_recognize") else {
             throw PluginTranscriptionError.apiError("Invalid Sber SaluteSpeech async recognition URL")
@@ -601,6 +634,7 @@ extension SaluteSpeechPlugin {
         let body = AsyncRecognitionRequest(
             options: AsyncRecognitionOptions(
                 model: modelId,
+                language: language,
                 audioEncoding: "PCM_S16LE",
                 sampleRate: sampleRate,
                 channelsCount: 1
@@ -873,12 +907,14 @@ extension SaluteSpeechPlugin {
 
     struct AsyncRecognitionOptions: Encodable {
         let model: String
+        let language: String
         let audioEncoding: String
         let sampleRate: Int
         let channelsCount: Int
 
         enum CodingKeys: String, CodingKey {
             case model
+            case language
             case audioEncoding = "audio_encoding"
             case sampleRate = "sample_rate"
             case channelsCount = "channels_count"
@@ -938,12 +974,14 @@ private extension SaluteSpeechPlugin {
     func recognizeSync(
         pcmData: Data,
         token: String,
-        modelId: String
+        modelId: String,
+        language: String
     ) async throws -> PluginTranscriptionResult {
         let request = try Self.makeSyncRecognitionRequest(
             pcmData: pcmData,
             token: token,
-            modelId: modelId
+            modelId: modelId,
+            language: language
         )
         let (data, response) = try await PluginHTTPClient.data(for: request)
         try Self.validateHTTPResponse(data: data, response: response)
@@ -954,6 +992,7 @@ private extension SaluteSpeechPlugin {
         pcmData: Data,
         token: String,
         modelId: String,
+        language: String,
         duration: TimeInterval
     ) async throws -> PluginTranscriptionResult {
         let uploadRequest = try Self.makeUploadRequest(pcmData: pcmData, token: token)
@@ -964,7 +1003,8 @@ private extension SaluteSpeechPlugin {
         let startRequest = try Self.makeStartAsyncRecognitionRequest(
             requestFileId: requestFileId,
             token: token,
-            modelId: modelId
+            modelId: modelId,
+            language: language
         )
         let (startData, startResponse) = try await PluginHTTPClient.data(for: startRequest)
         try Self.validateHTTPResponse(data: startData, response: startResponse)

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -257,6 +257,9 @@ private final class SaluteSpeechPluginState: @unchecked Sendable {
     func deactivate() {
         lock.withLock {
             host = nil
+            authorizationKey = nil
+            scope = SaluteSpeechPlugin.personalScope
+            selectedModelId = nil
         }
     }
 
@@ -296,15 +299,25 @@ private final class SaluteSpeechPluginState: @unchecked Sendable {
 private actor SaluteSpeechTokenCache {
     private var token: String?
     private var expiresAt: Date?
+    private var authorizationKey: String?
+    private var scope: String?
 
-    func cachedToken(now: Date = Date()) -> String? {
+    func cachedToken(authorizationKey: String, scope: String, now: Date = Date()) -> String? {
         guard let token, let expiresAt else { return nil }
+        guard self.authorizationKey == authorizationKey, self.scope == scope else { return nil }
         guard expiresAt.timeIntervalSince(now) > 60 else { return nil }
         return token
     }
 
-    func store(token: String, expiresAtMilliseconds: Int64?) {
+    func store(
+        token: String,
+        authorizationKey: String,
+        scope: String,
+        expiresAtMilliseconds: Int64?
+    ) {
         self.token = token
+        self.authorizationKey = authorizationKey
+        self.scope = scope
 
         guard let expiresAtMilliseconds else {
             expiresAt = Date().addingTimeInterval(29 * 60)
@@ -319,6 +332,8 @@ private actor SaluteSpeechTokenCache {
     func clear() {
         token = nil
         expiresAt = nil
+        authorizationKey = nil
+        scope = nil
     }
 }
 
@@ -373,6 +388,7 @@ private struct SaluteSpeechUsageState: Codable, Sendable {
 private final class SaluteSpeechUsageStore: @unchecked Sendable {
     private let lock = NSLock()
     private let fileName = "recognition-usage.json"
+    private let logger = Logger(subsystem: "com.typewhisper.sber-salutespeech", category: "Usage")
     private var fileURL: URL?
     private var state = SaluteSpeechUsageState()
 
@@ -394,7 +410,11 @@ private final class SaluteSpeechUsageStore: @unchecked Sendable {
         lock.withLock {
             state.trackedSeconds += seconds
             state.lastTranscriptionAt = Date()
-            try? persistLocked()
+            do {
+                try persistLocked()
+            } catch {
+                logger.error("Failed to persist Sber SaluteSpeech recognition usage: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -878,7 +898,10 @@ extension SaluteSpeechPlugin {
 
 private extension SaluteSpeechPlugin {
     func accessToken(authorizationKey: String, scope: String) async throws -> String {
-        if let cached = await tokenCache.cachedToken() {
+        if let cached = await tokenCache.cachedToken(
+            authorizationKey: authorizationKey,
+            scope: scope
+        ) {
             return cached
         }
 
@@ -888,6 +911,8 @@ private extension SaluteSpeechPlugin {
         )
         await tokenCache.store(
             token: response.accessToken,
+            authorizationKey: authorizationKey,
+            scope: scope,
             expiresAtMilliseconds: response.expiresAtMilliseconds
         )
         return response.accessToken

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
@@ -218,6 +218,83 @@ final class SaluteSpeechPluginTests: XCTestCase {
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Content-Type"), "audio/x-pcm;bit=16;rate=16000")
     }
 
+    func testSuccessfulTranscriptionTracksRecognitionUsageAndPersistsIt() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"access_token":"access-token","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":["Привет"]}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+                ),
+            ])
+        }
+
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.1], wavData: Data(), duration: 12.5),
+            language: "ru",
+            translate: false,
+            prompt: nil
+        )
+
+        let snapshot = plugin.usageSnapshotForSettings
+        XCTAssertEqual(snapshot.trackedSeconds, 12.5, accuracy: 0.001)
+        XCTAssertNotNil(snapshot.lastTranscriptionAt)
+
+        let reloadedPlugin = SaluteSpeechPlugin()
+        reloadedPlugin.activate(host: host)
+        XCTAssertEqual(reloadedPlugin.usageSnapshotForSettings.trackedSeconds, 12.5, accuracy: 0.001)
+    }
+
+    func testBalanceCorrectionEstimatesRemainingFromSubsequentUsage() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        let validUntil = Date(timeIntervalSince1970: 1_783_468_800)
+        try plugin.setUsageBalanceCorrection(remainingMinutes: 99, validUntil: validUntil)
+        XCTAssertEqual(plugin.usageSnapshotForSettings.estimatedRemainingSeconds, 99 * 60)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"access_token":"access-token","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":["Проверка"]}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+                ),
+            ])
+        }
+
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.1], wavData: Data(), duration: 60),
+            language: "ru",
+            translate: false,
+            prompt: nil
+        )
+
+        let snapshot = plugin.usageSnapshotForSettings
+        XCTAssertEqual(snapshot.spentSinceBalanceCorrectionSeconds, 60, accuracy: 0.001)
+        XCTAssertEqual(snapshot.estimatedRemainingSeconds, 98 * 60)
+        XCTAssertEqual(snapshot.balanceValidUntil, validUntil)
+    }
+
     func testHTTP401MapsToInvalidAuthorizationKey() {
         XCTAssertThrowsError(try SaluteSpeechPlugin.validateHTTPResponse(
             data: Data(#"{"message":"unauthorized"}"#.utf8),

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import TypeWhisperPluginSDK
+import XCTest
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import SaluteSpeechPlugin
+
+final class SaluteSpeechPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testPCM16LEEncodingClampsAndUsesLittleEndianSamples() {
+        let data = SaluteSpeechPlugin.makePCM16LEData(samples: [-1, 0, 1, 0.5])
+
+        XCTAssertEqual(
+            [UInt8](data),
+            [
+                0x00, 0x80,
+                0x00, 0x00,
+                0xff, 0x7f,
+                0xff, 0x3f,
+            ]
+        )
+    }
+
+    func testTokenRequestUsesBasicAuthRqUIDAndFormScope() throws {
+        let request = try SaluteSpeechPlugin.makeTokenRequest(
+            authorizationKey: "Basic encoded-key",
+            scope: SaluteSpeechPlugin.personalScope
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://ngw.devices.sberbank.ru:9443/api/v2/oauth")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Basic encoded-key")
+        XCTAssertNotNil(request.value(forHTTPHeaderField: "RqUID"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        XCTAssertEqual(String(data: request.httpBody ?? Data(), encoding: .utf8), "scope=SALUTE_SPEECH_PERS")
+    }
+
+    func testSyncRecognitionRequestUsesPCMContentTypeAndBearerToken() throws {
+        let request = try SaluteSpeechPlugin.makeSyncRecognitionRequest(
+            pcmData: Data([0x01, 0x02]),
+            token: "access-token",
+            modelId: "general"
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "smartspeech.sber.ru")
+        XCTAssertEqual(request.url?.path, "/rest/v1/speech:recognize")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer access-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "audio/x-pcm;bit=16;rate=16000")
+        XCTAssertEqual(request.httpBody, Data([0x01, 0x02]))
+
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        XCTAssertEqual(query["model"], "general")
+    }
+
+    func testStartAsyncRequestUsesPCMOptions() throws {
+        let request = try SaluteSpeechPlugin.makeStartAsyncRecognitionRequest(
+            requestFileId: "file-id",
+            token: "access-token",
+            modelId: "general"
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://smartspeech.sber.ru/rest/v1/speech:async_recognize")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer access-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try XCTUnwrap(request.httpBody)) as? [String: Any]
+        )
+        let options = try XCTUnwrap(json["options"] as? [String: Any])
+        XCTAssertEqual(json["request_file_id"] as? String, "file-id")
+        XCTAssertEqual(options["model"] as? String, "general")
+        XCTAssertEqual(options["audio_encoding"] as? String, "PCM_S16LE")
+        XCTAssertEqual(options["sample_rate"] as? Int, 16_000)
+        XCTAssertEqual(options["channels_count"] as? Int, 1)
+    }
+
+    func testParseTranscriptionResultPrefersNormalizedText() throws {
+        let result = try SaluteSpeechPlugin.parseTranscriptionResult(
+            Data(
+                """
+                [
+                  {
+                    "results": [
+                      { "text": "privet", "normalized_text": "Привет" },
+                      { "text": "mir", "normalized_text": "мир" }
+                    ]
+                  }
+                ]
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(result.text, "Привет мир")
+    }
+
+    func testParseSyncRecognitionResultArray() throws {
+        let result = try SaluteSpeechPlugin.parseTranscriptionResult(
+            Data(
+                """
+                {
+                  "result": ["Привет мир"],
+                  "emotions": [{ "negative": 0, "neutral": 1, "positive": 0 }],
+                  "person_identity": {
+                    "age": "age_none",
+                    "gender": "gender_none"
+                  },
+                  "status": 200
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(result.text, "Привет мир")
+    }
+
+    func testParseSyncRecognitionDoesNotUseMetadataAsTranscript() {
+        XCTAssertThrowsError(try SaluteSpeechPlugin.parseTranscriptionResult(
+            Data(
+                """
+                {
+                  "result": [""],
+                  "person_identity": {
+                    "age": "age_none",
+                    "gender": "gender_none"
+                  },
+                  "status": 200
+                }
+                """.utf8
+            )
+        ))
+    }
+
+    func testParseAsyncIdsFromNestedSberResponses() throws {
+        XCTAssertEqual(
+            try SaluteSpeechPlugin.parseRequestFileId(
+                Data(#"{"result":{"request_file_id":"request-file"}}"#.utf8)
+            ),
+            "request-file"
+        )
+        XCTAssertEqual(
+            try SaluteSpeechPlugin.parseTaskId(
+                Data(#"{"result":{"id":"task-id","status":"CREATED"}}"#.utf8)
+            ),
+            "task-id"
+        )
+
+        let status = try SaluteSpeechPlugin.parseTaskStatus(
+            Data(#"{"result":{"status":"DONE","response_file_id":"response-file"}}"#.utf8)
+        )
+        XCTAssertTrue(status.isFinished)
+        XCTAssertEqual(status.responseFileId, "response-file")
+    }
+
+    func testTranscribeFailsWithoutAuthorizationKey() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: AudioData(samples: [0], wavData: Data(), duration: 1),
+                language: nil,
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected notConfigured")
+        } catch let error as PluginTranscriptionError {
+            guard case .notConfigured = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testTranscribeUsesOAuthTokenThenSyncRecognition() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"access_token":"access-token","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"[{"results":[{"normalized_text":"Привет мир","text":"privet mir"}]}]"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.25, -0.25], wavData: Data(), duration: 0.2),
+            language: "ru",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Привет мир")
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[0].url?.path, "/api/v2/oauth")
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Authorization"), "Basic encoded-key")
+        XCTAssertEqual(requests[1].url?.path, "/rest/v1/speech:recognize")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer access-token")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Content-Type"), "audio/x-pcm;bit=16;rate=16000")
+    }
+
+    func testHTTP401MapsToInvalidAuthorizationKey() {
+        XCTAssertThrowsError(try SaluteSpeechPlugin.validateHTTPResponse(
+            data: Data(#"{"message":"unauthorized"}"#.utf8),
+            response: Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 401)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .invalidApiKey = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
@@ -218,6 +218,88 @@ final class SaluteSpeechPluginTests: XCTestCase {
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Content-Type"), "audio/x-pcm;bit=16;rate=16000")
     }
 
+    func testDeactivateClearsConfigurationSnapshot() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.isConfigured)
+
+        plugin.deactivate()
+
+        XCTAssertFalse(plugin.isConfigured)
+        do {
+            _ = try await plugin.transcribe(
+                audio: AudioData(samples: [0, 0.1], wavData: Data(), duration: 1),
+                language: "ru",
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected notConfigured")
+        } catch let error as PluginTranscriptionError {
+            guard case .notConfigured = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testTranscribeRefreshesOAuthTokenAfterAuthorizationKeyChange() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key-1"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"access_token":"access-token-1","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":["Первый"]}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"access_token":"access-token-2","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":["Второй"]}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+                ),
+            ])
+        }
+
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.1], wavData: Data(), duration: 1),
+            language: "ru",
+            translate: false,
+            prompt: nil
+        )
+        try plugin.setAuthorizationKey("encoded-key-2")
+        let secondResult = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.1], wavData: Data(), duration: 1),
+            language: "ru",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(secondResult.text, "Второй")
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 4)
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Authorization"), "Basic encoded-key-1")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer access-token-1")
+        XCTAssertEqual(requests[2].value(forHTTPHeaderField: "Authorization"), "Basic encoded-key-2")
+        XCTAssertEqual(requests[3].value(forHTTPHeaderField: "Authorization"), "Bearer access-token-2")
+    }
+
     func testSuccessfulTranscriptionTracksRecognitionUsageAndPersistsIt() async throws {
         let host = try PluginTestHostServices(
             defaults: ["scope": SaluteSpeechPlugin.personalScope],

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
@@ -38,11 +38,28 @@ final class SaluteSpeechPluginTests: XCTestCase {
         XCTAssertEqual(String(data: request.httpBody ?? Data(), encoding: .utf8), "scope=SALUTE_SPEECH_PERS")
     }
 
-    func testSyncRecognitionRequestUsesPCMContentTypeAndBearerToken() throws {
+    func testRecognitionLanguageMappingSupportsRussianEnglishAndDefault() {
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage(nil), "ru-RU")
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage(" "), "ru-RU")
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage("ru"), "ru-RU")
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage("ru_RU"), "ru-RU")
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage("en"), "en-US")
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage("en_GB"), "en-US")
+        XCTAssertEqual(SaluteSpeechPlugin.resolvedRecognitionLanguage("de"), "ru-RU")
+    }
+
+    func testSupportedLanguagesExposeRussianAndEnglish() {
+        let plugin = SaluteSpeechPlugin()
+
+        XCTAssertEqual(plugin.supportedLanguages, ["ru", "ru-RU", "en", "en-US"])
+    }
+
+    func testSyncRecognitionRequestUsesPCMContentTypeBearerTokenAndLanguage() throws {
         let request = try SaluteSpeechPlugin.makeSyncRecognitionRequest(
             pcmData: Data([0x01, 0x02]),
             token: "access-token",
-            modelId: "general"
+            modelId: "general",
+            language: "en-US"
         )
 
         XCTAssertEqual(request.httpMethod, "POST")
@@ -56,13 +73,15 @@ final class SaluteSpeechPluginTests: XCTestCase {
         let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
         let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
         XCTAssertEqual(query["model"], "general")
+        XCTAssertEqual(query["language"], "en-US")
     }
 
-    func testStartAsyncRequestUsesPCMOptions() throws {
+    func testStartAsyncRequestUsesPCMOptionsAndLanguage() throws {
         let request = try SaluteSpeechPlugin.makeStartAsyncRecognitionRequest(
             requestFileId: "file-id",
             token: "access-token",
-            modelId: "general"
+            modelId: "general",
+            language: "en-US"
         )
 
         XCTAssertEqual(request.httpMethod, "POST")
@@ -76,6 +95,7 @@ final class SaluteSpeechPluginTests: XCTestCase {
         let options = try XCTUnwrap(json["options"] as? [String: Any])
         XCTAssertEqual(json["request_file_id"] as? String, "file-id")
         XCTAssertEqual(options["model"] as? String, "general")
+        XCTAssertEqual(options["language"] as? String, "en-US")
         XCTAssertEqual(options["audio_encoding"] as? String, "PCM_S16LE")
         XCTAssertEqual(options["sample_rate"] as? Int, 16_000)
         XCTAssertEqual(options["channels_count"] as? Int, 1)
@@ -216,6 +236,110 @@ final class SaluteSpeechPluginTests: XCTestCase {
         XCTAssertEqual(requests[1].url?.path, "/rest/v1/speech:recognize")
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer access-token")
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Content-Type"), "audio/x-pcm;bit=16;rate=16000")
+
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(requests[1].url), resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        XCTAssertEqual(query["language"], "ru-RU")
+    }
+
+    func testTranscribeUsesSelectedEnglishLanguageForSyncRecognition() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"access_token":"access-token","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":["Hello world"]}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.25, -0.25], wavData: Data(), duration: 0.2),
+            language: "en",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Hello world")
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map(\.url?.path), ["/api/v2/oauth", "/rest/v1/speech:recognize"])
+
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(requests[1].url), resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        XCTAssertEqual(query["language"], "en-US")
+    }
+
+    func testTranscribeUsesSelectedEnglishLanguageForAsyncRecognition() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["scope": SaluteSpeechPlugin.personalScope],
+            secrets: ["authorization-key": "encoded-key"]
+        )
+        let plugin = SaluteSpeechPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"access_token":"access-token","expires_at":4102444800000}"#.utf8),
+                    Self.httpResponse(url: "https://ngw.devices.sberbank.ru:9443/api/v2/oauth", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":{"request_file_id":"request-file"}}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/data:upload", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":{"id":"task-id","status":"CREATED"}}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:async_recognize", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":{"status":"DONE","response_file_id":"response-file"}}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/task:get", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"result":["Hello async"]}"#.utf8),
+                    Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/data:download", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0.25, -0.25], wavData: Data(), duration: 61),
+            language: "en-US",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Hello async")
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(
+            requests.map(\.url?.path),
+            [
+                "/api/v2/oauth",
+                "/rest/v1/data:upload",
+                "/rest/v1/speech:async_recognize",
+                "/rest/v1/task:get",
+                "/rest/v1/data:download",
+            ]
+        )
+
+        let body = try XCTUnwrap(requests[2].httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try XCTUnwrap(json["options"] as? [String: Any])
+        XCTAssertEqual(options["language"] as? String, "en-US")
     }
 
     func testDeactivateClearsConfigurationSnapshot() async throws {

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
@@ -1,0 +1,16 @@
+{
+    "id": "com.typewhisper.sber-salutespeech",
+    "name": "Sber SaluteSpeech",
+    "version": "0.1.0",
+    "minHostVersion": "1.4.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Cloud transcription via the Sber SaluteSpeech REST API. Requires a SaluteSpeech Authorization Key.",
+    "category": "transcription",
+    "hosting": "cloud",
+    "iconSystemName": "waveform.badge.mic",
+    "principalClass": "SaluteSpeechPlugin",
+    "requiresAPIKey": true,
+    "detailsURL": "https://developers.sber.ru/docs/ru/salutespeech/quick-start/integration-individuals"
+}


### PR DESCRIPTION
## Summary

- Add a new external bundle transcription provider for Sber SaluteSpeech.
- Store the SaluteSpeech Authorization Key via plugin-scoped Keychain storage and support personal/corporate OAuth scopes.
- Use SaluteSpeech REST sync recognition for short clips and async upload/task/download recognition for longer clips.
- Disable transcript preview fallback to avoid repeated partial cloud requests during one recording.
- Track local recognition minutes and let users enter their current SaluteSpeech Studio remaining balance for estimated remaining minutes.

## Setup and provider access

- Supported platform: macOS 14.0+.
- Required credential: a user-provided SaluteSpeech Authorization Key from Sber Developer Studio.
- Supported scopes: `SALUTE_SPEECH_PERS` and `SALUTE_SPEECH_CORP`.
- Authorized provider path: the plugin uses the officially documented SaluteSpeech OAuth flow (`POST https://ngw.devices.sberbank.ru:9443/api/v2/oauth`) and REST recognition endpoints under `https://smartspeech.sber.ru/rest/v1`; it does not use hidden endpoints, consumer subscription credentials, or first-party client impersonation.
- Provider docs: [quick start](https://developers.sber.ru/docs/ru/salutespeech/quick-start/integration-individuals), [authentication](https://developers.sber.ru/docs/ru/salutespeech/api/authentication), [sync recognition](https://developers.sber.ru/docs/ru/salutespeech/rest/sync-general), [async recognition task](https://developers.sber.ru/docs/ru/salutespeech/rest/post-async-speech-recognition).

## Test plan

- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json >/dev/null`
- `swift package --package-path TypeWhisperPluginSDK dump-package >/tmp/typewhisper-sdk-package-dump.json`
- `swift test --package-path TypeWhisperPluginSDK --filter SaluteSpeechPluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -target SaluteSpeechPlugin -configuration Debug build`
- `codesign --verify --deep --strict build/Debug/SaluteSpeechPlugin.bundle`
- `plutil -lint TypeWhisper.xcodeproj/project.pbxproj`
- `git diff --check`
- Manual dev smoke: copied `build/Debug/SaluteSpeechPlugin.bundle` to `~/Library/Application Support/TypeWhisper-Dev/Plugins/`, restarted TypeWhisper Dev, enabled Sber SaluteSpeech, and verified OAuth plus `speech:recognize` returned HTTP 200 and inserted text into Safari.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sber SaluteSpeech transcription plugin with API-key + OAuth support, model selection, settings UI, and sync/async transcription flows.
  * Added usage tracking, balance correction, and persistence of recognition usage.

* **Tests**
  * Added end-to-end and unit tests covering encoding, auth flows, request/response construction, parsing, error mappings, and usage persistence.

* **Chores**
  * Integrated plugin into project/build configuration and package manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->