### PR TITLE
Set cloud ASR plugin host floor

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.assemblyai",
     "name": "AssemblyAI",
     "version": "1.0.4",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cartesia",
     "name": "Cartesia",
     "version": "1.0.0",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cloudflare-asr",
     "name": "Cloudflare ASR",
     "version": "1.0.0",
-    "minHostVersion": "0.9.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "yunluyl",

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.deepgram",
     "name": "Deepgram",
     "version": "1.0.4",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.elevenlabs",
     "name": "ElevenLabs",
     "version": "1.0.0",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gladia",
     "name": "Gladia",
     "version": "1.0.0",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.openai",
     "name": "OpenAI / ChatGPT",
     "version": "1.1.1",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
     "version": "1.1.1",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.speechmatics",
     "name": "Speechmatics",
     "version": "1.0.0",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.xai",
     "name": "xAI / Grok",
     "version": "1.0.0",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -125,7 +125,7 @@ final class PluginManifestValidationTests: XCTestCase {
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
-        XCTAssertEqual(manifest.minHostVersion, "1.4.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
         XCTAssertEqual(manifest.hosting, .cloud)
         XCTAssertEqual(manifest.requiresAPIKey, false)
         XCTAssertEqual(manifest.resolvedHosting, .cloud)

--- a/TypeWhisperTests/XAIPluginTests.swift
+++ b/TypeWhisperTests/XAIPluginTests.swift
@@ -90,7 +90,7 @@ final class XAIPluginTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.id, "com.typewhisper.xai")
-        XCTAssertEqual(manifest.minHostVersion, "1.4.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
         XCTAssertEqual(manifest.category, "transcription")
         XCTAssertEqual(manifest.categories, ["transcription", "llm", "tts"])
         XCTAssertEqual(manifest.resolvedCategoryIdentifiers, ["transcription", "llm", "tts"])


### PR DESCRIPTION
## Summary
- Follow-up to #780 / #794 before publishing the updated cloud ASR plugin bundles.
- Raises the affected plugin manifest `minHostVersion` values to `1.5.0` where they were still below the host version that contains the new shared upload SDK symbols.
- Keeps the already-compatible manifests unchanged.

## Test plan
- `git diff --check`
- `for f in TypeWhisperPluginSDK/Plugins/{AssemblyAIPlugin,CartesiaPlugin,CloudflareASRPlugin,DeepgramPlugin,ElevenLabsPlugin,GladiaPlugin,OpenAIPlugin,OpenRouterPlugin,SpeechmaticsPlugin,XAIPlugin}/manifest.json; do jq -e '.minHostVersion == "1.5.0"' "$f" >/dev/null; done`\n- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/PluginManifestValidationTests/testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement -only-testing:TypeWhisperTests/XAIPluginTests/testXAIManifestDeclaresCloudAPIKeyPlugin CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multiple speech and AI plugin manifests to require a newer host version (`minHostVersion` now set to `1.5.0`), improving compatibility consistency across the plugin set.
  * Older host versions are no longer supported for these plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->