### PR TITLE
Improve Japanese dictation post-processing

### DIFF
--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -476,7 +476,9 @@ final class DictionaryService: ObservableObject {
         }
 
         let startsAtBoundary = previous?.isWordLike != true || previous?.isJapaneseParticleBoundary == true
-        let endsAtBoundary = next?.isWordLike != true || next?.isJapaneseParticleBoundary == true
+        let endsAtBoundary = next?.isWordLike != true ||
+            next?.isJapaneseParticleBoundary == true ||
+            (original.count > 1 && String(text[range.upperBound...]).startsWithJapaneseParticleBoundary)
         return startsAtBoundary && endsAtBoundary
     }
 
@@ -679,6 +681,8 @@ private extension Character {
             CharacterSet.alphanumerics.contains(scalar) ||
             (0x3040...0x30FF).contains(Int(scalar.value)) ||
             (0x3400...0x9FFF).contains(Int(scalar.value)) ||
+            (0xF900...0xFAFF).contains(Int(scalar.value)) ||
+            (0x20000...0x323AF).contains(Int(scalar.value)) ||
             (0xFF66...0xFF9D).contains(Int(scalar.value))
         }
     }
@@ -704,6 +708,24 @@ private extension Character {
 }
 
 private extension String {
+    var startsWithJapaneseParticleBoundary: Bool {
+        [
+            "から",
+            "まで",
+            "より",
+            "には",
+            "では",
+            "にも",
+            "でも",
+            "とは",
+            "との",
+            "へは",
+            "への",
+            "だけ",
+            "など",
+        ].contains { hasPrefix($0) }
+    }
+
     var containsWordLikeCharacter: Bool {
         contains { $0.isWordLike }
     }

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -20,6 +20,12 @@ enum DictionaryServiceMutationError: LocalizedError {
     }
 }
 
