### PR TITLE
Delay Hybrid modifier hold activation

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -742,6 +742,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private func handleEvent(_ event: NSEvent, source: HotkeyEventSource) -> Bool {
         // Escape key cancels active recording/transcription
         if event.type == .keyDown && event.keyCode == Self.escapeKeyCode {
+            cancelPendingHybridModifierHold()
             if shouldDispatch(
                 target: .cancel,
                 phase: .down,

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -205,6 +205,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     var workflowTextProcessingModifierPollInterval: TimeInterval = 0.05
     var workflowTextProcessingModifierReleaseTimeout: TimeInterval = 2.0
     var workflowTextProcessingPostReleaseDelay: TimeInterval = 0.15
+    var hybridModifierHoldActivationDelay: TimeInterval = 0.35
 
     private var keyDownTime: Date?
     private var isActive = false
@@ -213,6 +214,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private(set) var activeProfileId: UUID?
     private(set) var activeWorkflowId: UUID?
     private var pushToTalkInterruptionSignaled = false
+    private var pendingHybridModifierHoldWorkItem: DispatchWorkItem?
+    private var pendingHybridModifierHoldHotkey: UnifiedHotkey?
+    private var pendingHybridModifierHoldGeneration: UInt64 = 0
+    private var activeDelayedHybridModifierHold = false
 
     private static let toggleThreshold: TimeInterval = 1.0
     private static let doubleTapThreshold: TimeInterval = 0.4
@@ -397,6 +402,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     }
 
     func cancelDictation() {
+        cancelPendingHybridModifierHold()
         isActive = false
         activeSlotType = nil
         activeGlobalHotkey = nil
@@ -405,9 +411,12 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         currentMode = nil
         keyDownTime = nil
         pushToTalkInterruptionSignaled = false
+        activeDelayedHybridModifierHold = false
     }
 
     private func resetPausedDictationHotkeyState() {
+        cancelPendingHybridModifierHold()
+
         for slotType in HotkeySlotType.allCases where slotType.startsDictation {
             guard var states = slots[slotType] else { continue }
             for index in states.indices {
@@ -495,6 +504,8 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     }
 
     private func setHotkeys(_ hotkeys: [UnifiedHotkey], for slotType: HotkeySlotType) {
+        cancelPendingHybridModifierHold()
+
         let uniqueHotkeys = Self.uniqueHotkeys(hotkeys)
         slots[slotType] = uniqueHotkeys.map { SlotState(hotkey: $0) }
         persistHotkeys(uniqueHotkeys, for: slotType)
@@ -603,6 +614,8 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     }
 
     private func tearDownMonitor() {
+        cancelPendingHybridModifierHold()
+
         if let monitor = globalMonitor {
             NSEvent.removeMonitor(monitor)
             globalMonitor = nil
@@ -740,6 +753,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             return false
         }
 
+        cancelPendingHybridModifierHoldIfInterrupted(by: event)
         signalPushToTalkInterruptionIfNeeded(for: event)
         updateCapsLockOriginTracker(for: event)
         var shouldSuppress = false
@@ -768,7 +782,15 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
                     fnTriggerMode: fnTriggerMode
                 )
                 states[index] = state
-                if isMatch { shouldSuppress = true }
+                if shouldSuppressGlobalMatch(
+                    slotType: slotType,
+                    hotkey: hotkey,
+                    keyDown: keyDown,
+                    keyUp: keyUp,
+                    isMatch: isMatch
+                ) {
+                    shouldSuppress = true
+                }
                 dispatchGlobalMatch(
                     slotType: slotType,
                     hotkey: hotkey,
@@ -876,6 +898,104 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         }
 
         return shouldSuppress
+    }
+
+    private func shouldSuppressGlobalMatch(
+        slotType: HotkeySlotType,
+        hotkey: UnifiedHotkey,
+        keyDown: Bool,
+        keyUp: Bool,
+        isMatch: Bool
+    ) -> Bool {
+        guard isMatch else { return false }
+        guard shouldDelayHybridModifierHold(for: slotType, hotkey: hotkey) else { return true }
+
+        if keyDown { return isActive }
+        if keyUp {
+            return isActive
+                && activeSlotType == .hybrid
+                && activeGlobalHotkey == hotkey
+                && activeDelayedHybridModifierHold
+        }
+        return false
+    }
+
+    private func shouldDelayHybridModifierHold(for slotType: HotkeySlotType, hotkey: UnifiedHotkey) -> Bool {
+        slotType == .hybrid && hotkey.kind == .modifierOnly && !hotkey.isDoubleTap
+    }
+
+    private func scheduleDelayedHybridModifierHoldStart(for hotkey: UnifiedHotkey) {
+        cancelPendingHybridModifierHold()
+
+        pendingHybridModifierHoldGeneration &+= 1
+        let generation = pendingHybridModifierHoldGeneration
+        pendingHybridModifierHoldHotkey = hotkey
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.activatePendingHybridModifierHold(generation: generation)
+        }
+        pendingHybridModifierHoldWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + hybridModifierHoldActivationDelay,
+            execute: workItem
+        )
+    }
+
+    private func activatePendingHybridModifierHold(generation: UInt64) {
+        guard generation == pendingHybridModifierHoldGeneration,
+              let hotkey = pendingHybridModifierHoldHotkey else {
+            return
+        }
+        guard !dictationHotkeysPaused,
+              !isActive,
+              isModifierOnlyHotkeyStillPressed(hotkey) else {
+            cancelPendingHybridModifierHold()
+            return
+        }
+
+        pendingHybridModifierHoldWorkItem = nil
+        pendingHybridModifierHoldHotkey = nil
+
+        activeSlotType = .hybrid
+        activeGlobalHotkey = hotkey
+        activeProfileId = nil
+        activeWorkflowId = nil
+        keyDownTime = Date()
+        isActive = true
+        pushToTalkInterruptionSignaled = false
+        activeDelayedHybridModifierHold = true
+        currentMode = .pushToTalk
+        onDictationStart?(Self.requestTimestamp())
+    }
+
+    private func cancelPendingHybridModifierHoldIfInterrupted(by event: NSEvent) {
+        guard let hotkey = pendingHybridModifierHoldHotkey else { return }
+
+        switch event.type {
+        case .flagsChanged:
+            if event.keyCode != hotkey.keyCode {
+                cancelPendingHybridModifierHold()
+            }
+        case .keyDown, .otherMouseDown:
+            cancelPendingHybridModifierHold()
+        default:
+            break
+        }
+    }
+
+    private func cancelPendingHybridModifierHold() {
+        pendingHybridModifierHoldWorkItem?.cancel()
+        pendingHybridModifierHoldWorkItem = nil
+        pendingHybridModifierHoldHotkey = nil
+        pendingHybridModifierHoldGeneration &+= 1
+    }
+
+    private func isModifierOnlyHotkeyStillPressed(_ hotkey: UnifiedHotkey) -> Bool {
+        guard hotkey.kind == .modifierOnly,
+              let flag = Self.modifierFlagForKeyCode(hotkey.keyCode) else {
+            return false
+        }
+        return modifierFlagsStateProvider().contains(flag)
     }
 
     private func updateCapsLockOriginTracker(for event: NSEvent) {
@@ -1056,10 +1176,12 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
 #if DEBUG
     func setHotkeyForTesting(_ hotkey: UnifiedHotkey, for slotType: HotkeySlotType) {
+        cancelPendingHybridModifierHold()
         slots[slotType] = [SlotState(hotkey: hotkey)]
     }
 
     func setHotkeysForTesting(_ hotkeys: [UnifiedHotkey], for slotType: HotkeySlotType) {
+        cancelPendingHybridModifierHold()
         slots[slotType] = Self.uniqueHotkeys(hotkeys).map { SlotState(hotkey: $0) }
     }
 
@@ -1379,6 +1501,11 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             return
         }
 
+        if !isActive, shouldDelayHybridModifierHold(for: slotType, hotkey: hotkey) {
+            scheduleDelayedHybridModifierHoldStart(for: hotkey)
+            return
+        }
+
         if isActive {
             // Any hotkey stops active recording
             isActive = false
@@ -1389,6 +1516,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             onDictationStop?()
         } else {
             let requestTimestamp = Self.requestTimestamp()
@@ -1399,16 +1527,33 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             keyDownTime = Date()
             isActive = true
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             currentMode = slotType == .toggle ? .toggle : .pushToTalk
             onDictationStart?(requestTimestamp)
         }
     }
 
     private func handleKeyUp(slotType: HotkeySlotType) {
+        if slotType == .hybrid, pendingHybridModifierHoldWorkItem != nil {
+            cancelPendingHybridModifierHold()
+            return
+        }
+
         guard isActive, slotType == activeSlotType, activeProfileId == nil, activeWorkflowId == nil else { return }
 
         switch slotType {
         case .hybrid:
+            if activeDelayedHybridModifierHold {
+                isActive = false
+                activeSlotType = nil
+                activeGlobalHotkey = nil
+                currentMode = nil
+                keyDownTime = nil
+                pushToTalkInterruptionSignaled = false
+                activeDelayedHybridModifierHold = false
+                onDictationStop?()
+                return
+            }
             guard let downTime = keyDownTime else { return }
             if Date().timeIntervalSince(downTime) < Self.toggleThreshold {
                 currentMode = .toggle
@@ -1419,6 +1564,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
                 currentMode = nil
                 keyDownTime = nil
                 pushToTalkInterruptionSignaled = false
+                activeDelayedHybridModifierHold = false
                 onDictationStop?()
             }
         case .pushToTalk:
@@ -1428,6 +1574,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             onDictationStop?()
         case .toggle:
             break
@@ -1455,6 +1602,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             onDictationStop?()
         } else {
             let requestTimestamp = Self.requestTimestamp()
@@ -1465,6 +1613,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             keyDownTime = Date()
             isActive = true
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             currentMode = .pushToTalk // hybrid behavior
             onProfileDictationStart?(profileId, requestTimestamp)
         }
@@ -1486,6 +1635,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             onDictationStop?()
         }
     }
