### PR TITLE
Update Soniox realtime model to v5

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -71,6 +71,8 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
     static let pluginId = "com.typewhisper.soniox"
     static let pluginName = "Soniox"
     static let asyncModelId = "stt-async-v5"
+    static let realtimeModelId = "stt-rt-v5"
+    private static let selectedModelKey = "selectedModel"
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
@@ -85,8 +87,10 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
     func activate(host: HostServices) {
         self.host = host
         _apiKey = host.loadSecret(key: "api-key")
-        _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
-            ?? transcriptionModels.first?.id
+        _selectedModelId = Self.resolvedRealtimeModelId(
+            host.userDefault(forKey: Self.selectedModelKey) as? String,
+            host: host
+        )
     }
 
     func deactivate() {
@@ -105,16 +109,16 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
 
     var transcriptionModels: [PluginModelInfo] {
         [
-            PluginModelInfo(id: "stt-rt-v4", displayName: "STT RT v4"),
-            PluginModelInfo(id: "stt-rt-preview", displayName: "STT RT Preview"),
+            PluginModelInfo(id: Self.realtimeModelId, displayName: "STT RT v5"),
         ]
     }
 
     var selectedModelId: String? { _selectedModelId }
 
     func selectModel(_ modelId: String) {
-        _selectedModelId = modelId
-        host?.setUserDefault(modelId, forKey: "selectedModel")
+        let resolvedModelId = Self.resolvedRealtimeModelId(modelId, host: host)
+        _selectedModelId = resolvedModelId
+        host?.setUserDefault(resolvedModelId, forKey: Self.selectedModelKey)
     }
 
     var supportsTranslation: Bool { true }
@@ -644,6 +648,19 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
             return [requestedLanguage]
         }
         return []
+    }
+
+    private static func resolvedRealtimeModelId(_ storedModelId: String?, host: HostServices?) -> String {
+        let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let supportedIds = Set([Self.realtimeModelId])
+        let modelId = trimmedModelId.flatMap { supportedIds.contains($0) ? $0 : nil }
+            ?? Self.realtimeModelId
+
+        if modelId != storedModelId {
+            host?.setUserDefault(modelId, forKey: Self.selectedModelKey)
+        }
+
+        return modelId
     }
 
     private func pollUntilCompleted(id: String, apiKey: String) async throws {

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -1,9 +1,31 @@
 import Foundation
 import XCTest
 import TypeWhisperPluginSDK
+@_spi(Testing) import TypeWhisperPluginSDKTesting
 @testable import SonioxPlugin
 
 final class SonioxPluginTests: XCTestCase {
+    func testDefaultRealtimeModelUsesRTV5AndPersistsSelection() throws {
+        let host = try PluginTestHostServices()
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "stt-rt-v5")
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["stt-rt-v5"])
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "stt-rt-v5")
+    }
+
+    func testRetiredRealtimeModelMigratesToRTV5() throws {
+        let host = try PluginTestHostServices(defaults: ["selectedModel": "stt-rt-v4"])
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "stt-rt-v5")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "stt-rt-v5")
+    }
+
     func testCreateTranscriptionRequestUsesAsyncV5Model() throws {
         let request = try SonioxPlugin.makeCreateTranscriptionRequest(
             fileId: "file_123",


### PR DESCRIPTION
## Summary
- update Soniox realtime/WebSocket transcription to use `stt-rt-v5`
- remove retired/preview realtime model choices from the visible model list
- normalize stale stored Soniox realtime selections such as `stt-rt-v4` to `stt-rt-v5` on activation

## Context
This addresses the follow-up in PR #703 asking for Soniox realtime v5 support after `stt-rt-v5` was released. The async REST path already uses `stt-async-v5`; this updates the realtime/WebSocket model path.

## Test plan
- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests`