### PR TITLE
Add Gemini speech transcription

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -172,10 +172,12 @@ final class GeminiPlugin: NSObject,
     var isConfigured: Bool { isAvailable }
 
     private static let defaultTranscriptionModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "gemini-flash-lite-latest", displayName: "Gemini Flash-Lite Latest"),
+        PluginModelInfo(id: "gemini-flash-latest", displayName: "Gemini Flash Latest"),
         PluginModelInfo(id: "gemini-3.1-flash-lite", displayName: "Gemini 3.1 Flash-Lite"),
+        PluginModelInfo(id: "gemini-3.5-flash", displayName: "Gemini 3.5 Flash"),
         PluginModelInfo(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash-Lite"),
         PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
-        PluginModelInfo(id: "gemini-3.5-flash", displayName: "Gemini 3.5 Flash"),
     ]
 
     private static var defaultTranscriptionModelId: String {

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -5,13 +5,22 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(GeminiPlugin)
-final class GeminiPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unchecked Sendable {
+final class GeminiPlugin: NSObject,
+    LLMProviderPlugin,
+    LLMModelSelectable,
+    TranscriptionEnginePlugin,
+    DictionaryTermsCapabilityProviding,
+    @unchecked Sendable
+{
     static let pluginId = "com.typewhisper.gemini"
     static let pluginName = "Gemini"
     private static let cachedLLMModelsKey = "fetchedLLMModels.v2"
     private static let legacyCachedLLMModelsKey = "fetchedLLMModels"
     private static let selectedLLMModelKey = "selectedLLMModel"
+    private static let selectedTranscriptionModelKey = "selectedModel"
     private static let compatibleModelsEndpoint = "https://generativelanguage.googleapis.com/v1beta/openai/models"
+    private static let generateContentAPIBase = "https://generativelanguage.googleapis.com/v1beta/models"
+    private static let transcriptionRequestTimeout: TimeInterval = 60
     private static let modelIdPrefix = "models/"
     private static let excludedCompatibleModelTokens = [
         "embedding",
@@ -27,6 +36,7 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedLLMModelId: String?
+    fileprivate var _selectedTranscriptionModelId: String?
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedLLMModels: [GeminiFetchedModel] = []
@@ -52,6 +62,10 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
         _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
             ?? 0.3
+        _selectedTranscriptionModelId = Self.resolvedTranscriptionModelId(
+            host.userDefault(forKey: Self.selectedTranscriptionModelKey) as? String,
+            host: host
+        )
         normalizeSelectedModel()
         refreshCompatibleModelsIfNeeded()
     }
@@ -148,6 +162,242 @@ final class GeminiPlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         let clamped = min(max(value, 0.0), 2.0)
         _llmTemperatureValue = clamped
         host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "gemini" }
+    var providerDisplayName: String { "Gemini" }
+
+    var isConfigured: Bool { isAvailable }
+
+    private static let defaultTranscriptionModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "gemini-3.1-flash-lite", displayName: "Gemini 3.1 Flash-Lite"),
+        PluginModelInfo(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash-Lite"),
+        PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+        PluginModelInfo(id: "gemini-3.5-flash", displayName: "Gemini 3.5 Flash"),
+    ]
+
+    private static var defaultTranscriptionModelId: String {
+        defaultTranscriptionModels[0].id
+    }
+
+    var transcriptionModels: [PluginModelInfo] { Self.defaultTranscriptionModels }
+
+    var selectedModelId: String? {
+        _selectedTranscriptionModelId ?? Self.defaultTranscriptionModelId
+    }
+
+    func selectModel(_ modelId: String) {
+        _selectedTranscriptionModelId = modelId
+        host?.setUserDefault(modelId, forKey: Self.selectedTranscriptionModelKey)
+    }
+
+    var supportsTranslation: Bool { false }
+    var supportsStreaming: Bool { false }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+
+    var supportedLanguages: [String] {
+        [
+            "ar", "cs", "da", "de", "el", "en", "es", "fi", "fr", "he",
+            "hi", "hu", "id", "it", "ja", "ko", "nl", "no", "pl", "pt",
+            "ro", "ru", "sv", "th", "tr", "uk", "vi", "zh",
+        ]
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("Gemini speech transcription does not support translation yet.")
+        }
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelId.isEmpty else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let request = try Self.makeTranscriptionRequest(
+            audio: audio,
+            apiKey: apiKey,
+            modelId: modelId,
+            language: language,
+            prompt: prompt,
+            timeout: Self.transcriptionRequestTimeout
+        )
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        try Self.validateTranscriptionResponse(data: data, response: response)
+        let text = try Self.parseTranscriptionResponse(data)
+        return PluginTranscriptionResult(text: text, detectedLanguage: language)
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        let result = try await transcribe(
+            audio: audio,
+            language: language,
+            translate: translate,
+            prompt: prompt
+        )
+        _ = onProgress(result.text)
+        return result
+    }
+
+    static func makeTranscriptionRequest(
+        audio: AudioData,
+        apiKey: String,
+        modelId: String,
+        language: String?,
+        prompt: String?,
+        timeout: TimeInterval
+    ) throws -> URLRequest {
+        guard let url = URL(string: "\(generateContentAPIBase)/\(modelId):generateContent") else {
+            throw PluginTranscriptionError.apiError("Invalid Gemini transcription URL.")
+        }
+
+        let renderedPrompt = transcriptionPrompt(dictionaryPrompt: prompt, language: language)
+        let body: [String: Any] = [
+            "contents": [[
+                "role": "user",
+                "parts": [
+                    ["text": renderedPrompt],
+                    [
+                        "inlineData": [
+                            "mimeType": "audio/wav",
+                            "data": audio.wavData.base64EncodedString(),
+                        ],
+                    ],
+                ],
+            ]],
+            "generationConfig": generationConfig(for: modelId),
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = timeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func validateTranscriptionResponse(data: Data, response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid Gemini response.")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return
+        case 401, 403:
+            throw PluginTranscriptionError.invalidApiKey
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        default:
+            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(transcriptionErrorMessage(from: data))")
+        }
+    }
+
+    static func parseTranscriptionResponse(_ data: Data) throws -> String {
+        struct GeminiPart: Decodable {
+            let text: String?
+        }
+        struct GeminiContent: Decodable {
+            let parts: [GeminiPart]?
+        }
+        struct GeminiCandidate: Decodable {
+            let content: GeminiContent?
+        }
+        struct GeminiResponse: Decodable {
+            let candidates: [GeminiCandidate]?
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
+            let text = decoded.candidates?.first?.content?.parts?
+                .compactMap(\.text)
+                .joined(separator: "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let text, !text.isEmpty else {
+                throw PluginTranscriptionError.apiError("Empty response from Gemini.")
+            }
+            return text
+        } catch let error as PluginTranscriptionError {
+            throw error
+        } catch {
+            throw PluginTranscriptionError.apiError("Failed to parse Gemini response: \(error.localizedDescription)")
+        }
+    }
+
+    static func transcriptionPrompt(dictionaryPrompt: String?, language: String?) -> String {
+        var sections = [
+            """
+            Transcribe the attached audio for technical dictation. Preserve proper nouns, model names, framework names, identifiers, CLI flags, version numbers, punctuation, and casing exactly when they are spoken. Use digits for numbers in technical contexts. Output only the transcription.
+            """,
+        ]
+
+        let terms = PluginDictionaryTerms.terms(fromPrompt: dictionaryPrompt)
+        if let termPrompt = PluginDictionaryTerms.prompt(from: terms, maxLength: 4_000) {
+            sections.append("User dictionary terms: \(termPrompt)")
+        }
+
+        if let language = language?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !language.isEmpty {
+            sections.append("Language hint: \(language)")
+        }
+
+        return sections.joined(separator: "\n\n")
+    }
+
+    private static func generationConfig(for modelId: String) -> [String: Any] {
+        var config: [String: Any] = [
+            "temperature": 0.2,
+            "maxOutputTokens": 2048,
+            "responseMimeType": "text/plain",
+        ]
+
+        if modelId.hasPrefix("gemini-3") {
+            config["thinkingConfig"] = ["thinkingLevel": "MINIMAL"]
+        } else if modelId.hasPrefix("gemini-2.5") {
+            config["thinkingConfig"] = ["thinkingBudget": 0]
+        }
+
+        return config
+    }
+
+    private static func transcriptionErrorMessage(from data: Data) -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = json["error"] as? [String: Any],
+              let message = error["message"] as? String,
+              !message.isEmpty else {
+            return "Gemini transcription request failed."
+        }
+        return message
+    }
+
+    private static func resolvedTranscriptionModelId(_ storedModelId: String?, host: HostServices) -> String {
+        let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let supportedIds = Set(defaultTranscriptionModels.map(\.id))
+        let modelId = trimmedModelId.flatMap { supportedIds.contains($0) ? $0 : nil }
+            ?? defaultTranscriptionModelId
+
+        if modelId != storedModelId {
+            host.setUserDefault(modelId, forKey: selectedTranscriptionModelKey)
+        }
+
+        return modelId
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
@@ -117,17 +117,19 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertFalse(plugin.supportsTranslation)
         XCTAssertFalse(plugin.supportsStreaming)
         XCTAssertEqual(plugin.dictionaryTermsSupport, .supported)
-        XCTAssertEqual(plugin.selectedModelId, "gemini-3.1-flash-lite")
+        XCTAssertEqual(plugin.selectedModelId, "gemini-flash-lite-latest")
         XCTAssertEqual(
             plugin.transcriptionModels.map(\.id),
             [
+                "gemini-flash-lite-latest",
+                "gemini-flash-latest",
                 "gemini-3.1-flash-lite",
+                "gemini-3.5-flash",
                 "gemini-2.5-flash-lite",
                 "gemini-2.5-flash",
-                "gemini-3.5-flash",
             ]
         )
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.1-flash-lite")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-flash-lite-latest")
     }
 
     func testSelectedTranscriptionModelPersistsAcrossActivation() throws {
@@ -151,15 +153,15 @@ final class GeminiPluginTests: XCTestCase {
 
         plugin.activate(host: host)
 
-        XCTAssertEqual(plugin.selectedModelId, "gemini-3.1-flash-lite")
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.1-flash-lite")
+        XCTAssertEqual(plugin.selectedModelId, "gemini-flash-lite-latest")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-flash-lite-latest")
     }
 
     func testTranscriptionRequestUsesGenerateContentJSONAudioPromptAndLanguage() throws {
         let request = try GeminiPlugin.makeTranscriptionRequest(
             audio: Self.audio(),
             apiKey: "gemini-key",
-            modelId: "gemini-3.1-flash-lite",
+            modelId: "gemini-flash-lite-latest",
             language: " de ",
             prompt: "Qwen3, MLX, proxy_read_timeout",
             timeout: 60
@@ -168,7 +170,7 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertEqual(
             request.url?.absoluteString,
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent"
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent"
         )
         XCTAssertEqual(request.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
@@ -181,7 +183,7 @@ final class GeminiPluginTests: XCTestCase {
         let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
         let promptText = try XCTUnwrap(parts.first?["text"] as? String)
         XCTAssertTrue(promptText.contains("technical dictation"))
-        XCTAssertTrue(promptText.contains("Qwen3, MLX, proxy_read_timeout"))
+        XCTAssertTrue(promptText.contains("User dictionary terms: Qwen3, MLX, proxy_read_timeout"))
         XCTAssertTrue(promptText.contains("Language hint: de"))
 
         let inlineData = try XCTUnwrap(parts.last?["inlineData"] as? [String: Any])
@@ -192,9 +194,42 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertEqual(generationConfig["temperature"] as? Double, 0.2)
         XCTAssertEqual(generationConfig["maxOutputTokens"] as? Int, 2048)
         XCTAssertEqual(generationConfig["responseMimeType"] as? String, "text/plain")
+        XCTAssertNil(generationConfig["thinkingConfig"])
+    }
+
+    func testPinnedGeminiThreeTranscriptionRequestUsesMinimalThinkingLevel() throws {
+        let request = try GeminiPlugin.makeTranscriptionRequest(
+            audio: Self.audio(),
+            apiKey: "gemini-key",
+            modelId: "gemini-3.1-flash-lite",
+            language: nil,
+            prompt: nil,
+            timeout: 60
+        )
+
+        let body = try Self.jsonBody(from: request)
+        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
         XCTAssertEqual(
             (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingLevel"] as? String,
             "MINIMAL"
+        )
+    }
+
+    func testPinnedGeminiTwoPointFiveTranscriptionRequestUsesZeroThinkingBudget() throws {
+        let request = try GeminiPlugin.makeTranscriptionRequest(
+            audio: Self.audio(),
+            apiKey: "gemini-key",
+            modelId: "gemini-2.5-flash",
+            language: nil,
+            prompt: nil,
+            timeout: 60
+        )
+
+        let body = try Self.jsonBody(from: request)
+        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
+        XCTAssertEqual(
+            (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingBudget"] as? Int,
+            0
         )
     }
 
@@ -202,7 +237,7 @@ final class GeminiPluginTests: XCTestCase {
         let request = try GeminiPlugin.makeTranscriptionRequest(
             audio: Self.audio(),
             apiKey: "gemini-key",
-            modelId: "gemini-2.5-flash",
+            modelId: "gemini-flash-lite-latest",
             language: " ",
             prompt: " ",
             timeout: 60
@@ -214,12 +249,6 @@ final class GeminiPluginTests: XCTestCase {
         let promptText = try XCTUnwrap(parts.first?["text"] as? String)
         XCTAssertFalse(promptText.contains("User dictionary terms:"))
         XCTAssertFalse(promptText.contains("Language hint:"))
-
-        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
-        XCTAssertEqual(
-            (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingBudget"] as? Int,
-            0
-        )
     }
 
     func testTranscribeFailsWithoutAPIKey() async throws {
@@ -270,7 +299,7 @@ final class GeminiPluginTests: XCTestCase {
         let host = try PluginTestHostServices(
             defaults: [
                 Self.cachedLLMModelsKey: try Self.cachedModelsData(),
-                "selectedModel": "gemini-3.1-flash-lite",
+                "selectedModel": "gemini-flash-lite-latest",
             ],
             secrets: ["api-key": "gemini-key"]
         )
@@ -296,7 +325,7 @@ final class GeminiPluginTests: XCTestCase {
                         }
                         """.utf8
                     ),
-                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent", statusCode: 200)
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent", statusCode: 200)
                 ),
             ])
         }
@@ -312,7 +341,7 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertEqual(result.detectedLanguage, "en")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        XCTAssertEqual(request.url?.path, "/v1beta/models/gemini-3.1-flash-lite:generateContent")
+        XCTAssertEqual(request.url?.path, "/v1beta/models/gemini-flash-lite-latest:generateContent")
         XCTAssertEqual(request.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
 
         let body = try Self.jsonBody(from: request)

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
@@ -8,6 +8,11 @@ final class GeminiPluginTests: XCTestCase {
     private static let cachedLLMModelsKey = "fetchedLLMModels.v2"
     private static let selectedLLMModelKey = "selectedLLMModel"
 
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
     private static func cachedModelsData() throws -> Data {
         try JSONEncoder().encode([
             GeminiFetchedModel(id: "gemini-2.0-flash", displayName: "Gemini 2.0 Flash"),
@@ -100,5 +105,281 @@ final class GeminiPluginTests: XCTestCase {
             (plugin as? LLMModelSelectable)?.preferredModelId,
             "gemini-2.5-flash"
         )
+    }
+
+    func testTranscriptionCapabilitiesAndDefaultModels() throws {
+        let host = try PluginTestHostServices()
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.providerId, "gemini")
+        XCTAssertEqual(plugin.providerDisplayName, "Gemini")
+        XCTAssertFalse(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .supported)
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.1-flash-lite")
+        XCTAssertEqual(
+            plugin.transcriptionModels.map(\.id),
+            [
+                "gemini-3.1-flash-lite",
+                "gemini-2.5-flash-lite",
+                "gemini-2.5-flash",
+                "gemini-3.5-flash",
+            ]
+        )
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.1-flash-lite")
+    }
+
+    func testSelectedTranscriptionModelPersistsAcrossActivation() throws {
+        let host = try PluginTestHostServices()
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectModel("gemini-2.5-flash")
+        plugin.deactivate()
+
+        let reloaded = GeminiPlugin()
+        reloaded.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-2.5-flash")
+        XCTAssertEqual(reloaded.selectedModelId, "gemini-2.5-flash")
+    }
+
+    func testInvalidStoredTranscriptionModelFallsBackAndPersistsDefault() throws {
+        let host = try PluginTestHostServices(defaults: ["selectedModel": "retired-gemini-stt"])
+        let plugin = GeminiPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.1-flash-lite")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.1-flash-lite")
+    }
+
+    func testTranscriptionRequestUsesGenerateContentJSONAudioPromptAndLanguage() throws {
+        let request = try GeminiPlugin.makeTranscriptionRequest(
+            audio: Self.audio(),
+            apiKey: "gemini-key",
+            modelId: "gemini-3.1-flash-lite",
+            language: " de ",
+            prompt: "Qwen3, MLX, proxy_read_timeout",
+            timeout: 60
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 60)
+
+        let body = try Self.jsonBody(from: request)
+        let contents = try XCTUnwrap(body["contents"] as? [[String: Any]])
+        XCTAssertEqual(contents.first?["role"] as? String, "user")
+
+        let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
+        let promptText = try XCTUnwrap(parts.first?["text"] as? String)
+        XCTAssertTrue(promptText.contains("technical dictation"))
+        XCTAssertTrue(promptText.contains("Qwen3, MLX, proxy_read_timeout"))
+        XCTAssertTrue(promptText.contains("Language hint: de"))
+
+        let inlineData = try XCTUnwrap(parts.last?["inlineData"] as? [String: Any])
+        XCTAssertEqual(inlineData["mimeType"] as? String, "audio/wav")
+        XCTAssertEqual(inlineData["data"] as? String, Data("wav".utf8).base64EncodedString())
+
+        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
+        XCTAssertEqual(generationConfig["temperature"] as? Double, 0.2)
+        XCTAssertEqual(generationConfig["maxOutputTokens"] as? Int, 2048)
+        XCTAssertEqual(generationConfig["responseMimeType"] as? String, "text/plain")
+        XCTAssertEqual(
+            (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingLevel"] as? String,
+            "MINIMAL"
+        )
+    }
+
+    func testTranscriptionRequestOmitsEmptyLanguageAndDictionaryTerms() throws {
+        let request = try GeminiPlugin.makeTranscriptionRequest(
+            audio: Self.audio(),
+            apiKey: "gemini-key",
+            modelId: "gemini-2.5-flash",
+            language: " ",
+            prompt: " ",
+            timeout: 60
+        )
+
+        let body = try Self.jsonBody(from: request)
+        let contents = try XCTUnwrap(body["contents"] as? [[String: Any]])
+        let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
+        let promptText = try XCTUnwrap(parts.first?["text"] as? String)
+        XCTAssertFalse(promptText.contains("User dictionary terms:"))
+        XCTAssertFalse(promptText.contains("Language hint:"))
+
+        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
+        XCTAssertEqual(
+            (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingBudget"] as? Int,
+            0
+        )
+    }
+
+    func testTranscribeFailsWithoutAPIKey() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: Self.audio(),
+                language: nil,
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected notConfigured")
+        } catch let error as PluginTranscriptionError {
+            guard case .notConfigured = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testTranscribeRejectsTranslateRequests() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [Self.cachedLLMModelsKey: try Self.cachedModelsData()],
+            secrets: ["api-key": "gemini-key"]
+        )
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: Self.audio(),
+                language: nil,
+                translate: true,
+                prompt: nil
+            )
+            XCTFail("Expected apiError")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "Gemini speech transcription does not support translation yet.")
+        }
+    }
+
+    func testTranscribeSendsGenerateContentRequestAndParsesText() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                Self.cachedLLMModelsKey: try Self.cachedModelsData(),
+                "selectedModel": "gemini-3.1-flash-lite",
+            ],
+            secrets: ["api-key": "gemini-key"]
+        )
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "candidates": [
+                            {
+                              "content": {
+                                "parts": [
+                                  { "text": " hello from gemini \\n" }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.audio(),
+            language: "en",
+            translate: false,
+            prompt: "TypeWhisper, Qwen3"
+        )
+
+        XCTAssertEqual(result.text, "hello from gemini")
+        XCTAssertEqual(result.detectedLanguage, "en")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/v1beta/models/gemini-3.1-flash-lite:generateContent")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
+
+        let body = try Self.jsonBody(from: request)
+        let contents = try XCTUnwrap(body["contents"] as? [[String: Any]])
+        let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
+        let promptText = try XCTUnwrap(parts.first?["text"] as? String)
+        XCTAssertTrue(promptText.contains("TypeWhisper, Qwen3"))
+    }
+
+    func testTranscriptionHTTPErrorMapping() {
+        XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"bad key"}}"#.utf8),
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 401)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .invalidApiKey = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"too large"}}"#.utf8),
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 413)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .fileTooLarge = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"slow down"}}"#.utf8),
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 429)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .rateLimited = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"server failed"}}"#.utf8),
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 500)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "HTTP 500: server failed")
+        }
+    }
+
+    private static func audio() -> AudioData {
+        AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1)
+    }
+
+    private static func jsonBody(from request: URLRequest) throws -> [String: Any] {
+        let data = try XCTUnwrap(request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
@@ -6,11 +6,12 @@
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
-    "description": "LLM provider via Google Gemini API. Requires API key.",
+    "description": "LLM provider and cloud speech transcription via Google Gemini API. Requires API key.",
     "descriptions": {
-        "de": "LLM-Anbieter über die Google Gemini API. Erfordert API-Key."
+        "de": "LLM-Anbieter und Cloud-Spracherkennung über die Google Gemini API. Erfordert API-Key."
     },
-    "category": "llm",
+    "category": "transcription",
+    "categories": ["transcription", "llm"],
     "iconSystemName": "sparkles",
     "iconURL": "https://www.typewhisper.com/brand-logos/gemini/logo.svg",
     "principalClass": "GeminiPlugin",


### PR DESCRIPTION
## Summary

Adds Gemini speech transcription to the existing `GeminiPlugin` instead of introducing a second Gemini STT plugin or API-key flow.

## Issue Context

Refs #710

This is the practical first step from the "audio + personal context" idea: Gemini now accepts dictation audio plus the app's existing Dictionary terms. This PR does not add the broader app-wide Context Profile described in #710, so it intentionally does not auto-close that issue.

## Reference Implementation

Based on ideas from #709, but not imported wholesale. The implementation keeps scope small by reusing the existing Gemini plugin, API key, settings surface, and release mapping.

## Changes

- Makes `GeminiPlugin` also conform to `TranscriptionEnginePlugin` and `DictionaryTermsCapabilityProviding`.
- Adds a Gemini transcription model list with `gemini-flash-lite-latest` as the default, `gemini-flash-latest` as an alias option, and pinned Gemini 3.x / 2.5 models for users who want stable model IDs.
- Sends inline WAV audio to Google Gemini's direct `generateContent` API with `x-goog-api-key` auth.
- Builds the transcription prompt from a short technical-dictation instruction, existing Dictionary terms, and an optional language hint.
- Avoids version-specific `thinkingConfig` for `latest` aliases, while keeping tuned thinking settings for pinned Gemini 3.x and 2.5 IDs.
- Keeps v1 intentionally non-streaming and transcription-only: translation, FLAC encoding, local Gemma audio, and a global Context Profile remain out of scope.
- Updates Gemini manifest metadata so the plugin is discoverable as both transcription-capable and LLM-capable.

## Test Plan

- `swift test --package-path TypeWhisperPluginSDK --filter GeminiPluginTests`
- `swift test --package-path TypeWhisperPluginSDK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini plugin adds audio transcription: choose and persist transcription model, language detection, and optional dictionary-term prompts.
  * Transcription returns detected language and trimmed transcribed text; translation is not supported.

* **Chores**
  * Plugin metadata updated so it’s listed as both "transcription" and "llm" in the manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->