### PR TITLE
Fix plugin host compatibility for 1.4

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -24,10 +24,7 @@ final class OpenRouterPlugin: NSObject,
     fileprivate var _fetchedLLMModels: [OpenRouterFetchedModel] = []
     fileprivate var _fetchedTranscriptionModels: [OpenRouterFetchedModel] = []
 
-    private let chatHelper = PluginOpenAIChatHelper(
-        baseURL: "https://openrouter.ai/api"
-    )
-
+    private static let chatRequestTimeout: TimeInterval = 30
     private static let transcriptionRequestTimeout: TimeInterval = 120
 
     private enum StorageKeys {
@@ -276,13 +273,17 @@ final class OpenRouterPlugin: NSObject,
             throw PluginChatError.notConfigured
         }
         let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
-        return try await chatHelper.process(
+        let request = try Self.makeChatRequest(
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
             userText: userText,
-            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
+            timeout: Self.chatRequestTimeout
         )
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        try Self.validateChatResponse(data: data, response: response)
+        return try Self.parseChatResponse(data)
     }
 
     func selectLLMModel(_ modelId: String) {
@@ -309,6 +310,68 @@ final class OpenRouterPlugin: NSObject,
         let clamped = min(max(value, 0.0), 2.0)
         _llmTemperatureValue = clamped
         host?.setUserDefault(clamped, forKey: Self.StorageKeys.llmTemperatureValue)
+    }
+
+    static func makeChatRequest(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        temperature: Double?,
+        timeout: TimeInterval
+    ) throws -> URLRequest {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/chat/completions") else {
+            throw PluginChatError.apiError("Invalid OpenRouter chat URL.")
+        }
+
+        var body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userText],
+            ],
+            "max_tokens": 4096,
+        ]
+        if let temperature {
+            body["temperature"] = temperature
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = timeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func validateChatResponse(data: Data, response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginChatError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return
+        case 401:
+            throw PluginChatError.invalidApiKey
+        case 429:
+            throw PluginChatError.rateLimited
+        default:
+            throw PluginChatError.apiError(Self.apiErrorMessage(from: data))
+        }
+    }
+
+    static func parseChatResponse(_ data: Data) throws -> String {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let first = choices.first,
+              let message = first["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw PluginChatError.apiError("Failed to parse response")
+        }
+
+        return content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -63,6 +63,83 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "openai/gpt-4o")
     }
 
