### PR TITLE
Route Soniox file transcription through async model

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Localizable.xcstrings
@@ -49,6 +49,22 @@
         }
       }
     },
+    "File transcription uses STT Async v5 automatically.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateitranskription verwendet automatisch STT Async v5."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル文字起こしではSTT Async v5が自動的に使用されます。"
+          }
+        }
+      }
+    },
     "Model": {
       "localizations": {
         "de": {
@@ -61,6 +77,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "モデル"
+          }
+        }
+      }
+    },
+    "Realtime model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echtzeitmodell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リアルタイムモデル"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -178,24 +178,6 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        try await transcribe(
-            audio: audio,
-            language: language,
-            translate: translate,
-            prompt: prompt,
-            onProgress: onProgress,
-            onSourceProgress: { _ in true }
-        )
-    }
-
-    func transcribe(
-        audio: AudioData,
-        language: String?,
-        translate: Bool,
-        prompt: String?,
-        onProgress: @Sendable @escaping (String) -> Bool,
-        onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
-    ) async throws -> PluginTranscriptionResult {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -208,7 +190,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
                 audio: audio, language: language, translate: translate,
                 modelId: modelId, prompt: prompt, apiKey: apiKey,
                 onProgress: onProgress,
-                onSourceProgress: onSourceProgress
+                onSourceProgress: { _ in true }
             )
         } catch {
             logger.warning("WebSocket streaming failed, falling back to REST: \(error.localizedDescription)")
@@ -224,19 +206,25 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
 
     func transcribe(
         audio: AudioData,
-        languageSelection: PluginLanguageSelection,
+        language: String?,
         translate: Bool,
         prompt: String?,
-        onProgress: @Sendable @escaping (String) -> Bool
+        onProgress: @Sendable @escaping (String) -> Bool,
+        onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        try await transcribe(
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let result = try await transcribeREST(
             audio: audio,
-            languageSelection: languageSelection,
+            language: language,
             translate: translate,
-            prompt: prompt,
-            onProgress: onProgress,
-            onSourceProgress: { _ in true }
+            apiKey: apiKey,
+            prompt: prompt
         )
+        Self.emitFinalProgress(result, onProgress: onProgress)
+        return result
     }
 
     func transcribe(
@@ -244,8 +232,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         languageSelection: PluginLanguageSelection,
         translate: Bool,
         prompt: String?,
-        onProgress: @Sendable @escaping (String) -> Bool,
-        onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
+        onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginTranscriptionError.notConfigured
@@ -269,7 +256,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
                 prompt: prompt,
                 apiKey: apiKey,
                 onProgress: onProgress,
-                onSourceProgress: onSourceProgress
+                onSourceProgress: { _ in true }
             )
         } catch {
             logger.warning("WebSocket streaming failed, falling back to REST: \(error.localizedDescription)")
@@ -282,6 +269,35 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
                 prompt: prompt
             )
         }
+    }
+
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool,
+        onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let effectiveHints = Self.resolvedLanguageHints(
+            requestedLanguage: languageSelection.requestedLanguage,
+            languageHints: languageSelection.languageHints
+        )
+
+        let result = try await transcribeREST(
+            audio: audio,
+            language: languageSelection.requestedLanguage,
+            languageHints: effectiveHints,
+            translate: translate,
+            apiKey: apiKey,
+            prompt: prompt
+        )
+        Self.emitFinalProgress(result, onProgress: onProgress)
+        return result
     }
 
     // MARK: - WebSocket Implementation
@@ -650,6 +666,13 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         return []
     }
 
