### PR TITLE
Fix Soniox region persistence

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -1617,8 +1617,10 @@ final class SonioxPlugin: NSObject,
     fileprivate var selectedTTSModelIdForSettings: String { _selectedTTSModelId ?? SonioxModelSelection.automatic }
     fileprivate var selectedVoiceIdForSettings: String { selectedVoiceId ?? Self.defaultVoiceId }
 
-    fileprivate func selectRegion(_ regionId: String) {
-        _selectedRegion = SonioxRegion.resolved(regionId, host: host)
+    func selectRegion(_ regionId: String) {
+        let region = SonioxRegion.resolved(regionId, host: nil)
+        _selectedRegion = region
+        host?.setUserDefault(region.id, forKey: SonioxDefaultsKey.selectedRegion)
         host?.notifyCapabilitiesChanged()
     }
 

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -83,6 +83,35 @@ final class SonioxPluginTests: XCTestCase {
         XCTAssertEqual(host.userDefault(forKey: "selectedRegion") as? String, "us")
     }
 
+    func testSelectedRegionPersistsAcrossPluginActivation() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectRegion("eu")
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedRegion") as? String, "eu")
+
+        let restartedPlugin = SonioxPlugin()
+        restartedPlugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data("{}".utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files", statusCode: 200)
+                ),
+            ])
+        }
+
+        let isValid = await restartedPlugin.validateApiKey("soniox-key")
+
+        XCTAssertTrue(isValid)
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.absoluteString, "https://api.eu.soniox.com/v1/files")
+    }
+
     func testSonioxPluginAdvertisesTTSProtocolAndDefaultVoice() throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
         let plugin = SonioxPlugin()


### PR DESCRIPTION
## Summary
- Persist Soniox region changes to the plugin host defaults instead of only updating in-memory state.
- Add a regression test that selects the EU region, re-activates a fresh plugin instance, and verifies API key validation uses the EU endpoint.

## Issue context
Issue #785 reports that the Soniox settings region resets to United States after restarting TypeWhisper. That makes EU or Japan API keys invalid after restart because the plugin falls back to the US base URL.

Root cause: `selectRegion(_:)` updated `_selectedRegion` for the current runtime session but did not write the selected region ID to the host defaults read by `activate(host:)` on the next launch.

Closes #785

## Test plan
- `git diff --check`
- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme SonioxPlugin -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Note: I also tried the target-form command from the implementation plan, `xcodebuild -project TypeWhisper.xcodeproj -target SonioxPlugin -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`. Xcode ignored the destination because no scheme was passed, built multiple archs, and failed resolving the local `TypeWhisperPluginSDK` module. The scheme command above builds the same Soniox plugin bundle successfully for the requested macOS arm64 destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Region selection now saves correctly and remains consistent after re-opening or reactivating the plugin.
  * The app now continues using the previously selected region when connecting again, helping ensure requests go to the expected endpoint.

* **Tests**
  * Added coverage for region persistence across plugin activation and reconnect flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->