### PR TITLE
Add Soniox region, TTS, and model catalog support

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Localizable.xcstrings
@@ -33,18 +33,66 @@
         }
       }
     },
-    "Invalid API Key": {
+    "Automatic (Latest)": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ungültiger API-Schlüssel"
+            "value": "Automatisch (neueste)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "無効なAPIキー"
+            "value": "自動（最新）"
+          }
+        }
+      }
+    },
+    "Check": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認"
+          }
+        }
+      }
+    },
+    "File transcription uses the latest async STT model automatically.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateitranskription verwendet automatisch das neueste Async-STT-Modell."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル文字起こしでは最新のAsync STTモデルが自動的に使用されます。"
+          }
+        }
+      }
+    },
+    "European Union": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Europäische Union"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "欧州連合"
           }
         }
       }
@@ -61,6 +109,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "ファイル文字起こしではSTT Async v5が自動的に使用されます。"
+          }
+        }
+      }
+    },
+    "Invalid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なAPIキー"
+          }
+        }
+      }
+    },
+    "Japan": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japan"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本"
           }
         }
       }
@@ -97,6 +177,70 @@
         }
       }
     },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Refreshing models...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle werden aktualisiert..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを更新中..."
+          }
+        }
+      }
+    },
+    "Region": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Region"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リージョン"
+          }
+        }
+      }
+    },
+    "Region: %@; Voice: %@; Soniox": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Region: %@; Stimme: %@; Soniox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リージョン: %@; 音声: %@; Soniox"
+          }
+        }
+      }
+    },
     "Remove": {
       "localizations": {
         "de": {
@@ -125,6 +269,54 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存"
+          }
+        }
+      }
+    },
+    "Text-to-Speech Voice": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text-to-Speech-Stimme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text-to-Speech音声"
+          }
+        }
+      }
+    },
+    "Text-to-Speech Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text-to-Speech-Modell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text-to-Speechモデル"
+          }
+        }
+      }
+    },
+    "United States": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vereinigte Staaten"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "米国"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -1,7 +1,39 @@
+import AVFoundation
 import Foundation
 import SwiftUI
 import os
 import TypeWhisperPluginSDK
+
+private enum SonioxDefaultsKey {
+    static let apiKey = "api-key"
+    static let selectedModel = "selectedModel"
+    static let selectedRegion = "selectedRegion"
+    static let selectedVoice = "selectedVoice"
+    static let selectedTTSModel = "selectedTTSModel"
+    static let fetchedModels = "fetchedModels"
+    static let fetchedTTSModels = "fetchedTTSModels"
+}
+
+private enum SonioxModelSelection {
+    static let automatic = "automatic"
+}
+
+private enum SonioxPluginError: LocalizedError {
+    case invalidURL(String)
+    case apiError(String)
+    case playbackUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL(let url):
+            "Invalid URL: \(url)"
+        case .apiError(let message):
+            "API error: \(message)"
+        case .playbackUnavailable(let message):
+            "Playback unavailable: \(message)"
+        }
+    }
+}
 
 // MARK: - Supported Languages
 
@@ -14,6 +46,269 @@ private let sonioxSupportedLanguages = [
     "pl", "pt", "ro", "ru", "sk", "sl", "so", "sq", "sr", "sv",
     "sw", "ta", "te", "th", "tr", "uk", "ur", "uz", "vi", "zh",
 ]
