### PR TITLE
Fix Cartesia plugin settings

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 		5B2200000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5B2200000000000000000030 /* TypeWhisperPluginSDK */; };
 		CART00000000000000000001 /* CartesiaPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CART00000000000000000010 /* CartesiaPlugin.swift */; };
 		CART00000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = CART00000000000000000011 /* manifest.json */; };
+		CART00000000000000000004 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CART00000000000000000013 /* Localizable.xcstrings */; };
 		CART00000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = CART00000000000000000030 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000217 /* IndicatorPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000207 /* IndicatorPreviewView.swift */; };
 		AA00000000000000000218 /* ObsidianPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000208 /* ObsidianPlugin.swift */; };
@@ -752,6 +753,7 @@
 		CART00000000000000000010 /* CartesiaPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartesiaPlugin.swift; sourceTree = "<group>"; };
 		CART00000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		CART00000000000000000012 /* CartesiaPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CartesiaPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		CART00000000000000000013 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000207 /* IndicatorPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorPreviewView.swift; sourceTree = "<group>"; };
 		BB00000000000000000208 /* ObsidianPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000209 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1859,6 +1861,7 @@
 			children = (
 				CART00000000000000000010 /* CartesiaPlugin.swift */,
 				CART00000000000000000011 /* manifest.json */,
+				CART00000000000000000013 /* Localizable.xcstrings */,
 			);
 			name = CartesiaPlugin;
 			path = TypeWhisperPluginSDK/Plugins/CartesiaPlugin;
@@ -3408,6 +3411,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CART00000000000000000002 /* manifest.json in Resources */,
+				CART00000000000000000004 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -266,6 +266,7 @@ let package = Package(
             path: "Plugins/CartesiaPlugin",
             exclude: ["Tests"],
             resources: [
+                .process("Localizable.xcstrings"),
                 .process("manifest.json"),
             ]
         ),

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -7,7 +7,6 @@ import os
 private enum CartesiaDefaultsKey {
     static let apiKey = "api-key"
     static let transcriptionLanguage = "transcriptionLanguage"
-    static let englishTranslationEnabled = "englishTranslationEnabled"
     static let selectedVoice = "selectedVoice"
     static let customVoiceId = "customVoiceId"
     static let fetchedVoices = "fetchedVoices"
@@ -235,14 +234,19 @@ final class CartesiaPlugin: NSObject,
     static let apiBaseURL = "https://api.cartesia.ai"
     static let apiVersion = "2026-03-01"
     static let sttModelId = "ink-whisper"
-    static let defaultTranscriptionLanguage = "ru"
-    static let translationLanguage = "en"
+    static let defaultTranscriptionLanguage = "en"
     static let ttsModelId = "sonic-3.5"
     static let ttsSampleRate = 44_100
     static let defaultVoiceId = "6ccbfb76-1fc6-48f7-b71d-91ac6298247b"
-    static let fallbackVoices = [
-        PluginVoiceInfo(id: defaultVoiceId, displayName: "Default Voice", localeIdentifier: "en")
-    ]
+    static var fallbackVoices: [PluginVoiceInfo] {
+        [
+            PluginVoiceInfo(
+                id: defaultVoiceId,
+                displayName: String(localized: "Default Voice", bundle: Bundle(for: CartesiaPlugin.self)),
+                localeIdentifier: "en"
+            )
+        ]
+    }
 
     static let sttSupportedLanguages = [
         "af", "am", "ar", "as", "az", "ba", "be", "bg", "bn", "bo",
@@ -271,8 +275,6 @@ final class CartesiaPlugin: NSObject,
             .sorted { lhs, rhs in
                 if lhs.code == defaultTranscriptionLanguage { return true }
                 if rhs.code == defaultTranscriptionLanguage { return false }
-                if lhs.code == translationLanguage { return true }
-                if rhs.code == translationLanguage { return false }
                 return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
             }
     }
@@ -281,7 +283,6 @@ final class CartesiaPlugin: NSObject,
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _transcriptionLanguage = CartesiaPlugin.defaultTranscriptionLanguage
-    fileprivate var _englishTranslationEnabled = false
     fileprivate var _selectedVoiceId: String?
     fileprivate var _customVoiceId = ""
     fileprivate var _fetchedVoices: [CartesiaFetchedVoice] = []
@@ -297,7 +298,6 @@ final class CartesiaPlugin: NSObject,
             host.userDefault(forKey: CartesiaDefaultsKey.transcriptionLanguage) as? String,
             supportedLanguages: Self.sttSupportedLanguages
         ) ?? Self.defaultTranscriptionLanguage
