### PR TITLE
Add inception plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Multiple engines can be loaded simultaneously for instant switching between work
 
 TypeWhisper supports plugins for adding custom LLM providers, transcription engines, TTS providers, post-processors, and action plugins. Plugins are macOS `.bundle` files placed in `~/Library/Application Support/TypeWhisper/Plugins/`.
 
-Bundled engines and integrations (WhisperKit, Parakeet, SpeechAnalyzer, Granite, Qwen3, Voxtral, Supertonic, Groq, OpenAI, xAI/Grok, OpenAI Compatible, Gemini, Linear, Webhook, and more) are implemented as plugins and serve as reference implementations.
+Bundled engines and integrations (WhisperKit, Parakeet, SpeechAnalyzer, Granite, Qwen3, Voxtral, Supertonic, Groq, OpenAI, Inception, xAI/Grok, OpenAI Compatible, Gemini, Linear, Webhook, and more) are implemented as plugins and serve as reference implementations.
 
 See [TypeWhisperPluginSDK/Plugins/README.md](TypeWhisperPluginSDK/Plugins/README.md) for the full plugin development guide, including the event bus, host services API, and manifest format.
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -388,6 +388,9 @@
 		AA00000000000000000268 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000256 /* manifest.json */; };
 		AA00000000000000000269 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000258 /* Localizable.xcstrings */; };
 		AA00000000000000000270 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000036 /* TypeWhisperPluginSDK */; };
+		1CE700000000000000000001 /* InceptionPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE700000000000000000010 /* InceptionPlugin.swift */; };
+		1CE700000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1CE700000000000000000011 /* manifest.json */; };
+		1CE700000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 1CE700000000000000000060 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000271 /* ClaudePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000259 /* ClaudePlugin.swift */; };
 		AA00000000000000000272 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000260 /* manifest.json */; };
 		AA00000000000000000273 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000261 /* Localizable.xcstrings */; };
@@ -869,6 +872,9 @@
 		BB00000000000000000256 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000257 /* CerebrasPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CerebrasPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000258 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		1CE700000000000000000010 /* InceptionPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InceptionPlugin.swift; sourceTree = "<group>"; };
+		1CE700000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		1CE700000000000000000012 /* InceptionPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InceptionPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000259 /* ClaudePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudePlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000260 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000261 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -1214,6 +1220,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1CE700000000000000000041 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CE700000000000000000003 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000132 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1353,6 +1367,7 @@
 				CC00000000000000000036 /* OpenAIVectorMemoryPlugin */,
 				CC00000000000000000037 /* FireworksPlugin */,
 				CC00000000000000000038 /* CerebrasPlugin */,
+				1CE700000000000000000020 /* InceptionPlugin */,
 				CC00000000000000000039 /* ClaudePlugin */,
 				CC00000000000000000041 /* GladiaPlugin */,
 				CC00000000000000000040 /* ElevenLabsPlugin */,
@@ -2005,6 +2020,16 @@
 			path = TypeWhisperPluginSDK/Plugins/CerebrasPlugin;
 			sourceTree = "<group>";
 		};
+		1CE700000000000000000020 /* InceptionPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				1CE700000000000000000010 /* InceptionPlugin.swift */,
+				1CE700000000000000000011 /* manifest.json */,
+			);
+			name = InceptionPlugin;
+			path = TypeWhisperPluginSDK/Plugins/InceptionPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000039 /* ClaudePlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2150,6 +2175,7 @@
 				BB00000000000000000234 /* OpenAIVectorMemoryPlugin.bundle */,
 				BB00000000000000000254 /* FireworksPlugin.bundle */,
 				BB00000000000000000257 /* CerebrasPlugin.bundle */,
+				1CE700000000000000000012 /* InceptionPlugin.bundle */,
 				BB00000000000000000262 /* ClaudePlugin.bundle */,
 				BB00000000000000000270 /* GladiaPlugin.bundle */,
 				BB00000000000000000266 /* ElevenLabsPlugin.bundle */,
@@ -2925,6 +2951,26 @@
 			productReference = BB00000000000000000257 /* CerebrasPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		1CE700000000000000000030 /* InceptionPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CE700000000000000000052 /* Build configuration list for PBXNativeTarget "InceptionPlugin" */;