+
+private let sonioxTTSSupportedLanguages = [
+    "af", "ar", "az", "be", "bg", "bn", "bs", "ca", "cs", "cy",
+    "da", "de", "el", "en", "es", "et", "eu", "fa", "fi", "fr",
+    "gl", "gu", "he", "hi", "hr", "hu", "id", "is", "it", "ja",
+    "kk", "kn", "ko", "lt", "lv", "mk", "ml", "mr", "ms", "nl",
+    "no", "pa", "pl", "pt", "ro", "ru", "sk", "sl", "sq", "sr",
+    "su", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "ur",
+    "vi", "zh",
+]
+
+struct SonioxRegion: Sendable, Hashable, Identifiable {
+    let id: String
+    let displayNameKey: String
+    let apiHost: String
+    let sttRealtimeHost: String
+    let ttsHost: String
+
+    static let unitedStates = SonioxRegion(
+        id: "us",
+        displayNameKey: "United States",
+        apiHost: "api.soniox.com",
+        sttRealtimeHost: "stt-rt.soniox.com",
+        ttsHost: "tts-rt.soniox.com"
+    )
+    static let europeanUnion = SonioxRegion(
+        id: "eu",
+        displayNameKey: "European Union",
+        apiHost: "api.eu.soniox.com",
+        sttRealtimeHost: "stt-rt.eu.soniox.com",
+        ttsHost: "tts-rt.eu.soniox.com"
+    )
+    static let japan = SonioxRegion(
+        id: "jp",
+        displayNameKey: "Japan",
+        apiHost: "api.jp.soniox.com",
+        sttRealtimeHost: "stt-rt.jp.soniox.com",
+        ttsHost: "tts-rt.jp.soniox.com"
+    )
+
+    static let all = [unitedStates, europeanUnion, japan]
+
+    static func resolved(_ storedRegionId: String?, host: HostServices?) -> SonioxRegion {
+        let trimmed = storedRegionId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let region = trimmed.flatMap { id in all.first { $0.id == id } } ?? .unitedStates
+        if region.id != storedRegionId {
+            host?.setUserDefault(region.id, forKey: SonioxDefaultsKey.selectedRegion)
+        }
+        return region
+    }
+
+    var apiBaseURL: String {
+        "https://\(apiHost)"
+    }
+
+    var sttRealtimeWebSocketURL: String {
+        "wss://\(sttRealtimeHost)/transcribe-websocket"
+    }
+
+    var ttsURL: String {
+        "https://\(ttsHost)/tts"
+    }
+}
+
+struct SonioxFetchedLanguage: Codable, Equatable, Sendable {
+    let code: String
+    let name: String?
+}
+
+struct SonioxFetchedVoice: Codable, Equatable, Sendable {
+    let id: String
+    let description: String?
+    let gender: String?
+}
+
+struct SonioxFetchedModel: Codable, Equatable, Sendable {
+    let id: String
+    let aliasedModelId: String?
+    let name: String?
+    let transcriptionMode: String?
+    let languages: [SonioxFetchedLanguage]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case aliasedModelId = "aliased_model_id"
+        case name
+        case transcriptionMode = "transcription_mode"
+        case languages
+    }
+}
+
+struct SonioxFetchedTTSModel: Codable, Equatable, Sendable {
+    let id: String
+    let aliasedModelId: String?
+    let name: String?
+    let languages: [SonioxFetchedLanguage]
+    let voices: [SonioxFetchedVoice]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case aliasedModelId = "aliased_model_id"
+        case name
+        case languages
+        case voices
+    }
+}
+
+protocol SonioxTTSAudioPlayback: AnyObject, Sendable {
+    var onDrained: (@Sendable () -> Void)? { get set }
+    func start(sampleRate: Int) throws
+    func appendPCM16(_ data: Data) throws
+    func finishInput()
+    func stop()
+}
+
+final class SonioxTTSPlaybackSession: TTSPlaybackSession, @unchecked Sendable {
+    private struct State {
+        var isActive = true
+        var onFinish: (@Sendable () -> Void)?
+    }
+
+    private let audioPlayback: SonioxTTSAudioPlayback
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(audioPlayback: SonioxTTSAudioPlayback) {
+        self.audioPlayback = audioPlayback
+        audioPlayback.onDrained = { [weak self] in
+            self?.finish()
+        }
+    }
+
+    var isActive: Bool {
+        state.withLock { $0.isActive }
+    }
+
+    var onFinish: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onFinish } }
+        set {
+            let shouldNotify = state.withLock { state in
+                state.onFinish = newValue
+                return !state.isActive
+            }
+            if shouldNotify {
+                newValue?()
+            }
+        }
+    }
+
+    func stop() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        audioPlayback.stop()
+        callback?()
+    }
+
+    func finish() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            guard state.isActive else { return nil }
+            state.isActive = false
+            return state.onFinish
+        }
+        callback?()
+    }
+}
+
+private final class SonioxAVAudioPlayback: SonioxTTSAudioPlayback, @unchecked Sendable {
+    private struct State {
+        var onDrained: (@Sendable () -> Void)?
+        var pendingBuffers = 0
+        var inputFinished = false
+        var stopped = false
+    }
+
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private var format: AVAudioFormat?
+
+    var onDrained: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onDrained } }
+        set { state.withLock { $0.onDrained = newValue } }
+    }
+
+    func start(sampleRate: Int) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw SonioxPluginError.playbackUnavailable("Could not create audio format")
+        }
+        self.format = format
+
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+        try engine.start()
+        player.play()
+    }
+
+    func appendPCM16(_ data: Data) throws {
+        guard !state.withLock({ $0.stopped }) else { return }
+        guard let format else {
+            throw SonioxPluginError.playbackUnavailable("Audio playback was not started")
+        }
+        guard data.count.isMultiple(of: MemoryLayout<Int16>.size) else {
+            throw SonioxPluginError.playbackUnavailable("PCM16 audio data must contain whole samples.")
+        }
+
+        let frameCount = data.count / MemoryLayout<Int16>.size
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(frameCount)
+              ),
+              let channel = buffer.floatChannelData?[0] else {
+            return
+        }
+
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        data.withUnsafeBytes { rawBuffer in
+            let int16Buffer = rawBuffer.bindMemory(to: Int16.self)
+            for index in 0..<frameCount {
+                channel[index] = Float(Int16(littleEndian: int16Buffer[index])) / Float(Int16.max)
+            }
+        }
+
+        state.withLock { $0.pendingBuffers += 1 }
+        player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [weak self] _ in
+            self?.markBufferPlayed()
+        }
+        if !player.isPlaying {
+            player.play()
+        }
+    }
+
+    func finishInput() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            state.inputFinished = true
+            return state.pendingBuffers == 0 && !state.stopped ? state.onDrained : nil
+        }
+        callback?()
+    }
+
+    func stop() {
+        state.withLock { $0.stopped = true }
+        player.stop()
+        engine.stop()
+        engine.detach(player)
+    }
+
+    private func markBufferPlayed() {
+        let callback = state.withLock { state -> (@Sendable () -> Void)? in
+            state.pendingBuffers = max(0, state.pendingBuffers - 1)
+            guard state.inputFinished, state.pendingBuffers == 0, !state.stopped else { return nil }
+            return state.onDrained
+        }
+        callback?()
+    }
+}
 
 // MARK: - Transcript Collector
 
