### PR TITLE
fix: cleanup plugin keychain data on uninstall

### DIFF
--- a/TypeWhisper/Services/Cloud/KeychainService.swift
+++ b/TypeWhisper/Services/Cloud/KeychainService.swift
@@ -57,6 +57,37 @@ struct KeychainService: Sendable {
             throw KeychainError.deleteFailed(status)
         }
     }
+
+    static func deleteAll(withServicePrefix prefix: String) throws {
+        let fullServicePrefix = servicePrefix + prefix
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            if status == errSecItemNotFound {
+                return
+            }
+            throw KeychainError.deleteFailed(status)
+        }
+        
+        for item in items {
+            if let serviceName = item[kSecAttrService as String] as? String,
+               serviceName.hasPrefix(fullServicePrefix) {
+                let deleteQuery: [String: Any] = [
+                    kSecClass as String: kSecClassGenericPassword,
+                    kSecAttrService as String: serviceName
+                ]
+                SecItemDelete(deleteQuery as CFDictionary)
+            }
+        }
+    }
 }
 
 enum KeychainError: LocalizedError {

--- a/TypeWhisper/Services/Cloud/KeychainService.swift
+++ b/TypeWhisper/Services/Cloud/KeychainService.swift
@@ -1,9 +1,20 @@
 import Foundation
 import Security
 
+/// Provides a type-safe interface for storing, retrieving, and removing
+/// generic-password items in the system Keychain.
 struct KeychainService: Sendable {
     private static let servicePrefix = AppConstants.keychainServicePrefix
 
+    /// Saves `key` as a generic-password item in the Keychain under `service`.
+    ///
+    /// Any pre-existing item for the same service is removed before the new
+    /// value is written, ensuring the stored credential is always up-to-date.
+    ///
+    /// - Parameters:
+    ///   - key: The secret string to persist (e.g. an API key or token).
+    ///   - service: A logical service identifier appended to the shared prefix.
+    /// - Throws: `KeychainError.saveFailed` if the Keychain write fails.
     static func save(key: String, service: String) throws {
         let fullService = servicePrefix + service
         guard let data = key.data(using: .utf8) else { return }
@@ -28,6 +39,12 @@ struct KeychainService: Sendable {
         }
     }
 
+    /// Retrieves the secret string previously saved under `service`.
+    ///
+    /// - Parameter service: The logical service identifier used when the item
+    ///   was saved.
+    /// - Returns: The stored string, or `nil` if no matching item exists or the
+    ///   data cannot be decoded as UTF-8.
     static func load(service: String) -> String? {
         let fullService = servicePrefix + service
         let query: [String: Any] = [
@@ -45,6 +62,12 @@ struct KeychainService: Sendable {
         return String(data: data, encoding: .utf8)
     }
 
+    /// Removes the Keychain item associated with `service`.
+    ///
+    /// - Parameter service: The logical service identifier of the item to delete.
+    /// - Throws: `KeychainError.deleteFailed` if the Keychain returns an
+    ///   unexpected status. A `errSecItemNotFound` result is treated as a
+    ///   no-op and does **not** throw.
     static func delete(service: String) throws {
         let fullService = servicePrefix + service
         let query: [String: Any] = [
@@ -58,6 +81,17 @@ struct KeychainService: Sendable {
         }
     }
 
+    /// Deletes every Keychain item whose service attribute starts with
+    /// `servicePrefix + prefix`.
+    ///
+    /// All matching items are enumerated first; deletion is then attempted for
+    /// each one individually.  If any deletion fails the method continues
+    /// removing remaining items and throws `KeychainError.deleteFailed` with
+    /// the last failing status code once the loop completes.
+    ///
+    /// - Parameter prefix: The service-name prefix used to scope deletions.
+    /// - Throws: `KeychainError.deleteFailed` if one or more items could not
+    ///   be removed from the Keychain.
     static func deleteAll(withServicePrefix prefix: String) throws {
         let fullServicePrefix = servicePrefix + prefix
         
@@ -77,6 +111,7 @@ struct KeychainService: Sendable {
             throw KeychainError.deleteFailed(status)
         }
         
+        var failedStatus: OSStatus?
         for item in items {
             if let serviceName = item[kSecAttrService as String] as? String,
                serviceName.hasPrefix(fullServicePrefix) {
@@ -84,16 +119,27 @@ struct KeychainService: Sendable {
                     kSecClass as String: kSecClassGenericPassword,
                     kSecAttrService as String: serviceName
                 ]
-                SecItemDelete(deleteQuery as CFDictionary)
+                let deleteStatus = SecItemDelete(deleteQuery as CFDictionary)
+                if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
+                    failedStatus = deleteStatus
+                }
             }
+        }
+        if let status = failedStatus {
+            throw KeychainError.deleteFailed(status)
         }
     }
 }
 
+/// Errors that can be thrown by ``KeychainService`` operations.
 enum KeychainError: LocalizedError {
+    /// A Keychain write operation failed with the given `OSStatus` code.
     case saveFailed(OSStatus)
+    /// A Keychain delete operation failed with the given `OSStatus` code.
     case deleteFailed(OSStatus)
 
+    /// A human-readable description of the error, including the raw
+    /// `OSStatus` code to aid debugging.
     var errorDescription: String? {
         switch self {
         case .saveFailed(let status):

--- a/TypeWhisper/Services/Cloud/KeychainService.swift
+++ b/TypeWhisper/Services/Cloud/KeychainService.swift
@@ -94,23 +94,23 @@ struct KeychainService: Sendable {
     ///   be removed from the Keychain.
     static func deleteAll(withServicePrefix prefix: String) throws {
         let fullServicePrefix = servicePrefix + prefix
-        
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll
         ]
-        
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        
+
         guard status == errSecSuccess, let items = result as? [[String: Any]] else {
             if status == errSecItemNotFound {
                 return
             }
             throw KeychainError.deleteFailed(status)
         }
-        
+
         var failedStatus: OSStatus?
         for item in items {
             if let serviceName = item[kSecAttrService as String] as? String,

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -777,16 +777,26 @@ final class PluginRegistryService: ObservableObject {
         logger.info("Removing installed plugin bundle at \(bundleURL.path, privacy: .public)")
         try? FileManager.default.removeItem(at: bundleURL)
 
+        var keychainError: Error?
         if deleteData {
             let dataDir = AppConstants.appSupportDirectory
                 .appendingPathComponent("PluginData", isDirectory: true)
                 .appendingPathComponent(pluginId, isDirectory: true)
             try? FileManager.default.removeItem(at: dataDir)
-            try KeychainService.deleteAll(withServicePrefix: "\(pluginId).")
+            do {
+                try KeychainService.deleteAll(withServicePrefix: "\(pluginId).")
+            } catch {
+                logger.error("Keychain cleanup failed for \(pluginId): \(error.localizedDescription)")
+                keychainError = error
+            }
         }
 
         UserDefaults.standard.removeObject(forKey: "plugin.\(pluginId).enabled")
         logger.info("Uninstalled plugin: \(pluginId)")
+
+        if let error = keychainError {
+            throw error
+        }
     }
 
     // MARK: - Install from File

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -768,7 +768,7 @@ final class PluginRegistryService: ObservableObject {
 
     // MARK: - Uninstall
 
-    func uninstallPlugin(_ pluginId: String, deleteData: Bool = false) {
+    func uninstallPlugin(_ pluginId: String, deleteData: Bool = false) throws {
         guard let bundleURL = PluginManager.shared.bundleURL(for: pluginId) else { return }
 
         PluginManager.shared.unloadPlugin(pluginId)
@@ -782,7 +782,7 @@ final class PluginRegistryService: ObservableObject {
                 .appendingPathComponent("PluginData", isDirectory: true)
                 .appendingPathComponent(pluginId, isDirectory: true)
             try? FileManager.default.removeItem(at: dataDir)
-            try? KeychainService.deleteAll(withServicePrefix: "\(pluginId).")
+            try KeychainService.deleteAll(withServicePrefix: "\(pluginId).")
         }
 
         UserDefaults.standard.removeObject(forKey: "plugin.\(pluginId).enabled")

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -782,6 +782,7 @@ final class PluginRegistryService: ObservableObject {
                 .appendingPathComponent("PluginData", isDirectory: true)
                 .appendingPathComponent(pluginId, isDirectory: true)
             try? FileManager.default.removeItem(at: dataDir)
+            try? KeychainService.deleteAll(withServicePrefix: "\(pluginId).")
         }
 
         UserDefaults.standard.removeObject(forKey: "plugin.\(pluginId).enabled")

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -207,10 +207,10 @@ struct PluginSettingsView: View {
             Button(String(localized: "Uninstall"), role: .destructive) {
                 do {
                     try registryService.uninstallPlugin(plugin.id, deleteData: true)
-                    pluginToUninstall = nil
                 } catch {
                     uninstallError = error.localizedDescription
                 }
+                pluginToUninstall = nil
             }
             Button(String(localized: "Cancel"), role: .cancel) {
                 pluginToUninstall = nil

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -173,6 +173,7 @@ struct PluginSettingsView: View {
     @State private var pendingBoundaryUpgradePlugin: RegistryPlugin?
     @State private var pendingBoundaryUpgradeNotice: ExternalBundleNotice?
     @State private var installFromFileError: String?
+    @State private var uninstallError: String?
     @State private var includeCommunityPlugins = true
     @State private var selectedCapabilityFilters: Set<PluginCategory> = []
     @State private var searchText = ""
@@ -204,8 +205,12 @@ struct PluginSettingsView: View {
         }
         .alert(String(localized: "Uninstall Plugin"), isPresented: $showUninstallAlert, presenting: pluginToUninstall) { plugin in
             Button(String(localized: "Uninstall"), role: .destructive) {
-                registryService.uninstallPlugin(plugin.id, deleteData: true)
-                pluginToUninstall = nil
+                do {
+                    try registryService.uninstallPlugin(plugin.id, deleteData: true)
+                    pluginToUninstall = nil
+                } catch {
+                    uninstallError = error.localizedDescription
+                }
             }
             Button(String(localized: "Cancel"), role: .cancel) {
                 pluginToUninstall = nil
@@ -250,6 +255,16 @@ struct PluginSettingsView: View {
             Button(String(localized: "OK")) { installFromFileError = nil }
         } message: {
             if let error = installFromFileError {
+                Text(error)
+            }
+        }
+        .alert(String(localized: "Uninstall Failed"), isPresented: .init(
+            get: { uninstallError != nil },
+            set: { if !$0 { uninstallError = nil } }
+        )) {
+            Button(String(localized: "OK")) { uninstallError = nil }
+        } message: {
+            if let error = uninstallError {
                 Text(error)
             }
         }

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -19,5 +19,5 @@
     "iconURL": "https://www.typewhisper.com/brand-logos/mistral/logo.svg",
     "principalClass": "MistralAIPlugin",
     "requiresAPIKey": true,
-    "detailsURL": "https://mistral.ai/"
+    "detailsURL": "https://www.typewhisper.com/addons/mistral/"
 }


### PR DESCRIPTION
## Summary

When a plugin is uninstalled via the Plugin Settings, its local application data directory is correctly removed. However, any secure credentials (like API keys) previously saved to the macOS Keychain by the plugin were left behind. This PR ensures that all scoped keychain items belonging to a plugin are successfully purged alongside the plugin bundle and data.

* Added `deleteAll(withServicePrefix:)` to `KeychainService` to allow filtering and purging of all `GenericPassword` items that match a specific plugin's prefix.
* Updated `PluginRegistryService.uninstallPlugin` to invoke the keychain cleanup for the specific `pluginId` when `deleteData` is true.

## Test Plan

- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

**Verification Steps:**
1. Build and run the `TypeWhisper` macOS target.
2. Install a plugin that securely stores an API key (e.g., `GroqPlugin`).
3. Enter an API key in the plugin's settings to store it in the macOS Keychain.
4. Uninstall the plugin using the "Uninstall" button in the Plugin Settings (this sets `deleteData: true`).
5. Verify in the macOS Keychain Access app (or programmatically) that the API key for the plugin is no longer present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin uninstall cleanup: when cleanup is enabled, the app now deletes all stored credential data for the plugin in Keychain in addition to removing plugin files.
  * More reliable uninstall behavior when no matching credential entries exist, treating missing items as a no-op.
  * Keychain cleanup errors are no longer silently ignored; failures are surfaced instead of failing unpredictably.

* **UI Improvements**
  * Added user-visible feedback when plugin uninstallation fails, including a “Uninstall Failed” alert that displays the error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->