### PR TITLE
fix: export text-only file subtitles

### DIFF
--- a/TypeWhisper/Services/SubtitleExporter.swift
+++ b/TypeWhisper/Services/SubtitleExporter.swift
@@ -17,6 +17,18 @@ enum SubtitleFormat: String, CaseIterable {
 
 enum SubtitleExporter {
 
+    static func exportContent(for result: TranscriptionResult, format: SubtitleFormat) -> String? {
+        let segments = subtitleSegments(for: result)
+        guard !segments.isEmpty else { return nil }
+
+        switch format {
+        case .srt:
+            return exportSRT(segments: segments)
+        case .vtt:
+            return exportVTT(segments: segments)
+        }
+    }
+
     static func exportSRT(segments: [TranscriptionSegment]) -> String {
         segments.enumerated().map { index, segment in
             let start = formatSRTTime(segment.start)
@@ -51,6 +63,16 @@ enum SubtitleExporter {
     }
 
     // MARK: - Time Formatting
+
+    private static func subtitleSegments(for result: TranscriptionResult) -> [TranscriptionSegment] {
+        guard result.segments.isEmpty else { return result.segments }
+
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return [] }
+
+        let endTime = result.duration.isFinite && result.duration > 0 ? result.duration : 1
+        return [TranscriptionSegment(text: text, start: 0, end: endTime)]
+    }
 
     private static func displayText(for segment: TranscriptionSegment) -> String {
         guard let speakerLabel = segment.speakerLabel?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/TypeWhisper/Services/SubtitleExporter.swift
+++ b/TypeWhisper/Services/SubtitleExporter.swift
@@ -73,7 +73,7 @@ enum SubtitleExporter {
             return true
         } catch {
             subtitleExporterLogger.error(
-                "Failed to export subtitle '\(suggestedName, privacy: .public)' to \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                "Failed to export subtitle '\(suggestedName, privacy: .private(mask: .hash))' to \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
             )
             return false
         }

--- a/TypeWhisper/Services/SubtitleExporter.swift
+++ b/TypeWhisper/Services/SubtitleExporter.swift
@@ -1,5 +1,8 @@
 import AppKit
+import os
 import UniformTypeIdentifiers
+
+private let subtitleExporterLogger = Logger(subsystem: AppConstants.loggerSubsystem, category: "SubtitleExporter")
 
 enum SubtitleFormat: String, CaseIterable {
     case srt
@@ -51,15 +54,29 @@ enum SubtitleExporter {
     }
 
     @MainActor
-    static func saveToFile(content: String, format: SubtitleFormat, suggestedName: String) {
+    @discardableResult
+    static func saveToFile(content: String, format: SubtitleFormat, suggestedName: String) -> Bool {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [format.utType]
         panel.nameFieldStringValue = "\(suggestedName).\(format.fileExtension)"
         panel.canCreateDirectories = true
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard panel.runModal() == .OK, let url = panel.url else { return false }
 
-        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return writeContent(content, to: url, suggestedName: suggestedName)
+    }
+
+    @discardableResult
+    static func writeContent(_ content: String, to url: URL, suggestedName: String) -> Bool {
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            return true
+        } catch {
+            subtitleExporterLogger.error(
+                "Failed to export subtitle '\(suggestedName, privacy: .public)' to \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
     }
 
     // MARK: - Time Formatting

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -171,7 +171,7 @@ final class FileTranscriptionViewModel: ObservableObject {
         }
         self.engineReadinessChecker = engineReadinessChecker
         self.subtitleFileSaver = subtitleFileSaver ?? { content, format, suggestedName in
-            SubtitleExporter.saveToFile(content: content, format: format, suggestedName: suggestedName)
+            _ = SubtitleExporter.saveToFile(content: content, format: format, suggestedName: suggestedName)
         }
         self.subtitleFolderPicker = subtitleFolderPicker ?? {
             let panel = NSOpenPanel()
@@ -479,7 +479,7 @@ final class FileTranscriptionViewModel: ObservableObject {
         for export in exports {
             let name = export.item.url.deletingPathExtension().lastPathComponent
             let fileURL = folder.appendingPathComponent("\(name).\(format.fileExtension)")
-            try? export.content.write(to: fileURL, atomically: true, encoding: .utf8)
+            SubtitleExporter.writeContent(export.content, to: fileURL, suggestedName: name)
         }
     }
 

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -27,6 +27,8 @@ final class FileTranscriptionViewModel: ObservableObject {
         @escaping CancellationChecker
     ) async throws -> TranscriptionResult
     typealias EngineReadinessChecker = @MainActor (String?) -> Bool
+    typealias SubtitleFileSaver = @MainActor (String, SubtitleFormat, String) -> Void
+    typealias SubtitleFolderPicker = @MainActor () -> URL?
 
     nonisolated(unsafe) static var _shared: FileTranscriptionViewModel?
     static var shared: FileTranscriptionViewModel {
@@ -112,6 +114,8 @@ final class FileTranscriptionViewModel: ObservableObject {
     private let audioSamplesLoader: AudioSamplesLoader
     private let transcriptionRunner: TranscriptionRunner
     private let engineReadinessChecker: EngineReadinessChecker?
+    private let subtitleFileSaver: SubtitleFileSaver
+    private let subtitleFolderPicker: SubtitleFolderPicker
     private var cancellables = Set<AnyCancellable>()
     private var isInitialized = false
     private var activeBatchTask: Task<Void, Never>?
@@ -129,7 +133,9 @@ final class FileTranscriptionViewModel: ObservableObject {
         defaults: UserDefaults = .standard,
         audioSamplesLoader: AudioSamplesLoader? = nil,
         transcriptionRunner: TranscriptionRunner? = nil,
-        engineReadinessChecker: EngineReadinessChecker? = nil
+        engineReadinessChecker: EngineReadinessChecker? = nil,
+        subtitleFileSaver: SubtitleFileSaver? = nil,
+        subtitleFolderPicker: SubtitleFolderPicker? = nil
     ) {
         self.modelManager = modelManager
         self.audioFileService = audioFileService
@@ -164,6 +170,19 @@ final class FileTranscriptionViewModel: ObservableObject {
             )
         }
         self.engineReadinessChecker = engineReadinessChecker
+        self.subtitleFileSaver = subtitleFileSaver ?? { content, format, suggestedName in
+            SubtitleExporter.saveToFile(content: content, format: format, suggestedName: suggestedName)
+        }
+        self.subtitleFolderPicker = subtitleFolderPicker ?? {
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.canCreateDirectories = true
+            panel.prompt = String(localized: "Export Here")
+
+            guard panel.runModal() == .OK else { return nil }
+            return panel.url
+        }
         self.languageSelection = LanguageSelection(
             storedValue: defaults.string(forKey: UserDefaultsKeys.fileTranscriptionLanguage),
             nilBehavior: .auto
@@ -429,49 +448,38 @@ final class FileTranscriptionViewModel: ObservableObject {
     }
 
     func exportSubtitles(for item: FileItem, format: SubtitleFormat) {
-        guard let result = item.result, !result.segments.isEmpty else { return }
-
-        let content: String
-        switch format {
-        case .srt: content = SubtitleExporter.exportSRT(segments: result.segments)
-        case .vtt: content = SubtitleExporter.exportVTT(segments: result.segments)
-        }
+        guard let result = item.result,
+              let content = SubtitleExporter.exportContent(for: result, format: format) else { return }
 
         let name = item.url.deletingPathExtension().lastPathComponent
-        SubtitleExporter.saveToFile(content: content, format: format, suggestedName: name)
+        subtitleFileSaver(content, format, name)
     }
 
     func exportAllSubtitles(format: SubtitleFormat) {
-        let completedFiles = files.filter { $0.state == .done && $0.result != nil }
-        guard !completedFiles.isEmpty else { return }
+        let exports: [(item: FileItem, content: String)] = files.compactMap { item in
+            guard item.state == .done,
+                  let result = item.result,
+                  let content = SubtitleExporter.exportContent(for: result, format: format) else {
+                return nil
+            }
+            return (item, content)
+        }
+        guard !exports.isEmpty else { return }
 
         // For single file, use save panel directly
-        if completedFiles.count == 1, let item = completedFiles.first {
-            exportSubtitles(for: item, format: format)
+        if exports.count == 1, let export = exports.first {
+            let name = export.item.url.deletingPathExtension().lastPathComponent
+            subtitleFileSaver(export.content, format, name)
             return
         }
 
         // For multiple files, choose a folder
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.canCreateDirectories = true
-        panel.prompt = String(localized: "Export Here")
+        guard let folder = subtitleFolderPicker() else { return }
 
-        guard panel.runModal() == .OK, let folder = panel.url else { return }
-
-        for item in completedFiles {
-            guard let result = item.result, !result.segments.isEmpty else { continue }
-
-            let content: String
-            switch format {
-            case .srt: content = SubtitleExporter.exportSRT(segments: result.segments)
-            case .vtt: content = SubtitleExporter.exportVTT(segments: result.segments)
-            }
-
-            let name = item.url.deletingPathExtension().lastPathComponent
+        for export in exports {
+            let name = export.item.url.deletingPathExtension().lastPathComponent
             let fileURL = folder.appendingPathComponent("\(name).\(format.fileExtension)")
-            try? content.write(to: fileURL, atomically: true, encoding: .utf8)
+            try? export.content.write(to: fileURL, atomically: true, encoding: .utf8)
         }
     }
 

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -285,6 +285,126 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         try await waitForBatchToFinish(viewModel)
     }
 
+    func testExportAllSubtitlesSavesTextOnlyResultAsSingleSRTCue() throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "team-meeting.wav")
+        var savedContent: String?
+        var savedFormat: SubtitleFormat?
+        var savedSuggestedName: String?
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            subtitleFileSaver: { content, format, suggestedName in
+                savedContent = content
+                savedFormat = format
+                savedSuggestedName = suggestedName
+            },
+            subtitleFolderPicker: {
+                XCTFail("Single-file export should use the save panel path")
+                return nil
+            }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.files[0].state = .done
+        viewModel.files[0].result = makeTranscriptionResult(
+            text: "  Full meeting transcript  ",
+            duration: 12.5,
+            segments: []
+        )
+
+        viewModel.exportAllSubtitles(format: .srt)
+
+        XCTAssertEqual(savedFormat, .srt)
+        XCTAssertEqual(savedSuggestedName, "team-meeting")
+        XCTAssertEqual(savedContent, "1\n00:00:00,000 --> 00:00:12,500\nFull meeting transcript")
+    }
+
+    func testExportAllSubtitlesWritesMultipleTextOnlyVTTFiles() throws {
+        let defaults = try makeDefaults()
+        let firstURL = makeTemporaryFile(named: "first-call.wav")
+        let secondURL = makeTemporaryFile(named: "second-call.wav")
+        let exportFolder = makeTemporaryDirectory()
+        var folderPickerCalls = 0
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            subtitleFileSaver: { _, _, _ in
+                XCTFail("Multi-file export should use the folder export path")
+            },
+            subtitleFolderPicker: {
+                folderPickerCalls += 1
+                return exportFolder
+            }
+        )
+
+        viewModel.addFiles([firstURL, secondURL])
+        viewModel.files[0].state = .done
+        viewModel.files[0].result = makeTranscriptionResult(
+            text: "First transcript",
+            duration: 1,
+            segments: []
+        )
+        viewModel.files[1].state = .done
+        viewModel.files[1].result = makeTranscriptionResult(
+            text: "Second transcript",
+            duration: 2.25,
+            segments: []
+        )
+
+        viewModel.exportAllSubtitles(format: .vtt)
+
+        XCTAssertEqual(folderPickerCalls, 1)
+        let firstContent = try String(contentsOf: exportFolder.appendingPathComponent("first-call.vtt"))
+        let secondContent = try String(contentsOf: exportFolder.appendingPathComponent("second-call.vtt"))
+        XCTAssertEqual(firstContent, "WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\nFirst transcript\n")
+        XCTAssertEqual(secondContent, "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.250\nSecond transcript\n")
+    }
+
+    func testExportSubtitlesPreservesTimestampedSegments() throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "captioned.wav")
+        var savedContent: String?
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            subtitleFileSaver: { content, _, _ in
+                savedContent = content
+            }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.files[0].state = .done
+        viewModel.files[0].result = makeTranscriptionResult(
+            text: "Fallback text should not be used",
+            duration: 60,
+            segments: [
+                TranscriptionSegment(text: "First segment", start: 0.25, end: 1.5),
+                TranscriptionSegment(text: "Second segment", start: 1.5, end: 2.75)
+            ]
+        )
+        let item = try XCTUnwrap(viewModel.files.first)
+
+        viewModel.exportSubtitles(for: item, format: .vtt)
+
+        XCTAssertEqual(
+            savedContent,
+            "WEBVTT\n\n1\n00:00:00.250 --> 00:00:01.500\nFirst segment\n\n2\n00:00:01.500 --> 00:00:02.750\nSecond segment\n"
+        )
+    }
+
+    func testTextOnlySubtitleExportUsesOneSecondCueForInvalidDuration() {
+        let content = SubtitleExporter.exportContent(
+            for: makeTranscriptionResult(text: "No duration transcript", duration: .nan),
+            format: .srt
+        )
+
+        XCTAssertEqual(content, "1\n00:00:00,000 --> 00:00:01,000\nNo duration transcript")
+    }
+
     func testStableProgressPreviewIgnoresDisjointReplacementText() {
         let current = "Basically, Deepgram, Whisper, Speechmatics, and Assembly."
         let candidate = "use Whisper through OpenAI APIs. They are a Mac file size"
@@ -498,6 +618,21 @@ final class FileTranscriptionViewModelTests: XCTestCase {
             try? FileManager.default.removeItem(at: directory)
         }
         return directory
+    }
+
+    private func makeTranscriptionResult(
+        text: String,
+        duration: TimeInterval,
+        segments: [TranscriptionSegment] = []
+    ) -> TranscriptionResult {
+        TranscriptionResult(
+            text: text,
+            detectedLanguage: "en",
+            duration: duration,
+            processingTime: 0.1,
+            engineUsed: "test",
+            segments: segments
+        )
     }
 
     private func waitForBatchToFinish(_ viewModel: FileTranscriptionViewModel) async throws {


### PR DESCRIPTION
## Summary
- Fixes manual File Transcription SRT/VTT export when an engine returns transcript text without timestamped segments.
- Uses existing timestamped segments when present; otherwise exports the transcript as one subtitle cue from `00:00` to the transcription duration, with a 1-second fallback for invalid or zero duration.
- Adds regression coverage for single-file save-panel export, multi-file folder export, timestamped segment preservation, and invalid-duration fallback.

Closes #741

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests -quiet`
- [x] `git diff --check`
- [x] `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved subtitle export generation for both SRT and VTT, including more reliable cue timing and text handling.
  * Enhanced saving behavior with clearer success/failure outcomes and consistent formatting across exports.
  * Batch exports now prompt once for a destination folder and export each file using the derived subtitle content.
* **Tests**
  * Expanded coverage for SRT/VTT exporting, single vs. batch behavior, and edge cases like invalid durations and text trimming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->