### PR TITLE
Prevent plugin releases from becoming latest

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -262,7 +262,8 @@ jobs:
           gh release create "$TAG" "$ASSET" \
             --target "$GITHUB_SHA" \
             --title "${TARGET} v${PLUGIN_VERSION}" \
-            --notes ""
+            --notes "" \
+            --latest=false
 
       - name: Update Plugin Registry
         env:


### PR DESCRIPTION
## Summary
- Prevent first-party plugin releases from taking over GitHub's repository-level Latest release marker.
- Keep the app release discovery path pointed at the stable TypeWhisper app release rather than plugin ZIP-only releases.

## Issue context
Issue #716 asks for TypeWhisper builds for Sonoma on Intel and Apple Silicon. Current app releases already satisfy that path: the published `v1.4.0` app ZIP contains both `x86_64` and `arm64` slices and requires macOS `14.0` or later. The confusing part was that GitHub `/releases/latest` had moved to the latest plugin release, which only exposes `CartesiaPlugin.zip` instead of the TypeWhisper app DMG/ZIP.

Closes #716

## Test plan
- `gh release create --help | rg -n -C 2 -- "latest|--latest"`
- `gh release download v1.4.0 --repo TypeWhisper/typewhisper-mac --pattern 'TypeWhisper-v1.4.0.zip'`
- `unzip -q TypeWhisper-v1.4.0.zip`
- `lipo -archs TypeWhisper.app/Contents/MacOS/TypeWhisper`
- `/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' TypeWhisper.app/Contents/Info.plist`
- `gh api repos/TypeWhisper/typewhisper-mac/releases/latest --jq '{tag_name,name,assets:[.assets[].name]}'`
- `git diff --check`

Verified results: `lipo` reported `x86_64 arm64`, `LSMinimumSystemVersion` reported `14.0`, and GitHub Latest now resolves to `v1.4.0` with `TypeWhisper-v1.4.0.dmg` and `TypeWhisper-v1.4.0.zip`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release management process configuration. Releases will no longer be automatically marked as the latest release in the repository. This change provides enhanced control over release visibility and classification, enabling more flexible release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->