### PR TITLE
Add Cartesia speech plugin

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -95,6 +95,7 @@ jobs:
             deepgram) TARGET="DeepgramPlugin" ;;
             assemblyai) TARGET="AssemblyAIPlugin" ;;
             smallest-pulse) TARGET="SmallestAIPlugin" ;;
+            cartesia) TARGET="CartesiaPlugin" ;;
             obsidian) TARGET="ObsidianPlugin" ;;
             script) TARGET="ScriptPlugin" ;;
             file-job-script) TARGET="FileJobScriptPlugin" ;;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -5221,7 +5221,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Cartesia;
@@ -5229,6 +5229,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = CartesiaPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 					/usr/lib/swift,
@@ -5241,7 +5242,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
 				);
 				SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
@@ -5257,7 +5258,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Cartesia;
@@ -5265,6 +5266,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = CartesiaPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 					/usr/lib/swift,
@@ -5277,7 +5279,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
+					"$(SRCROOT)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
 				);
 				SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -5219,17 +5219,30 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Cartesia;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPrincipalClass = CartesiaPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					/usr/lib/swift,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.cartesia";
 				PRODUCT_NAME = CartesiaPlugin;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
+				);
 				SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
 			};
@@ -5242,17 +5255,30 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)/PackageFrameworks",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Cartesia;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPrincipalClass = CartesiaPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					/usr/lib/swift,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.cartesia";
 				PRODUCT_NAME = CartesiaPlugin;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TypeWhisperPluginSDK/build/$(CONFIGURATION)",
+				);
 				SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
 			};

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -313,6 +313,9 @@
 		5A1100000000000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 5A1100000000000000000012 /* Localizable.xcstrings */; };
 		5A1100000000000000000004 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5A1100000000000000000030 /* TypeWhisperPluginSDK */; };
 		5A1100000000000000000005 /* smallest.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5A1100000000000000000014 /* smallest.svg */; };
+		CART00000000000000000001 /* CartesiaPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CART00000000000000000010 /* CartesiaPlugin.swift */; };
+		CART00000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = CART00000000000000000011 /* manifest.json */; };
+		CART00000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = CART00000000000000000030 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000207 /* IndicatorPreviewView.swift */; };
 		AA00000000000000000218 /* ObsidianPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000208 /* ObsidianPlugin.swift */; };
 		AA00000000000000000219 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000209 /* manifest.json */; };
@@ -740,6 +743,9 @@
 		5A1100000000000000000012 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		5A1100000000000000000013 /* SmallestAIPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SmallestAIPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A1100000000000000000014 /* smallest.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = smallest.svg; sourceTree = "<group>"; };
+		CART00000000000000000010 /* CartesiaPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartesiaPlugin.swift; sourceTree = "<group>"; };
+		CART00000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		CART00000000000000000012 /* CartesiaPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CartesiaPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000207 /* IndicatorPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorPreviewView.swift; sourceTree = "<group>"; };
 		BB00000000000000000208 /* ObsidianPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000209 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1079,6 +1085,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CART00000000000000000051 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CART00000000000000000003 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000096 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1310,6 +1324,7 @@
 				CC00000000000000000029 /* AssemblyAIPlugin */,
 				RESG00000000000000001 /* Reson8Plugin */,
 				5A1100000000000000000020 /* SmallestAIPlugin */,
+				CART00000000000000000020 /* CartesiaPlugin */,
 				CC00000000000000000030 /* ObsidianPlugin */,
 				CC00000000000000000031 /* ScriptPlugin */,
 				F18A00000000000000000020 /* FillerWordsPlugin */,
@@ -1814,6 +1829,16 @@
 			path = TypeWhisperPluginSDK/Plugins/SmallestAIPlugin;
 			sourceTree = "<group>";
 		};
+		CART00000000000000000020 /* CartesiaPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				CART00000000000000000010 /* CartesiaPlugin.swift */,
+				CART00000000000000000011 /* manifest.json */,
+			);
+			name = CartesiaPlugin;
+			path = TypeWhisperPluginSDK/Plugins/CartesiaPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000030 /* ObsidianPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2085,6 +2110,7 @@
 				BB00000000000000000199 /* DeepgramPlugin.bundle */,
 				BB00000000000000000203 /* AssemblyAIPlugin.bundle */,
 				5A1100000000000000000013 /* SmallestAIPlugin.bundle */,
+				CART00000000000000000012 /* CartesiaPlugin.bundle */,
 				BB00000000000000000211 /* ObsidianPlugin.bundle */,
 				BB00000000000000000215 /* ScriptPlugin.bundle */,
 				F18A00000000000000000012 /* FillerWordsPlugin.bundle */,
@@ -2568,6 +2594,26 @@
 			);
 			productName = SmallestAIPlugin;
 			productReference = 5A1100000000000000000013 /* SmallestAIPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		CART00000000000000000040 /* CartesiaPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CART00000000000000000062 /* Build configuration list for PBXNativeTarget "CartesiaPlugin" */;
