### PR TITLE
Allow trusted contributors through PR Guard

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -46,7 +46,7 @@ jobs:
             }
 
             const isBot = author.endsWith('[bot]');
-            const isInternal = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+            const isTrustedHuman = !isBot && ['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR'].includes(association);
             const isAllowlisted = defaultAllowlist.has(author);
 
             const upsertComment = async (body) => {
@@ -88,7 +88,7 @@ jobs:
               }
             };
 
-            if (isAllowlisted || isInternal) {
+            if (isAllowlisted || isTrustedHuman) {
               core.info(`PR Guard: allowing ${author} (${association})`);
               return;
             }


### PR DESCRIPTION
## Summary
- allow trusted human contributors through PR Guard without requiring a per-user allowlist entry
- keep non-allowlisted bot PRs blocked even if their author association is trusted

## Context
PR #749 is currently blocked by PR Guard because `personaltrainerkoichan` has `author_association=CONTRIBUTOR` and another open PR. Contributors already have accepted history in the repository, so they should be treated as trusted human authors for this concurrency check.

## Test plan
- `sed -n '1,160p' .github/workflows/pr-guard.yml`
- Node simulation covering `CONTRIBUTOR`, `NONE`, `COLLABORATOR`, a non-allowlisted bot, and `dependabot[bot]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR validation logic to recognize contributor accounts as trusted, streamlining PR processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->