+			buildPhases = (
+				1CE700000000000000000040 /* Sources */,
+				1CE700000000000000000041 /* Frameworks */,
+				1CE700000000000000000042 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InceptionPlugin;
+			packageProductDependencies = (
+				1CE700000000000000000060 /* TypeWhisperPluginSDK */,
+			);
+			productName = InceptionPlugin;
+			productReference = 1CE700000000000000000012 /* InceptionPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000027 /* ClaudePlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000134 /* Build configuration list for PBXNativeTarget "ClaudePlugin" */;
@@ -3209,6 +3255,7 @@
 				DD00000000000000000024 /* OpenAIVectorMemoryPlugin */,
 				DD00000000000000000025 /* FireworksPlugin */,
 				DD00000000000000000026 /* CerebrasPlugin */,
+				1CE700000000000000000030 /* InceptionPlugin */,
 				DD00000000000000000027 /* ClaudePlugin */,
 				DD00000000000000000029 /* GladiaPlugin */,
 				DD00000000000000000028 /* ElevenLabsPlugin */,
@@ -3520,6 +3567,14 @@
 			files = (
 				AA00000000000000000268 /* manifest.json in Resources */,
 				AA00000000000000000269 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CE700000000000000000042 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CE700000000000000000002 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4117,6 +4172,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000267 /* CerebrasPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1CE700000000000000000040 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CE700000000000000000001 /* InceptionPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6055,6 +6118,54 @@
 			};
 			name = Release;
 		};
+		1CE700000000000000000050 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Inception;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = InceptionPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.inception;
+				PRODUCT_NAME = InceptionPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		1CE700000000000000000051 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Inception;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = InceptionPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.inception;
+				PRODUCT_NAME = InceptionPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		XX00000000000000000109 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6814,6 +6925,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		1CE700000000000000000052 /* Build configuration list for PBXNativeTarget "InceptionPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CE700000000000000000050 /* Debug */,
+				1CE700000000000000000051 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000134 /* Build configuration list for PBXNativeTarget "ClaudePlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7138,6 +7258,10 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000036 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		1CE700000000000000000060 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		AA00000000000000000270 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000036 /* TypeWhisperPluginSDK */; };
 		1CE700000000000000000001 /* InceptionPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE700000000000000000010 /* InceptionPlugin.swift */; };
 		1CE700000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1CE700000000000000000011 /* manifest.json */; };
+		1CE700000000000000000004 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 1CE700000000000000000013 /* Localizable.xcstrings */; };
 		1CE700000000000000000003 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 1CE700000000000000000060 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000271 /* ClaudePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000259 /* ClaudePlugin.swift */; };
 		AA00000000000000000272 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000260 /* manifest.json */; };
@@ -875,6 +876,7 @@
 		1CE700000000000000000010 /* InceptionPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InceptionPlugin.swift; sourceTree = "<group>"; };
 		1CE700000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		1CE700000000000000000012 /* InceptionPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InceptionPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CE700000000000000000013 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000259 /* ClaudePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudePlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000260 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000261 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -2025,6 +2027,7 @@
 			children = (
 				1CE700000000000000000010 /* InceptionPlugin.swift */,
 				1CE700000000000000000011 /* manifest.json */,
+				1CE700000000000000000013 /* Localizable.xcstrings */,
 			);
 			name = InceptionPlugin;
 			path = TypeWhisperPluginSDK/Plugins/InceptionPlugin;