+    func testProcessSendsLocalChatRequestAndParsesText() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+        plugin.setLLMTemperatureMode(.custom)
+        plugin.setLLMTemperatureValue(0.7)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"choices":[{"message":{"content":" hello from chat \n"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.process(
+            systemPrompt: "System prompt",
+            userText: "User text",
+            model: nil
+        )
+
+        XCTAssertEqual(result, "hello from chat")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://openrouter.ai/api/v1/chat/completions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer openrouter-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 30)
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "openai/gpt-4o")
+        XCTAssertEqual(body["max_tokens"] as? Int, 4096)
+        XCTAssertEqual(body["temperature"] as? Double, 0.7)
+
+        let messages = try XCTUnwrap(body["messages"] as? [[String: String]])
+        XCTAssertEqual(messages, [
+            ["role": "system", "content": "System prompt"],
+            ["role": "user", "content": "User text"],
+        ])
+    }
+
+    func testChatHTTPErrorMapping() {
+        XCTAssertThrowsError(try OpenRouterPlugin.validateChatResponse(
+            data: Data(#"{"error":{"message":"bad key"}}"#.utf8),
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/chat/completions", statusCode: 401)
+        )) { error in
+            guard let pluginError = error as? PluginChatError,
+                  case .invalidApiKey = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try OpenRouterPlugin.validateChatResponse(
+            data: Data(#"{"error":{"message":"slow down"}}"#.utf8),
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/chat/completions", statusCode: 429)
+        )) { error in
+            guard let pluginError = error as? PluginChatError,
+                  case .rateLimited = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try OpenRouterPlugin.validateChatResponse(
+            data: Data(#"{"error":{"message":"server failed"}}"#.utf8),
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/chat/completions", statusCode: 500)
+        )) { error in
+            guard let pluginError = error as? PluginChatError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "server failed")
+        }
+    }
+
     func testLLMAndTranscriptionModelFetchesUseSeparateEndpointsAndCaches() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
         let plugin = OpenRouterPlugin()

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
-    "version": "1.1.0",
-    "minHostVersion": "0.9.0",
+    "version": "1.1.1",
+    "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -675,7 +675,7 @@ extension SaluteSpeechPlugin {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 120
+        request.timeoutInterval = 600
         return request
     }
 
@@ -1019,10 +1019,7 @@ private extension SaluteSpeechPlugin {
             responseFileId: responseFileId,
             token: token
         )
-        let (downloadData, downloadResponse) = try await PluginHTTPClient.data(
-            for: downloadRequest,
-            resourceTimeout: 600
-        )
+        let (downloadData, downloadResponse) = try await PluginHTTPClient.data(for: downloadRequest)
         try Self.validateHTTPResponse(data: downloadData, response: downloadResponse)
         return try Self.parseTranscriptionResult(downloadData)
     }

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
@@ -101,6 +101,24 @@ final class SaluteSpeechPluginTests: XCTestCase {
         XCTAssertEqual(options["channels_count"] as? Int, 1)
     }
 
+    func testDownloadRequestUsesBearerTokenAndLongTimeout() throws {
+        let request = try SaluteSpeechPlugin.makeDownloadRequest(
+            responseFileId: "response-file",
+            token: "access-token"
+        )
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "smartspeech.sber.ru")
+        XCTAssertEqual(request.url?.path, "/rest/v1/data:download")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer access-token")
+        XCTAssertEqual(request.timeoutInterval, 600)
+
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        XCTAssertEqual(query["response_file_id"], "response-file")
+    }
+
     func testParseTranscriptionResultPrefersNormalizedText() throws {
         let result = try SaluteSpeechPlugin.parseTranscriptionResult(
             Data(

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.sber-salutespeech",
     "name": "Sber SaluteSpeech",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary
- Fixes #766: the published OpenRouter 1.1.0 and Sber SaluteSpeech 0.1.0 plugin bundles referenced newer SDK symbols than TypeWhisper 1.4.0 exports, while their registry metadata still looked compatible with older hosts.
- Replaces OpenRouter's runtime dependency on `PluginOpenAIChatHelper` with a local OpenRouter chat request implemented through the stable `PluginHTTPClient.data(for:)` API, preserving API key auth, selected model, temperature handling, request body shape, and response/error parsing.
- Replaces SaluteSpeech's `PluginHTTPClient.data(for:resourceTimeout:)` usage with `PluginHTTPClient.data(for:)` and keeps the async result download request timeout at 600 seconds.
- Bumps the fixed plugin manifests to OpenRouter 1.1.1 and Sber SaluteSpeech 0.1.1 while keeping `sdkCompatibilityVersion: "v1"` and `minHostVersion: "1.4.0"`.

Closes #766

## Test plan
- `swift test --package-path TypeWhisperPluginSDK --filter OpenRouterPluginTests`
- `swift test --package-path TypeWhisperPluginSDK --filter SaluteSpeechPluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -target OpenRouterPlugin -configuration Release SYMROOT=/tmp/tw-plugin-build-766-openrouter CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.1.1`
- `xcodebuild -project TypeWhisper.xcodeproj -target SaluteSpeechPlugin -configuration Release SYMROOT=/tmp/tw-plugin-build-766-salute CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=0.1.1`
- `nm -u /tmp/tw-plugin-build-766-openrouter/Release/OpenRouterPlugin.bundle/Contents/MacOS/OpenRouterPlugin | xcrun swift-demangle | rg 'PluginOpenAIChatHelper|requestTimeout|thinkingEnabled'` (expected: no matches)
- `nm -u /tmp/tw-plugin-build-766-salute/Release/SaluteSpeechPlugin.bundle/Contents/MacOS/SaluteSpeechPlugin | xcrun swift-demangle | rg 'resourceTimeout'` (expected: no matches)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout interval for Salute Speech plugin download operations.

* **Chores**
  * Refactored OpenRouter plugin networking layer.
  * Version updates for OpenRouter (1.1.0 → 1.1.1) and Salute Speech (0.1.0 → 0.1.1) plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->