### PR TITLE
Improve Japanese settings localization

### DIFF
--- a/TypeWhisper/Models/DictationPunctuationProfile.swift
+++ b/TypeWhisper/Models/DictationPunctuationProfile.swift
@@ -10,22 +10,22 @@ enum PunctuationStrategy: String, Codable, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .nativeOnly:
-            return "Native"
+            return String(localized: "Native")
         case .automatic:
-            return "Automatic"
+            return String(localized: "Automatic")
         case .fallbackOnly:
-            return "Fallback"
+            return String(localized: "Fallback")
         }
     }
 
     var description: String {
         switch self {
         case .nativeOnly:
-            return "Use the engine output unchanged."
+            return String(localized: "Use the engine output unchanged.")
         case .automatic:
-            return "Prefer native punctuation and only fix visible spoken commands."
+            return String(localized: "Prefer native punctuation and only fix visible spoken commands.")
         case .fallbackOnly:
-            return "Always apply spoken punctuation fallback rules."
+            return String(localized: "Always apply spoken punctuation fallback rules.")
         }
     }
 }
@@ -39,13 +39,13 @@ enum PunctuationVerificationState: String, Codable {
     var statusText: String {
         switch self {
         case .unknown:
-            return "Unverified"
+            return String(localized: "Unverified")
         case .vendorHint:
-            return "Suggested default"
+            return String(localized: "Suggested default")
         case .userVerifiedGood:
-            return "Verified: native works"
+            return String(localized: "Verified: native works")
         case .userVerifiedBad:
-            return "Verified: fallback needed"
+            return String(localized: "Verified: fallback needed")
         }
     }
 }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -21392,16 +21392,6 @@
         }
       }
     },
-    "Use these phrases with (context.summary) in any text field. If the native output already matches the expected result, keep Native. Otherwise use Fallback for this combination.": {
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "任意のテキスト入力欄で (context.summary) を使って、以下のフレーズを試してください。ネイティブ出力が期待結果と一致する場合は「ネイティブ」のままにします。一致しない場合は、この組み合わせで「フォールバック」を使用します。"
-          }
-        }
-      }
-    },
     "No guided phrases are available for this language yet.": {
       "localizations": {
         "ja": {
@@ -21418,16 +21408,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "期待結果: %@"
-          }
-        }
-      }
-    },
-    "Expected: (scenario.expected)": {
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "期待結果: (scenario.expected)"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1617,7 +1617,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "APIキーが必要です - 統合設定で構成してください"
+            "value": "APIキーが必要です - プラグイン設定で構成してください"
           }
         }
       }
@@ -4794,7 +4794,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "統合へ"
+            "value": "プラグインへ"
           }
         }
       }
@@ -5406,7 +5406,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "「統合」タブで他のLLMプロバイダーをインストールしてください。"
+            "value": "「プラグイン」タブで他のLLMプロバイダーをインストールしてください。"
           }
         }
       }
@@ -5601,7 +5601,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "連携"
+            "value": "プラグイン"
           }
         }
       }
@@ -7014,7 +7014,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "アクティブなメモリ保存プラグインがありません。統合から1つを有効にしてください。"
+            "value": "アクティブなメモリ保存プラグインがありません。「プラグイン」から1つ有効にしてください。"
           }
         }
       }
@@ -7214,7 +7214,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "インストールされた文字起こしエンジンがありません。統合からエンジンをインストールしてください。"
+            "value": "インストールされた文字起こしエンジンがありません。「プラグイン」からエンジンをインストールしてください。"
           }
         }
       }
@@ -7588,7 +7588,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "統合を開く"
+            "value": "プラグインを開く"
           }
         }
       }
@@ -9362,7 +9362,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "レコーダーのファイルに文字起こしを保存します。以下の設定は通常のDictationではなくSystem Audio Recorderのみに適用されます。"
+            "value": "レコーダーのファイルに文字起こしを保存します。以下の設定は通常のディクテーションではなく、システムオーディオレコーダーのみに適用されます。"
           }
         }
       }
@@ -9495,7 +9495,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ライブテキストウィンドウを使用するには、Integrationsからライブテキストプラグインをインストールしてください。"
+            "value": "ライブテキストウィンドウを使用するには、「プラグイン」からライブテキストプラグインをインストールしてください。"
           }
         }
       }
@@ -9738,7 +9738,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存されたマイクおよびシステムオーディオ設定でSystem Audio Recorderを開始または停止します。"
+            "value": "保存されたマイクとシステムオーディオ設定でシステムオーディオレコーダーを開始または停止します。"
           }
         }
       }
@@ -9760,7 +9760,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "System Audio Recorderのショートカット"
+            "value": "システムオーディオレコーダーのショートカット"
           }
         }
       }
@@ -12164,7 +12164,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "AIプロンプトを使用するには、セットアップ後に「統合」タブからLLMプロバイダー（例: Groq、OpenAI）をインストールしてください。"
+            "value": "AIプロンプトを使用するには、セットアップ後に「プラグイン」タブからLLMプロバイダー（例: Groq、OpenAI）をインストールしてください。"
           }
         }
       }
@@ -14141,7 +14141,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "設定後、『統合』タブで他のエンジンをインストールできます。"
+            "value": "設定後、「プラグイン」タブで他のエンジンをインストールできます。"
           }
         }
       }
