### PR TITLE
Make OpenAI Compatible token parameter fallback generic

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -735,15 +735,31 @@ final class OpenAICompatiblePlugin: NSObject,
             : "api-key.\(canonicalProfileId(for: profileId))"
     }
 
-    nonisolated static func outputTokenParameter(for modelID: String) -> String {
-        let lowered = modelID.lowercased()
-        if lowered.hasPrefix("gpt-5")
-            || lowered.hasPrefix("o1")
-            || lowered.hasPrefix("o3")
-            || lowered.hasPrefix("o4") {
-            return "max_completion_tokens"
+    enum OutputTokenParameter: String {
+        case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+
+        var fallback: OutputTokenParameter {
+            switch self {
+            case .maxTokens:
+                .maxCompletionTokens
+            case .maxCompletionTokens:
+                .maxTokens
+            }
         }
-        return "max_tokens"
+    }
+
+    nonisolated static func fallbackOutputTokenParameter(
+        after parameter: OutputTokenParameter,
+        errorMessage: String
+    ) -> OutputTokenParameter? {
+        let lowered = errorMessage.lowercased()
+        let current = parameter.rawValue.lowercased()
+        let fallback = parameter.fallback.rawValue.lowercased()
+        guard lowered.contains(current), lowered.contains(fallback) else {
+            return nil
+        }
+        return parameter.fallback
     }
 
     private func processChatCompletion(
@@ -761,6 +777,52 @@ final class OpenAICompatiblePlugin: NSObject,
             throw PluginChatError.apiError("Invalid URL: \(endpoint)")
         }
 
+        let outputTokenParameter = OutputTokenParameter.maxTokens
+        do {
+            return try await performChatCompletionRequest(
+                url: url,
+                apiKey: apiKey,
+                model: model,
+                systemPrompt: systemPrompt,
+                userText: userText,
+                temperature: temperature,
+                requestTimeout: requestTimeout,
+                thinkingEnabled: thinkingEnabled,
+                outputTokenParameter: outputTokenParameter
+            )
+        } catch let error as PluginChatError {
+            guard case .apiError(let message) = error,
+                  let fallback = Self.fallbackOutputTokenParameter(
+                    after: outputTokenParameter,
+                    errorMessage: message
+                  ) else {
+                throw error
+            }
+            return try await performChatCompletionRequest(
+                url: url,
+                apiKey: apiKey,
+                model: model,
+                systemPrompt: systemPrompt,
+                userText: userText,
+                temperature: temperature,
+                requestTimeout: requestTimeout,
+                thinkingEnabled: thinkingEnabled,
+                outputTokenParameter: fallback
+            )
+        }
+    }
+
+    private func performChatCompletionRequest(
+        url: URL,
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        temperature: Double?,
+        requestTimeout: TimeInterval,
+        thinkingEnabled: Bool,
+        outputTokenParameter: OutputTokenParameter
+    ) async throws -> String {
         var requestBody: [String: Any] = [
             "model": model,
             "messages": [
@@ -771,7 +833,7 @@ final class OpenAICompatiblePlugin: NSObject,
                 "type": thinkingEnabled ? "enabled" : "disabled"
             ],
         ]
-        requestBody[Self.outputTokenParameter(for: model)] = 4096
+        requestBody[outputTokenParameter.rawValue] = 4096
         if let temperature {
             requestBody["temperature"] = temperature
         }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -273,7 +273,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let inception = plugin.addProfile(named: "Inception")
         plugin.setBaseURL("https://inception.test", for: inception.id)
         plugin.setApiKey("inception-token", for: inception.id)
-        plugin.selectLLMModel("gpt-5.5", for: inception.id)
+        plugin.selectLLMModel("inception-chat", for: inception.id)
         plugin.setLLMTemperatureMode(.custom, for: inception.id)
         plugin.setLLMTemperatureValue(0.9, for: inception.id)
         plugin.setThinkingEnabled(true, for: inception.id)
@@ -325,20 +325,92 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         let inceptionBody = try XCTUnwrap(requests[1].httpBody)
         let inceptionJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: inceptionBody) as? [String: Any])
