### PR TITLE
Add thinking mode toggle to OpenAI Compatible

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -113,6 +113,28 @@
         }
       }
     },
+    "Thinking Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denkmodus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thinking Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考モード"
+          }
+        }
+      }
+    },
     "Model name": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -17,10 +17,24 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var llmTemperatureValue: Double
     var fetchedModels: [FetchedModel]
     var chatRequestTimeoutSeconds: TimeInterval?
+    var thinkingEnabled: Bool
 
     static let defaultChatRequestTimeout: TimeInterval = 30
     static let minChatRequestTimeout: TimeInterval = 5
     static let maxChatRequestTimeout: TimeInterval = 3600
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case baseURL
+        case selectedModelId
+        case selectedLLMModelId
+        case llmTemperatureModeRaw
+        case llmTemperatureValue
+        case fetchedModels
+        case chatRequestTimeoutSeconds
+        case thinkingEnabled
+    }
 
     init(
         id: String,
@@ -31,7 +45,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
-        chatRequestTimeoutSeconds: TimeInterval? = nil
+        chatRequestTimeoutSeconds: TimeInterval? = nil,
+        thinkingEnabled: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -42,6 +57,21 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.llmTemperatureValue = llmTemperatureValue
         self.fetchedModels = fetchedModels
         self.chatRequestTimeoutSeconds = chatRequestTimeoutSeconds
+        self.thinkingEnabled = thinkingEnabled
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        baseURL = try container.decode(String.self, forKey: .baseURL)
+        selectedModelId = try container.decode(String.self, forKey: .selectedModelId)
+        selectedLLMModelId = try container.decode(String.self, forKey: .selectedLLMModelId)
+        llmTemperatureModeRaw = try container.decode(String.self, forKey: .llmTemperatureModeRaw)
+        llmTemperatureValue = try container.decode(Double.self, forKey: .llmTemperatureValue)
+        fetchedModels = try container.decode([FetchedModel].self, forKey: .fetchedModels)
+        chatRequestTimeoutSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .chatRequestTimeoutSeconds)
+        thinkingEnabled = try container.decodeIfPresent(Bool.self, forKey: .thinkingEnabled) ?? false
     }
 
     var isDefault: Bool { id == Self.defaultId }
@@ -65,7 +95,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
-        chatRequestTimeoutSeconds: TimeInterval? = nil
+        chatRequestTimeoutSeconds: TimeInterval? = nil,
+        thinkingEnabled: Bool = false
     ) -> OpenAICompatibleProfile {
         OpenAICompatibleProfile(
             id: defaultId,
@@ -76,7 +107,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             llmTemperatureModeRaw: llmTemperatureModeRaw,
             llmTemperatureValue: llmTemperatureValue,
             fetchedModels: fetchedModels,
-            chatRequestTimeoutSeconds: chatRequestTimeoutSeconds
+            chatRequestTimeoutSeconds: chatRequestTimeoutSeconds,
+            thinkingEnabled: thinkingEnabled
         )
     }
 }
@@ -242,6 +274,10 @@ final class OpenAICompatiblePlugin: NSObject,
         setLLMTemperatureValue(value, for: providerId)
     }
 
+    func setThinkingEnabled(_ enabled: Bool) {
+        setThinkingEnabled(enabled, for: providerId)
+    }
+
     // MARK: - Settings View
 
     var settingsView: AnyView? {
@@ -376,6 +412,12 @@ final class OpenAICompatiblePlugin: NSObject,
         }
     }
 
+    func setThinkingEnabled(_ enabled: Bool, for profileId: String) {
+        updateProfile(profileId) { profile in
+            profile.thinkingEnabled = enabled
+        }
+    }
+
     // MARK: - Profile Runtime
 
     func displayName(for profileId: String) -> String {
@@ -470,7 +512,8 @@ final class OpenAICompatiblePlugin: NSObject,
             systemPrompt: systemPrompt,
             userText: userText,
             temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective),
-            requestTimeout: profile.resolvedChatRequestTimeout
+            requestTimeout: profile.resolvedChatRequestTimeout,
+            thinkingEnabled: profile.thinkingEnabled
         )
     }
 
@@ -834,6 +877,7 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var manualLLMModel = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
+    @State private var thinkingEnabled = false
     @State private var chatTimeoutInput = ""
 
     private let bundle = pluginModuleBundle
@@ -936,6 +980,7 @@ private struct OpenAICompatibleSettingsView: View {
                     serverSection
                     modelSection
                     temperatureSection
+                    thinkingModeSection
                     timeoutSection
 
                     Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -1201,6 +1246,22 @@ private struct OpenAICompatibleSettingsView: View {
         }
     }
 
+    private var thinkingModeSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+
+            Toggle(isOn: $thinkingEnabled) {
+                Text("Thinking Mode", bundle: bundle)
+                    .font(.headline)
+            }
+            .onChange(of: thinkingEnabled) {
+                guard let selectedProfile else { return }
+                plugin.setThinkingEnabled(thinkingEnabled, for: selectedProfile.id)
+                reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+            }
+        }
+    }
+
     private var timeoutSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Divider()
