### PR TITLE
feat: surface auto-learned dictionary corrections

### DIFF
--- a/TypeWhisper/Models/DictionaryEntry.swift
+++ b/TypeWhisper/Models/DictionaryEntry.swift
@@ -20,6 +20,16 @@ enum DictionaryEntryType: String, Codable, CaseIterable {
     }
 }
 
+enum DictionaryEntrySource: String, Codable, CaseIterable, Sendable {
+    case manual
+    case autoLearned
+
+    static func source(for rawValue: String?) -> DictionaryEntrySource {
+        guard let rawValue else { return .manual }
+        return DictionaryEntrySource(rawValue: rawValue) ?? .manual
+    }
+}
+
 @Model
 final class DictionaryEntry {
     var id: UUID
@@ -32,10 +42,16 @@ final class DictionaryEntry {
     var createdAt: Date
     var updatedAt: Date?
     var usageCount: Int
+    var sourceRawValue: String?
 
     var type: DictionaryEntryType {
         get { DictionaryEntryType(rawValue: entryType) ?? .term }
         set { entryType = newValue.rawValue }
+    }
+
+    var source: DictionaryEntrySource {
+        get { DictionaryEntrySource.source(for: sourceRawValue) }
+        set { sourceRawValue = newValue.rawValue }
     }
 
     init(
@@ -46,6 +62,7 @@ final class DictionaryEntry {
         caseSensitive: Bool = false,
         isEnabled: Bool = true,
         ctcMinSimilarity: Float? = nil,
+        source: DictionaryEntrySource = .manual,
         createdAt: Date = Date(),
         updatedAt: Date? = nil,
         usageCount: Int = 0
@@ -60,6 +77,7 @@ final class DictionaryEntry {
         self.createdAt = createdAt
         self.updatedAt = updatedAt ?? createdAt
         self.usageCount = usageCount
+        self.sourceRawValue = source.rawValue
     }
 
     var effectiveUpdatedAt: Date {

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -21501,6 +21501,16 @@
         }
       }
     },
+    "Auto-learned": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch gelernt"
+          }
+        }
+      }
+    },
     "Correction learning undone": {
       "localizations": {
         "de": {
@@ -21537,6 +21547,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "„%@“ -> „%@“ gelernt"
+          }
+        }
+      }
+    },
+    "Saved %d corrections to Dictionary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d Korrekturen im Wörterbuch gespeichert"
+          }
+        }
+      }
+    },
+    "Saved to Dictionary: “%@” -> “%@”": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Wörterbuch gespeichert: „%@“ -> „%@“"
           }
         }
       }

--- a/TypeWhisper/Services/DictionaryExporter.swift
+++ b/TypeWhisper/Services/DictionaryExporter.swift
@@ -10,6 +10,7 @@ enum DictionaryExporter {
         let caseSensitive: Bool
         let isEnabled: Bool
         let ctcMinSimilarity: Float?
+        let source: DictionaryEntrySource
     }
 
     struct ImportResult {
@@ -32,6 +33,9 @@ enum DictionaryExporter {
             }
             if entry.type == .term, let ctcMinSimilarity = entry.ctcMinSimilarity {
                 dict["ctcMinSimilarity"] = ctcMinSimilarity
+            }
+            if entry.type == .correction, entry.source == .autoLearned {
+                dict["source"] = entry.source.rawValue
             }
             return dict
         }
@@ -91,7 +95,10 @@ enum DictionaryExporter {
                 isEnabled: dict["isEnabled"] as? Bool ?? true,
                 ctcMinSimilarity: type == .term ? parseOptionalFloat(
                     dict["ctcMinSimilarity"] ?? dict["ctc_min_similarity"]
-                ) : nil
+                ) : nil,
+                source: type == .correction
+                    ? DictionaryEntrySource.source(for: dict["source"] as? String)
+                    : .manual
             )
         }
     }
