### PR TITLE
Add automatic workflow output format resolution

### DIFF
--- a/TypeWhisper/Models/Workflow.swift
+++ b/TypeWhisper/Models/Workflow.swift
@@ -592,9 +592,15 @@ extension Workflow {
     func systemPrompt(
         fallbackTranslationTarget: String? = nil,
         detectedLanguage: String? = nil,
-        configuredLanguage: String? = nil
+        configuredLanguage: String? = nil,
+        resolvedOutputFormat: String? = nil
     ) -> String? {
-        let outputInstruction = workflowOutputInstruction(for: output)
+        let outputFormat = resolvedOutputFormat ?? WorkflowOutputFormatResolver.resolvedFormat(
+            storedFormat: output.format,
+            bundleIdentifier: nil,
+            url: nil
+        )
+        let outputInstruction = workflowOutputInstruction(outputFormat: outputFormat, output: output)
         let settingsInstruction = workflowSettingsInstruction(for: behavior.settings)
         let fineTuningInstruction = workflowFineTuningInstruction(for: behavior.fineTuning)
         let inputBoundaryInstruction = workflowInputBoundaryInstruction(for: template)
@@ -699,9 +705,9 @@ extension Workflow {
         return "\nFine-tuning:\n\(trimmed)"
     }
 
-    private func workflowOutputInstruction(for output: WorkflowOutput) -> String {
+    private func workflowOutputInstruction(outputFormat: String?, output: WorkflowOutput) -> String {
         var lines: [String] = []
-        if let format = output.format?.trimmingCharacters(in: .whitespacesAndNewlines), !format.isEmpty {
+        if let format = outputFormat?.trimmingCharacters(in: .whitespacesAndNewlines), !format.isEmpty {
             let normalizedFormat = format.lowercased()
             if normalizedFormat == "rtf" || normalizedFormat == "richtext" || normalizedFormat == "rich text" {
                 lines.append("Return Markdown-compatible text for rich-text conversion.")

--- a/TypeWhisper/Services/AppFormatterService.swift
+++ b/TypeWhisper/Services/AppFormatterService.swift
@@ -54,6 +54,7 @@ enum WorkflowOutputFormatResolver {
         storedFormat: String?,
         bundleIdentifier: String?,
         url: String? = nil,
+        // Reserved for future AX role hints; current auto detection stays deterministic by app and URL.
         accessibilityRole _: String? = nil
     ) -> String? {
         guard let storedFormat = trimmedNonEmpty(storedFormat) else {
@@ -90,6 +91,7 @@ enum WorkflowOutputFormatResolver {
             return plainTextFormat
         }
 
+        // Initial browser coverage is intentionally narrow; extend this list after validating more web editors.
         switch host {
         case "docs.google.com":
             return "rtf"

--- a/TypeWhisper/Services/AppFormatterService.swift
+++ b/TypeWhisper/Services/AppFormatterService.swift
@@ -3,10 +3,29 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "AppFormatterService")
 
-@MainActor
-final class AppFormatterService {
-    // Known app mappings for "auto" mode
-    private static let autoMappings: [String: String] = [
+enum WorkflowOutputFormatResolver {
+    static let automaticFormat = "auto"
+    static let plainTextFormat = "plaintext"
+
+    private static let browserBundleIdentifiers: Set<String> = [
+        "com.apple.Safari",
+        "company.thebrowser.Browser",
+        "com.google.Chrome",
+        "com.google.Chrome.canary",
+        "com.brave.Browser",
+        "com.microsoft.edgemac",
+        "com.operasoftware.Opera",
+        "com.vivaldi.Vivaldi",
+        "org.chromium.Chromium",
+        "org.mozilla.firefox",
+    ]
+
+    private static let nativeAppMappings: [String: String] = [
+        // Rich-text document apps
+        "com.apple.iWork.Pages": "rtf",
+        "com.microsoft.Word": "rtf",
+        "com.apple.TextEdit": "rtf",
+
         // Markdown apps
         "md.obsidian": "markdown",
         "notion.id": "markdown",
@@ -15,15 +34,15 @@ final class AppFormatterService {
         "com.bear.Bear": "markdown",
         "com.ulyssesapp.mac": "markdown",
 
-        // HTML apps (email clients)
+        // HTML apps and web app bundles
         "com.apple.mail": "html",
         "com.microsoft.Outlook": "html",
         "com.google.Chrome.app.mail": "html",
 
-        // Code editors
+        // Code editors and terminals
         "com.apple.dt.Xcode": "code",
         "com.microsoft.VSCode": "code",
-        "com.todesktop.230313mzl4w4u92": "code", // Cursor
+        "com.todesktop.230313mzl4w4u92": "code",
         "dev.zed.Zed": "code",
         "com.sublimetext.4": "code",
         "com.jetbrains.intellij": "code",
@@ -31,15 +50,85 @@ final class AppFormatterService {
         "com.apple.Terminal": "code",
     ]
 
-    func format(text: String, bundleId: String?, outputFormat: String?) -> String {
+    static func resolvedFormat(
+        storedFormat: String?,
+        bundleIdentifier: String?,
+        url: String? = nil,
+        accessibilityRole _: String? = nil
+    ) -> String? {
+        guard let storedFormat = trimmedNonEmpty(storedFormat) else {
+            return nil
+        }
+
+        guard isAutomaticFormat(storedFormat) else {
+            return storedFormat
+        }
+
+        return resolvedAutomaticFormat(bundleIdentifier: bundleIdentifier, url: url)
+    }
+
+    static func isAutomaticFormat(_ format: String?) -> Bool {
+        normalized(format) == automaticFormat
+    }
+
+    static func normalized(_ format: String?) -> String? {
+        trimmedNonEmpty(format)?.lowercased()
+    }
+
+    static func resolvedAutomaticFormat(bundleIdentifier: String?, url: String? = nil) -> String {
+        if let bundleIdentifier,
+           let nativeFormat = nativeAppMappings[bundleIdentifier] {
+            return nativeFormat
+        }
+
+        guard let bundleIdentifier,
+              browserBundleIdentifiers.contains(bundleIdentifier) else {
+            return plainTextFormat
+        }
+
+        guard let host = host(from: url) else {
+            return plainTextFormat
+        }
+
+        switch host {
+        case "docs.google.com":
+            return "rtf"
+        case "mail.google.com":
+            return "html"
+        default:
+            return plainTextFormat
+        }
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func host(from rawURL: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(rawURL) else { return nil }
+        let componentSource = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        return URLComponents(string: componentSource)?.host?.lowercased()
+    }
+}
+
+@MainActor
+final class AppFormatterService {
+    func format(text: String, bundleId: String?, url: String? = nil, outputFormat: String?) -> String {
         guard let outputFormat, !outputFormat.isEmpty else {
             return text
         }
 
         let normalizedOutputFormat = outputFormat.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let resolvedFormat: String
-        if normalizedOutputFormat == "auto" {
-            resolvedFormat = Self.resolveAutoFormat(bundleId: bundleId)
+        if WorkflowOutputFormatResolver.isAutomaticFormat(normalizedOutputFormat) {
+            resolvedFormat = WorkflowOutputFormatResolver.resolvedAutomaticFormat(
+                bundleIdentifier: bundleId,
+                url: url
+            )
         } else {
             resolvedFormat = normalizedOutputFormat
         }
@@ -51,7 +140,7 @@ final class AppFormatterService {
             return formatAsMarkdown(text)
         case "html":
             return formatAsHTML(text)
-        case "code", "plaintext", "rtf", "richtext", "rich text":
+        case "code", "plaintext", "plain text", "rtf", "richtext", "rich text":
             return text
         default:
             return text
@@ -59,11 +148,6 @@ final class AppFormatterService {
     }
 
     // MARK: - Private
-
-    private static func resolveAutoFormat(bundleId: String?) -> String {
-        guard let bundleId else { return "plaintext" }
-        return autoMappings[bundleId] ?? "plaintext"
-    }
 
     private func formatAsMarkdown(_ text: String) -> String {
         let lines = text.components(separatedBy: "\n")

--- a/TypeWhisper/Services/PostProcessingPipeline.swift
+++ b/TypeWhisper/Services/PostProcessingPipeline.swift
@@ -104,6 +104,7 @@ final class PostProcessingPipeline {
                     result = appFormatterService!.format(
                         text: result,
                         bundleId: context.bundleIdentifier,
+                        url: context.url,
                         outputFormat: outputFormat
                     )
                 case -5:

--- a/TypeWhisper/Services/WorkflowTextProcessingService.swift
+++ b/TypeWhisper/Services/WorkflowTextProcessingService.swift
@@ -88,7 +88,8 @@ struct WorkflowTextProcessingService {
         text: String,
         fallbackTranslationTarget: String? = nil,
         detectedLanguage: String? = nil,
-        configuredLanguage: String? = nil
+        configuredLanguage: String? = nil,
+        resolvedOutputFormat: String? = nil
     ) async throws -> String {
         if workflow.usesAppleTranslate {
             return try await processAppleTranslate(
@@ -103,7 +104,8 @@ struct WorkflowTextProcessingService {
         guard let systemPrompt = workflow.systemPrompt(
             fallbackTranslationTarget: fallbackTranslationTarget,
             detectedLanguage: detectedLanguage,
-            configuredLanguage: configuredLanguage
+            configuredLanguage: configuredLanguage,
+            resolvedOutputFormat: resolvedOutputFormat
         ) else {
             return text
         }
@@ -132,7 +134,8 @@ struct WorkflowTextProcessingService {
         workflow: Workflow,
         fallbackTranslationTarget: String? = nil,
         detectedLanguage: String? = nil,
-        configuredLanguage: String? = nil
+        configuredLanguage: String? = nil,
+        resolvedOutputFormat: String? = nil
     ) -> Bool {
         if workflow.usesAppleTranslate {
             return true
@@ -141,7 +144,8 @@ struct WorkflowTextProcessingService {
         return workflow.systemPrompt(
             fallbackTranslationTarget: fallbackTranslationTarget,
             detectedLanguage: detectedLanguage,
-            configuredLanguage: configuredLanguage
+            configuredLanguage: configuredLanguage,
+            resolvedOutputFormat: resolvedOutputFormat
         ) != nil
     }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1112,6 +1112,23 @@ final class DictationViewModel: ObservableObject {
         matchedWorkflow?.output.format
     }
 
+    private func resolvedEffectiveOutputFormat(
+        for activeApp: (name: String?, bundleId: String?, url: String?)
+    ) -> String? {
+        let storedFormat = effectiveOutputFormat
+        let resolvedFormat = WorkflowOutputFormatResolver.resolvedFormat(
+            storedFormat: storedFormat,
+            bundleIdentifier: activeApp.bundleId,
+            url: activeApp.url
+        )
+        if storedFormat != nil {
+            logger.info(
+                "Workflow output format resolved: stored=\(storedFormat ?? "nil", privacy: .public), resolved=\(resolvedFormat ?? "nil", privacy: .public), bundle=\(activeApp.bundleId ?? "nil", privacy: .public), url=\(activeApp.url ?? "nil", privacy: .public)"
+            )
+        }
+        return resolvedFormat
+    }
+
     private var effectiveNumberNormalizationOverride: Bool? {
         matchedWorkflow?.output.numberNormalizationMode.overrideValue
     }
@@ -1241,6 +1258,7 @@ final class DictationViewModel: ObservableObject {
                 await urlResolutionTask?.value
 
                 let activeApp = capturedActiveApp ?? textInsertionService.captureActiveApp()
+                let resolvedOutputFormat = self.resolvedEffectiveOutputFormat(for: activeApp)
                 let languageSelection = effectiveLanguageSelection
                 let language = languageSelection.requestedLanguage
                 let languageCandidates = languageSelection.selectedCodes
@@ -1289,7 +1307,8 @@ final class DictationViewModel: ObservableObject {
                 let llmHandler = buildLLMHandler(
                     translationTarget: translationTarget,
                     detectedLanguage: result.detectedLanguage,
-                    configuredLanguage: language
+                    configuredLanguage: language,
+                    resolvedOutputFormat: resolvedOutputFormat
                 )
 
                 guard !Task.isCancelled else { return }
@@ -1326,7 +1345,7 @@ final class DictationViewModel: ObservableObject {
                 )
                 let ppResult = try await postProcessingPipeline.process(
                     text: text, context: ppContext, dictationContext: dictationContext, llmHandler: llmHandler,
-                    outputFormat: self.effectiveOutputFormat,
+                    outputFormat: resolvedOutputFormat,
                     llmStepName: llmStepName,
                     normalizeNumbers: self.effectiveNumberNormalizationOverride
                 )
@@ -1364,7 +1383,7 @@ final class DictationViewModel: ObservableObject {
                         insertionText,
                         preserveClipboard: preserveClipboard,
                         autoEnter: self.effectiveAutoEnterEnabled,
-                        outputFormat: self.effectiveOutputFormat
+                        outputFormat: resolvedOutputFormat
                     )
                     if case .pasted(.unverified(let reason)) = insertionResult {
                         logger.info(
@@ -1676,12 +1695,14 @@ final class DictationViewModel: ObservableObject {
     private func buildLLMHandler(
         translationTarget: String?,
         detectedLanguage: String?,
-        configuredLanguage: String?
+        configuredLanguage: String?,
+        resolvedOutputFormat: String?
     ) -> ((String) async throws -> String)? {
         if let workflowHandler = buildWorkflowTextProcessingHandler(
             translationTarget: translationTarget,
             detectedLanguage: detectedLanguage,
-            configuredLanguage: configuredLanguage
+            configuredLanguage: configuredLanguage,
+            resolvedOutputFormat: resolvedOutputFormat
         ) {
             return workflowHandler
         }
@@ -1722,7 +1743,8 @@ final class DictationViewModel: ObservableObject {
     private func buildWorkflowTextProcessingHandler(
         translationTarget: String?,
         detectedLanguage: String?,
-        configuredLanguage: String?
+        configuredLanguage: String?,
+        resolvedOutputFormat: String?
     ) -> ((String) async throws -> String)? {
         guard let workflow = matchedWorkflow else { return nil }
 
@@ -1732,7 +1754,8 @@ final class DictationViewModel: ObservableObject {
             workflow: workflow,
             fallbackTranslationTarget: translationTarget,
             detectedLanguage: detectedLanguage,
-            configuredLanguage: configuredLanguage
+            configuredLanguage: configuredLanguage,
+            resolvedOutputFormat: resolvedOutputFormat
         ) else {
             return nil
         }
@@ -1748,7 +1771,8 @@ final class DictationViewModel: ObservableObject {
                 text: text,
                 fallbackTranslationTarget: translationTarget,
                 detectedLanguage: detectedLanguage,
-                configuredLanguage: configuredLanguage
+                configuredLanguage: configuredLanguage,
+                resolvedOutputFormat: resolvedOutputFormat
             )
         }
     }

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -32,6 +32,7 @@ final class PromptPaletteHandler {
     private let workflowTextProcessingService: WorkflowTextProcessingService
     private let soundService: SoundService
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
+    private let activateAndPasteOverride: (@MainActor (String?) async -> Bool)?
 
     var onShowNotchFeedback: ((String, String, TimeInterval, Bool, String?) -> Void)?
     var onShowError: ((String) -> Void)?
@@ -51,7 +52,8 @@ final class PromptPaletteHandler {
         workflowTextProcessingService: WorkflowTextProcessingService? = nil,
         soundService: SoundService,
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
-        promptPaletteController: any PromptPaletteControlling = PromptPaletteController()
+        promptPaletteController: any PromptPaletteControlling = PromptPaletteController(),
+        activateAndPasteOverride: (@MainActor (String?) async -> Bool)? = nil
     ) {
         self.promptPaletteController = promptPaletteController
         self.textInsertionService = textInsertionService
@@ -66,6 +68,7 @@ final class PromptPaletteHandler {
             )
         self.soundService = soundService
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
+        self.activateAndPasteOverride = activateAndPasteOverride
     }
 
     func hide() {
@@ -282,19 +285,34 @@ final class PromptPaletteHandler {
         Task { [weak self] in
             guard let self else { return }
             do {
+                let browserInfo = await ctx.browserInfoTask?.value
+                let resolvedUrl = browserInfo?.url ?? ctx.activeApp.url
+                let resolvedApp = (
+                    name: browserInfo?.title ?? ctx.activeApp.name,
+                    bundleId: ctx.activeApp.bundleId,
+                    url: resolvedUrl
+                )
+                let resolvedOutputFormat = WorkflowOutputFormatResolver.resolvedFormat(
+                    storedFormat: workflow.output.format,
+                    bundleIdentifier: ctx.activeApp.bundleId,
+                    url: resolvedUrl
+                )
+                if workflow.output.format != nil {
+                    logger.info(
+                        "[PromptPalette] Workflow output format resolved: stored=\(workflow.output.format ?? "nil", privacy: .public), resolved=\(resolvedOutputFormat ?? "nil", privacy: .public), bundle=\(ctx.activeApp.bundleId ?? "nil", privacy: .public), url=\(resolvedUrl ?? "nil", privacy: .public)"
+                    )
+                }
+
                 let result = try await workflowTextProcessingService.process(
                     workflow: workflow,
-                    text: ctx.text
+                    text: ctx.text,
+                    resolvedOutputFormat: resolvedOutputFormat
                 )
                 guard !Task.isCancelled else { return }
 
                 // Route to action plugin if configured
                 if let actionPluginId = workflow.output.targetActionPluginId,
                    let actionPlugin = PluginManager.shared.actionPlugin(for: actionPluginId) {
-                    let browserInfo = await ctx.browserInfoTask?.value
-                    let resolvedUrl = browserInfo?.url ?? ctx.activeApp.url
-                    let resolvedApp = (name: browserInfo?.title ?? ctx.activeApp.name,
-                                       bundleId: ctx.activeApp.bundleId, url: resolvedUrl)
                     try await executeActionPlugin?(
                         actionPlugin, actionPluginId, result,
                         resolvedApp, ctx.text, nil
@@ -319,10 +337,22 @@ final class PromptPaletteHandler {
                 // Always put result on clipboard so the user can paste it
                 let pasteboard = NSPasteboard.general
                 pasteboard.clearContents()
-                pasteboard.setString(result, forType: .string)
+                if let formattedClipboardPayload = ClipboardContentFormatter.payload(
+                    for: result,
+                    outputFormat: resolvedOutputFormat
+                ) {
+                    formattedClipboardPayload.write(to: pasteboard)
+                } else {
+                    pasteboard.setString(result, forType: .string)
+                }
+                let requiresPasteboardInsertion = ClipboardContentFormatter.requiresPasteboardInsertion(
+                    outputFormat: resolvedOutputFormat
+                )
 
                 let insertionOutcome: InsertionOutcome
-                if let selection = ctx.selection {
+                if requiresPasteboardInsertion {
+                    insertionOutcome = await activateAndPaste(bundleId: ctx.activeApp.bundleId) ? .insertedViaPaste : .failed
+                } else if let selection = ctx.selection {
                     insertionOutcome = await insertViaAXWithPasteFallback(
                         selection: selection,
                         result: result,
@@ -402,6 +432,10 @@ final class PromptPaletteHandler {
 
     /// Activate the source app and paste from clipboard. Result must already be on the clipboard.
     private func activateAndPaste(bundleId: String?) async -> Bool {
+        if let activateAndPasteOverride {
+            return await activateAndPasteOverride(bundleId)
+        }
+
         guard let bundleId,
               let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first else {
             logger.warning("[PromptPalette] No running app for bundleId: \(bundleId ?? "nil")")

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -37,6 +37,7 @@ struct WorkflowOutputFormatPreset: Identifiable, Equatable {
     var id: String { value }
 
     static let all: [WorkflowOutputFormatPreset] = [
+        WorkflowOutputFormatPreset(title: "Auto-Detect", value: "auto"),
         WorkflowOutputFormatPreset(title: "Markdown", value: "markdown"),
         WorkflowOutputFormatPreset(title: "HTML", value: "html"),
         WorkflowOutputFormatPreset(title: "RTF", value: "rtf"),
@@ -884,7 +885,7 @@ private struct WorkflowEditorPage: View {
                                     Text(localizedAppText("Output Format", de: "Ausgabeformat"))
                                         .font(.subheadline.weight(.semibold))
                                     HStack(spacing: 8) {
-                                        TextField(localizedAppText("e.g. Markdown, RTF, JSON, plain text", de: "z. B. Markdown, RTF, JSON, Plain Text"), text: $draft.outputFormat)
+                                        TextField(localizedAppText("e.g. Auto, Markdown, RTF, JSON, plain text", de: "z. B. Auto, Markdown, RTF, JSON, Plain Text"), text: $draft.outputFormat)
                                             .textFieldStyle(.roundedBorder)
 
                                         Menu {

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -69,6 +69,20 @@ final class AppFormatterServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testBrowserAutoFormattingUsesURLDomainForGoogleMail() {
+        let service = AppFormatterService()
+
+        let output = service.format(
+            text: "hello <team>\n- launch",
+            bundleId: "com.google.Chrome",
+            url: "https://mail.google.com/mail/u/0/#inbox",
+            outputFormat: "auto"
+        )
+
+        XCTAssertEqual(output, "<p>hello &lt;team&gt;</p>\n<ul>\n<li>launch</li>\n</ul>")
+    }
+
+    @MainActor
     func testRTFFormattingLeavesMarkdownTextForClipboardConversion() {
         let service = AppFormatterService()
 
@@ -79,6 +93,38 @@ final class AppFormatterServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(output, "**Launch**\n- Budget")
+    }
+
+    func testAutoFormatResolverMapsRichTextAndBrowserTargets() {
+        XCTAssertEqual(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: "auto",
+                bundleIdentifier: "com.microsoft.Word"
+            ),
+            "rtf"
+        )
+        XCTAssertEqual(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: "auto",
+                bundleIdentifier: "com.google.Chrome",
+                url: "https://docs.google.com/document/d/abc/edit"
+            ),
+            "rtf"
+        )
+        XCTAssertEqual(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: "auto",
+                bundleIdentifier: "com.google.Chrome",
+                url: "https://github.com/TypeWhisper/typewhisper-mac"
+            ),
+            "plaintext"
+        )
+        XCTAssertNil(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: nil,
+                bundleIdentifier: "com.microsoft.Word"
+            )
+        )
     }
 
     @MainActor

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -249,6 +249,81 @@ final class PromptPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(insertedText, "Processed: Selected source")
     }
 
+    func testDirectWorkflowHotkeyAutoRichTextUsesResolvedPasteboardPayload() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.captureActiveAppOverride = { ("Pages", "com.apple.iWork.Pages", nil) }
+        let selectedElement = AXUIElementCreateSystemWide()
+        textInsertionService.textSelectionOverride = {
+            TextInsertionService.TextSelection(text: "Selected source", element: selectedElement)
+        }
+
+        var insertedText: String?
+        textInsertionService.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        let pasteboard = NSPasteboard.general
+        let savedClipboard = textInsertionService.saveClipboard(from: pasteboard)
+        defer { textInsertionService.restoreClipboard(savedClipboard, to: pasteboard) }
+        pasteboard.clearContents()
+
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let workflow = Workflow(
+            name: "Direct Rich Summary",
+            template: .summary,
+            trigger: .hotkeys([
+                UnifiedHotkey(keyCode: 17, modifierFlags: 0, isFn: false)
+            ], behavior: .processSelectedText),
+            output: WorkflowOutput(format: "auto")
+        )
+
+        var capturedPrompt: String?
+        var pasteCount = 0
+        let controller = PromptPaletteControllerSpy()
+        let handler = PromptPaletteHandler(
+            textInsertionService: textInsertionService,
+            workflowService: workflowService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: RecentTranscriptionStore(),
+            promptProcessingService: PromptProcessingService(),
+            workflowTextProcessingService: WorkflowTextProcessingService(
+                promptProcessor: { prompt, _, _, _, _ in
+                    capturedPrompt = prompt
+                    return "**Launch**\n- Budget"
+                },
+                appleTranslator: nil
+            ),
+            soundService: SoundService(),
+            accessibilityAnnouncementService: AccessibilityAnnouncementService(),
+            promptPaletteController: controller,
+            activateAndPasteOverride: { _ in
+                pasteCount += 1
+                textInsertionService.pasteFromClipboard()
+                return true
+            }
+        )
+
+        handler.processWorkflowDirectly(
+            workflow: workflow,
+            currentState: .idle,
+            soundFeedbackEnabled: false
+        )
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertFalse(controller.isVisible)
+        XCTAssertNil(insertedText)
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertTrue(capturedPrompt?.contains("Return Markdown-compatible text for rich-text conversion.") == true)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Launch\n- Budget")
+        XCTAssertNotNil(pasteboard.data(forType: .rtf))
+    }
+
     func testDirectWorkflowHotkeyRoutesProcessedTextToActionPluginInsteadOfInsertion() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -1060,9 +1060,103 @@ final class WorkflowServiceTests: XCTestCase {
         assertNoAllCapsWorkflowSafetyProse(prompt)
     }
 
+    func testAutoWorkflowSystemPromptRequestsRichTextForNativeRichTextApps() throws {
+        let workflow = Workflow(
+            name: "Auto Rich Notes",
+            template: .meetingNotes,
+            trigger: .manual(),
+            output: WorkflowOutput(format: "auto")
+        )
+        let resolvedFormat = WorkflowOutputFormatResolver.resolvedFormat(
+            storedFormat: workflow.output.format,
+            bundleIdentifier: "com.apple.iWork.Pages"
+        )
+
+        let prompt = try XCTUnwrap(workflow.systemPrompt(resolvedOutputFormat: resolvedFormat))
+
+        XCTAssertEqual(resolvedFormat, "rtf")
+        XCTAssertTrue(prompt.contains("Return Markdown-compatible text for rich-text conversion."))
+        XCTAssertFalse(prompt.contains("Return the result as auto."))
+        assertNoAllCapsWorkflowSafetyProse(prompt)
+    }
+
+    func testAutoWorkflowSystemPromptRequestsRichTextForGoogleDocsBrowserContext() throws {
+        let workflow = Workflow(
+            name: "Auto Browser Notes",
+            template: .meetingNotes,
+            trigger: .manual(),
+            output: WorkflowOutput(format: "auto")
+        )
+        let resolvedFormat = WorkflowOutputFormatResolver.resolvedFormat(
+            storedFormat: workflow.output.format,
+            bundleIdentifier: "com.google.Chrome",
+            url: "https://docs.google.com/document/d/abc/edit"
+        )
+
+        let prompt = try XCTUnwrap(workflow.systemPrompt(resolvedOutputFormat: resolvedFormat))
+
+        XCTAssertEqual(resolvedFormat, "rtf")
+        XCTAssertTrue(prompt.contains("Return Markdown-compatible text for rich-text conversion."))
+        XCTAssertFalse(prompt.contains("Return the result as auto."))
+        assertNoAllCapsWorkflowSafetyProse(prompt)
+    }
+
+    func testAutoWorkflowSystemPromptFallsBackToPlainTextForUnknownBrowserContext() throws {
+        let workflow = Workflow(
+            name: "Auto GitHub Notes",
+            template: .meetingNotes,
+            trigger: .manual(),
+            output: WorkflowOutput(format: "auto")
+        )
+        let resolvedFormat = WorkflowOutputFormatResolver.resolvedFormat(
+            storedFormat: workflow.output.format,
+            bundleIdentifier: "com.google.Chrome",
+            url: "https://github.com/TypeWhisper/typewhisper-mac/issues/701"
+        )
+
+        let prompt = try XCTUnwrap(workflow.systemPrompt(resolvedOutputFormat: resolvedFormat))
+
+        XCTAssertEqual(resolvedFormat, "plaintext")
+        XCTAssertTrue(prompt.contains("Return the result as plaintext."))
+        XCTAssertFalse(prompt.contains("Return Markdown-compatible text for rich-text conversion."))
+        XCTAssertFalse(prompt.contains("Return the result as auto."))
+        assertNoAllCapsWorkflowSafetyProse(prompt)
+    }
+
+    func testExplicitWorkflowOutputFormatWinsOverAutomaticResolution() {
+        XCTAssertEqual(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: "rtf",
+                bundleIdentifier: "com.google.Chrome",
+                url: "https://github.com/TypeWhisper/typewhisper-mac/issues/701"
+            ),
+            "rtf"
+        )
+        XCTAssertEqual(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: "markdown",
+                bundleIdentifier: "com.apple.iWork.Pages"
+            ),
+            "markdown"
+        )
+        XCTAssertEqual(
+            WorkflowOutputFormatResolver.resolvedFormat(
+                storedFormat: "plaintext",
+                bundleIdentifier: "com.apple.iWork.Pages"
+            ),
+            "plaintext"
+        )
+    }
+
     func testWorkflowOutputFormatPresetsExposeRTF() {
         XCTAssertTrue(WorkflowOutputFormatPreset.all.contains { preset in
             preset.title == "RTF" && preset.value == "rtf"
+        })
+    }
+
+    func testWorkflowOutputFormatPresetsExposeAutoDetect() {
+        XCTAssertTrue(WorkflowOutputFormatPreset.all.contains { preset in
+            preset.title == "Auto-Detect" && preset.value == "auto"
         })
     }
 


### PR DESCRIPTION
## Summary

Implements automatic workflow output format resolution for issue #701.

Workflows can now choose `Auto-Detect` as their output format. At runtime, TypeWhisper resolves that stored `auto` value into a concrete output format using the active app bundle identifier and, for browsers, the current URL/domain. The resolved format is then used consistently for the workflow prompt, post-processing, and clipboard/RTF insertion.

## Issue context

Issue #701 asks for workflow output format auto-detection that behaves differently by target context. In particular, browser apps cannot be treated as one rich-text target because Google Docs, Gmail, GitHub, and unknown domains need different handling.

This PR adds a central resolver with these initial rules:

- Pages, Word, TextEdit -> `rtf`
- Browser + `docs.google.com` -> `rtf`
- Browser + `mail.google.com`, native Mail, Outlook -> `html`
- Known Markdown and code targets keep their existing `markdown` / `code` behavior
- Unknown apps or domains -> `plaintext`
- Explicit formats still override auto-detection
- Empty output format keeps the previous no-forced-format behavior

Closes #701

## Changes

- Add `WorkflowOutputFormatResolver` as the shared output-format resolution point.
- Route `AppFormatterService` auto behavior through the shared resolver.
- Pass the resolved output format into `Workflow.systemPrompt(...)` and `WorkflowTextProcessingService.process(...)`.
- Resolve the effective format in `DictationViewModel` after active app and browser URL resolution, then use that value for workflow processing, post-processing, and insertion.
- Route direct workflow execution in `PromptPaletteHandler` through the same resolver and write formatted clipboard payloads for rich-text output.
- Add `Auto-Detect` to workflow output format presets.
- Add focused regression coverage for workflow prompts, app formatter auto cases, and prompt palette rich-text insertion.

## Test plan

- `git diff --check origin/main...HEAD`
- `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WorkflowServiceTests -only-testing:TypeWhisperTests/AppFormatterServiceTests -only-testing:TypeWhisperTests/PromptPaletteHandlerTests`

## Verification results

- `git diff --check origin/main...HEAD` passed.
- Focused Xcode test run passed: 99 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Auto-Detect** option for workflow output format, selecting the best format using your active app and (when available) the browser URL domain.
  * Clipboard handling can now write a formatted payload for auto-detected rich text, improving paste behavior.
  * Prompt palette supports an injectable override for activate-and-paste behavior.
* **Bug Fixes**
  * Ensures the resolved output format is consistently used across workflow prompting, post-processing, and text insertion; app formatting now receives URL context.
* **Tests**
  * Added coverage for auto-detection mapping and clipboard/paste behavior under “output: auto”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->