### PR TITLE
Fix global push-to-talk hotkey detection

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -221,6 +221,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private static let escapeHotkey = UnifiedHotkey(keyCode: escapeKeyCode, modifierFlags: 0, isFn: false)
     private static let capsLockKeyCode: UInt16 = 0x39
     private static let capsLockSuppressionWindow: TimeInterval = 0.25
+    private nonisolated static let hotkeyEventTapPlacement: CGEventTapPlacement = .headInsertEventTap
 
     nonisolated static func requestTimestamp() -> UInt64 {
         DispatchTime.now().uptimeNanoseconds
@@ -539,7 +540,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
         // Try CGEventTap first - it can suppress hotkey events from reaching other apps
         if setupEventTap(includeMouse: needsSuppressingMouseEventTap) {
-            logger.info("Using tail-appended CGEventTap for hotkey monitoring with NSEvent compatibility fallback")
+            logger.info("Using head-inserted CGEventTap for hotkey monitoring with NSEvent compatibility fallback")
             installEventMonitors(includeMouse: includeMouse)
             return
         }
@@ -660,7 +661,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
-            place: .tailAppendEventTap,
+            place: Self.hotkeyEventTapPlacement,
             options: .defaultTap,
             eventsOfInterest: Self.suppressingEventTapMask(includeMouse: includeMouse),
             callback: callback,
@@ -1072,6 +1073,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     static func suppressingEventTapMaskForTesting(includeMouse: Bool = false) -> CGEventMask {
         suppressingEventTapMask(includeMouse: includeMouse)
+    }
+
+    static func eventTapPlacementForTesting() -> CGEventTapPlacement {
+        hotkeyEventTapPlacement
     }
 #endif
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7279,6 +7279,37 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testEventTapPushToTalkStartStopDedupesFollowingMonitorDispatches() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(controlSpaceHotkey(), for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true, flags: [.maskControl])
+        let keyUp = try makeKeyboardEvent(keyCode: 0x31, keyDown: false, flags: [.maskControl])
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .eventTap))
+        await Task.yield()
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .eventTap))
+        await Task.yield()
+        XCTAssertEqual(stopCount, 1)
+
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    @MainActor
     func testSuppressingEventTapMaskOnlyIncludesMouseEventsWhenRequested() {
         let keyboardOnlyMask = HotkeyService.suppressingEventTapMaskForTesting(includeMouse: false)
 
@@ -7295,6 +7326,11 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertNotEqual(mouseAwareMask & eventMask(for: .flagsChanged), 0)
         XCTAssertNotEqual(mouseAwareMask & eventMask(for: .otherMouseDown), 0)
         XCTAssertNotEqual(mouseAwareMask & eventMask(for: .otherMouseUp), 0)
+    }
+
+    @MainActor
+    func testHotkeyEventTapIsHeadInserted() {
+        XCTAssertEqual(HotkeyService.eventTapPlacementForTesting(), .headInsertEventTap)
     }
 
     @MainActor
@@ -8628,6 +8664,48 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testReplacingPushToTalkHotkeyPersistsPluralAndLegacyDefaults() throws {
+        try withCleanHotkeyDefaults {
+            let defaults = UserDefaults.standard
+            let oldHotkey = controlSpaceHotkey()
+            let newHotkey = commandOptionAHotkey()
+
+            let service = HotkeyService()
+            service.suspendMonitoring()
+            service.updateHotkey(oldHotkey, for: .pushToTalk)
+            service.replaceHotkey(oldHotkey, with: newHotkey, for: .pushToTalk)
+            service.suspendMonitoring()
+
+            let pluralData = try XCTUnwrap(defaults.data(forKey: HotkeySlotType.pushToTalk.hotkeysDefaultsKey))
+            XCTAssertEqual(try JSONDecoder().decode([UnifiedHotkey].self, from: pluralData), [newHotkey])
+
+            let legacyData = try XCTUnwrap(defaults.data(forKey: HotkeySlotType.pushToTalk.defaultsKey))
+            XCTAssertEqual(try JSONDecoder().decode(UnifiedHotkey.self, from: legacyData), newHotkey)
+
+            let restoredService = HotkeyService()
+            restoredService.loadHotkeysForTesting()
+            restoredService.suspendMonitoring()
+            XCTAssertEqual(restoredService.hotkeys(for: .pushToTalk), [newHotkey])
+
+            var startCount = 0
+            var stopCount = 0
+            restoredService.onDictationStart = { _ in startCount += 1 }
+            restoredService.onDictationStop = { stopCount += 1 }
+
+            let oldKeyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true, flags: [.maskControl])
+            XCTAssertFalse(restoredService.processEventForTesting(oldKeyDown, source: .eventTap))
+            XCTAssertEqual(startCount, 0)
+
+            let newKeyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+            let newKeyUp = try makeKeyboardEvent(keyCode: 0x00, keyDown: false, flags: [.maskCommand, .maskAlternate])
+            XCTAssertTrue(restoredService.processEventForTesting(newKeyDown, source: .eventTap))
+            XCTAssertTrue(restoredService.processEventForTesting(newKeyUp, source: .eventTap))
+            XCTAssertEqual(startCount, 1)
+            XCTAssertEqual(stopCount, 1)
+        }
+    }
+
+    @MainActor
     func testClearingGlobalSlotRemovesPluralAndLegacyPersistence() throws {
         try withCleanHotkeyDefaults {
             let defaults = UserDefaults.standard
@@ -8724,6 +8802,15 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         UnifiedHotkey(
             keyCode: 0x31,
             modifierFlags: NSEvent.ModifierFlags([.option, .command]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func controlSpaceHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x31,
+            modifierFlags: NSEvent.ModifierFlags.control.rawValue,
             isFn: false
         )
     }


### PR DESCRIPTION
## Summary
- Move the global hotkey CGEventTap from tail-appended to head-inserted while preserving the existing session tap, default tap options, tap re-enable handling, and NSEvent monitor fallback.
- Update the runtime log text so it accurately describes the head-inserted event tap.
- Add focused compatibility coverage for event-tap push-to-talk start/stop behavior, event-tap/monitor deduping, tap placement, and push-to-talk hotkey replacement persistence.

## Issue context
Issue #773 reports that push-to-talk only triggers while TypeWhisper is frontmost, even though Accessibility/Input Monitoring permissions are granted. The issue logs showed TypeWhisper using a tail-appended session CGEventTap, which can observe keyboard events only after competing session taps have already consumed or altered them; the local NSEvent fallback only covers the frontmost app case.

Closes #773

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7874/typewhisper-mac`

## Manual smoke
- Manual global-hotkey smoke in TextEdit/Safari: not run. The dev app was built and launched, and the runtime log confirms `Using head-inserted CGEventTap for hotkey monitoring with NSEvent compatibility fallback`, but I cannot reliably perform and observe the interactive background push-to-talk key-hold flow from this Codex environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotkey handling so push-to-talk actions are less likely to fire twice and now restore correctly after changing the shortcut.
  * Updated startup behavior to make hotkey activation more reliable in more situations.

* **Tests**
  * Added coverage for hotkey de-duplication, key-up behavior, and saved shortcut updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->