### PR TITLE
fix: learn target-app corrections only after commit

### DIFF
--- a/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
+++ b/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
@@ -81,6 +81,78 @@ final class TargetAppCorrectionCommitObserver: TargetAppCorrectionCommitObservin
     }
 }
 
+private final class TargetAppCorrectionWakeCoordinator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var sleepTask: Task<Void, Never>?
+    private var generation = 0
+
+    func wait(for duration: Duration) async {
+        guard duration > .seconds(0), !Task.isCancelled else { return }
+
+        await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume()
+                    return
+                }
+                let waitID = self.startWait(continuation)
+                let task = Task { [weak self] in
+                    try? await Task.sleep(for: duration)
+                    self?.resume(waitID: waitID)
+                }
+                self.storeSleepTask(task, waitID: waitID)
+            }
+        }, onCancel: {
+            resume()
+        })
+    }
+
+    func wake() {
+        resume()
+    }
+
+    private func startWait(_ continuation: CheckedContinuation<Void, Never>) -> Int {
+        lock.lock()
+        generation += 1
+        let waitID = generation
+        self.continuation = continuation
+        let oldTask = sleepTask
+        sleepTask = nil
+        lock.unlock()
+        oldTask?.cancel()
+        return waitID
+    }
+
+    private func storeSleepTask(_ task: Task<Void, Never>, waitID: Int) {
+        lock.lock()
+        guard waitID == generation, continuation != nil else {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        sleepTask = task
+        lock.unlock()
+    }
+
+    private func resume(waitID: Int? = nil) {
+        lock.lock()
+        if let waitID, waitID != generation {
+            lock.unlock()
+            return
+        }
+        generation += 1
+        let task = sleepTask
+        sleepTask = nil
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+
+        task?.cancel()
+        continuation?.resume()
+    }
+}
+
 @MainActor
 final class TargetAppCorrectionLearningService {
     private static let defaultPollSchedule: [Duration] = (1...30).map { .seconds($0) }
@@ -120,8 +192,10 @@ final class TargetAppCorrectionLearningService {
         guard !insertedText.isEmpty, !pollSchedule.isEmpty else { return [] }
 
         var commitSignal: TargetAppCorrectionCommitSignal?
+        let wakeCoordinator = TargetAppCorrectionWakeCoordinator()
         let commitObserver = makeCommitObserver { signal in
             commitSignal = signal
+            wakeCoordinator.wake()
         }
         commitObserver.start()
         defer { commitObserver.stop() }
@@ -129,19 +203,29 @@ final class TargetAppCorrectionLearningService {
         var latestSuggestions: [CorrectionSuggestion] = []
         var elapsed: Duration = .seconds(0)
         for pollOffset in pollSchedule {
+            let waitDuration: Duration
             if pollOffset > elapsed {
-                await sleep(pollOffset - elapsed)
+                waitDuration = pollOffset - elapsed
                 elapsed = pollOffset
             } else {
-                await sleep(.seconds(0))
+                waitDuration = .seconds(0)
+            }
+            if commitSignal == nil {
+                if waitDuration > .seconds(0) {
+                    await wakeCoordinator.wait(for: waitDuration)
+                } else {
+                    await sleep(.seconds(0))
+                }
             }
             guard !Task.isCancelled else { return [] }
 
             guard let observation = textInsertionService.recaptureFocusedTextObservation(matching: baseline) else {
-                if textInsertionService.focusedTextElementMatches(baseline) {
+                switch textInsertionService.focusedTextElementMatch(baseline) {
+                case .same, .unavailable:
                     return []
+                case .different:
+                    return dictionaryService.learnCorrections(latestSuggestions)
                 }
-                return dictionaryService.learnCorrections(latestSuggestions)
             }
 
             let suggestions = highConfidenceCorrectionSuggestions(
@@ -151,6 +235,8 @@ final class TargetAppCorrectionLearningService {
             )
             if !suggestions.isEmpty {
                 latestSuggestions = suggestions
+            } else {
+                latestSuggestions = []
             }
 
             if commitSignal != nil {

--- a/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
+++ b/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
@@ -1,27 +1,115 @@
+import AppKit
 import Foundation
+
+enum TargetAppCorrectionCommitSignal: Equatable, Sendable {
+    case returnKey
+    case tabKey
+    case activeApplicationChanged
+}
+
+@MainActor
+protocol TargetAppCorrectionCommitObserving: AnyObject {
+    func start()
+    func stop()
+}
+
+@MainActor
+final class TargetAppCorrectionCommitObserver: TargetAppCorrectionCommitObserving {
+    private static let returnKeyCode: UInt16 = 0x24
+    private static let keypadEnterKeyCode: UInt16 = 0x4C
+    private static let tabKeyCode: UInt16 = 0x30
+
+    private let onCommit: @MainActor (TargetAppCorrectionCommitSignal) -> Void
+    private var globalKeyMonitor: Any?
+    private var localKeyMonitor: Any?
+    private var appActivationObserver: NSObjectProtocol?
+
+    init(onCommit: @escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void) {
+        self.onCommit = onCommit
+    }
+
+    func start() {
+        stop()
+
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyEvent(event)
+        }
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyEvent(event)
+            return event
+        }
+        appActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onCommit(.activeApplicationChanged)
+            }
+        }
+    }
+
+    func stop() {
+        if let globalKeyMonitor {
+            NSEvent.removeMonitor(globalKeyMonitor)
+            self.globalKeyMonitor = nil
+        }
+        if let localKeyMonitor {
+            NSEvent.removeMonitor(localKeyMonitor)
+            self.localKeyMonitor = nil
+        }
+        if let appActivationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(appActivationObserver)
+            self.appActivationObserver = nil
+        }
+    }
+
+    private func handleKeyEvent(_ event: NSEvent) {
+        guard let signal = Self.commitSignal(forKeyCode: event.keyCode) else { return }
+        onCommit(signal)
+    }
+
+    static func commitSignal(forKeyCode keyCode: UInt16) -> TargetAppCorrectionCommitSignal? {
+        switch keyCode {
+        case returnKeyCode, keypadEnterKeyCode:
+            return .returnKey
+        case tabKeyCode:
+            return .tabKey
+        default:
+            return nil
+        }
+    }
+}
 
 @MainActor
 final class TargetAppCorrectionLearningService {
+    private static let defaultPollSchedule: [Duration] = (1...30).map { .seconds($0) }
+
     private let textInsertionService: TextInsertionService
     private let textDiffService: TextDiffService
     private let dictionaryService: DictionaryService
     private let pollSchedule: [Duration]
     private let sleep: @MainActor (Duration) async -> Void
+    private let makeCommitObserver: (@escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void) -> TargetAppCorrectionCommitObserving
 
     init(
         textInsertionService: TextInsertionService,
         textDiffService: TextDiffService,
         dictionaryService: DictionaryService,
-        pollSchedule: [Duration] = [.seconds(2), .seconds(5), .seconds(10)],
+        pollSchedule: [Duration]? = nil,
         sleep: @escaping @MainActor (Duration) async -> Void = { duration in
             try? await Task.sleep(for: duration)
+        },
+        makeCommitObserver: @escaping (@escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void) -> TargetAppCorrectionCommitObserving = {
+            TargetAppCorrectionCommitObserver(onCommit: $0)
         }
     ) {
         self.textInsertionService = textInsertionService
         self.textDiffService = textDiffService
         self.dictionaryService = dictionaryService
-        self.pollSchedule = pollSchedule
+        self.pollSchedule = pollSchedule ?? Self.defaultPollSchedule
         self.sleep = sleep
+        self.makeCommitObserver = makeCommitObserver
     }
 
     func trackInsertion(
@@ -31,7 +119,14 @@ final class TargetAppCorrectionLearningService {
         let insertedText = insertedText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !insertedText.isEmpty, !pollSchedule.isEmpty else { return [] }
 
-        var finalObservation: TextInsertionService.FocusedTextObservation?
+        var commitSignal: TargetAppCorrectionCommitSignal?
+        let commitObserver = makeCommitObserver { signal in
+            commitSignal = signal
+        }
+        commitObserver.start()
+        defer { commitObserver.stop() }
+
+        var latestSuggestions: [CorrectionSuggestion] = []
         var elapsed: Duration = .seconds(0)
         for pollOffset in pollSchedule {
             if pollOffset > elapsed {
@@ -41,23 +136,29 @@ final class TargetAppCorrectionLearningService {
                 await sleep(.seconds(0))
             }
             guard !Task.isCancelled else { return [] }
+
             guard let observation = textInsertionService.recaptureFocusedTextObservation(matching: baseline) else {
-                return []
+                if textInsertionService.focusedTextElementMatches(baseline) {
+                    return []
+                }
+                return dictionaryService.learnCorrections(latestSuggestions)
             }
-            finalObservation = observation
+
+            let suggestions = highConfidenceCorrectionSuggestions(
+                insertedText: insertedText,
+                baselineText: baseline.value,
+                editedText: observation.value
+            )
+            if !suggestions.isEmpty {
+                latestSuggestions = suggestions
+            }
+
+            if commitSignal != nil {
+                return dictionaryService.learnCorrections(latestSuggestions)
+            }
         }
 
-        guard let finalObservation,
-              finalObservation.value != baseline.value else {
-            return []
-        }
-
-        let suggestions = highConfidenceCorrectionSuggestions(
-            insertedText: insertedText,
-            baselineText: baseline.value,
-            editedText: finalObservation.value
-        )
-        return dictionaryService.learnCorrections(suggestions)
+        return []
     }
 
     func highConfidenceCorrectionSuggestions(

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -511,6 +511,11 @@ final class TextInsertionService {
         )
     }
 
+    func focusedTextElementMatches(_ observation: FocusedTextObservation) -> Bool {
+        guard let focusedElement = getFocusedTextElement() else { return false }
+        return focusedElement == observation.element
+    }
+
     func canRestoreClipboard(afterPasteUsing state: PasteVerificationState) -> Bool {
         guard let initialState = state.focusedTextState,
               let currentState = captureFocusedTextState(for: initialState.element) else {

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -511,9 +511,15 @@ final class TextInsertionService {
         )
     }
 
-    func focusedTextElementMatches(_ observation: FocusedTextObservation) -> Bool {
-        guard let focusedElement = getFocusedTextElement() else { return false }
-        return focusedElement == observation.element
+    enum FocusedTextElementMatch: Equatable {
+        case same
+        case different
+        case unavailable
+    }
+
+    func focusedTextElementMatch(_ observation: FocusedTextObservation) -> FocusedTextElementMatch {
+        guard let focusedElement = getFocusedTextElement() else { return .unavailable }
+        return focusedElement == observation.element ? .same : .different
     }
 
     func canRestoreClipboard(afterPasteUsing state: PasteVerificationState) -> Bool {

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -26,10 +26,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             textInsertionService: textInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: dictionaryService,
-            pollSchedule: [.milliseconds(0)],
-            sleep: { _ in
-                commitEmitter.emit(.returnKey)
-            },
+            pollSchedule: [.seconds(5)],
             makeCommitObserver: commitObserver(capturing: commitEmitter)
         )
         let baseline = TextInsertionService.FocusedTextObservation(
@@ -39,7 +36,15 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             selectedRange: NSRange(location: 19, length: 0)
         )
 
-        let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+        let task = Task { @MainActor in
+            await service.trackInsertion(insertedText: "teh", baseline: baseline)
+        }
+        for _ in 0..<1000 where !commitEmitter.isReady {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(commitEmitter.isReady)
+        commitEmitter.emit(.returnKey)
+        let learned = await task.value
 
         XCTAssertEqual(learned.count, 1)
         XCTAssertEqual(learned.first?.original, "teh")
@@ -169,6 +174,49 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
+    func testSkipsUnavailableFocusComparisonAfterCandidate() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        var focusAvailable = true
+        textInsertionService.focusedTextElementOverride = {
+            focusAvailable ? element : nil
+        }
+
+        var captureCount = 0
+        textInsertionService.focusedTextStateOverride = { _ in
+            captureCount += 1
+            if captureCount == 1 {
+                let value = "Please use the word"
+                return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+            }
+            focusAvailable = false
+            return nil
+        }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
+        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
     func testSkipsFocusElementChangesAndMissingTextState() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -213,6 +261,53 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let missingStateLearned = await missingStateService.trackInsertion(insertedText: "teh", baseline: baseline)
         XCTAssertTrue(missingStateLearned.isEmpty)
+    }
+
+    func testClearsStaleSuggestionsWhenEditIsUndoneBeforeCommit() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+
+        var observations = [
+            "Please use the word",
+            "Please use teh word",
+            "Please use teh word"
+        ]
+        textInsertionService.focusedTextStateOverride = { _ in
+            let value = observations.removeFirst()
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        var sleepCount = 0
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.milliseconds(0), .milliseconds(0), .milliseconds(0)],
+            sleep: { _ in
+                sleepCount += 1
+                if sleepCount == 3 {
+                    commitEmitter.emit(.returnKey)
+                }
+            },
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
+        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
     func testSkipsUnmappableLargeDuplicateCaseAndPunctuationOnlyEdits() async throws {
@@ -344,6 +439,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             box.emit = { signal in
                 onCommit(signal)
             }
+            box.isReady = true
             return TestTargetAppCorrectionCommitObserver()
         }
     }
@@ -352,6 +448,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 @MainActor
 private final class CommitEmitterBox {
     var emit: (TargetAppCorrectionCommitSignal) -> Void = { _ in }
+    var isReady = false
 }
 
 @MainActor

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class TargetAppCorrectionLearningServiceTests: XCTestCase {
-    func testLearnsSingleConfidentReplacementFromSameElementFinalEdit() async throws {
+    func testLearnsSingleConfidentReplacementAfterCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
@@ -13,7 +13,6 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         textInsertionService.focusedTextElementOverride = { element }
 
         var observations = [
-            "Please use teh word",
             "Please use the word"
         ]
         textInsertionService.focusedTextStateOverride = { _ in
@@ -21,12 +20,17 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
         }
 
+        let commitEmitter = CommitEmitterBox()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let service = TargetAppCorrectionLearningService(
             textInsertionService: textInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: dictionaryService,
-            pollSchedule: [.milliseconds(0), .milliseconds(0)]
+            pollSchedule: [.milliseconds(0)],
+            sleep: { _ in
+                commitEmitter.emit(.returnKey)
+            },
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
         )
         let baseline = TextInsertionService.FocusedTextObservation(
             element: element,
@@ -43,7 +47,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertEqual(dictionaryService.correctionsCount, 1)
     }
 
-    func testDefaultPollScheduleSleepsWithinTenSecondWindow() async throws {
+    func testTimeoutDoesNotLearnWithoutCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
@@ -52,8 +56,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         textInsertionService.focusedTextElementOverride = { element }
 
         var observations = [
-            "Please use teh word",
-            "Please use teh word",
+            "Please use the word",
             "Please use the word"
         ]
         textInsertionService.focusedTextStateOverride = { _ in
@@ -61,15 +64,13 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
         }
 
-        var sleeps: [Duration] = []
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let service = TargetAppCorrectionLearningService(
             textInsertionService: textInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: dictionaryService,
-            sleep: { duration in
-                sleeps.append(duration)
-            }
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
         )
         let baseline = TextInsertionService.FocusedTextObservation(
             element: element,
@@ -80,9 +81,92 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
 
-        XCTAssertEqual(sleeps, [.seconds(2), .seconds(3), .seconds(5)])
+        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
+    func testLearnsLatestConfidentReplacementWhenFocusLeavesSameElement() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        let otherElement = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
+        var focusLeft = false
+        textInsertionService.focusedTextElementOverride = {
+            focusLeft ? otherElement : element
+        }
+
+        var captureCount = 0
+        textInsertionService.focusedTextStateOverride = { _ in
+            captureCount += 1
+            if captureCount == 1 {
+                let value = "Please use the word"
+                return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+            }
+            focusLeft = true
+            return nil
+        }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
         XCTAssertEqual(learned.first?.original, "teh")
         XCTAssertEqual(learned.first?.replacement, "the")
+        XCTAssertEqual(dictionaryService.correctionsCount, 1)
+    }
+
+    func testSkipsMissingTextStateWithoutFocusChangeAfterCandidate() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+
+        var captureCount = 0
+        textInsertionService.focusedTextStateOverride = { _ in
+            captureCount += 1
+            if captureCount == 1 {
+                let value = "Please use the word"
+                return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+            }
+            return nil
+        }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
+        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
     func testSkipsFocusElementChangesAndMissingTextState() async throws {
@@ -108,7 +192,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             textInsertionService: changedFocusInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: changedFocusDictionary,
-            pollSchedule: [.milliseconds(0)]
+            pollSchedule: [.milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
         )
 
         let changedFocusLearned = await changedFocusService.trackInsertion(insertedText: "teh", baseline: baseline)
@@ -122,7 +207,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             textInsertionService: missingStateInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: missingStateDictionary,
-            pollSchedule: [.milliseconds(0)]
+            pollSchedule: [.milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
         )
 
         let missingStateLearned = await missingStateService.trackInsertion(insertedText: "teh", baseline: baseline)
@@ -141,7 +227,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             textInsertionService: TextInsertionService(),
             textDiffService: TextDiffService(),
             dictionaryService: dictionaryService,
-            pollSchedule: [.milliseconds(0)]
+            pollSchedule: [.milliseconds(0)],
+            makeCommitObserver: noopCommitObserver
         )
         let baseline = TextInsertionService.FocusedTextObservation(
             element: element,
@@ -179,11 +266,20 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         duplicateInsertionService.focusedTextStateOverride = { _ in
             (value: "Please use the word", selectedText: nil, selectedRange: NSRange(location: 19, length: 0))
         }
+        let duplicateCommitEmitter = CommitEmitterBox()
+        var duplicateSleepCount = 0
         let duplicateService = TargetAppCorrectionLearningService(
             textInsertionService: duplicateInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: dictionaryService,
-            pollSchedule: [.milliseconds(0)]
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            sleep: { _ in
+                duplicateSleepCount += 1
+                if duplicateSleepCount == 2 {
+                    duplicateCommitEmitter.emit(.returnKey)
+                }
+            },
+            makeCommitObserver: commitObserver(capturing: duplicateCommitEmitter)
         )
 
         let duplicateLearned = await duplicateService.trackInsertion(insertedText: "teh", baseline: baseline)
@@ -207,7 +303,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             textInsertionService: textInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: dictionaryService,
-            pollSchedule: [.seconds(60)]
+            pollSchedule: [.seconds(60)],
+            makeCommitObserver: noopCommitObserver
         )
         let baseline = TextInsertionService.FocusedTextObservation(
             element: element,
@@ -226,4 +323,39 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertTrue(learned.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
+
+    func testCommitObserverMapsReturnEnterAndTabKeys() {
+        XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x24), .returnKey)
+        XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x4C), .returnKey)
+        XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x30), .tabKey)
+        XCTAssertNil(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x31))
+    }
+
+    private func noopCommitObserver(
+        onCommit _: @escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void
+    ) -> TargetAppCorrectionCommitObserving {
+        TestTargetAppCorrectionCommitObserver()
+    }
+
+    private func commitObserver(
+        capturing box: CommitEmitterBox
+    ) -> (@escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void) -> TargetAppCorrectionCommitObserving {
+        { onCommit in
+            box.emit = { signal in
+                onCommit(signal)
+            }
+            return TestTargetAppCorrectionCommitObserver()
+        }
+    }
+}
+
+@MainActor
+private final class CommitEmitterBox {
+    var emit: (TargetAppCorrectionCommitSignal) -> Void = { _ in }
+}
+
+@MainActor
+private final class TestTargetAppCorrectionCommitObserver: TargetAppCorrectionCommitObserving {
+    func start() {}
+    func stop() {}
 }


### PR DESCRIPTION
## Summary
- Gate target-app correction learning on explicit commit-style signals instead of learning at observation timeout.
- Keep the latest high-confidence correction candidate during the bounded watch window, but write it only after Return/Enter, Tab, active app change, or actual focus loss.
- Treat missing AX text state on the same focused element as a safe skip, and cover fast commit, timeout, focus-loss, and duplicate cases in tests.

## Issue context
Issue #760 reports that the fixed observation timeout could learn from a half-finished edit while the user was still typing. Timeout now only ends the watch; learning happens after the edit is confirmed or the target field is actually left.

Closes #760

## Test Coverage
All new code paths have XCTest coverage:
- commit signal learning, including a fast commit before the next poll
- timeout without learning
- focus loss learning
- missing AX text state skip while focus remains on the same element
- Return/Enter/Tab key mapping
- duplicate skip behavior

## Pre-Landing Review
No issues found.

## Design Review
No visible SwiftUI/UI files changed; design review skipped.

## Eval Results
No prompt-related files changed; evals skipped.

## Scope Drift
Scope Check: CLEAN

## Plan Completion
No plan file detected.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/TargetAppCorrectionLearningServiceTests -quiet`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `bash scripts/check_first_party_warnings.sh /tmp/ship_typewhisper_tests.txt`
- [x] `git diff --check`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added commit-trigger detection (Return, Tab, and active-app changes) to drive when corrections are learned and applied.
  * Made correction learning more responsive to focus changes and updated internal text-element matching to provide richer same/different status.
* **Bug Fixes**
  * Prevents correction learning when the expected commit signal isn’t received, improving reliability and reducing unintended learn events.
* **Tests**
  * Updated and expanded coverage to validate commit-driven learning, timeouts, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->