+enum DictionaryCorrectionMatchPolicy {
+    case exact
+    case boundary
+    case substring
+}
+
 @MainActor
 final class DictionaryService: ObservableObject {
     private var modelContainer: ModelContainer?
@@ -383,15 +389,7 @@ final class DictionaryService: ObservableObject {
             guard let replacement = correction.replacement else { continue }
 
             let before = result
-            if correction.caseSensitive {
-                result = result.replacingOccurrences(of: correction.original, with: replacement)
-            } else {
-                result = result.replacingOccurrences(
-                    of: correction.original,
-                    with: replacement,
-                    options: .caseInsensitive
-                )
-            }
+            result = applyCorrection(correction, to: result, replacement: replacement)
 
             if result != before {
                 incrementUsageCount(for: correction)
@@ -399,6 +397,87 @@ final class DictionaryService: ObservableObject {
         }
 
         return result
+    }
+
+    private func applyCorrection(_ correction: DictionaryEntry, to text: String, replacement: String) -> String {
+        switch matchPolicy(for: correction) {
+        case .exact:
+            return textMatches(text, correction.original, caseSensitive: correction.caseSensitive) ? replacement : text
+        case .boundary:
+            return replacingBoundaryMatches(
+                of: correction.original,
+                in: text,
+                with: replacement,
+                caseSensitive: correction.caseSensitive
+            )
+        case .substring:
+            if correction.caseSensitive {
+                return text.replacingOccurrences(of: correction.original, with: replacement)
+            }
+            return text.replacingOccurrences(
+                of: correction.original,
+                with: replacement,
+                options: .caseInsensitive
+            )
+        }
+    }
+
+    private func matchPolicy(for correction: DictionaryEntry) -> DictionaryCorrectionMatchPolicy {
+        let original = correction.original.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !original.isEmpty else { return .exact }
+        return original.containsWordLikeCharacter ? .boundary : .substring
+    }
+
+    private func textMatches(_ text: String, _ original: String, caseSensitive: Bool) -> Bool {
+        if caseSensitive {
+            return text == original
+        }
+        return text.compare(original, options: [.caseInsensitive], locale: .current) == .orderedSame
+    }
+
+    private func replacingBoundaryMatches(
+        of original: String,
+        in text: String,
+        with replacement: String,
+        caseSensitive: Bool
+    ) -> String {
+        guard !original.isEmpty else { return text }
+
+        var result = ""
+        var searchStart = text.startIndex
+        let options: String.CompareOptions = caseSensitive ? [] : [.caseInsensitive]
+
+        while let range = text.range(of: original, options: options, range: searchStart..<text.endIndex, locale: .current) {
+            guard range.lowerBound < range.upperBound else { break }
+
+            if isBoundaryMatch(range, in: text, original: original) {
+                result += text[searchStart..<range.lowerBound]
+                result += replacement
+            } else {
+                result += text[searchStart..<range.upperBound]
+            }
+            searchStart = range.upperBound
+        }
+
+        result += text[searchStart..<text.endIndex]
+        return result
+    }
+
+    private func isBoundaryMatch(_ range: Range<String.Index>, in text: String, original: String) -> Bool {
+        let previous = range.lowerBound > text.startIndex ? text[text.index(before: range.lowerBound)] : nil
+        let next = range.upperBound < text.endIndex ? text[range.upperBound] : nil
+
+        if original.isAllKatakana {
+            return previous?.isKatakana != true && next?.isKatakana != true
+        }
+
+        if original.isAllLatinOrNumber {
+            return previous?.isLatinOrNumber != true && next?.isLatinOrNumber != true
+        }
+
+        let startsAtBoundary = previous?.isWordLike != true || previous?.isJapaneseParticleBoundary == true
+        let endsAtBoundary = next?.isWordLike != true || next?.isJapaneseParticleBoundary == true
+        return startsAtBoundary && endsAtBoundary
     }
 
     /// Add a correction learned from history edits
@@ -578,6 +657,66 @@ final class DictionaryService: ObservableObject {
             try context.save()
         } catch {
             logger.error("Failed to update usage count: \(error.localizedDescription)")
+        }
+    }
+}
+
+private extension Character {
+    var isKatakana: Bool {
+        unicodeScalars.allSatisfy { scalar in
+            (0x30A0...0x30FF).contains(Int(scalar.value)) ||
+            (0x31F0...0x31FF).contains(Int(scalar.value)) ||
+            (0xFF66...0xFF9D).contains(Int(scalar.value))
+        }
+    }
+
+    var isLatinOrNumber: Bool {
+        unicodeScalars.allSatisfy { CharacterSet.alphanumerics.contains($0) && $0.value < 0x3000 }
+    }
+
+    var isWordLike: Bool {
+        unicodeScalars.contains { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ||
+            (0x3040...0x30FF).contains(Int(scalar.value)) ||
+            (0x3400...0x9FFF).contains(Int(scalar.value)) ||
+            (0xFF66...0xFF9D).contains(Int(scalar.value))
+        }
+    }
+
+    var isJapaneseParticleBoundary: Bool {
+        guard unicodeScalars.count == 1, let scalar = unicodeScalars.first else { return false }
+        switch scalar.value {
+        case 0x3067, // で
+             0x306B, // に
+             0x306E, // の
+             0x306F, // は
+             0x3092, // を
+             0x304C, // が
+             0x3082, // も
+             0x3068, // と
+             0x3078, // へ
+             0x3088: // よ
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+private extension String {
+    var containsWordLikeCharacter: Bool {
+        contains { $0.isWordLike }
+    }
+
+    var isAllKatakana: Bool {
+        !isEmpty && allSatisfy { character in
+            character.isKatakana || character.unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
+        }
+    }
+
+    var isAllLatinOrNumber: Bool {
+        !isEmpty && allSatisfy { character in
+            character.isLatinOrNumber || character.unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/FillerWordsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/FillerWordsPlugin.swift
@@ -44,7 +44,17 @@ final class FillerWordsPlugin: NSObject, PostProcessorPlugin, @unchecked Sendabl
         let normalizedWords = normalizedWords(from: words)
         guard !normalizedWords.isEmpty else { return text }
 
-        let escapedWords = normalizedWords
+        var result = removeLatinFillerWords(from: text, words: normalizedWords)
+        result = removeJapaneseFillerWords(from: result, words: normalizedWords)
+
+        return result
+    }
+
+    private static func removeLatinFillerWords(from text: String, words: [String]) -> String {
+        let latinWords = words.filter { !$0.containsJapaneseScript }
+        guard !latinWords.isEmpty else { return text }
+
+        let escapedWords = latinWords
             .map(NSRegularExpression.escapedPattern(for:))
             .joined(separator: "|")
         let pattern = #"(?i)(?<![\p{L}\p{N}_])[,.!?]?[ \t]*(?:"# + escapedWords + #")(?![\p{L}\p{N}_])[ \t]*[,.!?]?"#
@@ -55,6 +65,28 @@ final class FillerWordsPlugin: NSObject, PostProcessorPlugin, @unchecked Sendabl
 
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
         let stripped = regex.stringByReplacingMatches(in: text, range: range, withTemplate: " ")
+        guard stripped != text else { return text }
+
+        return normalizeWhitespaceAfterRemoval(stripped, preservingPrefixFrom: text)
+    }
+
+    private static func removeJapaneseFillerWords(from text: String, words: [String]) -> String {
+        let japaneseWords = words.filter(\.containsJapaneseScript)
+        guard !japaneseWords.isEmpty else { return text }
+
+        let escapedWords = japaneseWords
+            .map(NSRegularExpression.escapedPattern(for:))
+            .joined(separator: "|")
+        let boundary = #"(^|[\s、。,.!?！？])"#
+        let trailingSeparator = #"(?:[ \t]*[、,][ \t]*|[ \t]+)?"#
+        let pattern = boundary + #"[ \t]*(?:"# + escapedWords + #")"# + trailingSeparator
+
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return text
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let stripped = regex.stringByReplacingMatches(in: text, range: range, withTemplate: "$1")
         guard stripped != text else { return text }
 
         return normalizeWhitespaceAfterRemoval(stripped, preservingPrefixFrom: text)
@@ -72,7 +104,21 @@ final class FillerWordsPlugin: NSObject, PostProcessorPlugin, @unchecked Sendabl
         "um",
         "umm",
         "äh",
-        "ähm"
+        "ähm",
+        "えっと",
+        "えーっと",
+        "ええと",
+        "えーと",
+        "えと",
+        "なんか",
+        "まぁ",
+        "まあ",
+        "あのー",
+        "あのぉ",
+        "そのー",
+        "そのぉ",
+        "うーん",
+        "うーむ"
     ]
 
     static func normalizedWords(from text: String) -> [String] {
@@ -123,7 +169,7 @@ final class FillerWordsPlugin: NSObject, PostProcessorPlugin, @unchecked Sendabl
 private final class FillerWordsSettingsStore: ObservableObject, @unchecked Sendable {
     private static let wordsKey = "words"
     private static let defaultsVersionKey = "wordsDefaultsVersion"
-    private static let currentDefaultsVersion = 2
+    private static let currentDefaultsVersion = 3
     private static let legacyDefaultFillerWords = [
         "ah",
         "ahh",
@@ -199,6 +245,19 @@ private final class FillerWordsSettingsStore: ObservableObject, @unchecked Senda
         host.setUserDefault(migratedWords, forKey: wordsKey)
         host.setUserDefault(currentDefaultsVersion, forKey: defaultsVersionKey)
         return migratedWords
+    }
+}
+
+private extension String {
+    var containsJapaneseScript: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3040...0x309F, 0x30A0...0x30FF, 0x31F0...0x31FF, 0x3400...0x4DBF, 0x4E00...0x9FFF:
+                return true
+            default:
+                return false
+            }
+        }
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/FillerWordsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/FillerWordsPlugin.swift
@@ -75,7 +75,13 @@ final class FillerWordsPlugin: NSObject, PostProcessorPlugin, @unchecked Sendabl
         guard !japaneseWords.isEmpty else { return text }
 
         let escapedWords = japaneseWords
-            .map(NSRegularExpression.escapedPattern(for:))
+            .map { word in
+                let escaped = NSRegularExpression.escapedPattern(for: word)
+                if word == "まあ" || word == "まぁ" {
+                    return escaped + #"(?!ま[あぁ])"#
+                }
+                return escaped
+            }
             .joined(separator: "|")
         let boundary = #"(^|[\s、。,.!?！？])"#
         let trailingSeparator = #"(?:[ \t]*[、,][ \t]*|[ \t]+)?"#

--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/Tests/FillerWordsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/Tests/FillerWordsPluginTests.swift
@@ -48,6 +48,14 @@ final class FillerWordsPluginTests: XCTestCase {
             FillerWordsPlugin.removeFillerWords(from: "あの人に確認してください。"),
             "あの人に確認してください。"
         )
+        XCTAssertEqual(
+            FillerWordsPlugin.removeFillerWords(from: "まあまあです。今日は、まあまあです。"),
+            "まあまあです。今日は、まあまあです。"
+        )
+        XCTAssertEqual(
+            FillerWordsPlugin.removeFillerWords(from: "まあまず確認してください。まあまた明日です。"),
+            "まず確認してください。また明日です。"
+        )
     }
 
     @MainActor

--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/Tests/FillerWordsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/Tests/FillerWordsPluginTests.swift
@@ -24,6 +24,32 @@ final class FillerWordsPluginTests: XCTestCase {
         XCTAssertEqual(result, "hello?")
     }
 
+    func testRemovesBuiltInJapaneseFillerWordsAtPhraseBoundaries() async throws {
+        let plugin = FillerWordsPlugin()
+
+        let result = try await plugin.process(
+            text: "えっと友達追加されたのは2月9日で、なんか様子を見たいです。まあ今日から開始してください。",
+            context: PostProcessingContext()
+        )
+
+        XCTAssertEqual(result, "友達追加されたのは2月9日で、様子を見たいです。今日から開始してください。")
+    }
+
+    func testPreservesMeaningfulJapaneseConnectorsAndDemonstratives() {
+        XCTAssertEqual(
+            FillerWordsPlugin.removeFillerWords(from: "あと最後に送信確認してください。"),
+            "あと最後に送信確認してください。"
+        )
+        XCTAssertEqual(
+            FillerWordsPlugin.removeFillerWords(from: "そのまま送信してください。"),
+            "そのまま送信してください。"
+        )
+        XCTAssertEqual(
+            FillerWordsPlugin.removeFillerWords(from: "あの人に確認してください。"),
+            "あの人に確認してください。"
+        )
+    }
+
     @MainActor
     func testActivationSeedsPluginScopedDefaultWords() throws {
         let host = try PluginTestHostServices()
@@ -59,7 +85,8 @@ final class FillerWordsPluginTests: XCTestCase {
         let storedWords = host.userDefault(forKey: "words") as? String
         XCTAssertTrue(storedWords?.contains("basically") == true)
         XCTAssertTrue(storedWords?.contains("ähm") == true)
-        XCTAssertEqual(host.userDefault(forKey: "wordsDefaultsVersion") as? Int, 2)
+        XCTAssertTrue(storedWords?.contains("えっと") == true)
+        XCTAssertEqual(host.userDefault(forKey: "wordsDefaultsVersion") as? Int, 3)
     }
 
     func testProcessUsesPluginScopedCustomWords() async throws {

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -135,6 +135,65 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testCorrectionsDoNotReplaceInsideLongerKatakanaWords() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "ライン", replacement: "LINE")
+        service.addEntry(type: .correction, original: "リフ", replacement: "LIFF")
+
+        XCTAssertEqual(service.applyCorrections(to: "具体的にはオンライン。"), "具体的にはオンライン。")
+        XCTAssertEqual(service.applyCorrections(to: "リファレンス。"), "リファレンス。")
+        XCTAssertEqual(service.applyCorrections(to: "ラインで送って。"), "LINEで送って。")
+    }
+
+    @MainActor
+    func testCorrectionsStillApplyForKnownJapaneseNameAndBrandTerms() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "恋ちゃん", replacement: "こいちゃん")
+        service.addEntry(type: .correction, original: "鯉フィット", replacement: "Koi-Fit")
+
+        XCTAssertEqual(service.applyCorrections(to: "恋ちゃんです。"), "こいちゃんです。")
+        XCTAssertEqual(service.applyCorrections(to: "今日は恋ちゃんです。"), "今日はこいちゃんです。")
+        XCTAssertEqual(service.applyCorrections(to: "鯉フィットの件です。"), "Koi-Fitの件です。")
+        XCTAssertEqual(service.applyCorrections(to: "今日は鯉フィットの件です。"), "今日はKoi-Fitの件です。")
+        XCTAssertEqual(service.applyCorrections(to: "鯉フィットネスではありません。"), "鯉フィットネスではありません。")
+    }
+
+    @MainActor
+    func testCorrectionsDoNotFoldJapaneseDakutenDifferences() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "ハン", replacement: "HAN")
+
+        XCTAssertEqual(service.applyCorrections(to: "ハンで始まる。"), "HANで始まる。")
+        XCTAssertEqual(service.applyCorrections(to: "バンで始まる。"), "バンで始まる。")
+    }
+
+    @MainActor
+    func testMixedJapaneseCorrectionsDoNotReplaceInsideCompoundWords() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "日本", replacement: "Japan")
+        service.addEntry(type: .correction, original: "東京", replacement: "Tokyo")
+
+        XCTAssertEqual(service.applyCorrections(to: "日本です。"), "Japanです。")
+        XCTAssertEqual(service.applyCorrections(to: "これは日本です。"), "これはJapanです。")
+        XCTAssertEqual(service.applyCorrections(to: "東京へ行く。"), "Tokyoへ行く。")
+        XCTAssertEqual(service.applyCorrections(to: "明日は東京へ行く。"), "明日はTokyoへ行く。")
+        XCTAssertEqual(service.applyCorrections(to: "日本語です。"), "日本語です。")
+        XCTAssertEqual(service.applyCorrections(to: "東京都です。"), "東京都です。")
+    }
+
+    @MainActor
     func testAPITermHelpersDeleteSingleTermWithoutClearingOthers() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -189,8 +189,32 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(service.applyCorrections(to: "これは日本です。"), "これはJapanです。")
         XCTAssertEqual(service.applyCorrections(to: "東京へ行く。"), "Tokyoへ行く。")
         XCTAssertEqual(service.applyCorrections(to: "明日は東京へ行く。"), "明日はTokyoへ行く。")
