### PR TITLE
Add pro transcription fallback

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -136,12 +136,14 @@ final class ServiceContainer: ObservableObject {
             modelManager: modelManagerService,
             audioFileService: audioFileService
         )
-        dictationRecoveryViewModel = DictationRecoveryViewModel(
+        let recoveryViewModel = DictationRecoveryViewModel(
             audioRecordingService: audioRecordingService,
             modelManager: modelManagerService,
             historyService: historyService,
-            audioFileService: audioFileService
+            audioFileService: audioFileService,
+            licenseService: licenseService
         )
+        dictationRecoveryViewModel = recoveryViewModel
         settingsViewModel = SettingsViewModel(modelManager: modelManagerService)
         dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
@@ -169,7 +171,13 @@ final class ServiceContainer: ObservableObject {
             speechFeedbackService: speechFeedbackService,
             accessibilityAnnouncementService: accessibilityAnnouncementService,
             errorLogService: errorLogService,
-            mediaPlaybackService: mediaPlaybackService
+            mediaPlaybackService: mediaPlaybackService,
+            recoveryFallbackConfigurationProvider: { [recoveryViewModel] primaryEngineId, task in
+                recoveryViewModel.automaticFallbackConfiguration(
+                    excluding: primaryEngineId,
+                    task: task
+                )
+            }
         )
         audioRecorderViewModel = AudioRecorderViewModel(
             recorderService: audioRecorderService,

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -128,6 +128,7 @@ enum UserDefaultsKeys {
     static let dictationRecoveryEngine = "dictationRecoveryEngine"
     static let dictationRecoveryModel = "dictationRecoveryModel"
     static let dictationRecoveryLanguage = "dictationRecoveryLanguage"
+    static let dictationRecoveryAutomaticFallbackEnabled = "dictationRecoveryAutomaticFallbackEnabled"
 
     // MARK: - Watch Folder
     static let watchFolderBookmark = "watchFolderBookmark"

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -200,6 +200,7 @@ final class LicenseService: ObservableObject {
 
     var isSupporter: Bool { supporterStatus == .active && supporterTier != nil }
     var hasCommercialLicense: Bool { licenseStatus == .active }
+    var canUseProTranscriptionFallback: Bool { hasCommercialLicense || isSupporter }
     var supporterClaimProof: SupporterClaimProof? {
         guard supporterStatus == .active,
               let supporterTier,

--- a/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
@@ -2,6 +2,11 @@ import Combine
 import Foundation
 import TypeWhisperPluginSDK
 
+struct DictationRecoveryFallbackConfiguration: Equatable, Sendable {
+    let engineId: String
+    let modelId: String?
+}
+
 @MainActor
 final class DictationRecoveryViewModel: ObservableObject {
     typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
@@ -66,10 +71,16 @@ final class DictationRecoveryViewModel: ObservableObject {
     @Published var selectedModel: String? {
         didSet { defaults.set(selectedModel, forKey: UserDefaultsKeys.dictationRecoveryModel) }
     }
+    @Published var automaticFallbackEnabled: Bool {
+        didSet {
+            defaults.set(automaticFallbackEnabled, forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
+        }
+    }
 
     private let audioRecordingService: AudioRecordingService
     private let modelManager: ModelManagerService
     private let historyService: HistoryService
+    private let licenseService: LicenseService?
     private let audioSamplesLoader: AudioSamplesLoader
     private let transcriptionRunner: TranscriptionRunner
     private let engineReadinessChecker: EngineReadinessChecker?
@@ -82,6 +93,7 @@ final class DictationRecoveryViewModel: ObservableObject {
         modelManager: ModelManagerService,
         historyService: HistoryService,
         audioFileService: AudioFileService,
+        licenseService: LicenseService? = nil,
         defaults: UserDefaults = .standard,
         audioSamplesLoader: AudioSamplesLoader? = nil,
         transcriptionRunner: TranscriptionRunner? = nil,
@@ -90,6 +102,7 @@ final class DictationRecoveryViewModel: ObservableObject {
         self.audioRecordingService = audioRecordingService
         self.modelManager = modelManager
         self.historyService = historyService
+        self.licenseService = licenseService
         self.defaults = defaults
         self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
             try await audioFileService.loadAudioSamples(from: url)
@@ -113,12 +126,20 @@ final class DictationRecoveryViewModel: ObservableObject {
         )
         self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryEngine)
         self.selectedModel = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryModel)
+        self.automaticFallbackEnabled = defaults.bool(forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
         self.isInitialized = true
 
         audioRecordingService.$recoverableRecordingURLs
             .receive(on: DispatchQueue.main)
             .sink { [weak self] urls in
                 self?.updateRecoveryURLs(urls)
+            }
+            .store(in: &cancellables)
+
+        licenseService?.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
             }
             .store(in: &cancellables)
 
@@ -185,6 +206,18 @@ final class DictationRecoveryViewModel: ObservableObject {
         resolvedEngine?.supportedLanguages.sorted() ?? []
     }
 
+    var canUseAutomaticFallback: Bool {
+        licenseService?.canUseProTranscriptionFallback ?? false
+    }
+
+    var automaticFallbackUnavailableMessage: String? {
+        guard !canUseAutomaticFallback else { return nil }
+        return localizedAppText(
+            "Automatic fallback requires a commercial license or active supporter status.",
+            de: "Automatischer Fallback benötigt eine kommerzielle Lizenz oder aktiven Supporter-Status."
+        )
+    }
+
     func observePluginManager() {
         guard let pluginManager = PluginManager.shared else { return }
         pluginManager.objectWillChange
@@ -198,6 +231,28 @@ final class DictationRecoveryViewModel: ObservableObject {
 
     func canUseForTranscription(_ engine: TranscriptionEnginePlugin) -> Bool {
         modelManager.canUseForTranscription(engine)
+    }
+
+    func automaticFallbackConfiguration(
+        excluding primaryEngineId: String?,
+        task: TranscriptionTask
+    ) -> DictationRecoveryFallbackConfiguration? {
+        guard automaticFallbackEnabled, canUseAutomaticFallback else { return nil }
+        guard let selectedEngine, !selectedEngine.isEmpty else { return nil }
+        guard selectedEngine != primaryEngineId else { return nil }
+        guard let engine = resolvedEngine else { return nil }
+        guard modelManager.canUseForTranscription(engine), engine.isConfigured else { return nil }
+        guard task != .translate || engine.supportsTranslation else { return nil }
+
+        if let selectedModel {
+            let modelIds = Set((engine.modelCatalog + engine.transcriptionModels).map(\.id))
+            guard modelIds.contains(selectedModel) else { return nil }
+        }
+
+        return DictationRecoveryFallbackConfiguration(
+            engineId: selectedEngine,
+            modelId: selectedModel
+        )
     }
 
     func transcribe() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -101,8 +101,8 @@ enum AutomaticRecoveryFallbackErrorPolicy {
             }
         }
 
-        if error is URLError {
-            return true
+        if let urlError = error as? URLError {
+            return urlError.code != .cancelled
         }
 
         return false

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -73,6 +73,39 @@ enum DictationTranscriptionOverrideResolver {
 /// Orchestrates the dictation flow: recording → transcription → text insertion.
 @MainActor
 final class DictationViewModel: ObservableObject {
+    typealias RecoveryFallbackConfigurationProvider = @MainActor (
+        _ primaryEngineId: String?,
+        _ task: TranscriptionTask
+    ) -> DictationRecoveryFallbackConfiguration?
+    typealias RecoveryFallbackRunner = @MainActor (
+        _ samples: [Float],
+        _ languageSelection: LanguageSelection,
+        _ task: TranscriptionTask,
+        _ configuration: DictationRecoveryFallbackConfiguration,
+        _ prompt: String?,
+        _ dictionaryTermHints: [PluginDictionaryTermHint],
+        _ normalizeNumbers: Bool?
+    ) async throws -> TranscriptionResult
+
+    private struct FinalTranscriptionOutput {
+        let result: TranscriptionResult
+        let modelId: String?
+        let modelDisplayName: String?
+        let usedRecoveryFallback: Bool
+    }
+
+    private struct AutomaticRecoveryFallbackFailure: LocalizedError {
+        let primaryDescription: String
+        let fallbackDescription: String
+
+        var errorDescription: String? {
+            localizedAppText(
+                "Primary transcription failed: \(primaryDescription). Recovery fallback failed: \(fallbackDescription)",
+                de: "Primäre Transkription fehlgeschlagen: \(primaryDescription). Recovery-Fallback fehlgeschlagen: \(fallbackDescription)"
+            )
+        }
+    }
+
     nonisolated(unsafe) static var _shared: DictationViewModel?
     static var shared: DictationViewModel {
         guard let instance = _shared else {
@@ -217,6 +250,8 @@ final class DictationViewModel: ObservableObject {
     private let errorLogService: ErrorLogService
     private let mediaPlaybackService: MediaPlaybackService
     private let postProcessingPipeline: PostProcessingPipeline
+    private let recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider
+    private let recoveryFallbackRunner: RecoveryFallbackRunner
     private var matchedWorkflow: Workflow?
     private var activeWorkflowMatch: WorkflowMatchResult?
     private var forcedWorkflowId: UUID?
@@ -304,7 +339,9 @@ final class DictationViewModel: ObservableObject {
         speechFeedbackService: SpeechFeedbackService,
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
         errorLogService: ErrorLogService,
-        mediaPlaybackService: MediaPlaybackService
+        mediaPlaybackService: MediaPlaybackService,
+        recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider? = nil,
+        recoveryFallbackRunner: RecoveryFallbackRunner? = nil
     ) {
         self.audioRecordingService = audioRecordingService
         self.textInsertionService = textInsertionService
@@ -340,6 +377,19 @@ final class DictationViewModel: ObservableObject {
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
         self.errorLogService = errorLogService
         self.mediaPlaybackService = mediaPlaybackService
+        self.recoveryFallbackConfigurationProvider = recoveryFallbackConfigurationProvider ?? { _, _ in nil }
+        self.recoveryFallbackRunner = recoveryFallbackRunner ?? { [modelManager] samples, languageSelection, task, configuration, prompt, dictionaryTermHints, normalizeNumbers in
+            try await modelManager.transcribe(
+                audioSamples: samples,
+                languageSelection: languageSelection,
+                task: task,
+                engineOverrideId: configuration.engineId,
+                cloudModelOverride: configuration.modelId,
+                prompt: prompt,
+                dictionaryTermHints: dictionaryTermHints,
+                normalizeNumbers: normalizeNumbers
+            )
+        }
         self.postProcessingPipeline = PostProcessingPipeline(
             snippetService: snippetService,
             dictionaryService: dictionaryService,
@@ -1287,24 +1337,37 @@ final class DictationViewModel: ObservableObject {
                 let engineOverride = effectiveEngineOverrideId
                 let cloudModelOverride = effectiveCloudModelOverride
                 let translationTarget = effectiveTranslationTarget
-                let dictionaryProviderId = engineOverride ?? modelManager.selectedProviderId
+                let primaryEngineId = engineOverride ?? modelManager.selectedProviderId
+                let dictionaryProviderId = primaryEngineId
                 let termsPrompt = dictionaryService.getTermsForPrompt(providerId: dictionaryProviderId)
                 let termHints = dictionaryService.getTermHints(providerId: dictionaryProviderId)
 
-                let result = if let liveSessionResult {
-                    liveSessionResult
+                let transcription = if let liveSessionResult {
+                    FinalTranscriptionOutput(
+                        result: liveSessionResult,
+                        modelId: modelManager.resolvedModelId(
+                            engineOverrideId: engineOverride,
+                            cloudModelOverride: cloudModelOverride
+                        ),
+                        modelDisplayName: modelManager.resolvedModelDisplayName(
+                            engineOverrideId: engineOverride,
+                            cloudModelOverride: cloudModelOverride
+                        ),
+                        usedRecoveryFallback: false
+                    )
                 } else {
-                    try await modelManager.transcribe(
+                    try await transcribeFinalAudio(
                         audioSamples: samples,
                         languageSelection: languageSelection,
                         task: task,
-                        engineOverrideId: engineOverride,
-                        cloudModelOverride: cloudModelOverride,
+                        primaryEngineId: primaryEngineId,
+                        primaryCloudModelOverride: cloudModelOverride,
                         prompt: termsPrompt,
                         dictionaryTermHints: termHints,
                         normalizeNumbers: effectiveNumberNormalizationOverride
                     )
                 }
+                let result = transcription.result
 
                 // Bail out if a new recording started while we were transcribing
                 guard !Task.isCancelled else { return }
@@ -1357,10 +1420,7 @@ final class DictationViewModel: ObservableObject {
                 )
                 let dictationContext = DictationRuntimeContext(
                     engineId: result.engineUsed,
-                    modelId: modelManager.resolvedModelId(
-                        engineOverrideId: engineOverride,
-                        cloudModelOverride: cloudModelOverride
-                    ),
+                    modelId: transcription.modelId,
                     configuredLanguage: language,
                     configuredLanguageCandidates: languageCandidates,
                     detectedLanguage: result.detectedLanguage
@@ -1429,10 +1489,11 @@ final class DictationViewModel: ObservableObject {
                     )))
                 }
 
-                let modelDisplayName = modelManager.resolvedModelDisplayName(
-                    engineOverrideId: engineOverride,
-                    cloudModelOverride: cloudModelOverride
-                )
+                let modelDisplayName = transcription.modelDisplayName
+                var pipelineSteps = ppResult.appliedSteps
+                if transcription.usedRecoveryFallback {
+                    pipelineSteps.append(localizedAppText("Recovery fallback", de: "Recovery-Fallback"))
+                }
 
                 if UserDefaults.standard.object(forKey: UserDefaultsKeys.historyEnabled) as? Bool ?? true {
                     historyService.addRecord(
@@ -1447,7 +1508,7 @@ final class DictationViewModel: ObservableObject {
                         engineUsed: result.engineUsed,
                         modelUsed: modelDisplayName,
                         audioSamples: audioSamplesForHistory,
-                        pipelineSteps: ppResult.appliedSteps.isEmpty ? nil : ppResult.appliedSteps
+                        pipelineSteps: pipelineSteps.isEmpty ? nil : pipelineSteps
                     )
                 }
 
@@ -1516,6 +1577,132 @@ final class DictationViewModel: ObservableObject {
             }
             self.transcriptionTask = nil
         }
+    }
+
+    private func transcribeFinalAudio(
+        audioSamples: [Float],
+        languageSelection: LanguageSelection,
+        task: TranscriptionTask,
+        primaryEngineId: String?,
+        primaryCloudModelOverride: String?,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        normalizeNumbers: Bool?
+    ) async throws -> FinalTranscriptionOutput {
+        do {
+            let result = try await modelManager.transcribe(
+                audioSamples: audioSamples,
+                languageSelection: languageSelection,
+                task: task,
+                engineOverrideId: primaryEngineId,
+                cloudModelOverride: primaryCloudModelOverride,
+                prompt: prompt,
+                dictionaryTermHints: dictionaryTermHints,
+                normalizeNumbers: normalizeNumbers
+            )
+            return finalTranscriptionOutput(
+                result: result,
+                engineId: primaryEngineId,
+                modelId: primaryCloudModelOverride,
+                usedRecoveryFallback: false
+            )
+        } catch {
+            let primaryError = error
+            guard shouldAttemptAutomaticRecoveryFallback(after: primaryError),
+                  let configuration = recoveryFallbackConfigurationProvider(primaryEngineId, task) else {
+                throw primaryError
+            }
+
+            logger.warning(
+                "Primary transcription failed; retrying with recovery fallback engine \(configuration.engineId, privacy: .public): \(primaryError.localizedDescription, privacy: .public)"
+            )
+
+            do {
+                let fallbackResult = try await recoveryFallbackRunner(
+                    audioSamples,
+                    languageSelection,
+                    task,
+                    configuration,
+                    prompt,
+                    dictionaryTermHints,
+                    normalizeNumbers
+                )
+                logger.info(
+                    "Recovery fallback transcription succeeded with engine \(configuration.engineId, privacy: .public)"
+                )
+                return finalTranscriptionOutput(
+                    result: fallbackResult,
+                    engineId: configuration.engineId,
+                    modelId: configuration.modelId,
+                    usedRecoveryFallback: true
+                )
+            } catch {
+                logger.error(
+                    "Recovery fallback transcription failed with engine \(configuration.engineId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                throw AutomaticRecoveryFallbackFailure(
+                    primaryDescription: primaryError.localizedDescription,
+                    fallbackDescription: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    private func finalTranscriptionOutput(
+        result: TranscriptionResult,
+        engineId: String?,
+        modelId: String?,
+        usedRecoveryFallback: Bool
+    ) -> FinalTranscriptionOutput {
+        FinalTranscriptionOutput(
+            result: result,
+            modelId: modelManager.resolvedModelId(
+                engineOverrideId: engineId,
+                cloudModelOverride: modelId
+            ),
+            modelDisplayName: modelManager.resolvedModelDisplayName(
+                engineOverrideId: engineId,
+                cloudModelOverride: modelId
+            ),
+            usedRecoveryFallback: usedRecoveryFallback
+        )
+    }
+
+    private func shouldAttemptAutomaticRecoveryFallback(after error: Error) -> Bool {
+        guard !(error is CancellationError), !Task.isCancelled else { return false }
+
+        if let pluginError = error as? PluginTranscriptionError {
+            switch pluginError {
+            case .fileTooLarge:
+                return false
+            case .notConfigured,
+                 .noModelSelected,
+                 .invalidApiKey,
+                 .rateLimited,
+                 .apiError(_),
+                 .networkError(_):
+                return true
+            }
+        }
+
+        if let transcriptionError = error as? TranscriptionEngineError {
+            switch transcriptionError {
+            case .unsupportedTask(_):
+                return false
+            case .modelNotLoaded,
+                 .appleSpeechModelNotLoaded,
+                 .transcriptionFailed(_),
+                 .modelLoadFailed(_),
+                 .modelDownloadFailed(_):
+                return true
+            }
+        }
+
+        if error is URLError {
+            return true
+        }
+
+        return true
     }
 
     func requestMicPermission() { settingsHandler.requestMicPermission() }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -70,6 +70,45 @@ enum DictationTranscriptionOverrideResolver {
     }
 }
 
+enum AutomaticRecoveryFallbackErrorPolicy {
+    static func shouldAttempt(after error: Error, taskIsCancelled: Bool = Task.isCancelled) -> Bool {
+        guard !(error is CancellationError), !taskIsCancelled else { return false }
+
+        if let pluginError = error as? PluginTranscriptionError {
+            switch pluginError {
+            case .fileTooLarge:
+                return false
+            case .notConfigured,
+                 .noModelSelected,
+                 .invalidApiKey,
+                 .rateLimited,
+                 .apiError(_),
+                 .networkError(_):
+                return true
+            }
+        }
+
+        if let transcriptionError = error as? TranscriptionEngineError {
+            switch transcriptionError {
+            case .unsupportedTask(_):
+                return false
+            case .modelNotLoaded,
+                 .appleSpeechModelNotLoaded,
+                 .transcriptionFailed(_),
+                 .modelLoadFailed(_),
+                 .modelDownloadFailed(_):
+                return true
+            }
+        }
+
+        if error is URLError {
+            return true
+        }
+
+        return false
+    }
+}
+
 /// Orchestrates the dictation flow: recording → transcription → text insertion.
 @MainActor
 final class DictationViewModel: ObservableObject {
@@ -1616,6 +1655,8 @@ final class DictationViewModel: ObservableObject {
             logger.warning(
                 "Primary transcription failed; retrying with recovery fallback engine \(configuration.engineId, privacy: .public): \(primaryError.localizedDescription, privacy: .public)"
             )
+            let fallbackPrompt = dictionaryService.getTermsForPrompt(providerId: configuration.engineId)
+            let fallbackDictionaryTermHints = dictionaryService.getTermHints(providerId: configuration.engineId)
 
             do {
                 let fallbackResult = try await recoveryFallbackRunner(
@@ -1623,8 +1664,8 @@ final class DictationViewModel: ObservableObject {
                     languageSelection,
                     task,
                     configuration,
-                    prompt,
-                    dictionaryTermHints,
+                    fallbackPrompt,
+                    fallbackDictionaryTermHints,
                     normalizeNumbers
                 )
                 logger.info(
@@ -1669,40 +1710,7 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func shouldAttemptAutomaticRecoveryFallback(after error: Error) -> Bool {
-        guard !(error is CancellationError), !Task.isCancelled else { return false }
-
-        if let pluginError = error as? PluginTranscriptionError {
-            switch pluginError {
-            case .fileTooLarge:
-                return false
-            case .notConfigured,
-                 .noModelSelected,
-                 .invalidApiKey,
-                 .rateLimited,
-                 .apiError(_),
-                 .networkError(_):
-                return true
-            }
-        }
-
-        if let transcriptionError = error as? TranscriptionEngineError {
-            switch transcriptionError {
-            case .unsupportedTask(_):
-                return false
-            case .modelNotLoaded,
-                 .appleSpeechModelNotLoaded,
-                 .transcriptionFailed(_),
-                 .modelLoadFailed(_),
-                 .modelDownloadFailed(_):
-                return true
-            }
-        }
-
-        if error is URLError {
-            return true
-        }
-
-        return true
+        AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: error)
     }
 
     func requestMicPermission() { settingsHandler.requestMicPermission() }

--- a/TypeWhisper/Views/DictationRecoveryView.swift
+++ b/TypeWhisper/Views/DictationRecoveryView.swift
@@ -6,18 +6,7 @@ struct DictationRecoveryView: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        Group {
-            if viewModel.hasRecoveryContent {
-                recoveryForm
-            } else {
-                ContentUnavailableView {
-                    Label(
-                        localizedAppText("No Recording to Recover", de: "Keine Aufnahme zur Wiederherstellung"),
-                        systemImage: "waveform"
-                    )
-                }
-            }
-        }
+        recoveryForm
         .frame(minWidth: 500, minHeight: 400)
     }
 
@@ -68,33 +57,43 @@ struct DictationRecoveryView: View {
                         recoveryRow(recovery)
                     }
                 }
+            } else if !viewModel.hasRecoveryContent {
+                Section {
+                    Label(
+                        localizedAppText("No Recording to Recover", de: "Keine Aufnahme zur Wiederherstellung"),
+                        systemImage: "waveform"
+                    )
+                    .foregroundStyle(.secondary)
+                }
+            }
 
-                Section(String(localized: "Transcription")) {
-                    Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
-                        Text(String(localized: "Default Engine")).tag(nil as String?)
-                        Divider()
-                        ForEach(viewModel.availableEngines, id: \.providerId) { engine in
-                            enginePickerLabel(for: engine)
-                                .tag(engine.providerId as String?)
-                                .disabled(!viewModel.canUseForTranscription(engine))
-                        }
+            Section(String(localized: "Transcription")) {
+                Picker(String(localized: "Engine"), selection: $viewModel.selectedEngine) {
+                    Text(String(localized: "Default Engine")).tag(nil as String?)
+                    Divider()
+                    ForEach(viewModel.availableEngines, id: \.providerId) { engine in
+                        enginePickerLabel(for: engine)
+                            .tag(engine.providerId as String?)
+                            .disabled(!viewModel.canUseForTranscription(engine))
                     }
-                    .disabled(viewModel.isProcessing)
+                }
+                .disabled(viewModel.isProcessing)
 
-                    if let engine = viewModel.resolvedEngine {
-                        let models = engine.transcriptionModels
-                        if models.count > 1 {
-                            Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
-                                Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
-                                Divider()
-                                ForEach(models, id: \.id) { model in
-                                    Text(model.displayName).tag(model.id as String?)
-                                }
+                if let engine = viewModel.resolvedEngine {
+                    let models = engine.transcriptionModels
+                    if models.count > 1 {
+                        Picker(String(localized: "Model"), selection: $viewModel.selectedModel) {
+                            Text(String(localized: "watchFolder.model.default")).tag(nil as String?)
+                            Divider()
+                            ForEach(models, id: \.id) { model in
+                                Text(model.displayName).tag(model.id as String?)
                             }
-                            .disabled(viewModel.isProcessing)
                         }
+                        .disabled(viewModel.isProcessing)
                     }
+                }
 
+                if viewModel.hasRecovery {
                     if viewModel.supportsTranslation {
                         Picker(String(localized: "Task"), selection: $viewModel.selectedTask) {
                             ForEach(TranscriptionTask.allCases) { task in
@@ -111,7 +110,25 @@ struct DictationRecoveryView: View {
                     )
                     .disabled(viewModel.isProcessing)
                 }
+            }
 
+            Section(localizedAppText("Automatic Fallback", de: "Automatischer Fallback")) {
+                Toggle(isOn: $viewModel.automaticFallbackEnabled) {
+                    Label(
+                        localizedAppText("Retry failed dictations with this engine", de: "Fehlgeschlagene Diktate mit dieser Engine erneut versuchen"),
+                        systemImage: "arrow.triangle.2.circlepath"
+                    )
+                }
+                .disabled(viewModel.isProcessing || !viewModel.canUseAutomaticFallback)
+
+                if let message = viewModel.automaticFallbackUnavailableMessage {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if viewModel.hasRecovery {
                 Section {
                     HStack {
                         Spacer()

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -99,16 +99,9 @@ struct SettingsView: View {
         .frame(minWidth: 950, idealWidth: 1050, minHeight: 550, idealHeight: 600)
         .onAppear {
             navigateToFileTranscriptionIfNeeded()
-            navigateAwayFromMissingRecoveryIfNeeded()
         }
         .onChange(of: fileTranscription.showFilePickerFromMenu) { _, _ in
             navigateToFileTranscriptionIfNeeded()
-        }
-        .onChange(of: dictationRecovery.hasRecovery) { _, _ in
-            navigateAwayFromMissingRecoveryIfNeeded()
-        }
-        .onChange(of: dictationRecovery.lastSavedHistoryRecordID) { _, _ in
-            navigateAwayFromMissingRecoveryIfNeeded()
         }
         .onChange(of: homeViewModel.navigateToHistory) { _, navigate in
             if navigate {
@@ -128,12 +121,12 @@ struct SettingsView: View {
                 selectedTab = .workflows
                 WorkflowsNavigationCoordinator.shared.showMine()
             default:
-                selectedTab = Self.availableTab(request.tab, hasRecoveryContent: dictationRecovery.hasRecoveryContent)
+                selectedTab = Self.availableTab(request.tab)
             }
         }
     }
 
-    static func availableTab(_ tab: SettingsTab, hasRecoveryContent _: Bool) -> SettingsTab {
+    static func availableTab(_ tab: SettingsTab) -> SettingsTab {
         tab
     }
 
@@ -141,10 +134,6 @@ struct SettingsView: View {
         if fileTranscription.showFilePickerFromMenu {
             selectedTab = .fileTranscription
         }
-    }
-
-    private func navigateAwayFromMissingRecoveryIfNeeded() {
-        selectedTab = Self.availableTab(selectedTab, hasRecoveryContent: dictationRecovery.hasRecoveryContent)
     }
 
     @ViewBuilder

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -42,14 +42,12 @@ struct SettingsView: View {
                 systemImage: "waveform.circle",
                 badge: nil
             ),
-            dictationRecovery.hasRecoveryContent
-                ? SettingsDestination(
-                    tab: .dictationRecovery,
-                    title: localizedAppText("Recovery", de: "Wiederherstellung"),
-                    systemImage: "waveform",
-                    badge: nil
-                )
-                : nil,
+            SettingsDestination(
+                tab: .dictationRecovery,
+                title: localizedAppText("Recovery", de: "Wiederherstellung"),
+                systemImage: "waveform",
+                badge: nil
+            ),
             SettingsDestination(tab: .fileTranscription, title: String(localized: "File Transcription"), systemImage: "doc.text", badge: nil),
             SettingsDestination(tab: .history, title: String(localized: "History"), systemImage: "clock.arrow.circlepath", badge: nil),
             SettingsDestination(tab: .dictionary, title: String(localized: "Dictionary"), systemImage: "book.closed", badge: nil),
@@ -135,8 +133,8 @@ struct SettingsView: View {
         }
     }
 
-    static func availableTab(_ tab: SettingsTab, hasRecoveryContent: Bool) -> SettingsTab {
-        tab == .dictationRecovery && !hasRecoveryContent ? .recording : tab
+    static func availableTab(_ tab: SettingsTab, hasRecoveryContent _: Bool) -> SettingsTab {
+        tab
     }
 
     private func navigateToFileTranscriptionIfNeeded() {

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -602,6 +602,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
 
     func testAutomaticRecoveryFallbackRejectsCancellation() {
         XCTAssertFalse(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: CancellationError()))
+        XCTAssertFalse(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: URLError(.cancelled)))
         XCTAssertFalse(
             AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(
                 after: PluginTranscriptionError.rateLimited,

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import XCTest
 import TypeWhisperPluginSDK
+import XCTest
 @testable import TypeWhisper
 
 @MainActor
@@ -582,10 +582,49 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: newerRecoveryURL.path))
     }
 
-    func testRecoverySettingsTabFallsBackWhenRecoveryIsUnavailable() {
-        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: false), .recording)
+    func testRecoverySettingsTabRemainsAvailableWithoutRecoveryContent() {
+        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: false), .dictationRecovery)
         XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: true), .dictationRecovery)
         XCTAssertEqual(SettingsView.availableTab(.fileTranscription, hasRecoveryContent: false), .fileTranscription)
+    }
+
+    func testRecoveryAutomaticFallbackRequiresCommercialOrSupporterAccess() throws {
+        setupPluginManager()
+        let defaults = try makeDefaults()
+        let license = LicenseService(defaults: defaults)
+        let viewModel = makeRecoveryViewModel(defaults: defaults, licenseService: license)
+
+        viewModel.selectedEngine = "backup"
+        viewModel.selectedModel = "backup-large"
+        viewModel.automaticFallbackEnabled = true
+
+        XCTAssertNil(viewModel.automaticFallbackConfiguration(excluding: "primary", task: .transcribe))
+
+        license.licenseStatus = .active
+        license.licenseTier = .individual
+
+        XCTAssertEqual(
+            viewModel.automaticFallbackConfiguration(excluding: "primary", task: .transcribe),
+            DictationRecoveryFallbackConfiguration(engineId: "backup", modelId: "backup-large")
+        )
+    }
+
+    func testRecoveryAutomaticFallbackAllowsSupporterAccessAndRejectsPrimaryEngine() throws {
+        setupPluginManager()
+        let defaults = try makeDefaults()
+        let license = LicenseService(defaults: defaults)
+        let viewModel = makeRecoveryViewModel(defaults: defaults, licenseService: license)
+
+        license.supporterStatus = .active
+        license.supporterTier = .bronze
+        viewModel.selectedEngine = "backup"
+        viewModel.automaticFallbackEnabled = true
+
+        XCTAssertNil(viewModel.automaticFallbackConfiguration(excluding: "backup", task: .transcribe))
+        XCTAssertEqual(
+            viewModel.automaticFallbackConfiguration(excluding: "primary", task: .transcribe),
+            DictationRecoveryFallbackConfiguration(engineId: "backup", modelId: nil)
+        )
     }
 
     private func makeDefaults() throws -> UserDefaults {
@@ -633,6 +672,49 @@ final class FileTranscriptionViewModelTests: XCTestCase {
             engineUsed: "test",
             segments: segments
         )
+    }
+
+    private func makeRecoveryViewModel(
+        defaults: UserDefaults,
+        licenseService: LicenseService
+    ) -> DictationRecoveryViewModel {
+        let directory = makeTemporaryDirectory()
+        let audioRecordingService = AudioRecordingService(
+            recoveryAudioStore: DictationRecoveryAudioStore(directory: directory)
+        )
+        return DictationRecoveryViewModel(
+            audioRecordingService: audioRecordingService,
+            modelManager: ModelManagerService(),
+            historyService: HistoryService(appSupportDirectory: makeTemporaryDirectory()),
+            audioFileService: AudioFileService(),
+            licenseService: licenseService,
+            defaults: defaults
+        )
+    }
+
+    private func setupPluginManager() {
+        let previousPluginManager = PluginManager.shared
+        addTeardownBlock {
+            PluginManager.shared = previousPluginManager
+        }
+
+        let appSupportDirectory = makeTemporaryDirectory()
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.backup",
+                    name: "Backup",
+                    version: "1.0.0",
+                    principalClass: "RecoveryFallbackMockTranscriptionPlugin"
+                ),
+                instance: RecoveryFallbackMockTranscriptionPlugin(),
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
     }
 
     private func waitForBatchToFinish(_ viewModel: FileTranscriptionViewModel) async throws {
@@ -715,5 +797,49 @@ private final class FileTranscriptionAppleSpeechCatalogPlugin: NSObject, Transcr
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
         throw PluginTranscriptionError.notConfigured
+    }
+}
+
+private final class RecoveryFallbackMockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    static var pluginId: String { "com.typewhisper.mock.backup" }
+    static var pluginName: String { "Backup" }
+
+    let providerId = "backup"
+    let providerDisplayName = "Backup"
+    var isConfigured: Bool { true }
+    var transcriptionModels: [PluginModelInfo] {
+        [
+            PluginModelInfo(id: "backup-large", displayName: "Backup Large"),
+            PluginModelInfo(id: "backup-small", displayName: "Backup Small")
+        ]
+    }
+    private(set) var selectedModelId: String? = "backup-large"
+    var supportsTranslation: Bool { true }
+    var supportsStreaming: Bool { false }
+    var supportedLanguages: [String] { ["de", "en"] }
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func selectModel(_ modelId: String) {
+        selectedModelId = modelId
+    }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "backup transcript", detectedLanguage: language)
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        _ = onProgress("backup transcript")
+        return PluginTranscriptionResult(text: "backup transcript", detectedLanguage: language)
     }
 }

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -583,9 +583,31 @@ final class FileTranscriptionViewModelTests: XCTestCase {
     }
 
     func testRecoverySettingsTabRemainsAvailableWithoutRecoveryContent() {
-        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: false), .dictationRecovery)
-        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery, hasRecoveryContent: true), .dictationRecovery)
-        XCTAssertEqual(SettingsView.availableTab(.fileTranscription, hasRecoveryContent: false), .fileTranscription)
+        XCTAssertEqual(SettingsView.availableTab(.dictationRecovery), .dictationRecovery)
+        XCTAssertEqual(SettingsView.availableTab(.fileTranscription), .fileTranscription)
+    }
+
+    func testAutomaticRecoveryFallbackAllowsKnownRecoverableErrors() {
+        XCTAssertTrue(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: PluginTranscriptionError.rateLimited))
+        XCTAssertTrue(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: PluginTranscriptionError.networkError("offline")))
+        XCTAssertTrue(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: TranscriptionEngineError.modelNotLoaded))
+        XCTAssertTrue(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: URLError(.timedOut)))
+    }
+
+    func testAutomaticRecoveryFallbackRejectsKnownNonRecoverableAndUnknownErrors() {
+        XCTAssertFalse(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: PluginTranscriptionError.fileTooLarge))
+        XCTAssertFalse(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: TranscriptionEngineError.unsupportedTask("translate")))
+        XCTAssertFalse(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: UnknownTranscriptionError()))
+    }
+
+    func testAutomaticRecoveryFallbackRejectsCancellation() {
+        XCTAssertFalse(AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(after: CancellationError()))
+        XCTAssertFalse(
+            AutomaticRecoveryFallbackErrorPolicy.shouldAttempt(
+                after: PluginTranscriptionError.rateLimited,
+                taskIsCancelled: true
+            )
+        )
     }
 
     func testRecoveryAutomaticFallbackRequiresCommercialOrSupporterAccess() throws {
@@ -769,6 +791,8 @@ private actor AsyncGate {
         return isOpen
     }
 }
+
+private struct UnknownTranscriptionError: Error {}
 
 private final class FileTranscriptionAppleSpeechCatalogPlugin: NSObject, TranscriptionModelCatalogProviding, @unchecked Sendable {
     static let pluginId = AppleSpeechModelSelection.manifestId


### PR DESCRIPTION
## Summary
- Adds an optional automatic speech-to-text fallback using the Recovery engine/model selection.
- Gates the automatic fallback behind a commercial license or active supporter status.
- Keeps the Recovery settings tab visible even when there is no recoverable recording, so the fallback can be configured proactively.

## Issue Context
Issue #652 asks for a backup transcription provider/model so dictation can keep working when the primary provider is rate limited, unavailable, or misconfigured. This implements the first version as a Pro-style fallback tied to the existing Recovery configuration instead of adding a separate provider-routing surface.

Closes #652

## Test Plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --clean --run /Users/marco/.codex/worktrees/979b/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Automatic Fallback” toggle for final dictation recovery, with license-aware eligibility and an alternate engine/model retry when compatible.
  * Fallback eligibility now includes active supporter access in addition to commercial licensing.

* **Bug Fixes**
  * Updated recovery UI to always show the recovery form (with “no recording” handled inside the form) and to keep the recovery tab available in navigation even when no recovery content exists.
  * Improved post-transcription history to reflect when fallback was used.

* **Tests**
  * Added/extended unit tests covering fallback error policy and automatic fallback configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->