-        _englishTranslationEnabled = host.userDefault(forKey: CartesiaDefaultsKey.englishTranslationEnabled) as? Bool ?? false
         _selectedVoiceId = host.userDefault(forKey: CartesiaDefaultsKey.selectedVoice) as? String
             ?? Self.defaultVoiceId
         _customVoiceId = host.userDefault(forKey: CartesiaDefaultsKey.customVoiceId) as? String ?? ""
@@ -311,7 +311,6 @@ final class CartesiaPlugin: NSObject,
         host = nil
         _apiKey = nil
         _transcriptionLanguage = Self.defaultTranscriptionLanguage
-        _englishTranslationEnabled = false
         _selectedVoiceId = Self.defaultVoiceId
         _customVoiceId = ""
         _fetchedVoices = []
@@ -354,7 +353,7 @@ final class CartesiaPlugin: NSObject,
 
     func selectModel(_ modelId: String) {}
 
-    var supportsTranslation: Bool { _englishTranslationEnabled }
+    var supportsTranslation: Bool { false }
     var supportedLanguages: [String] { Self.sttSupportedLanguages }
 
     func transcribe(
@@ -367,7 +366,6 @@ final class CartesiaPlugin: NSObject,
             audio: audio,
             language: language,
             languageHints: [],
-            translate: translate,
             prompt: prompt
         )
     }
@@ -382,7 +380,6 @@ final class CartesiaPlugin: NSObject,
             audio: audio,
             language: languageSelection.requestedLanguage,
             languageHints: languageSelection.languageHints,
-            translate: translate,
             prompt: prompt
         )
     }
@@ -391,19 +388,16 @@ final class CartesiaPlugin: NSObject,
         audio: AudioData,
         language: String?,
         languageHints: [String],
-        translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
         guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
-        let shouldTranslate = _englishTranslationEnabled
         let resolvedLanguage = Self.resolvedTranscriptionLanguage(
             requestedLanguage: language,
             languageHints: languageHints,
-            configuredLanguage: _transcriptionLanguage,
-            translate: shouldTranslate
+            configuredLanguage: _transcriptionLanguage
         )
         let request = try Self.makeTranscriptionRequest(
             wavData: audio.wavData,
@@ -416,7 +410,7 @@ final class CartesiaPlugin: NSObject,
         try Self.validateHTTPResponse(data: data, response: response)
         return try Self.parseTranscriptionResponse(
             data,
-            fallbackLanguage: shouldTranslate ? Self.translationLanguage : resolvedLanguage
+            fallbackLanguage: resolvedLanguage
         )
     }
 
@@ -444,8 +438,7 @@ final class CartesiaPlugin: NSObject,
         let voice = availableVoices.first { $0.id == selectedVoiceId }?.displayName
             ?? selectedVoiceId
             ?? "Default Voice"
