### PR TITLE
feat: clarify recorder transcription settings

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -111,6 +111,7 @@ enum UserDefaultsKeys {
     static let recorderSystemAudioEnabled = "recorderSystemAudioEnabled"
     static let recorderOutputFormat = "recorderOutputFormat"
     static let recorderTranscriptionEnabled = "recorderTranscriptionEnabled"
+    static let recorderLivePreviewEnabled = "recorderLivePreviewEnabled"
     static let recorderTranscriptionEngine = "recorderTranscriptionEngine"
     static let recorderTranscriptionModel = "recorderTranscriptionModel"
     static let recorderMicDuckingMode = "recorderMicDuckingMode"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9323,6 +9323,116 @@
         }
       }
     },
+    "recorder.createTranscriptAfterRecording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkript nach der Aufnahme erstellen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create transcript after recording"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音後に文字起こしを作成"
+          }
+        }
+      }
+    },
+    "recorder.createTranscriptAfterRecording.description": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichert ein Transkript fuer Recorder-Aufnahmen. Die Auswahl unten gilt nur fuer den System Audio Recorder, nicht fuer normale Dictation."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saves a transcript for recorder files. The settings below apply only to the System Audio Recorder, not normal dictation."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レコーダーのファイルに文字起こしを保存します。以下の設定は通常のDictationではなくSystem Audio Recorderのみに適用されます。"
+          }
+        }
+      }
+    },
+    "recorder.effectiveEngine": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorder-Engine"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorder engine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レコーダーエンジン"
+          }
+        }
+      }
+    },
+    "recorder.effectiveModel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorder-Modell"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recorder model"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レコーダーモデル"
+          }
+        }
+      }
+    },
+    "recorder.livePreviewLightweightHint": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Engine aktualisiert die Live-Vorschau nur alle paar Sekunden. Das finale Transkript wird nach dem Stoppen aus der gesamten Aufnahme erstellt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This engine updates the live preview every few seconds. The final transcript is still created from the full recording after you stop."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このエンジンはライブプレビューを数秒ごとに更新します。最終的な文字起こしは停止後に録音全体から作成されます。"
+          }
+        }
+      }
+    },
     "recorder.liveTranscript": {
       "extractionState": "stale",
       "localizations": {
@@ -9390,28 +9500,6 @@
         }
       }
     },
-    "recorder.liveTranscription": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Live-Transkription"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Live Transcription"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライブ音声認識"
-          }
-        }
-      }
-    },
     "recorder.mic": {
       "localizations": {
         "de": {
@@ -9430,6 +9518,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "マイク"
+          }
+        }
+      }
+    },
+    "recorder.noEngineSelected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Engine ausgewaehlt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No engine selected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エンジン未選択"
           }
         }
       }
@@ -9572,19 +9682,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aufnahme starten"
+            "value": "Recorder starten"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start Recording"
+            "value": "Start Recorder"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "録音を開始"
+            "value": "レコーダーを開始"
           }
         }
       }
@@ -9594,19 +9704,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aufnahme stoppen"
+            "value": "Recorder stoppen"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stop Recording"
+            "value": "Stop Recorder"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "録音を停止"
+            "value": "レコーダーを停止"
           }
         }
       }
@@ -9616,19 +9726,19 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Startet oder stoppt den Recorder mit deinen gespeicherten Mikrofon- und Systemaudio-Einstellungen."
+            "value": "Startet oder stoppt den System Audio Recorder mit deinen gespeicherten Mikrofon- und Systemaudio-Einstellungen."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start or stop the Recorder with your saved microphone and system audio settings."
+            "value": "Start or stop the System Audio Recorder with your saved microphone and system audio settings."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存されたマイクおよびシステムオーディオ設定を使用して、Recorderを開始または停止します。"
+            "value": "保存されたマイクおよびシステムオーディオ設定でSystem Audio Recorderを開始または停止します。"
           }
         }
       }
@@ -9638,19 +9748,41 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recorder-Shortcut"
+            "value": "System Audio Recorder Shortcut"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recorder shortcut"
+            "value": "System Audio Recorder shortcut"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recorderのショートカット"
+            "value": "System Audio Recorderのショートカット"
+          }
+        }
+      }
+    },
+    "recorder.showLiveTranscriptWhileRecording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live-Transkript waehrend der Aufnahme anzeigen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show live transcript while recording"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音中にライブ文字起こしを表示"
           }
         }
       }
