### PR TITLE
fix: normalize French point decimals

### DIFF
--- a/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
@@ -34,10 +34,10 @@ enum FrenchNumberWordParser {
         index = integer.nextIndex
         var replacement = "\(integer.value)"
 
-        if index < normalizedWords.count, normalizedWords[index] == "virgule" {
+        if index < normalizedWords.count, let decimalSeparator = decimalSeparator(for: normalizedWords[index]) {
             let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
             if !decimal.digits.isEmpty {
-                replacement += ",\(decimal.digits)"
+                replacement += "\(decimalSeparator)\(decimal.digits)"
                 index = decimal.nextIndex
             }
         }
@@ -208,6 +208,17 @@ enum FrenchNumberWordParser {
         }
 
         return (digits, index)
+    }
+
+    private static func decimalSeparator(for word: String) -> String? {
+        switch word {
+        case "virgule":
+            return ","
+        case "point":
+            return "."
+        default:
+            return nil
+        }
     }
 
     private static func unitValue(_ word: String, allowArticleOne: Bool) -> Int? {

--- a/TypeWhisper/Services/NumberWordNormalizer.swift
+++ b/TypeWhisper/Services/NumberWordNormalizer.swift
@@ -17,7 +17,10 @@ enum NumberWordNormalizer {
         var result = ""
         var index = 0
         while index < tokens.count {
-            if tokens[index].isWord,
+            if let decimal = parseDigitDecimal(startingAt: index, in: tokens, languageCode: languageCode) {
+                result.append(decimal.replacement)
+                index = decimal.endIndex
+            } else if tokens[index].isWord,
                let parsed = parseNumber(startingAt: index, in: tokens, languageCode: languageCode) {
                 result.append(parsed.replacement)
                 index = parsed.endIndex
@@ -37,6 +40,7 @@ enum NumberWordNormalizer {
 
     private enum TokenKind {
         case word
+        case digit
         case cjkNumber
         case other
 
@@ -44,7 +48,16 @@ enum NumberWordNormalizer {
             switch self {
             case .word, .cjkNumber:
                 return true
-            case .other:
+            case .digit, .other:
+                return false
+            }
+        }
+
+        var isDigit: Bool {
+            switch self {
+            case .digit:
+                return true
+            case .word, .cjkNumber, .other:
                 return false
             }
         }
@@ -55,6 +68,7 @@ enum NumberWordNormalizer {
         let kind: TokenKind
 
         var isWord: Bool { kind.isWord }
+        var isDigit: Bool { kind.isDigit }
     }
 
     private struct ParsedNumber {
@@ -65,6 +79,38 @@ enum NumberWordNormalizer {
     private struct WordCandidate {
         let tokenIndex: Int
         let text: String
+    }
+
+    private static func parseDigitDecimal(startingAt index: Int, in tokens: [Token], languageCode: String) -> ParsedNumber? {
+        guard let decimalSeparator = digitDecimalSeparator(for: languageCode),
+              index + 4 < tokens.count,
+              tokens[index].isDigit,
+              isWordConnector(tokens[index + 1].text),
+              tokens[index + 2].isWord,
+              normalizedDecimalWord(tokens[index + 2].text, languageCode: languageCode) == "point",
+              isWordConnector(tokens[index + 3].text),
+              tokens[index + 4].isDigit else {
+            return nil
+        }
+
+        return ParsedNumber(
+            replacement: tokens[index].text + decimalSeparator + tokens[index + 4].text,
+            endIndex: index + 5
+        )
+    }
+
+    private static func digitDecimalSeparator(for languageCode: String) -> String? {
+        switch languageCode {
+        case "fr":
+            return "."
+        default:
+            return nil
+        }
+    }
+
+    private static func normalizedDecimalWord(_ word: String, languageCode: String) -> String {
+        word.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: languageCode))
+            .lowercased()
     }
 
     private static func parseNumber(startingAt index: Int, in tokens: [Token], languageCode: String) -> ParsedNumber? {
@@ -152,6 +198,10 @@ enum NumberWordNormalizer {
             return .cjkNumber
         }
 
+        if isDigitCharacter(character) {
+            return .digit
+        }
+
         if isWordCharacter(character) {
             return .word
         }
@@ -161,6 +211,10 @@ enum NumberWordNormalizer {
 
     private static func isWordCharacter(_ character: Character) -> Bool {
         character.unicodeScalars.allSatisfy { CharacterSet.letters.contains($0) }
+    }
+
+    private static func isDigitCharacter(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { CharacterSet.decimalDigits.contains($0) }
     }
 
     private static func isWordConnector(_ text: String) -> Bool {

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -162,6 +162,25 @@ final class NumberWordNormalizerTests: XCTestCase {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "vingt trois fichiers", language: "fr"), "23 fichiers")
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "mille deux cent trente quatre", language: "fr"), "1234")
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "moins deux virgule cinq", language: "fr"), "-2,5")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "trois point six", language: "fr"), "3.6")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "moins trois point six", language: "fr"), "-3.6")
+    }
+
+    func testFrenchDigitPointDecimalsNormalizeToDigits() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "3 point 6", language: "fr"), "3.6")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "2 point 75", language: "fr"), "2.75")
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "la valeur est 3 point 6 aujourd'hui", language: "fr"),
+            "la valeur est 3.6 aujourd'hui"
+        )
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "3 Point 6", language: "fr"), "3.6")
+    }
+
+    func testFrenchPointIsPreservedOutsideDigitDecimals() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "point final", language: "fr"), "point final")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "au point du jour", language: "fr"), "au point du jour")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "3 point final", language: "fr"), "3 point final")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "3 point 6", language: "en"), "3 point 6")
     }
 
     func testFrenchArticleOneIsPreservedOutsideClearNumberConstructs() {


### PR DESCRIPTION
## Summary
- Adds French number normalization for spoken decimal `point` patterns reported in #727.
- Handles mixed digit forms like `3 point 6` / `2 point 75` and word forms like `trois point six`.
- Keeps ordinary French `point` phrases unchanged and preserves existing `virgule` comma behavior.

Closes #727

## Issue Context
Issue #727 reported that French dictation can produce decimal phrases with the word `point` between digits. The existing normalizer left those phrases as text, and a global dictionary replacement is not safe because `point` is common in normal French phrases.

## Test Coverage
All new code paths are covered by `NumberWordNormalizerTests`: French word decimals, mixed digit decimals, multi-digit fractional parts, sentence context, case-insensitive `point`, non-decimal French `point` phrases, and non-French language gating.

## Pre-Landing Review
No issues found. This is a deterministic normalization change with no SQL/data migrations, external process execution, UI changes, prompt changes, or CI/CD changes.

## Design Review
Skipped: no frontend or visual files changed.

## Eval Results
Skipped: no prompt-related or LLM behavior files changed.

## Scope Drift
Scope Check: CLEAN. The implementation is limited to French decimal normalization and targeted unit coverage for issue #727.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/NumberWordNormalizerTests`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * French number parsing now recognizes both traditional and alternative decimal separators for improved flexibility
  * Enhanced digit-based decimal pattern recognition across supported languages

* **Tests**
  * Added comprehensive test coverage for French decimal number handling with multiple formatting options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->