@@ -3575,6 +3578,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CE700000000000000000002 /* manifest.json in Resources */,
+				1CE700000000000000000004 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1521,7 +1521,7 @@ private struct InstalledPluginRow: View {
 
                     PluginBadgeLine(source: source, hosting: hosting, categories: categories)
 
-                    if let description = registryPlugin?.localizedDescription {
+                    if let description = registryPlugin?.localizedDescription ?? plugin.manifest.localizedDescription {
                         Text(description)
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -83,6 +83,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "InceptionPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/InceptionPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "FireworksPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/FireworksPlugin",
@@ -336,6 +345,15 @@ let package = Package(
                 "CerebrasPlugin",
             ],
             path: "Plugins/CerebrasPlugin/Tests"
+        ),
+        .testTarget(
+            name: "InceptionPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "InceptionPlugin",
+            ],
+            path: "Plugins/InceptionPlugin/Tests"
         ),
         .testTarget(
             name: "FireworksPluginTests",

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -88,6 +88,7 @@ let package = Package(
             path: "Plugins/InceptionPlugin",
             exclude: ["Tests"],
             resources: [
+                .process("Localizable.xcstrings"),
                 .process("manifest.json"),
             ]
         ),

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
@@ -1,0 +1,488 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+// MARK: - Plugin Entry Point
+
+@objc(InceptionPlugin)
+final class InceptionPlugin: NSObject,
+    LLMProviderPlugin,
+    LLMProviderIdentityProviding,
+    LLMTemperatureControllableProvider,
+    LLMModelSelectable,
+    @unchecked Sendable
+{
+    static let pluginId = "com.typewhisper.inception"
+    static let pluginName = "Inception"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.75
+    fileprivate var _reasoningEffort: String = "medium"
+    fileprivate var _fetchedModels: [InceptionFetchedModel] = []
+
+    private let chatHelper = PluginOpenAIChatHelper(
+        baseURL: "https://api.inceptionlabs.ai"
+    )
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: "api-key")
+        if let data = host.userDefault(forKey: "fetchedModels") as? Data,
+           let models = try? JSONDecoder().decode([InceptionFetchedModel].self, from: data) {
+            _fetchedModels = models
+        }
+        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.75
+        _reasoningEffort = host.userDefault(forKey: "reasoningEffort") as? String
+            ?? "medium"
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - LLMProviderPlugin
+
+    var providerName: String { "Inception" }
+    var providerId: String { Self.pluginId }
+    var providerDisplayName: String { providerName }
+
+    var isAvailable: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    private static let displayNames: [String: String] = [
+        "mercury-2": "Mercury 2",
+    ]
+
+    private static let fallbackModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "mercury-2", displayName: "Mercury 2"),
+    ]
+
+    var supportedModels: [PluginModelInfo] {
+        if _fetchedModels.isEmpty {
+            return Self.fallbackModels
+        }
+        return _fetchedModels.map {
+            PluginModelInfo(id: $0.id, displayName: Self.displayNames[$0.id] ?? $0.id)
+        }
+    }
+
+    func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginChatError.notConfigured
+        }
+        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
+        return try await chatHelper.process(
+            apiKey: apiKey,
+            model: modelId,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            maxOutputTokens: 8192,
+            reasoningEffort: _reasoningEffort,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
+            requestTimeout: 120
+        )
+    }
+
+    func selectLLMModel(_ modelId: String) {
+        _selectedLLMModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+    }
+
+    var selectedLLMModelId: String? { _selectedLLMModelId }
+    @objc var preferredModelId: String? { _selectedLLMModelId }
+
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(InceptionSettingsView(plugin: self))
+    }
+
+    func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: key)
+            } catch {
+                print("[InceptionPlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: "")
+            } catch {
+                print("[InceptionPlugin] Failed to delete API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func setReasoningEffort(_ value: String) {
+        guard Self.reasoningEfforts.contains(value) else { return }
+        _reasoningEffort = value
+        host?.setUserDefault(value, forKey: "reasoningEffort")
+    }
+
+    func validateApiKey(_ key: String) async -> Bool {
+        guard !key.isEmpty,
+              let url = URL(string: "https://api.inceptionlabs.ai/v1/models") else { return false }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return false }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    fileprivate func setFetchedModels(_ models: [InceptionFetchedModel]) {
+        _fetchedModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: "fetchedModels")
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func fetchModels() async -> [InceptionFetchedModel] {
+        guard let apiKey = _apiKey, !apiKey.isEmpty,
+              let url = URL(string: "https://api.inceptionlabs.ai/v1/models") else { return [] }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+
+            struct ModelsResponse: Decodable {
+                let data: [InceptionFetchedModel]
+            }
+
+            let decoded = try JSONDecoder().decode(ModelsResponse.self, from: data)
+            let chatModels = decoded.data.filter { $0.isChatCompletionsModel }
+            return chatModels.sorted { $0.id < $1.id }
+        } catch {
+            return []
+        }
+    }
+
+    fileprivate static let reasoningEfforts = ["instant", "low", "medium", "high"]
+}
+
+// MARK: - Fetched Model
+
+struct InceptionFetchedModel: Codable, Sendable {
+    let id: String
+    let displayName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case owned_by
+    }
+
+    var isChatCompletionsModel: Bool {
+        !id.localizedCaseInsensitiveContains("edit")
+    }
+
+    init(id: String, displayName: String?) {
+        self.id = id
+        self.displayName = displayName
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        _ = try container.decodeIfPresent(String.self, forKey: .owned_by)
+        displayName = nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+    }
+}
+
+// MARK: - Settings View
+
+private struct InceptionSettingsView: View {
+    let plugin: InceptionPlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    @State private var selectedModel: String = ""
+    @State private var reasoningEffort: String = "medium"
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.75
+    @State private var fetchedModels: [InceptionFetchedModel] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key")
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isAvailable {
+                        Button("Remove") {
+                            apiKeyInput = ""
+                            validationResult = nil
+                            plugin.removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button("Save") {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = validationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result ? .green : .red)
+                        Text(result ? "Valid API Key" : "Invalid API Key")
+                            .font(.caption)
+                            .foregroundStyle(result ? .green : .red)
+                    }
+                }
+
+                Link("Get API Key", destination: URL(string: "https://platform.inceptionlabs.ai/")!)
+                    .font(.caption)
+            }
+
+            if plugin.isAvailable {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("LLM Model")
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Picker("LLM Model", selection: $selectedModel) {
+                        ForEach(plugin.supportedModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedModel) {
+                        plugin.selectLLMModel(selectedModel)
+                    }
+
+                    if fetchedModels.isEmpty {
+                        Text("Using default models. Press Refresh to fetch available chat models.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Reasoning Effort")
+                        .font(.headline)
+
+                    Picker("Reasoning Effort", selection: $reasoningEffort) {
+                        ForEach(InceptionPlugin.reasoningEfforts, id: \.self) { value in
+                            Text(value.capitalized).tag(value)
+                        }
+                    }
+                    .onChange(of: reasoningEffort) {
+                        plugin.setReasoningEffort(reasoningEffort)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature")
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default").tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom").tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin._apiKey, !key.isEmpty {
+                apiKeyInput = key
+            }
+            selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            reasoningEffort = plugin._reasoningEffort
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
+            fetchedModels = plugin._fetchedModels
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        plugin.setApiKey(trimmedKey)
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            if isValid {
+                let models = await plugin.fetchModels()
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = true
+                    if !models.isEmpty {
+                        fetchedModels = models
+                        plugin.setFetchedModels(models)
+                    }
+                }
+            } else {
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = false
+                }
+            }
+        }
+    }
+
+    private func refreshModels() {
+        Task {
+            let models = await plugin.fetchModels()
+            await MainActor.run {
+                if !models.isEmpty {
+                    fetchedModels = models
+                    plugin.setFetchedModels(models)
+                    if !models.contains(where: { $0.id == selectedModel }),
+                       let first = models.first {
+                        selectedModel = first.id
+                        plugin.selectLLMModel(first.id)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
@@ -21,11 +21,8 @@ final class InceptionPlugin: NSObject,
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.75
     fileprivate var _reasoningEffort: String = "medium"
+    fileprivate var _outputModeRaw: String = InceptionOutputMode.streaming.rawValue
     fileprivate var _fetchedModels: [InceptionFetchedModel] = []
-
-    private let chatHelper = PluginOpenAIChatHelper(
-        baseURL: "https://api.inceptionlabs.ai"
-    )
 
     required override init() {
         super.init()
@@ -45,6 +42,8 @@ final class InceptionPlugin: NSObject,
             ?? 0.75
         _reasoningEffort = host.userDefault(forKey: "reasoningEffort") as? String
             ?? "medium"
+        _outputModeRaw = host.userDefault(forKey: "outputMode") as? String
+            ?? InceptionOutputMode.streaming.rawValue
     }
 
     func deactivate() {
@@ -98,7 +97,7 @@ final class InceptionPlugin: NSObject,
             throw PluginChatError.notConfigured
         }
         let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
-        return try await chatHelper.process(
+        return try await Self.processStreamingChatCompletion(
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
@@ -106,6 +105,7 @@ final class InceptionPlugin: NSObject,
             maxOutputTokens: 8192,
             reasoningEffort: _reasoningEffort,
             temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
+            outputMode: outputMode,
             requestTimeout: 120
         )
     }
@@ -175,6 +175,15 @@ final class InceptionPlugin: NSObject,
         host?.setUserDefault(value, forKey: "reasoningEffort")
     }
 
+    func setOutputMode(_ mode: InceptionOutputMode) {
+        _outputModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "outputMode")
+    }
+
+    var outputMode: InceptionOutputMode {
+        InceptionOutputMode(rawValue: _outputModeRaw) ?? .streaming
+    }
+
     func validateApiKey(_ key: String) async -> Bool {
         guard !key.isEmpty,
               let url = URL(string: "https://api.inceptionlabs.ai/v1/models") else { return false }
@@ -226,6 +235,145 @@ final class InceptionPlugin: NSObject,
     }
 
     fileprivate static let reasoningEfforts = ["instant", "low", "medium", "high"]
+
+    private static func processStreamingChatCompletion(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        maxOutputTokens: Int,
+        reasoningEffort: String,
+        temperature: Double?,
+        outputMode: InceptionOutputMode,
+        requestTimeout: TimeInterval
+    ) async throws -> String {
+        guard let url = URL(string: "https://api.inceptionlabs.ai/v1/chat/completions") else {
+            throw PluginChatError.apiError("Invalid Inception chat URL")
+        }
+
+        var requestBody: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userText],
+            ],
+            "max_tokens": maxOutputTokens,
+            "reasoning_effort": reasoningEffort,
+            "stream": true,
+        ]
+
+        if let temperature {
+            requestBody["temperature"] = temperature
+        }
+
+        if outputMode == .diffusion {
+            requestBody["diffusing"] = true
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = requestTimeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: requestTimeout)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginChatError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401:
+            throw PluginChatError.invalidApiKey
+        case 429:
+            throw PluginChatError.rateLimited
+        default:
+            throw PluginChatError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+        }
+
+        let content = try parseStreamingContent(from: data, outputMode: outputMode)
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func parseStreamingContent(from data: Data, outputMode: InceptionOutputMode) throws -> String {
+        guard let stream = String(data: data, encoding: .utf8) else {
+            throw PluginChatError.apiError("Failed to parse streaming response")
+        }
+
+        var accumulated = ""
+        var latest = ""
+
+        for rawLine in stream.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard line.hasPrefix("data: ") else { continue }
+
+            let payload = String(line.dropFirst(6))
+            guard payload != "[DONE]" else { continue }
+
+            guard let payloadData = payload.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]] else {
+                continue
+            }
+
+            for choice in choices {
+                guard let delta = choice["delta"] as? [String: Any],
+                      let content = delta["content"] as? String,
+                      !content.isEmpty else {
+                    continue
+                }
+
+                switch outputMode {
+                case .streaming:
+                    accumulated += content
+                case .diffusion:
+                    latest = content
+                }
+            }
+        }
+
+        let content = outputMode == .diffusion ? latest : accumulated
+        guard !content.isEmpty else {
+            throw PluginChatError.apiError("Failed to parse streaming response")
+        }
+        return content
+    }
+
+    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return "HTTP \(statusCode)"
+        }
+        if let detail = object["detail"] as? String, !detail.isEmpty {
+            return detail
+        }
+        if let error = object["error"] as? [String: Any],
+           let message = error["message"] as? String,
+           !message.isEmpty {
+            return message
+        }
+        if let message = object["message"] as? String, !message.isEmpty {
+            return message
+        }
+        return "HTTP \(statusCode)"
+    }
+}
+
+enum InceptionOutputMode: String, CaseIterable, Sendable {
+    case streaming
+    case diffusion
+
+    var displayName: String {
+        switch self {
+        case .streaming:
+            return "Streaming"
+        case .diffusion:
+            return "Diffusion"
+        }
+    }
 }
 
 // MARK: - Fetched Model
