### PR TITLE
Fix initial managed window opening

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -472,6 +472,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var appActivationObserver: NSObjectProtocol?
     private var workspaceWakeObserver: NSObjectProtocol?
     private var hasInteractiveForegroundContent = false
+    private var shouldOpenSettingsOnInitialLaunch = false
+    private var hasRequestedInitialManagedWindow = false
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
     var updateChecker: UpdateChecker {
@@ -551,11 +553,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             HomeViewModel.shared.showSetupWizard = true
             NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.openSetupWindow()
+                self.requestInitialManagedWindow(id: "setup")
             }
         } else if PostUpdatePromptCoordinator.shared.shouldAutoOpenSettingsOnLaunch {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                self.openSettingsWindow()
+                self.requestInitialManagedWindow(id: "settings")
+            }
+        } else {
+            shouldOpenSettingsOnInitialLaunch = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.openSettingsOnInitialLaunchIfNeeded()
             }
         }
 
@@ -605,6 +612,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         )
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+        openSettingsOnInitialLaunchIfNeeded()
+    }
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
         if !hasVisibleManagedWindow {
             if HomeViewModel.shared.showSetupWizard {
@@ -628,6 +639,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     private func openSetupWindow() {
         ManagedAppWindowOpener.shared.open(id: "setup")
+    }
+
+    private func requestInitialManagedWindow(id: String) {
+        guard !hasRequestedInitialManagedWindow else { return }
+        hasRequestedInitialManagedWindow = true
+        ManagedAppWindowOpener.shared.open(id: id)
+    }
+
+    private func openSettingsOnInitialLaunchIfNeeded() {
+        guard shouldOpenSettingsOnInitialLaunch else { return }
+        shouldOpenSettingsOnInitialLaunch = false
+
+        guard !hasVisibleManagedWindow else { return }
+        requestInitialManagedWindow(id: "settings")
     }
 
     private func handleIncomingURL(_ url: URL) {

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -472,7 +472,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var appActivationObserver: NSObjectProtocol?
     private var workspaceWakeObserver: NSObjectProtocol?
     private var hasInteractiveForegroundContent = false
-    private var shouldOpenSettingsOnInitialLaunch = false
+    private var pendingInitialManagedWindowId: String?
     private var hasRequestedInitialManagedWindow = false
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
@@ -552,18 +552,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             UserDefaults.standard.set(false, forKey: UserDefaultsKeys.setupWizardCompleted)
             HomeViewModel.shared.showSetupWizard = true
             NSApp.setActivationPolicy(.regular)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.requestInitialManagedWindow(id: "setup")
-            }
+            scheduleInitialManagedWindow(id: "setup", delay: 0.5)
         } else if PostUpdatePromptCoordinator.shared.shouldAutoOpenSettingsOnLaunch {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                self.requestInitialManagedWindow(id: "settings")
-            }
-        } else {
-            shouldOpenSettingsOnInitialLaunch = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.openSettingsOnInitialLaunchIfNeeded()
-            }
+            scheduleInitialManagedWindow(id: "settings", delay: 0.2)
         }
 
         // Observe appearance preference changes
@@ -613,7 +604,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        openSettingsOnInitialLaunchIfNeeded()
+        openPendingInitialManagedWindowIfNeeded()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
@@ -641,18 +632,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         ManagedAppWindowOpener.shared.open(id: "setup")
     }
 
+    private func scheduleInitialManagedWindow(id: String, delay: TimeInterval) {
+        guard pendingInitialManagedWindowId == nil, !hasRequestedInitialManagedWindow else { return }
+        pendingInitialManagedWindowId = id
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            self.openPendingInitialManagedWindowIfNeeded()
+        }
+    }
+
     private func requestInitialManagedWindow(id: String) {
         guard !hasRequestedInitialManagedWindow else { return }
         hasRequestedInitialManagedWindow = true
+        pendingInitialManagedWindowId = nil
         ManagedAppWindowOpener.shared.open(id: id)
     }
 
-    private func openSettingsOnInitialLaunchIfNeeded() {
-        guard shouldOpenSettingsOnInitialLaunch else { return }
-        shouldOpenSettingsOnInitialLaunch = false
+    private func openPendingInitialManagedWindowIfNeeded() {
+        guard let pendingInitialManagedWindowId else { return }
 
-        guard !hasVisibleManagedWindow else { return }
-        requestInitialManagedWindow(id: "settings")
+        guard !hasVisibleManagedWindow else {
+            self.pendingInitialManagedWindowId = nil
+            return
+        }
+        requestInitialManagedWindow(id: pendingInitialManagedWindowId)
     }
 
     private func handleIncomingURL(_ url: URL) {


### PR DESCRIPTION
## Problem
Some startup paths explicitly request a managed window immediately after launch, especially first-run setup and post-update Settings. Those `openWindow` calls can race with SwiftUI scene/window-opener registration, so the app may activate without showing the expected setup/settings window.

The normal configured startup path must remain quiet: when setup is complete and there is no pending post-update prompt, TypeWhisper should launch as a menu bar app and not automatically open Settings.

## Fix
- Track a pending initial managed-window id only for explicit startup requests: setup and post-update Settings.
- Retry that pending request when the app becomes active, and keep a single-request gate to avoid duplicate startup window opens.
- Remove the previous normal-launch fallback that scheduled Settings for every configured startup.

## Scope
This PR is intentionally limited to `AppDelegate` startup window handling. It does not include plugin changes, localization updates, or personal-build-only settings.

## Testing
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `xcodebuild -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`\n- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/DockIconVisibilityTests -only-testing:TypeWhisperTests/PostUpdatePromptCoordinatorTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`\n- Manual configured dev-app smoke using completed setup, menu bar icon enabled, personal OSS usage, and current release acknowledged: `CGWindowList` reported `windows=0`, so normal launch stayed quiet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial window opening behavior to prevent duplicate windows from appearing on startup and ensure windows open at the appropriate time when the app becomes active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->