### PR TITLE
Fix dictionary scroll crash

### DIFF
--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -193,6 +193,21 @@ final class DictionaryService: ObservableObject {
         }
     }
 
+    func setEntryEnabled(_ entry: DictionaryEntry, enabled: Bool) {
+        guard let context = modelContext else { return }
+        guard entry.isEnabled != enabled else { return }
+
+        entry.isEnabled = enabled
+        entry.updatedAt = Date()
+
+        do {
+            try context.save()
+            loadEntries()
+        } catch {
+            logger.error("Failed to set entry enabled state: \(error.localizedDescription)")
+        }
+    }
+
     /// Batch add multiple entries with a single save+reload
     func addEntries(_ items: [(type: DictionaryEntryType, original: String, replacement: String?, caseSensitive: Bool)]) {
         addEntries(items.map {

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -197,6 +197,8 @@ final class DictionaryService: ObservableObject {
         guard let context = modelContext else { return }
         guard entry.isEnabled != enabled else { return }
 
+        let previousEnabled = entry.isEnabled
+        let previousUpdatedAt = entry.updatedAt
         entry.isEnabled = enabled
         entry.updatedAt = Date()
 
@@ -204,6 +206,8 @@ final class DictionaryService: ObservableObject {
             try context.save()
             loadEntries()
         } catch {
+            entry.isEnabled = previousEnabled
+            entry.updatedAt = previousUpdatedAt
             logger.error("Failed to set entry enabled state: \(error.localizedDescription)")
         }
     }

--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -14,6 +14,25 @@ struct ActivatedTermPackState: Codable {
     let requiresCommercialLicense: Bool?
 }
 
+private func dictionaryReplacementDisplayText(_ replacement: String) -> String {
+    replacement.isEmpty ? "\"\"" : replacement
+}
+
+struct DictionaryEntryRow: Identifiable, Equatable {
+    let id: UUID
+    let type: DictionaryEntryType
+    let original: String
+    let replacement: String?
+    let caseSensitive: Bool
+    let isEnabled: Bool
+    let termBoostingLabel: String
+    let formattedCtcMinSimilarity: String
+
+    var replacementDisplayText: String? {
+        replacement.map(dictionaryReplacementDisplayText)
+    }
+}
+
 // MARK: - Dictionary ViewModel
 
 @MainActor
@@ -93,6 +112,10 @@ class DictionaryViewModel: ObservableObject {
         case .termPacks:
             return []
         }
+    }
+
+    var filteredEntryRows: [DictionaryEntryRow] {
+        filteredEntries.map(row)
     }
 
     var termsCount: Int { dictionaryService.termsCount }
@@ -201,6 +224,11 @@ class DictionaryViewModel: ObservableObject {
         setTermBoostingEditor(to: entry.type == .term ? entry.ctcMinSimilarity : nil)
     }
 
+    func startEditingEntry(id: UUID) {
+        guard let entry = entry(withID: id) else { return }
+        startEditing(entry)
+    }
+
     func cancelEditing() {
         isEditing = false
         isCreatingNew = false
@@ -246,7 +274,17 @@ class DictionaryViewModel: ObservableObject {
         dictionaryService.deleteEntry(entry)
     }
 
+    func deleteEntry(id: UUID) {
+        guard let entry = entry(withID: id) else { return }
+        dictionaryService.deleteEntry(entry)
+    }
+
     func toggleEntry(_ entry: DictionaryEntry) {
+        dictionaryService.toggleEntry(entry)
+    }
+
+    func toggleEntry(id: UUID) {
+        guard let entry = entry(withID: id) else { return }
         dictionaryService.toggleEntry(entry)
     }
 
@@ -265,6 +303,23 @@ class DictionaryViewModel: ObservableObject {
     func formattedCtcMinSimilarity(_ threshold: Float?) -> String {
         guard let threshold else { return "" }
         return String(format: "%.2f", Double(threshold))
+    }
+
+    private func row(for entry: DictionaryEntry) -> DictionaryEntryRow {
+        DictionaryEntryRow(
+            id: entry.id,
+            type: entry.type,
+            original: entry.original,
+            replacement: entry.replacement,
+            caseSensitive: entry.caseSensitive,
+            isEnabled: entry.isEnabled,
+            termBoostingLabel: termBoostingLabel(for: entry.ctcMinSimilarity),
+            formattedCtcMinSimilarity: formattedCtcMinSimilarity(entry.ctcMinSimilarity)
+        )
+    }
+
+    private func entry(withID id: UUID) -> DictionaryEntry? {
+        entries.first { $0.id == id }
     }
 
     private func resetTermBoostingEditor() {

--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -288,6 +288,11 @@ class DictionaryViewModel: ObservableObject {
         dictionaryService.toggleEntry(entry)
     }
 
+    func setEntryEnabled(id: UUID, enabled: Bool) {
+        guard let entry = entry(withID: id) else { return }
+        dictionaryService.setEntryEnabled(entry, enabled: enabled)
+    }
+
     func clearError() {
         error = nil
     }

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -109,7 +109,7 @@ struct DictionarySettingsView: View {
                     DictionaryEngineSupportSection(rows: engineSupportRows)
                 }
 
-                if viewModel.filteredEntries.isEmpty {
+                if viewModel.filteredEntryRows.isEmpty {
                     VStack(spacing: 8) {
                         Image(systemName: "line.3.horizontal.decrease.circle")
                             .font(.system(size: 32))
@@ -120,8 +120,13 @@ struct DictionarySettingsView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 48)
                 } else {
-                    ForEach(viewModel.filteredEntries) { entry in
-                        DictionaryCardView(entry: entry, viewModel: viewModel)
+                    ForEach(viewModel.filteredEntryRows) { row in
+                        DictionaryCardView(
+                            row: row,
+                            toggleEntry: { viewModel.toggleEntry(id: row.id) },
+                            editEntry: { viewModel.startEditingEntry(id: row.id) },
+                            deleteEntry: { viewModel.deleteEntry(id: row.id) }
+                        )
                     }
                 }
             }
@@ -524,23 +529,24 @@ private struct TermPackCardView: View {
 // MARK: - Dictionary Card
 
 private struct DictionaryCardView: View {
-    let entry: DictionaryEntry
-    @ObservedObject var viewModel: DictionaryViewModel
-    @State private var isHovering = false
+    let row: DictionaryEntryRow
+    let toggleEntry: () -> Void
+    let editEntry: () -> Void
+    let deleteEntry: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
-            Text(entry.type.displayName)
+            Text(row.type.displayName)
                 .font(.caption)
                 .fontWeight(.medium)
-                .foregroundStyle(entry.type == .correction ? Color.orange : Color.accentColor)
+                .foregroundStyle(row.type == .correction ? Color.orange : Color.accentColor)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
-                .background((entry.type == .correction ? Color.orange : Color.accentColor).opacity(0.12))
+                .background((row.type == .correction ? Color.orange : Color.accentColor).opacity(0.12))
                 .clipShape(RoundedRectangle(cornerRadius: 5))
 
-            if entry.type == .correction, let replacement = entry.replacement {
-                Text(entry.original)
+            if row.type == .correction, let replacement = row.replacementDisplayText {
+                Text(row.original)
                     .font(.callout)
                     .strikethrough()
                     .foregroundStyle(.secondary)
@@ -549,21 +555,21 @@ private struct DictionaryCardView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
 
-                Text(dictionaryReplacementDisplayText(replacement))
+                Text(replacement)
                     .font(.callout)
                     .fontWeight(.medium)
             } else {
-                Text(entry.original)
+                Text(row.original)
                     .font(.callout)
                     .fontWeight(.medium)
 
                 DictionaryBoostingBadge(
-                    label: viewModel.termBoostingLabel(for: entry.ctcMinSimilarity),
-                    value: viewModel.formattedCtcMinSimilarity(entry.ctcMinSimilarity)
+                    label: row.termBoostingLabel,
+                    value: row.formattedCtcMinSimilarity
                 )
             }
 
-            if entry.caseSensitive {
+            if row.caseSensitive {
                 Text("Aa")
                     .font(.caption2)
                     .padding(.horizontal, 5)
@@ -576,12 +582,12 @@ private struct DictionaryCardView: View {
             Spacer()
 
             Toggle("", isOn: Binding(
-                get: { entry.isEnabled },
-                set: { _ in viewModel.toggleEntry(entry) }
+                get: { row.isEnabled },
+                set: { _ in toggleEntry() }
             ))
             .toggleStyle(.switch)
             .labelsHidden()
-            .accessibilityLabel(String(localized: "Enable \(entry.original)"))
+            .accessibilityLabel(String(localized: "Enable \(row.original)"))
             .onTapGesture {}
         }
         .padding(.horizontal, 10)
@@ -592,23 +598,20 @@ private struct DictionaryCardView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(isHovering ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.06), lineWidth: 1)
+                .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
         )
         .contentShape(Rectangle())
-        .onHover { hovering in
-            isHovering = hovering
-        }
         .onTapGesture {
-            viewModel.startEditing(entry)
+            editEntry()
         }
         .accessibilityElement(children: .combine)
         .contextMenu {
             Button(String(localized: "Edit")) {
-                viewModel.startEditing(entry)
+                editEntry()
             }
             Divider()
             Button(String(localized: "Delete"), role: .destructive) {
-                viewModel.deleteEntry(entry)
+                deleteEntry()
             }
         }
     }

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -123,7 +123,7 @@ struct DictionarySettingsView: View {
                     ForEach(viewModel.filteredEntryRows) { row in
                         DictionaryCardView(
                             row: row,
-                            toggleEntry: { viewModel.toggleEntry(id: row.id) },
+                            setEntryEnabled: { viewModel.setEntryEnabled(id: row.id, enabled: $0) },
                             editEntry: { viewModel.startEditingEntry(id: row.id) },
                             deleteEntry: { viewModel.deleteEntry(id: row.id) }
                         )
@@ -530,7 +530,7 @@ private struct TermPackCardView: View {
 
 private struct DictionaryCardView: View {
     let row: DictionaryEntryRow
-    let toggleEntry: () -> Void
+    let setEntryEnabled: (Bool) -> Void
     let editEntry: () -> Void
     let deleteEntry: () -> Void
 
@@ -583,7 +583,7 @@ private struct DictionaryCardView: View {
 
             Toggle("", isOn: Binding(
                 get: { row.isEnabled },
-                set: { _ in toggleEntry() }
+                set: { setEntryEnabled($0) }
             ))
             .toggleStyle(.switch)
             .labelsHidden()

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -468,6 +468,81 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testDictionaryEntryRowsSnapshotLargeFilteredListsWithStableIDs() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let terms = (1...120).map {
+            (
+                type: DictionaryEntryType.term,
+                original: String(format: "Term-%03d", $0),
+                replacement: nil as String?,
+                caseSensitive: true,
+                ctcMinSimilarity: nil as Float?
+            )
+        }
+        let corrections = (1...120).map {
+            (
+                type: DictionaryEntryType.correction,
+                original: String(format: "Wrong-%03d", $0),
+                replacement: String(format: "Correct-%03d", $0) as String?,
+                caseSensitive: false,
+                ctcMinSimilarity: nil as Float?
+            )
+        }
+        service.addEntries(terms + corrections + [
+            (
+                type: DictionaryEntryType.correction,
+                original: "empty-replacement",
+                replacement: "" as String?,
+                caseSensitive: true,
+                ctcMinSimilarity: nil as Float?
+            )
+        ])
+
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+        viewModel.filterTab = .corrections
+        let correctionRows = viewModel.filteredEntryRows
+
+        XCTAssertEqual(correctionRows.count, 121)
+        XCTAssertTrue(correctionRows.allSatisfy { $0.type == .correction })
+        XCTAssertEqual(correctionRows.first { $0.original == "empty-replacement" }?.replacementDisplayText, "\"\"")
+
+        let correctionIDs = correctionRows.map(\.id)
+        viewModel.filterTab = .all
+        let allCorrectionIDs = viewModel.filteredEntryRows
+            .filter { $0.type == .correction }
+            .map(\.id)
+        XCTAssertEqual(allCorrectionIDs, correctionIDs)
+    }
+
+    @MainActor
+    func testDictionaryEntryIDActionsEditToggleAndDeleteMatchingEntry() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "teh", replacement: "the", caseSensitive: true)
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+        let row = try XCTUnwrap(viewModel.filteredEntryRows.first)
+
+        viewModel.toggleEntry(id: row.id)
+        XCTAssertFalse(try XCTUnwrap(service.entries.first { $0.id == row.id }).isEnabled)
+
+        viewModel.startEditingEntry(id: row.id)
+        XCTAssertTrue(viewModel.isEditing)
+        XCTAssertFalse(viewModel.isCreatingNew)
+        XCTAssertEqual(viewModel.editType, .correction)
+        XCTAssertEqual(viewModel.editOriginal, "teh")
+        XCTAssertEqual(viewModel.editReplacement, "the")
+        XCTAssertTrue(viewModel.editCaseSensitive)
+
+        viewModel.deleteEntry(id: row.id)
+        XCTAssertFalse(service.entries.contains { $0.id == row.id })
+    }
+
+    @MainActor
     func testTermPackActivationPreservesManualEntriesAndDeactivationRemovesOnlyPackEntries() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -518,7 +518,7 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
-    func testDictionaryEntryIDActionsEditToggleAndDeleteMatchingEntry() throws {
+    func testDictionaryEntryIDActionsEditSetEnabledToggleAndDeleteMatchingEntry() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
@@ -527,6 +527,12 @@ final class DictionaryServiceTests: XCTestCase {
         let viewModel = DictionaryViewModel(dictionaryService: service)
         let row = try XCTUnwrap(viewModel.filteredEntryRows.first)
 
+        viewModel.setEntryEnabled(id: row.id, enabled: false)
+        XCTAssertFalse(try XCTUnwrap(service.entries.first { $0.id == row.id }).isEnabled)
+        viewModel.setEntryEnabled(id: row.id, enabled: false)
+        XCTAssertFalse(try XCTUnwrap(service.entries.first { $0.id == row.id }).isEnabled)
+        viewModel.setEntryEnabled(id: row.id, enabled: true)
+        XCTAssertTrue(try XCTUnwrap(service.entries.first { $0.id == row.id }).isEnabled)
         viewModel.toggleEntry(id: row.id)
         XCTAssertFalse(try XCTUnwrap(service.entries.first { $0.id == row.id }).isEnabled)
 


### PR DESCRIPTION
## Summary
- Fixes the Dictionary settings long-list scroll path by rendering rows from immutable `DictionaryEntryRow` snapshots instead of live `DictionaryEntry` models.
- Routes edit, toggle, and delete actions back through row IDs so row views stay lightweight while actions still resolve against the current model list.
- Removes per-row hover `@State` mutations during scrolling.
- Adds focused `DictionaryViewModel` coverage for large mixed term/correction lists, stable row IDs, filtering, empty replacement display, and ID-based actions.

## Issue context
Issue #784 reports that the latest Daily crashes when trackpad-scrolling a long Dictionary / Corrections settings list. I could not reproduce a local crash with simulated scrolling and no `TypeWhisper` DiagnosticReports were produced, but the affected SwiftUI path was rendering live dictionary model objects inside the lazy list while also updating per-row hover state during scroll. This PR keeps the fix scoped to that row/list path.

Closes #784

## Test plan
- [x] `git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] Focused regression run: `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/DictionaryServiceTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] Manual long-list smoke:
  - `defaults write com.typewhisper.mac.dev apiServerEnabled -bool true`
  - `defaults write com.typewhisper.mac.dev apiServerRequiresAuthentication -bool false`
  - `defaults write com.typewhisper.mac.dev apiServerPort -int 8978`
  - `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/c363/typewhisper-mac`
  - `curl http://127.0.0.1:8978/v1/status`
  - Seeded 240 corrections through `PUT /v1/dictionary/corrections` and verified 252 corrections in the dev app.
  - Opened Settings > Dictionary with the long list, switched list tabs, opened and closed an edit sheet, attempted a visible row toggle, and exercised the long-list path with keyboard scroll. The app stayed ready and no new `TypeWhisper` DiagnosticReports appeared.

Manual trackpad behavior still needs real-device confirmation because automated tests and synthetic events cannot fully prove macOS trackpad scrolling behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dictionary settings now render dictionary entries using row-based formatting, including corrected replacement display.
  * Entry actions (enable/disable, edit, delete) use stable identifiers for more consistent selection.
  * The settings list now presents filtered “row” views for improved display.
* **Bug Fixes**
  * Empty replacement values display as a quoted `""`.
  * Enable/disable and other actions safely handle cases where the targeted entry is no longer available.
* **Tests**
  * Added coverage for row formatting, filtering behavior, editing state, and enablement actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->