@@ -1252,6 +1313,7 @@ private struct OpenAICompatibleSettingsView: View {
         manualLLMModel = profile.selectedLLMModelId
         llmTemperatureMode = PluginLLMTemperatureMode(rawValue: profile.llmTemperatureModeRaw) ?? .providerDefault
         llmTemperatureValue = profile.llmTemperatureValue
+        thinkingEnabled = profile.thinkingEnabled
         chatTimeoutInput = String(Int(profile.resolvedChatRequestTimeout))
         connectionResult = nil
     }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -28,6 +28,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         plugin.selectModel("whisper-1")
         plugin.selectLLMModel("gpt-4.1-mini")
+        plugin.setThinkingEnabled(true)
         plugin.deactivate()
 
         let reloaded = OpenAICompatiblePlugin()
@@ -35,6 +36,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(reloaded.selectedModelId, "whisper-1")
         XCTAssertEqual(reloaded.selectedLLMModelId, "gpt-4.1-mini")
+        XCTAssertEqual(reloaded.profileSnapshot(for: reloaded.providerId)?.thinkingEnabled, true)
     }
 
     func testLegacyConfigurationMigratesIntoDefaultProfile() throws {
@@ -65,9 +67,39 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(profile.selectedLLMModelId, "chat-legacy")
         XCTAssertEqual(profile.llmTemperatureModeRaw, PluginLLMTemperatureMode.custom.rawValue)
         XCTAssertEqual(profile.llmTemperatureValue, 0.7)
+        XCTAssertFalse(profile.thinkingEnabled)
         XCTAssertEqual(profile.fetchedModels.map(\.id), ["legacy-model"])
         XCTAssertEqual(plugin.apiKey(for: profile.id), "legacy-token")
         XCTAssertNotNil(host.userDefault(forKey: "profiles") as? Data)
+    }
+
+    func testSavedProfilesWithoutThinkingModeDecodeAsDisabled() throws {
+        let savedProfiles = Data(
+            """
+            [
+              {
+                "id": "openai-compatible",
+                "name": "OpenAI Compatible",
+                "baseURL": "https://legacy-profile.test",
+                "selectedModelId": "whisper-legacy",
+                "selectedLLMModelId": "chat-legacy",
+                "llmTemperatureModeRaw": "providerDefault",
+                "llmTemperatureValue": 0.3,
+                "fetchedModels": [],
+                "chatRequestTimeoutSeconds": 45
+              }
+            ]
+            """.utf8
+        )
+        let host = try PluginTestHostServices(defaults: ["profiles": savedProfiles])
+        let plugin = OpenAICompatiblePlugin()
+
+        plugin.activate(host: host)
+
+        let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+        XCTAssertFalse(profile.thinkingEnabled)
+        XCTAssertEqual(profile.resolvedChatRequestTimeout, 45)
+        XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
     }
 
     func testAdditionalProfilesExposeIndependentTranscriptionAndLLMRoles() throws {
@@ -244,6 +276,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.selectLLMModel("inception-chat", for: inception.id)
         plugin.setLLMTemperatureMode(.custom, for: inception.id)
         plugin.setLLMTemperatureValue(0.9, for: inception.id)
+        plugin.setThinkingEnabled(true, for: inception.id)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -286,11 +319,15 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let defaultJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: defaultBody) as? [String: Any])
         XCTAssertEqual(defaultJSON["model"] as? String, "default-chat")
         XCTAssertEqual(defaultJSON["temperature"] as? Double, 0.2)
