### PR TITLE
Localize Mistral plugin settings

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -308,28 +308,29 @@ struct MistralSettingsView: View {
     @State private var validationResult: Bool?
     @State private var selectedSTTModel: String = ""
     @State private var selectedLLMModel: String = ""
+    private let bundle = Bundle(for: MistralAIPlugin.self)
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Mistral AI")
+            Text("Mistral AI", bundle: bundle)
                 .font(.headline)
-            Text("Cloud API integration for Mistral LLMs and Voxtral STT.")
+            Text("Cloud API integration for Mistral LLMs and Voxtral STT.", bundle: bundle)
                 .font(.callout)
                 .foregroundColor(.secondary)
             
             Divider()
             
             VStack(alignment: .leading, spacing: 8) {
-                Text("API Key")
+                Text("API Key", bundle: bundle)
                     .font(.subheadline)
                     .fontWeight(.medium)
                 
                 HStack {
                     if showApiKey {
-                        TextField("e.g. LFztgP5WA...", text: $apiKeyInput)
+                        TextField(String(localized: "e.g. LFztgP5WA...", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                     } else {
-                        SecureField("e.g. LFztgP5WA...", text: $apiKeyInput)
+                        SecureField(String(localized: "e.g. LFztgP5WA...", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                     }
                     
@@ -339,7 +340,7 @@ struct MistralSettingsView: View {
                     .buttonStyle(.borderless)
                     
                     if !plugin.apiKey.isEmpty {
-                        Button("Remove") {
+                        Button(String(localized: "Remove", bundle: bundle)) {
                             apiKeyInput = ""
                             validationResult = nil
                             isValidating = false
@@ -349,7 +350,7 @@ struct MistralSettingsView: View {
                         .controlSize(.small)
                     }
                     
-                    Button("Save") {
+                    Button(String(localized: "Save", bundle: bundle)) {
                         validateAndSave()
                     }
                     .buttonStyle(.borderedProminent)
@@ -360,7 +361,7 @@ struct MistralSettingsView: View {
                 if isValidating {
                     HStack(spacing: 4) {
                         ProgressView().controlSize(.small)
-                        Text("Validating...")
+                        Text("Validating...", bundle: bundle)
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -368,7 +369,7 @@ struct MistralSettingsView: View {
                     HStack(spacing: 4) {
                         Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
                             .foregroundColor(result ? .green : .red)
-                        Text(result ? "Valid API Key" : "Invalid API Key")
+                        Text(result ? String(localized: "Valid API Key", bundle: bundle) : String(localized: "Invalid API Key", bundle: bundle))
                             .font(.caption)
                             .foregroundColor(result ? .green : .red)
                     }
@@ -379,12 +380,12 @@ struct MistralSettingsView: View {
             
             VStack(alignment: .leading, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Transcription Model")
+                    Text("Transcription Model", bundle: bundle)
                         .font(.subheadline)
                         .fontWeight(.medium)
                     
                     Picker("", selection: $selectedSTTModel) {
-                        Text("Select a Model").tag("")
+                        Text("Select a Model", bundle: bundle).tag("")
                         ForEach(plugin.transcriptionModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
@@ -397,12 +398,12 @@ struct MistralSettingsView: View {
                 }
                 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("LLM Model")
+                    Text("LLM Model", bundle: bundle)
                         .font(.subheadline)
                         .fontWeight(.medium)
                     
                     Picker("", selection: $selectedLLMModel) {
-                        Text("Select a Model").tag("")
+                        Text("Select a Model", bundle: bundle).tag("")
                         ForEach(plugin.supportedModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.minerale.mistralai",
     "name": "Mistral AI",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary
- Use the Mistral plugin bundle for all visible settings strings so the existing German translations render in the plugin UI.
- Bump the Mistral plugin manifest to 1.0.1 for a translation patch release.

## Test Plan
- cd TypeWhisperPluginSDK && swift test --filter MistralAIPluginTests
- xcodebuild -project TypeWhisper.xcodeproj -target MistralAIPlugin -configuration Release SYMROOT=/tmp/typewhisper-mistral-localization-build CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.0.1
- python3 -m json.tool TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings >/dev/null
- python3 -m json.tool TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json >/dev/null
- plutil -p /tmp/typewhisper-mistral-localization-build/Release/MistralAIPlugin.bundle/Contents/Resources/de.lproj/Localizable.strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MistralAI plugin settings interface now supports multiple languages, with all user-facing text translated including headers, buttons, validation messages, and form field labels.

* **Chores**
  * Version bumped to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->