@@ -271,6 +419,7 @@ private struct InceptionSettingsView: View {
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
     @State private var reasoningEffort: String = "medium"
+    @State private var outputMode: InceptionOutputMode = .streaming
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.75
     @State private var fetchedModels: [InceptionFetchedModel] = []
@@ -377,16 +526,32 @@ private struct InceptionSettingsView: View {
                 Divider()
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Reasoning Effort")
+                    Text("Thinking Level")
                         .font(.headline)
 
-                    Picker("Reasoning Effort", selection: $reasoningEffort) {
+                    Picker("Thinking Level", selection: $reasoningEffort) {
                         ForEach(InceptionPlugin.reasoningEfforts, id: \.self) { value in
                             Text(value.capitalized).tag(value)
                         }
                     }
                     .onChange(of: reasoningEffort) {
                         plugin.setReasoningEffort(reasoningEffort)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Output Mode")
+                        .font(.headline)
+
+                    Picker("Output Mode", selection: $outputMode) {
+                        ForEach(InceptionOutputMode.allCases, id: \.self) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .onChange(of: outputMode) {
+                        plugin.setOutputMode(outputMode)
                     }
                 }
 
@@ -434,6 +599,7 @@ private struct InceptionSettingsView: View {
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             reasoningEffort = plugin._reasoningEffort
+            outputMode = plugin.outputMode
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
             fetchedModels = plugin._fetchedModels

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
@@ -21,7 +21,6 @@ final class InceptionPlugin: NSObject,
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.75
     fileprivate var _reasoningEffort: String = "medium"
-    fileprivate var _outputModeRaw: String = InceptionOutputMode.streaming.rawValue
     fileprivate var _fetchedModels: [InceptionFetchedModel] = []
 
     required override init() {
@@ -42,8 +41,6 @@ final class InceptionPlugin: NSObject,
             ?? 0.75
         _reasoningEffort = host.userDefault(forKey: "reasoningEffort") as? String
             ?? "medium"
-        _outputModeRaw = host.userDefault(forKey: "outputMode") as? String
-            ?? InceptionOutputMode.streaming.rawValue
     }
 
     func deactivate() {
@@ -105,7 +102,6 @@ final class InceptionPlugin: NSObject,
             maxOutputTokens: 8192,
             reasoningEffort: _reasoningEffort,
             temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
-            outputMode: outputMode,
             requestTimeout: 120
         )
     }
@@ -175,15 +171,6 @@ final class InceptionPlugin: NSObject,
         host?.setUserDefault(value, forKey: "reasoningEffort")
     }
 
-    func setOutputMode(_ mode: InceptionOutputMode) {
-        _outputModeRaw = mode.rawValue
-        host?.setUserDefault(mode.rawValue, forKey: "outputMode")
-    }
-
-    var outputMode: InceptionOutputMode {
-        InceptionOutputMode(rawValue: _outputModeRaw) ?? .streaming
-    }
-
     func validateApiKey(_ key: String) async -> Bool {
         guard !key.isEmpty,
               let url = URL(string: "https://api.inceptionlabs.ai/v1/models") else { return false }
@@ -244,7 +231,6 @@ final class InceptionPlugin: NSObject,
         maxOutputTokens: Int,
         reasoningEffort: String,
         temperature: Double?,
-        outputMode: InceptionOutputMode,
         requestTimeout: TimeInterval
     ) async throws -> String {
         guard let url = URL(string: "https://api.inceptionlabs.ai/v1/chat/completions") else {
@@ -264,10 +250,6 @@ final class InceptionPlugin: NSObject,
 
         if let temperature {
             requestBody["temperature"] = temperature
-        }
-
-        if outputMode == .diffusion {
-            requestBody["diffusing"] = true
         }
 
         var request = URLRequest(url: url)
@@ -295,17 +277,16 @@ final class InceptionPlugin: NSObject,
             throw PluginChatError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
         }
 
-        let content = try parseStreamingContent(from: data, outputMode: outputMode)
+        let content = try parseStreamingContent(from: data)
         return content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    static func parseStreamingContent(from data: Data, outputMode: InceptionOutputMode) throws -> String {
+    static func parseStreamingContent(from data: Data) throws -> String {
         guard let stream = String(data: data, encoding: .utf8) else {
             throw PluginChatError.apiError("Failed to parse streaming response")
         }
 
         var accumulated = ""
-        var latest = ""
 
         for rawLine in stream.split(whereSeparator: \.isNewline) {
             let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -327,20 +308,14 @@ final class InceptionPlugin: NSObject,
                     continue
                 }
 
-                switch outputMode {
-                case .streaming:
-                    accumulated += content
-                case .diffusion:
-                    latest = content
-                }
+                accumulated += content
             }
         }
 
-        let content = outputMode == .diffusion ? latest : accumulated
-        guard !content.isEmpty else {
+        guard !accumulated.isEmpty else {
             throw PluginChatError.apiError("Failed to parse streaming response")
         }
-        return content
+        return accumulated
     }
 
     private static func errorMessage(from data: Data, statusCode: Int) -> String {
@@ -359,20 +334,6 @@ final class InceptionPlugin: NSObject,
             return message
         }
         return "HTTP \(statusCode)"
-    }
-}
-
-enum InceptionOutputMode: String, CaseIterable, Sendable {
-    case streaming
-    case diffusion
-
-    var displayName: String {
-        switch self {
-        case .streaming:
-            return "Streaming"
-        case .diffusion:
-            return "Diffusion"
-        }
     }
 }
 
@@ -419,7 +380,6 @@ private struct InceptionSettingsView: View {
     @State private var showApiKey = false
     @State private var selectedModel: String = ""
     @State private var reasoningEffort: String = "medium"
-    @State private var outputMode: InceptionOutputMode = .streaming
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.75
     @State private var fetchedModels: [InceptionFetchedModel] = []
@@ -539,24 +499,6 @@ private struct InceptionSettingsView: View {
                     }
                 }
 
-                Divider()
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Output Mode")
-                        .font(.headline)
-
-                    Picker("Output Mode", selection: $outputMode) {
-                        ForEach(InceptionOutputMode.allCases, id: \.self) { mode in
-                            Text(mode.displayName).tag(mode)
-                        }
-                    }
-                    .onChange(of: outputMode) {
-                        plugin.setOutputMode(outputMode)
-                    }
-                }
-
-                Divider()
-
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Temperature")
                         .font(.headline)
@@ -599,7 +541,6 @@ private struct InceptionSettingsView: View {
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             reasoningEffort = plugin._reasoningEffort
-            outputMode = plugin.outputMode
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
             fetchedModels = plugin._fetchedModels

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/InceptionPlugin.swift
@@ -341,27 +341,22 @@ final class InceptionPlugin: NSObject,
 
 struct InceptionFetchedModel: Codable, Sendable {
     let id: String
-    let displayName: String?
 
     enum CodingKeys: String, CodingKey {
         case id
-        case owned_by
     }
 
     var isChatCompletionsModel: Bool {
         !id.localizedCaseInsensitiveContains("edit")
     }
 
-    init(id: String, displayName: String?) {
+    init(id: String) {
         self.id = id
-        self.displayName = displayName
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
-        _ = try container.decodeIfPresent(String.self, forKey: .owned_by)
-        displayName = nil
     }
 
     func encode(to encoder: Encoder) throws {

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Localizable.xcstrings
@@ -1,0 +1,262 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキー"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel werden sicher im Schlüsselbund gespeichert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーはキーチェーンに安全に保存されます"
+          }
+        }
+      }
+    },
+    "Custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene Einstellung"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム"
+          }
+        }
+      }
+    },
+    "Get API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel erstellen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーを作成"
+          }
+        }
+      }
+    },
+    "Invalid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なAPIキー"
+          }
+        }
+      }
+    },
+    "LLM Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM-Modell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLMモデル"
+          }
+        }
+      }
+    },
+    "Provider Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider-Standard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロバイダーのデフォルト"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Temperature": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperatur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温度"
+          }
+        }
+      }
+    },
+    "Temperature Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperaturmodus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温度モード"
+          }
+        }
+      }
+    },
+    "Thinking Level": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denkstufe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考レベル"
+          }
+        }
+      }
+    },
+    "Using default models. Press Refresh to fetch available chat models.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardmodelle werden verwendet. Aktualisieren drücken, um verfügbare Chat-Modelle abzurufen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準モデルが使用されます。更新を押して、利用可能なチャットモデルを取得してください。"
+          }
+        }
+      }
+    },
+    "Valid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なAPIキー"
+          }
+        }
+      }
+    },
+    "Validating...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft ..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認中..."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
@@ -34,4 +34,35 @@ final class InceptionPluginTests: XCTestCase {
         XCTAssertTrue(InceptionFetchedModel(id: "mercury-2", displayName: nil).isChatCompletionsModel)
         XCTAssertFalse(InceptionFetchedModel(id: "mercury-edit-2", displayName: nil).isChatCompletionsModel)
     }