@@ -1503,6 +1653,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
                 currentMode = nil
                 keyDownTime = nil
                 pushToTalkInterruptionSignaled = false
+                activeDelayedHybridModifierHold = false
                 onDictationStop?()
                 return
             }
@@ -1519,6 +1670,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             onDictationStop?()
         } else {
             let requestTimestamp = Self.requestTimestamp()
@@ -1529,6 +1681,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             keyDownTime = Date()
             isActive = true
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             currentMode = .pushToTalk
             onWorkflowDictationStart?(workflowId, requestTimestamp)
         }
@@ -1555,6 +1708,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             currentMode = nil
             keyDownTime = nil
             pushToTalkInterruptionSignaled = false
+            activeDelayedHybridModifierHold = false
             onDictationStop?()
         }
     }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -8304,6 +8304,38 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testEscapeCancelsPendingHybridModifierHold() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.hybridModifierHoldActivationDelay = 0.02
+
+        service.setHotkeyForTesting(controlModifierHotkey(), for: .hybrid)
+
+        var currentFlags = NSEvent.ModifierFlags.control
+        service.modifierFlagsStateProvider = { currentFlags }
+
+        var startCount = 0
+        var cancelCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+        service.onCancelPressed = { cancelCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let escape = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [.maskControl])
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(escape, source: .monitor))
+
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(cancelCount, 1)
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+
+        currentFlags = []
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
+    }
+
+    @MainActor
     func testHybridModifierHoldStartsAfterDelayAndStopsOnRelease() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -8217,6 +8217,157 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testHybridModifierHoldDoesNotStartBeforeDelay() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.hybridModifierHoldActivationDelay = 0.05
