### PR TITLE
[Reference / please don't merge] Gemini STT plugin — multimodal audio + context transcription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ CodeSigning.local.xcconfig
 
 # Git worktrees
 .worktrees/
+
+# Plugin build artifacts
+Plugins/*/dist/
+*.profraw

--- a/Plugins/GeminiSTTPlugin/README.md
+++ b/Plugins/GeminiSTTPlugin/README.md
@@ -1,0 +1,121 @@
+# GeminiSTTPlugin
+
+Speech-to-text via **Google Gemini** (AI Studio direct — no proxy). Adds a
+`TranscriptionEnginePlugin` that calls `generativelanguage.googleapis.com`
+directly, with an editable **system prompt** and **glossary** in settings.
+
+## Why this exists (vs. the other Gemini plugins)
+
+| Plugin | Role | Uses audio? | Editable prompt? |
+|---|---|---|---|
+| `GeminiPlugin` (existing) | LLM text provider | No — text in, text out | No |
+| `OpenRouterPlugin` (existing) | LLM text provider via OpenRouter | No | No |
+| **`GeminiSTTPlugin` (this one)** | **Transcription engine** | **Yes — inline WAV → text** | **Yes** |
+
+## Benchmark that motivated this
+
+On a 4-file technical-dictation set (ML/AI jargon, Swift internals, infra
+configs), using the default system prompt + glossary shipped with the plugin:
+
+| Engine | Key-term accuracy | Median latency | Cost/hr |
+|---|---|---|---|
+| Groq Whisper Large v3 | 60.5 % | 1.4 s | $0.111 |
+| Gemini Flash-Lite via OpenRouter | 100 % | 3.2 s | $0.058 |
+| **Gemini Flash-Lite via Google direct (this plugin)** | **100 %** | **2.6 s** | **$0.058** |
+
+## Build & install (no Xcode required)
+
+Plain `swiftc` against the installed TypeWhisper.app's embedded
+`TypeWhisperPluginSDK.framework`. No SPM, no `project.pbxproj` edits, ~3s
+rebuilds.
+
+```bash
+cd Plugins/GeminiSTTPlugin
+./build-bundle.sh            # build + sign → dist/GeminiSTTPlugin.bundle
+./build-bundle.sh --install  # same, plus copy to ~/Library/Application Support/TypeWhisper/Plugins/
+./build-bundle.sh --debug    # -Onone + -g (faster builds, larger binary)
+./build-bundle.sh --app-path /path/to/TypeWhisper.app   # override framework source
+```
+
+**Prerequisites**:
+- Swift 6 toolchain (`xcode-select --install` is enough — Xcode.app GUI is NOT
+  needed, just the command-line tools).
+- `TypeWhisper.app` installed at `/Applications/` (or pass `--app-path`). The
+  build links against its embedded `TypeWhisperPluginSDK.framework`.
+
+### Project layout
+
+```
+Plugins/GeminiSTTPlugin/
+├── Sources/GeminiSTTPlugin/
+│   └── GeminiSTTPlugin.swift   # plugin class + settings view (~500 lines)
+├── manifest.json               # TypeWhisper plugin metadata (principalClass, etc.)
+├── build-bundle.sh             # two-step swiftc compile + bundle wrap + codesign
+└── README.md                   # this file
+```
+
+### How the build works (two-step swiftc)
+
+The shipped `TypeWhisperPluginSDK.framework` is binary-only (no `.swiftmodule`
+for the Swift compiler to consume), so we can't `import TypeWhisperPluginSDK`
+from it directly. We instead:
+
+1. **Rebuild the SDK's `.swiftmodule` from source** at
+   `../../TypeWhisperPluginSDK/Sources/` — produces just the module interface
+   (not a dylib). Cached in `build/sdk/`.
+2. **Compile + link the plugin** with `-I build/sdk` (for `import` resolution)
+   plus `-F /Applications/TypeWhisper.app/Contents/Frameworks -framework
+   TypeWhisperPluginSDK` (for link-time symbol binding against the exact SDK
+   version the host app loads).
+3. **Wrap as `.bundle`** — move the dylib to `Contents/MacOS/GeminiSTTPlugin`,
+   `install_name_tool -id` it, write `Contents/Info.plist` and
+   `Contents/Resources/manifest.json`, strip xattrs, ad-hoc sign
+   (`codesign -s -`).
+
+The final dylib's `LC_LOAD_DYLIB` for the SDK reads
+`@rpath/TypeWhisperPluginSDK.framework/Versions/A/TypeWhisperPluginSDK` — the
+exact same install name TypeWhisper.app has in its dyld cache, so when
+`Bundle.load()` runs, dyld reuses the already-loaded image. This is the same
+pattern the existing `STTFixerPlugin` uses in production.
+
+### After install
+
+Launch TypeWhisper → **Settings → Integrations** → enable **Gemini STT** →
+click the gear icon → paste your AI Studio API key.
+
+## Configuration
+
+- **API Key** — get one free at
+  [aistudio.google.com/apikey](https://aistudio.google.com/apikey). Stored in
+  Keychain, scoped to the plugin ID.
+- **Model** — defaults to `gemini-3.1-flash-lite-preview` (fastest + most
+  accurate in our tests). `gemini-3-flash-preview` is available as a
+  higher-quality fallback.
+- **System Prompt** — full template, editable. Use `{GLOSSARY}` as the token
+  that gets replaced with your glossary at request time.
+- **Glossary** — comma-separated terms. Merged with per-rule dictionary terms
+  that TypeWhisper passes via the `prompt` parameter.
+- **Temperature** (under Advanced) — defaults to `0.2`. Higher values add
+  creativity you probably don't want for transcription.
+
+## Network / latency notes
+
+- Endpoint: `generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`
+- Auth: `x-goog-api-key` header
+- `thinkingConfig.thinkingBudget: 0` is set on every request (critical for
+  Flash-Lite — otherwise the model silently "thinks" and adds seconds of
+  latency).
+- Audio is sent inline as base64 in `inlineData`. Safe for anything under
+  ~20 MB (a 50-second 16 kHz mono WAV is ~1.6 MB).
+- Uses `PluginHTTPClient` (fresh ephemeral session per request — avoids stale
+  HTTP/2 channels after sleep/wake).
+
+## Known limitations (v1.0.0)
+
+- `supportsTranslation` is `false`. Gemini can translate, but we haven't wired
+  the `translate` flag through to a second prompt variant. Easy to add.
+- `supportsStreaming` is `false`. Benchmarks showed streaming doesn't actually
+  help for short transcription outputs — TTFT ≈ E2E for this workload.
+- No "Test transcription" button in settings. API-key validation only.
+- No Vertex AI / OAuth path. AI Studio API key only. Regional endpoints don't
+  support Gemini 3 preview models anyway.

--- a/Plugins/GeminiSTTPlugin/README.md
+++ b/Plugins/GeminiSTTPlugin/README.md
@@ -88,7 +88,7 @@ click the gear icon → paste your AI Studio API key.
 - **API Key** — get one free at
   [aistudio.google.com/apikey](https://aistudio.google.com/apikey). Stored in
   Keychain, scoped to the plugin ID.
-- **Model** — defaults to `gemini-3.1-flash-lite-preview` (fastest + most
+- **Model** — defaults to `gemini-3.1-flash-lite` (fastest + most
   accurate in our tests). `gemini-3-flash-preview` is available as a
   higher-quality fallback.
 - **System Prompt** — full template, editable. Use `{GLOSSARY}` as the token

--- a/Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift
+++ b/Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import SwiftUI
 import TypeWhisperPluginSDK
@@ -26,7 +27,29 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
 
     func activate(host: HostServices) {
         self.host = host
-        _apiKey = host.loadSecret(key: "api-key")
+        // Shadow-cache the API key in UserDefaults so activate() doesn't hit the keychain
+        // on every plugin reload. Without this, every rebuild produces a new ad-hoc cdhash,
+        // which invalidates the keychain ACL and triggers a macOS "wants to access key …"
+        // prompt on each TypeWhisper restart.
+        //
+        // SECURITY TRADEOFF: ~/Library/Preferences/<bundle>.plist is user-UID-readable; any
+        // process running as the same user can `defaults read` it silently — strictly weaker
+        // than login.keychain. No at-rest encryption. The plist can end up in Time Machine
+        // and iCloud Desktop & Documents backups. The key is still written to the keychain
+        // as the source of truth; this is a dev/UX convenience only.
+        //
+        // CLEAN FIX (shipped builds): sign the plugin with the same Developer ID as the
+        // host + add `keychain-access-groups` entitlement. Then teamid:-partitioned ACLs
+        // match across rebuilds regardless of cdhash, and this shadow cache can be removed.
+        // See tests/research notes (2026-04-19) for the full analysis.
+        if let cached = host.userDefault(forKey: "apiKeyCache") as? String, !cached.isEmpty {
+            _apiKey = cached
+        } else {
+            _apiKey = host.loadSecret(key: "api-key")
+            if let key = _apiKey, !key.isEmpty {
+                host.setUserDefault(key, forKey: "apiKeyCache")
+            }
+        }
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.defaultModels.first?.id
         _systemPrompt = host.userDefault(forKey: "systemPrompt") as? String
@@ -34,6 +57,7 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         if let t = host.userDefault(forKey: "temperature") as? Double {
             _temperature = t
         }
+        warmUpConnection()
     }
 
     func deactivate() {
@@ -67,6 +91,9 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
     }
 
     var supportsTranslation: Bool { false }
+    // Streaming disabled: measured slower on every clip (Gemini batches SSE emission for
+    // transcription; TTFT ≈ total_http). See tests/gemini_phase3.jsonl.
+    var supportsStreaming: Bool { false }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
 
     // BCP-47 subset Gemini supports well for audio understanding
@@ -82,6 +109,42 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         translate _: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            language: language,
+            prompt: prompt,
+            onProgress: { _ in true }
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate _: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            language: language,
+            prompt: prompt,
+            onProgress: onProgress
+        )
+    }
+
+    // MARK: - Shared streaming transcription (Phase 3)
+    //
+    // Always uses `streamGenerateContent?alt=sse`. Non-streaming callers pass a no-op
+    // onProgress and simply receive the final accumulated text. Streaming callers see
+    // incremental text as Gemini emits SSE frames, which the host displays live via
+    // DictationViewModel.partialText / PartialTranscriptionUpdate events.
+
+    private func performTranscription(
+        audio: AudioData,
+        language: String?,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -90,21 +153,39 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         }
 
         let systemPrompt = renderSystemPrompt(perRulePromptTerms: prompt, language: language)
-        let b64 = audio.wavData.base64EncodedString()
+
+        // Compress audio to FLAC (lossless, ~50% of WAV). On encode failure fall back to
+        // WAV rather than failing the transcription — FLAC is a best-effort speed win.
+        let tEncodeStart = CFAbsoluteTimeGetCurrent()
+        let encodedAudio: Data
+        let mimeType: String
+        do {
+            encodedAudio = try encodeFlac(samples: audio.samples)
+            mimeType = "audio/flac"
+        } catch {
+            logger.error("FLAC encode failed, using WAV: \(error.localizedDescription, privacy: .public)")
+            encodedAudio = audio.wavData
+            mimeType = "audio/wav"
+        }
+        let tEncodeEnd = CFAbsoluteTimeGetCurrent()
+
+        let tB64Start = CFAbsoluteTimeGetCurrent()
+        let b64 = encodedAudio.base64EncodedString()
+        let tB64End = CFAbsoluteTimeGetCurrent()
 
         let body: [String: Any] = [
             "contents": [[
                 "role": "user",
                 "parts": [
                     ["text": systemPrompt],
-                    ["inlineData": ["mimeType": "audio/wav", "data": b64]],
+                    ["inlineData": ["mimeType": mimeType, "data": b64]],
                 ],
             ]],
             "generationConfig": [
                 "temperature": _temperature,
                 "maxOutputTokens": 2048,
                 "responseMimeType": "text/plain",
-                "thinkingConfig": ["thinkingBudget": 0],
+                "thinkingConfig": Self.thinkingConfig(for: modelId),
             ],
         ]
 
@@ -117,9 +198,14 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 60
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await PluginHTTPClient.data(for: request)
+        let tBodyStart = CFAbsoluteTimeGetCurrent()
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let tBodyEnd = CFAbsoluteTimeGetCurrent()
+
+        let tHTTPStart = CFAbsoluteTimeGetCurrent()
+        let (data, response) = try await Self.httpSession.data(for: request)
+        let tHTTPEnd = CFAbsoluteTimeGetCurrent()
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PluginTranscriptionError.networkError("Invalid response")
@@ -144,7 +230,32 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
             throw PluginTranscriptionError.apiError(message)
         }
 
+        let tParseStart = CFAbsoluteTimeGetCurrent()
         let text = try parseGeminiResponse(data)
+        let tParseEnd = CFAbsoluteTimeGetCurrent()
+
+        // onProgress gets called once with the full text so the host's streaming handler
+        // still receives the final value. This is a no-op for non-streaming callers.
+        _ = onProgress(text)
+
+        recordTimings(
+            model: modelId,
+            codec: mimeType,
+            audioDurationS: audio.duration,
+            wavBytes: audio.wavData.count,
+            encodedBytes: encodedAudio.count,
+            payloadBytes: b64.utf8.count,
+            encodeMs: (tEncodeEnd - tEncodeStart) * 1000,
+            b64Ms: (tB64End - tB64Start) * 1000,
+            bodyMs: (tBodyEnd - tBodyStart) * 1000,
+            httpMs: (tHTTPEnd - tHTTPStart) * 1000,
+            parseMs: (tParseEnd - tParseStart) * 1000,
+            ttftMs: 0,
+            chunks: 0,
+            status: httpResponse.statusCode,
+            resultChars: text.count
+        )
+
         return PluginTranscriptionResult(text: text, detectedLanguage: language)
     }
 
@@ -208,6 +319,221 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         }
     }
 
+    // MARK: - Audio compression (Phase 2 — FLAC)
+    //
+    // FLAC is lossless and natively supported by both AVAudioFile (`kAudioFormatFLAC`)
+    // and Gemini (`audio/flac`). Expected: ~50% of WAV size on 16 kHz mono voice, zero
+    // WER impact. Encoding overhead: tens of ms per 60 s of audio on Apple Silicon.
+
+    private func encodeFlac(samples: [Float], sampleRate: Int = 16000) throws -> Data {
+        guard !samples.isEmpty else { return Data() }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gemini-stt-\(UUID().uuidString).flac")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Write in a nested scope so AVAudioFile releases (and flushes its last page)
+        // before we read the bytes back.
+        try Self.writeFlacFile(samples: samples, sampleRate: sampleRate, url: tempURL)
+        return try Data(contentsOf: tempURL)
+    }
+
+    private static func writeFlacFile(samples: [Float], sampleRate: Int, url: URL) throws {
+        // Use Int16 throughout. If we pass Float32 buffers to AVAudioFile with a 16-bit
+        // FLAC setting, the encoder still writes 32-bit-depth FLAC (~no compression vs
+        // the float-wav baseline). Quantizing to Int16 in Swift gives us true 16-bit
+        // FLAC and ~50% compression on voice.
+        guard let pcmFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: true
+        ) else {
+            throw PluginTranscriptionError.apiError("Invalid PCM format for FLAC encode")
+        }
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatFLAC,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: settings,
+            commonFormat: .pcmFormatInt16,
+            interleaved: true
+        )
+
+        let chunkSize = 4096
+        var index = 0
+        while index < samples.count {
+            let frames = min(chunkSize, samples.count - index)
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: pcmFormat,
+                frameCapacity: AVAudioFrameCount(frames)
+            ), let channel = buffer.int16ChannelData?[0] else {
+                throw PluginTranscriptionError.apiError("FLAC buffer alloc failed")
+            }
+            buffer.frameLength = AVAudioFrameCount(frames)
+            for i in 0..<frames {
+                let clamped = max(-1.0, min(1.0, samples[index + i]))
+                channel[i] = Int16(clamped * 32767.0)
+            }
+            try file.write(from: buffer)
+            index += frames
+        }
+        // `file` goes out of scope here → AVAudioFile deinit flushes the FLAC stream to disk.
+    }
+
+    // MARK: - Gemini config helpers (Phase 1)
+
+    /// Gemini 3.x silently ignores `thinkingBudget: 0`; the documented minimum-thinking
+    /// flag for 3.x models is `thinkingLevel: "minimal"`. Gemini 2.5 keeps the older
+    /// `thinkingBudget: 0` contract. This helper picks the right one per model.
+    static func thinkingConfig(for modelId: String) -> [String: Any] {
+        if modelId.hasPrefix("gemini-3") {
+            return ["thinkingLevel": "minimal"]
+        }
+        return ["thinkingBudget": 0]
+    }
+
+    // MARK: - Long-lived URLSession + connection warm-up (Phase 1)
+    //
+    // The SDK's PluginHTTPClient creates a fresh ephemeral session per call to dodge
+    // a known macOS stale-connection bug after sleep/wake. That defeats TLS/H2/H3
+    // connection reuse — every transcription pays a full handshake to Google's edge.
+    // We trade that freshness for speed with a default session that reuses connections
+    // within the keepalive window (~6 min). Tight timeouts cap the blast radius of a
+    // genuinely stale connection to one slow call.
+
+    private static let httpSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 60
+        config.timeoutIntervalForResource = 120
+        config.httpMaximumConnectionsPerHost = 4
+        config.waitsForConnectivity = false
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(configuration: config)
+    }()
+
+    private func warmUpConnection() {
+        guard let url = URL(string: Self.apiBase) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.timeoutInterval = 5
+        Task.detached(priority: .userInitiated) {
+            _ = try? await Self.httpSession.data(for: request)
+        }
+    }
+
+    // MARK: - Timing instrumentation (Phase 0)
+    //
+    // Emits two artifacts per transcription:
+    //   1. A structured [GEMINI_TIMING] line via os.Logger — tail with:
+    //        log stream --predicate 'subsystem BEGINSWITH "com.typewhisper.gemini-stt"' | grep GEMINI_TIMING
+    //   2. A JSONL record at ~/Library/Application Support/TypeWhisper/PluginData/GeminiSTT/timings.jsonl
+    //      — analyze with jq, e.g.:
+    //        jq -s 'map(.steps_ms.http) | add/length' timings.jsonl
+
+    private static let timingsFileURL: URL? = {
+        guard let base = try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        let dir = base
+            .appendingPathComponent("TypeWhisper", isDirectory: true)
+            .appendingPathComponent("PluginData", isDirectory: true)
+            .appendingPathComponent("GeminiSTT", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("timings.jsonl")
+    }()
+
+    private static let timingsISOFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    fileprivate func recordTimings(
+        model: String,
+        codec: String,
+        audioDurationS: Double,
+        wavBytes: Int,
+        encodedBytes: Int,
+        payloadBytes: Int,
+        encodeMs: Double,
+        b64Ms: Double,
+        bodyMs: Double,
+        httpMs: Double,
+        parseMs: Double,
+        ttftMs: Double,
+        chunks: Int,
+        status: Int,
+        resultChars: Int
+    ) {
+        let totalMs = encodeMs + b64Ms + bodyMs + httpMs + parseMs
+        let record: [String: Any] = [
+            "ts": Self.timingsISOFormatter.string(from: Date()),
+            "model": model,
+            "codec": codec,
+            "audio_dur_s": audioDurationS,
+            "wav_bytes": wavBytes,
+            "encoded_bytes": encodedBytes,
+            "payload_bytes": payloadBytes,
+            "steps_ms": [
+                "encode": encodeMs,
+                "b64_encode": b64Ms,
+                "body_serialize": bodyMs,
+                "http": httpMs,
+                "parse": parseMs,
+            ],
+            "ttft_ms": ttftMs,
+            "stream_chunks": chunks,
+            "total_plugin_ms": totalMs,
+            "http_status": status,
+            "result_chars": resultChars,
+        ]
+
+        logger.info("""
+        [GEMINI_TIMING] model=\(model, privacy: .public) \
+        codec=\(codec, privacy: .public) \
+        dur=\(audioDurationS, format: .fixed(precision: 2), privacy: .public)s \
+        wav=\(wavBytes, privacy: .public)B \
+        enc=\(encodedBytes, privacy: .public)B \
+        payload=\(payloadBytes, privacy: .public)B \
+        encode_ms=\(encodeMs, format: .fixed(precision: 1), privacy: .public) \
+        b64_ms=\(b64Ms, format: .fixed(precision: 1), privacy: .public) \
+        body_ms=\(bodyMs, format: .fixed(precision: 1), privacy: .public) \
+        http_ms=\(httpMs, format: .fixed(precision: 1), privacy: .public) \
+        parse_ms=\(parseMs, format: .fixed(precision: 1), privacy: .public) \
+        ttft_ms=\(ttftMs, format: .fixed(precision: 1), privacy: .public) \
+        chunks=\(chunks, privacy: .public) \
+        total_ms=\(totalMs, format: .fixed(precision: 1), privacy: .public) \
+        chars=\(resultChars, privacy: .public)
+        """)
+
+        guard let url = Self.timingsFileURL,
+              let data = try? JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
+        else { return }
+
+        var line = data
+        line.append(0x0a) // newline
+
+        if let handle = try? FileHandle(forWritingTo: url) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: line)
+        } else {
+            try? line.write(to: url, options: .atomic)
+        }
+    }
+
     // MARK: - Settings hooks
 
     var settingsView: AnyView? {
@@ -219,6 +545,7 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         if let host {
             do { try host.storeSecret(key: "api-key", value: key) }
             catch { logger.error("Failed to store API key: \(error.localizedDescription, privacy: .public)") }
+            host.setUserDefault(key, forKey: "apiKeyCache")
             host.notifyCapabilitiesChanged()
         }
     }
@@ -228,6 +555,7 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         if let host {
             do { try host.storeSecret(key: "api-key", value: "") }
             catch { logger.error("Failed to delete API key: \(error.localizedDescription, privacy: .public)") }
+            host.setUserDefault("", forKey: "apiKeyCache")
             host.notifyCapabilitiesChanged()
         }
     }

--- a/Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift
+++ b/Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift
@@ -52,6 +52,12 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
         }
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.defaultModels.first?.id
+        // Migration: the 3.1 Flash Lite preview graduated to a stable model id.
+        // Remap any persisted preview selection so existing users move to the stable model.
+        if _selectedModelId == "gemini-3.1-flash-lite-preview" {
+            _selectedModelId = "gemini-3.1-flash-lite"
+            host.setUserDefault("gemini-3.1-flash-lite", forKey: "selectedModel")
+        }
         _systemPrompt = host.userDefault(forKey: "systemPrompt") as? String
         _glossary = host.userDefault(forKey: "glossary") as? String
         if let t = host.userDefault(forKey: "temperature") as? Double {
@@ -75,7 +81,8 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
     }
 
     static let defaultModels: [PluginModelInfo] = [
-        PluginModelInfo(id: "gemini-3.1-flash-lite-preview", displayName: "Gemini 3.1 Flash Lite (fastest, 100% accurate w/ glossary)"),
+        PluginModelInfo(id: "gemini-3.5-flash", displayName: "Gemini 3.5 Flash (newest, thinking disabled)"),
+        PluginModelInfo(id: "gemini-3.1-flash-lite", displayName: "Gemini 3.1 Flash Lite (fastest, 100% accurate w/ glossary)"),
         PluginModelInfo(id: "gemini-3-flash-preview", displayName: "Gemini 3 Flash (higher quality)"),
         PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash (stable)"),
         PluginModelInfo(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite (stable, cheapest)"),
@@ -391,10 +398,22 @@ final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerm
 
     // MARK: - Gemini config helpers (Phase 1)
 
-    /// Gemini 3.x silently ignores `thinkingBudget: 0`; the documented minimum-thinking
-    /// flag for 3.x models is `thinkingLevel: "minimal"`. Gemini 2.5 keeps the older
-    /// `thinkingBudget: 0` contract. This helper picks the right one per model.
+    /// Per-model "no thinking" configuration. Validated 2026-05-27 against
+    /// `usageMetadata.thoughtsTokenCount` (smoking gun: 0/absent = no thinking,
+    /// any positive value = the model still thought).
+    ///
+    /// - `gemini-3.5-flash`: thinks ~1963 tokens by default. `thinkingBudget: 0`
+    ///   was validated to produce `thoughtsTokenCount: None` (1.9s vs 10.5s
+    ///   default). `thinkingLevel: "minimal"` also works but is less aggressive
+    ///   and the two are mutually exclusive (HTTP 400 if both set).
+    /// - `gemini-3.1-flash-lite` / `gemini-3-flash-preview`: `thinkingLevel:
+    ///   "minimal"` validated to produce 0 thoughts.
+    /// - `gemini-2.5*`: `thinkingBudget: 0` is the documented disable knob.
+    /// - `thinkingLevel: "off"` and `"none"` are rejected by the API (HTTP 400).
     static func thinkingConfig(for modelId: String) -> [String: Any] {
+        if modelId == "gemini-3.5-flash" {
+            return ["thinkingBudget": 0]
+        }
         if modelId.hasPrefix("gemini-3") {
             return ["thinkingLevel": "minimal"]
         }

--- a/Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift
+++ b/Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift
@@ -1,0 +1,504 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+import os
+
+// MARK: - Plugin Entry Point
+
+@objc(GeminiSTTPlugin)
+final class GeminiSTTPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.gemini-stt"
+    static let pluginName = "Gemini STT"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedModelId: String?
+    fileprivate var _systemPrompt: String?
+    fileprivate var _glossary: String?
+    fileprivate var _temperature: Double = 0.2
+
+    private let logger = Logger(subsystem: "com.typewhisper.gemini-stt", category: "Plugin")
+    private static let apiBase = "https://generativelanguage.googleapis.com/v1beta/models"
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: "api-key")
+        _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
+            ?? Self.defaultModels.first?.id
+        _systemPrompt = host.userDefault(forKey: "systemPrompt") as? String
+        _glossary = host.userDefault(forKey: "glossary") as? String
+        if let t = host.userDefault(forKey: "temperature") as? Double {
+            _temperature = t
+        }
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "gemini-stt" }
+    var providerDisplayName: String { "Gemini STT" }
+
+    var isConfigured: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    static let defaultModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "gemini-3.1-flash-lite-preview", displayName: "Gemini 3.1 Flash Lite (fastest, 100% accurate w/ glossary)"),
+        PluginModelInfo(id: "gemini-3-flash-preview", displayName: "Gemini 3 Flash (higher quality)"),
+        PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash (stable)"),
+        PluginModelInfo(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite (stable, cheapest)"),
+    ]
+
+    var transcriptionModels: [PluginModelInfo] { Self.defaultModels }
+
+    var selectedModelId: String? { _selectedModelId }
+
+    func selectModel(_ modelId: String) {
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedModel")
+    }
+
+    var supportsTranslation: Bool { false }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+
+    // BCP-47 subset Gemini supports well for audio understanding
+    var supportedLanguages: [String] {
+        ["en", "es", "fr", "de", "it", "pt", "nl", "pl", "ru", "tr",
+         "ja", "ko", "zh", "ar", "hi", "id", "th", "vi", "sv", "da",
+         "no", "fi", "cs", "el", "he", "hu", "ro", "uk"]
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate _: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let systemPrompt = renderSystemPrompt(perRulePromptTerms: prompt, language: language)
+        let b64 = audio.wavData.base64EncodedString()
+
+        let body: [String: Any] = [
+            "contents": [[
+                "role": "user",
+                "parts": [
+                    ["text": systemPrompt],
+                    ["inlineData": ["mimeType": "audio/wav", "data": b64]],
+                ],
+            ]],
+            "generationConfig": [
+                "temperature": _temperature,
+                "maxOutputTokens": 2048,
+                "responseMimeType": "text/plain",
+                "thinkingConfig": ["thinkingBudget": 0],
+            ],
+        ]
+
+        guard let url = URL(string: "\(Self.apiBase)/\(modelId):generateContent") else {
+            throw PluginTranscriptionError.apiError("Invalid URL for model \(modelId)")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 60
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401, 403:
+            throw PluginTranscriptionError.invalidApiKey
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        default:
+            var message = "HTTP \(httpResponse.statusCode)"
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let err = json["error"] as? [String: Any],
+               let m = err["message"] as? String {
+                message = m
+            }
+            throw PluginTranscriptionError.apiError(message)
+        }
+
+        let text = try parseGeminiResponse(data)
+        return PluginTranscriptionResult(text: text, detectedLanguage: language)
+    }
+
+    // MARK: - Prompt rendering
+
+    static let defaultGlossary = """
+    Qwen3, Qwen3-VL, Qwen3-ASR, Gemma, Llama, DeepSeek, Claude, GPT-5, o3, Sonnet, Opus, Haiku; LoRA, QLoRA, RLHF, DPO, GRPO, vLLM, SGLang, MLX, MLX-LM, llama.cpp, ONNX, TensorRT, Triton, PyTorch, JAX, HuggingFace, Transformers, TRL, Accelerate, bitsandbytes; Groq, OpenRouter, Anthropic, OpenAI, Together, Replicate, Fireworks, Modal, Runpod, Lambda Labs; Cloudflare Workers, SearXNG, Langfuse, LangSmith, LangChain, LlamaIndex, ClickHouse, Postgres, Supabase, Redis, Upstash, Neon, Turso; Next.js, SvelteKit, Astro, Remix, BetterAuth, Clerk, Auth.js, Resend, Nginx, Caddy, Traefik, Docker, Kubernetes; SSE, WebSocket, PKCE, OAuth, JWT, keepalive, proxy_read_timeout, proxy_buffering, X-Accel-Buffering; AVAudioEngine, AUInterfaceBase, AudioUnitPropertyListener, CoreAudio, Swift, ARC, dealloc, destructor, mutex, dispatch queue, teardown; M1 Max, M2, M3, M4, Apple Silicon, CUDA, ROCm, Metal
+    """
+
+    static let defaultSystemPrompt = """
+    You are transcribing technical dictation from an ML/AI engineer. The speaker commonly uses these proper nouns (non-exhaustive):
+
+    {GLOSSARY}
+
+    Accurate spelling of model names, framework names, and technical terms is required. Additionally:
+    - Preserve exact version numbers and numeric config values as spoken (e.g., "GPT-5.4", "Python 3.14", "keepalive 64"). Do NOT round toward familiar versions you know.
+    - Preserve underscores, hyphens, and dots in identifiers and CLI flags exactly (e.g., proxy_read_timeout, --no-verify, X-Accel-Buffering, .tsx).
+    - Collapse compound technical names without spaces (BetterAuth, ClickHouse, AVAudioEngine), and preserve CamelCase (useState, useEffect).
+    - Numbers in technical contexts are digits, not words (write "404", not "four oh four").
+
+    Use proper punctuation and casing. Output only the transcription, nothing else.
+    """
+
+    /// Merges plugin-level glossary with per-rule dictionary terms passed from the host.
+    private func renderSystemPrompt(perRulePromptTerms: String?, language: String?) -> String {
+        let template = (_systemPrompt?.isEmpty == false ? _systemPrompt : nil) ?? Self.defaultSystemPrompt
+        let baseGlossary = (_glossary?.isEmpty == false ? _glossary : nil) ?? Self.defaultGlossary
+
+        let baseTerms = PluginDictionaryTerms.terms(fromPrompt: baseGlossary)
+        let ruleTerms = PluginDictionaryTerms.terms(fromPrompt: perRulePromptTerms)
+        let merged = PluginDictionaryTerms.normalizedTerms(from: baseTerms + ruleTerms)
+        let glossaryText = merged.joined(separator: ", ")
+
+        var prompt = template.replacingOccurrences(of: "{GLOSSARY}", with: glossaryText)
+        if let lang = language, !lang.isEmpty {
+            prompt += "\n\nLanguage: \(lang)"
+        }
+        return prompt
+    }
+
+    private func parseGeminiResponse(_ data: Data) throws -> String {
+        struct GeminiPart: Decodable { let text: String? }
+        struct GeminiContent: Decodable { let parts: [GeminiPart]? }
+        struct GeminiCandidate: Decodable {
+            let content: GeminiContent?
+            let finishReason: String?
+        }
+        struct GeminiResponse: Decodable { let candidates: [GeminiCandidate]? }
+
+        do {
+            let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
+            guard let text = decoded.candidates?.first?.content?.parts?.compactMap(\.text).joined(),
+                  !text.isEmpty else {
+                throw PluginTranscriptionError.apiError("Empty response from Gemini")
+            }
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch let e as PluginTranscriptionError {
+            throw e
+        } catch {
+            throw PluginTranscriptionError.apiError("Failed to parse response: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Settings hooks
+
+    var settingsView: AnyView? {
+        AnyView(GeminiSTTSettingsView(plugin: self))
+    }
+
+    func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do { try host.storeSecret(key: "api-key", value: key) }
+            catch { logger.error("Failed to store API key: \(error.localizedDescription, privacy: .public)") }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do { try host.storeSecret(key: "api-key", value: "") }
+            catch { logger.error("Failed to delete API key: \(error.localizedDescription, privacy: .public)") }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func validateApiKey(_ key: String) async -> Bool {
+        guard !key.isEmpty,
+              let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models") else {
+            return false
+        }
+        var request = URLRequest(url: url)
+        request.setValue(key, forHTTPHeaderField: "x-goog-api-key")
+        request.timeoutInterval = 10
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    func setSystemPrompt(_ prompt: String) {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        _systemPrompt = trimmed.isEmpty ? nil : trimmed
+        host?.setUserDefault(_systemPrompt, forKey: "systemPrompt")
+    }
+
+    func setGlossary(_ glossary: String) {
+        let trimmed = glossary.trimmingCharacters(in: .whitespacesAndNewlines)
+        _glossary = trimmed.isEmpty ? nil : trimmed
+        host?.setUserDefault(_glossary, forKey: "glossary")
+    }
+
+    func setTemperature(_ value: Double) {
+        let clamped = min(max(value, 0.0), 1.0)
+        _temperature = clamped
+        host?.setUserDefault(clamped, forKey: "temperature")
+    }
+
+    var currentTemperature: Double { _temperature }
+}
+
+// MARK: - Settings View
+
+private struct GeminiSTTSettingsView: View {
+    let plugin: GeminiSTTPlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    @State private var selectedModel: String = ""
+    @State private var systemPromptText: String = ""
+    @State private var glossaryText: String = ""
+    @State private var temperature: Double = 0.2
+    @State private var showAdvanced = false
+    private let bundle = Bundle(for: GeminiSTTPlugin.self)
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                apiKeySection
+                if plugin.isConfigured {
+                    Divider()
+                    modelSection
+                    Divider()
+                    systemPromptSection
+                    Divider()
+                    glossarySection
+                    Divider()
+                    advancedSection
+                }
+
+                Text("API keys are stored securely in the Keychain. Audio is sent directly to Google AI Studio (no third-party proxy).", bundle: bundle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding()
+        }
+        .frame(minWidth: 520, minHeight: 560)
+        .onAppear(perform: loadStateFromPlugin)
+    }
+
+    // MARK: Sections
+
+    private var apiKeySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Google AI Studio API Key", bundle: bundle)
+                .font(.headline)
+
+            HStack(spacing: 8) {
+                if showApiKey {
+                    TextField("API Key", text: $apiKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                } else {
+                    SecureField("API Key", text: $apiKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                }
+                Button { showApiKey.toggle() } label: {
+                    Image(systemName: showApiKey ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.borderless)
+
+                if plugin.isConfigured {
+                    Button(String(localized: "Remove", bundle: bundle)) {
+                        apiKeyInput = ""
+                        validationResult = nil
+                        plugin.removeApiKey()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .foregroundStyle(.red)
+                } else {
+                    Button(String(localized: "Save", bundle: bundle)) { saveApiKey() }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+
+            if isValidating {
+                HStack(spacing: 4) {
+                    ProgressView().controlSize(.small)
+                    Text("Validating...", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else if let result = validationResult {
+                HStack(spacing: 4) {
+                    Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(result ? .green : .red)
+                    Text(result
+                         ? String(localized: "Valid API Key", bundle: bundle)
+                         : String(localized: "Invalid API Key", bundle: bundle))
+                        .font(.caption)
+                        .foregroundStyle(result ? .green : .red)
+                }
+            }
+
+            Text("Get a free key at aistudio.google.com/apikey", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var modelSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Model", bundle: bundle)
+                .font(.headline)
+
+            Picker("Model", selection: $selectedModel) {
+                ForEach(plugin.transcriptionModels, id: \.id) { model in
+                    Text(model.displayName).tag(model.id)
+                }
+            }
+            .labelsHidden()
+            .onChange(of: selectedModel) { plugin.selectModel(selectedModel) }
+        }
+    }
+
+    private var systemPromptSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("System Prompt", bundle: bundle)
+                    .font(.headline)
+                Spacer()
+                Button(String(localized: "Reset to Default", bundle: bundle)) {
+                    systemPromptText = GeminiSTTPlugin.defaultSystemPrompt
+                    plugin.setSystemPrompt(systemPromptText)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            Text("Instructions for Gemini. Use `{GLOSSARY}` as a placeholder — it gets replaced with your glossary terms at request time.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextEditor(text: $systemPromptText)
+                .font(.body.monospaced())
+                .frame(minHeight: 160)
+                .scrollContentBackground(.hidden)
+                .padding(4)
+                .background(.quaternary.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .onChange(of: systemPromptText) { plugin.setSystemPrompt(systemPromptText) }
+        }
+    }
+
+    private var glossarySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Glossary", bundle: bundle)
+                    .font(.headline)
+                Spacer()
+                Button(String(localized: "Reset to Default", bundle: bundle)) {
+                    glossaryText = GeminiSTTPlugin.defaultGlossary
+                    plugin.setGlossary(glossaryText)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            Text("Technical terms, comma-separated. These are substituted into `{GLOSSARY}` in the system prompt. Add terms you use that Gemini might mishear (model names, frameworks, internal tools).", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextEditor(text: $glossaryText)
+                .font(.body.monospaced())
+                .frame(minHeight: 120)
+                .scrollContentBackground(.hidden)
+                .padding(4)
+                .background(.quaternary.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .onChange(of: glossaryText) { plugin.setGlossary(glossaryText) }
+        }
+    }
+
+    private var advancedSection: some View {
+        DisclosureGroup(isExpanded: $showAdvanced) {
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Temperature", bundle: bundle)
+                            .font(.subheadline)
+                        Spacer()
+                        Text(String(format: "%.2f", temperature))
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $temperature, in: 0.0...1.0, step: 0.05)
+                        .onChange(of: temperature) { plugin.setTemperature(temperature) }
+                    Text("0 = deterministic. 0.2 is the validated sweet spot for transcription; higher values add creativity you probably don't want.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.top, 4)
+        } label: {
+            Text("Advanced", bundle: bundle)
+                .font(.headline)
+        }
+    }
+
+    // MARK: Actions
+
+    private func loadStateFromPlugin() {
+        if let key = plugin._apiKey, !key.isEmpty { apiKeyInput = key }
+        selectedModel = plugin.selectedModelId
+            ?? plugin.transcriptionModels.first?.id
+            ?? ""
+        systemPromptText = plugin._systemPrompt ?? GeminiSTTPlugin.defaultSystemPrompt
+        glossaryText = plugin._glossary ?? GeminiSTTPlugin.defaultGlossary
+        temperature = plugin.currentTemperature
+    }
+
+    private func saveApiKey() {
+        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        plugin.setApiKey(trimmed)
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmed)
+            await MainActor.run {
+                isValidating = false
+                validationResult = isValid
+            }
+        }
+    }
+}

--- a/Plugins/GeminiSTTPlugin/build-bundle.sh
+++ b/Plugins/GeminiSTTPlugin/build-bundle.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Build GeminiSTTPlugin.bundle directly with swiftc — no Xcode, no SPM.
+#
+# Links against the TypeWhisperPluginSDK.framework shipped inside the
+# installed TypeWhisper.app, so the plugin binds to the exact same SDK
+# symbols the host already has in memory. This is the pattern that was
+# proven to work for STTFixerPlugin on 2026-04-10.
+#
+# Output: dist/GeminiSTTPlugin.bundle (ad-hoc signed, ready to install)
+#
+# Usage:
+#   ./build-bundle.sh                # build + sign + leave in dist/
+#   ./build-bundle.sh --install      # build + copy to ~/Library/Application Support/TypeWhisper/Plugins/
+#   ./build-bundle.sh --app-path /path/TypeWhisper.app   # override framework source
+set -euo pipefail
+
+PLUGIN_ID="GeminiSTTPlugin"
+APP_PATH="/Applications/TypeWhisper.app"
+INSTALL=false
+CONFIG="release"  # kept for future -Onone toggle; swiftc -O is the default here
+
+for arg in "$@"; do
+  case "$arg" in
+    --install) INSTALL=true ;;
+    --app-path) shift; APP_PATH="$1" ;;
+    --app-path=*) APP_PATH="${arg#*=}" ;;
+    --debug) CONFIG="debug" ;;
+    --help|-h) grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "Unknown option: $arg"; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+FRAMEWORK_DIR="$APP_PATH/Contents/Frameworks"
+SDK_FRAMEWORK="$FRAMEWORK_DIR/TypeWhisperPluginSDK.framework"
+
+if [[ ! -d "$SDK_FRAMEWORK" ]]; then
+  echo "ERROR: TypeWhisperPluginSDK.framework not found at $SDK_FRAMEWORK" >&2
+  echo "       Install TypeWhisper.app first, or pass --app-path /path/to/TypeWhisper.app" >&2
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+SDK_PATH="$(xcrun --show-sdk-path)"
+DEPLOYMENT_TARGET="14.0"
+SOURCES=(Sources/GeminiSTTPlugin/*.swift)
+SDK_SOURCES=(../../TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/*.swift)
+
+echo "=== Building $PLUGIN_ID ($ARCH, linking against $APP_PATH) ==="
+
+OUT="dist/${PLUGIN_ID}.bundle"
+SDK_BUILD="build/sdk"
+rm -rf dist build
+mkdir -p "$OUT/Contents/MacOS" "$OUT/Contents/Resources" "$SDK_BUILD"
+
+OPTIMIZATION=(-O -whole-module-optimization)
+if [[ "$CONFIG" == "debug" ]]; then
+  OPTIMIZATION=(-Onone -g)
+fi
+
+# Step 1: build the SDK .swiftmodule from source. Required because the shipped
+# TypeWhisperPluginSDK.framework inside TypeWhisper.app is binary-only (no
+# Modules/ dir), so swiftc can't `import TypeWhisperPluginSDK` from it.
+echo "--- Compiling SDK .swiftmodule (for import resolution only) ---"
+swiftc "${OPTIMIZATION[@]}" \
+  -module-name TypeWhisperPluginSDK \
+  -target "${ARCH}-apple-macosx${DEPLOYMENT_TARGET}" \
+  -sdk "$SDK_PATH" \
+  -emit-module \
+  -emit-module-path "$SDK_BUILD/TypeWhisperPluginSDK.swiftmodule" \
+  -parse-as-library \
+  "${SDK_SOURCES[@]}"
+
+# Step 2: compile + link the plugin. Use -I for the SDK module interface and
+# -F/-framework to bind link-time symbols against the framework that
+# TypeWhisper.app already has loaded. @executable_path resolves relative to
+# the HOST app's executable — for TypeWhisper.app that's
+# /Applications/TypeWhisper.app/Contents/MacOS/, so ../Frameworks lands us
+# on the correct embedded framework. We add a second fallback rpath for
+# cases where the plugin happens to live inside a host bundle directly.
+echo "--- Compiling plugin + linking against TypeWhisper framework ---"
+swiftc "${OPTIMIZATION[@]}" \
+  -module-name "$PLUGIN_ID" \
+  -target "${ARCH}-apple-macosx${DEPLOYMENT_TARGET}" \
+  -sdk "$SDK_PATH" \
+  -emit-library \
+  -I "$SDK_BUILD" \
+  -F "$FRAMEWORK_DIR" \
+  -framework TypeWhisperPluginSDK \
+  -Xlinker -rpath -Xlinker "@executable_path/../Frameworks" \
+  -Xlinker -rpath -Xlinker "@loader_path/../../../../Frameworks" \
+  -o "$OUT/Contents/MacOS/$PLUGIN_ID" \
+  "${SOURCES[@]}"
+
+# Self-referential install name
+install_name_tool -id "@loader_path/$PLUGIN_ID" "$OUT/Contents/MacOS/$PLUGIN_ID"
+
+# Copy TypeWhisper's manifest (principalClass, version, etc.)
+cp manifest.json "$OUT/Contents/Resources/manifest.json"
+
+# Read version from manifest so Info.plist stays in sync
+VERSION="$(python3 -c "import json; print(json.load(open('manifest.json'))['version'])")"
+BUNDLE_ID="$(python3 -c "import json; print(json.load(open('manifest.json'))['id'])")"
+
+cat > "$OUT/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>${BUNDLE_ID}</string>
+    <key>CFBundleName</key>
+    <string>${PLUGIN_ID}</string>
+    <key>CFBundleExecutable</key>
+    <string>${PLUGIN_ID}</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>NSPrincipalClass</key>
+    <string>${PLUGIN_ID}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>${DEPLOYMENT_TARGET}</string>
+</dict>
+</plist>
+EOF
+
+# Strip Finder-set xattrs that would upset codesign
+find "$OUT" -exec xattr -c {} + 2>/dev/null || true
+
+# Ad-hoc sign — required for Bundle.load() in sandboxed host apps on macOS 13+
+codesign --force --sign - --timestamp=none "$OUT"
+codesign --verify --strict --verbose=2 "$OUT" 2>&1 | sed 's/^/  /'
+
+echo "✓ Built $OUT"
+echo "  Size: $(du -sh "$OUT" | cut -f1)"
+
+# Sanity check the link: confirm we reference the framework install name, not a dylib
+LINK=$(otool -L "$OUT/Contents/MacOS/$PLUGIN_ID" | awk '/TypeWhisperPluginSDK/ {print $1; exit}')
+echo "  Linked against: $LINK"
+if [[ "$LINK" != *"TypeWhisperPluginSDK.framework"* ]]; then
+  echo "  WARNING: linkage looks wrong — should reference TypeWhisperPluginSDK.framework" >&2
+fi
+
+if $INSTALL; then
+  TARGET_DIR="$HOME/Library/Application Support/TypeWhisper/Plugins"
+  mkdir -p "$TARGET_DIR"
+  INSTALLED="$TARGET_DIR/${PLUGIN_ID}.bundle"
+
+  rm -rf "$INSTALLED"
+  cp -R "$OUT" "$INSTALLED"
+
+  echo "✓ Installed to $INSTALLED"
+  echo "  Restart TypeWhisper and enable 'Gemini STT' in Settings → Integrations."
+fi

--- a/Plugins/GeminiSTTPlugin/manifest.json
+++ b/Plugins/GeminiSTTPlugin/manifest.json
@@ -1,0 +1,17 @@
+{
+    "id": "com.typewhisper.gemini-stt",
+    "name": "Gemini STT",
+    "version": "1.0.0",
+    "sdkCompatibilityVersion": "v1",
+    "minHostVersion": "0.9.0",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Speech-to-text via Google Gemini (AI Studio direct). Editable system prompt and glossary for high-accuracy technical dictation. Requires API key.",
+    "descriptions": {
+        "de": "Spracherkennung \u00fcber Google Gemini (AI Studio direkt). Bearbeitbarer System-Prompt und Glossar f\u00fcr pr\u00e4zise technische Diktate. Erfordert API-Key."
+    },
+    "category": "transcription",
+    "iconSystemName": "sparkles",
+    "requiresAPIKey": true,
+    "principalClass": "GeminiSTTPlugin"
+}


### PR DESCRIPTION

## Summary

This adds **Gemini STT**, a `TranscriptionEnginePlugin` that sends audio to Google Gemini (AI Studio, direct — no proxy) **together with an editable system prompt + glossary**, for high-accuracy technical dictation.

> ⚠️ **This PR is a reference implementation — please don't merge it.** I don't have the time to maintain it as a real contribution. I'm opening it only to (a) share the idea and (b) show that it genuinely works. It pairs with #710 (the "audio + personal context" proposal). Treat it as a worked example, not a merge candidate — close it whenever, no hard feelings. 🙂

### What it does
- **Multimodal transcription:** inline audio (FLAC) + a free-text **system prompt** → transcript. It's an LLM that *understands* the audio, not a phoneme-only ASR model.
- **Editable system prompt** (ML-engineer persona + identifier-preservation rules) and **glossary** (merged at request time with the app's existing Dictionary terms via `PluginDictionaryTerms`).
- Defaults to `gemini-3.1-flash-lite` (fastest + most accurate in my tests). `thinkingConfig.thinkingBudget: 0` on every request (critical for Flash-Lite latency). FLAC encode (~50% of WAV), long-lived `URLSession` + connection warm-up, and per-request timing instrumentation.

### Benchmark that motivated it (my own 4-file technical-dictation set)
| Engine | Key-term accuracy | Median latency | Cost/hr |
|---|---|---|---|
| Groq Whisper Large v3 | 60.5 % | 1.4 s | $0.111 |
| **Gemini 3.1 Flash-Lite (this plugin)** | **100 %** | **2.6 s** | **$0.058** |

The win is on the words that actually matter for dev dictation — model names, framework names, CLI flags, identifiers — exactly where generic ASR falls down.

### Why the directory layout differs from the other plugins
The other bundled plugins are Xcode targets with `PluginName.swift` + `manifest.json` directly in the plugin folder. This one **can't be** — it links against the app's embedded `TypeWhisperPluginSDK.framework` at compile time. So it ships as an SPM-style `Sources/` layout plus:
- `build-bundle.sh` — two-step `swiftc` compile → `.bundle` wrap → ad-hoc codesign (no Xcode/pbxproj edits, ~3s rebuilds), and
- `README.md` — explains the build.

This is the same `@rpath`-against-the-host-SDK pattern the existing `STTFixerPlugin` uses. Worth a look even if the layout never lands as-is.

### What's included (source-only)
- `Plugins/GeminiSTTPlugin/Sources/GeminiSTTPlugin/GeminiSTTPlugin.swift`
- `Plugins/GeminiSTTPlugin/manifest.json`
- `Plugins/GeminiSTTPlugin/README.md`
- `Plugins/GeminiSTTPlugin/build-bundle.sh`
- (+ 4 lines added to root `.gitignore` to keep build artifacts out)

Build artifacts (`dist/`, `build/`, `*.profraw`, `.DS_Store`) are gitignored and **not** part of this PR.

### On secrets / privacy
The API key is **user-supplied at runtime** (Keychain via `host.storeSecret`/`loadSecret`, plus a documented UserDefaults shadow-cache for dev UX). Nothing is hardcoded, nothing is logged (timings record only byte/char counts + model id — never the key, transcript, or audio), and audio is sent **directly to Google AI Studio** with no third-party proxy.

## Test Plan
- [x] Built and ran locally — `./build-bundle.sh --install` (Swift 6 command-line tools; `TypeWhisper.app` installed at `/Applications/`)
- [x] Tested the changed functionality manually — Settings → Integrations → **Gemini STT** → paste AI Studio API key → dictate
- [x] No regressions — additive plugin, no changes to core transcription paths