-        let translation = _englishTranslationEnabled ? "; Translate enabled" : ""
-        return "Speech: \(speechLanguage); Voice: \(voice)\(translation); Cartesia"
+        return "Speech: \(speechLanguage); Voice: \(voice); Cartesia"
     }
 
     func selectVoice(_ voiceId: String?) {
@@ -505,7 +498,6 @@ final class CartesiaPlugin: NSObject,
 
     fileprivate var apiKeyForSettings: String? { _apiKey }
     fileprivate var transcriptionLanguageForSettings: String { _transcriptionLanguage }
-    fileprivate var englishTranslationEnabledForSettings: Bool { _englishTranslationEnabled }
 
     fileprivate func setApiKey(_ key: String) throws {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -540,13 +532,6 @@ final class CartesiaPlugin: NSObject,
         guard resolved != _transcriptionLanguage else { return }
         _transcriptionLanguage = resolved
         host?.setUserDefault(resolved, forKey: CartesiaDefaultsKey.transcriptionLanguage)
-        host?.notifyCapabilitiesChanged()
-    }
-
-    fileprivate func setEnglishTranslationEnabled(_ enabled: Bool) {
-        guard enabled != _englishTranslationEnabled else { return }
-        _englishTranslationEnabled = enabled
-        host?.setUserDefault(enabled, forKey: CartesiaDefaultsKey.englishTranslationEnabled)
         host?.notifyCapabilitiesChanged()
     }
 
@@ -602,10 +587,7 @@ extension CartesiaPlugin {
         requestedLanguage: String?,
         languageHints: [String],
         configuredLanguage: String?,
-        translate: Bool = false,
     ) -> String? {
-        guard !translate else { return nil }
-
         if let requested = resolvedLanguage(requestedLanguage, supportedLanguages: sttSupportedLanguages) {
             return requested
         }
@@ -834,24 +816,24 @@ private struct CartesiaSettingsView: View {
     @State private var validationResult: CartesiaAPIKeyValidationResult?
     @State private var settingsErrorMessage: String?
     @State private var transcriptionLanguage = CartesiaPlugin.defaultTranscriptionLanguage
-    @State private var englishTranslationEnabled = false
     @State private var voiceOptions: [PluginVoiceInfo] = []
     @State private var selectedVoiceId = ""
     @State private var customVoiceId = ""
+    private let bundle = Bundle(for: CartesiaPlugin.self)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-                Text("API Key")
+                Text("API Key", bundle: bundle)
                     .font(.headline)
 
                 HStack(spacing: 8) {
                     if showApiKey {
-                        TextField("API Key", text: $apiKeyInput)
+                        TextField(String(localized: "API Key", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
                     } else {
-                        SecureField("API Key", text: $apiKeyInput)
+                        SecureField(String(localized: "API Key", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                     }
 
@@ -863,14 +845,14 @@ private struct CartesiaSettingsView: View {
                     .buttonStyle(.borderless)
 
                     if plugin.isConfigured {
-                        Button("Remove") {
+                        Button(String(localized: "Remove", bundle: bundle)) {
                             removeApiKey()
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .foregroundStyle(.red)
                     } else {
-                        Button("Save") {
+                        Button(String(localized: "Save", bundle: bundle)) {
                             saveApiKey()
                         }
                         .buttonStyle(.borderedProminent)
@@ -886,27 +868,19 @@ private struct CartesiaSettingsView: View {
                 Divider()
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Speech Recognition")
+                    Text("Speech Recognition", bundle: bundle)
                         .font(.headline)
 
-                    Picker("Spoken Language", selection: $transcriptionLanguage) {
+                    Picker(String(localized: "Spoken Language", bundle: bundle), selection: $transcriptionLanguage) {
                         ForEach(CartesiaPlugin.sttLanguageOptions) { language in
                             Text(language.displayName).tag(language.code)
                         }
                     }
-                    .disabled(englishTranslationEnabled)
                     .onChange(of: transcriptionLanguage) {
                         plugin.selectTranscriptionLanguage(transcriptionLanguage)
                     }
 
-                    Toggle("Enable Translate to English", isOn: $englishTranslationEnabled)
-                        .onChange(of: englishTranslationEnabled) {
-                            plugin.setEnglishTranslationEnabled(englishTranslationEnabled)
-                        }
-
-                    Text(englishTranslationEnabled
-                         ? "Translation mode ignores the spoken language picker and asks Cartesia for English output."
-                         : "Spoken Language is the source audio language. Choose English only when the audio itself is English.")
+                    Text("Spoken Language is the source audio language. Choose English only when the audio itself is English.", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -915,17 +889,17 @@ private struct CartesiaSettingsView: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Text("Text-to-Speech Voice")
+                        Text("Text-to-Speech Voice", bundle: bundle)
                             .font(.headline)
                         Spacer()
-                        Button("Refresh") {
+                        Button(String(localized: "Refresh", bundle: bundle)) {
                             refreshVoices()
                         }
                         .controlSize(.small)
                         .disabled(isRefreshingVoices)
                     }
 
-                    Picker("Text-to-Speech Voice", selection: $selectedVoiceId) {
+                    Picker(String(localized: "Text-to-Speech Voice", bundle: bundle), selection: $selectedVoiceId) {
                         ForEach(voiceOptions, id: \.id) { voice in
                             Text(voice.displayName).tag(voice.id)
                         }
@@ -936,10 +910,10 @@ private struct CartesiaSettingsView: View {
                     }
 
                     HStack(spacing: 8) {
-                        TextField("Custom Voice ID", text: $customVoiceId)
+                        TextField(String(localized: "Custom Voice ID", bundle: bundle), text: $customVoiceId)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
-                        Button("Use") {
+                        Button(String(localized: "Use", bundle: bundle)) {
                             plugin.setCustomVoiceId(customVoiceId)
                             selectedVoiceId = plugin.selectedVoiceId ?? CartesiaPlugin.defaultVoiceId
                         }
@@ -949,7 +923,7 @@ private struct CartesiaSettingsView: View {
                 }
             }
 
-            Text("API keys are stored securely in the Keychain")
+            Text("API keys are stored securely in the Keychain", bundle: bundle)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -965,7 +939,7 @@ private struct CartesiaSettingsView: View {
         if isValidating {
             HStack(spacing: 4) {
                 ProgressView().controlSize(.small)
-                Text("Validating...")
+                Text("Validating...", bundle: bundle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -1039,7 +1013,6 @@ private struct CartesiaSettingsView: View {
 
     private func refreshLocalVoiceState() {
         transcriptionLanguage = plugin.transcriptionLanguageForSettings
-        englishTranslationEnabled = plugin.englishTranslationEnabledForSettings
         voiceOptions = plugin.availableVoices
         selectedVoiceId = plugin.selectedVoiceId ?? CartesiaPlugin.defaultVoiceId
         customVoiceId = plugin._customVoiceId
@@ -1050,13 +1023,21 @@ private struct CartesiaSettingsView: View {
     ) -> (systemName: String, message: String, color: Color) {
         switch result {
         case .valid:
-            return ("checkmark.circle.fill", "Valid API Key", .green)
+            return (
+                "checkmark.circle.fill",
+                String(localized: "Valid API Key", bundle: bundle),
+                .green
+            )
         case .invalidKey:
-            return ("xmark.circle.fill", "Invalid API Key", .red)
+            return (
+                "xmark.circle.fill",
+                String(localized: "Invalid API Key", bundle: bundle),
+                .red
+            )
         case .transientError:
             return (
                 "exclamationmark.triangle.fill",
-                "Could not validate API Key. Check your connection and try again.",
+                String(localized: "Could not validate API Key. Check your connection and try again.", bundle: bundle),
                 .orange
             )
         }

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -242,7 +242,7 @@ final class CartesiaPlugin: NSObject,
         [
             PluginVoiceInfo(
                 id: defaultVoiceId,
-                displayName: String(localized: "Default Voice", bundle: Bundle(for: CartesiaPlugin.self)),
+                displayName: String(localized: "Default Voice", bundle: pluginModuleBundle),
                 localeIdentifier: "en"
             )
         ]
@@ -437,8 +437,9 @@ final class CartesiaPlugin: NSObject,
         let speechLanguage = Self.displayName(forLanguageCode: _transcriptionLanguage)
         let voice = availableVoices.first { $0.id == selectedVoiceId }?.displayName
             ?? selectedVoiceId
-            ?? "Default Voice"
-        return "Speech: \(speechLanguage); Voice: \(voice); Cartesia"
+            ?? String(localized: "Default Voice", bundle: pluginModuleBundle)
+        let format = String(localized: "Speech: %@; Voice: %@; Cartesia", bundle: pluginModuleBundle)
+        return String(format: format, speechLanguage, voice)
     }
 
     func selectVoice(_ voiceId: String?) {
@@ -819,7 +820,7 @@ private struct CartesiaSettingsView: View {
     @State private var voiceOptions: [PluginVoiceInfo] = []
     @State private var selectedVoiceId = ""
     @State private var customVoiceId = ""
-    private let bundle = Bundle(for: CartesiaPlugin.self)
+    private let bundle = pluginModuleBundle
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -1043,6 +1044,14 @@ private struct CartesiaSettingsView: View {
         }
     }
 }
+
+private let pluginModuleBundle: Bundle = {
+#if SWIFT_PACKAGE
+    Bundle.module
+#else
+    Bundle(for: CartesiaPlugin.self)
+#endif
+}()
 
 private extension Data {
     mutating func appendMultipartField(boundary: String, name: String, value: String) {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Localizable.xcstrings
@@ -161,6 +161,22 @@
         }
       }
     },
+    "Speech: %@; Voice: %@; Cartesia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache: %@; Stimme: %@; Cartesia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声認識: %@; 音声: %@; Cartesia"
+          }
+        }
+      }
+    },
     "Spoken Language": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Localizable.xcstrings
@@ -1,0 +1,262 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキー"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Keys werden sicher im Schluesselbund gespeichert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーはキーチェーンに安全に保存されます"
+          }
+        }
+      }
+    },
+    "Could not validate API Key. Check your connection and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Key konnte nicht geprueft werden. Pruefe die Verbindung und versuche es erneut."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーの検証に失敗しました。接続を確認し、再度試してください。"
+          }
+        }
+      }
+    },
+    "Custom Voice ID": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene Voice-ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタムVoice ID"
+          }
+        }
+      }
+    },
+    "Default Voice": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardstimme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト音声"
+          }
+        }
+      }
+    },
+    "Invalid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungueltiger API-Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なAPIキー"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Speech Recognition": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spracherkennung"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声認識"
+          }
+        }
+      }
+    },
+    "Spoken Language": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesprochene Sprache"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "話し言葉"
+          }
+        }
+      }
+    },
+    "Spoken Language is the source audio language. Choose English only when the audio itself is English.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesprochene Sprache ist die Sprache der Audioquelle. Waehle Englisch nur, wenn die Aufnahme selbst Englisch ist."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "話し言葉は音声ソースの言語です。音声自体が英語の場合のみ英語を選択してください。"
+          }
+        }
+      }
+    },
+    "Text-to-Speech Voice": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text-zu-Sprache-Stimme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ音声"
+          }
+        }
+      }
+    },
+    "Use": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用"
+          }
+        }
+      }
+    },
+    "Valid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gueltiger API-Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なAPIキー"
+          }
+        }
+      }
+    },
+    "Validating...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird geprueft..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証中..."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -22,17 +22,17 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertFalse(transcriptionPlugin.supportsTranslation)
     }
 
