### PR TITLE
Wire Mistral plugin release

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -85,6 +85,7 @@ jobs:
             webhook) TARGET="WebhookPlugin" ;;
             groq) TARGET="GroqPlugin" ;;
             openai) TARGET="OpenAIPlugin" ;;
+            mistral) TARGET="MistralAIPlugin" ;;
             gemini) TARGET="GeminiPlugin" ;;
             whisperkit) TARGET="WhisperKitPlugin" ;;
             parakeet) TARGET="ParakeetPlugin" ;;

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -16,7 +16,7 @@
         "llm"
     ],
     "hosting": "cloud",
-    "iconURL": "https://upload.wikimedia.org/wikipedia/commons/e/e6/Mistral_AI_logo_%282025%E2%80%93%29.svg",
+    "iconURL": "https://www.typewhisper.com/brand-logos/mistral/logo.svg",
     "principalClass": "MistralAIPlugin",
     "requiresAPIKey": true,
     "detailsURL": "https://mistral.ai/"


### PR DESCRIPTION
## Summary

- Add the `mistral` slug to the plugin release workflow mapping.
- Point the Mistral plugin manifest icon to the TypeWhisper-hosted brand logo URL instead of Wikimedia.

## Test Plan

- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json >/dev/null`
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/plugin-release.yml"); puts "yaml ok"'`\n- `cd TypeWhisperPluginSDK && swift test --filter MistralAIPluginTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Mistral AI plugin icon with the new TypeWhisper brand logo for visual consistency.
  * Enhanced release workflow automation to properly recognize and build the Mistral plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->