### PR TITLE
test: cover Latin word replacement boundaries

### DIFF
--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -187,6 +187,20 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testLatinCorrectionsMatchWholeWordsOnly() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "rake", replacement: "RAKE")
+
+        XCTAssertEqual(service.applyCorrections(to: "rake"), "RAKE")
+        XCTAssertEqual(service.applyCorrections(to: "Rake"), "RAKE")
+        XCTAssertEqual(service.applyCorrections(to: "brake rakes"), "brake rakes")
+        XCTAssertEqual(service.applyCorrections(to: "Use rake, rake/brake, and (rake)."), "Use RAKE, RAKE/brake, and (RAKE).")
+    }
+
+    @MainActor
     func testCorrectionsDoNotReplaceInsideLongerKatakanaWords() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary
- add a Latin dictionary-correction regression test for whole-word matching
- cover the reported `rake` -> `RAKE` case so `brake` and `rakes` stay unchanged
- verify punctuation and separators around `rake` still allow the correction to apply

## Issue context
Issue #725 reports that word replacements could fire inside larger words, making short dictionary corrections unsafe. The app already has boundary-aware correction matching on `main`; this PR locks the reported Latin-word behavior with an explicit XCTest regression.

Closes #725

## Pre-Landing Review
- Scope check: clean, test-only change in `TypeWhisperTests/DictionaryServiceTests.swift`.
- No application logic, UI, persistence schema, networking, or security-sensitive path changed.

## Test plan
- [x] `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictionaryServiceTests/testLatinCorrectionsMatchWholeWordsOnly`
- [x] `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictionaryServiceTests`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests verifying Latin corrections apply only to whole-word matches, properly respecting word boundaries and case sensitivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->