### PR TITLE
Fix OpenAI Compatible GPT-5 token parameter

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -735,6 +735,17 @@ final class OpenAICompatiblePlugin: NSObject,
             : "api-key.\(canonicalProfileId(for: profileId))"
     }
 
+    nonisolated static func outputTokenParameter(for modelID: String) -> String {
+        let lowered = modelID.lowercased()
+        if lowered.hasPrefix("gpt-5")
+            || lowered.hasPrefix("o1")
+            || lowered.hasPrefix("o3")
+            || lowered.hasPrefix("o4") {
+            return "max_completion_tokens"
+        }
+        return "max_tokens"
+    }
+
     private func processChatCompletion(
         apiKey: String,
         baseURL: String,
@@ -756,11 +767,11 @@ final class OpenAICompatiblePlugin: NSObject,
                 ["role": "system", "content": systemPrompt],
                 ["role": "user", "content": userText],
             ],
-            "max_tokens": 4096,
             "thinking": [
                 "type": thinkingEnabled ? "enabled" : "disabled"
             ],
         ]
+        requestBody[Self.outputTokenParameter(for: model)] = 4096
         if let temperature {
             requestBody["temperature"] = temperature
         }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -273,7 +273,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let inception = plugin.addProfile(named: "Inception")
         plugin.setBaseURL("https://inception.test", for: inception.id)
         plugin.setApiKey("inception-token", for: inception.id)
-        plugin.selectLLMModel("inception-chat", for: inception.id)
+        plugin.selectLLMModel("gpt-5.5", for: inception.id)
         plugin.setLLMTemperatureMode(.custom, for: inception.id)
         plugin.setLLMTemperatureValue(0.9, for: inception.id)
         plugin.setThinkingEnabled(true, for: inception.id)
@@ -325,11 +325,20 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         let inceptionBody = try XCTUnwrap(requests[1].httpBody)
         let inceptionJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: inceptionBody) as? [String: Any])
-        XCTAssertEqual(inceptionJSON["model"] as? String, "inception-chat")
-        XCTAssertEqual(inceptionJSON["max_tokens"] as? Int, 4096)
+        XCTAssertEqual(inceptionJSON["model"] as? String, "gpt-5.5")
+        XCTAssertEqual(inceptionJSON["max_completion_tokens"] as? Int, 4096)
+        XCTAssertNil(inceptionJSON["max_tokens"])
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
         let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
         XCTAssertEqual(inceptionThinking["type"], "enabled")
+    }
+
+    func testOutputTokenParameterUsesMaxCompletionTokensForReasoningFamilies() {
+        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "gpt-5.5"), "max_completion_tokens")
+        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "o1-preview"), "max_completion_tokens")
+        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "o3-mini"), "max_completion_tokens")
+        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "o4-mini"), "max_completion_tokens")
+        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "gpt-4o"), "max_tokens")
     }
 
     func testProcessSurfacesOpenAICompatibleErrorMessage() async throws {


### PR DESCRIPTION
## Summary
- update OpenAI Compatible chat requests to use `max_completion_tokens` for GPT-5 and reasoning-family model IDs
- keep `max_tokens` for non-reasoning OpenAI-compatible chat models
- preserve the existing per-profile Thinking Mode request payload

## Issue Context
Issue #774 reports that TypeWhisper 1.4.0 with OpenAICompatiblePlugin sends `max_tokens` to GPT-5-series models, which OpenAI rejects with an unsupported-parameter error. This PR fixes the 1.5-compatible plugin line by matching the official OpenAI plugin token-parameter rule for GPT-5/o1/o3/o4 model families.

Closes #774

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAIChatHelperTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat request handling so token limits are sent in the format expected by different model families.
  * Helps ensure newer reasoning models work correctly while keeping existing model behavior unchanged.

* **Tests**
  * Expanded automated coverage for model-specific token limit behavior and request formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->