### PR TITLE
Fix OpenAI compatible plugin host SDK compatibility

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -498,16 +498,16 @@ final class OpenAICompatiblePlugin: NSObject,
         temperatureDirective: PluginLLMTemperatureDirective,
         profileId: String
     ) async throws -> String {
-        guard let profile = profile(for: profileId),
-              let helper = makeChatHelper(for: profile) else {
+        guard let profile = profile(for: profileId), !profile.baseURL.isEmpty else {
             throw PluginChatError.notConfigured
         }
         let modelId = model ?? selectedLLMModelId(for: profileId) ?? ""
         guard !modelId.isEmpty else {
             throw PluginChatError.noModelSelected
         }
-        return try await helper.process(
+        return try await processChatCompletion(
             apiKey: apiKey(for: profileId) ?? "",
+            baseURL: profile.baseURL,
             model: modelId,
             systemPrompt: systemPrompt,
             userText: userText,
@@ -607,11 +607,6 @@ final class OpenAICompatiblePlugin: NSObject,
     private func makeTranscriptionHelper(for profile: OpenAICompatibleProfile) -> PluginOpenAITranscriptionHelper? {
         guard !profile.baseURL.isEmpty else { return nil }
         return PluginOpenAITranscriptionHelper(baseURL: profile.baseURL, responseFormat: "json")
-    }
-
-    private func makeChatHelper(for profile: OpenAICompatibleProfile) -> PluginOpenAIChatHelper? {
-        guard !profile.baseURL.isEmpty else { return nil }
-        return PluginOpenAIChatHelper(baseURL: profile.baseURL)
     }
 
     private func updateProfile(
@@ -738,6 +733,104 @@ final class OpenAICompatiblePlugin: NSObject,
         canonicalProfileId(for: profileId) == OpenAICompatibleProfile.defaultId
             ? "api-key"
             : "api-key.\(canonicalProfileId(for: profileId))"
+    }
+
+    private func processChatCompletion(
+        apiKey: String,
+        baseURL: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        temperature: Double?,
+        requestTimeout: TimeInterval,
+        thinkingEnabled: Bool
+    ) async throws -> String {
+        let endpoint = "\(baseURL)/v1/chat/completions"
+        guard let url = URL(string: endpoint) else {
+            throw PluginChatError.apiError("Invalid URL: \(endpoint)")
+        }
+
+        var requestBody: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userText],
+            ],
+            "max_tokens": 4096,
+            "thinking": [
+                "type": thinkingEnabled ? "enabled" : "disabled"
+            ],
+        ]
+        if let temperature {
+            requestBody["temperature"] = temperature
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = requestTimeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: requestTimeout)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginChatError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401:
+            throw PluginChatError.invalidApiKey
+        case 429:
+            throw PluginChatError.rateLimited
+        default:
+            throw PluginChatError.apiError(Self.chatErrorMessage(from: data, statusCode: httpResponse.statusCode))
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let first = choices.first,
+              let message = first["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw PluginChatError.apiError("Failed to parse response")
+        }
+
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func chatErrorMessage(from data: Data, statusCode: Int) -> String {
+        let json = try? JSONSerialization.jsonObject(with: data)
+
+        let object: [String: Any]?
+        if let dictionary = json as? [String: Any] {
+            object = dictionary
+        } else if let array = json as? [Any],
+                  let first = array.first as? [String: Any] {
+            object = first
+        } else {
+            object = nil
+        }
+
+        if let object, let message = message(fromChatErrorObject: object) {
+            return message
+        }
+        return "HTTP \(statusCode)"
+    }
+
+    private static func message(fromChatErrorObject object: [String: Any]) -> String? {
+        if let detail = object["detail"] as? String, !detail.isEmpty {
+            return detail
+        }
+        if let error = object["error"] as? [String: Any],
+           let message = error["message"] as? String, !message.isEmpty {
+            return message
+        }
+        if let message = object["message"] as? String, !message.isEmpty {
+            return message
+        }
+        return nil
     }
 
     private static func normalizedBaseURL(_ url: String) -> String {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -318,6 +318,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let defaultBody = try XCTUnwrap(requests[0].httpBody)
         let defaultJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: defaultBody) as? [String: Any])
         XCTAssertEqual(defaultJSON["model"] as? String, "default-chat")
+        XCTAssertEqual(defaultJSON["max_tokens"] as? Int, 4096)
         XCTAssertEqual(defaultJSON["temperature"] as? Double, 0.2)
         let defaultThinking = try XCTUnwrap(defaultJSON["thinking"] as? [String: String])
         XCTAssertEqual(defaultThinking["type"], "disabled")
@@ -325,9 +326,39 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let inceptionBody = try XCTUnwrap(requests[1].httpBody)
         let inceptionJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: inceptionBody) as? [String: Any])
         XCTAssertEqual(inceptionJSON["model"] as? String, "inception-chat")
+        XCTAssertEqual(inceptionJSON["max_tokens"] as? Int, 4096)
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
         let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
         XCTAssertEqual(inceptionThinking["type"], "enabled")
+    }
+
+    func testProcessSurfacesOpenAICompatibleErrorMessage() async throws {
+        let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.selectLLMModel("missing-model")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"[{"error":{"message":"model not found"}}]"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/chat/completions", statusCode: 404)
+                )
+            ])
+        }
+
+        do {
+            _ = try await plugin.process(systemPrompt: "Fix", userText: "hello", model: nil)
+            XCTFail("Expected apiError")
+        } catch let error as PluginChatError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "model not found")
+        }
+
+        XCTAssertEqual(store.sessions[0].requestedPaths, ["/v1/chat/completions"])
     }
 
     func testSetChatRequestTimeoutIgnoresNonFiniteValues() throws {


### PR DESCRIPTION
## Summary
- Fixes the OpenAI Compatible plugin 1.1.1 compatibility regression with existing TypeWhisper 1.5.0 RC host builds.
- Keeps the Issue #762 `thinking` request body behavior, but stops the plugin binary from referencing the new `PluginOpenAIChatHelper.process(...thinkingEnabled:)` SDK symbol.
- Adds plugin-level coverage for the preserved chat request body and OpenAI-compatible error parsing.

## Context
Issue #762 added per-profile Thinking Mode support. The released plugin 1.1.1 correctly sent `thinking: { type: "enabled" | "disabled" }`, but the plugin binary called a new SDK helper overload. Existing 1.5.0 RC host builds do not export that new SDK symbol, so the plugin can fail to load in those builds.

This PR keeps the SDK helper API for future SDK callers, but makes the OpenAI Compatible plugin build its chat request locally through existing SDK surfaces (`PluginHTTPClient`, `PluginChatError`). That preserves host compatibility while keeping the request body introduced for #762.

Related to #762 and follow-up to #763.

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAIChatHelperTests`
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild -project TypeWhisper.xcodeproj -target OpenAICompatiblePlugin -configuration Release SYMROOT="$TMPDIR/openai-compatible-build" CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.1.2`
- `nm -u "$TMPDIR/openai-compatible-build/Release/OpenAICompatiblePlugin.bundle/Contents/MacOS/OpenAICompatiblePlugin" | rg -i "thinkingEnabled|PluginOpenAIChatHelperV7process.*thinking|PluginOpenAIChatHelper"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OpenAI-compatible API requests with clearer error messages for invalid API keys and rate limiting scenarios.
  * Enhanced validation of profile configuration to ensure proper setup before API calls.

* **Tests**
  * Expanded test coverage for error handling and request validation with OpenAI-compatible providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->