### PR TITLE
chore: update Mistral AI plugin details URL and version

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -19,5 +19,5 @@
     "iconURL": "https://www.typewhisper.com/brand-logos/mistral/logo.svg",
     "principalClass": "MistralAIPlugin",
     "requiresAPIKey": true,
-    "detailsURL": "https://mistral.ai/"
+    "detailsURL": "https://www.typewhisper.com/addons/mistral/"
 }


### PR DESCRIPTION
## Summary

Updates the `manifest.json` for the Mistral AI plugin:
- Updated the `detailsURL` to point to the new TypeWhisper documentation page (`https://www.typewhisper.com/addons/mistral/`) instead of the default Mistral AI website. This ensures that users are directed to the correct plugin documentation when clicking the details button.

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features
- [x] Verified `https://www.typewhisper.com/addons/mistral/` returns HTTP 200