### PR TITLE
feat: pause dictation hotkeys from menu

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -15,6 +15,7 @@ enum UserDefaultsKeys {
     static let indicatorTranscriptPreviewFontSizeOffset = "indicatorTranscriptPreviewFontSizeOffset"
     static let preserveClipboard = "preserveClipboard"
     static let mediaPauseEnabled = "mediaPauseEnabled"
+    static let dictationHotkeysPaused = "dictationHotkeysPaused"
     static let transcribeShortQuietClipsAggressively = "transcribeShortQuietClipsAggressively"
     static let microphoneBoostEnabled = "microphoneBoostEnabled"
 

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -3517,6 +3517,22 @@
         }
       }
     },
+    "Dictation hotkeys paused": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktat-Hotkeys pausiert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディクテーションのホットキーは一時停止中"
+          }
+        }
+      }
+    },
     "Dictionary": {
       "localizations": {
         "de": {
@@ -7826,6 +7842,22 @@
         }
       }
     },
+    "Pause Dictation Hotkeys": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktat-Hotkeys pausieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディクテーションのホットキーを一時停止"
+          }
+        }
+      }
+    },
     "Pay-what-you-want starting at the listed price. Click a tier to open the checkout page.": {
       "localizations": {
         "de": {
@@ -10321,6 +10353,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "貼り付け後、クリップボードを復元します。このオプションがない場合、音声入力後クリップボードには文字起こしのテキストが含まれます。"
+          }
+        }
+      }
+    },
+    "Resume Dictation Hotkeys": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktat-Hotkeys fortsetzen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディクテーションのホットキーを再開"
           }
         }
       }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -126,6 +126,17 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
     }
 }
 
+private extension HotkeySlotType {
+    var startsDictation: Bool {
+        switch self {
+        case .hybrid, .pushToTalk, .toggle:
+            true
+        case .promptPalette, .recentTranscriptions, .copyLastTranscription, .recorderToggle:
+            false
+        }
+    }
+}
+
 /// Manages global hotkeys for dictation and standalone app actions.
 final class HotkeyService: ObservableObject, @unchecked Sendable {
     struct MenuShortcutDescriptor: Equatable, Sendable {
@@ -167,6 +178,14 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     }
 
     @Published private(set) var currentMode: HotkeyMode?
+    @Published var dictationHotkeysPaused: Bool = UserDefaults.standard.bool(forKey: UserDefaultsKeys.dictationHotkeysPaused) {
+        didSet {
+            UserDefaults.standard.set(dictationHotkeysPaused, forKey: UserDefaultsKeys.dictationHotkeysPaused)
+            if dictationHotkeysPaused {
+                resetPausedDictationHotkeyState()
+            }
+        }
+    }
 
     var onDictationStart: ((UInt64) -> Void)?
     var onDictationStop: (() -> Void)?
@@ -385,6 +404,28 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         currentMode = nil
         keyDownTime = nil
         pushToTalkInterruptionSignaled = false
+    }
+
+    private func resetPausedDictationHotkeyState() {
+        for slotType in HotkeySlotType.allCases where slotType.startsDictation {
+            guard var states = slots[slotType] else { continue }
+            for index in states.indices {
+                states[index].resetTransientState()
+            }
+            slots[slotType] = states
+        }
+
+        for profileId in Array(profileSlots.keys) {
+            profileSlots[profileId]?.resetTransientState()
+        }
+
+        for workflowId in Array(workflowSlots.keys) {
+            guard var states = workflowSlots[workflowId] else { continue }
+            for index in states.indices where states[index].behavior == .startDictation {
+                states[index].resetTransientState()
+            }
+            workflowSlots[workflowId] = states
+        }
     }
 
     // MARK: - Profile Hotkeys