+        let defaultThinking = try XCTUnwrap(defaultJSON["thinking"] as? [String: String])
+        XCTAssertEqual(defaultThinking["type"], "disabled")
 
         let inceptionBody = try XCTUnwrap(requests[1].httpBody)
         let inceptionJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: inceptionBody) as? [String: Any])
         XCTAssertEqual(inceptionJSON["model"] as? String, "inception-chat")
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
+        let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
+        XCTAssertEqual(inceptionThinking["type"], "enabled")
     }
 
     func testSetChatRequestTimeoutIgnoresNonFiniteValues() throws {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -690,6 +690,32 @@ public struct PluginOpenAIChatHelper: Sendable {
         temperature: Double?,
         requestTimeout: TimeInterval
     ) async throws -> String {
+        try await process(
+            apiKey: apiKey,
+            model: model,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            maxOutputTokens: maxOutputTokens,
+            maxOutputTokenParameter: maxOutputTokenParameter,
+            reasoningEffort: reasoningEffort,
+            temperature: temperature,
+            requestTimeout: requestTimeout,
+            thinkingEnabled: nil
+        )
+    }
+
+    public func process(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        maxOutputTokens: Int? = 4096,
+        maxOutputTokenParameter: String = "max_tokens",
+        reasoningEffort: String? = nil,
+        temperature: Double?,
+        requestTimeout: TimeInterval,
+        thinkingEnabled: Bool?
+    ) async throws -> String {
         let endpoint = "\(baseURL)\(chatEndpoint)"
         guard let url = URL(string: endpoint) else {
             throw PluginChatError.apiError("Invalid URL: \(endpoint)")
@@ -702,7 +728,8 @@ public struct PluginOpenAIChatHelper: Sendable {
             maxOutputTokens: maxOutputTokens,
             maxOutputTokenParameter: maxOutputTokenParameter,
             reasoningEffort: reasoningEffort,
-            temperature: temperature
+            temperature: temperature,
+            thinkingEnabled: thinkingEnabled
         )
 
         var request = URLRequest(url: url)
@@ -856,6 +883,28 @@ public struct PluginOpenAIChatHelper: Sendable {
         reasoningEffort: String?,
         temperature: Double?
     ) -> [String: Any] {
+        requestBody(
+            model: model,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            maxOutputTokens: maxOutputTokens,
+            maxOutputTokenParameter: maxOutputTokenParameter,
+            reasoningEffort: reasoningEffort,
+            temperature: temperature,
+            thinkingEnabled: nil
+        )
+    }
+
+    func requestBody(
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        maxOutputTokens: Int?,
+        maxOutputTokenParameter: String,
+        reasoningEffort: String?,
+        temperature: Double?,
+        thinkingEnabled: Bool?
+    ) -> [String: Any] {
         var requestBody: [String: Any] = [
             "model": model,
             "messages": [
@@ -874,6 +923,12 @@ public struct PluginOpenAIChatHelper: Sendable {
 
         if let reasoningEffort, !reasoningEffort.isEmpty {
             requestBody["reasoning_effort"] = reasoningEffort
+        }
+
+        if let thinkingEnabled {
+            requestBody["thinking"] = [
+                "type": thinkingEnabled ? "enabled" : "disabled"
+            ]
         }
 
         return requestBody

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
@@ -71,6 +71,59 @@ final class OpenAIChatHelperTests: XCTestCase {
         XCTAssertEqual(requestBody["reasoning_effort"] as? String, "high")
     }
 
+    func testRequestBodyIncludesEnabledThinkingWhenRequested() throws {
+        let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
+
+        let requestBody = helper.requestBody(
+            model: "deepseek-v4-flash",
+            systemPrompt: "Fix grammar",
+            userText: "hello world",
+            maxOutputTokens: 4096,
+            maxOutputTokenParameter: "max_tokens",
+            reasoningEffort: nil,
+            temperature: 0.3,
+            thinkingEnabled: true
+        )
+
+        let thinking = try XCTUnwrap(requestBody["thinking"] as? [String: String])
+        XCTAssertEqual(thinking["type"], "enabled")
+    }
+
+    func testRequestBodyIncludesDisabledThinkingWhenRequested() throws {
+        let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
+
+        let requestBody = helper.requestBody(
+            model: "deepseek-v4-flash",
+            systemPrompt: "Fix grammar",
+            userText: "hello world",
+            maxOutputTokens: 4096,
+            maxOutputTokenParameter: "max_tokens",
+            reasoningEffort: nil,
+            temperature: 0.3,
+            thinkingEnabled: false
+        )
+
+        let thinking = try XCTUnwrap(requestBody["thinking"] as? [String: String])
+        XCTAssertEqual(thinking["type"], "disabled")
+    }
+
+    func testRequestBodyOmitsThinkingWhenUnset() {
+        let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
+
+        let requestBody = helper.requestBody(
+            model: "deepseek-v4-flash",
+            systemPrompt: "Fix grammar",
+            userText: "hello world",
+            maxOutputTokens: 4096,
+            maxOutputTokenParameter: "max_tokens",
+            reasoningEffort: nil,
+            temperature: 0.3,
+            thinkingEnabled: nil
+        )
+
+        XCTAssertNil(requestBody["thinking"])
+    }
+
     func testRequestBodyOmitsTemperatureWhenRequested() {
         let helper = PluginOpenAIChatHelper(baseURL: "https://example.com")
 


### PR DESCRIPTION
## Summary
- add a per-profile Thinking Mode toggle to the OpenAI Compatible plugin
- send DeepSeek-compatible `thinking.type` as `enabled` or `disabled` on OpenAI Compatible LLM requests
- extend `PluginOpenAIChatHelper` with optional `thinkingEnabled` support while preserving existing callers
- compare other OpenAI-compatible provider plugins and leave them unchanged because Fireworks/OpenRouter/Groq/Cerebras use provider-specific reasoning parameters, while Gemini already has its native thinking config

## Issue Context
Issue #762 requests a per-profile Thinking Mode setting for the OpenAI Compatible plugin so users can disable reasoning for quick tasks on providers such as DeepSeek, then re-enable it for deeper reasoning work.

Closes #762

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAIChatHelperTests`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`
- `swift test --package-path TypeWhisperPluginSDK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Thinking Mode" setting per profile, allowing users to enable or disable thinking for individual AI profiles.
  * Thinking Mode can be toggled in the profile settings UI.

* **Localization**
  * Added "Thinking Mode" translations in German, English, and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->