### PR TITLE
Compress cloud ASR uploads

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -187,7 +187,10 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         prompt: String?,
         speakerDiarizationEnabled: Bool
     ) async throws -> PluginStructuredTranscriptionResult {
-        let uploadURL = try await uploadAudio(wavData: audio.wavData, apiKey: apiKey)
+        let uploadURL = try await uploadAudio(
+            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
+            apiKey: apiKey
+        )
         let transcriptId = try await submitTranscription(
             audioURL: uploadURL,
             modelId: modelId,
@@ -199,7 +202,7 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         return try await pollTranscription(transcriptId: transcriptId, apiKey: apiKey)
     }
 
-    private func uploadAudio(wavData: Data, apiKey: String) async throws -> String {
+    private func uploadAudio(uploadFile: PluginAudioUploadFile, apiKey: String) async throws -> String {
         guard let url = URL(string: "https://api.assemblyai.com/v2/upload") else {
             throw PluginTranscriptionError.apiError("Invalid upload URL")
         }
@@ -208,7 +211,7 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "Authorization")
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        request.httpBody = wavData
+        request.httpBody = uploadFile.data
         request.timeoutInterval = 120
 
         let (data, response) = try await PluginHTTPClient.data(for: request)

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
@@ -1,9 +1,14 @@
 import XCTest
 import TypeWhisperPluginSDK
-import TypeWhisperPluginSDKTesting
+@_spi(Testing) import TypeWhisperPluginSDKTesting
 @testable import AssemblyAIPlugin
 
 final class AssemblyAIPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
     func testSpeakerDiarizationSettingPersistsAndNotifies() throws {
         let host = try PluginTestHostServices()
         let plugin = AssemblyAIPlugin()
@@ -89,5 +94,50 @@ final class AssemblyAIPluginTests: XCTestCase {
         XCTAssertEqual(result.text, "plain transcript")
         XCTAssertEqual(result.detectedLanguage, "de")
         XCTAssertTrue(result.segments.isEmpty)
+    }
+
+    func testRESTTranscriptionUploadsCompressedM4A() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "assembly-key"])
+        let plugin = AssemblyAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"upload_url":"https://cdn.example.test/audio.m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/upload", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"id":"transcript_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/transcript", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"status":"completed","text":"hello","language_code":"en"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/transcript/transcript_123", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: "en", translate: false, prompt: "TypeWhisper")
+
+        XCTAssertEqual(result.text, "hello")
+        let uploadRequest = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(uploadRequest.url?.path, "/v2/upload")
+        XCTAssertEqual(uploadRequest.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
+        let uploadBody = try XCTUnwrap(uploadRequest.httpBody)
+        XCTAssertTrue(String(decoding: uploadBody.prefix(64), as: UTF8.self).contains("ftyp"))
+        XCTAssertNotEqual(uploadBody, audio.wavData)
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -400,7 +400,7 @@ final class CartesiaPlugin: NSObject,
             configuredLanguage: _transcriptionLanguage
         )
         let request = try Self.makeTranscriptionRequest(
-            wavData: audio.wavData,
+            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
             apiKey: apiKey,
             modelId: Self.sttModelId,
             language: resolvedLanguage
@@ -620,7 +620,7 @@ extension CartesiaPlugin {
     }
 
     static func makeTranscriptionRequest(
-        wavData: Data,
+        uploadFile: PluginAudioUploadFile,
         apiKey: String,
         modelId: String,
         language: String?
@@ -641,9 +641,9 @@ extension CartesiaPlugin {
         body.appendMultipartFile(
             boundary: boundary,
             name: "file",
-            filename: "audio.wav",
-            contentType: "audio/wav",
-            data: wavData
+            filename: uploadFile.filename,
+            contentType: uploadFile.contentType,
+            data: uploadFile.data
         )
         body.appendMultipartField(boundary: boundary, name: "model", value: modelId)
         if let language, !language.isEmpty {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -399,8 +399,10 @@ final class CartesiaPlugin: NSObject,
             languageHints: languageHints,
             configuredLanguage: _transcriptionLanguage
         )
+        let uploadFile = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
         let request = try Self.makeTranscriptionRequest(
-            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
+            uploadFile: uploadFile,
             apiKey: apiKey,
             modelId: Self.sttModelId,
             language: resolvedLanguage

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -338,6 +338,36 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 
+    func testTranscribeFallsBackToWavWhenM4AEncodingFails() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"type":"transcript","text":"Hello from wav","language":"en","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                )
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: [], wavData: Data("fallback-wav".utf8), duration: 1),
+            language: nil,
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Hello from wav")
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        XCTAssertTrue(body.contains(#"name="file"; filename="audio.wav""#))
+        XCTAssertTrue(body.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(body.contains("fallback-wav"))
+    }
+
     func testTranscribeUsesConfiguredEnglishLanguageWhenSelected() async throws {
         let host = try PluginTestHostServices(
             defaults: ["transcriptionLanguage": "en"],

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -162,7 +162,12 @@ final class CartesiaPluginTests: XCTestCase {
 
     func testTranscriptionRequestUsesNativeCartesiaEndpointHeadersLanguageAndWordTimestamps() throws {
         let request = try CartesiaPlugin.makeTranscriptionRequest(
-            wavData: Data("wav".utf8),
+            uploadFile: PluginAudioUploadFile(
+                data: Data("m4a".utf8),
+                filename: "audio.m4a",
+                contentType: "audio/mp4",
+                format: "m4a"
+            ),
             apiKey: "sk_car_test",
             modelId: CartesiaPlugin.sttModelId,
             language: "de"
@@ -178,8 +183,8 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertEqual(request.timeoutInterval, 600)
 
         let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
-        XCTAssertTrue(body.contains(#"name="file"; filename="audio.wav""#))
-        XCTAssertTrue(body.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(body.contains(#"name="file"; filename="audio.m4a""#))
+        XCTAssertTrue(body.contains("Content-Type: audio/mp4"))
         XCTAssertTrue(body.contains("name=\"model\"\r\n\r\nink-whisper"))
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
         XCTAssertTrue(body.contains("name=\"timestamp_granularities[]\"\r\n\r\nword"))

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
@@ -102,51 +102,62 @@ final class CloudflareASRPlugin: NSObject, TranscriptionEnginePlugin, Dictionary
             throw PluginTranscriptionError.apiError("Invalid URL: \(endpoint)")
         }
 
-        let boundary = UUID().uuidString
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 30
+        func perform(uploadFile: PluginAudioUploadFile) async throws -> (Data, HTTPURLResponse) {
+            let boundary = UUID().uuidString
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = 30
 
-        // Cloudflare tunnel service token headers
-        if let cfId = _cfClientId, !cfId.isEmpty,
-           let cfSecret = _cfClientSecret, !cfSecret.isEmpty {
-            request.setValue(cfId, forHTTPHeaderField: "CF-Access-Client-Id")
-            request.setValue(cfSecret, forHTTPHeaderField: "CF-Access-Client-Secret")
+            // Cloudflare tunnel service token headers
+            if let cfId = _cfClientId, !cfId.isEmpty,
+               let cfSecret = _cfClientSecret, !cfSecret.isEmpty {
+                request.setValue(cfId, forHTTPHeaderField: "CF-Access-Client-Id")
+                request.setValue(cfSecret, forHTTPHeaderField: "CF-Access-Client-Secret")
+            }
+
+            // Optional Bearer token for the upstream API
+            if let apiKey = _apiKey, !apiKey.isEmpty {
+                request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            }
+
+            var body = Data()
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+            body.append(uploadFile.data)
+            body.append("\r\n".data(using: .utf8)!)
+
+            body.cfAppendFormField(boundary: boundary, name: "model", value: modelId)
+            body.cfAppendFormField(boundary: boundary, name: "response_format", value: "json")
+
+            if !translate, let language, !language.isEmpty {
+                body.cfAppendFormField(boundary: boundary, name: "language", value: language)
+            }
+
+            if let prompt, !prompt.isEmpty {
+                body.cfAppendFormField(boundary: boundary, name: "prompt", value: prompt)
+            }
+
+            body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+            request.httpBody = body
+
+            let (responseData, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw PluginTranscriptionError.networkError("Invalid response")
+            }
+            return (responseData, httpResponse)
         }
 
-        // Optional Bearer token for the upstream API
-        if let apiKey = _apiKey, !apiKey.isEmpty {
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-
-        // Multipart form body
-        var body = Data()
-
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
-        body.append(audio.wavData)
-        body.append("\r\n".data(using: .utf8)!)
-
-        body.cfAppendFormField(boundary: boundary, name: "model", value: modelId)
-        body.cfAppendFormField(boundary: boundary, name: "response_format", value: "json")
-
-        if !translate, let language, !language.isEmpty {
-            body.cfAppendFormField(boundary: boundary, name: "language", value: language)
-        }
-
-        if let prompt, !prompt.isEmpty {
-            body.cfAppendFormField(boundary: boundary, name: "prompt", value: prompt)
-        }
-
-        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
-        request.httpBody = body
-
-        let (responseData, response) = try await PluginHTTPClient.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw PluginTranscriptionError.networkError("Invalid response")
+        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        var (responseData, httpResponse) = try await perform(uploadFile: preferredUpload)
+        if preferredUpload.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: responseData
+           ) {
+            (responseData, httpResponse) = try await perform(uploadFile: PluginAudioUploadEncoder.wavUpload(from: audio))
         }
 
         switch httpResponse.statusCode {

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -475,11 +475,13 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
         components.queryItems = queryItems
 
+        let uploadFile = try PluginAudioUploadEncoder.compressedM4AUpload(from: audio)
+
         var request = URLRequest(url: components.url!)
         request.httpMethod = "POST"
         request.setValue(authHeaderValue(apiKey: apiKey), forHTTPHeaderField: effectiveAuthHeader)
-        request.setValue("audio/wav", forHTTPHeaderField: "Content-Type")
-        request.httpBody = audio.wavData
+        request.setValue(uploadFile.contentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = uploadFile.data
         request.timeoutInterval = 60
 
         let (data, response) = try await PluginHTTPClient.data(for: request)

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -200,13 +200,15 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 120
 
+        let uploadFile = try PluginAudioUploadEncoder.compressedM4AUpload(from: audio)
+
         var body = Data()
         body.appendMultipartFile(
             boundary: boundary,
             name: "file",
-            filename: "audio.wav",
-            contentType: "audio/wav",
-            data: audio.wavData
+            filename: uploadFile.filename,
+            contentType: uploadFile.contentType,
+            data: uploadFile.data
         )
         body.appendMultipartField(boundary: boundary, name: "model_id", value: modelId)
         if let language, !language.isEmpty {

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -224,15 +224,33 @@ final class GeminiPlugin: NSObject,
             throw PluginTranscriptionError.noModelSelected
         }
 
-        let request = try Self.makeTranscriptionRequest(
-            audio: audio,
+        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        var request = try Self.makeTranscriptionRequest(
+            uploadFile: preferredUpload,
             apiKey: apiKey,
             modelId: modelId,
             language: language,
             prompt: prompt,
             timeout: Self.transcriptionRequestTimeout
         )
-        let (data, response) = try await PluginHTTPClient.data(for: request)
+        var (data, response) = try await PluginHTTPClient.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse,
+           preferredUpload.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: data
+           ) {
+            request = try Self.makeTranscriptionRequest(
+                uploadFile: PluginAudioUploadEncoder.wavUpload(from: audio),
+                apiKey: apiKey,
+                modelId: modelId,
+                language: language,
+                prompt: prompt,
+                timeout: Self.transcriptionRequestTimeout
+            )
+            (data, response) = try await PluginHTTPClient.data(for: request)
+        }
         try Self.validateTranscriptionResponse(data: data, response: response)
         let text = try Self.parseTranscriptionResponse(data)
         return PluginTranscriptionResult(text: text, detectedLanguage: language)
@@ -256,7 +274,7 @@ final class GeminiPlugin: NSObject,
     }
 
     static func makeTranscriptionRequest(
-        audio: AudioData,
+        uploadFile: PluginAudioUploadFile,
         apiKey: String,
         modelId: String,
         language: String?,
@@ -275,8 +293,8 @@ final class GeminiPlugin: NSObject,
                     ["text": renderedPrompt],
                     [
                         "inlineData": [
-                            "mimeType": "audio/wav",
-                            "data": audio.wavData.base64EncodedString(),
+                            "mimeType": uploadFile.contentType,
+                            "data": uploadFile.data.base64EncodedString(),
                         ],
                     ],
                 ],

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
@@ -159,7 +159,7 @@ final class GeminiPluginTests: XCTestCase {
 
     func testTranscriptionRequestUsesGenerateContentJSONAudioPromptAndLanguage() throws {
         let request = try GeminiPlugin.makeTranscriptionRequest(
-            audio: Self.audio(),
+            uploadFile: Self.m4aUpload(),
             apiKey: "gemini-key",
             modelId: "gemini-flash-lite-latest",
             language: " de ",
@@ -187,8 +187,8 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertTrue(promptText.contains("Language hint: de"))
 
         let inlineData = try XCTUnwrap(parts.last?["inlineData"] as? [String: Any])
-        XCTAssertEqual(inlineData["mimeType"] as? String, "audio/wav")
-        XCTAssertEqual(inlineData["data"] as? String, Data("wav".utf8).base64EncodedString())
+        XCTAssertEqual(inlineData["mimeType"] as? String, "audio/mp4")
+        XCTAssertEqual(inlineData["data"] as? String, Data("m4a".utf8).base64EncodedString())
 
         let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
         XCTAssertEqual(generationConfig["temperature"] as? Double, 0.2)
@@ -199,7 +199,7 @@ final class GeminiPluginTests: XCTestCase {
 
     func testPinnedGeminiThreeTranscriptionRequestUsesMinimalThinkingLevel() throws {
         let request = try GeminiPlugin.makeTranscriptionRequest(
-            audio: Self.audio(),
+            uploadFile: Self.m4aUpload(),
             apiKey: "gemini-key",
             modelId: "gemini-3.1-flash-lite",
             language: nil,
@@ -217,7 +217,7 @@ final class GeminiPluginTests: XCTestCase {
 
     func testPinnedGeminiTwoPointFiveTranscriptionRequestUsesZeroThinkingBudget() throws {
         let request = try GeminiPlugin.makeTranscriptionRequest(
-            audio: Self.audio(),
+            uploadFile: Self.m4aUpload(),
             apiKey: "gemini-key",
             modelId: "gemini-2.5-flash",
             language: nil,
@@ -235,7 +235,7 @@ final class GeminiPluginTests: XCTestCase {
 
     func testTranscriptionRequestOmitsEmptyLanguageAndDictionaryTerms() throws {
         let request = try GeminiPlugin.makeTranscriptionRequest(
-            audio: Self.audio(),
+            uploadFile: Self.m4aUpload(),
             apiKey: "gemini-key",
             modelId: "gemini-flash-lite-latest",
             language: " ",
@@ -349,6 +349,68 @@ final class GeminiPluginTests: XCTestCase {
         let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
         let promptText = try XCTUnwrap(parts.first?["text"] as? String)
         XCTAssertTrue(promptText.contains("TypeWhisper, Qwen3"))
+        let inlineData = try XCTUnwrap(parts.last?["inlineData"] as? [String: Any])
+        XCTAssertEqual(inlineData["mimeType"] as? String, "audio/mp4")
+    }
+
+    func testTranscribeRetriesWithWavWhenM4AIsRejected() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                Self.cachedLLMModelsKey: try Self.cachedModelsData(),
+                "selectedModel": "gemini-flash-lite-latest",
+            ],
+            secrets: ["api-key": "gemini-key"]
+        )
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"unsupported audio format"}}"#.utf8),
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent", statusCode: 415)
+                ),
+                .success(
+                    Data(
+                        """
+                        {
+                          "candidates": [
+                            {
+                              "content": {
+                                "parts": [
+                                  { "text": " fallback transcript " }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.audio(),
+            language: "de",
+            translate: false,
+            prompt: "TypeWhisper"
+        )
+
+        XCTAssertEqual(result.text, "fallback transcript")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        let firstBody = try Self.jsonBody(from: requests[0])
+        let firstParts = try XCTUnwrap((firstBody["contents"] as? [[String: Any]])?.first?["parts"] as? [[String: Any]])
+        XCTAssertEqual((firstParts.last?["inlineData"] as? [String: Any])?["mimeType"] as? String, "audio/mp4")
+        let retryBody = try Self.jsonBody(from: requests[1])
+        let retryParts = try XCTUnwrap((retryBody["contents"] as? [[String: Any]])?.first?["parts"] as? [[String: Any]])
+        XCTAssertEqual((retryParts.last?["inlineData"] as? [String: Any])?["mimeType"] as? String, "audio/wav")
+        let retryPrompt = try XCTUnwrap(retryParts.first?["text"] as? String)
+        XCTAssertTrue(retryPrompt.contains("TypeWhisper"))
+        XCTAssertTrue(retryPrompt.contains("Language hint: de"))
     }
 
     func testTranscriptionHTTPErrorMapping() {
@@ -395,7 +457,17 @@ final class GeminiPluginTests: XCTestCase {
     }
 
     private static func audio() -> AudioData {
-        AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1)
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        return AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1)
+    }
+
+    private static func m4aUpload() -> PluginAudioUploadFile {
+        PluginAudioUploadFile(
+            data: Data("m4a".utf8),
+            filename: "audio.m4a",
+            contentType: "audio/mp4",
+            format: "m4a"
+        )
     }
 
     private static func jsonBody(from request: URLRequest) throws -> [String: Any] {

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -255,7 +255,10 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        let audioURL = try await uploadAudio(audio.wavData, apiKey: apiKey)
+        let audioURL = try await uploadAudio(
+            try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
+            apiKey: apiKey
+        )
         let resultURL = try await submitPreRecorded(
             audioURL: audioURL,
             language: language,
@@ -267,7 +270,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         return try await pollResult(url: resultURL, apiKey: apiKey, fallbackLanguage: language)
     }
 
-    private func uploadAudio(_ wavData: Data, apiKey: String) async throws -> String {
+    private func uploadAudio(_ uploadFile: PluginAudioUploadFile, apiKey: String) async throws -> String {
         guard let url = URL(string: "https://api.gladia.io/v2/upload") else {
             throw PluginTranscriptionError.apiError("Invalid Gladia upload URL")
         }
@@ -283,9 +286,9 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         body.appendMultipartFile(
             boundary: boundary,
             name: "audio",
-            filename: "audio.wav",
-            contentType: "audio/wav",
-            data: wavData
+            filename: uploadFile.filename,
+            contentType: uploadFile.contentType,
+            data: uploadFile.data
         )
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
         request.httpBody = body

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -221,44 +221,58 @@ struct MistralAPIClient {
         guard let url = URL(string: "https://api.mistral.ai/v1/audio/transcriptions") else {
             throw MistralAPIError.invalidURL
         }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        
-        let boundary = UUID().uuidString
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        
-        var body = Data()
-        let filename = "audio.wav"
-        let mimeType = "audio/wav"
-        
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
-        body.append(audio.wavData)
-        body.append("\r\n".data(using: .utf8)!)
-        
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\n".data(using: .utf8)!)
-        body.append("\(model)\r\n".data(using: .utf8)!)
 
-        
-        if let language = language {
+        func makeRequest(uploadFile: PluginAudioUploadFile) -> URLRequest {
+            let boundary = UUID().uuidString
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+            var body = Data()
             body.append("--\(boundary)\r\n".data(using: .utf8)!)
-            body.append("Content-Disposition: form-data; name=\"language\"\r\n\r\n".data(using: .utf8)!)
-            body.append("\(language)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+            body.append(uploadFile.data)
+            body.append("\r\n".data(using: .utf8)!)
+
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\n".data(using: .utf8)!)
+            body.append("\(model)\r\n".data(using: .utf8)!)
+
+            if let language = language {
+                body.append("--\(boundary)\r\n".data(using: .utf8)!)
+                body.append("Content-Disposition: form-data; name=\"language\"\r\n\r\n".data(using: .utf8)!)
+                body.append("\(language)\r\n".data(using: .utf8)!)
+            }
+
+            body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+            request.httpBody = body
+            return request
         }
-        
-        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
-        request.httpBody = body
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
-        guard let httpResponse = response as? HTTPURLResponse else {
+
+        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        var (data, response) = try await PluginHTTPClient.data(for: makeRequest(uploadFile: preferredUpload))
+
+        guard var httpResponse = response as? HTTPURLResponse else {
             throw MistralAPIError.invalidResponse
         }
-        
+
+        if preferredUpload.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: data
+           ) {
+            (data, response) = try await PluginHTTPClient.data(
+                for: makeRequest(uploadFile: PluginAudioUploadEncoder.wavUpload(from: audio))
+            )
+            guard let retryResponse = response as? HTTPURLResponse else {
+                throw MistralAPIError.invalidResponse
+            }
+            httpResponse = retryResponse
+        }
+
         if httpResponse.statusCode == 200 {
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let text = json["text"] as? String else {

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -228,6 +228,7 @@ struct MistralAPIClient {
             request.httpMethod = "POST"
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
             request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = 120
 
             var body = Data()
             body.append("--\(boundary)\r\n".data(using: .utf8)!)

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
@@ -112,6 +112,7 @@ final class MistralAIPluginTests: XCTestCase {
         XCTAssertEqual(result.text, "bonjour")
         let requests = store.sessions[0].requestedRequests
         XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests.map(\.timeoutInterval), [120, 120])
         let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
         XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
         XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
@@ -4,6 +4,10 @@ import TypeWhisperPluginSDK
 @testable import MistralAIPlugin
 
 final class MistralAIPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
 
     func testMistralAIPluginAdvertisesProtocols() {
         let plugin: Any = MistralAIPlugin()
@@ -80,5 +84,50 @@ final class MistralAIPluginTests: XCTestCase {
         plugin.selectLLMModel("pixtral-12b-2409")
         
         XCTAssertEqual(selectable.preferredModelId ?? nil, "pixtral-12b-2409")
+    }
+
+    func testTranscriptionRetriesWithWavWhenM4AIsRejected() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
+        let plugin = MistralAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"message":"unsupported audio format"}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/audio/transcriptions", statusCode: 415)
+                ),
+                .success(
+                    Data(#"{"text":"bonjour"}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: "fr", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "bonjour")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nvoxtral-mini-latest"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nfr"))
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -480,7 +480,7 @@ final class OpenAICompatiblePlugin: NSObject,
             throw PluginTranscriptionError.noModelSelected
         }
 
-        return try await helper.transcribe(
+        return try await helper.transcribeCompressedAudioWithWavFallback(
             audio: audio,
             apiKey: apiKey(for: profileId) ?? "",
             modelName: modelId,

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -215,6 +215,49 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(result.text, "hello")
         XCTAssertEqual(store.sessions[0].requestedPaths, ["/v1/audio/transcriptions"])
         XCTAssertEqual(store.sessions[0].requestedRequests.first?.timeoutInterval, 600)
+        let body = String(decoding: try XCTUnwrap(store.sessions[0].requestedRequests.first?.httpBody), as: UTF8.self)
+        XCTAssertTrue(body.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(body.contains("Content-Type: audio/mp4"))
+    }
+
+    func testTranscribeRetriesWithWavWhenCompatibleServerRejectsM4A() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedModel": "large-v3",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":"unsupported audio format"}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/audio/transcriptions", statusCode: 415)
+                ),
+                .success(
+                    Data(#"{"text":"fallback hello"}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: "de", translate: false, prompt: "TypeWhisper")
+
+        XCTAssertEqual(result.text, "fallback hello")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nlarge-v3"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
     }
 
     func testProfileSpecificTranscriptionUsesSeparateCredentialsAndURLs() async throws {

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -1499,13 +1499,14 @@ final class OpenAIPlugin: NSObject,
 
         let responseFormat = modelId.hasPrefix("gpt-4o") ? "json" : "verbose_json"
 
-        return try await transcriptionHelper.transcribe(
+        return try await transcriptionHelper.transcribeCompressedAudio(
             audio: audio,
             apiKey: apiKey,
             modelName: modelId,
             language: language,
             translate: translate && !modelId.hasPrefix("gpt-4o"),
             prompt: prompt,
+            requestTimeout: 30,
             responseFormat: responseFormat
         )
     }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -1499,7 +1499,7 @@ final class OpenAIPlugin: NSObject,
 
         let responseFormat = modelId.hasPrefix("gpt-4o") ? "json" : "verbose_json"
 
-        return try await transcriptionHelper.transcribeCompressedAudio(
+        return try await transcriptionHelper.transcribeCompressedAudioWithWavFallback(
             audio: audio,
             apiKey: apiKey,
             modelName: modelId,

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -66,6 +66,43 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertTrue(plugin.authStatus(for: .tts).isAvailable)
     }
 
+    func testOpenAITranscribeUploadsCompressedM4AForRESTModels() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "whisper-1"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"hello","language":"en"}"#.utf8),
+                    Self.httpResponse(url: "https://api.openai.com/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let result = try await plugin.transcribe(audio: audio, language: "en", translate: false, prompt: "TypeWhisper")
+
+        XCTAssertEqual(result.text, "hello")
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
+        XCTAssertTrue(body.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(body.contains("Content-Type: audio/mp4"))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
+        XCTAssertTrue(body.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
+        XCTAssertFalse(body.contains(#"filename="audio.wav""#))
+    }
+
     func testOpenAIWithoutCredentialsMakesCloudAuthRolesUnavailable() throws {
         let host = try PluginTestHostServices()
         let plugin = OpenAIPlugin()

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -103,6 +103,51 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertFalse(body.contains(#"filename="audio.wav""#))
     }
 
+    func testOpenAITranscribeRetriesWithWavWhenM4AIsRejected() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "whisper-1"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":"unsupported audio format"}"#.utf8),
+                    Self.httpResponse(url: "https://api.openai.com/v1/audio/transcriptions", statusCode: 415)
+                ),
+                .success(
+                    Data(#"{"text":"hello","language":"en"}"#.utf8),
+                    Self.httpResponse(url: "https://api.openai.com/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let result = try await plugin.transcribe(audio: audio, language: "en", translate: false, prompt: "TypeWhisper")
+
+        XCTAssertEqual(result.text, "hello")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))
+
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nen"))
+        XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
+    }
+
     func testOpenAIWithoutCredentialsMakesCloudAuthRolesUnavailable() throws {
         let host = try PluginTestHostServices()
         let plugin = OpenAIPlugin()

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -140,20 +140,37 @@ final class OpenRouterPlugin: NSObject,
             throw PluginTranscriptionError.apiError("OpenRouter speech-to-text does not support translation.")
         }
 
-        let request = try Self.makeTranscriptionRequest(
-            audio: audio,
+        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        var request = try Self.makeTranscriptionRequest(
+            uploadFile: preferredUpload,
             apiKey: apiKey,
             modelId: modelId,
             language: language,
             timeout: Self.transcriptionRequestTimeout
         )
-        let (data, response) = try await PluginHTTPClient.data(for: request)
+        var (data, response) = try await PluginHTTPClient.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse,
+           preferredUpload.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: data
+           ) {
+            request = try Self.makeTranscriptionRequest(
+                uploadFile: PluginAudioUploadEncoder.wavUpload(from: audio),
+                apiKey: apiKey,
+                modelId: modelId,
+                language: language,
+                timeout: Self.transcriptionRequestTimeout
+            )
+            (data, response) = try await PluginHTTPClient.data(for: request)
+        }
         try Self.validateTranscriptionResponse(data: data, response: response)
         return try Self.parseTranscriptionResponse(data)
     }
 
     static func makeTranscriptionRequest(
-        audio: AudioData,
+        uploadFile: PluginAudioUploadFile,
         apiKey: String,
         modelId: String,
         language: String?,
@@ -166,8 +183,8 @@ final class OpenRouterPlugin: NSObject,
         var body: [String: Any] = [
             "model": modelId,
             "input_audio": [
-                "data": audio.wavData.base64EncodedString(),
-                "format": "wav",
+                "data": uploadFile.data.base64EncodedString(),
+                "format": uploadFile.format,
             ],
         ]
         let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -260,7 +260,7 @@ final class OpenRouterPluginTests: XCTestCase {
 
     func testTranscriptionRequestUsesJSONBase64AndLanguage() throws {
         let request = try OpenRouterPlugin.makeTranscriptionRequest(
-            audio: Self.audio(),
+            uploadFile: Self.m4aUpload(),
             apiKey: "openrouter-key",
             modelId: "openai/whisper-1",
             language: " de ",
@@ -278,13 +278,13 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(body["language"] as? String, "de")
 
         let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
-        XCTAssertEqual(inputAudio["format"] as? String, "wav")
-        XCTAssertEqual(inputAudio["data"] as? String, Data("wav".utf8).base64EncodedString())
+        XCTAssertEqual(inputAudio["format"] as? String, "m4a")
+        XCTAssertEqual(inputAudio["data"] as? String, Data("m4a".utf8).base64EncodedString())
     }
 
     func testTranscriptionRequestOmitsEmptyLanguageAndPrompt() throws {
         let request = try OpenRouterPlugin.makeTranscriptionRequest(
-            audio: Self.audio(),
+            uploadFile: Self.m4aUpload(),
             apiKey: "openrouter-key",
             modelId: "openai/whisper-1",
             language: " ",
@@ -331,6 +331,50 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(body["model"] as? String, "openai/whisper-1")
         XCTAssertEqual(body["language"] as? String, "de")
         XCTAssertNil(body["prompt"])
+        let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
+        XCTAssertEqual(inputAudio["format"] as? String, "m4a")
+    }
+
+    func testTranscribeRetriesWithWavWhenM4AIsRejected() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "openai/whisper-1"],
+            secrets: ["api-key": "openrouter-key"]
+        )
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"unsupported audio format"}}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 415)
+                ),
+                .success(
+                    Data(#"{"text":"fallback transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.audio(),
+            language: "de",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "fallback transcript")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        let firstBody = try Self.jsonBody(from: requests[0])
+        let firstAudio = try XCTUnwrap(firstBody["input_audio"] as? [String: Any])
+        XCTAssertEqual(firstAudio["format"] as? String, "m4a")
+        let retryBody = try Self.jsonBody(from: requests[1])
+        let retryAudio = try XCTUnwrap(retryBody["input_audio"] as? [String: Any])
+        XCTAssertEqual(retryAudio["format"] as? String, "wav")
+        XCTAssertEqual(retryBody["model"] as? String, "openai/whisper-1")
+        XCTAssertEqual(retryBody["language"] as? String, "de")
     }
 
     func testTranscriptionHTTPErrorMapping() {
@@ -367,7 +411,17 @@ final class OpenRouterPluginTests: XCTestCase {
     }
 
     private static func audio() -> AudioData {
-        AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1)
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        return AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1)
+    }
+
+    private static func m4aUpload() -> PluginAudioUploadFile {
+        PluginAudioUploadFile(
+            data: Data("m4a".utf8),
+            filename: "audio.m4a",
+            contentType: "audio/mp4",
+            format: "m4a"
+        )
     }
 
     private static func jsonBody(from request: URLRequest) throws -> [String: Any] {

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -996,7 +996,10 @@ final class SonioxPlugin: NSObject,
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        let fileId = try await uploadFile(wavData: audio.wavData, apiKey: apiKey)
+        let fileId = try await uploadFile(
+            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
+            apiKey: apiKey
+        )
         let transcriptionId = try await createTranscription(
             fileId: fileId,
             language: language,
@@ -1009,7 +1012,7 @@ final class SonioxPlugin: NSObject,
         return try await fetchTranscript(id: transcriptionId, apiKey: apiKey, language: language)
     }
 
-    private func uploadFile(wavData: Data, apiKey: String) async throws -> String {
+    private func uploadFile(uploadFile: PluginAudioUploadFile, apiKey: String) async throws -> String {
         guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/files") else {
             throw PluginTranscriptionError.apiError("Invalid upload URL")
         }
@@ -1023,9 +1026,9 @@ final class SonioxPlugin: NSObject,
 
         var body = Data()
         body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
-        body.append(wavData)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+        body.append(uploadFile.data)
         body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
         request.httpBody = body
 

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -233,6 +233,11 @@ final class SonioxPluginTests: XCTestCase {
             ]
         )
 
+        let uploadRequest = try XCTUnwrap(session.requestedRequests.first { $0.url?.path == "/v1/files" })
+        let uploadBody = String(decoding: try XCTUnwrap(uploadRequest.httpBody), as: UTF8.self)
+        XCTAssertTrue(uploadBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(uploadBody.contains("Content-Type: audio/mp4"))
+
         let createRequest = try XCTUnwrap(session.requestedRequests.first { $0.url?.path == "/v1/transcriptions" })
         let body = try Self.jsonBody(from: createRequest)
         XCTAssertEqual(body["model"] as? String, "stt-async-v5")

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -183,7 +183,7 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
         let jobId = try await submitJob(
-            wavData: audio.wavData,
+            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
             language: language,
             modelId: modelId,
             apiKey: apiKey,
@@ -193,7 +193,7 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
     }
 
     private func submitJob(
-        wavData: Data,
+        uploadFile: PluginAudioUploadFile,
         language: String?,
         modelId: String,
         apiKey: String,
@@ -230,9 +230,9 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         body.append("\r\n".data(using: .utf8)!)
         // Audio part
         body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"data_file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
-        body.append(wavData)
+        body.append("Content-Disposition: form-data; name=\"data_file\"; filename=\"\(uploadFile.filename)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+        body.append(uploadFile.data)
         body.append("\r\n".data(using: .utf8)!)
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
@@ -1056,28 +1056,46 @@ final class XAIPlugin: NSObject,
             throw XAIPluginError.invalidURL("https://api.x.ai/v1/stt")
         }
 
-        let boundary = UUID().uuidString
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 120
+        func makeRequest(uploadFile: PluginAudioUploadFile) -> URLRequest {
+            let boundary = UUID().uuidString
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = 120
 
-        var body = Data()
-        if let language, !language.isEmpty {
-            body.appendFormField(boundary: boundary, name: "format", value: "true")
-            body.appendFormField(boundary: boundary, name: "language", value: language)
+            var body = Data()
+            if let language, !language.isEmpty {
+                body.appendFormField(boundary: boundary, name: "format", value: "true")
+                body.appendFormField(boundary: boundary, name: "language", value: language)
+            }
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+            body.append(uploadFile.data)
+            body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+            request.httpBody = body
+            return request
         }
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
-        body.append(audio.wavData)
-        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
-        request.httpBody = body
 
-        let (data, response) = try await PluginHTTPClient.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
+        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        var (data, response) = try await PluginHTTPClient.data(for: makeRequest(uploadFile: preferredUpload))
+        guard var httpResponse = response as? HTTPURLResponse else {
             throw PluginTranscriptionError.networkError("Invalid response")
+        }
+        if preferredUpload.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: data
+           ) {
+            (data, response) = try await PluginHTTPClient.data(
+                for: makeRequest(uploadFile: PluginAudioUploadEncoder.wavUpload(from: audio))
+            )
+            guard let retryResponse = response as? HTTPURLResponse else {
+                throw PluginTranscriptionError.networkError("Invalid response")
+            }
+            httpResponse = retryResponse
         }
 
         switch httpResponse.statusCode {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -246,6 +246,146 @@ public struct PluginWavEncoder {
     }
 }
 
+public struct PluginAudioUploadFile: Sendable, Equatable {
+    public let data: Data
+    public let filename: String
+    public let contentType: String
+    public let format: String
+
+    public init(data: Data, filename: String, contentType: String, format: String) {
+        self.data = data
+        self.filename = filename
+        self.contentType = contentType
+        self.format = format
+    }
+}
+
+public enum PluginAudioUploadEncoder {
+    public static let sampleRate = 16_000
+    private static let compressedUploadChunkFrames = 16_000 * 30
+
+    public static func wavUpload(from audio: AudioData) -> PluginAudioUploadFile {
+        PluginAudioUploadFile(
+            data: audio.wavData,
+            filename: "audio.wav",
+            contentType: "audio/wav",
+            format: "wav"
+        )
+    }
+
+    public static func wavUpload(from samples: [Float], sampleRate: Int = 16_000) -> PluginAudioUploadFile {
+        PluginAudioUploadFile(
+            data: PluginWavEncoder.encode(samples, sampleRate: sampleRate),
+            filename: "audio.wav",
+            contentType: "audio/wav",
+            format: "wav"
+        )
+    }
+
+    public static func compressedM4AUpload(from audio: AudioData) throws -> PluginAudioUploadFile {
+        try compressedM4AUpload(from: audio.samples)
+    }
+
+    public static func compressedM4AUpload(from samples: [Float]) throws -> PluginAudioUploadFile {
+        PluginAudioUploadFile(
+            data: try compressedM4AData(from: samples),
+            filename: "audio.m4a",
+            contentType: "audio/mp4",
+            format: "m4a"
+        )
+    }
+
+    public static func shouldRetryWithWavUpload(statusCode: Int, responseData: Data) -> Bool {
+        guard [400, 415, 422].contains(statusCode) else {
+            return false
+        }
+
+        guard statusCode != 415 else { return true }
+
+        let message = String(data: responseData, encoding: .utf8) ?? ""
+        return indicatesUnsupportedAudioUpload(message)
+    }
+
+    public static func shouldRetryWithWavUpload(error: Error) -> Bool {
+        guard case PluginTranscriptionError.apiError(let message) = error else {
+            return false
+        }
+
+        if message.localizedCaseInsensitiveContains("Failed to encode compressed upload") {
+            return true
+        }
+
+        if message.contains("HTTP 415:") {
+            return true
+        }
+
+        guard message.contains("HTTP 400:") || message.contains("HTTP 422:") else {
+            return false
+        }
+
+        return indicatesUnsupportedAudioUpload(message)
+    }
+
+    private static func indicatesUnsupportedAudioUpload(_ message: String) -> Bool {
+        let lowercased = message.lowercased()
+        let formatTerms = [
+            "unsupported", "format", "media", "mime", "content-type", "content type",
+            "audio", "file", "codec", "container", "m4a", "mp4", "aac",
+        ]
+        return formatTerms.contains { lowercased.contains($0) }
+    }
+
+    private static func compressedM4AData(from samples: [Float]) throws -> Data {
+        guard !samples.isEmpty else {
+            throw PluginTranscriptionError.apiError("Cannot encode empty audio upload")
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("typewhisper-upload-\(UUID().uuidString).m4a")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: Double(sampleRate),
+            AVNumberOfChannelsKey: 1,
+        ]
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw PluginTranscriptionError.apiError("Failed to create compressed upload format")
+        }
+
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: settings,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+
+        var offset = 0
+        while offset < samples.count {
+            let count = min(compressedUploadChunkFrames, samples.count - offset)
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(count)
+            ) else {
+                throw PluginTranscriptionError.apiError("Failed to create compressed upload buffer")
+            }
+            buffer.frameLength = AVAudioFrameCount(count)
+            samples.withUnsafeBufferPointer { pointer in
+                buffer.floatChannelData?[0].update(from: pointer.baseAddress! + offset, count: count)
+            }
+            try file.write(from: buffer)
+            offset += count
+        }
+
+        return try Data(contentsOf: url)
+    }
+}
+
 // MARK: - OpenAI-Compatible Transcription Helper
 
 public enum PluginTranscriptionError: LocalizedError, Sendable {
@@ -283,13 +423,6 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
     private static let defaultRequestTimeout: TimeInterval = 30
     static let minimumUploadDuration: TimeInterval = 1.0
     static let uploadSampleRate = 16000
-    private static let compressedUploadChunkFrames = 16_000 * 30
-
-    private struct UploadFile {
-        let data: Data
-        let filename: String
-        let contentType: String
-    }
 
     public init(baseURL: String, responseFormat: String = "verbose_json") {
         self.baseURL = baseURL
@@ -367,9 +500,9 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         responseFormat: String? = nil
     ) async throws -> PluginTranscriptionResult {
         let uploadAudio = normalizedAudioForUpload(audio)
-        let compressedData: Data
+        let uploadFile: PluginAudioUploadFile
         do {
-            compressedData = try Self.makeCompressedM4AData(from: uploadAudio.samples)
+            uploadFile = try PluginAudioUploadEncoder.compressedM4AUpload(from: uploadAudio)
         } catch {
             throw PluginTranscriptionError.apiError(
                 "Failed to encode compressed upload: \(error.localizedDescription)"
@@ -385,11 +518,113 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
             prompt: prompt,
             responseFormat: responseFormat,
             requestTimeout: requestTimeout,
-            uploadFile: UploadFile(
-                data: compressedData,
-                filename: "audio.m4a",
-                contentType: "audio/mp4"
+            uploadFile: uploadFile
+        )
+    }
+
+    public func transcribeCompressedAudioWithWavFallback(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil
+    ) async throws -> PluginTranscriptionResult {
+        do {
+            return try await transcribeCompressedAudio(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                translate: translate,
+                prompt: prompt,
+                requestTimeout: requestTimeout,
+                responseFormat: responseFormat
             )
+        } catch {
+            guard PluginAudioUploadEncoder.shouldRetryWithWavUpload(error: error) else {
+                throw error
+            }
+
+            return try await transcribe(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                translate: translate,
+                prompt: prompt,
+                requestTimeout: requestTimeout,
+                responseFormat: responseFormat
+            )
+        }
+    }
+
+    public func transcribeWithUploadFallback(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        uploadFile: PluginAudioUploadFile
+    ) async throws -> PluginTranscriptionResult {
+        do {
+            return try await performTranscribe(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                translate: translate,
+                prompt: prompt,
+                responseFormat: responseFormat,
+                requestTimeout: requestTimeout,
+                uploadFile: uploadFile
+            )
+        } catch {
+            guard uploadFile.format != "wav",
+                  PluginAudioUploadEncoder.shouldRetryWithWavUpload(error: error) else {
+                throw error
+            }
+
+            return try await performTranscribe(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                translate: translate,
+                prompt: prompt,
+                responseFormat: responseFormat,
+                requestTimeout: requestTimeout,
+                uploadFile: PluginAudioUploadEncoder.wavUpload(from: normalizedAudioForUpload(audio))
+            )
+        }
+    }
+
+    public func transcribe(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        uploadFile: PluginAudioUploadFile
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            requestTimeout: requestTimeout,
+            uploadFile: uploadFile
         )
     }
 
@@ -402,7 +637,7 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         prompt: String?,
         responseFormat: String?,
         requestTimeout: TimeInterval,
-        uploadFile: UploadFile? = nil
+        uploadFile: PluginAudioUploadFile? = nil
     ) async throws -> PluginTranscriptionResult {
         let endpoint: String
         if translate {
@@ -423,11 +658,7 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         request.timeoutInterval = requestTimeout
 
         let uploadAudio = uploadFile == nil ? normalizedAudioForUpload(audio) : audio
-        let uploadFile = uploadFile ?? UploadFile(
-            data: uploadAudio.wavData,
-            filename: "audio.wav",
-            contentType: "audio/wav"
-        )
+        let uploadFile = uploadFile ?? PluginAudioUploadEncoder.wavUpload(from: uploadAudio)
         var body = Data()
 
         // file field
@@ -478,58 +709,6 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         }
 
         return try parseResponse(responseData)
-    }
-
-    private static func makeCompressedM4AData(from samples: [Float]) throws -> Data {
-        guard !samples.isEmpty else {
-            throw PluginTranscriptionError.apiError("Cannot encode empty audio upload")
-        }
-
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("typewhisper-upload-\(UUID().uuidString).m4a")
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        let settings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatMPEG4AAC,
-            AVSampleRateKey: Double(uploadSampleRate),
-            AVNumberOfChannelsKey: 1,
-        ]
-        guard let format = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Double(uploadSampleRate),
-            channels: 1,
-            interleaved: false
-        ) else {
-            throw PluginTranscriptionError.apiError("Failed to create compressed upload format")
-        }
-
-        do {
-            let file = try AVAudioFile(
-                forWriting: url,
-                settings: settings,
-                commonFormat: .pcmFormatFloat32,
-                interleaved: false
-            )
-
-            var offset = 0
-            while offset < samples.count {
-                let count = min(compressedUploadChunkFrames, samples.count - offset)
-                guard let buffer = AVAudioPCMBuffer(
-                    pcmFormat: format,
-                    frameCapacity: AVAudioFrameCount(count)
-                ) else {
-                    throw PluginTranscriptionError.apiError("Failed to create compressed upload buffer")
-                }
-                buffer.frameLength = AVAudioFrameCount(count)
-                samples.withUnsafeBufferPointer { pointer in
-                    buffer.floatChannelData?[0].update(from: pointer.baseAddress! + offset, count: count)
-                }
-                try file.write(from: buffer)
-                offset += count
-            }
-        }
-
-        return try Data(contentsOf: url)
     }
 
     public func validateApiKey(_ apiKey: String) async -> Bool {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -328,11 +328,15 @@ public enum PluginAudioUploadEncoder {
 
     private static func indicatesUnsupportedAudioUpload(_ message: String) -> Bool {
         let lowercased = message.lowercased()
-        let formatTerms = [
-            "unsupported", "format", "media", "mime", "content-type", "content type",
-            "audio", "file", "codec", "container", "m4a", "mp4", "aac",
+        let rejectionTerms = [
+            "unsupported", "not supported", "does not support", "invalid", "unrecognized", "unknown",
         ]
-        return formatTerms.contains { lowercased.contains($0) }
+        let mediaTerms = [
+            "format", "media", "mime", "content-type", "content type",
+            "codec", "container", "file type", "m4a", "mp4", "aac", "wav",
+        ]
+        return rejectionTerms.contains { lowercased.contains($0) }
+            && mediaTerms.contains { lowercased.contains($0) }
     }
 
     private static func compressedM4AData(from samples: [Float]) throws -> Data {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -127,6 +127,39 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         XCTAssertTrue(String(decoding: upload.data.prefix(64), as: UTF8.self).contains("ftyp"))
     }
 
+    func testWavFallbackRetryClassifierRequiresMediaFormatRejectionFor400And422() {
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"error":"unsupported audio format"}"#.utf8)
+            )
+        )
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 422,
+                responseData: Data(#"{"error":"invalid MIME type audio/mp4"}"#.utf8)
+            )
+        )
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 415,
+                responseData: Data(#"{"error":"bad upload"}"#.utf8)
+            )
+        )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"error":"file too large"}"#.utf8)
+            )
+        )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 422,
+                responseData: Data(#"{"error":"audio too short"}"#.utf8)
+            )
+        )
+    }
+
     func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {
         let store = OpenAITranscriptionMockSessionStore()
         PluginHTTPClient.configureForTesting { _ in

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -97,6 +97,36 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         XCTAssertEqual(normalized.wavData, wavData)
     }
 
+    func testPluginAudioUploadEncoderCreatesWavUploadMetadata() {
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let upload = PluginAudioUploadEncoder.wavUpload(from: audio)
+
+        XCTAssertEqual(upload.filename, "audio.wav")
+        XCTAssertEqual(upload.contentType, "audio/wav")
+        XCTAssertEqual(upload.format, "wav")
+        XCTAssertEqual(String(data: upload.data.prefix(4), encoding: .utf8), "RIFF")
+    }
+
+    func testPluginAudioUploadEncoderCreatesCompressedM4AUpload() throws {
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let wavData = PluginWavEncoder.encode(samples)
+
+        let upload = try PluginAudioUploadEncoder.compressedM4AUpload(from: samples)
+
+        XCTAssertEqual(upload.filename, "audio.m4a")
+        XCTAssertEqual(upload.contentType, "audio/mp4")
+        XCTAssertEqual(upload.format, "m4a")
+        XCTAssertTrue(upload.data.count > 0)
+        XCTAssertLessThan(upload.data.count, wavData.count)
+        XCTAssertTrue(String(decoding: upload.data.prefix(64), as: UTF8.self).contains("ftyp"))
+    }
+
     func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {
         let store = OpenAITranscriptionMockSessionStore()
         PluginHTTPClient.configureForTesting { _ in
@@ -151,14 +181,103 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
 
         XCTAssertTrue(store.sessions.isEmpty)
     }
+
+    func testCompressedAudioWithWavFallbackRetriesUnsupportedMediaAndPreservesFields() async throws {
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":"unsupported audio format"}"#.utf8),
+                    415
+                ),
+                .success(
+                    Data(#"{"text":"fallback ok","language":"de"}"#.utf8),
+                    200
+                ),
+            ])
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let result = try await helper.transcribeCompressedAudioWithWavFallback(
+            audio: audio,
+            apiKey: "test-key",
+            modelName: "whisper-1",
+            language: "de",
+            translate: false,
+            prompt: "TypeWhisper",
+            requestTimeout: 600
+        )
+
+        XCTAssertEqual(result.text, "fallback ok")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests.map(\.timeoutInterval), [600, 600])
+
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))
+
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nwhisper-1"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
+    }
+
+    func testCompressedAudioWithWavFallbackDoesNotRetryAuthFailure() async throws {
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [
+                .success(Data(#"{"error":"bad key"}"#.utf8), 401),
+                .success(Data(#"{"text":"should not retry"}"#.utf8), 200),
+            ])
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        do {
+            _ = try await helper.transcribeCompressedAudioWithWavFallback(
+                audio: audio,
+                apiKey: "bad-key",
+                modelName: "whisper-1",
+                language: nil,
+                translate: false,
+                prompt: nil,
+                requestTimeout: 600
+            )
+            XCTFail("Expected invalid API key")
+        } catch PluginTranscriptionError.invalidApiKey {
+            // Expected
+        }
+
+        XCTAssertEqual(store.sessions.first?.requestedRequests.count, 1)
+    }
 }
 
 private final class OpenAITranscriptionMockSessionStore: @unchecked Sendable {
     private let lock = NSLock()
     private(set) var sessions: [OpenAITranscriptionMockSession] = []
 
-    func makeSession() -> OpenAITranscriptionMockSession {
-        let session = OpenAITranscriptionMockSession()
+    func makeSession(
+        outcomes: [OpenAITranscriptionMockSession.Outcome] = [
+            .success(Data(#"{"text":"ok","language":"en"}"#.utf8), 200),
+        ]
+    ) -> OpenAITranscriptionMockSession {
+        let session = OpenAITranscriptionMockSession(outcomes: outcomes)
         lock.withLock {
             sessions.append(session)
         }
@@ -167,21 +286,40 @@ private final class OpenAITranscriptionMockSessionStore: @unchecked Sendable {
 }
 
 private final class OpenAITranscriptionMockSession: PluginHTTPClientSession, @unchecked Sendable {
+    enum Outcome {
+        case success(Data, Int)
+        case failure(Error)
+    }
+
     private let lock = NSLock()
+    private var outcomes: [Outcome]
     private(set) var requestedRequests: [URLRequest] = []
 
+    init(outcomes: [Outcome]) {
+        self.outcomes = outcomes
+    }
+
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        lock.withLock {
+        let outcome = lock.withLock {
             requestedRequests.append(request)
+            if outcomes.count > 1 {
+                return outcomes.removeFirst()
+            }
+            return outcomes.first ?? .failure(URLError(.badServerResponse))
         }
 
-        let response = HTTPURLResponse(
-            url: request.url!,
-            statusCode: 200,
-            httpVersion: nil,
-            headerFields: nil
-        )!
-        return (Data(#"{"text":"ok","language":"en"}"#.utf8), response)
+        switch outcome {
+        case .success(let data, let statusCode):
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (data, response)
+        case .failure(let error):
+            throw error
+        }
     }
 
     func finishTasksAndInvalidate() {}


### PR DESCRIPTION
## Summary
- Adds a shared `PluginAudioUploadFile` / `PluginAudioUploadEncoder` path for cloud ASR upload payloads.
- Uploads 16 kHz mono AAC-in-M4A (`audio.m4a`, `audio/mp4`) for supported REST cloud providers to reduce large WAV upload latency from #780.
- Adds WAV fallback retries for format/media rejection responses on compatible REST providers, while preserving model, language, prompt, and other request fields.
- Leaves streaming/WebSocket/live-preview PCM paths unchanged and keeps WAV/PCM-only providers on their existing formats.

## Issue Context
Issue #780 reports high latency and timeout risk because online ASR processing uploads large WAV files, especially for longer recordings. This PR compresses REST cloud ASR uploads automatically where supported, without adding a visible WAV/M4A setting.

Closes #780

## Test Plan
- `cd TypeWhisperPluginSDK && swift test --filter TypeWhisperPluginSDKTests`
- `cd TypeWhisperPluginSDK && swift test --filter OpenAIPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter OpenAICompatiblePluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter GroqPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter AssemblyAIPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter CartesiaPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter GeminiPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter MistralAIPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter OpenRouterPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter SonioxPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter SaluteSpeechPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter SmallestAIPluginTests`
- `git diff --check`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcription requests now preferentially use compressed M4A uploads to reduce payload size.
  * When a service rejects the initial format, flows automatically retry using a WAV upload fallback.
* **Bug Fixes**
  * Improved compatibility by ensuring multipart uploads use the correct file metadata for the chosen format.
  * Preserves transcription request parameters across retries for more consistent results.
* **Tests**
  * Added and expanded coverage for compressed upload selection, WAV fallback retry logic, and multipart request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->