### PR TITLE
fix: restore built-in mic capture during FaceTime

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -2248,14 +2248,67 @@ enum AudioInputBufferNormalizer {
         }
 
         monoBuffer.frameLength = buffer.frameLength
+        let selectedChannel = strongestChannelIndex(
+            sourceChannels: sourceChannels,
+            frameCount: frameCount,
+            channelCount: channelCount,
+            isInterleaved: buffer.format.isInterleaved
+        )
+
         for frameIndex in 0..<frameCount {
-            var sum: Float = 0
-            for channelIndex in 0..<channelCount {
-                sum += sourceChannels[channelIndex][frameIndex]
-            }
-            monoChannel[frameIndex] = sum / Float(channelCount)
+            monoChannel[frameIndex] = sample(
+                sourceChannels: sourceChannels,
+                frameIndex: frameIndex,
+                channelIndex: selectedChannel,
+                channelCount: channelCount,
+                isInterleaved: buffer.format.isInterleaved
+            )
         }
         return monoBuffer
+    }
+
+    private static func strongestChannelIndex(
+        sourceChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        frameCount: Int,
+        channelCount: Int,
+        isInterleaved: Bool
+    ) -> Int {
+        var bestChannel = 0
+        var bestEnergy: Float = -1
+
+        for channelIndex in 0..<channelCount {
+            var energy: Float = 0
+            for frameIndex in 0..<frameCount {
+                let value = sample(
+                    sourceChannels: sourceChannels,
+                    frameIndex: frameIndex,
+                    channelIndex: channelIndex,
+                    channelCount: channelCount,
+                    isInterleaved: isInterleaved
+                )
+                energy += value * value
+            }
+
+            if energy > bestEnergy {
+                bestEnergy = energy
+                bestChannel = channelIndex
+            }
+        }
+
+        return bestChannel
+    }
+
+    private static func sample(
+        sourceChannels: UnsafePointer<UnsafeMutablePointer<Float>>,
+        frameIndex: Int,
+        channelIndex: Int,
+        channelCount: Int,
+        isInterleaved: Bool
+    ) -> Float {
+        if isInterleaved {
+            return sourceChannels[0][frameIndex * channelCount + channelIndex]
+        }
+        return sourceChannels[channelIndex][frameIndex]
     }
 }
 

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import AVFoundation
+import CoreAudio
 import ScreenCaptureKit
 import Combine
 import os
@@ -460,6 +461,8 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     var currentBufferOverride: (() -> [Float])?
 
     private var audioEngine: AVAudioEngine?
+    private let micDefaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController()
+    private let micTransportResolver: AudioDeviceTransportResolving = CoreAudioDeviceTransportResolver()
     private let micFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
     private var scStream: SCStream?
     private var streamOutput: SystemAudioStreamOutput?
@@ -765,10 +768,14 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     private func startMicRecording(outputURL: URL) throws {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
+        var inputFormat = inputNode.outputFormat(forBus: 0)
 
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
             throw RecorderError.engineStartFailed("No audio input available")
+        }
+
+        if try enableMicVoiceProcessingIfNeeded(on: inputNode, currentFormat: inputFormat) {
+            inputFormat = inputNode.outputFormat(forBus: 0)
         }
 
         // Write at native format to preserve quality
@@ -792,11 +799,15 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             interleaved: false
         )!
 
+        let tapFormat = Self.micTapFormat(for: inputFormat)
+        let converterInputFormat = tapFormat.channelCount == 1
+            ? tapFormat
+            : (AudioInputBufferNormalizer.monoFloatFormat(for: tapFormat) ?? tapFormat)
         let converter: AVAudioConverter?
-        if inputFormat.channelCount > 1 || inputFormat.commonFormat != .pcmFormatFloat32 {
-            converter = AVAudioConverter(from: inputFormat, to: monoFormat)
-        } else {
+        if Self.audioFormatsMatch(converterInputFormat, monoFormat) {
             converter = nil
+        } else {
+            converter = AVAudioConverter(from: converterInputFormat, to: monoFormat)
         }
 
         // 16kHz converter for transcription buffer
@@ -812,12 +823,13 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
         micFileLock.withLock { $0 = audioFile }
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { [weak self] buffer, _ in
             guard let self else { return }
+            guard let micBuffer = Self.normalizedMicInputBuffer(buffer) else { return }
 
             let writeBuffer: AVAudioPCMBuffer
             if let converter {
-                let frameCount = AVAudioFrameCount(buffer.frameLength)
+                let frameCount = AVAudioFrameCount(micBuffer.frameLength)
                 guard let converted = AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: frameCount) else { return }
                 var error: NSError?
                 let consumed = OSAllocatedUnfairLock(initialState: false)
@@ -832,12 +844,12 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
                         return nil
                     }
                     outStatus.pointee = .haveData
-                    return buffer
+                    return micBuffer
                 }
                 guard error == nil, converted.frameLength > 0 else { return }
                 writeBuffer = converted
             } else {
-                writeBuffer = buffer
+                writeBuffer = micBuffer
             }
 
             // Calculate level