@@ -14157,7 +14157,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "設定後、『プロンプト』および『統合』タブでプロンプトを管理し、他のプロバイダーをインストールできます。"
+            "value": "設定後、「プロンプト」および「プラグイン」タブでプロンプトを管理し、他のプロバイダーをインストールできます。"
           }
         }
       }
@@ -16837,7 +16837,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "見つける"
+            "value": "探す"
           }
         }
       }
@@ -16907,7 +16907,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "プラグインを見つける"
+            "value": "プラグインを探す"
           }
         }
       }
@@ -16917,7 +16917,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新しいプラグインを見つける"
+            "value": "新しいプラグインを探す"
           }
         }
       }
@@ -16927,7 +16927,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "利用可能なアドオンを探し、次の連携機能をここから直接インストールします。"
+            "value": "利用可能なアドオンを探し、次のプラグインをここから直接インストールします。"
           }
         }
       }
@@ -17907,7 +17907,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "「インテグレーション」でプロバイダーを設定してください。"
+            "value": "「プラグイン」でプロバイダーを設定してください。"
           }
         }
       }
@@ -19787,7 +19787,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "インテグレーションで管理"
+            "value": "プラグインで管理"
           }
         }
       }
@@ -20137,7 +20137,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ワークフローエンジンの上書きを使用する前に、「インテグレーション」で文字起こしエンジンをインストールしてください。"
+            "value": "ワークフローエンジンの上書きを使用する前に、「プラグイン」で文字起こしエンジンをインストールしてください。"
           }
         }
       }
@@ -20277,7 +20277,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ワークフローの上書きを使用する前に、「インテグレーション」でLLMプロバイダをインストールしてください。"
+            "value": "ワークフローの上書きを使用する前に、「プラグイン」でLLMプロバイダーをインストールしてください。"
           }
         }
       }
@@ -20317,7 +20317,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このプロバイダの準備がまだ完了していません。このワークフローで使用するには、先に「インテグレーション」でセットアップを完了してください。"
+            "value": "このプロバイダーの準備がまだ完了していません。このワークフローで使用するには、先に「プラグイン」でセットアップを完了してください。"
           }
         }
       }
@@ -21218,6 +21218,246 @@
           "stringUnit": {
             "state": "translated",
             "value": "利用不可"
+          }
+        }
+      }
+    },
+    "Spoken Punctuation": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ句読点"
+          }
+        }
+      }
+    },
+    "Strategy": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "処理方法"
+          }
+        }
+      }
+    },
+    "Native": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネイティブ"
+          }
+        }
+      }
+    },
+    "Fallback": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォールバック"
+          }
+        }
+      }
+    },
+    "Use the engine output unchanged.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エンジンの出力を変更せずに使用します。"
+          }
+        }
+      }
+    },
+    "Prefer native punctuation and only fix visible spoken commands.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エンジン側の句読点処理を優先し、明らかに残った読み上げコマンドだけを修正します。"
+          }
+        }
+      }
+    },
+    "Always apply spoken punctuation fallback rules.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ句読点のフォールバック規則を常に適用します。"
+          }
+        }
+      }
+    },
+    "Unverified": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未確認"
+          }
+        }
+      }
+    },
+    "Suggested default": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推奨デフォルト"
+          }
+        }
+      }
+    },
+    "Verified: native works": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認済み: ネイティブで動作"
+          }
+        }
+      }
+    },
+    "Verified: fallback needed": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認済み: フォールバックが必要"
+          }
+        }
+      }
+    },
+    "Test Spoken Punctuation…": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ句読点をテスト…"
+          }
+        }
+      }
+    },
+    "Test Spoken Punctuation": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み上げ句読点のテスト"
+          }
+        }
+      }
+    },
+    "Set a spoken language to configure punctuation behavior.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "句読点の動作を設定するには、話す言語を設定してください。"
+          }
+        }
+      }
+    },
+    "Select a transcription engine to configure punctuation behavior.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "句読点の動作を設定するには、文字起こしエンジンを選択してください。"
+          }
+        }
+      }
+    },
+    "No punctuation profile is available for the current selection.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の選択に利用できる句読点プロファイルはありません。"
+          }
+        }
+      }
+    },
+    "Use these phrases with %@ in any text field. If the native output already matches the expected result, keep Native. Otherwise use Fallback for this combination.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意のテキスト入力欄で %@ を使って、以下のフレーズを試してください。ネイティブ出力が期待結果と一致する場合は「ネイティブ」のままにします。一致しない場合は、この組み合わせで「フォールバック」を使用します。"
+          }
+        }
+      }
+    },
+    "Use these phrases with (context.summary) in any text field. If the native output already matches the expected result, keep Native. Otherwise use Fallback for this combination.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意のテキスト入力欄で (context.summary) を使って、以下のフレーズを試してください。ネイティブ出力が期待結果と一致する場合は「ネイティブ」のままにします。一致しない場合は、この組み合わせで「フォールバック」を使用します。"
+          }
+        }
+      }
+    },
+    "No guided phrases are available for this language yet.": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この言語で使えるガイド付きフレーズはまだありません。"
+          }
+        }
+      }
+    },
+    "Expected: %@": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期待結果: %@"
+          }
+        }
+      }
+    },
+    "Expected: (scenario.expected)": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期待結果: (scenario.expected)"
+          }
+        }
+      }
+    },
+    "Keep Automatic": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動のまま"
+          }
+        }
+      }
+    },
+    "Use Fallback": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォールバックを使用"
+          }
+        }
+      }
+    },
+    "Native Works": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネイティブで動作"
           }
         }
       }