-    func testTranslationCapabilityIsOptIn() throws {
+    func testTranslationCapabilityIsNeverAdvertised() throws {
         let plugin = CartesiaPlugin()
         plugin.activate(host: try PluginTestHostServices(secrets: ["api-key": "sk_car_live"]))
         XCTAssertFalse(plugin.supportsTranslation)
 
-        let enabledPlugin = CartesiaPlugin()
-        enabledPlugin.activate(host: try PluginTestHostServices(
+        let pluginWithStaleTranslationDefault = CartesiaPlugin()
+        pluginWithStaleTranslationDefault.activate(host: try PluginTestHostServices(
             defaults: ["englishTranslationEnabled": true],
             secrets: ["api-key": "sk_car_live"]
         ))
-        XCTAssertTrue(enabledPlugin.supportsTranslation)
+        XCTAssertFalse(pluginWithStaleTranslationDefault.supportsTranslation)
     }
 
     func testAuthRolesRequireCartesiaAPIKeyForSTTAndTTS() throws {
@@ -67,7 +67,7 @@ final class CartesiaPluginTests: XCTestCase {
         ))
 
         XCTAssertTrue(plugin.isConfigured)
-        XCTAssertTrue(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.supportsTranslation)
         XCTAssertEqual(plugin.selectedVoiceId, "custom-voice")
         XCTAssertEqual(plugin.availableVoices.map(\.id), ["voice-x"])
 
@@ -148,15 +148,15 @@ final class CartesiaPluginTests: XCTestCase {
                 languageHints: [],
                 configuredLanguage: "xx-YY"
             ),
-            "ru"
+            "en"
         )
-        XCTAssertNil(
+        XCTAssertEqual(
             CartesiaPlugin.resolvedTranscriptionLanguage(
                 requestedLanguage: "ru-RU",
                 languageHints: [],
-                configuredLanguage: "ru-RU",
-                translate: true
-            )
+                configuredLanguage: "ru-RU"
+            ),
+            "ru"
         )
     }
 
@@ -304,7 +304,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
     }
 
