### PR TITLE
Require TypeWhisper 1.5 for Gemini plugin

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gemini",
     "name": "Gemini",
     "version": "1.0.12",
-    "minHostVersion": "0.9.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary
- Raise the Gemini plugin minHostVersion from 0.9.0 to 1.5.0.
- Prevent hosts older than TypeWhisper 1.5 from installing or activating the Gemini plugin after the speech transcription capability was added.

## Context
- Follow-up to #720 / plugin-gemini-v1.0.17.
- The Gemini plugin is now transcription-capable and should require the host version that supports those plugin capabilities.

## Test Plan
- `jq empty TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json`
- `swift test --package-path TypeWhisperPluginSDK --filter GeminiPluginTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GeminiPlugin now requires host version 1.5.0 or later to function. Users running earlier host versions will need to update before using this plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->