+
+        service.setHotkeyForTesting(controlModifierHotkey(), for: .hybrid)
+
+        var currentFlags = NSEvent.ModifierFlags.control
+        service.modifierFlagsStateProvider = { currentFlags }
+
+        var startCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+
+        currentFlags = []
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
+        try await Task.sleep(for: .milliseconds(60))
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testHybridModifierShortTapDoesNotToggleDictation() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.hybridModifierHoldActivationDelay = 0.02
+
+        service.setHotkeyForTesting(controlModifierHotkey(), for: .hybrid)
+
+        var currentFlags = NSEvent.ModifierFlags.control
+        service.modifierFlagsStateProvider = { currentFlags }
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        currentFlags = []
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(startCount, 0)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testHybridModifierShortcutCancelsPendingHold() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.hybridModifierHoldActivationDelay = 0.02
+
+        service.setHotkeyForTesting(controlModifierHotkey(), for: .hybrid)
+
+        var currentFlags = NSEvent.ModifierFlags.control
+        service.modifierFlagsStateProvider = { currentFlags }
+
+        var startCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let shortcutKeyDown = try makeKeyboardEvent(keyCode: 0x30, keyDown: true, flags: [.maskControl])
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(shortcutKeyDown, source: .monitor))
+
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+
+        currentFlags = []
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
+    }
+
+    @MainActor
+    func testHybridModifierHoldStartsAfterDelayAndStopsOnRelease() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.hybridModifierHoldActivationDelay = 0.02
+
+        service.setHotkeyForTesting(controlModifierHotkey(), for: .hybrid)
+
+        var currentFlags = NSEvent.ModifierFlags.control
+        service.modifierFlagsStateProvider = { currentFlags }
+
+        var startCount = 0
+        var stopCount = 0
+        let started = expectation(description: "hybrid modifier hold starts after delay")
+        service.onDictationStart = { _ in
+            startCount += 1
+            started.fulfill()
+        }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        await fulfillment(of: [started], timeout: 1.0)
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        currentFlags = []
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testHybridModifierDoubleTapStillTogglesDictation() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(controlModifierHotkey(isDoubleTap: true), for: .hybrid)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 0)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .toggle)
+    }
+
+    @MainActor
     func testMonitorFallbackToggleFnStillWorksOnRelease() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -9128,6 +9279,16 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
     }
 