+        XCTAssertEqual(service.applyCorrections(to: "日本から出発します。"), "Japanから出発します。")
+        XCTAssertEqual(service.applyCorrections(to: "日本まで送ってください。"), "Japanまで送ってください。")
         XCTAssertEqual(service.applyCorrections(to: "日本語です。"), "日本語です。")
         XCTAssertEqual(service.applyCorrections(to: "東京都です。"), "東京都です。")
+    }
+
+    @MainActor
+    func testShortJapaneseCorrectionsDoNotReplaceInsideWordsContainingParticles() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "だ", replacement: "です")
+
+        XCTAssertEqual(service.applyCorrections(to: "からだです。"), "からだです。")
+    }
+
+    @MainActor
+    func testSingleCharacterCorrectionsDoNotUseMultiCharacterParticleSuffixesInsideWords() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "ち", replacement: "地")
+
+        XCTAssertEqual(service.applyCorrections(to: "ちからです。"), "ちからです。")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add Japanese filler-word defaults and phrase-boundary removal for the Filler Words plugin
- avoid replacing dictionary corrections inside longer Japanese, katakana, or Latin/number words
- keep Japanese particles usable as correction boundaries so brand/name corrections still apply in natural sentences

## Test plan
- `swift test --filter FillerWordsPluginTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/DictionaryServiceTests/testCorrectionsDoNotReplaceInsideLongerKatakanaWords -only-testing:TypeWhisperTests/DictionaryServiceTests/testCorrectionsStillApplyForKnownJapaneseNameAndBrandTerms -only-testing:TypeWhisperTests/DictionaryServiceTests/testCorrectionsDoNotFoldJapaneseDakutenDifferences -only-testing:TypeWhisperTests/DictionaryServiceTests/testMixedJapaneseCorrectionsDoNotReplaceInsideCompoundWords`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dictionary correction replacements by using smarter boundary-aware matching and more reliable handling of Japanese script, particles, and casing.
* **New Features**
  * Updated filler-word removal to run separate Latin and Japanese cleanup passes, with expanded Japanese filler vocabulary and better boundary/context handling.
* **Tests**
  * Added coverage for Japanese correction boundary scenarios and verified filler-word processing, plus updated default-migration expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->