-    func testTranscribeDefaultsAutoSelectionToConfiguredRussianLanguage() async throws {
+    func testTranscribeDefaultsAutoSelectionToConfiguredEnglishLanguage() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
         let plugin = CartesiaPlugin()
         plugin.activate(host: host)
@@ -313,7 +313,7 @@ final class CartesiaPluginTests: XCTestCase {
         PluginHTTPClientTestHarness.configure { _ in
             store.makeSession(outcomes: [
                 .success(
-                    Data(#"{"type":"transcript","text":"Привет, как дела?","language":"ru","words":[]}"#.utf8),
+                    Data(#"{"type":"transcript","text":"Hello, how are you?","language":"en","words":[]}"#.utf8),
                     Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
                 )
             ])
@@ -326,11 +326,11 @@ final class CartesiaPluginTests: XCTestCase {
             prompt: nil
         )
 
-        XCTAssertEqual(result.text, "Привет, как дела?")
+        XCTAssertEqual(result.text, "Hello, how are you?")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
         let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
-        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 
     func testTranscribeUsesConfiguredEnglishLanguageWhenSelected() async throws {
@@ -392,20 +392,20 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
     }
 
-    func testTranscribeOmitsLanguageWhenPluginEnglishTranslationIsEnabled() async throws {
+    func testTranscribeIgnoresStaleEnglishTranslationDefault() async throws {
         let host = try PluginTestHostServices(
             defaults: ["englishTranslationEnabled": true],
             secrets: ["api-key": "sk_car_live"]
         )
         let plugin = CartesiaPlugin()
         plugin.activate(host: host)
-        XCTAssertTrue(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.supportsTranslation)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
             store.makeSession(outcomes: [
                 .success(
-                    Data(#"{"type":"transcript","text":"Hello, how are you?","language":"en","words":[]}"#.utf8),
+                    Data(#"{"type":"transcript","text":"Привет, как дела?","language":"ru","words":[]}"#.utf8),
                     Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
                 )
             ])
@@ -418,12 +418,12 @@ final class CartesiaPluginTests: XCTestCase {
             prompt: nil
         )
 
-        XCTAssertEqual(result.text, "Hello, how are you?")
-        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.text, "Привет, как дела?")
+        XCTAssertEqual(result.detectedLanguage, "ru")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
         let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
-        XCTAssertFalse(body.contains("name=\"language\""))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
     }
 
     func testTranscribeUsesFirstLanguageHintWhenNoExactLanguageSelected() async throws {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -304,7 +304,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
     }
 
-    func testTranscribeDefaultsAutoSelectionToConfiguredEnglishLanguage() async throws {
+    func testTranscribeDefaultsToEnglishWhenNoLanguageConfigured() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
         let plugin = CartesiaPlugin()
         plugin.activate(host: host)


### PR DESCRIPTION
## Summary
- Remove Cartesia's custom translation mode and keep it aligned with normal speech-recognition plugins.
- Default Cartesia speech recognition to English instead of Russian.
- Localize the Cartesia settings UI and bundle the new string catalog for SwiftPM and Xcode plugin builds.

## Test Plan
- `git diff --check`
- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Localizable.xcstrings >/dev/null`
- `swift test --package-path TypeWhisperPluginSDK --filter CartesiaPluginTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --clean --run CartesiaPlugin /Users/marco/.codex/worktrees/6ec1/typewhisper-mac`
- Verified the installed dev plugin contains `de.lproj/Localizable.strings`, `ja.lproj/Localizable.strings`, and `manifest.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added complete localization for the plugin UI (English, German, Japanese) and included localized strings in the packaged plugin.

* **Changes**
  * Removed the transcription "translate to English" feature and its toggle from settings.
  * Default transcription language changed to English.
  * Settings UI labels, buttons and validation messages are now localized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->