### PR TITLE
Add PR preflight and cancel stale CI runs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ## Test Plan
 
+- [ ] Ran `scripts/pr-preflight.sh`
 - [ ] Built and ran locally
 - [ ] Tested the changed functionality manually
 - [ ] No regressions in existing features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   SCHEME: TypeWhisper
   PROJECT: TypeWhisper.xcodeproj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,9 @@
 name: CodeQL
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+base_ref="${1:-origin/main}"
+
+log() {
+  printf '[pr-preflight] %s\n' "$*"
+}
+
+run_if_exists() {
+  local script_path="$1"
+  shift
+
+  if [[ -x "$script_path" ]]; then
+    "$script_path" "$@"
+  else
+    bash "$script_path" "$@"
+  fi
+}
+
+cd "$repo_root"
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  log "warning: base ref '$base_ref' was not found; falling back to HEAD~1"
+  base_ref="HEAD~1"
+fi
+
+log "checking whitespace and conflict markers against $base_ref"
+git diff --check "$base_ref"...HEAD
+
+log "checking shell scripts parse"
+while IFS= read -r script_file; do
+  [[ -n "$script_file" ]] || continue
+  bash -n "$script_file"
+done < <(git ls-files 'scripts/*.sh')
+
+log "running Python script tests"
+python3 scripts/test_assemble_community_plugin_registry.py
+python3 scripts/test_plugin_registry_metadata.py
+
+log "checking release instrumentation helper"
+run_if_exists scripts/check_release_binary_instrumentation.sh --self-test
+
+log "running Plugin SDK tests"
+swift test --package-path TypeWhisperPluginSDK
+
+log "preflight complete"

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -22,8 +22,9 @@ run_if_exists() {
 cd "$repo_root"
 
 if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
-  log "warning: base ref '$base_ref' was not found; falling back to HEAD~1"
-  base_ref="HEAD~1"
+  log "error: base ref '$base_ref' was not found"
+  log "hint: fetch the base branch first, or pass an existing ref explicitly"
+  exit 2
 fi
 
 log "checking whitespace and conflict markers against $base_ref"


### PR DESCRIPTION
## Summary

- add `scripts/pr-preflight.sh` to run the local checks expected before opening or updating a PR
- add the preflight command to the PR template
- add concurrency cancellation to the Build DMG and CodeQL workflows so superseded runs on the same branch do not keep consuming macOS/analysis minutes

## Test Plan

- [x] Ran `scripts/pr-preflight.sh origin/main`
- [x] Parsed changed workflow YAML with Ruby Psych
- [x] Ran `git diff --check`

## Notes

This does not change CodeRabbit or GitHub Codex organization settings, because those are configured outside the repository UI and this account only has read permission on the upstream repo settings. This PR covers the repo-level mitigation: catch common issues locally before automated review, and cancel stale CI runs after follow-up pushes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by enabling automatic cancellation of in-progress runs when newer runs start (including CodeQL).
* **Chores**
  * Added a PR preflight script to perform repository checks and run validation tests before merging.
  * Updated the pull request checklist to include the new preflight verification step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->