### PR TITLE
Fix idle local model auto-unload

### DIFF
--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -422,7 +422,7 @@ final class ErrorLogService: ObservableObject {
         let defaults = UserDefaults.standard
         let pluginManager = PluginManager.shared ?? container.pluginManager
         let outputSnapshot = CoreAudioOutputVolumeController().defaultOutputSnapshot()
-        let modelAutoUnloadSeconds = defaults.integer(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        let modelAutoUnloadSeconds = ModelAutoUnloadPolicy.effectiveSeconds(defaults: defaults)
         let indicatorStyle = DictationViewModel.loadIndicatorStyle(defaults: defaults)
         let indicatorPreviewEnabled = DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults)
         let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
@@ -571,7 +571,7 @@ final class ErrorLogService: ObservableObject {
                 memoryCaptureScope: MemoryCaptureScope.load(from: defaults).rawValue,
                 appFormattingEnabled: defaults.bool(forKey: UserDefaultsKeys.appFormattingEnabled),
                 modelAutoUnloadSeconds: modelAutoUnloadSeconds,
-                modelAutoUnloadPolicy: Self.modelAutoUnloadPolicy(seconds: modelAutoUnloadSeconds),
+                modelAutoUnloadPolicy: ModelAutoUnloadPolicy.policyName(seconds: modelAutoUnloadSeconds),
                 indicatorStyle: indicatorStyle.rawValue,
                 indicatorSupportsTranscriptPreview: indicatorStyle.supportsTranscriptPreview,
                 indicatorTranscriptPreviewEnabled: indicatorPreviewEnabled,
@@ -655,17 +655,6 @@ final class ErrorLogService: ObservableObject {
     private static func trimmedOrNil(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
-    }
-
-    private static func modelAutoUnloadPolicy(seconds: Int) -> String {
-        switch seconds {
-        case 0:
-            return "never"
-        case -1:
-            return "immediate"
-        default:
-            return "afterSeconds"
-        }
     }
 
     private func loadEntries() {

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -36,6 +36,28 @@ extension TranscriptionEnginePlugin {
     }
 }
 
+enum ModelAutoUnloadPolicy {
+    static let defaultSeconds = 600
+
+    static func effectiveSeconds(defaults: UserDefaults = .standard) -> Int {
+        guard defaults.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds) != nil else {
+            return defaultSeconds
+        }
+        return defaults.integer(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+    }
+
+    static func policyName(seconds: Int) -> String {
+        switch seconds {
+        case 0:
+            return "never"
+        case -1:
+            return "immediate"
+        default:
+            return "afterSeconds"
+        }
+    }
+}
+
 @MainActor
 final class ModelManagerService: ObservableObject {
     struct LiveTranscriptionSessionHandle: Sendable {
@@ -71,7 +93,7 @@ final class ModelManagerService: ObservableObject {
     private let modelKey = UserDefaultsKeys.selectedModelId
 
     init() {
-        self.autoUnloadSeconds = UserDefaults.standard.integer(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        self.autoUnloadSeconds = ModelAutoUnloadPolicy.effectiveSeconds()
         self.selectedProviderId = UserDefaults.standard.string(forKey: providerKey)
     }
 
@@ -157,6 +179,7 @@ final class ModelManagerService: ObservableObject {
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.restoreProviderSelection()
+                self.scheduleAutoUnloadIfNeeded()
                 self.objectWillChange.send()
             }
             .store(in: &cancellables)
@@ -715,16 +738,45 @@ final class ModelManagerService: ObservableObject {
     // MARK: - Auto-Unload
 
     func scheduleAutoUnloadIfNeeded() {
-        guard let providerId = selectedProviderId,
-              let plugin = PluginManager.shared.transcriptionEngine(for: providerId),
-              plugin.isConfigured else { return }
+        var scheduledKeys = Set<ObjectIdentifier>()
 
-        scheduleAutoUnloadIfNeeded(for: plugin)
+        for plugin in PluginManager.shared.transcriptionEngines where plugin.isConfigured {
+            scheduleAutoUnloadIfNeeded(for: plugin, scheduledKeys: &scheduledKeys)
+        }
+
+        for plugin in PluginManager.shared.llmProviders
+            where plugin.isAvailable && Self.shouldAutoUnloadLocalLLMProvider(plugin) {
+            scheduleAutoUnloadIfNeeded(for: plugin, scheduledKeys: &scheduledKeys)
+        }
     }
 
     func scheduleAutoUnloadIfNeeded(for plugin: any TypeWhisperPlugin) {
         guard let nsPlugin = plugin as? NSObject else { return }
+        var scheduledKeys = Set<ObjectIdentifier>()
+        scheduleAutoUnloadIfNeeded(for: nsPlugin, scheduledKeys: &scheduledKeys)
+    }
+
+    private static func shouldAutoUnloadLocalLLMProvider(_ plugin: any LLMProviderPlugin) -> Bool {
+        guard let setupStatus = plugin as? any LLMProviderSetupStatusProviding else {
+            return false
+        }
+        return !setupStatus.requiresExternalCredentials
+    }
+
+    private func scheduleAutoUnloadIfNeeded(
+        for plugin: any TypeWhisperPlugin,
+        scheduledKeys: inout Set<ObjectIdentifier>
+    ) {
+        guard let nsPlugin = plugin as? NSObject else { return }
+        scheduleAutoUnloadIfNeeded(for: nsPlugin, scheduledKeys: &scheduledKeys)
+    }
+
+    private func scheduleAutoUnloadIfNeeded(
+        for nsPlugin: NSObject,
+        scheduledKeys: inout Set<ObjectIdentifier>
+    ) {
         let key = ObjectIdentifier(nsPlugin)
+        guard scheduledKeys.insert(key).inserted else { return }
 
         autoUnloadTasks[key]?.cancel()
         autoUnloadTasks[key] = nil

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -748,6 +748,13 @@ final class ModelManagerService: ObservableObject {
             where plugin.isAvailable && Self.shouldAutoUnloadLocalLLMProvider(plugin) {
             scheduleAutoUnloadIfNeeded(for: plugin, scheduledKeys: &scheduledKeys)
         }
+
+        let existingKeys = Set(autoUnloadTasks.keys).union(autoUnloadTargets.keys)
+        for key in existingKeys.subtracting(scheduledKeys) {
+            autoUnloadTasks[key]?.cancel()
+            autoUnloadTasks[key] = nil
+            autoUnloadTargets[key] = nil
+        }
     }
 
     func scheduleAutoUnloadIfNeeded(for plugin: any TypeWhisperPlugin) {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -157,6 +157,44 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    private func waitForAutoUnloadCount(
+        _ plugin: MockLLMProviderPlugin,
+        toBecome expected: Int,
+        timeout: Duration = .seconds(2),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if plugin.autoUnloadCount == expected {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(plugin.autoUnloadCount, expected, file: file, line: line)
+    }
+
+    @MainActor
+    private func assertAutoUnloadCount(
+        _ plugin: MockLLMProviderPlugin,
+        remains expected: Int,
+        duration: Duration = .milliseconds(500),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while ContinuousClock.now < deadline {
+            let actual = plugin.autoUnloadCount
+            if actual != expected {
+                XCTFail("Expected autoUnloadCount to remain \(expected), got \(actual)", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(plugin.autoUnloadCount, expected, file: file, line: line)
+    }
+
+    @MainActor
     private final class MemoryRetrieverSpy: MemoryRetrieving {
         private(set) var requestedTexts: [String] = []
         var context = """
@@ -6172,8 +6210,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
 
         XCTAssertEqual(result, "processed")
-        try await Task.sleep(for: .milliseconds(150))
-        XCTAssertEqual(plugin.autoUnloadCount, 1)
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
     }
 
     @MainActor
@@ -6224,8 +6261,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
 
         XCTAssertEqual(result, "processed")
-        try await Task.sleep(for: .milliseconds(150))
-        XCTAssertEqual(plugin.autoUnloadCount, 0)
+        await assertAutoUnloadCount(plugin, remains: 0)
     }
 
     @MainActor
@@ -6276,8 +6312,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
 
         XCTAssertEqual(result, "processed")
-        try await Task.sleep(for: .milliseconds(150))
-        XCTAssertEqual(plugin.autoUnloadCount, 0)
+        await assertAutoUnloadCount(plugin, remains: 0)
     }
 
     @MainActor
@@ -6358,8 +6393,53 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let modelManager = ModelManagerService()
         modelManager.scheduleAutoUnloadIfNeeded()
 
-        try await Task.sleep(for: .milliseconds(150))
-        XCTAssertEqual(plugin.autoUnloadCount, 1)
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testModelManagerCancelsAutoUnloadWhenLocalLLMBecomesUnavailable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.local-llm",
+                    name: "Mock Local LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.scheduleAutoUnloadIfNeeded()
+
+        plugin.available = false
+        modelManager.scheduleAutoUnloadIfNeeded()
+
+        await assertAutoUnloadCount(plugin, remains: 0)
     }
 
     @MainActor
@@ -6419,9 +6499,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let modelManager = ModelManagerService()
         modelManager.scheduleAutoUnloadIfNeeded()
 
-        try await Task.sleep(for: .milliseconds(150))
-        XCTAssertEqual(remotePlugin.autoUnloadCount, 0)
-        XCTAssertEqual(unavailableLocalPlugin.autoUnloadCount, 0)
+        await assertAutoUnloadCount(remotePlugin, remains: 0)
+        await assertAutoUnloadCount(unavailableLocalPlugin, remains: 0)
     }
 
     @MainActor

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -6281,6 +6281,150 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testModelAutoUnloadDefaultsToTenMinutesWhenUnset() throws {
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let modelManager = ModelManagerService()
+
+        XCTAssertEqual(ModelAutoUnloadPolicy.effectiveSeconds(), 600)
+        XCTAssertEqual(modelManager.autoUnloadSeconds, 600)
+        XCTAssertEqual(ModelAutoUnloadPolicy.policyName(seconds: modelManager.autoUnloadSeconds), "afterSeconds")
+    }
+
+    @MainActor
+    func testModelAutoUnloadKeepsExplicitNever() throws {
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let modelManager = ModelManagerService()
+
+        XCTAssertEqual(ModelAutoUnloadPolicy.effectiveSeconds(), 0)
+        XCTAssertEqual(modelManager.autoUnloadSeconds, 0)
+        XCTAssertEqual(ModelAutoUnloadPolicy.policyName(seconds: modelManager.autoUnloadSeconds), "never")
+    }
+
+    @MainActor
+    func testModelManagerAutoUnloadsAvailableLocalLLMWithoutPromptProcessing() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = MockLLMProviderPlugin()
+        plugin.configuredProviderName = "Gemma 4 (MLX)"
+        plugin.requiresExternalCredentials = false
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.local-llm",
+                    name: "Mock Local LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.scheduleAutoUnloadIfNeeded()
+
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(plugin.autoUnloadCount, 1)
+    }
+
+    @MainActor
+    func testModelManagerSkipsRemoteAndUnavailableLLMProviders() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let remotePlugin = MockLLMProviderPlugin()
+        remotePlugin.configuredProviderName = "Gemini"
+        remotePlugin.requiresExternalCredentials = true
+
+        let unavailableLocalPlugin = MockLLMProviderPlugin()
+        unavailableLocalPlugin.configuredProviderName = "Gemma 4 (MLX)"
+        unavailableLocalPlugin.requiresExternalCredentials = false
+        unavailableLocalPlugin.available = false
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.remote-llm",
+                    name: "Mock Remote LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: remotePlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ),
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.unavailable-local-llm",
+                    name: "Mock Unavailable Local LLM",
+                    version: "1.0.0",
+                    principalClass: "APIRouterMockLLMProviderPlugin"
+                ),
+                instance: unavailableLocalPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ),
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.scheduleAutoUnloadIfNeeded()
+
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(remotePlugin.autoUnloadCount, 0)
+        XCTAssertEqual(unavailableLocalPlugin.autoUnloadCount, 0)
+    }
+
+    @MainActor
     func testPromptProcessingSkipsHighPriorityActivityForRemoteProviders() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary

Issue #788 reports TypeWhisper 1.5.0 daily 20260625 reaching more than 50 GB physical footprint after several idle hours. The attached sample points at restored local MLX providers, including Qwen3Plugin and Gemma4Plugin, remaining loaded while the app is idle.

This PR treats that as a local model retention issue:

- Defaults an unset `modelAutoUnloadSeconds` setting to 600 seconds while preserving explicit `0` as Never and `-1` as immediate.
- Schedules auto-unload for already-loaded local transcription engines and available local LLM providers after plugin state changes, without changing the plugin SDK/API.
- Cancels stale auto-unload timers when a provider is no longer configured, available, or local.
- Keeps Qwen3/Gemma4 persistence behavior intact, but prevents restored-at-startup local models from being retained forever by default.
- Reports the effective auto-unload policy in diagnostics so unset settings show the effective 10-minute policy instead of Never.

Closes #788

## Test Coverage

All new code paths have focused XCTest coverage:

- unset auto-unload default resolves to 10 minutes
- explicit Never remains `0`
- restored/available local LLM gets auto-unloaded without a prompt-processing call
- stale auto-unload timers are canceled when a local LLM becomes unavailable
- remote LLM and unavailable local LLM are not scheduled
- auto-unload timing tests use polling instead of fixed sleeps around the 100 ms immediate-unload delay

## Pre-Landing Review

CodeRabbit comments were addressed in `8da45c509`:

- cancel stale auto-unload tasks/targets after each full eligibility rescan
- replace tight fixed sleeps in auto-unload tests with polling helpers and a regression case

## Design Review

No frontend files changed, design review skipped.

## Eval Results

No prompt-related files changed, evals skipped.

## Scope Drift

Scope Check: CLEAN. The diff implements the requested local MLX model auto-unload behavior and focused regression coverage only.

## Test plan

- [x] `git diff --check`
- [x] `xcodebuild -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests test`
  - Passed after CodeRabbit follow-up: `APIRouterAndHandlersTests` executed 149 tests with 0 failures.
- [x] `xcodebuild -scheme TypeWhisper -destination 'platform=macOS' build`
  - Passed after CodeRabbit follow-up: build succeeded.
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/e559/typewhisper-mac`
  - Passed after CodeRabbit follow-up: dev app built, signed with Apple Development, and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model auto-unload behavior for local providers, ensuring consistent scheduling across all eligible local LLMs.
* **Bug Fixes**
  * Diagnostics now reflect the actual auto-unload configuration more accurately, including correct policy labeling.
  * Auto-unload timers respond properly to plugin availability changes, avoiding missed unloads and canceling pending unloads when providers become unavailable.
* **Tests**
  * Added async polling helpers and expanded coverage for default timing, “never” configuration, and local vs. remote/unavailable provider auto-unload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->