### PR TITLE
Require confirmation before Esc cancels dictation

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -8457,6 +8457,22 @@
         }
       }
     },
+    "Press Esc again to cancel transcription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drücke Esc erneut, um die Transkription abzubrechen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escを再度押して文字起こしをキャンセル"
+          }
+        }
+      }
+    },
     "Press to start, press again to stop.": {
       "localizations": {
         "de": {

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -145,6 +145,7 @@ final class HotkeyService: ObservableObject {
 
     private struct HotkeyDispatchKey: Hashable {
         enum Target: Hashable {
+            case cancel
             case slot(HotkeySlotType)
             case profile(UUID)
             case workflow(UUID)
@@ -191,6 +192,8 @@ final class HotkeyService: ObservableObject {
     private static let toggleThreshold: TimeInterval = 1.0
     private static let doubleTapThreshold: TimeInterval = 0.4
     private static let monitorDedupWindow: TimeInterval = 0.12
+    private static let escapeKeyCode: UInt16 = 0x35
+    private static let escapeHotkey = UnifiedHotkey(keyCode: escapeKeyCode, modifierFlags: 0, isFn: false)
     private static let capsLockKeyCode: UInt16 = 0x39
     private static let capsLockSuppressionWindow: TimeInterval = 0.25
 
@@ -668,8 +671,15 @@ final class HotkeyService: ObservableObject {
     @discardableResult
     private func handleEvent(_ event: NSEvent, source: HotkeyEventSource) -> Bool {
         // Escape key cancels active recording/transcription
-        if event.type == .keyDown && event.keyCode == 0x35 {
-            onCancelPressed?()
+        if event.type == .keyDown && event.keyCode == Self.escapeKeyCode {
+            if shouldDispatch(
+                target: .cancel,
+                phase: .down,
+                hotkey: Self.escapeHotkey,
+                source: source
+            ) {
+                onCancelPressed?()
+            }
             return false
         }
 

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -60,7 +60,7 @@ struct IndicatorPresentationData {
     let activeRuleName: String?
     let activeAppIcon: NSImage?
     let isRecordingInputReady: Bool
-    let recordingCancelWarningMessage: String?
+    let cancelWarningMessage: String?
     let processingPhase: String?
     let actionFeedbackMessage: String?
     let actionFeedbackIcon: String?
@@ -92,7 +92,7 @@ struct IndicatorPresentationData {
                 activeRuleName: dictation.activeRuleName,
                 activeAppIcon: dictation.activeAppIcon,
                 isRecordingInputReady: dictation.isRecordingInputReady,
-                recordingCancelWarningMessage: dictation.recordingCancelWarningMessage,
+                cancelWarningMessage: dictation.cancelWarningMessage,
                 processingPhase: dictation.processingPhase,
                 actionFeedbackMessage: dictation.actionFeedbackMessage,
                 actionFeedbackIcon: dictation.actionFeedbackIcon,
@@ -109,7 +109,7 @@ struct IndicatorPresentationData {
                 activeRuleName: nil,
                 activeAppIcon: nil,
                 isRecordingInputReady: true,
-                recordingCancelWarningMessage: nil,
+                cancelWarningMessage: nil,
                 processingPhase: nil,
                 actionFeedbackMessage: nil,
                 actionFeedbackIcon: nil,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -91,7 +91,14 @@ final class DictationViewModel: ObservableObject {
         case error(String)
     }
 
-    @Published var state: State = .idle
+    private enum CancelWarningTarget {
+        case recording
+        case processing
+    }
+
+    @Published var state: State = .idle {
+        didSet { clearCancelWarningIfStateNoLongerMatches() }
+    }
     @Published var audioLevel: Float = 0
     @Published var recordingDuration: TimeInterval = 0
     @Published var hotkeyMode: HotkeyService.HotkeyMode?
@@ -223,7 +230,7 @@ final class DictationViewModel: ObservableObject {
     private var transcriptionTask: Task<Void, Never>?
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
-    @Published private(set) var recordingCancelWarningActive: Bool = false
+    @Published private var cancelWarningTarget: CancelWarningTarget?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
     var pasteboardProvider: () -> NSPasteboard = { .general }
@@ -254,9 +261,15 @@ final class DictationViewModel: ObservableObject {
     private var dictationSessionOrder: [UUID] = []
     private let maxTrackedDictationSessions = 100
 
-    var recordingCancelWarningMessage: String? {
-        guard state == .recording, recordingCancelWarningActive else { return nil }
-        return String(localized: "Press Esc again to cancel recording")
+    var cancelWarningMessage: String? {
+        switch (state, cancelWarningTarget) {
+        case (.recording, .recording):
+            return String(localized: "Press Esc again to cancel recording")
+        case (.processing, .processing):
+            return String(localized: "Press Esc again to cancel transcription")
+        default:
+            return nil
+        }
     }
 
     init(
@@ -809,27 +822,42 @@ final class DictationViewModel: ObservableObject {
     }
 
     func handleCancelHotkey() {
-        switch state {
-        case .recording:
-            if recordingCancelWarningActive {
-                recordingCancelWarningActive = false
-                cancelCurrentOperation()
-            } else {
-                recordingCancelWarningActive = true
-            }
-        case .processing:
+        guard let target = cancelWarningTargetForCurrentState() else { return }
+
+        if cancelWarningTarget == target {
+            clearCancelWarning()
             cancelCurrentOperation()
-        default:
-            break
+        } else {
+            cancelWarningTarget = target
         }
     }
 
-    private func clearRecordingCancelWarning() {
-        recordingCancelWarningActive = false
+    private func cancelWarningTargetForCurrentState() -> CancelWarningTarget? {
+        switch state {
+        case .recording:
+            return .recording
+        case .processing:
+            return .processing
+        default:
+            return nil
+        }
+    }
+
+    private func clearCancelWarningIfStateNoLongerMatches() {
+        guard let cancelWarningTarget,
+              cancelWarningTargetForCurrentState() != cancelWarningTarget else {
+            return
+        }
+        self.cancelWarningTarget = nil
+    }
+
+    private func clearCancelWarning() {
+        cancelWarningTarget = nil
     }
 
     private func cancelCurrentOperation() {
         let cancelledMessage = String(localized: "Cancelled")
+        clearCancelWarning()
 
         switch state {
         case .recording:
@@ -863,7 +891,7 @@ final class DictationViewModel: ObservableObject {
         transcriptionTask = nil
         insertingResetTask?.cancel()
         insertingResetTask = nil
-        clearRecordingCancelWarning()
+        clearCancelWarning()
         pendingPushToTalkDiscardMessage = nil
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
@@ -1101,7 +1129,7 @@ final class DictationViewModel: ObservableObject {
 
     private func stopDictation() {
         guard state == .recording, !isStopInFlight else { return }
-        clearRecordingCancelWarning()
+        clearCancelWarning()
         isStopInFlight = true
         Task {
             await finalizeStopDictation()
@@ -1474,7 +1502,7 @@ final class DictationViewModel: ObservableObject {
         activeDictationSessionID = nil
         pendingPushToTalkDiscardMessage = nil
         clearRecordingStartCueState()
-        clearRecordingCancelWarning()
+        clearCancelWarning()
         state = .idle
         partialText = ""
         recordingStartTime = nil

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -44,9 +44,8 @@ struct MinimalIndicatorView: View {
         return presentation.actionFeedbackMessage
     }
 
-    private var recordingCancelWarningMessage: String? {
-        guard presentation.state == .recording else { return nil }
-        return presentation.recordingCancelWarningMessage
+    private var cancelWarningMessage: String? {
+        presentation.cancelWarningMessage
     }
 
     private var errorMessage: String? {
@@ -55,7 +54,7 @@ struct MinimalIndicatorView: View {
     }
 
     private var showsExpandedMessage: Bool {
-        recordingCancelWarningMessage != nil || actionFeedbackMessage != nil || errorMessage != nil
+        cancelWarningMessage != nil || actionFeedbackMessage != nil || errorMessage != nil
     }
 
     private var currentWidth: CGFloat {
@@ -107,7 +106,7 @@ struct MinimalIndicatorView: View {
         }
 
     private var accessibilityLabel: String {
-        if let message = recordingCancelWarningMessage {
+        if let message = cancelWarningMessage {
             return message
         }
 
@@ -140,7 +139,7 @@ struct MinimalIndicatorView: View {
                     icon: "xmark.circle.fill",
                     iconColor: .red
                 )
-            } else if let message = recordingCancelWarningMessage {
+            } else if let message = cancelWarningMessage {
                 compactMessage(
                     text: message,
                     icon: "exclamationmark.triangle.fill",

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -57,8 +57,8 @@ struct NotchIndicatorView: View {
         presentation.state == .inserting && presentation.actionFeedbackMessage != nil
     }
 
-    private var hasRecordingCancelWarning: Bool {
-        presentation.state == .recording && presentation.recordingCancelWarningMessage != nil
+    private var hasCancelWarning: Bool {
+        presentation.cancelWarningMessage != nil
     }
 
     private var hasProcessingPhase: Bool {
@@ -78,7 +78,7 @@ struct NotchIndicatorView: View {
     }
 
     private var expansionMode: NotchExpansionMode {
-        if hasRecordingCancelWarning { return .feedback }
+        if hasCancelWarning { return .feedback }
         if transcriptBodyVisible { return .transcript }
         if hasActionFeedback { return .feedback }
         if hasProcessingPhase { return .processing }
@@ -109,7 +109,7 @@ struct NotchIndicatorView: View {
     }
 
     private var expandedBodyHeight: CGFloat {
-        if hasRecordingCancelWarning {
+        if hasCancelWarning {
             return feedbackBodyHeight
         }
         if hasTranscriptSection {
@@ -197,7 +197,7 @@ struct NotchIndicatorView: View {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
-            if let warning = presentation.recordingCancelWarningMessage {
+            if let warning = presentation.cancelWarningMessage {
                 return warning
             }
             if !presentation.isRecordingInputReady {
@@ -205,6 +205,9 @@ struct NotchIndicatorView: View {
             }
             return String(localized: "Recording")
         case .processing:
+            if let warning = presentation.cancelWarningMessage {
+                return warning
+            }
             return String(localized: "Processing transcription")
         case .inserting:
             if let feedback = presentation.actionFeedbackMessage {
@@ -235,9 +238,9 @@ struct NotchIndicatorView: View {
 
     @ViewBuilder
     private var expandedBodyContent: some View {
-        if hasRecordingCancelWarning {
+        if hasCancelWarning {
             IndicatorActionFeedback(
-                message: presentation.recordingCancelWarningMessage ?? "",
+                message: presentation.cancelWarningMessage ?? "",
                 icon: "exclamationmark.triangle.fill",
                 isError: false,
                 iconColor: .yellow,

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -49,8 +49,8 @@ struct OverlayIndicatorView: View {
         presentation.state == .inserting && presentation.actionFeedbackMessage != nil
     }
 
-    private var hasRecordingCancelWarning: Bool {
-        presentation.state == .recording && presentation.recordingCancelWarningMessage != nil
+    private var hasCancelWarning: Bool {
+        presentation.cancelWarningMessage != nil
     }
 
     private var transcriptPreviewState: OverlayTranscriptPreviewState {
@@ -77,7 +77,7 @@ struct OverlayIndicatorView: View {
     }
 
     private var currentWidth: CGFloat {
-        if hasRecordingCancelWarning { return max(closedWidth, 340) }
+        if hasCancelWarning { return max(closedWidth, 340) }
         if transcriptBodyVisible { return max(closedWidth, 400) }
         if hasActionFeedback { return max(closedWidth, 340) }
         return closedWidth
@@ -166,7 +166,7 @@ struct OverlayIndicatorView: View {
     }
 
     private var accessibilityLabel: String {
-        if let warning = presentation.recordingCancelWarningMessage, presentation.state == .recording {
+        if let warning = presentation.cancelWarningMessage {
             return warning
         }
 
@@ -195,9 +195,9 @@ struct OverlayIndicatorView: View {
 
     @ViewBuilder
     private var expandableContent: some View {
-        if hasRecordingCancelWarning {
+        if hasCancelWarning {
             IndicatorActionFeedback(
-                message: presentation.recordingCancelWarningMessage ?? "",
+                message: presentation.cancelWarningMessage ?? "",
                 icon: "exclamationmark.triangle.fill",
                 isError: false,
                 iconColor: .yellow,

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -6769,7 +6769,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(context.dictationViewModel.state, .recording)
         XCTAssertEqual(
-            context.dictationViewModel.recordingCancelWarningMessage,
+            context.dictationViewModel.cancelWarningMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel recording")
         )
         XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
@@ -6792,7 +6792,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         context.dictationViewModel.handleCancelHotkey()
 
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
-        XCTAssertNil(context.dictationViewModel.recordingCancelWarningMessage)
+        XCTAssertNil(context.dictationViewModel.cancelWarningMessage)
         XCTAssertEqual(
             context.dictationViewModel.actionFeedbackMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Cancelled")
@@ -6843,7 +6843,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testHandleCancelHotkey_processingStillCancelsImmediately() throws {
+    func testHandleCancelHotkey_processingRequiresSecondEscapeToCancel() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?
         defer {
@@ -6857,8 +6857,17 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         context.dictationViewModel.handleCancelHotkey()
 
+        XCTAssertEqual(context.dictationViewModel.state, .processing)
+        XCTAssertEqual(
+            context.dictationViewModel.cancelWarningMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Press Esc again to cancel transcription")
+        )
+        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
+
+        context.dictationViewModel.handleCancelHotkey()
+
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
-        XCTAssertNil(context.dictationViewModel.recordingCancelWarningMessage)
+        XCTAssertNil(context.dictationViewModel.cancelWarningMessage)
         XCTAssertEqual(
             context.dictationViewModel.actionFeedbackMessage,
             try TestSupport.localizedCatalogValueForCurrentLocale(for: "Cancelled")
@@ -6927,7 +6936,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         context.dictationViewModel.handleCancelHotkey()
         context.dictationViewModel.state = .processing
 
-        XCTAssertNil(context.dictationViewModel.recordingCancelWarningMessage)
+        XCTAssertNil(context.dictationViewModel.cancelWarningMessage)
     }
 }
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -6983,6 +6983,26 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testEscapeKeyDedupesFollowingEventTapDispatch() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        var cancelCount = 0
+        service.onCancelPressed = {
+            cancelCount += 1
+        }
+
+        let escape = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+
+        XCTAssertFalse(service.processEventForTesting(escape, source: .eventTap))
+        await Task.yield()
+        XCTAssertEqual(cancelCount, 1)
+
+        XCTAssertFalse(service.processEventForTesting(escape, source: .monitor))
+        XCTAssertEqual(cancelCount, 1)
+    }
+
+    @MainActor
     func testMonitorFallbackStartsToggleHotkey() throws {
         let service = HotkeyService()
         service.suspendMonitoring()


### PR DESCRIPTION
## Summary
- Require a second `Esc` press before cancelling an active dictation recording or transcription processing run.
- Replace the recording-only cancel warning state with a generic cancel warning that can surface during recording and processing.
- Deduplicate `Esc` dispatches across the CGEventTap and NSEvent fallback monitor so one physical key press cannot count as both warning and confirmation.
- Show the warning in Notch, Overlay, and Minimal indicators, including accessibility labels, and add German/Japanese localization for the processing warning.

## Issue context
Issue #704 reports accidental global `Esc` presses during Zoom calls cancelling long-running transcriptions and losing the transcript. This keeps `Esc` as an emergency cancel path while preventing a single accidental key press from stopping an active recording or in-flight transcription.

Closes #704

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- Automated app hotkey smoke test against `127.0.0.1:8978`: `Option+Command+A` starts recording, first `Esc` keeps `is_recording: true`, second `Esc` returns `is_recording: false`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cancel hotkey now available during transcription processing in addition to recording.
  * Two-press confirmation for transcription cancellation operations.

* **Bug Fixes**
  * Improved Escape key handling and hotkey dispatch routing.

* **Documentation**
  * Updated cancel hotkey prompt messaging for consistency across recording and transcription states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->