--- a/TypeWhisper/Views/SpokenPunctuationSettingsSection.swift
+++ b/TypeWhisper/Views/SpokenPunctuationSettingsSection.swift
@@ -11,7 +11,7 @@ struct SpokenPunctuationSettingsSection: View {
     private let punctuationVerificationService = ServiceContainer.shared.punctuationVerificationService
 
     var body: some View {
-        Section("Spoken Punctuation") {
+        Section(String(localized: "Spoken Punctuation")) {
             if let context = activePunctuationContext,
                let resolved = resolvedPunctuationStrategy(for: context) {
                 VStack(alignment: .leading, spacing: 12) {
@@ -26,7 +26,7 @@ struct SpokenPunctuationSettingsSection: View {
                         }
                     } label: {
                         SettingsInfoLabel(
-                            title: "Strategy",
+                            title: String(localized: "Strategy"),
                             info: "\(context.summary)\n\n\(resolved.strategy.description)"
                         )
                     }
@@ -35,21 +35,21 @@ struct SpokenPunctuationSettingsSection: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    Button("Test Spoken Punctuation…") {
+                    Button(String(localized: "Test Spoken Punctuation…")) {
                         showPunctuationTestSheet = true
                     }
                     .buttonStyle(.bordered)
                 }
             } else if settings.selectedLanguage == nil {
-                Text("Set a spoken language to configure punctuation behavior.")
+                Text(String(localized: "Set a spoken language to configure punctuation behavior."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else if modelManager.selectedProviderId == nil {
-                Text("Select a transcription engine to configure punctuation behavior.")
+                Text(String(localized: "Select a transcription engine to configure punctuation behavior."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {
-                Text("No punctuation profile is available for the current selection.")
+                Text(String(localized: "No punctuation profile is available for the current selection."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -160,21 +160,24 @@ private struct PunctuationVerificationSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Test Spoken Punctuation")
+            Text(String(localized: "Test Spoken Punctuation"))
                 .font(.headline)
 
-            Text("Use these phrases with \(context.summary) in any text field. If the native output already matches the expected result, keep Native. Otherwise use Fallback for this combination.")
+            Text(String(
+                format: String(localized: "Use these phrases with %@ in any text field. If the native output already matches the expected result, keep Native. Otherwise use Fallback for this combination."),
+                context.summary
+            ))
                 .foregroundStyle(.secondary)
 
             if scenarios.isEmpty {
-                Text("No guided phrases are available for this language yet.")
+                Text(String(localized: "No guided phrases are available for this language yet."))
                     .foregroundStyle(.secondary)
             } else {
                 List(scenarios, id: \.self) { scenario in
                     VStack(alignment: .leading, spacing: 4) {
                         Text(scenario.spoken)
                             .font(.body.monospaced())
-                        Text("Expected: \(scenario.expected)")
+                        Text(String(format: String(localized: "Expected: %@"), scenario.expected))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -184,16 +187,16 @@ private struct PunctuationVerificationSheet: View {
             }
 
             HStack {
-                Button("Keep Automatic") {
+                Button(String(localized: "Keep Automatic")) {
                     dismiss()
                 }
                 Spacer()
-                Button("Use Fallback") {
+                Button(String(localized: "Use Fallback")) {
                     onDecision(.fallbackOnly, .userVerifiedBad)
                     dismiss()
                 }
                 .buttonStyle(.bordered)
-                Button("Native Works") {
+                Button(String(localized: "Native Works")) {
                     onDecision(.nativeOnly, .userVerifiedGood)
                     dismiss()
                 }

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via AssemblyAI API with real-time WebSocket streaming. Requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die AssemblyAI-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key."
+        "de": "Cloud-Transkription über die AssemblyAI-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key.",
+        "ja": "AssemblyAI APIによるクラウド文字起こしです。リアルタイムWebSocketストリーミングに対応し、APIキーが必要です。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "Cloud speech-to-text and text-to-speech via Cartesia APIs. Requires a Cartesia API key.",
     "descriptions": {
-        "de": "Cloud Speech-to-Text und Text-to-Speech über Cartesia APIs. Erfordert einen Cartesia API-Key."
+        "de": "Cloud Speech-to-Text und Text-to-Speech über Cartesia APIs. Erfordert einen Cartesia API-Key.",
+        "ja": "Cartesia APIによるクラウド音声認識と音声合成です。Cartesia APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "tts"],
+    "categories": [
+        "transcription",
+        "tts"
+    ],
     "hosting": "cloud",
     "iconSystemName": "waveform",
     "principalClass": "CartesiaPlugin",

--- a/TypeWhisperPluginSDK/Plugins/CerebrasPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CerebrasPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Ultra-fast LLM inference via Cerebras API. Up to 3,000 tokens/sec. Requires API key.",
     "descriptions": {
-        "de": "Ultra-schnelle LLM-Inferenz über die Cerebras-API. Bis zu 3.000 Tokens/Sek. Erfordert API-Key."
+        "de": "Ultra-schnelle LLM-Inferenz über die Cerebras-API. Bis zu 3.000 Tokens/Sek. Erfordert API-Key.",
+        "ja": "Cerebras APIによる超高速LLM推論です。最大3,000トークン/秒に対応し、APIキーが必要です。"
     },
     "category": "llm",
     "iconSystemName": "bolt.fill",

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "LLM provider via Anthropic Claude API. Requires API key.",
     "descriptions": {
-        "de": "LLM-Anbieter über die Anthropic Claude API. Erfordert API-Key."
+        "de": "LLM-Anbieter über die Anthropic Claude API. Erfordert API-Key.",
+        "ja": "Anthropic Claude APIによるLLMプロバイダーです。APIキーが必要です。"
     },
     "category": "llm",
     "iconSystemName": "brain.head.profile",

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
@@ -13,6 +13,7 @@
     "principalClass": "CloudflareASRPlugin",
     "detailsURL": "https://www.typewhisper.com/addons/cloudflare-asr/",
     "descriptions": {
+        "de": "OpenAI-kompatible Transkription über einen Cloudflare-Tunnel mit Service-Token-Authentifizierung. Zugangsdaten werden im macOS-Schlüsselbund gespeichert.",
         "ja": "サービストークン認証付きのCloudflareトンネル経由でOpenAI互換の文字起こしを行います。認証情報はmacOSキーチェーンに保存されます。"
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
@@ -11,5 +11,8 @@
     "iconSystemName": "shield.lefthalf.filled",
     "iconURL": "https://www.typewhisper.com/brand-logos/cloudflare/logo.svg",
     "principalClass": "CloudflareASRPlugin",
-    "detailsURL": "https://www.typewhisper.com/addons/cloudflare-asr/"
+    "detailsURL": "https://www.typewhisper.com/addons/cloudflare-asr/",
+    "descriptions": {
+        "ja": "サービストークン認証付きのCloudflareトンネル経由でOpenAI互換の文字起こしを行います。認証情報はmacOSキーチェーンに保存されます。"
+    }
 }

--- a/TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via Cohere Transcribe API. State-of-the-art accuracy across 14 languages. Requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Cohere Transcribe API. Beste Genauigkeit für 14 Sprachen. Erfordert API-Key."
+        "de": "Cloud-Transkription über die Cohere Transcribe API. Beste Genauigkeit für 14 Sprachen. Erfordert API-Key.",
+        "ja": "Cohere Transcribe APIによるクラウド文字起こしです。14言語で高精度に対応し、APIキーが必要です。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via Deepgram API with real-time WebSocket streaming. Requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Deepgram-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key."
+        "de": "Cloud-Transkription über die Deepgram-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key.",
+        "ja": "Deepgram APIによるクラウド文字起こしです。リアルタイムWebSocketストリーミングに対応し、APIキーが必要です。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via ElevenLabs Scribe API with real-time WebSocket streaming.",
     "descriptions": {
-        "de": "Cloud-Transkription über die ElevenLabs-Scribe-API mit Echtzeit-WebSocket-Streaming."
+        "de": "Cloud-Transkription über die ElevenLabs-Scribe-API mit Echtzeit-WebSocket-Streaming.",
+        "ja": "ElevenLabs Scribe APIによるクラウド文字起こしです。リアルタイムWebSocketストリーミングに対応します。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Run shell scripts for watch-folder file jobs. Scripts can replace the final exported artifact.",
     "descriptions": {
-        "de": "Shell-Skripte für Watch-Folder-Dateijobs ausführen. Skripte können das finale Export-Artefakt ersetzen."
+        "de": "Shell-Skripte für Watch-Folder-Dateijobs ausführen. Skripte können das finale Export-Artefakt ersetzen.",
+        "ja": "監視フォルダのファイルジョブでシェルスクリプトを実行します。スクリプトで最終出力ファイルを置き換えられます。"
     },
     "category": "file-automation",
     "iconSystemName": "folder.badge.gearshape",

--- a/TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Store memories as local JSON files with text-based search. Fully offline, no API key required.",
     "descriptions": {
-        "de": "Speichert Erinnerungen als lokale JSON-Dateien mit textbasierter Suche. Komplett offline, kein API-Key nötig."
+        "de": "Speichert Erinnerungen als lokale JSON-Dateien mit textbasierter Suche. Komplett offline, kein API-Key nötig.",
+        "ja": "メモリをローカルJSONファイルとして保存し、テキスト検索できます。完全オフラインで動作し、APIキーは不要です。"
     },
     "category": "memory",
     "iconSystemName": "doc.text",

--- a/TypeWhisperPluginSDK/Plugins/FireworksPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FireworksPlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription and LLM via Fireworks AI. Streaming transcription, fast inference, requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription und LLM über Fireworks AI. Streaming-Transkription, schnelle Inferenz, erfordert API-Key."
+        "de": "Cloud-Transkription und LLM über Fireworks AI. Streaming-Transkription, schnelle Inferenz, erfordert API-Key.",
+        "ja": "Fireworks AIによるクラウド文字起こしとLLMです。ストリーミング文字起こしと高速推論に対応し、APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm"],
+    "categories": [
+        "transcription",
+        "llm"
+    ],
     "iconSystemName": "flame.fill",
     "principalClass": "FireworksPlugin",
     "requiresAPIKey": true,

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "LLM provider and cloud speech transcription via Google Gemini API. Requires API key.",
     "descriptions": {
-        "de": "LLM-Anbieter und Cloud-Spracherkennung über die Google Gemini API. Erfordert API-Key."
+        "de": "LLM-Anbieter und Cloud-Spracherkennung über die Google Gemini API. Erfordert API-Key.",
+        "ja": "Google Gemini APIによるLLMプロバイダーとクラウド音声文字起こしです。APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm"],
+    "categories": [
+        "transcription",
+        "llm"
+    ],
     "iconSystemName": "sparkles",
     "iconURL": "https://www.typewhisper.com/brand-logos/gemini/logo.svg",
     "principalClass": "GeminiPlugin",

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Local LLM powered by Google Gemma 4 on Apple Silicon via MLX. No API key required.",
     "descriptions": {
-        "de": "Lokales LLM mit Google Gemma 4 auf Apple Silicon via MLX. Kein API-Key erforderlich."
+        "de": "Lokales LLM mit Google Gemma 4 auf Apple Silicon via MLX. Kein API-Key erforderlich.",
+        "ja": "Apple Silicon上でMLX経由で動作するGoogle Gemma 4ローカルLLMです。APIキーは不要です。"
     },
     "category": "llm",
     "iconSystemName": "cpu",

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via Gladia Solaria API with real-time WebSocket streaming.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Gladia-Solaria-API mit Echtzeit-WebSocket-Streaming."
+        "de": "Cloud-Transkription über die Gladia-Solaria-API mit Echtzeit-WebSocket-Streaming.",
+        "ja": "Gladia Solaria APIによるクラウド文字起こしです。リアルタイムWebSocketストリーミングに対応します。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via Google Cloud Speech-to-Text using a service-account JSON key. Handles long recordings by chunking audio into multiple recognize requests.",
     "descriptions": {
-        "de": "Cloud-Transkription über Google Cloud Speech-to-Text mit einem Service-Account-JSON-Schlüssel. Zerlegt längere Aufnahmen automatisch in mehrere Recognize-Requests."
+        "de": "Cloud-Transkription über Google Cloud Speech-to-Text mit einem Service-Account-JSON-Schlüssel. Zerlegt längere Aufnahmen automatisch in mehrere Recognize-Requests.",
+        "ja": "サービスアカウントJSONキーを使うGoogle Cloud Speech-to-Textのクラウド文字起こしです。長時間録音は音声を分割して複数の認識リクエストで処理します。"
     },
     "category": "transcription",
     "iconSystemName": "globe.badge.chevron.backward",

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Local speech-to-text and translation by IBM, powered by MLX on Apple Silicon. 6 languages with bidirectional translation.",
     "descriptions": {
-        "de": "Lokale Spracherkennung und Übersetzung von IBM mit MLX auf Apple Silicon. 6 Sprachen mit bidirektionaler Übersetzung."
+        "de": "Lokale Spracherkennung und Übersetzung von IBM mit MLX auf Apple Silicon. 6 Sprachen mit bidirektionaler Übersetzung.",
+        "ja": "Apple Silicon上のMLXで動作するIBMのローカル音声認識と翻訳です。6言語の双方向翻訳に対応します。"
     },
     "category": "transcription",
     "iconSystemName": "cpu",

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription and LLM via Groq API. Fast inference, requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription und LLM über die Groq-API. Schnelle Inferenz, erfordert API-Key."
+        "de": "Cloud-Transkription und LLM über die Groq-API. Schnelle Inferenz, erfordert API-Key.",
+        "ja": "Groq APIによるクラウド文字起こしとLLMです。高速推論に対応し、APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm"],
+    "categories": [
+        "transcription",
+        "llm"
+    ],
     "iconSystemName": "bolt.fill",
     "iconURL": "https://www.typewhisper.com/brand-logos/groq/logo.svg",
     "principalClass": "GroqPlugin",

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Create Linear issues from transcribed or processed text. Requires a Linear API key.",
     "descriptions": {
-        "de": "Linear-Issues aus transkribiertem oder verarbeitetem Text erstellen. Erfordert einen Linear-API-Key."
+        "de": "Linear-Issues aus transkribiertem oder verarbeitetem Text erstellen. Erfordert einen Linear-API-Key.",
+        "ja": "文字起こし済みまたは処理済みのテキストからLinearのIssueを作成します。Linear APIキーが必要です。"
     },
     "category": "action",
     "iconSystemName": "list.bullet.rectangle",

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Show a floating live transcript window during recording.",
     "descriptions": {
-        "de": "Zeigt ein schwebendes Live-Transkript-Fenster während der Aufnahme."
+        "de": "Zeigt ein schwebendes Live-Transkript-Fenster während der Aufnahme.",
+        "ja": "録音中にフローティングのライブ文字起こしウィンドウを表示します。"
     },
     "category": "utility",
     "iconSystemName": "text.bubble",

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "MinerAle",
     "description": "LLM provider and cloud speech transcription via Mistral AI API. Requires API key.",
     "descriptions": {
-        "de": "LLM-Anbieter und Cloud-Spracherkennung über die Mistral AI API. Erfordert API-Key."
+        "de": "LLM-Anbieter und Cloud-Spracherkennung über die Mistral AI API. Erfordert API-Key.",
+        "ja": "Mistral AI APIによるLLMプロバイダーとクラウド音声文字起こしです。APIキーが必要です。"
     },
     "category": "transcription",
     "categories": [

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Save transcriptions to your Obsidian vault as Markdown notes. Supports daily notes, frontmatter, and auto-export.",
     "descriptions": {
-        "de": "Transkriptionen als Markdown-Notizen in deinem Obsidian-Vault speichern. Unterstützt Tagesnotizen, Frontmatter und Auto-Export."
+        "de": "Transkriptionen als Markdown-Notizen in deinem Obsidian-Vault speichern. Unterstützt Tagesnotizen, Frontmatter und Auto-Export.",
+        "ja": "文字起こしをMarkdownノートとしてObsidian Vaultに保存します。デイリーノート、frontmatter、自動エクスポートに対応します。"
     },
     "category": "action",
     "iconSystemName": "doc.text",

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "Connect to any OpenAI-compatible API server for transcription and LLM. Works with Ollama, LM Studio, vLLM, and more.",
     "descriptions": {
-        "de": "Verbindung zu jedem OpenAI-kompatiblen API-Server für Transkription und LLM. Funktioniert mit Ollama, LM Studio, vLLM und mehr."
+        "de": "Verbindung zu jedem OpenAI-kompatiblen API-Server für Transkription und LLM. Funktioniert mit Ollama, LM Studio, vLLM und mehr.",
+        "ja": "文字起こしとLLM用に任意のOpenAI互換APIサーバーへ接続します。Ollama、LM Studio、vLLMなどで動作します。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm"],
+    "categories": [
+        "transcription",
+        "llm"
+    ],
     "iconSystemName": "server.rack",
     "principalClass": "OpenAICompatiblePlugin",
     "detailsURL": "https://www.typewhisper.com/addons/openai-compatible/"

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
@@ -8,10 +8,15 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription, OpenAI/ChatGPT prompts, and text-to-speech. Use an API key for STT/TTS or ChatGPT login for prompts.",
     "descriptions": {
-        "de": "Cloud-Transkription, OpenAI-/ChatGPT-Prompts und Text-to-Speech. STT/TTS brauchen einen API-Key, Prompts funktionieren auch per ChatGPT-Login."
+        "de": "Cloud-Transkription, OpenAI-/ChatGPT-Prompts und Text-to-Speech. STT/TTS brauchen einen API-Key, Prompts funktionieren auch per ChatGPT-Login.",
+        "ja": "クラウド文字起こし、OpenAI/ChatGPTプロンプト、音声合成に対応します。音声認識/音声合成にはAPIキー、プロンプトにはChatGPTログインを使用できます。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm", "tts"],
+    "categories": [
+        "transcription",
+        "llm",
+        "tts"
+    ],
     "hosting": "cloud",
     "iconSystemName": "brain",
     "iconURL": "https://www.typewhisper.com/brand-logos/openai/logo-light.svg",

--- a/TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Store and search memories using the OpenAI Vector Store API with semantic embeddings.",
     "descriptions": {
-        "de": "Speichert und durchsucht Erinnerungen über die OpenAI Vector Store API mit semantischen Embeddings."
+        "de": "Speichert und durchsucht Erinnerungen über die OpenAI Vector Store API mit semantischen Embeddings.",
+        "ja": "OpenAI Vector Store APIとセマンティック埋め込みを使ってメモリを保存・検索します。"
     },
     "category": "memory",
     "iconSystemName": "brain",

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "Access OpenRouter speech-to-text models and 300+ LLMs from OpenAI, Anthropic, Meta, Google and more. Shows model pricing and account balance. Requires API key.",
     "descriptions": {
-        "de": "Zugriff auf OpenRouter-Spracherkennungsmodelle und über 300 LLMs von OpenAI, Anthropic, Meta, Google und mehr. Zeigt Modellpreise und Kontoguthaben. Erfordert API-Key."
+        "de": "Zugriff auf OpenRouter-Spracherkennungsmodelle und über 300 LLMs von OpenAI, Anthropic, Meta, Google und mehr. Zeigt Modellpreise und Kontoguthaben. Erfordert API-Key.",
+        "ja": "OpenAI、Anthropic、Meta、GoogleなどのOpenRouter音声認識モデルと300以上のLLMにアクセスできます。モデル料金とアカウント残高を表示し、APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm"],
+    "categories": [
+        "transcription",
+        "llm"
+    ],
     "iconSystemName": "globe",
     "iconURL": "https://www.typewhisper.com/brand-logos/openrouter/logo-light.svg",
     "iconDarkURL": "https://www.typewhisper.com/brand-logos/openrouter/logo-dark.svg",

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by NVIDIA Parakeet TDT. Fast and accurate, 25 languages.",
     "descriptions": {
-        "de": "Lokale Spracherkennung mit NVIDIA Parakeet TDT. Schnell und präzise, 25 Sprachen."
+        "de": "Lokale Spracherkennung mit NVIDIA Parakeet TDT. Schnell und präzise, 25 Sprachen.",
+        "ja": "NVIDIA Parakeet TDTによるローカル音声認識です。高速かつ高精度で、25言語に対応します。"
     },
     "category": "transcription",
     "capabilities": [

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Local Qwen3-ASR speech-to-text powered by MLX on Apple Silicon. 30 languages plus Chinese dialect coverage, no API key required.",
     "descriptions": {
-        "de": "Lokale Qwen3-ASR-Spracherkennung mit MLX auf Apple Silicon. 30 Sprachen plus chinesische Dialektabdeckung, kein API-Key nötig."
+        "de": "Lokale Qwen3-ASR-Spracherkennung mit MLX auf Apple Silicon. 30 Sprachen plus chinesische Dialektabdeckung, kein API-Key nötig.",
+        "ja": "Apple Silicon上のMLXで動作するローカルQwen3-ASR音声認識です。30言語と中国語方言に対応し、APIキーは不要です。"
     },
     "category": "transcription",
     "iconSystemName": "cpu",

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "Y. Vos",
     "description": "Cloud transcription via Reson8 speech-to-text API with real-time WebSocket streaming. Requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Reson8-Speech-to-Text-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key."
+        "de": "Cloud-Transkription über die Reson8-Speech-to-Text-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key.",
+        "ja": "Reson8音声認識APIによるクラウド文字起こしです。リアルタイムWebSocketストリーミングに対応し、APIキーが必要です。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
@@ -12,5 +12,8 @@
     "iconSystemName": "waveform.badge.mic",
     "principalClass": "SaluteSpeechPlugin",
     "requiresAPIKey": true,
-    "detailsURL": "https://developers.sber.ru/docs/ru/salutespeech/quick-start/integration-individuals"
+    "detailsURL": "https://developers.sber.ru/docs/ru/salutespeech/quick-start/integration-individuals",
+    "descriptions": {
+        "ja": "Sber SaluteSpeech REST APIによるクラウド文字起こしです。SaluteSpeech Authorization Keyが必要です。"
+    }
 }

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
@@ -14,6 +14,7 @@
     "requiresAPIKey": true,
     "detailsURL": "https://developers.sber.ru/docs/ru/salutespeech/quick-start/integration-individuals",
     "descriptions": {
+        "de": "Cloud-Transkription über die Sber SaluteSpeech REST API. Erfordert einen SaluteSpeech Authorization Key.",
         "ja": "Sber SaluteSpeech REST APIによるクラウド文字起こしです。SaluteSpeech Authorization Keyが必要です。"
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ScriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ScriptPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Post-process transcribed text through custom shell scripts. Pass text via stdin, get results via stdout.",
     "descriptions": {
-        "de": "Transkribierten Text durch eigene Shell-Skripte nachbearbeiten. Text wird per stdin übergeben, Ergebnis per stdout zurückgegeben."
+        "de": "Transkribierten Text durch eigene Shell-Skripte nachbearbeiten. Text wird per stdin übergeben, Ergebnis per stdout zurückgegeben.",
+        "ja": "カスタムシェルスクリプトで文字起こしテキストを後処理します。stdinでテキストを渡し、stdoutから結果を受け取ります。"
     },
     "category": "post-processor",
     "iconSystemName": "terminal",

--- a/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via the Smallest AI Pulse STT API. Requires a Smallest API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Smallest AI Pulse STT API. Erfordert einen Smallest API-Key."
+        "de": "Cloud-Transkription über die Smallest AI Pulse STT API. Erfordert einen Smallest API-Key.",
+        "ja": "Smallest AI Pulse STT APIによるクラウド文字起こしです。Smallest APIキーが必要です。"
     },
     "category": "transcription",
     "hosting": "cloud",

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -8,10 +8,14 @@
     "author": "TypeWhisper",
     "description": "Cloud speech-to-text and text-to-speech via Soniox APIs with regional endpoint support. Requires API key.",
     "descriptions": {
-        "de": "Cloud Speech-to-Text und Text-to-Speech über Soniox APIs mit regionaler Endpunkt-Auswahl. Erfordert API-Key."
+        "de": "Cloud Speech-to-Text und Text-to-Speech über Soniox APIs mit regionaler Endpunkt-Auswahl. Erfordert API-Key.",
+        "ja": "Soniox APIによるクラウド音声認識と音声合成です。リージョン別エンドポイントに対応し、APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "tts"],
+    "categories": [
+        "transcription",
+        "tts"
+    ],
     "capabilities": [
         "source-footage-progress"
     ],

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "On-device speech recognition using Apple's Speech framework. Requires macOS 26+, streaming support.",
     "descriptions": {
-        "de": "Gerätebasierte Spracherkennung mit Apples Speech-Framework. Erfordert macOS 26+, Streaming-Unterstützung."
+        "de": "Gerätebasierte Spracherkennung mit Apples Speech-Framework. Erfordert macOS 26+, Streaming-Unterstützung.",
+        "ja": "Apple Speechフレームワークを使うオンデバイス音声認識です。macOS 26以降が必要で、ストリーミングに対応します。"
     },
     "category": "transcription",
     "iconSystemName": "apple.logo",

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Cloud transcription via Speechmatics API with real-time WebSocket streaming. Requires API key.",
     "descriptions": {
-        "de": "Cloud-Transkription über die Speechmatics-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key."
+        "de": "Cloud-Transkription über die Speechmatics-API mit Echtzeit-WebSocket-Streaming. Erfordert API-Key.",
+        "ja": "Speechmatics APIによるクラウド文字起こしです。リアルタイムWebSocketストリーミングに対応し、APIキーが必要です。"
     },
     "category": "transcription",
     "iconSystemName": "waveform.badge.mic",

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Experimental local text-to-speech with Supertonic 3 ONNX models. Requires accepting the OpenRAIL-M model license before downloading model assets.",
     "descriptions": {
-        "de": "Experimentelles lokales Text-to-Speech mit Supertonic-3-ONNX-Modellen. Vor dem Download der Modellassets muss die OpenRAIL-M-Modelllizenz akzeptiert werden."
+        "de": "Experimentelles lokales Text-to-Speech mit Supertonic-3-ONNX-Modellen. Vor dem Download der Modellassets muss die OpenRAIL-M-Modelllizenz akzeptiert werden.",
+        "ja": "Supertonic 3 ONNXモデルによる実験的なローカル音声合成です。モデルアセットのダウンロード前にOpenRAIL-Mモデルライセンスへの同意が必要です。"
     },
     "category": "tts",
     "categories": [

--- a/TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Text-to-speech via the built-in macOS AVSpeechSynthesizer voices for spoken feedback.",
     "descriptions": {
-        "de": "Text-zu-Sprache über die integrierten macOS-AVSpeechSynthesizer-Stimmen für gesprochenes Feedback."
+        "de": "Text-zu-Sprache über die integrierten macOS-AVSpeechSynthesizer-Stimmen für gesprochenes Feedback.",
+        "ja": "macOS標準のAVSpeechSynthesizer音声を使って、読み上げフィードバック用の音声合成を行います。"
     },
     "category": "tts",
     "iconSystemName": "speaker.wave.2.fill",

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by Voxtral MLX on Apple Silicon. Fast and accurate.",
     "descriptions": {
-        "de": "Lokale Spracherkennung mit Voxtral MLX auf Apple Silicon. Schnell und präzise."
+        "de": "Lokale Spracherkennung mit Voxtral MLX auf Apple Silicon. Schnell und präzise.",
+        "ja": "Apple Silicon上のVoxtral MLXで動作するローカル音声認識です。高速かつ高精度です。"
     },
     "category": "transcription",
     "iconSystemName": "cpu",

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
@@ -8,7 +8,8 @@
     "author": "TypeWhisper",
     "description": "Send transcribed or processed text to any webhook URL via HTTP POST.",
     "descriptions": {
-        "de": "Transkribierten oder verarbeiteten Text per HTTP POST an eine beliebige Webhook-URL senden."
+        "de": "Transkribierten oder verarbeiteten Text per HTTP POST an eine beliebige Webhook-URL senden.",
+        "ja": "文字起こし済みまたは処理済みのテキストをHTTP POSTで任意のWebhook URLへ送信します。"
     },
     "category": "post-processor",
     "iconSystemName": "arrow.up.forward.app",

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -11,7 +11,8 @@
     "author": "TypeWhisper",
     "description": "Local speech-to-text powered by WhisperKit. 8 model sizes, 99 languages, streaming support.",
     "descriptions": {
-        "de": "Lokale Spracherkennung mit WhisperKit. 8 Modellgrößen, 99 Sprachen, Streaming-Unterstützung."
+        "de": "Lokale Spracherkennung mit WhisperKit. 8 Modellgrößen, 99 Sprachen, Streaming-Unterstützung.",
+        "ja": "WhisperKitによるローカル音声認識です。8種類のモデルサイズ、99言語、ストリーミングに対応します。"
     },
     "category": "transcription",
     "capabilities": [

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
@@ -8,10 +8,15 @@
     "author": "TypeWhisper",
     "description": "Cloud LLM, speech-to-text, and text-to-speech via xAI Grok APIs. Requires an xAI API key.",
     "descriptions": {
-        "de": "Cloud-LLM, Speech-to-Text und Text-to-Speech über xAI-Grok-APIs. Erfordert einen xAI API-Key."
+        "de": "Cloud-LLM, Speech-to-Text und Text-to-Speech über xAI-Grok-APIs. Erfordert einen xAI API-Key.",
+        "ja": "xAI Grok APIによるクラウドLLM、音声認識、音声合成です。xAI APIキーが必要です。"
     },
     "category": "transcription",
-    "categories": ["transcription", "llm", "tts"],
+    "categories": [
+        "transcription",
+        "llm",
+        "tts"
+    ],
     "hosting": "cloud",
     "iconSystemName": "sparkles",
     "iconURL": "https://www.typewhisper.com/brand-logos/xai/logo-light.svg",


### PR DESCRIPTION
## Summary
- Localize newly added spoken punctuation settings and punctuation strategy/status labels in Japanese
- Rename the Japanese Integrations navigation and plugin-management copy to プラグイン where it refers to the plugin catalog
- Add Japanese descriptions for plugin manifests so plugin cards show localized summaries
- Polish System Audio Recorder Japanese copy

## Tests
- xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' build
- xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginManifestValidationTests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Expanded Japanese language support across the app and plugin catalog.
  * Fully localized Spoken Punctuation settings, verification UI, and related guidance/empty states.
  * Refreshed Japanese terminology (e.g., “Integrations” → “Plugins”) in setup and recorder-related text.
  * Added Japanese (`ja`) manifest descriptions to many plugins (alongside existing German `de`); also normalized some manifest formatting.
* **Refactor**
  * Updated user-facing punctuation strategy and verification status text to use localized strings for consistent internationalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->