-        XCTAssertEqual(inceptionJSON["model"] as? String, "gpt-5.5")
-        XCTAssertEqual(inceptionJSON["max_completion_tokens"] as? Int, 4096)
-        XCTAssertNil(inceptionJSON["max_tokens"])
+        XCTAssertEqual(inceptionJSON["model"] as? String, "inception-chat")
+        XCTAssertEqual(inceptionJSON["max_tokens"] as? Int, 4096)
+        XCTAssertNil(inceptionJSON["max_completion_tokens"])
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
         let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
         XCTAssertEqual(inceptionThinking["type"], "enabled")
     }
 
-    func testOutputTokenParameterUsesMaxCompletionTokensForReasoningFamilies() {
-        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "gpt-5.5"), "max_completion_tokens")
-        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "o1-preview"), "max_completion_tokens")
-        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "o3-mini"), "max_completion_tokens")
-        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "o4-mini"), "max_completion_tokens")
-        XCTAssertEqual(OpenAICompatiblePlugin.outputTokenParameter(for: "gpt-4o"), "max_tokens")
+    func testProcessRetriesWithMaxCompletionTokensWhenProviderRequestsIt() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedLLMModel": "future-chat",
+            ],
+            secrets: ["api-key": "secret-token"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setLLMTemperatureMode(.custom)
+        plugin.setLLMTemperatureValue(0.4)
+        plugin.setThinkingEnabled(true)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        #"{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}"#.utf8
+                    ),
+                    Self.httpResponse(url: "https://example.test/v1/chat/completions", statusCode: 400)
+                ),
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"processed"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.process(
+            systemPrompt: "Fix",
+            userText: "hello",
+            model: nil,
+            temperatureDirective: .inheritProviderSetting
+        )
+
+        XCTAssertEqual(result, "processed")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+
+        let firstBody = try XCTUnwrap(requests[0].httpBody)
+        let firstJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: firstBody) as? [String: Any])
+        XCTAssertEqual(firstJSON["model"] as? String, "future-chat")
+        XCTAssertEqual(firstJSON["max_tokens"] as? Int, 4096)
+        XCTAssertNil(firstJSON["max_completion_tokens"])
+
+        let retryBody = try XCTUnwrap(requests[1].httpBody)
+        let retryJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: retryBody) as? [String: Any])
+        XCTAssertEqual(retryJSON["model"] as? String, "future-chat")
+        XCTAssertEqual(retryJSON["max_completion_tokens"] as? Int, 4096)
+        XCTAssertNil(retryJSON["max_tokens"])
+        XCTAssertEqual(retryJSON["temperature"] as? Double, 0.4)
+        let retryThinking = try XCTUnwrap(retryJSON["thinking"] as? [String: String])
+        XCTAssertEqual(retryThinking["type"], "enabled")
+    }
+
+    func testFallbackOutputTokenParameterRequiresBothParameterNames() {
+        XCTAssertEqual(
+            OpenAICompatiblePlugin.fallbackOutputTokenParameter(
+                after: .maxTokens,
+                errorMessage: "Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead."
+            ),
+            .maxCompletionTokens
+        )
+        XCTAssertEqual(
+            OpenAICompatiblePlugin.fallbackOutputTokenParameter(
+                after: .maxCompletionTokens,
+                errorMessage: "Unsupported parameter: 'max_completion_tokens'. Use 'max_tokens' instead."
+            ),
+            .maxTokens
+        )
+        XCTAssertNil(
+            OpenAICompatiblePlugin.fallbackOutputTokenParameter(
+                after: .maxTokens,
+                errorMessage: "model not found"
+            )
+        )
     }
 
     func testProcessSurfacesOpenAICompatibleErrorMessage() async throws {


### PR DESCRIPTION
## Summary
- remove the hard-coded OpenAI model-family token parameter heuristic from OpenAI Compatible
- send `max_tokens` by default for generic OpenAI-compatible servers
- retry once with the alternate token parameter when the provider explicitly asks for `max_completion_tokens` or `max_tokens` in its API error

## Issue Context
Issue #774 exposed the token-parameter mismatch through a GPT-5-series model, but OpenAI Compatible should not need model-family-specific product knowledge for this. This follow-up keeps the plugin generic and lets the provider error drive the compatible retry behavior.

Closes #774

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAIChatHelperTests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat request handling so the app can retry with the correct output token limit field when a provider rejects the first attempt.
  * Made token limit selection more reliable across different compatible models.
  * Preserved request settings like model, temperature, and thinking mode during retry.
* **Tests**
  * Added coverage for retrying after a token-field error.
  * Updated validation for output token field fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->