### PR TITLE
Fix preserve-clipboard insertion fallback for TaskForge

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -420,18 +420,11 @@ final class TextInsertionService {
               let currentState = captureFocusedTextState(for: element) else {
             return false
         }
-        return Self.focusedTextDidChange(
-            from: (
-                value: initialState.value,
-                selectedText: initialState.selectedText,
-                selectedRange: initialState.selectedRange
-            ),
-            to: (
-                value: currentState.value,
-                selectedText: currentState.selectedText,
-                selectedRange: currentState.selectedRange
-            )
-        )
+        guard let initialValue = initialState.value,
+              let currentValue = currentState.value else {
+            return false
+        }
+        return initialValue != currentValue
     }
 
     /// Saves all current clipboard contents for later restoration.

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -420,11 +420,10 @@ final class TextInsertionService {
               let currentState = captureFocusedTextState(for: element) else {
             return false
         }
-        guard let initialValue = initialState.value,
-              let currentValue = currentState.value else {
+        guard let currentValue = currentState.value else {
             return false
         }
-        return initialValue != currentValue
+        return initialState.value != currentValue
     }
 
     /// Saves all current clipboard contents for later restoration.

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3312,6 +3312,45 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testPreserveClipboardAvoidsPasteboardWhenAccessibilityInsertionChangesNilValue() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { element }
+
+        var stateReadCount = 0
+        service.focusedTextStateOverride = { _ in
+            defer { stateReadCount += 1 }
+            if stateReadCount == 0 {
+                return (value: nil, selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+            }
+            return (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+        }
+
+        var insertedText: String?
+        service.insertTextAtOverride = { _, text in
+            insertedText = text
+            return true
+        }
+
+        var didSimulatePaste = false
+        service.pasteSimulatorOverride = {
+            didSimulatePaste = true
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+
+        _ = try await service.insertText("Hello", preserveClipboard: true)
+
+        XCTAssertEqual(insertedText, "Hello")
+        XCTAssertFalse(didSimulatePaste)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
+    @MainActor
     func testPreserveClipboardFallsBackToPasteboardWhenVerifiedAccessibilityInsertionFails() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3185,6 +3185,49 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testPreserveClipboardFallsBackToSyntheticPasteWhenDirectAXOnlyMovesSelection() async throws {
+        let service = TextInsertionService()
+        let pasteboard = NSPasteboard.withUniqueName()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { element }
+        service.verifiedRestoreGraceDelay = .milliseconds(1)
+
+        var didAttemptDirectAXInsertion = false
+        var pasteCount = 0
+        service.focusedTextStateOverride = { _ in
+            if pasteCount > 0 {
+                return (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+            }
+            if didAttemptDirectAXInsertion {
+                return (value: "", selectedText: nil, selectedRange: NSRange(location: 1, length: 0))
+            }
+            return (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+        }
+
+        var insertedText: String?
+        service.insertTextAtOverride = { _, text in
+            insertedText = text
+            didAttemptDirectAXInsertion = true
+            return true
+        }
+        service.pasteSimulatorOverride = {
+            pasteCount += 1
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString("Existing", forType: .string)
+
+        let result = try await service.insertText("Hello", preserveClipboard: true)
+
+        XCTAssertEqual(insertedText, "Hello")
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(result, .pasted(verification: .verified))
+        XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+    }
+
+    @MainActor
     func testAutoEnterSkipsReturnWithoutFocusedTextField() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()


### PR DESCRIPTION
## Summary
- Fix preserve-clipboard insertion for TaskForge-like fields by only treating direct Accessibility insertion as verified when the focused element text value actually changes.
- Let the existing synthetic Cmd+V fallback run when direct AX insertion only moves caret or selection state.
- Add regression coverage for the selection-only AX false positive and for `nil` → value AX verification while keeping the verified value-change success path covered.

## Issue Context
TaskForge does not receive dictated text when `Preserve clipboard content` is enabled, even though TypeWhisper restores the original clipboard. The preserve-clipboard path attempted direct Accessibility insertion first and could incorrectly treat selection or caret movement as a successful text insertion, skipping the synthetic paste fallback that would have inserted the dictated text.

Closes #783

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardFallsBackToSyntheticPasteWhenDirectAXOnlyMovesSelection -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardAvoidsPasteboardWhenVerifiedAccessibilityInsertionSucceeds -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardAvoidsPasteboardWhenAccessibilityInsertionChangesNilValue CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/8cd7/typewhisper-mac`
- Manual TaskForge field smoke was not completed in this run because it requires an interactive TaskForge field/microphone/focus setup; the dev app was built and launched at `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.