@@ -892,6 +904,66 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
         try engine.start()
         audioEngine = engine
+    }
+
+    private func enableMicVoiceProcessingIfNeeded(
+        on inputNode: AVAudioInputNode,
+        currentFormat: AVAudioFormat
+    ) throws -> Bool {
+        guard currentFormat.channelCount == 3,
+              defaultInputUsesBuiltInTransport() else {
+            return false
+        }
+
+        do {
+            try inputNode.setVoiceProcessingEnabled(true)
+            inputNode.isVoiceProcessingBypassed = false
+            inputNode.isVoiceProcessingAGCEnabled = true
+            inputNode.isVoiceProcessingInputMuted = false
+            logger.info("Recorder microphone enabled voice processing for 3-channel built-in default input")
+            return true
+        } catch {
+            logger.warning("Recorder microphone could not enable voice processing for 3-channel built-in default input: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    private func defaultInputUsesBuiltInTransport() -> Bool {
+        guard let defaultInputDeviceID = micDefaultInputController.defaultInputDeviceID(),
+              let transportType = micTransportResolver.transportType(for: defaultInputDeviceID) else {
+            return false
+        }
+        return transportType == kAudioDeviceTransportTypeBuiltIn
+    }
+
+    private static func micTapFormat(for inputFormat: AVAudioFormat) -> AVAudioFormat {
+        if inputFormat.channelCount == 3 {
+            return inputFormat
+        }
+        if inputFormat.channelCount > 1,
+           let mono = AVAudioFormat(
+               commonFormat: .pcmFormatFloat32,
+               sampleRate: inputFormat.sampleRate,
+               channels: 1,
+               interleaved: false
+           ) {
+            return mono
+        }
+        return inputFormat
+    }
+
+    private static func normalizedMicInputBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard buffer.format.channelCount > 1 else {
+            return buffer
+        }
+        return AudioInputBufferNormalizer.monoFloatBuffer(from: buffer)
+    }
+
+    private static func audioFormatsMatch(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+        lhs.sampleRate == rhs.sampleRate
+            && lhs.channelCount == rhs.channelCount
+            && lhs.commonFormat == rhs.commonFormat
+            && lhs.isInterleaved == rhs.isInterleaved
     }
 
     // MARK: - System Audio Recording

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -1,6 +1,7 @@
 import Foundation
 @preconcurrency import AVFoundation
 import AudioToolbox
+import CoreAudio
 import AppKit
 import Combine
 import os
@@ -196,6 +197,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing
     private let inputReadinessChecker: AudioInputReadinessChecking
     private let inputCaptureFactory: AudioInputCaptureFactory
+    private let defaultInputController: AudioInputDeviceDefaultControlling
+    private let inputTransportResolver: AudioDeviceTransportResolving
     private let initialInputTapSeenLock = OSAllocatedUnfairLock(initialState: false)
     private var _lastStopGraceCaptureApplied = false
     private var recordingRequestUptimeNanoseconds: UInt64?
@@ -211,6 +214,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
         inputReadinessChecker: AudioInputReadinessChecking = BluetoothInputReadinessChecker(),
         inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory(),
+        defaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController(),
+        inputTransportResolver: AudioDeviceTransportResolving = CoreAudioDeviceTransportResolver(),
         recoveryAudioStore: DictationRecoveryAudioStore = DictationRecoveryAudioStore()
     ) {
         self.outputVolumeGuard = outputVolumeGuard
@@ -218,6 +223,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         self.bluetoothInputRouteStabilizer = bluetoothInputRouteStabilizer
         self.inputReadinessChecker = inputReadinessChecker
         self.inputCaptureFactory = inputCaptureFactory
+        self.defaultInputController = defaultInputController
+        self.inputTransportResolver = inputTransportResolver
         self.recoveryAudioStore = recoveryAudioStore
         let recoveryURLs = recoveryAudioStore.recoveryURLs
         self.recoverableRecordingURLs = recoveryURLs
@@ -301,7 +308,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     /// Focusrite Scarlett) to mono. By requesting a mono tap format, AVAudioEngine
     /// performs the channel downmix internally — which handles arbitrary layouts
     /// correctly — and the converter only needs to resample.
-    private static func monoTapFormat(for inputFormat: AVAudioFormat) -> AVAudioFormat {
+    private static func tapFormat(for inputFormat: AVAudioFormat) -> AVAudioFormat {
+        if inputFormat.channelCount == 3 {
+            return inputFormat
+        }
         if inputFormat.channelCount > 1,
            let mono = AVAudioFormat(
                commonFormat: .pcmFormatFloat32,
@@ -728,7 +738,19 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         let inputNode = engine.inputNode
-        let inputFormat = try settledInputFormat(for: inputNode, preferredDeviceID: inputRoute.engineDeviceID, label: label)
+        var inputFormat = try settledInputFormat(for: inputNode, preferredDeviceID: inputRoute.engineDeviceID, label: label)
+        if try enableVoiceProcessingIfNeeded(
+            on: inputNode,
+            inputRoute: inputRoute,
+            currentFormat: inputFormat,
+            label: label
+        ) {
+            inputFormat = try settledInputFormat(
+                for: inputNode,
+                preferredDeviceID: inputRoute.engineDeviceID,
+                label: "\(label)-voice-processing"
+            )
+        }
         logger.info("\(label, privacy: .public) input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
 
         try validateRecordingInputFormat(inputFormat, preferredDeviceID: inputRoute.engineDeviceID)
@@ -745,9 +767,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let currentInputFormat = try settledInputFormat(for: inputNode, preferredDeviceID: inputRoute.engineDeviceID, label: "\(label)-tap")
         try validateTapInstallationPreconditions(expected: inputFormat, current: currentInputFormat)
 
-        let tapFormat = Self.monoTapFormat(for: currentInputFormat)
+        let tapFormat = Self.tapFormat(for: currentInputFormat)
+        let converterInputFormat = tapFormat.channelCount == 1
+            ? tapFormat
+            : (AudioInputBufferNormalizer.monoFloatFormat(for: tapFormat) ?? tapFormat)
 
-        guard let converter = AVAudioConverter(from: tapFormat, to: targetFormat) else {
+        guard let converter = AVAudioConverter(from: converterInputFormat, to: targetFormat) else {
             throw AudioRecordingError.engineStartFailed("Cannot create audio converter")
         }
 
@@ -756,8 +781,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         do {
             _ = try ObjCExceptionCatcher.catching {
                 inputNode.installTap(onBus: 0, bufferSize: Self.captureTapFrames, format: tapFormat) { [weak self] buffer, _ in
-                    self?.markInitialInputTapSeenIfNeeded(buffer)
-                    self?.processAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
+                    guard let normalizedBuffer = Self.normalizedInputBuffer(buffer) else {
+                        return
+                    }
+                    self?.markInitialInputTapSeenIfNeeded(normalizedBuffer)
+                    self?.processAudioBuffer(normalizedBuffer, converter: converter, targetFormat: targetFormat)
                 }
             }
         } catch {
@@ -938,6 +966,47 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func markInitialInputTapSeenIfNeeded(_ buffer: AVAudioPCMBuffer) {
         guard AudioInputSignal.containsSignal(buffer) else { return }
         initialInputTapSeenLock.withLock { $0 = true }
+    }
+
+    private func enableVoiceProcessingIfNeeded(
+        on inputNode: AVAudioInputNode,
+        inputRoute: (selectedDeviceID: AudioDeviceID?, engineDeviceID: AudioDeviceID?),
+        currentFormat: AVAudioFormat,
+        label: String
+    ) throws -> Bool {
+        guard inputRoute.selectedDeviceID == nil,
+              inputRoute.engineDeviceID == nil,
+              currentFormat.channelCount == 3,
+              defaultInputUsesBuiltInTransport() else {
+            return false
+        }
+
+        do {
+            try inputNode.setVoiceProcessingEnabled(true)
+            inputNode.isVoiceProcessingBypassed = false
+            inputNode.isVoiceProcessingAGCEnabled = true
+            inputNode.isVoiceProcessingInputMuted = false
+            logger.info("\(label, privacy: .public) enabled voice processing for 3-channel built-in default input")
+            return true
+        } catch {
+            logger.warning("\(label, privacy: .public) could not enable voice processing for 3-channel built-in default input: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    private func defaultInputUsesBuiltInTransport() -> Bool {
+        guard let defaultInputDeviceID = defaultInputController.defaultInputDeviceID(),
+              let transportType = inputTransportResolver.transportType(for: defaultInputDeviceID) else {
+            return false
+        }
+        return transportType == kAudioDeviceTransportTypeBuiltIn
+    }
+
+    private static func normalizedInputBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard buffer.format.channelCount > 1 else {
+            return buffer
+        }
+        return AudioInputBufferNormalizer.monoFloatBuffer(from: buffer)
     }
 
     private func processAudioBuffer(

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -130,7 +130,7 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         )
     }
 
-    func testAudioInputBufferNormalizerDownmixesMultiChannelFloatBuffers() throws {
+    func testAudioInputBufferNormalizerSelectsStrongestNonInterleavedChannel() throws {
         let stereoFormat = try XCTUnwrap(AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 96_000,
@@ -146,7 +146,7 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         stereoBuffer.floatChannelData?[0][1] = 0.5
         stereoBuffer.floatChannelData?[0][2] = -1
         stereoBuffer.floatChannelData?[1][0] = -1
-        stereoBuffer.floatChannelData?[1][1] = 0.5
+        stereoBuffer.floatChannelData?[1][1] = 2
         stereoBuffer.floatChannelData?[1][2] = 1
 
         let monoBuffer = try XCTUnwrap(AudioInputBufferNormalizer.monoFloatBuffer(from: stereoBuffer))
@@ -154,9 +154,39 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertEqual(monoBuffer.format.sampleRate, 96_000)
         XCTAssertEqual(monoBuffer.format.channelCount, 1)
         let monoChannel = try XCTUnwrap(monoBuffer.floatChannelData?[0])
-        XCTAssertEqual(monoChannel[0], 0, accuracy: Float(0.0001))
-        XCTAssertEqual(monoChannel[1], 0.5, accuracy: Float(0.0001))
-        XCTAssertEqual(monoChannel[2], 0, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[0], -1, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[1], 2, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[2], 1, accuracy: Float(0.0001))
+    }
+
+    func testAudioInputBufferNormalizerReadsInterleavedMultiChannelBuffers() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 44_100,
+            channels: 2,
+            interleaved: true
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: 3
+        ))
+        buffer.frameLength = 3
+        let samples = try XCTUnwrap(buffer.floatChannelData?[0])
+        samples[0] = 0.01
+        samples[1] = 0.50
+        samples[2] = 0.01
+        samples[3] = -0.60
+        samples[4] = 0.01
+        samples[5] = 0.70
+
+        let monoBuffer = try XCTUnwrap(AudioInputBufferNormalizer.monoFloatBuffer(from: buffer))
+
+        XCTAssertEqual(monoBuffer.format.sampleRate, 44_100)
+        XCTAssertEqual(monoBuffer.format.channelCount, 1)
+        let monoChannel = try XCTUnwrap(monoBuffer.floatChannelData?[0])
+        XCTAssertEqual(monoChannel[0], 0.50, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[1], -0.60, accuracy: Float(0.0001))
+        XCTAssertEqual(monoChannel[2], 0.70, accuracy: Float(0.0001))
     }
 
     func testInputFormatStabilizerRejectsStaleDefaultFormatAfterBluetoothDeviceSwitch() {


### PR DESCRIPTION
## Summary
- enable `AVAudioInputNode` voice processing for the built-in 3-channel default input route that FaceTime exposes on macOS
- normalize multi-channel input by selecting the strongest speech channel instead of averaging active speech with quiet channels
- apply the same route-safe capture behavior to dictation and recorder microphone capture, without including the meeting calendar sync feature

## Context
This is an independent bugfix PR split out from the meeting auto-recording work. While testing FaceTime-triggered recording, the built-in MacBook microphone reported a 3-channel input route where speech was effectively lost by the normal mono path. The fix is scoped to the built-in default input route so Bluetooth/AirPods and explicitly selected external devices keep their existing behavior.

## Test plan
- [x] `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/facetime-mic/typewhisper-mac`
- [x] Live recorder API smoke with FaceTime open and built-in 3-channel input: session `04AD8C6C-F318-4C8E-9F1D-BE8EC8620EA3` completed with transcript and log `Recorder microphone enabled voice processing for 3-channel built-in default input`
- [x] Live dictation API smoke with FaceTime open and built-in 3-channel input: log `recording enabled voice processing for 3-channel built-in default input`, first buffer received, `peakLevel=0.0459`, decision `transcribe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio quality for multi-channel microphone inputs by selecting the strongest input channel instead of averaging all channels.
  * Enhanced support for 3-channel built-in microphone devices with automatic voice processing optimization and standardized audio preprocessing before transcription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->