### PR TITLE
docs: add 1.5.0-rc1 release notes

### DIFF
--- a/docs/release-notes/1.5.0-rc1.md
+++ b/docs/release-notes/1.5.0-rc1.md
@@ -1,0 +1,28 @@
+TypeWhisper `1.5.0-rc1` opens the `1.5` release-candidate line with app-aware dictation insertion, virtual audio input support, broader number normalization, new speech providers, and a focused reliability pass across plugins, model handling, workflows, and release metadata.
+
+## Highlights
+
+- Added app-aware smart insertion so dictation output better respects the surrounding text, sentence position, trailing spaces, terminal paste behavior, and target-app context.
+- Added virtual audio input device support and hardened media pause/resume handling, recording start feedback, mouse-button shortcuts, and Safari/fullscreen indicator behavior.
+- Expanded number normalization across generic transcription output, multilingual number words, Dutch number words, English ordinals, and English digit sequences.
+- Added new bundled speech providers and plugin releases, including Gemini speech transcription, Cartesia speech transcription, Sber SaluteSpeech, OpenRouter speech-to-text, Reson8, OpenAI-compatible profiles, and the experimental SenseVoice line before its removal from the bundled set.
+- Added Japanese localization and dictation support, ordered language hints, recent transcriptions in the workflow palette, source progress for file transcription, recorder-specific engine overrides, and a short-dictation workflow AI-skip setting.
+- Added commercial Cloud Folder Sync, the standalone setup wizard, README screenshot automation, plugin update-state diagnostics, repair actions, and clearer issue-template diagnostics guidance.
+
+## Reliability and Fixes
+
+- Fixed smart insertion mid-sentence edge cases, terminal clipboard restore races, trailing-space insertion, middle-mouse pass-through, indicator visibility over fullscreen apps, and overlay live transcript preview expansion.
+- Improved long file transcription progress, Groq uploads, Apple Speech first-use model selection, selected Apple Speech model restoration, custom workflow fine-tuning prompts, and workflow prompt casing diagnostics.
+- Hardened cloud LLM behavior by honoring plugin model selection, parsing Gemini array errors, and avoiding legacy global model poisoning.
+- Updated Soniox async transcription to model v5 and disabled dictionary-term prompts for Qwen3 ASR where they do not apply.
+- Treated Reson8 as a single-language engine, added configurable LLM request timeout support to the OpenAI Compatible plugin, and required TypeWhisper 1.5 for the Gemini plugin.
+- Fixed Cartesia plugin settings and prevented plugin releases from taking over the repository-level GitHub "latest" marker.
+
+## Testing Focus
+
+- Verify app-aware insertion in plain text, mid-sentence, terminal, and rich-text targets.
+- Verify virtual audio input recording, media pause/resume, mouse-button shortcuts, and indicator behavior in Safari fullscreen and other fullscreen apps.
+- Verify number normalization for multilingual number words, Dutch, English ordinals, English digit sequences, and API/CLI dictionary corrections.
+- Smoke-test Gemini, Cartesia, Sber SaluteSpeech, OpenRouter STT, Reson8, and OpenAI-compatible profile setup paths.
+- Verify file transcription progress, recent-transcription workflow palette behavior, ordered language hints, Japanese dictation, and short-dictation AI-skip workflows.
+- Confirm `v1.5.0-rc1` publishes on the `release-candidate` Sparkle channel, remains a GitHub prerelease, and does not update Homebrew or the stable website release path.


### PR DESCRIPTION
## Summary
- Add curated release notes for `v1.5.0-rc1` so the release workflow can publish human-written notes instead of generating them from the Git log.
- Keep this PR intentionally limited to the release notes file. No app code, version settings, or workflow files are changed.

## Release context
`v1.5.0-rc1` will be cut from `main` after this notes-only PR lands. The RC should publish as a GitHub prerelease on the `release-candidate` Sparkle channel, while stable latest, Homebrew, and stable website release paths remain unchanged.

## Test plan
- [x] `git diff --check`
- [ ] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [ ] `swift test --package-path TypeWhisperPluginSDK`
- [ ] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee build.log`
- [ ] `bash scripts/check_first_party_warnings.sh build.log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: TypeWhisper v1.5.0-rc1

* **New Features**
  * App-aware dictation insertion behavior
  * Virtual audio input support
  * Enhanced number normalization for multiple languages
  * Japanese localization and dictation support
  * Improved workflow controls and file-transcription progress tracking

* **Bug Fixes**
  * Smart-insertion edge cases and clipboard handling
  * Input indicator behavior improvements, including Safari fullscreen support
  * Plugin stability enhancements across multiple providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->