@@ -9770,19 +9902,63 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transkription"
+            "value": "Recorder-Transkriptionseinstellungen"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Transcription"
+            "value": "Recorder transcription settings"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "音声認識"
+            "value": "レコーダーの文字起こし設定"
+          }
+        }
+      }
+    },
+    "recorder.transcriptionSettingsDisabledHint": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviere das Transkript, um Engine, Modell, Sprache und Aufgabe fuer Recorder-Aufnahmen zu aendern."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn on transcript creation to change the engine, model, language, and task for recorder files."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レコーダーファイルのエンジン、モデル、言語、タスクを変更するには文字起こし作成をオンにしてください。"
+          }
+        }
+      }
+    },
+    "recorder.useDictationDefaultEngine": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dictation-Standard-Engine verwenden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Dictation default engine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dictationのデフォルトエンジンを使用"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9748,7 +9748,7 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "System Audio Recorder Shortcut"
+            "value": "System-Audio-Recorder-Kurzbefehl"
           }
         },
         "en": {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -102,6 +102,9 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var transcriptionEnabled: Bool {
         didSet { defaults.set(transcriptionEnabled, forKey: UserDefaultsKeys.recorderTranscriptionEnabled) }
     }
+    @Published var livePreviewEnabled: Bool {
+        didSet { defaults.set(livePreviewEnabled, forKey: UserDefaultsKeys.recorderLivePreviewEnabled) }
+    }
     @Published var selectedEngine: String? {
         didSet {
             defaults.set(selectedEngine, forKey: UserDefaultsKeys.recorderTranscriptionEngine)
@@ -165,6 +168,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private let dictionaryService: DictionaryService
     private let defaults: UserDefaults
     private let streamingHandler: StreamingHandler
+    private let livePreviewStartObserver: (() -> Void)?
     private var cancellables = Set<AnyCancellable>()
     private var currentOutputURL: URL?
     private var activeRecorderAPISessionID: UUID?
@@ -175,12 +179,14 @@ final class AudioRecorderViewModel: ObservableObject {
         recorderService: AudioRecorderService,
         modelManager: ModelManagerService,
         dictionaryService: DictionaryService,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        livePreviewStartObserver: (() -> Void)? = nil
     ) {
         self.recorderService = recorderService
         self.modelManager = modelManager
         self.dictionaryService = dictionaryService
         self.defaults = defaults
+        self.livePreviewStartObserver = livePreviewStartObserver
         self.streamingHandler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { [weak recorderService] in
@@ -230,6 +236,11 @@ final class AudioRecorderViewModel: ObservableObject {
             self.transcriptionEnabled = true
         } else {
             self.transcriptionEnabled = defaults.bool(forKey: UserDefaultsKeys.recorderTranscriptionEnabled)
+        }
+        if defaults.object(forKey: UserDefaultsKeys.recorderLivePreviewEnabled) == nil {
+            self.livePreviewEnabled = false
+        } else {
+            self.livePreviewEnabled = defaults.bool(forKey: UserDefaultsKeys.recorderLivePreviewEnabled)
         }
         self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionEngine)
         self.selectedModel = defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel)
@@ -437,7 +448,7 @@ final class AudioRecorderViewModel: ObservableObject {
 
         EventBus.shared.emit(.recordingStarted(RecordingStartedPayload()))
 
-        if transcriptionEnabled {
+        if transcriptionEnabled && livePreviewEnabled {
             startStreamingTranscription()
         } else {
             isTranscribing = false
@@ -485,7 +496,7 @@ final class AudioRecorderViewModel: ObservableObject {
             }
 
             // Emit final transcript to LiveTranscriptPlugin
-            if !partialText.isEmpty {
+            if livePreviewEnabled && !partialText.isEmpty {
                 EventBus.shared.emit(.partialTranscriptionUpdate(PartialTranscriptionPayload(
                     text: partialText, isFinal: true, elapsedSeconds: recordingDuration
                 )))
@@ -685,6 +696,7 @@ final class AudioRecorderViewModel: ObservableObject {
             return
         }
 
+        livePreviewStartObserver?()
         let task = (selectedTask == .translate && !plugin.supportsTranslation) ? .transcribe : selectedTask
         streamingHandler.start(
             streamPrompt: dictionaryService.getTermsForPrompt(providerId: providerId) ?? "",

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -160,85 +160,105 @@ struct AudioRecorderView: View {
 
             // Transcription Settings
             Section(String(localized: "recorder.transcription")) {
-                Toggle(String(localized: "recorder.liveTranscription"), isOn: $viewModel.transcriptionEnabled)
+                Toggle(String(localized: "recorder.createTranscriptAfterRecording"), isOn: $viewModel.transcriptionEnabled)
                     .disabled(isEditingLocked)
 
-                if viewModel.transcriptionEnabled {
-                    // Engine picker
-                    let engines = pluginManager.transcriptionEngines
-                    Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
-                        Text(String(localized: "Default Engine")).tag(nil as String?)
-                        Divider()
-                        ForEach(engines, id: \.providerId) { engine in
-                            enginePickerLabel(for: engine)
-                                .tag(engine.providerId as String?)
-                                .disabled(!viewModel.canUseForTranscription(engine))
-                        }
-                    }
-                    .disabled(isEditingLocked)
+                Text(String(localized: "recorder.createTranscriptAfterRecording.description"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
-                    if let notice = transcriptionAuthNotice(for: engines) {
-                        Label(notice, systemImage: "key")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    // Model picker
-                    if let engine = viewModel.resolvedEngine,
-                       viewModel.canUseForTranscription(engine) {
-                        let models = engine.transcriptionModels
-                        if models.count > 1 {
-                            Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
-                                Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
-                                Divider()
-                                ForEach(models, id: \.id) { model in
-                                    Text(model.displayName).tag(model.id as String?)
-                                }
-                            }
-                            .disabled(isEditingLocked)
-                        }
-
-                        if !modelManager.supportsLiveTranscriptionSession(engineOverrideId: engine.providerId) {
-                            Label(
-                                localizedAppText(
-                                    "This engine uses a lightweight live preview that updates every few seconds. Final transcription still runs on the full recording after you stop.",
-                                    de: "Diese Engine nutzt eine leichte Live-Vorschau, die nur alle paar Sekunden aktualisiert wird. Die finale Transkription laeuft nach dem Stoppen weiterhin auf der gesamten Aufnahme."
-                                ),
-                                systemImage: "info.circle"
-                            )
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    let languageOptions: [(code: String, name: String)] = {
-                        let supportedLanguages = viewModel.selectedEngineSupportedLanguages
-                        guard !supportedLanguages.isEmpty else {
-                            return SettingsViewModel.shared.availableLanguages
-                        }
-                        return localizedAppLanguageOptions(for: supportedLanguages)
-                            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                            .map { (code: $0.code, name: $0.name) }
-                    }()
-
-                    LanguageSelectionEditor(
-                        selection: $viewModel.languageSelection,
-                        availableLanguages: languageOptions,
-                        hintBehavior: LanguageSelectionHintBehavior(engine: viewModel.resolvedEngine)
+                VStack(alignment: .leading, spacing: 4) {
+                    recorderSummaryRow(
+                        title: String(localized: "recorder.effectiveEngine"),
+                        value: viewModel.activeEngineName ?? String(localized: "recorder.noEngineSelected")
                     )
-                    .disabled(isEditingLocked)
+                    recorderSummaryRow(
+                        title: String(localized: "recorder.effectiveModel"),
+                        value: viewModel.activeModelName ?? String(localized: "watchFolder.model.default")
+                    )
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-                    // Task picker (transcribe/translate)
-                    if viewModel.supportsTranslation {
-                        Picker(String(localized: "Task"), selection: $viewModel.selectedTask) {
-                            ForEach(TranscriptionTask.allCases) { task in
-                                Text(task.displayName).tag(task)
+                let engines = pluginManager.transcriptionEngines
+                Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
+                    Text(String(localized: "recorder.useDictationDefaultEngine")).tag(nil as String?)
+                    Divider()
+                    ForEach(engines, id: \.providerId) { engine in
+                        enginePickerLabel(for: engine)
+                            .tag(engine.providerId as String?)
+                            .disabled(!viewModel.canUseForTranscription(engine))
+                    }
+                }
+                .disabled(isEditingLocked || !viewModel.transcriptionEnabled)
+
+                if let notice = transcriptionAuthNotice(for: engines) {
+                    Label(notice, systemImage: "key")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let engine = viewModel.resolvedEngine,
+                   viewModel.canUseForTranscription(engine) {
+                    let models = engine.transcriptionModels
+                    if models.count > 1 {
+                        Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
+                            Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
+                            Divider()
+                            ForEach(models, id: \.id) { model in
+                                Text(model.displayName).tag(model.id as String?)
                             }
                         }
-                        .disabled(isEditingLocked)
+                        .disabled(isEditingLocked || !viewModel.transcriptionEnabled)
+                    }
+                }
+
+                let languageOptions: [(code: String, name: String)] = {
+                    let supportedLanguages = viewModel.selectedEngineSupportedLanguages
+                    guard !supportedLanguages.isEmpty else {
+                        return SettingsViewModel.shared.availableLanguages
+                    }
+                    return localizedAppLanguageOptions(for: supportedLanguages)
+                        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                        .map { (code: $0.code, name: $0.name) }
+                }()
+
+                LanguageSelectionEditor(
+                    selection: $viewModel.languageSelection,
+                    availableLanguages: languageOptions,
+                    hintBehavior: LanguageSelectionHintBehavior(engine: viewModel.resolvedEngine)
+                )
+                .disabled(isEditingLocked || !viewModel.transcriptionEnabled)
+
+                if viewModel.supportsTranslation {
+                    Picker(String(localized: "Task"), selection: $viewModel.selectedTask) {
+                        ForEach(TranscriptionTask.allCases) { task in
+                            Text(task.displayName).tag(task)
+                        }
+                    }
+                    .disabled(isEditingLocked || !viewModel.transcriptionEnabled)
+                }
+
+                if !viewModel.transcriptionEnabled {
+                    Label(String(localized: "recorder.transcriptionSettingsDisabledHint"), systemImage: "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Toggle(String(localized: "recorder.showLiveTranscriptWhileRecording"), isOn: $viewModel.livePreviewEnabled)
+                    .disabled(isEditingLocked || !viewModel.transcriptionEnabled)
+
+                if viewModel.livePreviewEnabled {
+                    if let engine = viewModel.resolvedEngine,
+                       !modelManager.supportsLiveTranscriptionSession(engineOverrideId: engine.providerId) {
+                        Label(
+                            String(localized: "recorder.livePreviewLightweightHint"),
+                            systemImage: "info.circle"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
 
-                    // LiveTranscriptPlugin status
                     if isLiveTranscriptPluginActive {
                         Label(
                             String(localized: "recorder.liveTranscriptActive"),
@@ -297,6 +317,17 @@ struct AudioRecorderView: View {
 
     private var isLiveTranscriptPluginActive: Bool {
         pluginManager.loadedPlugins.contains { $0.manifest.id == "com.typewhisper.livetranscript" && $0.isEnabled }
+    }
+
+    private func recorderSummaryRow(title: String, value: String) -> some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .frame(width: 96, alignment: .leading)
+            Text(value)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
     }
 }
 

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -93,16 +93,82 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.effectiveProviderId, "groq")
     }
 
+    func testRecorderLivePreviewDefaultsOffAndPersistsSeparately() throws {
+        let defaults = try makeDefaults()
+
+        let viewModel = makeViewModel(defaults: defaults)
+
+        XCTAssertFalse(viewModel.livePreviewEnabled)
+        XCTAssertNil(defaults.object(forKey: UserDefaultsKeys.recorderLivePreviewEnabled))
+
+        viewModel.livePreviewEnabled = true
+
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultsKeys.recorderLivePreviewEnabled))
+    }
+
+    func testLivePreviewStartsOnlyWhenTranscriptAndPreviewAreEnabled() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager()
+
+        let disabledCount = try await livePreviewStartCount(
+            transcriptionEnabled: false,
+            livePreviewEnabled: true
+        )
+        let transcriptOnlyCount = try await livePreviewStartCount(
+            transcriptionEnabled: true,
+            livePreviewEnabled: false
+        )
+        let splitEnabledCount = try await livePreviewStartCount(
+            transcriptionEnabled: true,
+            livePreviewEnabled: true
+        )
+
+        XCTAssertEqual(disabledCount, 0)
+        XCTAssertEqual(transcriptOnlyCount, 0)
+        XCTAssertEqual(splitEnabledCount, 1)
+    }
+
     private func makeViewModel(
         defaults: UserDefaults,
-        modelManager: ModelManagerService = ModelManagerService()
+        modelManager: ModelManagerService = ModelManagerService(),
+        recorderService: AudioRecorderService = AudioRecorderService(),
+        livePreviewStartObserver: (() -> Void)? = nil
     ) -> AudioRecorderViewModel {
         AudioRecorderViewModel(
-            recorderService: AudioRecorderService(),
+            recorderService: recorderService,
             modelManager: modelManager,
             dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
-            defaults: defaults
+            defaults: defaults,
+            livePreviewStartObserver: livePreviewStartObserver
         )
+    }
+
+    private func livePreviewStartCount(
+        transcriptionEnabled: Bool,
+        livePreviewEnabled: Bool
+    ) async throws -> Int {
+        let defaults = try makeDefaults()
+        let recorderService = AudioRecorderService()
+        recorderService.recordingsDirectoryOverride = makeTemporaryDirectory()
+        recorderService.startRecordingOverride = { _, _, _, outputURL in
+            try Data("placeholder".utf8).write(to: outputURL)
+            return outputURL
+        }
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        var startCount = 0
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: recorderService,
+            livePreviewStartObserver: { startCount += 1 }
+        )
+        viewModel.transcriptionEnabled = transcriptionEnabled
+        viewModel.livePreviewEnabled = livePreviewEnabled
+
+        _ = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+
+        return startCount
     }
 
     private func setupPluginManager() {

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -51,6 +51,7 @@
 - Community term pack download and apply
 - Built-in term packs render localized metadata in English and German
 - App audio recording with separate tracks
+- System Audio Recorder settings: verify final transcript creation and live transcript preview are separate toggles, and recorder engine/model controls remain visible when live preview is off
 - Google Cloud Speech-to-Text plugin
 - Sound feedback settings (enable, disable, and custom sounds)
 - Non-blocking model download


### PR DESCRIPTION
## Summary

Closes #726.

This PR reorganizes the System Audio Recorder transcription UI so users can tell the difference between final recorder transcripts and optional live preview behavior.

- Splits recorder transcript creation from live preview with a new `recorderLivePreviewEnabled` preference.
- Keeps recorder engine, model, language, and task controls visible even when final transcript creation is off, while disabling them to show what they control.
- Adds a recorder-specific engine/model summary and clearer labels for System Audio Recorder shortcuts/menu actions.
- Updates English, German, and Japanese localizations.
- Adds regression coverage for live preview persistence and streaming start conditions.

## Test Coverage

All new recorder state paths are covered by XCTest:

- `recorderLivePreviewEnabled` defaults off and persists independently.
- Final recorder transcript creation can remain enabled while live preview is disabled.
- Streaming/live preview only starts when both final transcript creation and live preview are enabled.
- Existing recorder API session final-transcription tests continue to pass as part of the full suite.

Tests: existing suite plus focused recorder coverage in `TypeWhisperTests/AudioRecorderViewModelTests.swift`.

## Pre-Landing Review

No issues found.

Scope Check: CLEAN

Intent: make recorder transcription settings discoverable and separate final transcript creation from optional live preview.
Delivered: recorder UI, persistence, runtime gating, labels, localizations, and tests for the split behavior.

## Design Review

SwiftUI settings surface changed. A dedicated visual pass was not run in-browser because this is a native macOS app flow, not a web UI. The dev app build completed successfully.

## Documentation

- Updated `docs/release-checklist.md` with a smoke check for the System Audio Recorder transcript/live-preview split.
- Public website docs did not need changes; no `typewhisper.com` PR created.

## Eval Results

No prompt-related files changed, evals skipped.

## Plan Completion

No external plan file detected. The implementation matches the requested issue scope:

- Final transcript creation and live preview are separate toggles.
- Recorder engine/model settings stay visible and are disabled rather than hidden when transcript creation is off.
- Recorder-specific labels distinguish Dictation from System Audio Recorder.
- UserDefaults compatibility is preserved for existing recorder transcript, engine, and model settings.

## Test plan

- [x] `jq empty TypeWhisper/Resources/Localizable.xcstrings && git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/.codex/worktrees/c589/typewhisper-mac`

Verification result: 949 tests, 0 failures. Dev app build succeeded and produced `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “show live transcript while recording” toggle with a persisted preference.
  * Refined recorder settings with an effective engine/model summary, improved engine/model/language/task presentation, and conditional pickers and hints.
* **Bug Fixes**
  * Live transcription and final transcript streaming updates now occur only when live preview is enabled.
* **Localization**
  * Updated recorder UI labels and hints for clearer messaging, including start/stop and missing-engine states.
* **Tests / Documentation**
  * Added tests for live preview default/persistence and start behavior; updated the release smoke-check checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
