### PR TITLE
fix: invalidate CGEventTap Mach port on teardown to prevent stale tap accumulation

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -611,13 +611,22 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             NSEvent.removeMonitor(monitor)
             localMonitor = nil
         }
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            eventTap = nil
-        }
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            // Invalidate the source so it is fully unregistered, not just removed
+            // from the main run loop.
+            CFRunLoopSourceInvalidate(source)
             runLoopSource = nil
+        }
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            // Disabling a tap leaves its Mach port registered with the system, so
+            // each setup/teardown cycle (settings changes, recorder open/close,
+            // wake) would otherwise leak a stale session-level flagsChanged filter
+            // tap. Those linger in the modifier-event path and can break the
+            // system's double-tap-modifier detection (e.g. Apple Dictation).
+            CFMachPortInvalidate(tap)
+            eventTap = nil
         }
         recentEventTapDispatches.removeAll()
         capsLockOriginSuppressionUntil = nil


### PR DESCRIPTION
## Summary

`HotkeyService.tearDownMonitor()` disables the `CGEventTap` and removes its run loop source, but never invalidates either. A disabled tap keeps its Mach port registered with the system, so every setup/teardown cycle leaks a stale session-level `keyDown`/`keyUp`/`flagsChanged` filter tap.

`setupMonitor()` / `resumeMonitoring()` run on nearly every hotkey lifecycle interaction: hotkey changes (`setHotkeys`), `HotkeyRecorderView` open/close (`suspendMonitoring` / `resumeMonitoring`), profile/workflow registration, and app relaunch. The leak can therefore accumulate quickly.

This PR invalidates the run loop source (`CFRunLoopSourceInvalidate`) and the Mach port (`CFMachPortInvalidate`) before dropping the references, so each teardown fully unregisters the tap.

## Issue context

Issue #786 reports unreliable global hotkey detection on macOS 27 Beta 2 with TypeWhisper `v1.5.0-daily.20260625`: the reporter has Accessibility granted, but hotkeys often stop being detected outside TypeWhisper after reboot/setup, and restarting or disabling Launch at Login does not reliably recover the behavior.

This is the same event-tap reliability area as #773/#778. #778 moved the active tap to a head-inserted session tap so background push-to-talk can be observed earlier in the event chain. This PR fixes the remaining teardown bug: stale taps can remain registered after setup/teardown cycles, leaving extra session-level filter taps in the keyboard event path. That can make hotkey handling flaky across app launches and hotkey reconfiguration.

Closes #786
Refs #773
Follow-up to #778

## Evidence

On a real session, enumerating taps via `CGGetEventTapList` showed 5 live TypeWhisper keyboard taps: 1 active plus 4 stale/disabled. With this fix, the count holds at 1 across the same setup/teardown cycles.

## Test plan

- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/f2f7/typewhisper-mac`

## Manual smoke

Manual background-hotkey smoke was not claimed here. The available verification is focused XCTest coverage plus building and launching the dev app; a physical GUI retest is still the right confirmation for #786 once the next daily build includes this fix.