### PR TITLE
Fix dictation language visibility and release guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,16 @@ jobs:
             -configuration Release \
             -derivedDataPath build \
             -destination 'generic/platform=macOS' \
+            ENABLE_CODE_COVERAGE=NO \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO | tee build.log
 
       - name: Check First-Party Warnings
         run: bash scripts/check_first_party_warnings.sh build.log
+
+      - name: Check Release Binary Instrumentation
+        run: bash scripts/check_release_binary_instrumentation.sh build/Build/Products/Release/TypeWhisper.app/Contents/MacOS/typewhisper-cli
 
       - name: Install dmgbuild
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
           done
           exit 1
 
+      - name: Verify Instrumentation Check Script
+        run: bash scripts/check_release_binary_instrumentation.sh --self-test
+
       - name: Build App
         run: |
           set -o pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,16 @@ jobs:
             -configuration Release \
             -derivedDataPath verify-build \
             -destination 'generic/platform=macOS' \
+            ENABLE_CODE_COVERAGE=NO \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO | tee verify-build.log
 
       - name: Check First-Party Warnings
         run: bash scripts/check_first_party_warnings.sh verify-build.log
+
+      - name: Check Release Binary Instrumentation
+        run: bash scripts/check_release_binary_instrumentation.sh verify-build/Build/Products/Release/TypeWhisper.app/Contents/MacOS/typewhisper-cli
 
   app-tests:
     needs: [prepare]
@@ -225,6 +229,7 @@ jobs:
             -configuration Release \
             -derivedDataPath build \
             -destination 'generic/platform=macOS' \
+            ENABLE_CODE_COVERAGE=NO \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
@@ -234,6 +239,9 @@ jobs:
 
       - name: Check First-Party Warnings
         run: bash scripts/check_first_party_warnings.sh build.log
+
+      - name: Check Release Binary Instrumentation
+        run: bash scripts/check_release_binary_instrumentation.sh build/Build/Products/Release/TypeWhisper.app/Contents/MacOS/typewhisper-cli
 
       - name: Configure Release Channel
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
             -project $PROJECT \
             -scheme $SCHEME
 
+      - name: Verify Instrumentation Check Script
+        run: bash scripts/check_release_binary_instrumentation.sh --self-test
+
       - name: Verify Release Build
         run: |
           set -o pipefail
@@ -201,6 +204,9 @@ jobs:
 
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
           echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+
+      - name: Verify Instrumentation Check Script
+        run: bash scripts/check_release_binary_instrumentation.sh --self-test
 
       - name: Build App
         run: |

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -11905,18 +11905,18 @@
         }
       }
     },
-    "The language being spoken. Setting this explicitly improves accuracy.": {
+    "Controls push-to-talk dictation, workflows that inherit the global spoken language, and CLI/API defaults when they use app defaults. Recorder and Recovery have separate language settings.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die gesprochene Sprache. Explizites Festlegen verbessert die Genauigkeit."
+            "value": "Steuert Push-to-Talk-Diktat, Workflows, die die globale gesprochene Sprache übernehmen, und CLI/API-Standardwerte, wenn sie App-Standardwerte verwenden. Recorder und Wiederherstellung haben separate Spracheinstellungen."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "話している言語です。明示的に設定すると精度が向上します。"
+            "value": "プッシュ・トゥ・トークのディクテーション、グローバルの話す言語を継承するワークフロー、およびアプリのデフォルトを使用する場合のCLI/APIデフォルトを制御します。レコーダーとリカバリーには別の言語設定があります。"
           }
         }
       }

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -93,7 +93,7 @@ struct GeneralSettingsView: View {
                     hintBehavior: LanguageSelectionHintBehavior(engine: settings.activeTranscriptionEngine)
                 )
 