@@ -103,7 +110,7 @@ enum DictionaryExporter {
         let items = parsed.map {
             (type: $0.type, original: $0.original, replacement: $0.replacement,
              caseSensitive: $0.caseSensitive, isEnabled: $0.isEnabled,
-             ctcMinSimilarity: $0.ctcMinSimilarity)
+             ctcMinSimilarity: $0.ctcMinSimilarity, source: $0.source)
         }
         service.importEntries(items)
 

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -113,7 +113,8 @@ final class DictionaryService: ObservableObject {
         original: String,
         replacement: String? = nil,
         caseSensitive: Bool = false,
-        ctcMinSimilarity: Float? = nil
+        ctcMinSimilarity: Float? = nil,
+        source: DictionaryEntrySource = .manual
     ) {
         guard let context = modelContext else { return }
 
@@ -129,6 +130,7 @@ final class DictionaryService: ObservableObject {
             replacement: replacement,
             caseSensitive: caseSensitive,
             ctcMinSimilarity: Self.normalizedCtcMinSimilarity(type == .term ? ctcMinSimilarity : nil),
+            source: source,
             createdAt: now,
             updatedAt: now
         )
@@ -222,6 +224,15 @@ final class DictionaryService: ObservableObject {
 
     /// Batch add multiple entries with a single save+reload
     func addEntries(_ items: [(type: DictionaryEntryType, original: String, replacement: String?, caseSensitive: Bool, ctcMinSimilarity: Float?)]) {
+        addEntries(items.map {
+            (type: $0.type, original: $0.original, replacement: $0.replacement,
+             caseSensitive: $0.caseSensitive, ctcMinSimilarity: $0.ctcMinSimilarity,
+             source: DictionaryEntrySource.manual)
+        })
+    }
+
+    /// Batch add multiple entries with a single save+reload
+    func addEntries(_ items: [(type: DictionaryEntryType, original: String, replacement: String?, caseSensitive: Bool, ctcMinSimilarity: Float?, source: DictionaryEntrySource)]) {
         guard let context = modelContext, !items.isEmpty else { return }
 
         var existingOriginals = Set(entries.map { "\($0.type.rawValue):\($0.original.lowercased())" })
@@ -237,6 +248,7 @@ final class DictionaryService: ObservableObject {
                 replacement: item.replacement,
                 caseSensitive: item.caseSensitive,
                 ctcMinSimilarity: Self.normalizedCtcMinSimilarity(item.type == .term ? item.ctcMinSimilarity : nil),
+                source: item.source,
                 createdAt: now,
                 updatedAt: now
             )
@@ -262,6 +274,15 @@ final class DictionaryService: ObservableObject {
 
     /// Import entries preserving all fields including isEnabled state
     func importEntries(_ items: [(type: DictionaryEntryType, original: String, replacement: String?, caseSensitive: Bool, isEnabled: Bool, ctcMinSimilarity: Float?)]) {
+        importEntries(items.map {
+            (type: $0.type, original: $0.original, replacement: $0.replacement,
+             caseSensitive: $0.caseSensitive, isEnabled: $0.isEnabled,
+             ctcMinSimilarity: $0.ctcMinSimilarity, source: DictionaryEntrySource.manual)
+        })
+    }
+
+    /// Import entries preserving all fields including isEnabled state
+    func importEntries(_ items: [(type: DictionaryEntryType, original: String, replacement: String?, caseSensitive: Bool, isEnabled: Bool, ctcMinSimilarity: Float?, source: DictionaryEntrySource)]) {
         guard let context = modelContext, !items.isEmpty else { return }
 
         var existingOriginals = Set(entries.map { "\($0.type.rawValue):\($0.original.lowercased())" })
@@ -278,6 +299,7 @@ final class DictionaryService: ObservableObject {
                 caseSensitive: item.caseSensitive,
                 isEnabled: item.isEnabled,
                 ctcMinSimilarity: Self.normalizedCtcMinSimilarity(item.type == .term ? item.ctcMinSimilarity : nil),
+                source: item.source,
                 createdAt: now,
                 updatedAt: now
             )
@@ -655,6 +677,7 @@ final class DictionaryService: ObservableObject {
                 original: original,
                 replacement: replacement,
                 caseSensitive: false,
+                source: .autoLearned,
                 createdAt: now,
                 updatedAt: now
             )
@@ -720,6 +743,7 @@ final class DictionaryService: ObservableObject {
             entry.replacement = replacement
             entry.caseSensitive = caseSensitive
             entry.isEnabled = true
+            entry.source = .manual
             entry.updatedAt = Date()
         } else {
             let now = Date()
@@ -729,6 +753,7 @@ final class DictionaryService: ObservableObject {
                 replacement: replacement,
                 caseSensitive: caseSensitive,
                 isEnabled: true,
+                source: .manual,
                 createdAt: now,
                 updatedAt: now
             )
@@ -787,6 +812,7 @@ final class DictionaryService: ObservableObject {
                 replacement: entry.type == .correction ? (entry.replacement ?? "") : nil,
                 caseSensitive: entry.caseSensitive,
                 isEnabled: entry.isEnabled,
+                source: entry.source == .manual ? nil : entry.source,
                 createdAt: entry.createdAt,
                 updatedAt: entry.effectiveUpdatedAt
             )
@@ -832,6 +858,7 @@ final class DictionaryService: ObservableObject {
             entry.replacement = replacement
             entry.caseSensitive = synced.caseSensitive
             entry.isEnabled = synced.isEnabled
+            entry.source = synced.source ?? .manual
             entry.updatedAt = synced.updatedAt
             return
         }
@@ -842,6 +869,7 @@ final class DictionaryService: ObservableObject {
             replacement: replacement,
             caseSensitive: synced.caseSensitive,
             isEnabled: synced.isEnabled,
+            source: synced.source ?? .manual,
             createdAt: synced.createdAt,
             updatedAt: synced.updatedAt
         ))

--- a/TypeWhisper/Services/Sync/UserDataSync.swift
+++ b/TypeWhisper/Services/Sync/UserDataSync.swift
@@ -24,6 +24,7 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
     let replacement: String?
     let caseSensitive: Bool
     let isEnabled: Bool
+    let source: DictionaryEntrySource?
     let createdAt: Date
     let updatedAt: Date
 
@@ -33,6 +34,7 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         replacement: String?,
         caseSensitive: Bool,
         isEnabled: Bool,
+        source: DictionaryEntrySource? = nil,
         createdAt: Date,
         updatedAt: Date
     ) {
@@ -41,8 +43,45 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         self.replacement = replacement
         self.caseSensitive = caseSensitive
         self.isEnabled = isEnabled
+        self.source = source
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case entryType
+        case original
+        case replacement
+        case caseSensitive
+        case isEnabled
+        case source
+        case createdAt
+        case updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        entryType = try container.decode(UserDataSyncDictionaryEntryType.self, forKey: .entryType)
+        original = try container.decode(String.self, forKey: .original)
+        replacement = try container.decodeIfPresent(String.self, forKey: .replacement)
+        caseSensitive = try container.decode(Bool.self, forKey: .caseSensitive)
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        let sourceRawValue = try container.decodeIfPresent(String.self, forKey: .source)
+        source = sourceRawValue.flatMap(DictionaryEntrySource.init(rawValue:))
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(entryType, forKey: .entryType)
+        try container.encode(original, forKey: .original)
+        try container.encodeIfPresent(replacement, forKey: .replacement)
+        try container.encode(caseSensitive, forKey: .caseSensitive)
+        try container.encode(isEnabled, forKey: .isEnabled)
+        try container.encodeIfPresent(source?.rawValue, forKey: .source)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
     }
 }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2153,13 +2153,13 @@ final class DictationViewModel: ObservableObject {
         let message: String
         if learned.count == 1, let correction = learned.first {
             message = String.localizedStringWithFormat(
-                String(localized: "Learned “%@” -> “%@”"),
+                String(localized: "Saved to Dictionary: “%@” -> “%@”"),
                 correction.original,
                 correction.replacement
             )
         } else {
             message = String.localizedStringWithFormat(
-                String(localized: "Learned %d corrections"),
+                String(localized: "Saved %d corrections to Dictionary"),
                 learned.count
             )
         }
@@ -2167,7 +2167,7 @@ final class DictationViewModel: ObservableObject {
         showNotchFeedback(
             message: message,
             icon: "wand.and.sparkles",
-            duration: 8.0,
+            duration: 12.0,
             undoTitle: String(localized: "Undo")
         )
     }

--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -25,6 +25,7 @@ struct DictionaryEntryRow: Identifiable, Equatable {
     let replacement: String?
     let caseSensitive: Bool
     let isEnabled: Bool
+    let source: DictionaryEntrySource
     let termBoostingLabel: String
     let formattedCtcMinSimilarity: String
 
@@ -51,7 +52,7 @@ class DictionaryViewModel: ObservableObject {
 
     // Filter
     enum FilterTab: Int, CaseIterable {
-        case all, terms, corrections, termPacks
+        case all, terms, corrections, autoLearned, termPacks
     }
 
     enum TermBoostingMode: String, CaseIterable, Identifiable {
@@ -109,6 +110,8 @@ class DictionaryViewModel: ObservableObject {
             return entries.filter { $0.type == .term }
         case .corrections:
             return entries.filter { $0.type == .correction }
+        case .autoLearned:
+            return entries.filter { $0.type == .correction && $0.source == .autoLearned }
         case .termPacks:
             return []
         }
@@ -318,6 +321,7 @@ class DictionaryViewModel: ObservableObject {
             replacement: entry.replacement,
             caseSensitive: entry.caseSensitive,
             isEnabled: entry.isEnabled,
+            source: entry.source,
             termBoostingLabel: termBoostingLabel(for: entry.ctcMinSimilarity),
             formattedCtcMinSimilarity: formattedCtcMinSimilarity(entry.ctcMinSimilarity)
         )

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -59,10 +59,11 @@ struct DictionarySettingsView: View {
                 Text(String(localized: "All")).tag(DictionaryViewModel.FilterTab.all)
                 Text(String(localized: "Terms")).tag(DictionaryViewModel.FilterTab.terms)
                 Text(String(localized: "Corrections")).tag(DictionaryViewModel.FilterTab.corrections)
+                Text(String(localized: "Auto-learned")).tag(DictionaryViewModel.FilterTab.autoLearned)
                 Text(String(localized: "Term Packs")).tag(DictionaryViewModel.FilterTab.termPacks)
             }
             .pickerStyle(.segmented)
-            .frame(width: 340)
+            .frame(width: 470)
 
             Spacer()
 
@@ -579,6 +580,10 @@ private struct DictionaryCardView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 3))
             }
 
+            if row.source == .autoLearned {
+                DictionarySourceBadge()
+            }
+
             Spacer()
 
             Toggle("", isOn: Binding(
@@ -614,6 +619,19 @@ private struct DictionaryCardView: View {
                 deleteEntry()
             }
         }
+    }
+}
+
+private struct DictionarySourceBadge: View {
+    var body: some View {
+        Label(String(localized: "Auto-learned"), systemImage: "wand.and.sparkles")
+            .font(.caption2)
+            .lineLimit(1)
+            .foregroundStyle(Color.yellow)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(Color.yellow.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }
 

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -464,6 +464,38 @@ final class CloudFolderSyncTests: XCTestCase {
     }
 
     @MainActor
+    func testHostStorePreservesAutoLearnedDictionarySource() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncAutoLearnedSource")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        dictionaryService.learnCorrection(original: "recieve", replacement: "receive")
+
+        let store = TypeWhisperUserDataSyncStore(
+            dictionaryService: dictionaryService,
+            snippetService: snippetService
+        )
+
+        XCTAssertEqual(store.snapshot().dictionaryEntries.first?.source, .autoLearned)
+
+        try store.apply([
+            .upsertDictionary(Self.dictionaryEntry(
+                entryType: .correction,
+                original: "langauge",
+                replacement: "language",
+                source: .autoLearned,
+                updatedAt: Self.date(30)
+            ))
+        ])
+
+        XCTAssertEqual(
+            dictionaryService.entries.first { $0.original == "langauge" }?.source,
+            .autoLearned
+        )
+    }
+
+    @MainActor
     func testHostApplyMergesDuplicateNaturalKeys() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncMerge")
         defer { TestSupport.remove(appSupportDirectory) }
@@ -502,6 +534,7 @@ final class CloudFolderSyncTests: XCTestCase {
         entryType: UserDataSyncDictionaryEntryType = .term,
         original: String,
         replacement: String? = nil,
+        source: DictionaryEntrySource? = nil,
         updatedAt: Date
     ) -> UserDataSyncDictionaryEntry {
         UserDataSyncDictionaryEntry(
@@ -510,6 +543,7 @@ final class CloudFolderSyncTests: XCTestCase {
             replacement: replacement,
             caseSensitive: false,
             isEnabled: true,
+            source: source,
             createdAt: date(1),
             updatedAt: updatedAt
         )

--- a/TypeWhisperTests/DictionaryExporterTests.swift
+++ b/TypeWhisperTests/DictionaryExporterTests.swift
@@ -178,6 +178,41 @@ final class DictionaryExporterTests: XCTestCase {
     }
 
     @MainActor
+    func testRoundTripPreservesAutoLearnedSource() throws {
+        let appDir = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appDir) }
+        let service = DictionaryService(appSupportDirectory: appDir)
+        service.learnCorrection(original: "recieve", replacement: "receive")
+
+        let json = DictionaryExporter.exportJSON(service.entries)
+        let array = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [[String: Any]])
+        XCTAssertEqual(array.first?["source"] as? String, DictionaryEntrySource.autoLearned.rawValue)
+
+        let parsed = try DictionaryExporter.parseJSON(Data(json.utf8))
+        let correction = try XCTUnwrap(parsed.first)
+        XCTAssertEqual(correction.source, .autoLearned)
+
+        let importedDir = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(importedDir) }
+        let importedService = DictionaryService(appSupportDirectory: importedDir)
+        let result = DictionaryExporter.importEntries(parsed, into: importedService)
+
+        XCTAssertEqual(result.imported, 1)
+        XCTAssertEqual(importedService.entries.first?.source, .autoLearned)
+    }
+
+    @MainActor
+    func testParseDefaultsUnknownSourceToManual() throws {
+        let json = """
+        [{"type": "correction", "original": "teh", "replacement": "the", "source": "future"}]
+        """
+
+        let items = try DictionaryExporter.parseJSON(Data(json.utf8))
+
+        XCTAssertEqual(items.first?.source, .manual)
+    }
+
+    @MainActor
     func testImportWithDuplicateDetection() throws {
         let appDir = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appDir) }

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -131,6 +131,10 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(learned.count, 2)
         XCTAssertEqual(learned.map(\.original), ["langauge", "recieve"])
         XCTAssertEqual(service.correctionsCount, 3)
+        XCTAssertEqual(
+            service.corrections.filter { $0.source == .autoLearned }.map(\.original),
+            ["langauge", "recieve"]
+        )
 
         let protectedEntry = try XCTUnwrap(service.corrections.first { $0.original == "langauge" })
         service.updateEntry(
@@ -312,6 +316,7 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(service.corrections.first?.original, "TEH")
         XCTAssertEqual(service.corrections.first?.replacement, "The")
         XCTAssertEqual(service.corrections.first?.caseSensitive, true)
+        XCTAssertEqual(service.corrections.first?.source, .manual)
         XCTAssertEqual(service.corrections.first?.usageCount, 1)
         XCTAssertTrue(try service.deleteAPICorrection(original: "teh"))
         XCTAssertEqual(service.correctionsCount, 0)
@@ -515,6 +520,13 @@ final class DictionaryServiceTests: XCTestCase {
             .filter { $0.type == .correction }
             .map(\.id)
         XCTAssertEqual(allCorrectionIDs, correctionIDs)
+
+        service.learnCorrection(original: "autolearned", replacement: "auto learned")
+        let autoLearnedViewModel = DictionaryViewModel(dictionaryService: service)
+        autoLearnedViewModel.filterTab = .autoLearned
+        let autoLearnedRows = autoLearnedViewModel.filteredEntryRows
+        XCTAssertEqual(autoLearnedRows.map(\.original), ["autolearned"])
+        XCTAssertTrue(autoLearnedRows.allSatisfy { $0.source == .autoLearned })
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Customer feedback: the learned-correction feedback near the notch was easy to miss and disappeared too quickly, and the Dictionary screen needed a way to filter automatically learned corrections.

This PR:
- tracks dictionary entry source for newly auto-learned corrections while treating old, missing, or unknown source values as manual
- preserves the optional source field through dictionary export/import and Cloud Folder Sync
- keeps manual creation, imports, API upserts, and term packs on the manual path
- extends the Dictionary filter with Auto-learned and adds an Auto-learned badge on correction rows
- makes learned-correction feedback clearer and keeps it visible for 12 seconds with Undo available for the full duration

## Test Coverage

All new source-tracking paths have regression coverage:
- auto-learned source assignment and Dictionary filtering
- API correction helpers staying manual
- export/import round-trip preserving auto-learned source
- unknown source values defaulting to manual
- Cloud Folder Sync preserving auto-learned source

## Pre-Landing Review

No issues found.

## Design Review

Code-level UI review completed for the Dictionary segmented picker, Auto-learned badge, and feedback copy/duration. No blocking issues found.

## Eval Results

No prompt-related files changed, evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: make auto-learned correction feedback more visible and make auto-learned dictionary entries filterable.

Delivered: source tracking, sync/export/import support, Dictionary filter and badge, longer clearer feedback, and focused regression coverage.

## Plan Completion

User-provided implementation plan addressed:
- [x] dictionary source metadata with backward-compatible manual fallback
- [x] auto-learned source assignment for learned corrections
- [x] manual source behavior for manual/API/import paths
- [x] optional export/import and Cloud Folder Sync source field
- [x] 12-second learned-correction feedback with clearer copy
- [x] Auto-learned Dictionary filter and badge
- [x] English and German localized strings
- [x] focused and full TypeWhisper app tests
- [x] dev app build verification

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests -only-testing:TypeWhisperTests/DictionaryExporterTests -only-testing:TypeWhisperTests/CloudFolderSyncTests -only-testing:TypeWhisperTests/TargetAppCorrectionLearningServiceTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh /Users/marco/.codex/worktrees/9261/typewhisper-mac`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Auto-learned” filter in Dictionary settings to quickly view learned corrections.
  * Show learned entries with a clear badge so they’re easier to identify.
  * Updated success messages to say when corrections are saved to the dictionary.

* **Bug Fixes**
  * Learned corrections now keep their saved status when exported, imported, or synced.
  * Unknown saved-entry labels now safely fall back to the standard manual type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Documentation

- Public docs PR: https://github.com/TypeWhisper/typewhisper.com/pull/97
- Updated macOS feature docs in English and German to mention undoable auto-learn feedback and the Auto-learned Dictionary filter.
