### PR TITLE
Fix Qwen3 French trailing oui cleanup

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -531,7 +531,7 @@ enum QwenTranscriptGuard {
 
         let artifactPattern = #"(?i)[.!?;:]\s+oui[.!?]*$"#
         guard let artifactRange = trimmed.range(of: artifactPattern, options: .regularExpression) else {
-            return text
+            return removingBareTrailingOuiArtifact(from: trimmed) ?? text
         }
 
         let artifact = String(trimmed[artifactRange])
@@ -542,6 +542,22 @@ enum QwenTranscriptGuard {
         guard !prefix.isEmpty else { return text }
 
         return "\(prefix)\(punctuation)"
+    }
+
+    private static func removingBareTrailingOuiArtifact(from text: String) -> String? {
+        let artifactPattern = #"(?i)(?:,\s+|\s+)oui[.!?]*$"#
+        guard let artifactRange = text.range(of: artifactPattern, options: .regularExpression) else {
+            return nil
+        }
+
+        let prefix = text[..<artifactRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixWords = words(in: String(prefix))
+        guard prefixWords.count >= 4, prefixWords.last != "que" else {
+            return nil
+        }
+
+        return String(prefix)
     }
 
     static func isLikelyLooped(_ text: String) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -69,6 +69,30 @@ final class Qwen3PluginTests: XCTestCase {
         )
     }
 
+    func testFrenchTrailingOuiArtifactIsRemovedAfterLongBarePhrase() {
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(
+                from: "Je vais envoyer le fichier oui",
+                languageName: "French"
+            ),
+            "Je vais envoyer le fichier"
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(
+                from: "Je vais envoyer le fichier, oui.",
+                languageName: "French"
+            ),
+            "Je vais envoyer le fichier"
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(
+                from: "Je vais envoyer le fichier Oui!",
+                languageName: "French"
+            ),
+            "Je vais envoyer le fichier"
+        )
+    }
+
     func testFrenchTrailingOuiGuardPreservesRealOuiUsages() {
         XCTAssertEqual(
             QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "Oui.", languageName: "French"),
@@ -77,6 +101,14 @@ final class Qwen3PluginTests: XCTestCase {
         XCTAssertEqual(
             QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "Je pense que oui.", languageName: "French"),
             "Je pense que oui."
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "Je suis certain que oui.", languageName: "French"),
+            "Je suis certain que oui."
+        )
+        XCTAssertEqual(
+            QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "Je confirme oui.", languageName: "French"),
+            "Je confirme oui."
         )
         XCTAssertEqual(
             QwenTranscriptGuard.removingLikelyTrailingArtifact(from: "I will send it. oui", languageName: "English"),


### PR DESCRIPTION
## Summary
- expands the French-only Qwen3 trailing `oui` guard to catch bare or comma-separated final `oui` artifacts after longer French transcripts
- preserves short/affirmative real `oui` usages such as `Oui.`, `Je pense que oui.`, and `Je confirme oui.`
- adds focused Qwen3 plugin tests for the reported follow-up variants

## Issue Context
Issue #743 reports that Qwen3 1.7B 8-bit frequently appends an extra standalone `oui` to French dictation. This is a follow-up to the earlier #489 fix: the existing guard handled punctuation-separated endings like `. oui`, but did not cover a bare final ` oui` or comma-separated `, oui`.

Closes #743

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme Qwen3Plugin -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`\n- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run Qwen3Plugin /Users/marco/.codex/worktrees/158c/typewhisper-mac`\n- `codesign --verify --deep --strict --verbose=2 '/Users/marco/Library/Application Support/TypeWhisper-Dev/Plugins/Qwen3Plugin.bundle'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved French language transcription accuracy by refining the detection and removal of trailing artifacts, ensuring legitimate words are preserved in longer transcriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->