-                Text(String(localized: "The language being spoken. Setting this explicitly improves accuracy."))
+                Text(String(localized: "Controls push-to-talk dictation, workflows that inherit the global spoken language, and CLI/API defaults when they use app defaults. Recorder and Recovery have separate language settings."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -398,6 +398,7 @@ private struct SettingsSidebarBadge: View {
 
 struct RecordingSettingsView: View {
     @ObservedObject private var dictation = DictationViewModel.shared
+    @ObservedObject private var settings = SettingsViewModel.shared
     @ObservedObject private var audioDevice = ServiceContainer.shared.audioDeviceService
     @ObservedObject private var pluginManager = PluginManager.shared
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
@@ -435,6 +436,18 @@ struct RecordingSettingsView: View {
         Form {
             if needsPermissions {
                 PermissionsBanner(dictation: dictation)
+            }
+
+            Section(String(localized: "Spoken Language")) {
+                LanguageSelectionEditor(
+                    selection: $settings.languageSelection,
+                    availableLanguages: settings.availableLanguages,
+                    hintBehavior: LanguageSelectionHintBehavior(engine: settings.activeTranscriptionEngine)
+                )
+
+                Text(String(localized: "Controls push-to-talk dictation, workflows that inherit the global spoken language, and CLI/API defaults when they use app defaults. Recorder and Recovery have separate language settings."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section(String(localized: "Engine")) {

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -227,19 +227,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             throw PluginTranscriptionError.notConfigured
         }
 
-        var options = DecodingOptions(
-            verbose: false,
-            task: translate ? .translate : .transcribe,
-            language: language,
-            temperature: 0.0,
-            temperatureFallbackCount: 3,
-            usePrefillPrompt: true,
-            usePrefillCache: true,
-            detectLanguage: language == nil,
-            skipSpecialTokens: true,
-            withoutTimestamps: false,
-            chunkingStrategy: .vad
-        )
+        var options = Self.decodingOptions(language: language, translate: translate)
         let effectivePrompt = Self.conditioningPrompt(from: prompt)
         if let tokenizer = whisperKit.tokenizer,
            let promptTokens = Self.promptTokens(from: effectivePrompt, tokenizer: tokenizer) {
@@ -290,19 +278,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             throw PluginTranscriptionError.notConfigured
         }
 
-        var options = DecodingOptions(
-            verbose: false,
-            task: translate ? .translate : .transcribe,
-            language: language,
-            temperature: 0.0,
-            temperatureFallbackCount: 3,
-            usePrefillPrompt: true,
-            usePrefillCache: true,
-            detectLanguage: language == nil,
-            skipSpecialTokens: true,
-            withoutTimestamps: false,
-            chunkingStrategy: .vad
-        )
+        var options = Self.decodingOptions(language: language, translate: translate)
         let effectivePrompt = Self.conditioningPrompt(from: prompt)
         if let tokenizer = whisperKit.tokenizer,
            let promptTokens = Self.promptTokens(from: effectivePrompt, tokenizer: tokenizer) {
@@ -341,6 +317,22 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         }
 
         return PluginTranscriptionResult(text: text, detectedLanguage: detectedLanguage, segments: segments)
+    }
+
+    static func decodingOptions(language: String?, translate: Bool) -> DecodingOptions {
+        DecodingOptions(
+            verbose: false,
+            task: translate ? .translate : .transcribe,
+            language: language,
+            temperature: 0.0,
+            temperatureFallbackCount: 3,
+            usePrefillPrompt: true,
+            usePrefillCache: true,
+            detectLanguage: language == nil,
+            skipSpecialTokens: true,
+            withoutTimestamps: false,
+            chunkingStrategy: .vad
+        )
     }
 
     static func sourceProgress(

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -4780,6 +4780,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(LanguageSelection(storedValue: nil, nilBehavior: .inheritGlobal), .inheritGlobal)
         XCTAssertEqual(LanguageSelection(storedValue: "auto", nilBehavior: .auto), .auto)
         XCTAssertEqual(LanguageSelection(storedValue: "de", nilBehavior: .auto), .exact("de"))
+        XCTAssertEqual(LanguageSelection(storedValue: "zh", nilBehavior: .auto), .exact("zh"))
         XCTAssertEqual(
             LanguageSelection(storedValue: #"["de","en"]"#, nilBehavior: .auto),
             .hints(["de", "en"])

--- a/TypeWhisperTests/SoundServiceTests.swift
+++ b/TypeWhisperTests/SoundServiceTests.swift
@@ -56,6 +56,19 @@ final class SoundServiceTests: XCTestCase {
         XCTAssertEqual(try TestSupport.localizedCatalogValue(for: "Off", language: "de"), "Aus")
     }
 
+    func testRecordingSpokenLanguageCopyIsLocalizedInCatalog() throws {
+        let copy = "Controls push-to-talk dictation, workflows that inherit the global spoken language, and CLI/API defaults when they use app defaults. Recorder and Recovery have separate language settings."
+
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(for: copy, preferredLanguages: ["en-US"]),
+            copy
+        )
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(for: copy, language: "de"),
+            "Steuert Push-to-Talk-Diktat, Workflows, die die globale gesprochene Sprache übernehmen, und CLI/API-Standardwerte, wenn sie App-Standardwerte verwenden. Recorder und Wiederherstellung haben separate Spracheinstellungen."
+        )
+    }
+
     @MainActor
     func testSoundResolutionCachesImportedCustomSounds() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import WhisperKit
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
@@ -48,6 +49,13 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(model?.displayName, "Distil Large v3 Turbo")
         XCTAssertEqual(model?.sizeDescription, "~600 MB")
         XCTAssertEqual(model?.ramRequirement, "8 GB+")
+    }
+
+    func testExactChineseLanguageDisablesWhisperKitLanguageDetection() {
+        let options = WhisperKitPlugin.decodingOptions(language: "zh", translate: false)
+
+        XCTAssertEqual(options.language, "zh")
+        XCTAssertFalse(options.detectLanguage)
     }
 
     func testActivationPromotesPersistedLoadedModelToSelectedModelWhenSelectionMissing() async throws {

--- a/TypeWhisperTests/WorkflowServiceTests.swift
+++ b/TypeWhisperTests/WorkflowServiceTests.swift
@@ -2265,6 +2265,15 @@ final class DictationLanguageResolverTests: XCTestCase {
         XCTAssertEqual(resolved, .exact("fr"))
     }
 
+    func testNoWorkflowUsesGlobalChineseLanguage() {
+        let resolved = DictationLanguageResolver.resolve(
+            workflow: nil,
+            globalLanguageSelection: .exact("zh")
+        )
+
+        XCTAssertEqual(resolved, .exact("zh"))
+    }
+
     func testWorkflowAutoOverridesGlobalLanguage() {
         let workflow = Workflow(
             name: "Auto Workflow",

--- a/scripts/build-release-local.sh
+++ b/scripts/build-release-local.sh
@@ -38,6 +38,7 @@ xcodebuild -project "$PROJECT_DIR/$PROJECT" \
   -configuration Release \
   -derivedDataPath "$BUILD_DIR" \
   -destination 'platform=macOS,arch=arm64' \
+  ENABLE_CODE_COVERAGE=NO \
   CODE_SIGN_IDENTITY="-" \
   CODE_SIGNING_REQUIRED=NO \
   CODE_SIGNING_ALLOWED=NO | tee "$BUILD_DIR/build.log"
@@ -50,6 +51,8 @@ if [ ! -d "$APP_PATH" ]; then
   echo "ERROR: App not found at $APP_PATH"
   exit 1
 fi
+
+bash "$PROJECT_DIR/scripts/check_release_binary_instrumentation.sh" "$APP_PATH/Contents/MacOS/typewhisper-cli"
 
 echo "--- App built at $APP_PATH ---"
 

--- a/scripts/check_release_binary_instrumentation.sh
+++ b/scripts/check_release_binary_instrumentation.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <binary-path> | --self-test" >&2
+}
+
+contains_llvm_instrumentation() {
+  grep -E '(^|[[:space:]])__llvm_(prf|cov)[[:alnum:]_]*([[:space:]]|$)' >/dev/null
+}
+
+self_test() {
+  local clean_output instrumented_output
+  clean_output=$'Load command 0\n      cmd LC_SEGMENT_64\n  sectname __text\n   segname __TEXT\n  sectname __swift5_types\n   segname __TEXT'
+  instrumented_output=$'Load command 1\n      cmd LC_SEGMENT_64\n  sectname __llvm_prf_cnts\n   segname __DATA\n  sectname __llvm_covmap\n   segname __LLVM'
+
+  if printf '%s\n' "$clean_output" | contains_llvm_instrumentation; then
+    echo "self-test failed: clean fixture was flagged as instrumented" >&2
+    return 1
+  fi
+
+  if ! printf '%s\n' "$instrumented_output" | contains_llvm_instrumentation; then
+    echo "self-test failed: instrumented fixture was not flagged" >&2
+    return 1
+  fi
+
+  echo "release binary instrumentation self-test passed"
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "$1" == "--self-test" ]]; then
+  self_test
+  exit 0
+fi
+
+binary_path="$1"
+if [[ ! -f "$binary_path" ]]; then
+  echo "error: binary not found: $binary_path" >&2
+  exit 2
+fi
+
+if ! otool_output="$(otool -l "$binary_path" 2>&1)"; then
+  echo "error: failed to inspect binary with otool: $binary_path" >&2
+  printf '%s\n' "$otool_output" >&2
+  exit 2
+fi
+
+if printf '%s\n' "$otool_output" | contains_llvm_instrumentation; then
+  echo "error: release binary contains LLVM coverage/profile instrumentation: $binary_path" >&2
+  printf '%s\n' "$otool_output" | grep -E '(^|[[:space:]])__llvm_(prf|cov)[[:alnum:]_]*([[:space:]]|$)' >&2
+  exit 1
+fi
+
+echo "release binary instrumentation check passed: $binary_path"


### PR DESCRIPTION
## Summary
- Surface the existing global spoken-language selector in Recording settings so dictation users can find the language lock without adding another preference or defaults key.
- Clarify that the setting controls push-to-talk dictation, workflows that inherit the global spoken language, and CLI/API defaults when they use app defaults; Recorder and Recovery keep separate language settings.
- Add a release guard that rejects packaged `typewhisper-cli` binaries containing `__llvm_prf*` or `__llvm_cov*` sections, and run it after Release app builds.

## Issue context
Issue #767 reports that WhisperKit push-to-talk dictation can translate Chinese speech into English on English-system Macs when language detection is automatic, while `typewhisper-cli --language zh` works. The app already has one source of truth for this lock through `SettingsViewModel.languageSelection` / `UserDefaultsKeys.selectedLanguage`; this PR makes that existing lock visible in Recording settings and verifies that exact Chinese stays `zh` through dictation resolution and WhisperKit decoding options.

The same issue also notes that the 1.4.0 cask shipped a `typewhisper-cli` binary with LLVM coverage/profile sections, which could write `default.profraw`. This PR forces Release app build commands to disable coverage and then verifies the packaged CLI binary with `otool` before release packaging continues.

Closes #767

## Test Plan
- `bash -n scripts/check_release_binary_instrumentation.sh && bash scripts/check_release_binary_instrumentation.sh --self-test`
- `jq empty TypeWhisper/Resources/Localizable.xcstrings`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testLanguageSelectionCodecSupportsLegacyAndHintValues -only-testing:TypeWhisperTests/DictationLanguageResolverTests -only-testing:TypeWhisperTests/SoundServiceTests/testRecordingSpokenLanguageCopyIsLocalizedInCatalog -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests/testExactChineseLanguageDisablesWhisperKitLanguageDetection CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Release -derivedDataPath build -destination 'generic/platform=macOS' ENABLE_CODE_COVERAGE=NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee build.log`
- `bash scripts/check_first_party_warnings.sh build.log`
- `bash scripts/check_release_binary_instrumentation.sh build/Build/Products/Release/TypeWhisper.app/Contents/MacOS/typewhisper-cli`
- `otool -l build/Build/Products/Release/TypeWhisper.app/Contents/MacOS/typewhisper-cli | grep -E 'sectname __llvm_(prf|cov)' || true`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Spoken Language” section to Recording settings, enabling users to configure recording-specific language preferences for dictation.

* **Documentation**
  * Updated the Spoken Language help text to explain how push-to-talk dictation, workflow language inheritance, and CLI/API defaults interact (including separate settings for Recorder and Recovery), with corresponding updated translations.

* **Chores / Tests**
  * Strengthened release build verification by adding a self-test and post-build checks to ensure release binaries don’t include instrumentation, while disabling code coverage for Release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->