@@ -67,16 +362,59 @@ private actor TranscriptCollector {
 // MARK: - Plugin Entry Point
 
 @objc(SonioxPlugin)
-final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
+final class SonioxPlugin: NSObject,
+    SourceProgressLanguageHintTranscriptionEnginePlugin,
+    DictionaryTermsCapabilityProviding,
+    DictionaryTermsBudgetProviding,
+    TTSProviderPlugin,
+    PluginAuthRoleStatusProviding,
+    @unchecked Sendable {
     static let pluginId = "com.typewhisper.soniox"
     static let pluginName = "Soniox"
-    static let asyncModelId = "stt-async-v5"
-    static let realtimeModelId = "stt-rt-v5"
-    private static let selectedModelKey = "selectedModel"
+    static let defaultAsyncModelId = "stt-async-v5"
+    static let defaultRealtimeModelId = "stt-rt-v5"
+    static let defaultTTSModelId = "tts-rt-v1"
+    static let ttsSampleRate = 24_000
+    static let defaultVoiceId = "Maya"
+    static let fallbackVoices: [PluginVoiceInfo] = [
+        PluginVoiceInfo(id: "Maya", displayName: "Maya"),
+        PluginVoiceInfo(id: "Daniel", displayName: "Daniel"),
+        PluginVoiceInfo(id: "Noah", displayName: "Noah"),
+        PluginVoiceInfo(id: "Nina", displayName: "Nina"),
+        PluginVoiceInfo(id: "Emma", displayName: "Emma"),
+        PluginVoiceInfo(id: "Jack", displayName: "Jack"),
+        PluginVoiceInfo(id: "Adrian", displayName: "Adrian"),
+        PluginVoiceInfo(id: "Claire", displayName: "Claire"),
+        PluginVoiceInfo(id: "Grace", displayName: "Grace"),
+        PluginVoiceInfo(id: "Owen", displayName: "Owen"),
+        PluginVoiceInfo(id: "Mina", displayName: "Mina"),
+        PluginVoiceInfo(id: "Kenji", displayName: "Kenji"),
+        PluginVoiceInfo(id: "Rafael", displayName: "Rafael"),
+        PluginVoiceInfo(id: "Mateo", displayName: "Mateo"),
+        PluginVoiceInfo(id: "Lucia", displayName: "Lucia"),
+        PluginVoiceInfo(id: "Sofia", displayName: "Sofia"),
+        PluginVoiceInfo(id: "Oliver", displayName: "Oliver"),
+        PluginVoiceInfo(id: "Arthur", displayName: "Arthur"),
+        PluginVoiceInfo(id: "Isla", displayName: "Isla"),
+        PluginVoiceInfo(id: "Victoria", displayName: "Victoria"),
+        PluginVoiceInfo(id: "Cooper", displayName: "Cooper"),
+        PluginVoiceInfo(id: "Mason", displayName: "Mason"),
+        PluginVoiceInfo(id: "Ruby", displayName: "Ruby"),
+        PluginVoiceInfo(id: "Elise", displayName: "Elise"),
+        PluginVoiceInfo(id: "Arjun", displayName: "Arjun"),
+        PluginVoiceInfo(id: "Rohan", displayName: "Rohan"),
+        PluginVoiceInfo(id: "Priya", displayName: "Priya"),
+        PluginVoiceInfo(id: "Meera", displayName: "Meera"),
+    ]
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedModelId: String?
+    fileprivate var _selectedRegion = SonioxRegion.unitedStates
+    fileprivate var _selectedTTSModelId: String?
+    fileprivate var _selectedVoiceId: String?
+    fileprivate var _fetchedModels: [SonioxFetchedModel] = []
+    fileprivate var _fetchedTTSModels: [SonioxFetchedTTSModel] = []
 
     private let logger = Logger(subsystem: "com.typewhisper.soniox", category: "Plugin")
 
@@ -86,11 +424,29 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
 
     func activate(host: HostServices) {
         self.host = host
-        _apiKey = host.loadSecret(key: "api-key")
+        _apiKey = host.loadSecret(key: SonioxDefaultsKey.apiKey)
         _selectedModelId = Self.resolvedRealtimeModelId(
-            host.userDefault(forKey: Self.selectedModelKey) as? String,
+            host.userDefault(forKey: SonioxDefaultsKey.selectedModel) as? String,
             host: host
         )
+        _selectedRegion = SonioxRegion.resolved(
+            host.userDefault(forKey: SonioxDefaultsKey.selectedRegion) as? String,
+            host: host
+        )
+        _selectedTTSModelId = Self.resolvedTTSModelId(
+            host.userDefault(forKey: SonioxDefaultsKey.selectedTTSModel) as? String,
+            host: host
+        )
+        _selectedVoiceId = Self.resolvedVoiceId(
+            host.userDefault(forKey: SonioxDefaultsKey.selectedVoice) as? String,
+            host: host
+        )
+        if let data = host.userDefault(forKey: SonioxDefaultsKey.fetchedModels) as? Data {
+            _fetchedModels = (try? JSONDecoder().decode([SonioxFetchedModel].self, from: data)) ?? []
+        }
+        if let data = host.userDefault(forKey: SonioxDefaultsKey.fetchedTTSModels) as? Data {
+            _fetchedTTSModels = (try? JSONDecoder().decode([SonioxFetchedTTSModel].self, from: data)) ?? []
+        }
     }
 
     func deactivate() {
@@ -103,22 +459,26 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
     var providerDisplayName: String { "Soniox" }
 
     var isConfigured: Bool {
-        guard let key = _apiKey else { return false }
+        guard let key = normalizedAPIKey else { return false }
         return !key.isEmpty
     }
 
     var transcriptionModels: [PluginModelInfo] {
-        [
-            PluginModelInfo(id: Self.realtimeModelId, displayName: "STT RT v5"),
-        ]
+        let models = Self.realtimeModels(from: _fetchedModels)
+        guard !models.isEmpty else {
+            return [PluginModelInfo(id: Self.defaultRealtimeModelId, displayName: "STT RT v5")]
+        }
+        return models.map { model in
+            PluginModelInfo(id: model.id, displayName: model.name ?? model.id)
+        }
     }
 
-    var selectedModelId: String? { _selectedModelId }
+    var selectedModelId: String? { effectiveRealtimeModelId }
 
     func selectModel(_ modelId: String) {
         let resolvedModelId = Self.resolvedRealtimeModelId(modelId, host: host)
         _selectedModelId = resolvedModelId
-        host?.setUserDefault(resolvedModelId, forKey: Self.selectedModelKey)
+        host?.setUserDefault(resolvedModelId, forKey: SonioxDefaultsKey.selectedModel)
     }
 
     var supportsTranslation: Bool { true }
@@ -128,10 +488,134 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
 
     var supportedLanguages: [String] { sonioxSupportedLanguages }
 
+    private var normalizedAPIKey: String? {
+        guard let apiKey = _apiKey?.trimmingCharacters(in: .whitespacesAndNewlines), !apiKey.isEmpty else {
+            return nil
+        }
+        return apiKey
+    }
+
+    // MARK: - PluginAuthRoleStatusProviding
+
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        switch role {
+        case .transcription, .tts:
+            return PluginAuthRoleStatus.legacyFallback(
+                isConfigured: isConfigured,
+                unavailableReason: "Soniox API key is required.",
+                requiredCredentialLabel: "Soniox API key"
+            )
+        case .llm:
+            return .unavailable(reason: "Soniox does not provide LLM capabilities.")
+        }
+    }
+
+    // MARK: - TTSProviderPlugin
+
+    var availableVoices: [PluginVoiceInfo] {
+        if let model = _fetchedTTSModels.first(where: { $0.id == effectiveTTSModelId }),
+           !model.voices.isEmpty {
+            return model.voices.map { PluginVoiceInfo(id: $0.id, displayName: $0.id) }
+        }
+        return Self.fallbackVoices
+    }
+
+    var ttsModels: [PluginModelInfo] {
+        guard !_fetchedTTSModels.isEmpty else {
+            return [PluginModelInfo(id: Self.defaultTTSModelId, displayName: "TTS v1")]
+        }
+        return _fetchedTTSModels.map { model in
+            PluginModelInfo(id: model.id, displayName: model.name ?? model.id)
+        }
+    }
+
+    private var effectiveRealtimeModelId: String {
+        guard _selectedModelId == SonioxModelSelection.automatic else {
+            return _selectedModelId ?? Self.defaultRealtimeModelId
+        }
+        return Self.preferredSTTModelId(
+            from: _fetchedModels,
+            transcriptionMode: "real_time",
+            fallback: Self.defaultRealtimeModelId
+        )
+    }
+
+    private var effectiveAsyncModelId: String {
+        Self.preferredSTTModelId(
+            from: _fetchedModels,
+            transcriptionMode: "async",
+            fallback: Self.defaultAsyncModelId
+        )
+    }
+
+    private var effectiveTTSModelId: String {
+        guard _selectedTTSModelId == SonioxModelSelection.automatic else {
+            return _selectedTTSModelId ?? Self.defaultTTSModelId
+        }
+        return Self.preferredTTSModelId(from: _fetchedTTSModels, fallback: Self.defaultTTSModelId)
+    }
+
+    var selectedVoiceId: String? {
+        let voices = availableVoices
+        if let selected = _selectedVoiceId, voices.contains(where: { $0.id == selected }) {
+            return selected
+        }
+        if voices.contains(where: { $0.id == Self.defaultVoiceId }) {
+            return Self.defaultVoiceId
+        }
+        return voices.first?.id ?? Self.defaultVoiceId
+    }
+
+    var settingsSummary: String? {
+        let region = String(localized: String.LocalizationValue(_selectedRegion.displayNameKey), bundle: Bundle(for: SonioxPlugin.self))
+        let voice = availableVoices.first { $0.id == selectedVoiceId }?.displayName ?? selectedVoiceId ?? Self.defaultVoiceId
+        let format = String(localized: "Region: %@; Voice: %@; Soniox", bundle: Bundle(for: SonioxPlugin.self))
+        return String(format: format, region, voice)
+    }
+
+    func selectVoice(_ voiceId: String?) {
+        _selectedVoiceId = Self.resolvedVoiceId(voiceId, host: host)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        guard let apiKey = normalizedAPIKey else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        let text = request.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw SonioxPluginError.apiError("TTS text is empty.")
+        }
+
+        let urlRequest = try Self.makeTTSRequest(
+            apiKey: apiKey,
+            text: text,
+            voiceId: selectedVoiceId ?? Self.defaultVoiceId,
+            language: Self.resolvedTTSLanguage(request.language),
+            modelID: effectiveTTSModelId,
+            regionID: _selectedRegion.id
+        )
+
+        let (data, response) = try await PluginHTTPClient.data(for: urlRequest)
+        try Self.validateHTTPResponse(data: data, response: response)
+
+        let playback = SonioxAVAudioPlayback()
+        do {
+            try playback.start(sampleRate: Self.ttsSampleRate)
+            let session = SonioxTTSPlaybackSession(audioPlayback: playback)
+            try playback.appendPCM16(data)
+            playback.finishInput()
+            return session
+        } catch {
+            playback.stop()
+            throw error
+        }
+    }
+
     // MARK: - Transcription (REST Fallback)
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
@@ -150,7 +634,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
@@ -178,7 +662,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
         guard let modelId = _selectedModelId else {
@@ -212,7 +696,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         onProgress: @Sendable @escaping (String) -> Bool,
         onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
@@ -234,7 +718,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
         guard let modelId = _selectedModelId else {
@@ -279,7 +763,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         onProgress: @Sendable @escaping (String) -> Bool,
         onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
 
@@ -313,7 +797,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         onProgress: @Sendable @escaping (String) -> Bool,
         onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        guard let url = URL(string: "wss://stt-rt.soniox.com/transcribe-websocket") else {
+        guard let url = URL(string: _selectedRegion.sttRealtimeWebSocketURL) else {
             throw PluginTranscriptionError.apiError("Invalid Soniox WebSocket URL")
         }
 
@@ -526,7 +1010,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
     }
 
     private func uploadFile(wavData: Data, apiKey: String) async throws -> String {
-        guard let url = URL(string: "https://api.soniox.com/v1/files") else {
+        guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/files") else {
             throw PluginTranscriptionError.apiError("Invalid upload URL")
         }
 
@@ -583,7 +1067,9 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
             languageHints: languageHints,
             translate: translate,
             apiKey: apiKey,
-            prompt: prompt
+            prompt: prompt,
+            modelID: effectiveAsyncModelId,
+            regionID: _selectedRegion.id
         )
 
         let (data, response) = try await PluginHTTPClient.data(for: request)
@@ -615,15 +1101,18 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         languageHints: [String] = [],
         translate: Bool,
         apiKey: String,
-        prompt: String?
+        prompt: String?,
+        modelID: String = SonioxPlugin.defaultAsyncModelId,
+        regionID: String? = nil
     ) throws -> URLRequest {
-        guard let url = URL(string: "https://api.soniox.com/v1/transcriptions") else {
+        let region = SonioxRegion.resolved(regionID, host: nil)
+        guard let url = URL(string: "\(region.apiBaseURL)/v1/transcriptions") else {
             throw PluginTranscriptionError.apiError("Invalid transcriptions URL")
         }
 
         var body: [String: Any] = [
             "file_id": fileId,
-            "model": Self.asyncModelId,
+            "model": modelID,
         ]
 
         let effectiveHints = Self.resolvedLanguageHints(requestedLanguage: language, languageHints: languageHints)
@@ -648,6 +1137,155 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         request.timeoutInterval = 30
         return request
+    }
+
+    static func makeTTSRequest(
+        apiKey: String,
+        text: String,
+        voiceId: String,
+        language: String?,
+        modelID: String = SonioxPlugin.defaultTTSModelId,
+        regionID: String? = nil
+    ) throws -> URLRequest {
+        let region = SonioxRegion.resolved(regionID, host: nil)
+        guard let url = URL(string: region.ttsURL) else {
+            throw SonioxPluginError.invalidURL(region.ttsURL)
+        }
+
+        let body: [String: Any] = [
+            "model": modelID,
+            "language": Self.resolvedTTSLanguage(language),
+            "voice": voiceId,
+            "audio_format": "pcm_s16le",
+            "text": text,
+            "sample_rate": Self.ttsSampleRate,
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func validateHTTPResponse(data: Data, response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200, 201:
+            return
+        case 401, 403:
+            throw PluginTranscriptionError.invalidApiKey
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        default:
+            throw PluginTranscriptionError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+        }
+    }
+
+    // MARK: - Model Catalog
+
+    fileprivate func refreshModels(apiKey: String? = nil) async -> Bool {
+        guard let key = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? normalizedAPIKey else {
+            return false
+        }
+
+        let fetchedSTTModels = await fetchSTTModels(apiKey: key)
+        let fetchedTTSModels = await fetchTTSModels(apiKey: key)
+
+        var didFetch = false
+        if !fetchedSTTModels.isEmpty {
+            setFetchedModels(fetchedSTTModels)
+            didFetch = true
+        }
+        if !fetchedTTSModels.isEmpty {
+            setFetchedTTSModels(fetchedTTSModels)
+            didFetch = true
+        }
+        return didFetch
+    }
+
+    fileprivate func fetchSTTModels(apiKey: String) async -> [SonioxFetchedModel] {
+        do {
+            let request = try Self.makeSTTModelsRequest(apiKey: apiKey, regionID: _selectedRegion.id)
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+            return try Self.parseSTTModelsResponse(data)
+        } catch {
+            return []
+        }
+    }
+
+    fileprivate func fetchTTSModels(apiKey: String) async -> [SonioxFetchedTTSModel] {
+        do {
+            let request = try Self.makeTTSModelsRequest(apiKey: apiKey, regionID: _selectedRegion.id)
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+            return try Self.parseTTSModelsResponse(data)
+        } catch {
+            return []
+        }
+    }
+
+    fileprivate func setFetchedModels(_ models: [SonioxFetchedModel]) {
+        _fetchedModels = Self.sortedModels(models)
+        if let data = try? JSONEncoder().encode(_fetchedModels) {
+            host?.setUserDefault(data, forKey: SonioxDefaultsKey.fetchedModels)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func setFetchedTTSModels(_ models: [SonioxFetchedTTSModel]) {
+        _fetchedTTSModels = models.sorted { Self.compareModelIDs($0.id, $1.id) }
+        if let data = try? JSONEncoder().encode(_fetchedTTSModels) {
+            host?.setUserDefault(data, forKey: SonioxDefaultsKey.fetchedTTSModels)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    static func makeSTTModelsRequest(apiKey: String, regionID: String? = nil) throws -> URLRequest {
+        let region = SonioxRegion.resolved(regionID, host: nil)
+        guard let url = URL(string: "\(region.apiBaseURL)/v1/models") else {
+            throw SonioxPluginError.invalidURL("\(region.apiBaseURL)/v1/models")
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        return request
+    }
+
+    static func makeTTSModelsRequest(apiKey: String, regionID: String? = nil) throws -> URLRequest {
+        let region = SonioxRegion.resolved(regionID, host: nil)
+        guard let url = URL(string: "\(region.apiBaseURL)/v1/tts-models") else {
+            throw SonioxPluginError.invalidURL("\(region.apiBaseURL)/v1/tts-models")
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        return request
+    }
+
+    static func parseSTTModelsResponse(_ data: Data) throws -> [SonioxFetchedModel] {
+        struct ModelsResponse: Decodable {
+            let models: [SonioxFetchedModel]
+        }
+        return sortedModels(try JSONDecoder().decode(ModelsResponse.self, from: data).models)
+    }
+
+    static func parseTTSModelsResponse(_ data: Data) throws -> [SonioxFetchedTTSModel] {
+        struct ModelsResponse: Decodable {
+            let models: [SonioxFetchedTTSModel]
+        }
+        return try JSONDecoder().decode(ModelsResponse.self, from: data).models
+            .sorted { compareModelIDs($0.id, $1.id) }
     }
 
     private static func contextPayload(prompt: String?) -> [String: Any]? {
@@ -675,19 +1313,129 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
 
     private static func resolvedRealtimeModelId(_ storedModelId: String?, host: HostServices?) -> String {
         let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let supportedIds = Set([Self.realtimeModelId])
-        let modelId = trimmedModelId.flatMap { supportedIds.contains($0) ? $0 : nil }
-            ?? Self.realtimeModelId
+        let modelId: String
+        switch trimmedModelId {
+        case nil, "", "stt-rt-v3", "stt-rt-v4", Self.defaultRealtimeModelId:
+            modelId = SonioxModelSelection.automatic
+        case let value?:
+            modelId = value
+        }
 
         if modelId != storedModelId {
-            host?.setUserDefault(modelId, forKey: Self.selectedModelKey)
+            host?.setUserDefault(modelId, forKey: SonioxDefaultsKey.selectedModel)
         }
 
         return modelId
     }
 
+    private static func resolvedTTSModelId(_ storedModelId: String?, host: HostServices?) -> String {
+        let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelId: String
+        switch trimmedModelId {
+        case nil, "", Self.defaultTTSModelId:
+            modelId = SonioxModelSelection.automatic
+        case let value?:
+            modelId = value
+        }
+
+        if modelId != storedModelId {
+            host?.setUserDefault(modelId, forKey: SonioxDefaultsKey.selectedTTSModel)
+        }
+
+        return modelId
+    }
+
+    private static func resolvedVoiceId(_ storedVoiceId: String?, host: HostServices?) -> String {
+        let trimmedVoiceId = storedVoiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let supportedIds = Set(fallbackVoices.map(\.id))
+        let voiceId = trimmedVoiceId.flatMap { supportedIds.contains($0) ? $0 : nil }
+            ?? Self.defaultVoiceId
+
+        if voiceId != storedVoiceId {
+            host?.setUserDefault(voiceId, forKey: SonioxDefaultsKey.selectedVoice)
+        }
+
+        return voiceId
+    }
+
+    private static func realtimeModels(from models: [SonioxFetchedModel]) -> [SonioxFetchedModel] {
+        sortedModels(models.filter { $0.transcriptionMode == "real_time" })
+    }
+
+    private static func asyncModels(from models: [SonioxFetchedModel]) -> [SonioxFetchedModel] {
+        sortedModels(models.filter { $0.transcriptionMode == "async" })
+    }
+
+    private static func preferredSTTModelId(
+        from models: [SonioxFetchedModel],
+        transcriptionMode: String,
+        fallback: String
+    ) -> String {
+        let scoped = transcriptionMode == "async" ? asyncModels(from: models) : realtimeModels(from: models)
+        return preferredModelId(
+            from: scoped.map { (id: $0.id, aliasedModelId: $0.aliasedModelId) },
+            fallback: fallback
+        )
+    }
+
+    private static func preferredTTSModelId(from models: [SonioxFetchedTTSModel], fallback: String) -> String {
+        preferredModelId(
+            from: models.map { (id: $0.id, aliasedModelId: $0.aliasedModelId) },
+            fallback: fallback
+        )
+    }
+
+    private static func preferredModelId(
+        from models: [(id: String, aliasedModelId: String?)],
+        fallback: String
+    ) -> String {
+        let aliases = models.filter { $0.aliasedModelId != nil }
+        if let preferredAlias = aliases.first(where: { model in
+            let lowercased = model.id.lowercased()
+            return lowercased.contains("latest") || lowercased.contains("default") || lowercased.contains("recommended")
+        }) {
+            return preferredAlias.id
+        }
+        return models.max { lhs, rhs in
+            compareModelIDs(lhs.id, rhs.id)
+        }?.id ?? fallback
+    }
+
+    private static func sortedModels(_ models: [SonioxFetchedModel]) -> [SonioxFetchedModel] {
+        models.sorted { lhs, rhs in
+            compareModelIDs(lhs.id, rhs.id)
+        }
+    }
+
+    private static func compareModelIDs(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsNumbers = versionNumbers(in: lhs)
+        let rhsNumbers = versionNumbers(in: rhs)
+        if lhsNumbers != rhsNumbers {
+            return lhsNumbers.lexicographicallyPrecedes(rhsNumbers)
+        }
+        return lhs.localizedStandardCompare(rhs) == .orderedAscending
+    }
+
+    private static func versionNumbers(in id: String) -> [Int] {
+        id.split(whereSeparator: { !$0.isNumber })
+            .compactMap { Int($0) }
+    }
+
+    private static func resolvedTTSLanguage(_ language: String?) -> String {
+        let supported = Set(sonioxTTSSupportedLanguages)
+        let trimmed = language?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmed, supported.contains(trimmed) {
+            return trimmed
+        }
+        if let prefix = trimmed?.split(separator: "-").first.map(String.init),
+           supported.contains(prefix) {
+            return prefix
+        }
+        return "en"
+    }
+
     private func pollUntilCompleted(id: String, apiKey: String) async throws {
-        guard let url = URL(string: "https://api.soniox.com/v1/transcriptions/\(id)") else {
+        guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/transcriptions/\(id)") else {
             throw PluginTranscriptionError.apiError("Invalid poll URL")
         }
 
@@ -737,7 +1485,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
     }
 
     private func fetchTranscript(id: String, apiKey: String, language: String?) async throws -> PluginTranscriptionResult {
-        guard let url = URL(string: "https://api.soniox.com/v1/transcriptions/\(id)/transcript") else {
+        guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/transcriptions/\(id)/transcript") else {
             throw PluginTranscriptionError.apiError("Invalid transcript URL")
         }
 
@@ -785,11 +1533,13 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
 
     // MARK: - API Key Validation
 
-    fileprivate func validateApiKey(_ key: String) async -> Bool {
-        guard let url = URL(string: "https://api.soniox.com/v1/files") else { return false }
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 10
+    func validateApiKey(_ key: String) async -> Bool {
+        let request: URLRequest
+        do {
+            request = try Self.makeAPIKeyValidationRequest(apiKey: key, regionID: _selectedRegion.id)
+        } catch {
+            return false
+        }
 
         do {
             let (_, response) = try await PluginHTTPClient.data(for: request)
@@ -798,6 +1548,36 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         } catch {
             return false
         }
+    }
+
+    static func makeAPIKeyValidationRequest(apiKey: String, regionID: String? = nil) throws -> URLRequest {
+        let region = SonioxRegion.resolved(regionID, host: nil)
+        guard let url = URL(string: "\(region.apiBaseURL)/v1/files") else {
+            throw SonioxPluginError.invalidURL("\(region.apiBaseURL)/v1/files")
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        return request
+    }
+
+    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let message = json["error_message"] as? String {
+                return message
+            }
+            if let message = json["message"] as? String {
+                return message
+            }
+            if let error = json["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                return message
+            }
+        }
+        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
+            return "HTTP \(statusCode): \(body)"
+        }
+        return "HTTP \(statusCode)"
     }
 
     // MARK: - Settings View
@@ -812,7 +1592,7 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         _apiKey = key
         if let host {
             do {
-                try host.storeSecret(key: "api-key", value: key)
+                try host.storeSecret(key: SonioxDefaultsKey.apiKey, value: key)
             } catch {
                 print("[SonioxPlugin] Failed to store API key: \(error)")
             }
@@ -824,12 +1604,28 @@ final class SonioxPlugin: NSObject, SourceProgressLanguageHintTranscriptionEngin
         _apiKey = nil
         if let host {
             do {
-                try host.storeSecret(key: "api-key", value: "")
+                try host.storeSecret(key: SonioxDefaultsKey.apiKey, value: "")
             } catch {
                 print("[SonioxPlugin] Failed to delete API key: \(error)")
             }
             host.notifyCapabilitiesChanged()
         }
+    }
+
+    fileprivate var selectedRegionIdForSettings: String { _selectedRegion.id }
+    fileprivate var selectedModelIdForSettings: String { _selectedModelId ?? SonioxModelSelection.automatic }
+    fileprivate var selectedTTSModelIdForSettings: String { _selectedTTSModelId ?? SonioxModelSelection.automatic }
+    fileprivate var selectedVoiceIdForSettings: String { selectedVoiceId ?? Self.defaultVoiceId }
+
+    fileprivate func selectRegion(_ regionId: String) {
+        _selectedRegion = SonioxRegion.resolved(regionId, host: host)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func selectTTSModel(_ modelId: String) {
+        _selectedTTSModelId = Self.resolvedTTSModelId(modelId, host: host)
+        host?.setUserDefault(_selectedTTSModelId, forKey: SonioxDefaultsKey.selectedTTSModel)
+        host?.notifyCapabilitiesChanged()
     }
 }
 
@@ -841,7 +1637,12 @@ private struct SonioxSettingsView: View {
     @State private var isValidating = false
     @State private var validationResult: Bool?
     @State private var showApiKey = false
+    @State private var originalApiKeyInput = ""
     @State private var selectedModel: String = ""
+    @State private var selectedTTSModel: String = ""
+    @State private var selectedRegion: String = ""
+    @State private var selectedVoice: String = ""
+    @State private var isRefreshingModels = false
     private let bundle = Bundle(for: SonioxPlugin.self)
 
     var body: some View {
@@ -868,9 +1669,17 @@ private struct SonioxSettingsView: View {
                     }
                     .buttonStyle(.borderless)
 
-                    if plugin.isConfigured {
+                    if plugin.isConfigured, !hasPendingApiKeyChange {
+                        Button(String(localized: "Check", bundle: bundle)) {
+                            checkApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(trimmedApiKeyInput.isEmpty || isValidating)
+
                         Button(String(localized: "Remove", bundle: bundle)) {
                             apiKeyInput = ""
+                            originalApiKeyInput = ""
                             validationResult = nil
                             plugin.removeApiKey()
                         }
@@ -883,7 +1692,19 @@ private struct SonioxSettingsView: View {
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
-                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .disabled(trimmedApiKeyInput.isEmpty || isValidating)
+
+                        if plugin.isConfigured {
+                            Button(String(localized: "Remove", bundle: bundle)) {
+                                apiKeyInput = ""
+                                originalApiKeyInput = ""
+                                validationResult = nil
+                                plugin.removeApiKey()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .foregroundStyle(.red)
+                        }
                     }
                 }
 
@@ -903,6 +1724,20 @@ private struct SonioxSettingsView: View {
                             .foregroundStyle(result ? .green : .red)
                     }
                 }
+
+                Picker(String(localized: "Region", bundle: bundle), selection: $selectedRegion) {
+                    ForEach(SonioxRegion.all) { region in
+                        Text(String(localized: String.LocalizationValue(region.displayNameKey), bundle: bundle))
+                            .tag(region.id)
+                    }
+                }
+                .onChange(of: selectedRegion) {
+                    plugin.selectRegion(selectedRegion)
+                    validationResult = nil
+                    if plugin.isConfigured {
+                        refreshModels()
+                    }
+                }
             }
 
             if plugin.isConfigured {
@@ -910,10 +1745,24 @@ private struct SonioxSettingsView: View {
 
                 // Model Selection
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Realtime model", bundle: bundle)
-                        .font(.headline)
+                    HStack {
+                        Text("Realtime model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(isRefreshingModels)
+                    }
 
                     Picker("Realtime model", selection: $selectedModel) {
+                        Text("Automatic (Latest)", bundle: bundle).tag(SonioxModelSelection.automatic)
                         ForEach(plugin.transcriptionModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
@@ -923,9 +1772,48 @@ private struct SonioxSettingsView: View {
                         plugin.selectModel(selectedModel)
                     }
 
-                    Text("File transcription uses STT Async v5 automatically.", bundle: bundle)
+                    Text("File transcription uses the latest async STT model automatically.", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    if isRefreshingModels {
+                        HStack(spacing: 4) {
+                            ProgressView().controlSize(.small)
+                            Text("Refreshing models...", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Text-to-Speech Model", bundle: bundle)
+                        .font(.headline)
+
+                    Picker(String(localized: "Text-to-Speech Model", bundle: bundle), selection: $selectedTTSModel) {
+                        Text("Automatic (Latest)", bundle: bundle).tag(SonioxModelSelection.automatic)
+                        ForEach(plugin.ttsModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .onChange(of: selectedTTSModel) {
+                        plugin.selectTTSModel(selectedTTSModel)
+                        selectedVoice = plugin.selectedVoiceIdForSettings
+                    }
+
+                    Text("Text-to-Speech Voice", bundle: bundle)
+                        .font(.headline)
+
+                    Picker(String(localized: "Text-to-Speech Voice", bundle: bundle), selection: $selectedVoice) {
+                        ForEach(plugin.availableVoices, id: \.id) { voice in
+                            Text(voice.displayName).tag(voice.id)
+                        }
+                    }
+                    .onChange(of: selectedVoice) {
+                        plugin.selectVoice(selectedVoice)
+                    }
                 }
             }
 
@@ -937,16 +1825,26 @@ private struct SonioxSettingsView: View {
         .onAppear {
             if let key = plugin._apiKey, !key.isEmpty {
                 apiKeyInput = key
+                originalApiKeyInput = key
             }
-            selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+            selectedModel = plugin.selectedModelIdForSettings
+            selectedTTSModel = plugin.selectedTTSModelIdForSettings
+            selectedRegion = plugin.selectedRegionIdForSettings
+            selectedVoice = plugin.selectedVoiceIdForSettings
         }
     }
 
-    private func saveApiKey() {
-        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedKey.isEmpty else { return }
+    private var trimmedApiKeyInput: String {
+        apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
-        plugin.setApiKey(trimmedKey)
+    private var hasPendingApiKeyChange: Bool {
+        trimmedApiKeyInput != originalApiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = trimmedApiKeyInput
+        guard !trimmedKey.isEmpty else { return }
 
         isValidating = true
         validationResult = nil
@@ -955,6 +1853,42 @@ private struct SonioxSettingsView: View {
             await MainActor.run {
                 isValidating = false
                 validationResult = isValid
+                guard isValid else { return }
+
+                plugin.setApiKey(trimmedKey)
+                originalApiKeyInput = trimmedKey
+                refreshModels()
+            }
+        }
+    }
+
+    private func checkApiKey() {
+        let trimmedKey = trimmedApiKeyInput
+        guard !trimmedKey.isEmpty else { return }
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            await MainActor.run {
+                isValidating = false
+                validationResult = isValid
+                if isValid {
+                    refreshModels()
+                }
+            }
+        }
+    }
+
+    private func refreshModels() {
+        isRefreshingModels = true
+        Task {
+            _ = await plugin.refreshModels(apiKey: trimmedApiKeyInput)
+            await MainActor.run {
+                isRefreshingModels = false
+                selectedModel = plugin.selectedModelIdForSettings
+                selectedTTSModel = plugin.selectedTTSModelIdForSettings
+                selectedVoice = plugin.selectedVoiceIdForSettings
             }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -18,7 +18,7 @@ final class SonioxPluginTests: XCTestCase {
 
         XCTAssertEqual(plugin.selectedModelId, "stt-rt-v5")
         XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["stt-rt-v5"])
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "stt-rt-v5")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "automatic")
     }
 
     func testRetiredRealtimeModelMigratesToRTV5() throws {
@@ -28,7 +28,70 @@ final class SonioxPluginTests: XCTestCase {
         plugin.activate(host: host)
 
         XCTAssertEqual(plugin.selectedModelId, "stt-rt-v5")
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "stt-rt-v5")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "automatic")
+    }
+
+    func testFetchedRealtimeModelsDriveAutomaticLatestSelection() throws {
+        let models = [
+            SonioxFetchedModel(
+                id: "stt-rt-v5",
+                aliasedModelId: nil,
+                name: "STT RT v5",
+                transcriptionMode: "real_time",
+                languages: []
+            ),
+            SonioxFetchedModel(
+                id: "stt-rt-v6",
+                aliasedModelId: nil,
+                name: "STT RT v6",
+                transcriptionMode: "real_time",
+                languages: []
+            ),
+            SonioxFetchedModel(
+                id: "stt-async-v6",
+                aliasedModelId: nil,
+                name: "STT Async v6",
+                transcriptionMode: "async",
+                languages: []
+            ),
+        ]
+        let data = try JSONEncoder().encode(models)
+        let host = try PluginTestHostServices(defaults: ["fetchedModels": data])
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "stt-rt-v6")
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["stt-rt-v5", "stt-rt-v6"])
+    }
+
+    func testDefaultRegionUsesUSAndPersistsSelection() throws {
+        let host = try PluginTestHostServices()
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedRegion") as? String, "us")
+    }
+
+    func testInvalidStoredRegionMigratesToUS() throws {
+        let host = try PluginTestHostServices(defaults: ["selectedRegion": "moon"])
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedRegion") as? String, "us")
+    }
+
+    func testSonioxPluginAdvertisesTTSProtocolAndDefaultVoice() throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedVoiceId, "Maya")
+        XCTAssertTrue(plugin.availableVoices.contains { $0.id == "Adrian" })
+        XCTAssertTrue(plugin.authStatus(for: .tts).isAvailable)
     }
 
     func testCreateTranscriptionRequestUsesAsyncV5Model() throws {
@@ -55,6 +118,59 @@ final class SonioxPluginTests: XCTestCase {
         let translation = try XCTUnwrap(body["translation"] as? [String: Any])
         XCTAssertEqual(translation["type"] as? String, "one_way")
         XCTAssertEqual(translation["target_language"] as? String, "en")
+    }
+
+    func testCreateTranscriptionRequestUsesEURegionWhenSelected() throws {
+        let request = try SonioxPlugin.makeCreateTranscriptionRequest(
+            fileId: "file_123",
+            language: "de",
+            translate: false,
+            apiKey: "soniox-key",
+            prompt: nil,
+            regionID: "eu"
+        )
+
+        XCTAssertEqual(request.url?.absoluteString, "https://api.eu.soniox.com/v1/transcriptions")
+    }
+
+    func testCreateTranscriptionRequestAcceptsDynamicAsyncModel() throws {
+        let request = try SonioxPlugin.makeCreateTranscriptionRequest(
+            fileId: "file_123",
+            language: "de",
+            translate: false,
+            apiKey: "soniox-key",
+            prompt: nil,
+            modelID: "stt-async-v6",
+            regionID: "eu"
+        )
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "stt-async-v6")
+    }
+
+    func testTTSRequestUsesJapanRegionAndPCMOutput() throws {
+        let request = try SonioxPlugin.makeTTSRequest(
+            apiKey: "soniox-key",
+            text: "Hello",
+            voiceId: "Adrian",
+            language: "de-DE",
+            modelID: "tts-rt-v2",
+            regionID: "jp"
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://tts-rt.jp.soniox.com/tts")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 120)
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "tts-rt-v2")
+        XCTAssertEqual(body["language"] as? String, "de")
+        XCTAssertEqual(body["voice"] as? String, "Adrian")
+        XCTAssertEqual(body["audio_format"] as? String, "pcm_s16le")
+        XCTAssertEqual(body["text"] as? String, "Hello")
+        XCTAssertEqual(body["sample_rate"] as? Int, 24_000)
     }
 
     func testSourceProgressTranscriptionUsesAsyncV5RESTPathAndEmitsFinalProgress() async throws {
@@ -121,6 +237,152 @@ final class SonioxPluginTests: XCTestCase {
         let body = try Self.jsonBody(from: createRequest)
         XCTAssertEqual(body["model"] as? String, "stt-async-v5")
         XCTAssertEqual(body["language_hints"] as? [String], ["en", "de"])
+    }
+
+    func testSourceProgressTranscriptionUsesSelectedRegionalRESTPath() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedRegion": "eu"],
+            secrets: ["api-key": "soniox-key"]
+        )
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/transcriptions/transcription_123", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"text":"EU transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/transcriptions/transcription_123/transcript", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            languageSelection: PluginLanguageSelection(languageHints: ["en"]),
+            translate: false,
+            prompt: nil,
+            onProgress: { _ in true },
+            onSourceProgress: { _ in true }
+        )
+
+        XCTAssertEqual(result.text, "EU transcript")
+        let session = try XCTUnwrap(store.sessions.first)
+        XCTAssertEqual(
+            session.requestedRequests.map { $0.url?.absoluteString },
+            [
+                "https://api.eu.soniox.com/v1/files",
+                "https://api.eu.soniox.com/v1/transcriptions",
+                "https://api.eu.soniox.com/v1/transcriptions/transcription_123",
+                "https://api.eu.soniox.com/v1/transcriptions/transcription_123/transcript",
+            ]
+        )
+    }
+
+    func testValidateAPIKeyUsesSelectedRegion() async throws {
+        let host = try PluginTestHostServices(defaults: ["selectedRegion": "jp"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data("{}".utf8),
+                    Self.httpResponse(url: "https://api.jp.soniox.com/v1/files", statusCode: 200)
+                ),
+            ])
+        }
+
+        let isValid = await plugin.validateApiKey("soniox-key")
+
+        XCTAssertTrue(isValid)
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.absoluteString, "https://api.jp.soniox.com/v1/files")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+    }
+
+    func testAPIKeyValidationRequestUsesEURegion() throws {
+        let request = try SonioxPlugin.makeAPIKeyValidationRequest(
+            apiKey: "soniox-key",
+            regionID: "eu"
+        )
+
+        XCTAssertEqual(request.url?.absoluteString, "https://api.eu.soniox.com/v1/files")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+        XCTAssertEqual(request.timeoutInterval, 10)
+    }
+
+    func testModelCatalogRequestsUseSelectedRegion() throws {
+        let sttRequest = try SonioxPlugin.makeSTTModelsRequest(apiKey: "soniox-key", regionID: "eu")
+        let ttsRequest = try SonioxPlugin.makeTTSModelsRequest(apiKey: "soniox-key", regionID: "jp")
+
+        XCTAssertEqual(sttRequest.url?.absoluteString, "https://api.eu.soniox.com/v1/models")
+        XCTAssertEqual(ttsRequest.url?.absoluteString, "https://api.jp.soniox.com/v1/tts-models")
+        XCTAssertEqual(sttRequest.value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+        XCTAssertEqual(ttsRequest.value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+    }
+
+    func testParseTTSModelsExposesFetchedVoices() throws {
+        let data = Data(
+            #"""
+            {
+              "models": [
+                {
+                  "id": "tts-rt-v2",
+                  "aliased_model_id": null,
+                  "name": "TTS v2",
+                  "languages": [{ "code": "de", "name": "German" }],
+                  "voices": [{ "id": "NewVoice", "description": "Fresh", "gender": "female" }]
+                }
+              ]
+            }
+            """#.utf8
+        )
+        let host = try PluginTestHostServices(defaults: [
+            "fetchedTTSModels": try JSONEncoder().encode(SonioxPlugin.parseTTSModelsResponse(data)),
+        ])
+        let plugin = SonioxPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.ttsModels.map(\.id), ["tts-rt-v2"])
+        XCTAssertEqual(plugin.availableVoices.map(\.id), ["NewVoice"])
+        XCTAssertEqual(plugin.selectedVoiceId, "NewVoice")
+    }
+
+    func testValidateAPIKeyReturnsFalseForUnauthorizedResponse() async throws {
+        let host = try PluginTestHostServices(defaults: ["selectedRegion": "eu"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error_type":"unauthenticated"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files", statusCode: 401)
+                ),
+            ])
+        }
+
+        let isValid = await plugin.validateApiKey("bad-key")
+
+        XCTAssertFalse(isValid)
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.absoluteString, "https://api.eu.soniox.com/v1/files")
     }
 
     func testSourceProgressUsesFinalOriginalTokenTiming() {

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -1,16 +1,17 @@
 {
     "id": "com.typewhisper.soniox",
     "name": "Soniox",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
-    "description": "Cloud transcription via Soniox API with real-time WebSocket streaming and translation support. Requires API key.",
+    "description": "Cloud speech-to-text and text-to-speech via Soniox APIs with regional endpoint support. Requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Soniox-API mit Echtzeit-WebSocket-Streaming und Übersetzungsunterstützung. Erfordert API-Key."
+        "de": "Cloud Speech-to-Text und Text-to-Speech über Soniox APIs mit regionaler Endpunkt-Auswahl. Erfordert API-Key."
     },
     "category": "transcription",
+    "categories": ["transcription", "tts"],
     "capabilities": [
         "source-footage-progress"
     ],


### PR DESCRIPTION
## Summary

Implements Soniox regional endpoint support for issue #740 and expands the macOS Soniox plugin with TTS and dynamic model catalog handling.

- Adds a Soniox region selector for United States, European Union, and Japan.
- Routes API-key validation, realtime STT, file transcription, model refresh, and TTS through the selected region.
- Adds Soniox TTS playback with selectable voices.
- Fetches STT and TTS model catalogs from Soniox and supports Automatic (Latest) model selection.
- Keeps existing users on the US/default path unless they change region.
- Bumps the Soniox plugin manifest to 1.2.0.

Closes #740

## Test Plan

- `jq empty TypeWhisperPluginSDK/Plugins/SonioxPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json`
- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests`
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run SonioxPlugin /Users/marco/.codex/worktrees/1784/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added region selection (US, EU, Japan) to configure endpoints for transcription and text-to-speech services.
  * Introduced automatic model selection with "Latest" version support.
  * Added text-to-speech voice and model customization options.
  * Enhanced text-to-speech playback capabilities with voice configuration.

* **Tests**
  * Expanded test coverage for region handling and dynamic model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->