+			buildPhases = (
+				CART00000000000000000050 /* Sources */,
+				CART00000000000000000051 /* Frameworks */,
+				CART00000000000000000052 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CartesiaPlugin;
+			packageProductDependencies = (
+				CART00000000000000000030 /* TypeWhisperPluginSDK */,
+			);
+			productName = CartesiaPlugin;
+			productReference = CART00000000000000000012 /* CartesiaPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		DD00000000000000000018 /* ObsidianPlugin */ = {
@@ -3102,6 +3148,7 @@
 				DD00000000000000000016 /* DeepgramPlugin */,
 				DD00000000000000000017 /* AssemblyAIPlugin */,
 				5A1100000000000000000040 /* SmallestAIPlugin */,
+				CART00000000000000000040 /* CartesiaPlugin */,
 				DD00000000000000000018 /* ObsidianPlugin */,
 				DD00000000000000000019 /* ScriptPlugin */,
 				F18A00000000000000000030 /* FillerWordsPlugin */,
@@ -3298,6 +3345,14 @@
 				5A1100000000000000000002 /* manifest.json in Resources */,
 				5A1100000000000000000003 /* Localizable.xcstrings in Resources */,
 				5A1100000000000000000005 /* smallest.svg in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CART00000000000000000052 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CART00000000000000000002 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3903,6 +3958,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				5A1100000000000000000001 /* SmallestAIPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CART00000000000000000050 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CART00000000000000000001 /* CartesiaPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5142,6 +5205,52 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.smallest-pulse";
 				PRODUCT_NAME = SmallestAIPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		CART00000000000000000060 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Cartesia;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = CartesiaPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.cartesia";
+				PRODUCT_NAME = CartesiaPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		CART00000000000000000061 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Cartesia;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = CartesiaPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.cartesia";
+				PRODUCT_NAME = CartesiaPlugin;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
@@ -6407,6 +6516,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		CART00000000000000000062 /* Build configuration list for PBXNativeTarget "CartesiaPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CART00000000000000000060 /* Debug */,
+				CART00000000000000000061 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000098 /* Build configuration list for PBXNativeTarget "ObsidianPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6783,6 +6901,11 @@
 		};
 		5A1100000000000000000030 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		CART00000000000000000030 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = RR00000000000000000005 /* XCLocalSwiftPackageReference "TypeWhisperPluginSDK" */;
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000025 /* TypeWhisperPluginSDK */ = {

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1122,6 +1122,7 @@ struct PluginSettingsView: View {
 
 private let typeWhisperAddonSlugsByPluginID: [String: String] = [
     "com.typewhisper.assemblyai": "assemblyai",
+    "com.typewhisper.cartesia": "cartesia",
     "com.typewhisper.cerebras": "cerebras",
     "com.typewhisper.claude": "claude",
     "com.typewhisper.cloudflare-asr": "cloudflare-asr",

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -252,6 +252,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "CartesiaPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/CartesiaPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "WebhookPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/WebhookPlugin",
@@ -467,6 +476,15 @@ let package = Package(
                 "SmallestAIPlugin",
             ],
             path: "Plugins/SmallestAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "CartesiaPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "CartesiaPlugin",
+            ],
+            path: "Plugins/CartesiaPlugin/Tests"
         ),
         .testTarget(
             name: "WebhookPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -1,0 +1,933 @@
+import AVFoundation
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+import os
+
+private enum CartesiaDefaultsKey {
+    static let apiKey = "api-key"
+    static let selectedVoice = "selectedVoice"
+    static let customVoiceId = "customVoiceId"
+    static let fetchedVoices = "fetchedVoices"
+}
+
+private enum CartesiaPluginError: LocalizedError {
+    case invalidURL(String)
+    case apiError(String)
+    case playbackUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL(let url):
+            "Invalid URL: \(url)"
+        case .apiError(let message):
+            "API error: \(message)"
+        case .playbackUnavailable(let message):
+            "Playback unavailable: \(message)"
+        }
+    }
+}
+
+enum CartesiaAPIKeyValidationResult: Equatable {
+    case valid
+    case invalidKey
+    case transientError
+}
+
+struct CartesiaFetchedVoice: Codable, Sendable, Hashable {
+    let id: String
+    let name: String?
+    let language: String?
+    let country: String?
+
+    var displayName: String {
+        let trimmedName = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedName.isEmpty ? id : trimmedName
+    }
+
+    var localeIdentifier: String? {
+        guard let language = language?.trimmingCharacters(in: .whitespacesAndNewlines), !language.isEmpty else {
+            return nil
+        }
+        let country = country?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let country, !country.isEmpty else { return language }
+        return "\(language)-\(country)"
+    }
+}
+
+protocol CartesiaTTSAudioPlayback: AnyObject, Sendable {
+    var onDrained: (@Sendable () -> Void)? { get set }
+    func start(sampleRate: Int) throws
+    func appendPCM16(_ data: Data) throws
+    func finishInput()
+    func stop()
+}
+
+final class CartesiaTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    private struct State {
+        var isActive = true
+        var onFinish: (@Sendable () -> Void)?
+    }
+
+    private let audioPlayback: CartesiaTTSAudioPlayback
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(audioPlayback: CartesiaTTSAudioPlayback) {
+        self.audioPlayback = audioPlayback
+        audioPlayback.onDrained = { [weak self] in
+            self?.finish()
+        }
+    }
+
+    var isActive: Bool {
+        state.withLock { $0.isActive }
+    }
+
+    var onFinish: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onFinish } }
+        set {
+            let shouldNotify = state.withLock { state in
+                state.onFinish = newValue
+                return !state.isActive
+            }
+            if shouldNotify {
+                newValue?()
+            }
+        }
+    }
+
+    func stop() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        audioPlayback.stop()
+        callback?()
+    }
+
+    func finish() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        callback?()
+    }
+}
+
+private final class CartesiaAVAudioPlayback: CartesiaTTSAudioPlayback, @unchecked Sendable {
+    private struct State {
+        var onDrained: (@Sendable () -> Void)?
+        var pendingBuffers = 0
+        var inputFinished = false
+        var stopped = false
+    }
+
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private var format: AVAudioFormat?
+
+    var onDrained: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onDrained } }
+        set { state.withLock { $0.onDrained = newValue } }
+    }
+
+    func start(sampleRate: Int) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw CartesiaPluginError.playbackUnavailable("Could not create audio format")
+        }
+        self.format = format
+
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+        try engine.start()
+        player.play()
+    }
+
+    func appendPCM16(_ data: Data) throws {
+        guard !state.withLock({ $0.stopped }) else { return }
+        guard let format else {
+            throw CartesiaPluginError.playbackUnavailable("Audio playback was not started")
+        }
+
+        let frameCount = data.count / MemoryLayout<Int16>.size
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(frameCount)
+              ),
+              let channel = buffer.floatChannelData?[0] else {
+            return
+        }
+
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        data.withUnsafeBytes { rawBuffer in
+            let int16Buffer = rawBuffer.bindMemory(to: Int16.self)
+            for index in 0..<frameCount {
+                channel[index] = Float(Int16(littleEndian: int16Buffer[index])) / Float(Int16.max)
+            }
+        }
+
+        state.withLock { $0.pendingBuffers += 1 }
+        player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+            self?.markBufferPlayed()
+        }
+        if !player.isPlaying {
+            player.play()
+        }
+    }
+
+    func finishInput() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            state.inputFinished = true
+            return state.pendingBuffers == 0 && !state.stopped ? state.onDrained : nil
+        }
+        callback?()
+    }
+
+    func stop() {
+        state.withLock { $0.stopped = true }
+        player.stop()
+        engine.stop()
+        engine.detach(player)
+    }
+
+    private func markBufferPlayed() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            state.pendingBuffers = max(0, state.pendingBuffers - 1)
+            guard state.inputFinished, state.pendingBuffers == 0, !state.stopped else { return nil }
+            return state.onDrained
+        }
+        callback?()
+    }
+}
+
+@objc(CartesiaPlugin)
+final class CartesiaPlugin: NSObject,
+    TranscriptionEnginePlugin,
+    TTSProviderPlugin,
+    PluginAuthRoleStatusProviding,
+    @unchecked Sendable
+{
+    static let pluginId = "com.typewhisper.cartesia"
+    static let pluginName = "Cartesia"
+
+    static let apiBaseURL = "https://api.cartesia.ai"
+    static let apiVersion = "2026-03-01"
+    static let sttModelId = "ink-whisper"
+    static let ttsModelId = "sonic-3.5"
+    static let ttsSampleRate = 44_100
+    static let defaultVoiceId = "6ccbfb76-1fc6-48f7-b71d-91ac6298247b"
+    static let fallbackVoices = [
+        PluginVoiceInfo(id: defaultVoiceId, displayName: "Default Voice", localeIdentifier: "en")
+    ]
+
+    static let sttSupportedLanguages = [
+        "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo",
+        "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es",
+        "et", "eu", "fa", "fi", "fo", "fr", "gl", "gu", "ha", "haw",
+        "he", "hi", "hr", "ht", "hu", "hy", "id", "is", "it", "ja",
+        "jw", "ka", "kk", "km", "kn", "ko", "la", "lb", "lo", "lt",
+        "lv", "mg", "mi", "mk", "ml", "mn", "mr", "ms", "mt", "my",
+        "ne", "nl", "nn", "no", "oc", "pa", "pl", "ps", "pt", "ro",
+        "ru", "sa", "sd", "si", "sk", "sl", "sn", "so", "sq", "sr",
+        "su", "sv", "sw", "ta", "te", "tg", "th", "tk", "tl", "tr",
+        "tt", "uk", "ur", "uz", "vi", "yi", "yo", "yue", "zh",
+    ]
+
+    static let ttsSupportedLanguages = [
+        "ar", "bg", "bn", "cs", "da", "de", "el", "en", "es", "fi",
+        "fr", "gu", "he", "hi", "hr", "hu", "id", "it", "ja", "ka",
+        "kn", "ko", "ml", "mr", "ms", "nl", "no", "pa", "pl", "pt",
+        "ro", "ru", "sk", "sv", "ta", "te", "th", "tl", "tr", "uk",
+        "vi", "zh",
+    ]
+
+    private let logger = Logger(subsystem: "com.typewhisper.cartesia", category: "Plugin")
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedVoiceId: String?
+    fileprivate var _customVoiceId = ""
+    fileprivate var _fetchedVoices: [CartesiaFetchedVoice] = []
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: CartesiaDefaultsKey.apiKey)
+        _selectedVoiceId = host.userDefault(forKey: CartesiaDefaultsKey.selectedVoice) as? String
+            ?? Self.defaultVoiceId
+        _customVoiceId = host.userDefault(forKey: CartesiaDefaultsKey.customVoiceId) as? String ?? ""
+        if let data = host.userDefault(forKey: CartesiaDefaultsKey.fetchedVoices) as? Data,
+           let voices = try? JSONDecoder().decode([CartesiaFetchedVoice].self, from: data) {
+            _fetchedVoices = voices
+        }
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        switch role {
+        case .transcription, .tts:
+            guard normalizedAPIKey != nil else {
+                return .unavailable(
+                    reason: "Cartesia requires a Cartesia API key.",
+                    requiredCredentialLabel: "Cartesia API key"
+                )
+            }
+            return .available
+        case .llm:
+            return .unavailable(
+                reason: "Cartesia does not provide a TypeWhisper prompt processor.",
+                requiredCredentialLabel: nil
+            )
+        }
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "cartesia" }
+    var providerDisplayName: String { "Cartesia" }
+
+    var isConfigured: Bool {
+        normalizedAPIKey != nil
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: Self.sttModelId, displayName: "Ink Whisper"),
+        ]
+    }
+
+    var selectedModelId: String? { Self.sttModelId }
+
+    func selectModel(_ modelId: String) {}
+
+    var supportsTranslation: Bool { false }
+    var supportedLanguages: [String] { Self.sttSupportedLanguages }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("Cartesia does not support Whisper Translate.")
+        }
+        guard let apiKey = normalizedAPIKey else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let resolvedLanguage = Self.resolvedLanguage(
+            language,
+            supportedLanguages: Self.sttSupportedLanguages
+        )
+        let request = try Self.makeTranscriptionRequest(
+            wavData: audio.wavData,
+            apiKey: apiKey,
+            modelId: Self.sttModelId,
+            language: resolvedLanguage
+        )
+
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        try Self.validateHTTPResponse(data: data, response: response)
+        return try Self.parseTranscriptionResponse(data, fallbackLanguage: resolvedLanguage)
+    }
+
+    // MARK: - TTSProviderPlugin
+
+    var availableVoices: [PluginVoiceInfo] {
+        if !_fetchedVoices.isEmpty {
+            return _fetchedVoices.map {
+                PluginVoiceInfo(id: $0.id, displayName: $0.displayName, localeIdentifier: $0.localeIdentifier)
+            }
+        }
+        return Self.fallbackVoices
+    }
+
+    var selectedVoiceId: String? {
+        let custom = _customVoiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !custom.isEmpty {
+            return custom
+        }
+        return _selectedVoiceId ?? Self.defaultVoiceId
+    }
+
+    var settingsSummary: String? {
+        let voice = availableVoices.first { $0.id == selectedVoiceId }?.displayName
+            ?? selectedVoiceId
+            ?? "Default Voice"
+        return "Voice: \(voice); Cartesia"
+    }
+
+    func selectVoice(_ voiceId: String?) {
+        _selectedVoiceId = voiceId ?? Self.defaultVoiceId
+        _customVoiceId = ""
+        host?.setUserDefault(_selectedVoiceId, forKey: CartesiaDefaultsKey.selectedVoice)
+        host?.setUserDefault("", forKey: CartesiaDefaultsKey.customVoiceId)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        guard let apiKey = normalizedAPIKey else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        let text = request.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw CartesiaPluginError.apiError("TTS text is empty.")
+        }
+
+        let language = Self.resolvedLanguage(
+            request.language,
+            supportedLanguages: Self.ttsSupportedLanguages
+        ) ?? Self.resolvedLanguage(
+            availableVoices.first { $0.id == selectedVoiceId }?.localeIdentifier,
+            supportedLanguages: Self.ttsSupportedLanguages
+        )
+
+        let urlRequest = try Self.makeTTSRequest(
+            apiKey: apiKey,
+            text: text,
+            voiceId: selectedVoiceId ?? Self.defaultVoiceId,
+            language: language,
+            modelId: Self.ttsModelId
+        )
+
+        let (data, response) = try await PluginHTTPClient.data(for: urlRequest)
+        try Self.validateHTTPResponse(data: data, response: response)
+
+        let playback = CartesiaAVAudioPlayback()
+        do {
+            try playback.start(sampleRate: Self.ttsSampleRate)
+            let session = CartesiaTTSPlaybackSession(audioPlayback: playback)
+            try playback.appendPCM16(data)
+            playback.finishInput()
+            return session
+        } catch {
+            playback.stop()
+            throw error
+        }
+    }
+
+    var settingsView: AnyView? {
+        AnyView(CartesiaSettingsView(plugin: self))
+    }
+
+    // MARK: - Settings Support
+
+    fileprivate var apiKeyForSettings: String? { _apiKey }
+
+    fileprivate func setApiKey(_ key: String) throws {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let host else {
+            throw CartesiaPluginError.apiError("Cartesia is not connected to TypeWhisper.")
+        }
+        try host.storeSecret(key: CartesiaDefaultsKey.apiKey, value: trimmed)
+        _apiKey = trimmed
+        host.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func removeApiKey() throws {
+        guard let host else {
+            throw CartesiaPluginError.apiError("Cartesia is not connected to TypeWhisper.")
+        }
+        try host.storeSecret(key: CartesiaDefaultsKey.apiKey, value: "")
+        _apiKey = nil
+        host.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func setCustomVoiceId(_ voiceId: String) {
+        _customVoiceId = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        host?.setUserDefault(_customVoiceId, forKey: CartesiaDefaultsKey.customVoiceId)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func validateApiKey(_ key: String) async -> CartesiaAPIKeyValidationResult {
+        guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .invalidKey
+        }
+
+        do {
+            let request = try Self.makeListVoicesRequest(apiKey: key, limit: 1)
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            return Self.apiKeyValidationResult(data: data, response: response)
+        } catch {
+            return .transientError
+        }
+    }
+
+    fileprivate func refreshVoices() async -> [CartesiaFetchedVoice] {
+        guard let apiKey = normalizedAPIKey else { return [] }
+        do {
+            let request = try Self.makeListVoicesRequest(apiKey: apiKey, limit: 100)
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            try Self.validateHTTPResponse(data: data, response: response)
+            let voices = try Self.parseVoicesResponse(data)
+            setFetchedVoices(voices)
+            return voices
+        } catch {
+            logger.error("Failed to fetch Cartesia voices: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    fileprivate func setFetchedVoices(_ voices: [CartesiaFetchedVoice]) {
+        _fetchedVoices = voices
+        if let data = try? JSONEncoder().encode(voices) {
+            host?.setUserDefault(data, forKey: CartesiaDefaultsKey.fetchedVoices)
+        }
+        if selectedVoiceId == nil, let firstVoice = voices.first {
+            _selectedVoiceId = firstVoice.id
+            host?.setUserDefault(firstVoice.id, forKey: CartesiaDefaultsKey.selectedVoice)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    private var normalizedAPIKey: String? {
+        let trimmed = (_apiKey ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+extension CartesiaPlugin {
+    static func resolvedLanguage(_ language: String?, supportedLanguages: [String]) -> String? {
+        guard let language else { return nil }
+        let normalized = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+        guard !normalized.isEmpty else { return nil }
+
+        let primary = normalized.split(separator: "-").first.map(String.init) ?? normalized
+        return supportedLanguages.contains(primary) ? primary : nil
+    }
+
+    static func makeTranscriptionRequest(
+        wavData: Data,
+        apiKey: String,
+        modelId: String,
+        language: String?
+    ) throws -> URLRequest {
+        guard let url = URL(string: "\(apiBaseURL)/stt") else {
+            throw CartesiaPluginError.invalidURL("\(apiBaseURL)/stt")
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(apiVersion, forHTTPHeaderField: "Cartesia-Version")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 600
+
+        var body = Data()
+        body.appendMultipartFile(
+            boundary: boundary,
+            name: "file",
+            filename: "audio.wav",
+            contentType: "audio/wav",
+            data: wavData
+        )
+        body.appendMultipartField(boundary: boundary, name: "model", value: modelId)
+        if let language, !language.isEmpty {
+            body.appendMultipartField(boundary: boundary, name: "language", value: language)
+        }
+        body.appendMultipartField(boundary: boundary, name: "timestamp_granularities[]", value: "word")
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+        return request
+    }
+
+    static func makeTTSRequest(
+        apiKey: String,
+        text: String,
+        voiceId: String,
+        language: String?,
+        modelId: String
+    ) throws -> URLRequest {
+        guard let url = URL(string: "\(apiBaseURL)/tts/bytes") else {
+            throw CartesiaPluginError.invalidURL("\(apiBaseURL)/tts/bytes")
+        }
+
+        var body: [String: Any] = [
+            "model_id": modelId,
+            "transcript": text,
+            "voice": [
+                "mode": "id",
+                "id": voiceId,
+            ],
+            "output_format": [
+                "container": "raw",
+                "encoding": "pcm_s16le",
+                "sample_rate": ttsSampleRate,
+            ],
+        ]
+        if let language, !language.isEmpty {
+            body["language"] = language
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(apiVersion, forHTTPHeaderField: "Cartesia-Version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func makeListVoicesRequest(apiKey: String, limit: Int) throws -> URLRequest {
+        var components = URLComponents(string: "\(apiBaseURL)/voices")
+        components?.queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        guard let url = components?.url else {
+            throw CartesiaPluginError.invalidURL("\(apiBaseURL)/voices")
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(apiVersion, forHTTPHeaderField: "Cartesia-Version")
+        request.timeoutInterval = 15
+        return request
+    }
+
+    static func validateHTTPResponse(data: Data, response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return
+        case 401, 403:
+            throw PluginTranscriptionError.invalidApiKey
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        default:
+            throw PluginTranscriptionError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+        }
+    }
+
+    static func apiKeyValidationResult(data: Data, response: URLResponse) -> CartesiaAPIKeyValidationResult {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return .transientError
+        }
+        switch httpResponse.statusCode {
+        case 200:
+            return .valid
+        case 401, 403:
+            return .invalidKey
+        default:
+            return .transientError
+        }
+    }
+
+    static func parseTranscriptionResponse(_ data: Data, fallbackLanguage: String?) throws -> PluginTranscriptionResult {
+        let response: TranscriptionResponse
+        do {
+            response = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+        } catch {
+            throw PluginTranscriptionError.apiError("Failed to parse Cartesia transcription response: \(error.localizedDescription)")
+        }
+
+        let text = response.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw PluginTranscriptionError.apiError("Cartesia response did not include transcription text.")
+        }
+
+        let segments = (response.words ?? []).map {
+            PluginTranscriptionSegment(text: $0.word, start: $0.start, end: $0.end)
+        }
+        return PluginTranscriptionResult(
+            text: text,
+            detectedLanguage: response.language ?? fallbackLanguage,
+            segments: segments
+        )
+    }
+
+    static func parseVoicesResponse(_ data: Data) throws -> [CartesiaFetchedVoice] {
+        do {
+            let response = try JSONDecoder().decode(VoicesResponse.self, from: data)
+            return response.data.sorted {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+        } catch {
+            throw CartesiaPluginError.apiError("Failed to parse Cartesia voices response: \(error.localizedDescription)")
+        }
+    }
+
+    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let message = json["message"] as? String {
+                return message
+            }
+            if let error = json["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                return message
+            }
+        }
+        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
+            return "HTTP \(statusCode): \(body)"
+        }
+        return "HTTP \(statusCode)"
+    }
+
+    struct TranscriptionResponse: Decodable {
+        let text: String
+        let language: String?
+        let words: [TranscriptionWord]?
+    }
+
+    struct TranscriptionWord: Decodable {
+        let word: String
+        let start: Double
+        let end: Double
+    }
+
+    struct VoicesResponse: Decodable {
+        let data: [CartesiaFetchedVoice]
+    }
+}
+
+private struct CartesiaSettingsView: View {
+    let plugin: CartesiaPlugin
+
+    @State private var apiKeyInput = ""
+    @State private var showApiKey = false
+    @State private var isValidating = false
+    @State private var isRefreshingVoices = false
+    @State private var validationResult: CartesiaAPIKeyValidationResult?
+    @State private var settingsErrorMessage: String?
+    @State private var voiceOptions: [PluginVoiceInfo] = []
+    @State private var selectedVoiceId = ""
+    @State private var customVoiceId = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key")
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isConfigured {
+                        Button("Remove") {
+                            removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button("Save") {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                validationFeedbackView
+            }
+
+            if plugin.isConfigured {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Text-to-Speech Voice")
+                            .font(.headline)
+                        Spacer()
+                        Button("Refresh") {
+                            refreshVoices()
+                        }
+                        .controlSize(.small)
+                        .disabled(isRefreshingVoices)
+                    }
+
+                    Picker("Text-to-Speech Voice", selection: $selectedVoiceId) {
+                        ForEach(voiceOptions, id: \.id) { voice in
+                            Text(voice.displayName).tag(voice.id)
+                        }
+                    }
+                    .onChange(of: selectedVoiceId) {
+                        plugin.selectVoice(selectedVoiceId)
+                        customVoiceId = ""
+                    }
+
+                    HStack(spacing: 8) {
+                        TextField("Custom Voice ID", text: $customVoiceId)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                        Button("Use") {
+                            plugin.setCustomVoiceId(customVoiceId)
+                            selectedVoiceId = plugin.selectedVoiceId ?? CartesiaPlugin.defaultVoiceId
+                        }
+                        .controlSize(.small)
+                        .disabled(customVoiceId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            apiKeyInput = plugin.apiKeyForSettings ?? ""
+            refreshLocalVoiceState()
+        }
+    }
+
+    @ViewBuilder
+    private var validationFeedbackView: some View {
+        if isValidating {
+            HStack(spacing: 4) {
+                ProgressView().controlSize(.small)
+                Text("Validating...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } else if let settingsErrorMessage {
+            HStack(spacing: 4) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                Text(settingsErrorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        } else if let validationResult {
+            let feedback = validationFeedback(for: validationResult)
+            HStack(spacing: 4) {
+                Image(systemName: feedback.systemName)
+                    .foregroundStyle(feedback.color)
+                Text(feedback.message)
+                    .font(.caption)
+                    .foregroundStyle(feedback.color)
+            }
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        isValidating = true
+        validationResult = nil
+        settingsErrorMessage = nil
+
+        Task {
+            let result = await plugin.validateApiKey(trimmed)
+            await MainActor.run {
+                isValidating = false
+                validationResult = result
+                guard result == .valid else { return }
+                do {
+                    try plugin.setApiKey(trimmed)
+                    refreshLocalVoiceState()
+                } catch {
+                    validationResult = nil
+                    settingsErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func removeApiKey() {
+        do {
+            try plugin.removeApiKey()
+            apiKeyInput = ""
+            validationResult = nil
+            settingsErrorMessage = nil
+            refreshLocalVoiceState()
+        } catch {
+            settingsErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshVoices() {
+        isRefreshingVoices = true
+        Task {
+            _ = await plugin.refreshVoices()
+            await MainActor.run {
+                isRefreshingVoices = false
+                refreshLocalVoiceState()
+            }
+        }
+    }
+
+    private func refreshLocalVoiceState() {
+        voiceOptions = plugin.availableVoices
+        selectedVoiceId = plugin.selectedVoiceId ?? CartesiaPlugin.defaultVoiceId
+        customVoiceId = plugin._customVoiceId
+    }
+
+    private func validationFeedback(
+        for result: CartesiaAPIKeyValidationResult
+    ) -> (systemName: String, message: String, color: Color) {
+        switch result {
+        case .valid:
+            return ("checkmark.circle.fill", "Valid API Key", .green)
+        case .invalidKey:
+            return ("xmark.circle.fill", "Invalid API Key", .red)
+        case .transientError:
+            return (
+                "exclamationmark.triangle.fill",
+                "Could not validate API Key. Check your connection and try again.",
+                .orange
+            )
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendMultipartField(boundary: String, name: String, value: String) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        append(value.data(using: .utf8)!)
+        append("\r\n".data(using: .utf8)!)
+    }
+
+    mutating func appendMultipartFile(
+        boundary: String,
+        name: String,
+        filename: String,
+        contentType: String,
+        data: Data
+    ) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+        append("Content-Type: \(contentType)\r\n\r\n".data(using: .utf8)!)
+        append(data)
+        append("\r\n".data(using: .utf8)!)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -212,6 +212,7 @@ private final class CartesiaAVAudioPlayback: CartesiaTTSAudioPlayback, @unchecke
 @objc(CartesiaPlugin)
 final class CartesiaPlugin: NSObject,
     TranscriptionEnginePlugin,
+    LanguageHintTranscriptionEnginePlugin,
     TTSProviderPlugin,
     PluginAuthRoleStatusProviding,
     @unchecked Sendable
@@ -222,6 +223,7 @@ final class CartesiaPlugin: NSObject,
     static let apiBaseURL = "https://api.cartesia.ai"
     static let apiVersion = "2026-03-01"
     static let sttModelId = "ink-whisper"
+    static let defaultSTTLanguage = "ru"
     static let ttsModelId = "sonic-3.5"
     static let ttsSampleRate = 44_100
     static let defaultVoiceId = "6ccbfb76-1fc6-48f7-b71d-91ac6298247b"
@@ -323,6 +325,37 @@ final class CartesiaPlugin: NSObject,
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            language: language,
+            languageHints: [],
+            translate: translate,
+            prompt: prompt
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            language: languageSelection.requestedLanguage,
+            languageHints: languageSelection.languageHints,
+            translate: translate,
+            prompt: prompt
+        )
+    }
+
+    private func transcribe(
+        audio: AudioData,
+        language: String?,
+        languageHints: [String],
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
         guard !translate else {
             throw PluginTranscriptionError.apiError("Cartesia does not support Whisper Translate.")
         }
@@ -330,9 +363,9 @@ final class CartesiaPlugin: NSObject,
             throw PluginTranscriptionError.notConfigured
         }
 
-        let resolvedLanguage = Self.resolvedLanguage(
-            language,
-            supportedLanguages: Self.sttSupportedLanguages
+        let resolvedLanguage = Self.resolvedTranscriptionLanguage(
+            requestedLanguage: language,
+            languageHints: languageHints
         )
         let request = try Self.makeTranscriptionRequest(
             wavData: audio.wavData,
@@ -502,6 +535,18 @@ final class CartesiaPlugin: NSObject,
 }
 
 extension CartesiaPlugin {
+    static func resolvedTranscriptionLanguage(requestedLanguage: String?, languageHints: [String]) -> String {
+        if let requested = resolvedLanguage(requestedLanguage, supportedLanguages: sttSupportedLanguages) {
+            return requested
+        }
+        for hint in languageHints {
+            if let resolved = resolvedLanguage(hint, supportedLanguages: sttSupportedLanguages) {
+                return resolved
+            }
+        }
+        return defaultSTTLanguage
+    }
+
     static func resolvedLanguage(_ language: String?, supportedLanguages: [String]) -> String? {
         guard let language else { return nil }
         let normalized = language

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -223,7 +223,7 @@ final class CartesiaPlugin: NSObject,
     static let apiBaseURL = "https://api.cartesia.ai"
     static let apiVersion = "2026-03-01"
     static let sttModelId = "ink-whisper"
-    static let defaultSTTLanguage = "ru"
+    static let translationLanguage = "en"
     static let ttsModelId = "sonic-3.5"
     static let ttsSampleRate = 44_100
     static let defaultVoiceId = "6ccbfb76-1fc6-48f7-b71d-91ac6298247b"
@@ -316,7 +316,7 @@ final class CartesiaPlugin: NSObject,
 
     func selectModel(_ modelId: String) {}
 
-    var supportsTranslation: Bool { false }
+    var supportsTranslation: Bool { true }
     var supportedLanguages: [String] { Self.sttSupportedLanguages }
 
     func transcribe(
@@ -356,16 +356,14 @@ final class CartesiaPlugin: NSObject,
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        guard !translate else {
-            throw PluginTranscriptionError.apiError("Cartesia does not support Whisper Translate.")
-        }
         guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
         let resolvedLanguage = Self.resolvedTranscriptionLanguage(
             requestedLanguage: language,
-            languageHints: languageHints
+            languageHints: languageHints,
+            translate: translate
         )
         let request = try Self.makeTranscriptionRequest(
             wavData: audio.wavData,
@@ -376,7 +374,10 @@ final class CartesiaPlugin: NSObject,
 
         let (data, response) = try await PluginHTTPClient.data(for: request)
         try Self.validateHTTPResponse(data: data, response: response)
-        return try Self.parseTranscriptionResponse(data, fallbackLanguage: resolvedLanguage)
+        return try Self.parseTranscriptionResponse(
+            data,
+            fallbackLanguage: translate ? Self.translationLanguage : resolvedLanguage
+        )
     }
 
     // MARK: - TTSProviderPlugin
@@ -535,7 +536,14 @@ final class CartesiaPlugin: NSObject,
 }
 
 extension CartesiaPlugin {
-    static func resolvedTranscriptionLanguage(requestedLanguage: String?, languageHints: [String]) -> String {
+    static func resolvedTranscriptionLanguage(
+        requestedLanguage: String?,
+        languageHints: [String],
+        translate: Bool = false,
+        preferredLanguages: [String] = Locale.preferredLanguages
+    ) -> String? {
+        guard !translate else { return nil }
+
         if let requested = resolvedLanguage(requestedLanguage, supportedLanguages: sttSupportedLanguages) {
             return requested
         }
@@ -544,7 +552,20 @@ extension CartesiaPlugin {
                 return resolved
             }
         }
-        return defaultSTTLanguage
+
+        // Cartesia documents the batch STT language default as "en". For normal
+        // transcription, send a concrete source language so the empty-language
+        // path is reserved for the explicit "Translate to English" task.
+        return preferredTranscriptionLanguage(preferredLanguages: preferredLanguages) ?? Self.translationLanguage
+    }
+
+    static func preferredTranscriptionLanguage(preferredLanguages: [String]) -> String? {
+        for language in preferredLanguages {
+            if let resolved = resolvedLanguage(language, supportedLanguages: sttSupportedLanguages) {
+                return resolved
+            }
+        }
+        return nil
     }
 
     static func resolvedLanguage(_ language: String?, supportedLanguages: [String]) -> String? {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -385,18 +385,16 @@ final class CartesiaPlugin: NSObject,
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        guard !translate || _englishTranslationEnabled else {
-            throw PluginTranscriptionError.apiError("Enable Cartesia Translate to English in plugin settings before using this task.")
-        }
         guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
+        let shouldTranslate = _englishTranslationEnabled
         let resolvedLanguage = Self.resolvedTranscriptionLanguage(
             requestedLanguage: language,
             languageHints: languageHints,
             configuredLanguage: _transcriptionLanguage,
-            translate: translate
+            translate: shouldTranslate
         )
         let request = try Self.makeTranscriptionRequest(
             wavData: audio.wavData,
@@ -409,7 +407,7 @@ final class CartesiaPlugin: NSObject,
         try Self.validateHTTPResponse(data: data, response: response)
         return try Self.parseTranscriptionResponse(
             data,
-            fallbackLanguage: translate ? Self.translationLanguage : resolvedLanguage
+            fallbackLanguage: shouldTranslate ? Self.translationLanguage : resolvedLanguage
         )
     }
 
@@ -887,6 +885,7 @@ private struct CartesiaSettingsView: View {
                             Text(language.displayName).tag(language.code)
                         }
                     }
+                    .disabled(englishTranslationEnabled)
                     .onChange(of: transcriptionLanguage) {
                         plugin.selectTranscriptionLanguage(transcriptionLanguage)
                     }
@@ -896,7 +895,9 @@ private struct CartesiaSettingsView: View {
                             plugin.setEnglishTranslationEnabled(englishTranslationEnabled)
                         }
 
-                    Text("Cartesia batch speech recognition requires a source language. English translation is off by default.")
+                    Text(englishTranslationEnabled
+                         ? "Translation mode ignores the spoken language picker and asks Cartesia for English output."
+                         : "Spoken Language is the source audio language. Choose English only when the audio itself is English.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -6,6 +6,8 @@ import os
 
 private enum CartesiaDefaultsKey {
     static let apiKey = "api-key"
+    static let transcriptionLanguage = "transcriptionLanguage"
+    static let englishTranslationEnabled = "englishTranslationEnabled"
     static let selectedVoice = "selectedVoice"
     static let customVoiceId = "customVoiceId"
     static let fetchedVoices = "fetchedVoices"
@@ -53,6 +55,13 @@ struct CartesiaFetchedVoice: Codable, Sendable, Hashable {
         guard let country, !country.isEmpty else { return language }
         return "\(language)-\(country)"
     }
+}
+
+struct CartesiaLanguageOption: Sendable, Hashable, Identifiable {
+    let code: String
+    let displayName: String
+
+    var id: String { code }
 }
 
 protocol CartesiaTTSAudioPlayback: AnyObject, Sendable {
@@ -223,6 +232,7 @@ final class CartesiaPlugin: NSObject,
     static let apiBaseURL = "https://api.cartesia.ai"
     static let apiVersion = "2026-03-01"
     static let sttModelId = "ink-whisper"
+    static let defaultTranscriptionLanguage = "ru"
     static let translationLanguage = "en"
     static let ttsModelId = "sonic-3.5"
     static let ttsSampleRate = 44_100
@@ -252,9 +262,23 @@ final class CartesiaPlugin: NSObject,
         "vi", "zh",
     ]
 
+    static var sttLanguageOptions: [CartesiaLanguageOption] {
+        sttSupportedLanguages
+            .map { CartesiaLanguageOption(code: $0, displayName: displayName(forLanguageCode: $0)) }
+            .sorted { lhs, rhs in
+                if lhs.code == defaultTranscriptionLanguage { return true }
+                if rhs.code == defaultTranscriptionLanguage { return false }
+                if lhs.code == translationLanguage { return true }
+                if rhs.code == translationLanguage { return false }
+                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            }
+    }
+
     private let logger = Logger(subsystem: "com.typewhisper.cartesia", category: "Plugin")
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
+    fileprivate var _transcriptionLanguage = CartesiaPlugin.defaultTranscriptionLanguage
+    fileprivate var _englishTranslationEnabled = false
     fileprivate var _selectedVoiceId: String?
     fileprivate var _customVoiceId = ""
     fileprivate var _fetchedVoices: [CartesiaFetchedVoice] = []
@@ -266,6 +290,11 @@ final class CartesiaPlugin: NSObject,
     func activate(host: HostServices) {
         self.host = host
         _apiKey = host.loadSecret(key: CartesiaDefaultsKey.apiKey)
+        _transcriptionLanguage = Self.resolvedLanguage(
+            host.userDefault(forKey: CartesiaDefaultsKey.transcriptionLanguage) as? String,
+            supportedLanguages: Self.sttSupportedLanguages
+        ) ?? Self.defaultTranscriptionLanguage
+        _englishTranslationEnabled = host.userDefault(forKey: CartesiaDefaultsKey.englishTranslationEnabled) as? Bool ?? false
         _selectedVoiceId = host.userDefault(forKey: CartesiaDefaultsKey.selectedVoice) as? String
             ?? Self.defaultVoiceId
         _customVoiceId = host.userDefault(forKey: CartesiaDefaultsKey.customVoiceId) as? String ?? ""
@@ -316,7 +345,7 @@ final class CartesiaPlugin: NSObject,
 
     func selectModel(_ modelId: String) {}
 
-    var supportsTranslation: Bool { true }
+    var supportsTranslation: Bool { _englishTranslationEnabled }
     var supportedLanguages: [String] { Self.sttSupportedLanguages }
 
     func transcribe(
@@ -356,6 +385,9 @@ final class CartesiaPlugin: NSObject,
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
+        guard !translate || _englishTranslationEnabled else {
+            throw PluginTranscriptionError.apiError("Enable Cartesia Translate to English in plugin settings before using this task.")
+        }
         guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -363,6 +395,7 @@ final class CartesiaPlugin: NSObject,
         let resolvedLanguage = Self.resolvedTranscriptionLanguage(
             requestedLanguage: language,
             languageHints: languageHints,
+            configuredLanguage: _transcriptionLanguage,
             translate: translate
         )
         let request = try Self.makeTranscriptionRequest(
@@ -400,10 +433,12 @@ final class CartesiaPlugin: NSObject,
     }
 
     var settingsSummary: String? {
+        let speechLanguage = Self.displayName(forLanguageCode: _transcriptionLanguage)
         let voice = availableVoices.first { $0.id == selectedVoiceId }?.displayName
             ?? selectedVoiceId
             ?? "Default Voice"
-        return "Voice: \(voice); Cartesia"
+        let translation = _englishTranslationEnabled ? "; Translate enabled" : ""
+        return "Speech: \(speechLanguage); Voice: \(voice)\(translation); Cartesia"
     }
 
     func selectVoice(_ voiceId: String?) {
@@ -462,6 +497,8 @@ final class CartesiaPlugin: NSObject,
     // MARK: - Settings Support
 
     fileprivate var apiKeyForSettings: String? { _apiKey }
+    fileprivate var transcriptionLanguageForSettings: String { _transcriptionLanguage }
+    fileprivate var englishTranslationEnabledForSettings: Bool { _englishTranslationEnabled }
 
     fileprivate func setApiKey(_ key: String) throws {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -485,6 +522,24 @@ final class CartesiaPlugin: NSObject,
     fileprivate func setCustomVoiceId(_ voiceId: String) {
         _customVoiceId = voiceId.trimmingCharacters(in: .whitespacesAndNewlines)
         host?.setUserDefault(_customVoiceId, forKey: CartesiaDefaultsKey.customVoiceId)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func selectTranscriptionLanguage(_ language: String) {
+        let resolved = Self.resolvedLanguage(
+            language,
+            supportedLanguages: Self.sttSupportedLanguages
+        ) ?? Self.defaultTranscriptionLanguage
+        guard resolved != _transcriptionLanguage else { return }
+        _transcriptionLanguage = resolved
+        host?.setUserDefault(resolved, forKey: CartesiaDefaultsKey.transcriptionLanguage)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func setEnglishTranslationEnabled(_ enabled: Bool) {
+        guard enabled != _englishTranslationEnabled else { return }
+        _englishTranslationEnabled = enabled
+        host?.setUserDefault(enabled, forKey: CartesiaDefaultsKey.englishTranslationEnabled)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -539,8 +594,8 @@ extension CartesiaPlugin {
     static func resolvedTranscriptionLanguage(
         requestedLanguage: String?,
         languageHints: [String],
+        configuredLanguage: String?,
         translate: Bool = false,
-        preferredLanguages: [String] = Locale.preferredLanguages
     ) -> String? {
         guard !translate else { return nil }
 
@@ -553,19 +608,8 @@ extension CartesiaPlugin {
             }
         }
 
-        // Cartesia documents the batch STT language default as "en". For normal
-        // transcription, send a concrete source language so the empty-language
-        // path is reserved for the explicit "Translate to English" task.
-        return preferredTranscriptionLanguage(preferredLanguages: preferredLanguages) ?? Self.translationLanguage
-    }
-
-    static func preferredTranscriptionLanguage(preferredLanguages: [String]) -> String? {
-        for language in preferredLanguages {
-            if let resolved = resolvedLanguage(language, supportedLanguages: sttSupportedLanguages) {
-                return resolved
-            }
-        }
-        return nil
+        return resolvedLanguage(configuredLanguage, supportedLanguages: sttSupportedLanguages)
+            ?? Self.defaultTranscriptionLanguage
     }
 
     static func resolvedLanguage(_ language: String?, supportedLanguages: [String]) -> String? {
@@ -578,6 +622,11 @@ extension CartesiaPlugin {
 
         let primary = normalized.split(separator: "-").first.map(String.init) ?? normalized
         return supportedLanguages.contains(primary) ? primary : nil
+    }
+
+    static func displayName(forLanguageCode code: String) -> String {
+        let name = Locale.current.localizedString(forLanguageCode: code) ?? code.uppercased()
+        return "\(name) (\(code))"
     }
 
     static func makeTranscriptionRequest(
@@ -777,6 +826,8 @@ private struct CartesiaSettingsView: View {
     @State private var isRefreshingVoices = false
     @State private var validationResult: CartesiaAPIKeyValidationResult?
     @State private var settingsErrorMessage: String?
+    @State private var transcriptionLanguage = CartesiaPlugin.defaultTranscriptionLanguage
+    @State private var englishTranslationEnabled = false
     @State private var voiceOptions: [PluginVoiceInfo] = []
     @State private var selectedVoiceId = ""
     @State private var customVoiceId = ""
@@ -825,6 +876,31 @@ private struct CartesiaSettingsView: View {
             }
 
             if plugin.isConfigured {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Speech Recognition")
+                        .font(.headline)
+
+                    Picker("Spoken Language", selection: $transcriptionLanguage) {
+                        ForEach(CartesiaPlugin.sttLanguageOptions) { language in
+                            Text(language.displayName).tag(language.code)
+                        }
+                    }
+                    .onChange(of: transcriptionLanguage) {
+                        plugin.selectTranscriptionLanguage(transcriptionLanguage)
+                    }
+
+                    Toggle("Enable Translate to English", isOn: $englishTranslationEnabled)
+                        .onChange(of: englishTranslationEnabled) {
+                            plugin.setEnglishTranslationEnabled(englishTranslationEnabled)
+                        }
+
+                    Text("Cartesia batch speech recognition requires a source language. English translation is off by default.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 Divider()
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -952,6 +1028,8 @@ private struct CartesiaSettingsView: View {
     }
 
     private func refreshLocalVoiceState() {
+        transcriptionLanguage = plugin.transcriptionLanguageForSettings
+        englishTranslationEnabled = plugin.englishTranslationEnabledForSettings
         voiceOptions = plugin.availableVoices
         selectedVoiceId = plugin.selectedVoiceId ?? CartesiaPlugin.defaultVoiceId
         customVoiceId = plugin._customVoiceId

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -165,6 +165,9 @@ private final class CartesiaAVAudioPlayback: CartesiaTTSAudioPlayback, @unchecke
         guard let format else {
             throw CartesiaPluginError.playbackUnavailable("Audio playback was not started")
         }
+        guard data.count.isMultiple(of: MemoryLayout<Int16>.size) else {
+            throw CartesiaPluginError.playbackUnavailable("PCM16 audio data must contain whole samples.")
+        }
 
         let frameCount = data.count / MemoryLayout<Int16>.size
         guard frameCount > 0,

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -306,6 +306,12 @@ final class CartesiaPlugin: NSObject,
 
     func deactivate() {
         host = nil
+        _apiKey = nil
+        _transcriptionLanguage = Self.defaultTranscriptionLanguage
+        _englishTranslationEnabled = false
+        _selectedVoiceId = Self.defaultVoiceId
+        _customVoiceId = ""
+        _fetchedVoices = []
     }
 
     func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -10,13 +10,16 @@ final class CartesiaPluginTests: XCTestCase {
         super.tearDown()
     }
 
-    func testPluginAdvertisesTranscriptionAndTTSProtocols() {
-        let plugin: Any = CartesiaPlugin()
+    func testPluginAdvertisesTranscriptionAndTTSProtocols() throws {
+        let cartesiaPlugin = CartesiaPlugin()
+        cartesiaPlugin.activate(host: try PluginTestHostServices())
+        let plugin: Any = cartesiaPlugin
 
         XCTAssertTrue(plugin is any TranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any LanguageHintTranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any TTSProviderPlugin)
-        XCTAssertTrue((plugin as? any TranscriptionEnginePlugin)?.supportsTranslation == false)
+        let transcriptionPlugin = try XCTUnwrap(plugin as? any TranscriptionEnginePlugin)
+        XCTAssertFalse(transcriptionPlugin.supportsTranslation)
     }
 
     func testTranslationCapabilityIsOptIn() throws {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import TypeWhisperPluginSDK
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+import XCTest
+@testable import CartesiaPlugin
+
+final class CartesiaPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testPluginAdvertisesTranscriptionAndTTSProtocols() {
+        let plugin: Any = CartesiaPlugin()
+
+        XCTAssertTrue(plugin is any TranscriptionEnginePlugin)
+        XCTAssertTrue(plugin is any TTSProviderPlugin)
+    }
+
+    func testAuthRolesRequireCartesiaAPIKeyForSTTAndTTS() throws {
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: try PluginTestHostServices())
+
+        XCTAssertFalse(plugin.authStatus(for: .transcription).isAvailable)
+        XCTAssertFalse(plugin.authStatus(for: .tts).isAvailable)
+
+        let configuredPlugin = CartesiaPlugin()
+        configuredPlugin.activate(host: try PluginTestHostServices(secrets: ["api-key": "sk_car_live"]))
+
+        XCTAssertTrue(configuredPlugin.authStatus(for: .transcription).isAvailable)
+        XCTAssertTrue(configuredPlugin.authStatus(for: .tts).isAvailable)
+        XCTAssertFalse(configuredPlugin.authStatus(for: .llm).isAvailable)
+    }
+
+    func testLanguageResolutionUsesPrimarySubtagAndDropsUnsupportedValues() {
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedLanguage("de-DE", supportedLanguages: CartesiaPlugin.sttSupportedLanguages),
+            "de"
+        )
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedLanguage("pt_BR", supportedLanguages: CartesiaPlugin.sttSupportedLanguages),
+            "pt"
+        )
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedLanguage("yue-HK", supportedLanguages: CartesiaPlugin.sttSupportedLanguages),
+            "yue"
+        )
+        XCTAssertNil(CartesiaPlugin.resolvedLanguage("xx", supportedLanguages: CartesiaPlugin.sttSupportedLanguages))
+        XCTAssertNil(CartesiaPlugin.resolvedLanguage("  ", supportedLanguages: CartesiaPlugin.sttSupportedLanguages))
+    }
+
+    func testTranscriptionRequestUsesNativeCartesiaEndpointHeadersLanguageAndWordTimestamps() throws {
+        let request = try CartesiaPlugin.makeTranscriptionRequest(
+            wavData: Data("wav".utf8),
+            apiKey: "sk_car_test",
+            modelId: CartesiaPlugin.sttModelId,
+            language: "de"
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "api.cartesia.ai")
+        XCTAssertEqual(request.url?.path, "/stt")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk_car_test")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cartesia-Version"), CartesiaPlugin.apiVersion)
+        XCTAssertTrue(request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=") == true)
+        XCTAssertEqual(request.timeoutInterval, 600)
+
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains(#"name="file"; filename="audio.wav""#))
+        XCTAssertTrue(body.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(body.contains("name=\"model\"\r\n\r\nink-whisper"))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertTrue(body.contains("name=\"timestamp_granularities[]\"\r\n\r\nword"))
+    }
+
+    func testTTSRequestUsesBytesEndpointRawPCMVoiceLanguageAndVersionHeader() throws {
+        let request = try CartesiaPlugin.makeTTSRequest(
+            apiKey: "sk_car_test",
+            text: "Hello",
+            voiceId: "voice-1",
+            language: "en",
+            modelId: CartesiaPlugin.ttsModelId
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "api.cartesia.ai")
+        XCTAssertEqual(request.url?.path, "/tts/bytes")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk_car_test")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cartesia-Version"), CartesiaPlugin.apiVersion)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 120)
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: try XCTUnwrap(request.httpBody)) as? [String: Any])
+        XCTAssertEqual(json["model_id"] as? String, "sonic-3.5")
+        XCTAssertEqual(json["transcript"] as? String, "Hello")
+        XCTAssertEqual(json["language"] as? String, "en")
+
+        let voice = try XCTUnwrap(json["voice"] as? [String: Any])
+        XCTAssertEqual(voice["mode"] as? String, "id")
+        XCTAssertEqual(voice["id"] as? String, "voice-1")
+
+        let outputFormat = try XCTUnwrap(json["output_format"] as? [String: Any])
+        XCTAssertEqual(outputFormat["container"] as? String, "raw")
+        XCTAssertEqual(outputFormat["encoding"] as? String, "pcm_s16le")
+        XCTAssertEqual(outputFormat["sample_rate"] as? Int, 44_100)
+    }
+
+    func testListVoicesRequestUsesCartesiaVersionAndLimit() throws {
+        let request = try CartesiaPlugin.makeListVoicesRequest(apiKey: "sk_car_test", limit: 1)
+
+        XCTAssertEqual(request.url?.host, "api.cartesia.ai")
+        XCTAssertEqual(request.url?.path, "/voices")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk_car_test")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cartesia-Version"), CartesiaPlugin.apiVersion)
+
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        XCTAssertEqual(query["limit"], "1")
+    }
+
+    func testParseTranscriptionResponseBuildsWordSegments() throws {
+        let result = try CartesiaPlugin.parseTranscriptionResponse(
+            Data(
+                """
+                {
+                  "type": "transcript",
+                  "text": "Hello world",
+                  "language": "en",
+                  "words": [
+                    { "word": "Hello", "start": 0.1, "end": 0.4 },
+                    { "word": "world", "start": 0.5, "end": 0.9 }
+                  ]
+                }
+                """.utf8
+            ),
+            fallbackLanguage: "de"
+        )
+
+        XCTAssertEqual(result.text, "Hello world")
+        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.segments[0].text, "Hello")
+        XCTAssertEqual(result.segments[0].start, 0.1)
+        XCTAssertEqual(result.segments[1].text, "world")
+        XCTAssertEqual(result.segments[1].end, 0.9)
+    }
+
+    func testTranscribeSendsRequestAndParsesResponse() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "type": "transcript",
+                          "text": "Hallo Welt",
+                          "language": "de",
+                          "words": [
+                            { "word": "Hallo", "start": 0.0, "end": 0.3 },
+                            { "word": "Welt", "start": 0.4, "end": 0.7 }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            language: "de-DE",
+            translate: false,
+            prompt: "ignored"
+        )
+
+        XCTAssertEqual(result.text, "Hallo Welt")
+        XCTAssertEqual(result.detectedLanguage, "de")
+        XCTAssertEqual(result.segments.count, 2)
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/stt")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cartesia-Version"), CartesiaPlugin.apiVersion)
+
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
+    }
+
+    func testParseVoicesResponseSortsAndBuildsLocales() throws {
+        let voices = try CartesiaPlugin.parseVoicesResponse(
+            Data(
+                """
+                {
+                  "data": [
+                    {
+                      "id": "voice-b",
+                      "name": "Zara",
+                      "language": "en",
+                      "country": "US"
+                    },
+                    {
+                      "id": "voice-a",
+                      "name": "Ana",
+                      "language": "es",
+                      "country": "ES"
+                    }
+                  ],
+                  "has_more": false,
+                  "next_page": null
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(voices.map(\.id), ["voice-a", "voice-b"])
+        XCTAssertEqual(voices[0].localeIdentifier, "es-ES")
+        XCTAssertEqual(voices[1].localeIdentifier, "en-US")
+    }
+
+    func testHTTPStatusMapping() {
+        XCTAssertThrowsError(try CartesiaPlugin.validateHTTPResponse(
+            data: Data(#"{"message":"bad key"}"#.utf8),
+            response: Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 403)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .invalidApiKey = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertEqual(
+            CartesiaPlugin.apiKeyValidationResult(
+                data: Data(),
+                response: Self.httpResponse(url: "https://api.cartesia.ai/voices", statusCode: 401)
+            ),
+            .invalidKey
+        )
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -318,28 +318,36 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 
-    func testTranscribeRejectsTranslationWhenTranslationIsDisabled() async throws {
+    func testTranscribeIgnoresTranslateTaskWhenPluginTranslationIsDisabled() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
         let plugin = CartesiaPlugin()
         plugin.activate(host: host)
 
-        do {
-            _ = try await plugin.transcribe(
-                audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
-                language: "ru-RU",
-                translate: true,
-                prompt: nil
-            )
-            XCTFail("Expected disabled translation to throw")
-        } catch let error as PluginTranscriptionError {
-            guard case .apiError(let message) = error else {
-                return XCTFail("Unexpected error: \(error)")
-            }
-            XCTAssertTrue(message.contains("Enable Cartesia Translate to English"))
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"type":"transcript","text":"Привет, как дела?","language":"ru","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
         }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            language: "ru-RU",
+            translate: true,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Привет, как дела?")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
     }
 
-    func testTranscribeTranslateOmitsLanguageForOptInEnglishTranslation() async throws {
+    func testTranscribeOmitsLanguageWhenPluginEnglishTranslationIsEnabled() async throws {
         let host = try PluginTestHostServices(
             defaults: ["englishTranslationEnabled": true],
             secrets: ["api-key": "sk_car_live"]
@@ -361,7 +369,7 @@ final class CartesiaPluginTests: XCTestCase {
         let result = try await plugin.transcribe(
             audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
             language: "ru-RU",
-            translate: true,
+            translate: false,
             prompt: nil
         )
 

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -16,7 +16,20 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(plugin is any TranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any LanguageHintTranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any TTSProviderPlugin)
-        XCTAssertTrue((plugin as? any TranscriptionEnginePlugin)?.supportsTranslation == true)
+        XCTAssertTrue((plugin as? any TranscriptionEnginePlugin)?.supportsTranslation == false)
+    }
+
+    func testTranslationCapabilityIsOptIn() throws {
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: try PluginTestHostServices(secrets: ["api-key": "sk_car_live"]))
+        XCTAssertFalse(plugin.supportsTranslation)
+
+        let enabledPlugin = CartesiaPlugin()
+        enabledPlugin.activate(host: try PluginTestHostServices(
+            defaults: ["englishTranslationEnabled": true],
+            secrets: ["api-key": "sk_car_live"]
+        ))
+        XCTAssertTrue(enabledPlugin.supportsTranslation)
     }
 
     func testAuthRolesRequireCartesiaAPIKeyForSTTAndTTS() throws {
@@ -51,12 +64,12 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertNil(CartesiaPlugin.resolvedLanguage("  ", supportedLanguages: CartesiaPlugin.sttSupportedLanguages))
     }
 
-    func testTranscriptionLanguageResolutionUsesSelectedHintsAndPreferredLanguage() {
+    func testTranscriptionLanguageResolutionUsesSelectedHintsAndConfiguredLanguage() {
         XCTAssertEqual(
             CartesiaPlugin.resolvedTranscriptionLanguage(
                 requestedLanguage: nil,
                 languageHints: [],
-                preferredLanguages: ["ru-RU", "en-US"]
+                configuredLanguage: "ru-RU"
             ),
             "ru"
         )
@@ -64,32 +77,40 @@ final class CartesiaPluginTests: XCTestCase {
             CartesiaPlugin.resolvedTranscriptionLanguage(
                 requestedLanguage: " ",
                 languageHints: [],
-                preferredLanguages: ["de-DE"]
+                configuredLanguage: "de-DE"
             ),
             "de"
         )
         XCTAssertEqual(
-            CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: nil, languageHints: ["en-US", "de-DE"]),
+            CartesiaPlugin.resolvedTranscriptionLanguage(
+                requestedLanguage: nil,
+                languageHints: ["en-US", "de-DE"],
+                configuredLanguage: "ru"
+            ),
             "en"
         )
         XCTAssertEqual(
-            CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: "de-DE", languageHints: ["en-US"]),
+            CartesiaPlugin.resolvedTranscriptionLanguage(
+                requestedLanguage: "de-DE",
+                languageHints: ["en-US"],
+                configuredLanguage: "ru"
+            ),
             "de"
         )
         XCTAssertEqual(
             CartesiaPlugin.resolvedTranscriptionLanguage(
                 requestedLanguage: nil,
                 languageHints: [],
-                preferredLanguages: ["xx-YY"]
+                configuredLanguage: "xx-YY"
             ),
-            "en"
+            "ru"
         )
         XCTAssertNil(
             CartesiaPlugin.resolvedTranscriptionLanguage(
                 requestedLanguage: "ru-RU",
                 languageHints: [],
-                translate: true,
-                preferredLanguages: ["ru-RU"]
+                configuredLanguage: "ru-RU",
+                translate: true
             )
         )
     }
@@ -238,10 +259,94 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
     }
 
-    func testTranscribeTranslateOmitsLanguageForOptInEnglishTranslation() async throws {
+    func testTranscribeDefaultsAutoSelectionToConfiguredRussianLanguage() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
         let plugin = CartesiaPlugin()
         plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"type":"transcript","text":"Привет, как дела?","language":"ru","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            language: nil,
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Привет, как дела?")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
+    }
+
+    func testTranscribeUsesConfiguredEnglishLanguageWhenSelected() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["transcriptionLanguage": "en"],
+            secrets: ["api-key": "sk_car_live"]
+        )
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"type":"transcript","text":"Hello","language":"en","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
+        }
+
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            language: nil,
+            translate: false,
+            prompt: nil
+        )
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
+    }
+
+    func testTranscribeRejectsTranslationWhenTranslationIsDisabled() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+                language: "ru-RU",
+                translate: true,
+                prompt: nil
+            )
+            XCTFail("Expected disabled translation to throw")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.contains("Enable Cartesia Translate to English"))
+        }
+    }
+
+    func testTranscribeTranslateOmitsLanguageForOptInEnglishTranslation() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["englishTranslationEnabled": true],
+            secrets: ["api-key": "sk_car_live"]
+        )
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+        XCTAssertTrue(plugin.supportsTranslation)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -47,6 +47,48 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertFalse(configuredPlugin.authStatus(for: .llm).isAvailable)
     }
 
+    func testDeactivateClearsCachedConfigurationSnapshot() async throws {
+        let fetchedVoices = try JSONEncoder().encode([
+            CartesiaFetchedVoice(id: "voice-x", name: "Voice X", language: "en", country: "US")
+        ])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: try PluginTestHostServices(
+            defaults: [
+                "transcriptionLanguage": "en",
+                "englishTranslationEnabled": true,
+                "selectedVoice": "voice-x",
+                "customVoiceId": "custom-voice",
+                "fetchedVoices": fetchedVoices,
+            ],
+            secrets: ["api-key": "sk_car_live"]
+        ))
+
+        XCTAssertTrue(plugin.isConfigured)
+        XCTAssertTrue(plugin.supportsTranslation)
+        XCTAssertEqual(plugin.selectedVoiceId, "custom-voice")
+        XCTAssertEqual(plugin.availableVoices.map(\.id), ["voice-x"])
+
+        plugin.deactivate()
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertFalse(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.authStatus(for: .transcription).isAvailable)
+        XCTAssertEqual(plugin.selectedVoiceId, CartesiaPlugin.defaultVoiceId)
+        XCTAssertEqual(plugin.availableVoices.map(\.id), [CartesiaPlugin.defaultVoiceId])
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+                language: "en-US",
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected deactivated plugin to require configuration")
+        } catch PluginTranscriptionError.notConfigured {
+            // Expected.
+        }
+    }
+
     func testLanguageResolutionUsesPrimarySubtagAndDropsUnsupportedValues() {
         XCTAssertEqual(
             CartesiaPlugin.resolvedLanguage("de-DE", supportedLanguages: CartesiaPlugin.sttSupportedLanguages),

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -16,6 +16,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(plugin is any TranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any LanguageHintTranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any TTSProviderPlugin)
+        XCTAssertTrue((plugin as? any TranscriptionEnginePlugin)?.supportsTranslation == true)
     }
 
     func testAuthRolesRequireCartesiaAPIKeyForSTTAndTTS() throws {
@@ -50,9 +51,23 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertNil(CartesiaPlugin.resolvedLanguage("  ", supportedLanguages: CartesiaPlugin.sttSupportedLanguages))
     }
 
-    func testTranscriptionLanguageResolutionDefaultsToRussianAndUsesHints() {
-        XCTAssertEqual(CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: nil, languageHints: []), "ru")
-        XCTAssertEqual(CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: " ", languageHints: []), "ru")
+    func testTranscriptionLanguageResolutionUsesSelectedHintsAndPreferredLanguage() {
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedTranscriptionLanguage(
+                requestedLanguage: nil,
+                languageHints: [],
+                preferredLanguages: ["ru-RU", "en-US"]
+            ),
+            "ru"
+        )
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedTranscriptionLanguage(
+                requestedLanguage: " ",
+                languageHints: [],
+                preferredLanguages: ["de-DE"]
+            ),
+            "de"
+        )
         XCTAssertEqual(
             CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: nil, languageHints: ["en-US", "de-DE"]),
             "en"
@@ -60,6 +75,22 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertEqual(
             CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: "de-DE", languageHints: ["en-US"]),
             "de"
+        )
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedTranscriptionLanguage(
+                requestedLanguage: nil,
+                languageHints: [],
+                preferredLanguages: ["xx-YY"]
+            ),
+            "en"
+        )
+        XCTAssertNil(
+            CartesiaPlugin.resolvedTranscriptionLanguage(
+                requestedLanguage: "ru-RU",
+                languageHints: [],
+                translate: true,
+                preferredLanguages: ["ru-RU"]
+            )
         )
     }
 
@@ -207,7 +238,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
     }
 
-    func testTranscribeDefaultsAutoSelectionToRussianLanguage() async throws {
+    func testTranscribeTranslateOmitsLanguageForOptInEnglishTranslation() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
         let plugin = CartesiaPlugin()
         plugin.activate(host: host)
@@ -216,7 +247,7 @@ final class CartesiaPluginTests: XCTestCase {
         PluginHTTPClientTestHarness.configure { _ in
             store.makeSession(outcomes: [
                 .success(
-                    Data(#"{"type":"transcript","text":"Привет, как дела?","language":"ru","words":[]}"#.utf8),
+                    Data(#"{"type":"transcript","text":"Hello, how are you?","language":"en","words":[]}"#.utf8),
                     Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
                 )
             ])
@@ -224,16 +255,17 @@ final class CartesiaPluginTests: XCTestCase {
 
         let result = try await plugin.transcribe(
             audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
-            language: nil,
-            translate: false,
+            language: "ru-RU",
+            translate: true,
             prompt: nil
         )
 
-        XCTAssertEqual(result.text, "Привет, как дела?")
+        XCTAssertEqual(result.text, "Hello, how are you?")
+        XCTAssertEqual(result.detectedLanguage, "en")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
         let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
-        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
+        XCTAssertFalse(body.contains("name=\"language\""))
     }
 
     func testTranscribeUsesFirstLanguageHintWhenNoExactLanguageSelected() async throws {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -14,6 +14,7 @@ final class CartesiaPluginTests: XCTestCase {
         let plugin: Any = CartesiaPlugin()
 
         XCTAssertTrue(plugin is any TranscriptionEnginePlugin)
+        XCTAssertTrue(plugin is any LanguageHintTranscriptionEnginePlugin)
         XCTAssertTrue(plugin is any TTSProviderPlugin)
     }
 
@@ -47,6 +48,19 @@ final class CartesiaPluginTests: XCTestCase {
         )
         XCTAssertNil(CartesiaPlugin.resolvedLanguage("xx", supportedLanguages: CartesiaPlugin.sttSupportedLanguages))
         XCTAssertNil(CartesiaPlugin.resolvedLanguage("  ", supportedLanguages: CartesiaPlugin.sttSupportedLanguages))
+    }
+
+    func testTranscriptionLanguageResolutionDefaultsToRussianAndUsesHints() {
+        XCTAssertEqual(CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: nil, languageHints: []), "ru")
+        XCTAssertEqual(CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: " ", languageHints: []), "ru")
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: nil, languageHints: ["en-US", "de-DE"]),
+            "en"
+        )
+        XCTAssertEqual(
+            CartesiaPlugin.resolvedTranscriptionLanguage(requestedLanguage: "de-DE", languageHints: ["en-US"]),
+            "de"
+        )
     }
 
     func testTranscriptionRequestUsesNativeCartesiaEndpointHeadersLanguageAndWordTimestamps() throws {
@@ -191,6 +205,62 @@ final class CartesiaPluginTests: XCTestCase {
 
         let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
+    }
+
+    func testTranscribeDefaultsAutoSelectionToRussianLanguage() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"type":"transcript","text":"Привет, как дела?","language":"ru","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            language: nil,
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Привет, как дела?")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
+    }
+
+    func testTranscribeUsesFirstLanguageHintWhenNoExactLanguageSelected() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"type":"transcript","text":"Hello","language":"en","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
+        }
+
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            languageSelection: PluginLanguageSelection(languageHints: ["en-US", "de-DE"]),
+            translate: false,
+            prompt: nil
+        )
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 
     func testParseVoicesResponseSortsAndBuildsLocales() throws {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
@@ -1,0 +1,21 @@
+{
+    "id": "com.typewhisper.cartesia",
+    "name": "Cartesia",
+    "version": "1.0.0",
+    "minHostVersion": "1.4.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Cloud speech-to-text and text-to-speech via Cartesia APIs. Requires a Cartesia API key.",
+    "descriptions": {
+        "de": "Cloud Speech-to-Text und Text-to-Speech über Cartesia APIs. Erfordert einen Cartesia API-Key."
+    },
+    "category": "transcription",
+    "categories": ["transcription", "tts"],
+    "hosting": "cloud",
+    "iconSystemName": "waveform",
+    "principalClass": "CartesiaPlugin",
+    "requiresAPIKey": true,
+    "detailsURL": "https://www.typewhisper.com/addons/cartesia/",
+    "homepageURL": "https://www.cartesia.ai/"
+}


### PR DESCRIPTION
## Summary

- Add a Cartesia plugin target that provides cloud speech-to-text via `ink-whisper` and text-to-speech via `sonic-3.5`.
- Store a user-supplied Cartesia API key via plugin-scoped Keychain storage; the plugin does not ship or rely on bundled provider credentials.
- Add explicit spoken-language selection for Cartesia STT and make English translation opt-in, so Russian speech is transcribed as Russian unless translation mode is enabled.
- Wire the plugin release workflow mapping for `cartesia -> CartesiaPlugin` without embedding the bundle in the app target.

## Provider behavior

- Required credential: a user-provided Cartesia API key.
- STT endpoint: Cartesia `/stt` with `model=ink-whisper`, word timestamp granularity, and a `language` multipart field when normal transcription is used.
- Supported STT languages: Cartesia's `ink-whisper` language list exposed by the plugin, including Russian (`ru`) and English (`en`).
- Translation behavior: the plugin only asks Cartesia for English output when the plugin setting `Enable Translate to English` is enabled. Otherwise, TypeWhisper translate requests are ignored for this provider and the selected/derived source language is sent.
- TTS behavior: Cartesia `/tts/bytes` with `sonic-3.5`, raw PCM16 output, fetched voice list support, and a custom voice ID fallback.
- Current short/long audio behavior: Cartesia STT uses a single synchronous upload request for each transcription; there is no async upload/task/download split in this plugin.

## Release path

- Release tag format: `plugin-cartesia-v<version>`.
- The plugin release workflow maps `cartesia` to `CartesiaPlugin`, builds/signs the bundle, and publishes the release asset.
- Manifest compatibility is `sdkCompatibilityVersion: v1` and `minHostVersion: 1.4.0`, so the release workflow writes the registry release into the `plugins-v1.json` path.
- If the plugin needs a newer SDK before shipping, the manifest and provider docs should be updated together.

## Docs

- Companion website/docs PR: TypeWhisper/typewhisper.com#90.
- I checked the provider-docs requirements raised on #706 and this PR plus the docs PR cover the same app-side setup/release/compatibility notes.

## Test plan

- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json >/dev/null`
- `plutil -lint TypeWhisper.xcodeproj/project.pbxproj`
- `git diff --check`
- `swift test --package-path TypeWhisperPluginSDK --filter CartesiaPluginTests`
- `xcodebuild -quiet -project TypeWhisper.xcodeproj -target CartesiaPlugin -configuration Debug CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cartesia plugin for speech-to-text and text-to-speech capabilities
  * Configure API key, select from available voices, and customize transcription language
  * Support for custom voice IDs and automatic voice list management
  * Real-time audio playback for speech synthesis
  * Full plugin activation and deactivation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->