+
+    func testStreamingParserAppendsDeltaChunks() throws {
+        let data = Data(
+            """
+            data: {"choices":[{"delta":{"content":"Hello"}}]}
+            data: {"choices":[{"delta":{"content":" world"}}]}
+            data: [DONE]
+
+            """.utf8
+        )
+
+        let content = try InceptionPlugin.parseStreamingContent(from: data, outputMode: .streaming)
+
+        XCTAssertEqual(content, "Hello world")
+    }
+
+    func testDiffusionParserReturnsLatestRefinedChunk() throws {
+        let data = Data(
+            """
+            data: {"choices":[{"delta":{"content":"Hxlxo"}}]}
+            data: {"choices":[{"delta":{"content":"Hello"}}]}
+            data: {"choices":[{"delta":{"content":"Hello world"}}]}
+            data: [DONE]
+
+            """.utf8
+        )
+
+        let content = try InceptionPlugin.parseStreamingContent(from: data, outputMode: .diffusion)
+
+        XCTAssertEqual(content, "Hello world")
+    }
 }

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import TypeWhisperPluginSDK
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import InceptionPlugin
+
+final class InceptionPluginTests: XCTestCase {
+    func testDefaultModelIsMercury2() throws {
+        let host = try PluginTestHostServices()
+        let plugin = InceptionPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["mercury-2"])
+        XCTAssertEqual(plugin.supportedModels.first?.displayName, "Mercury 2")
+    }
+
+    func testPreferredModelIdReflectsSelectedLLMModel() throws {
+        let host = try PluginTestHostServices()
+        let plugin = InceptionPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertNil(
+            (plugin as? LLMModelSelectable)?.preferredModelId ?? nil,
+            "preferredModelId must be nil until the user selects a model"
+        )
+
+        let target = try XCTUnwrap(plugin.supportedModels.first?.id)
+        plugin.selectLLMModel(target)
+
+        let preferred = (plugin as? LLMModelSelectable)?.preferredModelId
+        XCTAssertEqual(preferred, target)
+    }
+
+    func testEditModelsAreNotExposedForChatProcessing() {
+        XCTAssertTrue(InceptionFetchedModel(id: "mercury-2", displayName: nil).isChatCompletionsModel)
+        XCTAssertFalse(InceptionFetchedModel(id: "mercury-edit-2", displayName: nil).isChatCompletionsModel)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
@@ -45,23 +45,7 @@ final class InceptionPluginTests: XCTestCase {
             """.utf8
         )
 
-        let content = try InceptionPlugin.parseStreamingContent(from: data, outputMode: .streaming)
-
-        XCTAssertEqual(content, "Hello world")
-    }
-
-    func testDiffusionParserReturnsLatestRefinedChunk() throws {
-        let data = Data(
-            """
-            data: {"choices":[{"delta":{"content":"Hxlxo"}}]}
-            data: {"choices":[{"delta":{"content":"Hello"}}]}
-            data: {"choices":[{"delta":{"content":"Hello world"}}]}
-            data: [DONE]
-
-            """.utf8
-        )
-
-        let content = try InceptionPlugin.parseStreamingContent(from: data, outputMode: .diffusion)
+        let content = try InceptionPlugin.parseStreamingContent(from: data)
 
         XCTAssertEqual(content, "Hello world")
     }

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/Tests/InceptionPluginTests.swift
@@ -31,8 +31,8 @@ final class InceptionPluginTests: XCTestCase {
     }
 
     func testEditModelsAreNotExposedForChatProcessing() {
-        XCTAssertTrue(InceptionFetchedModel(id: "mercury-2", displayName: nil).isChatCompletionsModel)
-        XCTAssertFalse(InceptionFetchedModel(id: "mercury-edit-2", displayName: nil).isChatCompletionsModel)
+        XCTAssertTrue(InceptionFetchedModel(id: "mercury-2").isChatCompletionsModel)
+        XCTAssertFalse(InceptionFetchedModel(id: "mercury-edit-2").isChatCompletionsModel)
     }
 
     func testStreamingParserAppendsDeltaChunks() throws {

--- a/TypeWhisperPluginSDK/Plugins/InceptionPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/InceptionPlugin/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "com.typewhisper.inception",
+  "name": "Inception",
+  "version": "1.0.0",
+  "minHostVersion": "1.5.0",
+  "sdkCompatibilityVersion": "v1",
+  "minOSVersion": "14.0",
+  "author": "TypeWhisper",
+  "description": "LLM post-processing via Inception Mercury diffusion models. Requires an Inception API key.",
+  "descriptions": {
+    "de": "LLM-Nachbearbeitung über Inception Mercury Diffusion-Modelle. Erfordert einen Inception API-Key."
+  },
+  "category": "llm",
+  "iconSystemName": "sparkles",
+  "principalClass": "InceptionPlugin",
+  "requiresAPIKey": true,
+  "detailsURL": "https://www.inceptionlabs.ai/models"
+}

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -81,7 +81,7 @@ Bundled MLX plugins such as Qwen3, Granite, and Voxtral store their optional Hug
 
 Bundled experimental local TTS plugins such as Supertonic store optional HuggingFace tokens the same way, but model weights are not bundled in the plugin ZIP. Supertonic downloads `Supertone/supertonic-3` assets only after the user accepts the OpenRAIL-M model license in plugin settings. That model-license confirmation is scoped to the model download and does not change TypeWhisper app licensing.
 
-Bundled cloud plugins include Groq, OpenAI, OpenAI Compatible, and xAI/Grok. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
+Bundled cloud plugins include Groq, OpenAI, Inception, OpenAI Compatible, and xAI/Grok. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
 
 ## Example
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift
@@ -22,6 +22,8 @@ public struct PluginManifest: Codable, Equatable, Sendable {
     public let minOSVersion: String?
     public let supportedArchitectures: [String]?
     public let author: String?
+    public let description: String?
+    public let descriptions: [String: String]?
     public let principalClass: String
     public let requiresAPIKey: Bool?
     public let hosting: PluginHosting?
@@ -44,6 +46,8 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         minOSVersion: String? = nil,
         supportedArchitectures: [String]? = nil,
         author: String? = nil,
+        description: String? = nil,
+        descriptions: [String: String]? = nil,
         principalClass: String,
         requiresAPIKey: Bool? = nil,
         hosting: PluginHosting? = nil,
@@ -65,6 +69,8 @@ public struct PluginManifest: Codable, Equatable, Sendable {
         self.minOSVersion = minOSVersion
         self.supportedArchitectures = supportedArchitectures
         self.author = author
+        self.description = description
+        self.descriptions = descriptions
         self.principalClass = principalClass
         self.requiresAPIKey = requiresAPIKey
         self.hosting = hosting
@@ -83,6 +89,15 @@ public struct PluginManifest: Codable, Equatable, Sendable {
 public extension PluginManifest {
     var resolvedHosting: PluginHosting {
         hosting ?? PluginHosting.fallback(requiresAPIKey: requiresAPIKey)
+    }
+
+    var localizedDescription: String? {
+        if let descriptions,
+           let lang = Locale.current.language.languageCode?.identifier,
+           let localized = descriptions[lang] {
+            return localized
+        }
+        return description
     }
 
     var resolvedCategoryIdentifiers: [String] {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
@@ -13,6 +13,10 @@ final class PluginManifestTests: XCTestCase {
               "sdkCompatibilityVersion": "v1",
               "minOSVersion": "14.0",
               "author": "TypeWhisper",
+              "description": "Mock plugin description.",
+              "descriptions": {
+                "de": "Beschreibung des Mock-Plugins."
+              },
               "principalClass": "MockPlugin"
             }
             """.utf8
@@ -30,9 +34,13 @@ final class PluginManifestTests: XCTestCase {
                 sdkCompatibilityVersion: "v1",
                 minOSVersion: "14.0",
                 author: "TypeWhisper",
+                description: "Mock plugin description.",
+                descriptions: ["de": "Beschreibung des Mock-Plugins."],
                 principalClass: "MockPlugin"
             )
         )
+        XCTAssertEqual(manifest.description, "Mock plugin description.")
+        XCTAssertEqual(manifest.descriptions, ["de": "Beschreibung des Mock-Plugins."])
     }
 
     func testPluginManifestDecodesSupportedArchitecturesWhenPresent() throws {


### PR DESCRIPTION
## Summary

Adds an Inception LLM provider plugin for Mercury models, including API key setup, model selection, thinking level, and temperature controls.

The plugin uses Inception’s streaming chat completions API internally and returns the final accumulated response. The visible diffusion output mode was removed because TypeWhisper’s current LLM plugin path only supports final-string responses, so intermediate diffusion updates cannot be shown yet.

Logo note: this PR keeps the SF Symbol fallback for Inception. Existing branded plugin logos are hosted under `https://www.typewhisper.com/brand-logos/...`; an Inception logo can be added later using the same pattern, for example from https://lobehub.com/icons/inception once approved/hosted by the project.

Adresses #717 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Inception as a bundled AI provider plugin with API key management, model selection, temperature and reasoning-effort controls, and a settings UI.

* **Tests**
  * Added tests validating plugin initialization, model selection, streaming response parsing, and defaults.

* **Documentation**
  * Updated plugin docs and README to list Inception.

* **Localization**
  * Added English source with German and Japanese localized strings for the Inception UI.

* **UI**
  * Plugin settings list now prefers registry-provided descriptions when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->