+    private static func emitFinalProgress(
+        _ result: PluginTranscriptionResult,
+        onProgress: @Sendable (String) -> Bool
+    ) {
+        _ = onProgress(result.text)
+    }
+
     private static func resolvedRealtimeModelId(_ storedModelId: String?, host: HostServices?) -> String {
         let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let supportedIds = Set([Self.realtimeModelId])
@@ -887,10 +910,10 @@ private struct SonioxSettingsView: View {
 
                 // Model Selection
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Model", bundle: bundle)
+                    Text("Realtime model", bundle: bundle)
                         .font(.headline)
 
-                    Picker("Model", selection: $selectedModel) {
+                    Picker("Realtime model", selection: $selectedModel) {
                         ForEach(plugin.transcriptionModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
@@ -899,6 +922,10 @@ private struct SonioxSettingsView: View {
                     .onChange(of: selectedModel) {
                         plugin.selectModel(selectedModel)
                     }
+
+                    Text("File transcription uses STT Async v5 automatically.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
 

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -5,6 +5,11 @@ import TypeWhisperPluginSDK
 @testable import SonioxPlugin
 
 final class SonioxPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
     func testDefaultRealtimeModelUsesRTV5AndPersistsSelection() throws {
         let host = try PluginTestHostServices()
         let plugin = SonioxPlugin()
@@ -52,6 +57,72 @@ final class SonioxPluginTests: XCTestCase {
         XCTAssertEqual(translation["target_language"] as? String, "en")
     }
 
+    func testSourceProgressTranscriptionUsesAsyncV5RESTPathAndEmitsFinalProgress() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"text":"Async file transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript", statusCode: 200)
+                ),
+            ])
+        }
+
+        let progressRecorder = StringRecorder()
+        let sourceProgressRecorder = SourceProgressRecorder()
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            languageSelection: PluginLanguageSelection(languageHints: ["en", "de"]),
+            translate: false,
+            prompt: nil,
+            onProgress: { text in
+                progressRecorder.append(text)
+                return true
+            },
+            onSourceProgress: { progress in
+                sourceProgressRecorder.append(progress)
+                return true
+            }
+        )
+
+        XCTAssertEqual(result.text, "Async file transcript")
+        XCTAssertEqual(progressRecorder.values, ["Async file transcript"])
+        XCTAssertEqual(sourceProgressRecorder.count, 0)
+
+        let session = try XCTUnwrap(store.sessions.first)
+        XCTAssertEqual(
+            session.requestedPaths,
+            [
+                "/v1/files",
+                "/v1/transcriptions",
+                "/v1/transcriptions/transcription_123",
+                "/v1/transcriptions/transcription_123/transcript",
+            ]
+        )
+
+        let createRequest = try XCTUnwrap(session.requestedRequests.first { $0.url?.path == "/v1/transcriptions" })
+        let body = try Self.jsonBody(from: createRequest)
+        XCTAssertEqual(body["model"] as? String, "stt-async-v5")
+        XCTAssertEqual(body["language_hints"] as? [String], ["en", "de"])
+    }
+
     func testSourceProgressUsesFinalOriginalTokenTiming() {
         let progress = SonioxPlugin.sourceProgress(
             fromTokens: [
@@ -94,5 +165,44 @@ final class SonioxPluginTests: XCTestCase {
     private static func jsonBody(from request: URLRequest) throws -> [String: Any] {
         let data = try XCTUnwrap(request.httpBody)
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}
+
+private final class StringRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.withLock { storage }
+    }
+
+    func append(_ value: String) {
+        lock.withLock {
+            storage.append(value)
+        }
+    }
+}
+
+private final class SourceProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [PluginTranscriptionSourceProgress] = []
+
+    var count: Int {
+        lock.withLock { storage.count }
+    }
+
+    func append(_ value: PluginTranscriptionSourceProgress) {
+        lock.withLock {
+            storage.append(value)
+        }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.soniox",
     "name": "Soniox",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

Follow-up to PR #703 feedback from yvos: manually installed Soniox v5 plugin file uploads were still reaching the realtime/source-progress path, even though Soniox `stt-async-v5` is the cheaper and intended model for uploaded files.

Speaker diarization is tracked separately in #738 and is intentionally not bundled into this hotfix.

## Summary

- Route Soniox source-progress/file transcription calls through the REST async flow using `stt-async-v5`.
- Keep live/realtime progress transcription on WebSocket `stt-rt-v5`.
- Emit the final async transcript once via `onProgress(result.text)` without fake source-progress percentages.
- Rename the settings picker to "Realtime model" and note that file transcription uses STT Async v5 automatically.
- Bump the Soniox plugin manifest version to `1.1.1` for the hotfix release.

## Test Plan

- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German and Japanese language translations for multi-language support
  * Added informational caption clarifying that file transcription automatically uses STT Async v5

* **Improvements**
  * Updated settings UI with clearer labeling ("Realtime model" designation)
  * Enhanced progress callback and final progress reporting during transcription operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->