+    @MainActor
+    private func controlModifierHotkey(isDoubleTap: Bool = false) -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x3B,
+            modifierFlags: 0,
+            isFn: false,
+            isDoubleTap: isDoubleTap
+        )
+    }
+
     private func makeKeyboardEvent(
         keyCode: UInt16,
         keyDown: Bool,
@@ -9175,6 +9336,13 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
                 isARepeat: false,
                 keyCode: keyCode
             )
+        )
+    }
+
+    private func makeControlModifierEvent(isDown: Bool) throws -> NSEvent {
+        try makeFlagsChangedEvent(
+            keyCode: 0x3B,
+            modifierFlags: isDown ? [.control] : []
         )
     }
 


### PR DESCRIPTION
## Issue Context
Issue #782 reports accidental Hybrid activation when modifier-only Control is used as the Hybrid hold key. A short Control tap or Control+Tab should continue through to macOS/apps, while Double-Tap Control remains the hands-free toggle path.

Closes #782

## Changes
- Adds an internal 350 ms hold delay for non-double-tap modifier-only Hybrid hotkeys.
- Leaves initial modifier events unsuppressed while pending, and cancels pending activation on release, another key/modifier, pause, cancel, monitor teardown, or hotkey change.
- Starts delayed Hybrid activation in push-to-talk mode and stops it on release, independent of the existing 1 s Hybrid toggle threshold.
- Keeps Push-to-Talk, Toggle, profile/workflow hotkeys, non-dictation hotkeys, and double-tap hotkeys unchanged.

## Test Plan
- `git diff --check`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests test`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' test`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/1f7b/typewhisper-mac`

## Manual Smoke
- Dev app built and launched at `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app` for interactive verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delayed activation for hybrid “modifier-only” hotkeys, so push-to-talk starts only after a configurable hold delay.
  * Control-based hybrid shortcuts now support delayed dictation start while preserving double-tap toggle behavior.
* **Bug Fixes**
  * Pending delayed activations are now canceled more reliably when input changes occur (e.g., key release, interrupted modifier state, or other shortcut presses), and delayed-hold state is cleared on session stop.
* **Tests**
  * Expanded async coverage for Control hybrid timing, cancellation scenarios (including Escape), and delayed start/stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->