@@ -699,6 +740,11 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             for index in states.indices {
                 var state = states[index]
                 guard let hotkey = state.hotkey else { continue }
+                if dictationHotkeysPaused, slotType.startsDictation {
+                    state.resetTransientState()
+                    states[index] = state
+                    continue
+                }
                 let fnTriggerMode: FnTriggerMode = slotType == .toggle ? .releaseOnly : .pressThenRelease
                 if shouldSuppressForCapsLockOrigin(event, hotkey: hotkey, keyWasDown: state.keyWasDown) {
                     state.resetTransientState()
@@ -727,6 +773,11 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         // Profile slots
         for profileId in Array(profileSlots.keys) {
             guard var pState = profileSlots[profileId] else { continue }
+            if dictationHotkeysPaused {
+                pState.resetTransientState()
+                profileSlots[profileId] = pState
+                continue
+            }
             if shouldSuppressForCapsLockOrigin(event, hotkey: pState.hotkey, keyWasDown: pState.keyWasDown) {
                 pState.resetTransientState()
                 profileSlots[profileId] = pState
@@ -766,6 +817,11 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             guard var states = workflowSlots[workflowId] else { continue }
             for index in states.indices {
                 var wState = states[index]
+                if dictationHotkeysPaused, wState.behavior == .startDictation {
+                    wState.resetTransientState()
+                    states[index] = wState
+                    continue
+                }
                 if shouldSuppressForCapsLockOrigin(event, hotkey: wState.hotkey, keyWasDown: wState.keyWasDown) {
                     wState.resetTransientState()
                     states[index] = wState

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -13,6 +13,7 @@ private final class MenuBarState: ObservableObject {
     @Published var hasRecoverableRecording: Bool
     @Published var recorderState: AudioRecorderViewModel.RecorderState
     @Published var canToggleRecorder: Bool
+    @Published var dictationHotkeysPaused: Bool
     @Published var recentTranscriptionsMenuShortcut: HotkeyService.MenuShortcutDescriptor?
     @Published var copyLastTranscriptionMenuShortcut: HotkeyService.MenuShortcutDescriptor?
     @Published var recorderToggleMenuShortcut: HotkeyService.MenuShortcutDescriptor?
@@ -26,6 +27,7 @@ private final class MenuBarState: ObservableObject {
         let historyService = ServiceContainer.shared.historyService
         let recentTranscriptionStore = ServiceContainer.shared.recentTranscriptionStore
         let recorder = AudioRecorderViewModel.shared
+        let hotkeyService = ServiceContainer.shared.hotkeyService
 
         // Set initial values immediately
         self.isModelReady = modelManager.isModelReady
@@ -35,6 +37,7 @@ private final class MenuBarState: ObservableObject {
         self.hasRecoverableRecording = audioRecordingService.latestRecoveryRecordingURL != nil
         self.recorderState = recorder.state
         self.canToggleRecorder = recorder.canToggleRecording
+        self.dictationHotkeysPaused = hotkeyService.dictationHotkeysPaused
         self.recentTranscriptionsMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recentTranscriptions)
         self.copyLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .copyLastTranscription)
         self.recorderToggleMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recorderToggle)
@@ -107,10 +110,26 @@ private final class MenuBarState: ObservableObject {
                 self?.refreshMenuShortcuts()
             }
             .store(in: &cancellables)
+
+        hotkeyService.$dictationHotkeysPaused
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] paused in
+                self?.dictationHotkeysPaused = paused
+                self?.update(state: dictation.state)
+            }
+            .store(in: &cancellables)
     }
 
     private func update(state: DictationViewModel.State) {
         let modelManager = ServiceContainer.shared.modelManagerService
+        if dictationHotkeysPaused, state == .idle {
+            statusText = String(localized: "Dictation hotkeys paused")
+            statusImage = "pause.circle.fill"
+            isModelReady = modelManager.isModelReady
+            return
+        }
+
         switch state {
         case .recording:
             statusText = String(localized: "Recording...")
@@ -171,6 +190,7 @@ enum MenuBarMenuItem: Hashable {
     case history
     case errorLog
     case toggleRecorder
+    case toggleDictationHotkeysPause
     case transcribeFile
     case recoverLastRecording
     case recentTranscriptions
@@ -214,8 +234,8 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
             [.toggleRecorder]
         case .transcription:
             hasRecoverableRecording
-                ? [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
-                : [.transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+                ? [.toggleDictationHotkeysPause, .transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+                : [.toggleDictationHotkeysPause, .transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         case .updates:
             [.checkForUpdates]
         }
@@ -293,6 +313,13 @@ struct MenuBarView: View {
             .keyboardShortcut(keyboardShortcut(from: status.recorderToggleMenuShortcut))
             .disabled(!status.canToggleRecorder)
 
+        case .toggleDictationHotkeysPause:
+            Button {
+                ServiceContainer.shared.hotkeyService.dictationHotkeysPaused.toggle()
+            } label: {
+                Label(dictationHotkeysPauseTitle, systemImage: dictationHotkeysPauseSystemImage)
+            }
+
         case .transcribeFile:
             Button {
                 openManagedWindow("settings")
@@ -366,6 +393,16 @@ struct MenuBarView: View {
         case .finalizing:
             "arrow.triangle.2.circlepath"
         }
+    }
+
+    private var dictationHotkeysPauseTitle: String {
+        status.dictationHotkeysPaused
+            ? String(localized: "Resume Dictation Hotkeys")
+            : String(localized: "Pause Dictation Hotkeys")
+    }
+
+    private var dictationHotkeysPauseSystemImage: String {
+        status.dictationHotkeysPaused ? "play.circle" : "pause.circle"
     }
 
     private func keyboardShortcut(

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7146,6 +7146,25 @@ final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {
 }
 
 final class HotkeyServiceCompatibilityTests: XCTestCase {
+    private var originalDictationHotkeysPausedDefault: Any?
+
+    override func setUp() {
+        super.setUp()
+        originalDictationHotkeysPausedDefault = UserDefaults.standard.object(forKey: UserDefaultsKeys.dictationHotkeysPaused)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.dictationHotkeysPaused)
+    }
+
+    override func tearDown() {
+        let key = UserDefaultsKeys.dictationHotkeysPaused
+        if let originalDictationHotkeysPausedDefault {
+            UserDefaults.standard.set(originalDictationHotkeysPausedDefault, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        originalDictationHotkeysPausedDefault = nil
+        super.tearDown()
+    }
+
     @MainActor
     func testEscapeKeyStillInvokesCancelHandlerWithoutSuppression() throws {
         let service = HotkeyService()
@@ -7197,6 +7216,45 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
         XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
         XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testPausedDictationHotkeysIgnoreGlobalDictationSlots() throws {
+        try withCleanDictationHotkeysPausedDefault {
+            let service = HotkeyService()
+            service.suspendMonitoring()
+            service.dictationHotkeysPaused = true
+
+            service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
+            service.setHotkeyForTesting(commandOptionAHotkey(), for: .hybrid)
+            service.setHotkeyForTesting(controlShiftComboHotkey(), for: .pushToTalk)
+
+            var startCount = 0
+            service.onDictationStart = { _ in startCount += 1 }
+
+            let toggleDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+            let hybridDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+            let pushToTalkDown = try makeFlagsChangedEvent(keyCode: 0x38, modifierFlags: [.control, .shift])
+
+            XCTAssertFalse(service.processEventForTesting(toggleDown, source: .monitor))
+            XCTAssertFalse(service.processEventForTesting(hybridDown, source: .monitor))
+            XCTAssertFalse(service.processEventForTesting(pushToTalkDown, source: .monitor))
+            XCTAssertEqual(startCount, 0)
+            XCTAssertNil(service.currentMode)
+        }
+    }
+
+    @MainActor
+    func testPausedDictationHotkeysPersistAcrossServiceInstances() throws {
+        try withCleanDictationHotkeysPausedDefault {
+            let service = HotkeyService()
+            XCTAssertFalse(service.dictationHotkeysPaused)
+
+            service.dictationHotkeysPaused = true
+
+            let restoredService = HotkeyService()
+            XCTAssertTrue(restoredService.dictationHotkeysPaused)
+        }
     }
 
     @MainActor
@@ -8034,6 +8092,29 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testPausedDictationHotkeysKeepRecorderToggleActive() throws {
+        try withCleanDictationHotkeysPausedDefault {
+            let service = HotkeyService()
+            service.suspendMonitoring()
+            service.dictationHotkeysPaused = true
+
+            service.setHotkeyForTesting(commandOptionAHotkey(), for: .recorderToggle)
+
+            var callbackCount = 0
+            var startCount = 0
+            service.onRecorderToggle = { callbackCount += 1 }
+            service.onDictationStart = { _ in startCount += 1 }
+
+            let keyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+
+            XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+            XCTAssertEqual(callbackCount, 1)
+            XCTAssertEqual(startCount, 0)
+            XCTAssertNil(service.currentMode)
+        }
+    }
+
+    @MainActor
     func testRecorderToggleHotkeyDoesNotStopActiveDictation() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -8172,6 +8253,28 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testPausedDictationHotkeysIgnoreWorkflowDictationHotkey() throws {
+        try withCleanDictationHotkeysPausedDefault {
+            let service = HotkeyService()
+            service.suspendMonitoring()
+            service.dictationHotkeysPaused = true
+
+            let workflowId = UUID()
+            service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey(), behavior: .startDictation)])
+
+            var startedWorkflowId: UUID?
+            service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowId = workflowId }
+
+            let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+
+            XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+            XCTAssertNil(startedWorkflowId)
+            XCTAssertNil(service.currentMode)
+            XCTAssertNil(service.activeWorkflowId)
+        }
+    }
+
+    @MainActor
     func testWorkflowHotkeyTextProcessingCallbackDoesNotStartDictation() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -8204,6 +8307,52 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
         await fulfillment(of: [textProcessingCallback], timeout: 1.0)
         XCTAssertEqual(textWorkflowId, workflowId)
+        XCTAssertNil(service.currentMode)
+        XCTAssertNil(service.activeWorkflowId)
+    }
+
+    @MainActor
+    func testPausedDictationHotkeysKeepWorkflowTextProcessingActive() async throws {
+        let defaults = UserDefaults.standard
+        let key = UserDefaultsKeys.dictationHotkeysPaused
+        let original = defaults.object(forKey: key)
+        defaults.removeObject(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.dictationHotkeysPaused = true
+        service.workflowTextProcessingModifierPollInterval = 0.001
+        service.workflowTextProcessingModifierReleaseTimeout = 0.25
+        service.workflowTextProcessingPostReleaseDelay = 0.001
+        service.modifierFlagsStateProvider = { [] }
+
+        let workflowId = UUID()
+        service.registerWorkflowHotkeys([(id: workflowId, hotkey: spaceHotkey(), behavior: .processSelectedText)])
+
+        var textWorkflowId: UUID?
+        var startedWorkflowId: UUID?
+        let textProcessingCallback = expectation(description: "workflow text processing callback")
+        service.onWorkflowTextProcessing = {
+            textWorkflowId = $0
+            textProcessingCallback.fulfill()
+        }
+        service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowId = workflowId }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        let keyUp = try makeKeyboardEvent(keyCode: 0x31, keyDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        await fulfillment(of: [textProcessingCallback], timeout: 1.0)
+        XCTAssertEqual(textWorkflowId, workflowId)
+        XCTAssertNil(startedWorkflowId)
         XCTAssertNil(service.currentMode)
         XCTAssertNil(service.activeWorkflowId)
     }
@@ -8539,6 +8688,22 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
                 } else {
                     defaults.removeObject(forKey: key)
                 }
+            }
+        }
+
+        try body()
+    }
+
+    private func withCleanDictationHotkeysPausedDefault(_ body: () throws -> Void) throws {
+        let defaults = UserDefaults.standard
+        let key = UserDefaultsKeys.dictationHotkeysPaused
+        let original = defaults.object(forKey: key)
+        defaults.removeObject(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
             }
         }
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -571,11 +571,11 @@ final class MenuBarGroupingTests: XCTestCase {
         )
         XCTAssertEqual(
             MenuBarMenuSection.transcription.items(hasRecoverableRecording: true),
-            [.transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+            [.toggleDictationHotkeysPause, .transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         )
         XCTAssertEqual(
             MenuBarMenuSection.transcription.items(hasRecoverableRecording: false),
-            [.transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+            [.toggleDictationHotkeysPause, .transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
         )
         XCTAssertEqual(
             MenuBarMenuSection.updates.items,


### PR DESCRIPTION
## Summary
Implements the global dictation hotkey pause requested in #735.

Issue context: the requester clarified that the pause should temporarily disable dictation/hotkeys globally, including the left Ctrl trigger, and should not be treated as a Recorder pause control.

Changes:
- Add a persisted `dictationHotkeysPaused` setting, defaulting to off for new users.
- Add a Transcription menu toggle that switches between `Pause Dictation Hotkeys` and `Resume Dictation Hotkeys`.
- Show `Dictation hotkeys paused` in the menu status while idle and paused.
- Ignore dictation-starting global, profile, and workflow hotkeys while paused.
- Keep Recorder toggle, Prompt Palette, Recent Transcriptions, Copy Last Transcription, workflow text processing hotkeys, menu actions, and Escape cancel available.
- Add regression coverage for paused global dictation slots, workflow dictation hotkeys, workflow text processing, recorder toggle behavior, and persistence.

Closes #735

## Test Coverage
All new code paths have focused XCTest coverage:
- Paused `.hybrid`, `.pushToTalk`, and `.toggle` global slots do not start dictation.
- Paused workflow `startDictation` hotkeys do not start dictation.
- Workflow text-processing hotkeys continue to dispatch when paused.
- Recorder toggle hotkey continues to dispatch when paused.
- Pause state persists through `UserDefaults`.
- Menu grouping includes the new Transcription toggle.

## Pre-Landing Review
No issues found in the diff-scoped pre-landing review.

## Design Review
SwiftUI menu surface changed. Web design review skipped; menu placement and status copy were checked against the requested scope.

## Eval Results
No prompt-related files changed, evals skipped.

## Plan Completion
Plan items completed:
- Persisted `dictationHotkeysPaused` setting.
- Observable HotkeyService pause state.
- Dictation-starting hotkey dispatches ignored while paused.
- Recorder and non-dictating actions remain available.
- Menu toggle and paused status line added.
- Tests added for the requested behavior.

## Verification Results
TypeWhisper app workflow verified locally against current `origin/main`.

## Test plan
- [x] `python3 -m json.tool TypeWhisper/Resources/Localizable.xcstrings >/dev/null`
- [x] `git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/.codex/worktrees/c89c/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new menu option to pause or resume dictation hotkeys.
  * The paused state is now saved and restored automatically between app launches.

* **Bug Fixes**
  * Dictation hotkeys now stay inactive while paused, preventing accidental triggering.
  * Updated labels and status text to reflect the current pause state in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->