### PR TITLE
fix: recover stalled Gemma 4 model downloads

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -125,6 +125,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     private let modelLoadClock = ContinuousClock()
     private var lastModelLoadProgressInstant = ContinuousClock().now
     private var lastModelLoadProgressFraction = 0.0
+    private var activeModelLoadTask: (generation: Int, task: Task<ModelContainer, Error>)?
 
     private func modelsDirectory() -> URL {
         host?.pluginDataDirectory.appendingPathComponent("models")
@@ -440,24 +441,33 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                     id: modelDef.repoId,
                     extraEOSTokens: ["<turn|>"]
                 )
-            let container = try await VLMModelFactory.shared.loadContainer(
-                from: downloader,
-                using: Gemma4TokenizerLoader(),
-                configuration: configuration
-            ) { progress in
-                guard !Task.isCancelled else { return }
-                let fraction = max(0.0, min(progress.fractionCompleted, 1.0))
-                let mapped = Self.initialDownloadProgress + fraction * 0.78
-                Task { @MainActor in
-                    guard self.recordModelLoadProgress(fraction: fraction, generation: loadGeneration) else {
-                        return
-                    }
-                    self.downloadProgress = max(self.downloadProgress, mapped)
-                    if case .downloading = self.modelState {
-                        self.host?.notifyCapabilitiesChanged()
+            let loadTask = Task<ModelContainer, Error> {
+                try await VLMModelFactory.shared.loadContainer(
+                    from: downloader,
+                    using: Gemma4TokenizerLoader(),
+                    configuration: configuration
+                ) { progress in
+                    guard !Task.isCancelled else { return }
+                    let fraction = max(0.0, min(progress.fractionCompleted, 1.0))
+                    let mapped = Self.initialDownloadProgress + fraction * 0.78
+                    Task { @MainActor in
+                        guard self.recordModelLoadProgress(fraction: fraction, generation: loadGeneration) else {
+                            return
+                        }
+                        self.downloadProgress = max(self.downloadProgress, mapped)
+                        if case .downloading = self.modelState {
+                            self.host?.notifyCapabilitiesChanged()
+                        }
                     }
                 }
             }
+            activeModelLoadTask = (generation: loadGeneration, task: loadTask)
+            defer {
+                if activeModelLoadTask?.generation == loadGeneration {
+                    activeModelLoadTask = nil
+                }
+            }
+            let container = try await loadTask.value
 
             try Task.checkCancellation()
             guard isCurrentModelLoad(loadGeneration) else { return }
@@ -535,7 +545,10 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             host?.setUserDefault(nil, forKey: "loadedModel")
             return
         }
-        guard allowDownloads || isModelDownloaded(modelDef) else { return }
+        guard allowDownloads || isModelDownloaded(modelDef) else {
+            host?.setUserDefault(nil, forKey: "loadedModel")
+            return
+        }
         try? await loadModel(modelDef)
     }
 
@@ -549,6 +562,8 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     private func invalidateModelLoad() {
         modelLoadGeneration += 1
+        activeModelLoadTask?.task.cancel()
+        activeModelLoadTask = nil
     }
 
     private func isCurrentModelLoad(_ generation: Int) -> Bool {
@@ -570,7 +585,6 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         let timeout = modelLoadTimeoutDuration
         Task { [weak self] in
             while true {
-                try? await Task.sleep(for: timeout)
                 guard let self,
                       self.isCurrentModelLoad(generation),
                       self.loadedModelId == nil else {
@@ -585,7 +599,10 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                 }
 
                 let elapsed = self.lastModelLoadProgressInstant.duration(to: self.modelLoadClock.now)
-                guard elapsed >= timeout else { continue }
+                guard elapsed >= timeout else {
+                    try? await Task.sleep(for: timeout - elapsed)
+                    continue
+                }
 
                 self.invalidateModelLoad()
                 self.modelContainer = nil
@@ -662,6 +679,10 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     func invalidateModelLoadForTesting() {
         invalidateModelLoad()
+    }
+
+    func isCurrentModelLoadForTesting(_ generation: Int) -> Bool {
+        isCurrentModelLoad(generation)
     }
     #endif
 

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -96,6 +96,11 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     static let defaultGenerationTemperature = 0.1
     static let experimentalModelWarning = "Experimental. You can try it at your own risk."
     static let promptMaxTokens = 2048
+    private static let initialDownloadProgress = 0.0
+    private static let downloadedModelLoadProgress = 0.8
+    private static let loadedModelPreparationProgress = 0.9
+    private static let minimumVisibleDownloadProgress = 0.01
+    private static let minimumProgressAdvance = 0.001
 
     enum DownloadError: LocalizedError {
         case invalidRepositoryID(String)
@@ -115,6 +120,11 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     fileprivate var _generationTemperature: Double = 0.1
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.custom.rawValue
     fileprivate var _hfToken: String?
+    private var modelLoadGeneration = 0
+    private var modelLoadTimeoutDuration: Duration = .seconds(300)
+    private let modelLoadClock = ContinuousClock()
+    private var lastModelLoadProgressInstant = ContinuousClock().now
+    private var lastModelLoadProgressFraction = 0.0
 
     private func modelsDirectory() -> URL {
         host?.pluginDataDirectory.appendingPathComponent("models")
@@ -123,6 +133,26 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     private func localModelDirectory(for repoId: String) -> URL {
         modelsDirectory().appendingPathComponent(repoId, isDirectory: true)
+    }
+
+    private func hubCacheDirectory(for repoId: String) -> URL {
+        let cacheName = "models--" + repoId.replacingOccurrences(of: "/", with: "--")
+        return modelsDirectory().appendingPathComponent(cacheName, isDirectory: true)
+    }
+
+    private func hubLockDirectory(for repoId: String) -> URL {
+        let cacheName = "models--" + repoId.replacingOccurrences(of: "/", with: "--")
+        return modelsDirectory()
+            .appendingPathComponent(".locks", isDirectory: true)
+            .appendingPathComponent(cacheName, isDirectory: true)
+    }
+
+    private func modelCacheDirectories(for modelDef: Gemma4ModelDef) -> [URL] {
+        [
+            localModelDirectory(for: modelDef.repoId),
+            hubCacheDirectory(for: modelDef.repoId),
+            hubLockDirectory(for: modelDef.repoId),
+        ]
     }
     fileprivate var downloadProgress: Double = 0
 
@@ -156,6 +186,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     }
 
     func deactivate() {
+        invalidateModelLoad()
         modelContainer = nil
         loadedModelId = nil
         downloadProgress = 0
@@ -180,7 +211,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     var downloadedModels: [PluginModelInfo] {
         Self.availableModels
-            .filter { hasDownloadedModel($0) }
+            .filter { isModelDownloaded($0) }
             .map { def in
                 PluginModelInfo(
                     id: def.id,
@@ -284,6 +315,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     var preferredModelId: String? { _selectedLLMModelId }
     var huggingFaceToken: String? { _hfToken }
     var currentDownloadProgress: Double { downloadProgress }
+    var hasVisibleDownloadProgress: Bool { downloadProgress >= Self.minimumVisibleDownloadProgress }
 
     var generationTemperature: Double { _generationTemperature }
     var llmTemperatureMode: PluginLLMTemperatureMode {
@@ -350,17 +382,29 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     }
 
     func isModelDownloaded(_ modelDef: Gemma4ModelDef) -> Bool {
-        hasDownloadedModel(modelDef)
+        isUsableDownloadedModel(modelDef)
     }
 
-    func beginModelLoad(for modelDef: Gemma4ModelDef, isAlreadyDownloaded: Bool) {
+    func hasCachedModelFiles(_ modelDef: Gemma4ModelDef) -> Bool {
+        modelCacheDirectories(for: modelDef).contains { cacheDir in
+            var isDirectory: ObjCBool = false
+            return FileManager.default.fileExists(atPath: cacheDir.path, isDirectory: &isDirectory)
+                && isDirectory.boolValue
+        }
+    }
+
+    @discardableResult
+    func beginModelLoad(for modelDef: Gemma4ModelDef, isAlreadyDownloaded: Bool) -> Int {
+        let generation = beginModelLoad()
         _selectedLLMModelId = modelDef.id
         modelState = isAlreadyDownloaded ? .loading : .downloading
-        downloadProgress = isAlreadyDownloaded ? 0.8 : 0.02
+        downloadProgress = isAlreadyDownloaded ? Self.downloadedModelLoadProgress : Self.initialDownloadProgress
         host?.notifyCapabilitiesChanged()
+        return generation
     }
 
     func cancelModelLoad() {
+        invalidateModelLoad()
         downloadProgress = 0
         modelState = .notLoaded
         host?.notifyCapabilitiesChanged()
@@ -370,12 +414,16 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     func loadModel(_ modelDef: Gemma4ModelDef) async throws {
         try Task.checkCancellation()
-        let isAlreadyDownloaded = hasDownloadedModel(modelDef)
-        beginModelLoad(for: modelDef, isAlreadyDownloaded: isAlreadyDownloaded)
+        let isAlreadyDownloaded = isModelDownloaded(modelDef)
+        let loadGeneration = beginModelLoad(for: modelDef, isAlreadyDownloaded: isAlreadyDownloaded)
+        startModelLoadTimeout(generation: loadGeneration, modelName: modelDef.displayName)
         do {
             let token = _hfToken?.trimmingCharacters(in: .whitespacesAndNewlines)
             let modelsDir = modelsDirectory()
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
+            if !isAlreadyDownloaded {
+                removeIncompleteModelIfNeeded(modelDef)
+            }
 
             let hubClient = HubClient(
                 host: HubClient.defaultHost,
@@ -383,10 +431,15 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                 cache: HubCache(cacheDirectory: modelsDir)
             )
             let downloader = Gemma4HubDownloader(client: hubClient, modelsDirectory: modelsDir)
-            let configuration = ModelConfiguration(
-                id: modelDef.repoId,
-                extraEOSTokens: ["<turn|>"]
-            )
+            let configuration = isAlreadyDownloaded
+                ? ModelConfiguration(
+                    directory: localModelDirectory(for: modelDef.repoId),
+                    extraEOSTokens: ["<turn|>"]
+                )
+                : ModelConfiguration(
+                    id: modelDef.repoId,
+                    extraEOSTokens: ["<turn|>"]
+                )
             let container = try await VLMModelFactory.shared.loadContainer(
                 from: downloader,
                 using: Gemma4TokenizerLoader(),
@@ -394,9 +447,12 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             ) { progress in
                 guard !Task.isCancelled else { return }
                 let fraction = max(0.0, min(progress.fractionCompleted, 1.0))
-                let mapped = 0.02 + fraction * 0.78
+                let mapped = Self.initialDownloadProgress + fraction * 0.78
                 Task { @MainActor in
-                    self.downloadProgress = mapped
+                    guard self.recordModelLoadProgress(fraction: fraction, generation: loadGeneration) else {
+                        return
+                    }
+                    self.downloadProgress = max(self.downloadProgress, mapped)
                     if case .downloading = self.modelState {
                         self.host?.notifyCapabilitiesChanged()
                     }
@@ -404,8 +460,9 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             }
 
             try Task.checkCancellation()
+            guard isCurrentModelLoad(loadGeneration) else { return }
             modelState = .loading
-            downloadProgress = 0.9
+            downloadProgress = Self.loadedModelPreparationProgress
             modelContainer = container
             loadedModelId = modelDef.id
             _selectedLLMModelId = modelDef.id
@@ -416,11 +473,18 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             host?.notifyCapabilitiesChanged()
         } catch {
             if error is CancellationError {
-                cancelModelLoad()
+                if isCurrentModelLoad(loadGeneration) {
+                    cancelModelLoad()
+                }
                 throw error
             }
+            guard isCurrentModelLoad(loadGeneration) else { return }
+            modelContainer = nil
+            loadedModelId = nil
             downloadProgress = 0
             modelState = .error(Self.userFacingLoadErrorMessage(for: error, modelDef: modelDef))
+            host?.setUserDefault(nil, forKey: "loadedModel")
+            host?.notifyCapabilitiesChanged()
             throw error
         }
     }
@@ -429,6 +493,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
 
     func unloadModel(clearPersistence: Bool = true) {
+        invalidateModelLoad()
         modelContainer = nil
         loadedModelId = nil
         downloadProgress = 0
@@ -440,13 +505,21 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     }
 
     func deleteModelFiles(_ modelDef: Gemma4ModelDef) throws {
-        let repoDir = localModelDirectory(for: modelDef.repoId)
-        if FileManager.default.fileExists(atPath: repoDir.path) {
-            try FileManager.default.removeItem(at: repoDir)
+        let fileManager = FileManager.default
+        for cacheDir in modelCacheDirectories(for: modelDef) {
+            if fileManager.fileExists(atPath: cacheDir.path) {
+                try fileManager.removeItem(at: cacheDir)
+            }
+        }
+
+        let repoNamespaceDir = localModelDirectory(for: modelDef.repoId).deletingLastPathComponent()
+        if (try? fileManager.contentsOfDirectory(atPath: repoNamespaceDir.path).isEmpty) == true {
+            try? fileManager.removeItem(at: repoNamespaceDir)
         }
     }
 
     func resetCachedModel(_ modelDef: Gemma4ModelDef) {
+        invalidateModelLoad()
         modelContainer = nil
         loadedModelId = nil
         downloadProgress = 0
@@ -462,17 +535,135 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             host?.setUserDefault(nil, forKey: "loadedModel")
             return
         }
-        guard allowDownloads || hasDownloadedModel(modelDef) else { return }
+        guard allowDownloads || isModelDownloaded(modelDef) else { return }
         try? await loadModel(modelDef)
     }
 
-    private func hasDownloadedModel(_ modelDef: Gemma4ModelDef) -> Bool {
-        let repoDir = localModelDirectory(for: modelDef.repoId)
-
-        var isDirectory: ObjCBool = false
-        return FileManager.default.fileExists(atPath: repoDir.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
+    @discardableResult
+    private func beginModelLoad() -> Int {
+        modelLoadGeneration += 1
+        lastModelLoadProgressInstant = modelLoadClock.now
+        lastModelLoadProgressFraction = 0
+        return modelLoadGeneration
     }
+
+    private func invalidateModelLoad() {
+        modelLoadGeneration += 1
+    }
+
+    private func isCurrentModelLoad(_ generation: Int) -> Bool {
+        generation == modelLoadGeneration
+    }
+
+    private func recordModelLoadProgress(fraction: Double, generation: Int) -> Bool {
+        guard isCurrentModelLoad(generation) else { return false }
+        let normalized = max(0.0, min(fraction, 1.0))
+        guard normalized - lastModelLoadProgressFraction >= Self.minimumProgressAdvance else {
+            return false
+        }
+        lastModelLoadProgressFraction = normalized
+        lastModelLoadProgressInstant = modelLoadClock.now
+        return true
+    }
+
+    private func startModelLoadTimeout(generation: Int, modelName: String) {
+        let timeout = modelLoadTimeoutDuration
+        Task { [weak self] in
+            while true {
+                try? await Task.sleep(for: timeout)
+                guard let self,
+                      self.isCurrentModelLoad(generation),
+                      self.loadedModelId == nil else {
+                    return
+                }
+
+                switch self.modelState {
+                case .downloading, .loading:
+                    break
+                default:
+                    return
+                }
+
+                let elapsed = self.lastModelLoadProgressInstant.duration(to: self.modelLoadClock.now)
+                guard elapsed >= timeout else { continue }
+
+                self.invalidateModelLoad()
+                self.modelContainer = nil
+                self.loadedModelId = nil
+                self.downloadProgress = 0
+                self.modelState = .error(Self.stalledDownloadMessage(for: modelName))
+                self.host?.setUserDefault(nil, forKey: "loadedModel")
+                self.host?.notifyCapabilitiesChanged()
+                return
+            }
+        }
+    }
+
+    private func isUsableDownloadedModel(_ modelDef: Gemma4ModelDef) -> Bool {
+        let repoDir = localModelDirectory(for: modelDef.repoId)
+        return Self.isUsableDownloadedModel(at: repoDir)
+    }
+
+    static func isUsableDownloadedModel(at repoDir: URL) -> Bool {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: repoDir.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return false
+        }
+
+        let requiredRootFiles = [
+            "config.json",
+            "tokenizer.json",
+        ]
+        guard requiredRootFiles.allSatisfy({ fileManager.fileExists(atPath: repoDir.appendingPathComponent($0).path) }) else {
+            return false
+        }
+
+        guard let enumerator = fileManager.enumerator(
+            at: repoDir,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        for case let fileURL as URL in enumerator where fileURL.pathExtension == "safetensors" {
+            return true
+        }
+        return false
+    }
+
+    private func removeIncompleteModelIfNeeded(_ modelDef: Gemma4ModelDef) {
+        let repoDir = localModelDirectory(for: modelDef.repoId)
+        guard hasCachedModelFiles(modelDef), !Self.isUsableDownloadedModel(at: repoDir) else { return }
+        try? deleteModelFiles(modelDef)
+    }
+
+    #if DEBUG
+    func setModelLoadTimeoutForTesting(_ timeout: Duration) {
+        modelLoadTimeoutDuration = timeout
+    }
+
+    @discardableResult
+    func startModelLoadTimeoutForTesting(modelName: String) -> Int {
+        let generation = beginModelLoad()
+        modelState = .downloading
+        downloadProgress = Self.initialDownloadProgress
+        startModelLoadTimeout(generation: generation, modelName: modelName)
+        return generation
+    }
+
+    func recordModelLoadProgressForTesting(fraction: Double, generation: Int? = nil) {
+        let resolvedGeneration = generation ?? modelLoadGeneration
+        guard recordModelLoadProgress(fraction: fraction, generation: resolvedGeneration) else { return }
+        downloadProgress = Self.initialDownloadProgress + max(0.0, min(fraction, 1.0)) * 0.78
+    }
+
+    func invalidateModelLoadForTesting() {
+        invalidateModelLoad()
+    }
+    #endif
 
     // MARK: - Settings Activity
 
@@ -483,7 +674,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         case .downloading:
             return PluginSettingsActivity(
                 message: "Downloading model",
-                progress: downloadProgress
+                progress: hasVisibleDownloadProgress ? downloadProgress : nil
             )
         case .loading:
             return PluginSettingsActivity(message: "Preparing model")
@@ -585,6 +776,15 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         }
 
         return error.localizedDescription
+    }
+
+    private static func stalledDownloadMessage(for modelName: String) -> String {
+        let bundle = Bundle(for: Gemma4Plugin.self)
+        let format = String(
+            localized: "Downloading or preparing %@ has not made progress for several minutes. Cancel, delete the cached model if one is shown, and try again. Adding an optional HuggingFace token may also help if Hugging Face is throttling downloads.",
+            bundle: bundle
+        )
+        return String(format: format, modelName)
     }
 
     private static func isRecoverableCacheError(_ rawMessage: String) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -350,13 +350,20 @@ struct Gemma4SettingsView: View {
         loadTask = nil
         isPolling = false
         Task {
-            try? await plugin.deleteDownloadedModel(modelDef.id)
-            await MainActor.run {
-                if selectedModelId == modelDef.id {
-                    selectedModelId = plugin.selectedLLMModelId ?? Gemma4Plugin.availableModels.first?.id ?? ""
+            do {
+                try await plugin.deleteDownloadedModel(modelDef.id)
+                await MainActor.run {
+                    if selectedModelId == modelDef.id {
+                        selectedModelId = plugin.selectedLLMModelId ?? Gemma4Plugin.availableModels.first?.id ?? ""
+                    }
+                    modelState = plugin.modelState
+                    downloadProgress = plugin.currentDownloadProgress
                 }
-                modelState = plugin.modelState
-                downloadProgress = plugin.currentDownloadProgress
+            } catch {
+                await MainActor.run {
+                    modelState = .error(error.localizedDescription)
+                    downloadProgress = plugin.currentDownloadProgress
+                }
             }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -214,13 +214,21 @@ struct Gemma4SettingsView: View {
 
             Spacer()
 
+            let isDownloaded = plugin.isModelDownloaded(modelDef)
+            let hasCachedModelFiles = plugin.hasCachedModelFiles(modelDef)
+
             if case .downloading = modelState, selectedModelId == modelDef.id {
                 HStack(spacing: 8) {
-                    ProgressView(value: downloadProgress)
-                        .frame(width: 80)
-                    Text("\(Int(downloadProgress * 100))%")
-                        .font(.caption)
-                        .monospacedDigit()
+                    if plugin.hasVisibleDownloadProgress {
+                        ProgressView(value: downloadProgress)
+                            .frame(width: 80)
+                        Text("\(Int(downloadProgress * 100))%")
+                            .font(.caption)
+                            .monospacedDigit()
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
                     Button(String(localized: "Cancel", bundle: bundle)) {
                         cancelCurrentLoad()
                     }
@@ -242,7 +250,13 @@ struct Gemma4SettingsView: View {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                     Button(String(localized: "Unload", bundle: bundle)) {
-                        resetCachedModel(modelDef)
+                        unloadCurrentModel()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+
+                    Button(String(localized: "Remove", bundle: bundle), role: .destructive) {
+                        removeDownloadedModel(modelDef)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
@@ -253,6 +267,26 @@ struct Gemma4SettingsView: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+            } else if isDownloaded || hasCachedModelFiles {
+                HStack(spacing: 8) {
+                    Button(
+                        isDownloaded
+                            ? String(localized: "Load", bundle: bundle)
+                            : String(localized: "Download & Load", bundle: bundle)
+                    ) {
+                        startLoading(modelDef)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(modelState == .downloading || modelState == .loading)
+
+                    Button(String(localized: "Remove", bundle: bundle), role: .destructive) {
+                        removeDownloadedModel(modelDef)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(modelState == .downloading || modelState == .loading)
+                }
             } else if let experimentalWarning = modelDef.experimentalWarning {
                 VStack(alignment: .trailing, spacing: 6) {
                     Text("Experimental", bundle: bundle)
@@ -287,7 +321,7 @@ struct Gemma4SettingsView: View {
     private func isRecoverableCachedModelError(for modelDef: Gemma4ModelDef) -> Bool {
         if case .error = modelState,
            selectedModelId == modelDef.id,
-           plugin.isModelDownloaded(modelDef) {
+           plugin.hasCachedModelFiles(modelDef) {
             return true
         }
         return false
@@ -300,6 +334,31 @@ struct Gemma4SettingsView: View {
         plugin.resetCachedModel(modelDef)
         modelState = plugin.modelState
         downloadProgress = plugin.currentDownloadProgress
+    }
+
+    private func unloadCurrentModel() {
+        loadTask?.cancel()
+        loadTask = nil
+        isPolling = false
+        plugin.unloadModel()
+        modelState = plugin.modelState
+        downloadProgress = plugin.currentDownloadProgress
+    }
+
+    private func removeDownloadedModel(_ modelDef: Gemma4ModelDef) {
+        loadTask?.cancel()
+        loadTask = nil
+        isPolling = false
+        Task {
+            try? await plugin.deleteDownloadedModel(modelDef.id)
+            await MainActor.run {
+                if selectedModelId == modelDef.id {
+                    selectedModelId = plugin.selectedLLMModelId ?? Gemma4Plugin.availableModels.first?.id ?? ""
+                }
+                modelState = plugin.modelState
+                downloadProgress = plugin.currentDownloadProgress
+            }
+        }
     }
 
     private func startLoading(_ modelDef: Gemma4ModelDef) {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings
@@ -65,6 +65,22 @@
         }
       }
     },
+    "Downloading or preparing %@ has not made progress for several minutes. Cancel, delete the cached model if one is shown, and try again. Adding an optional HuggingFace token may also help if Hugging Face is throttling downloads.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Laden oder Vorbereiten von %@ gab es mehrere Minuten keinen Fortschritt. Breche ab, lösche das zwischengespeicherte Modell, falls es angezeigt wird, und versuche es erneut. Ein optionaler HuggingFace-Token kann ebenfalls helfen, wenn Hugging Face Downloads drosselt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のダウンロードまたは準備が数分間進んでいません。キャンセルし、表示されている場合はキャッシュされたモデルを削除してから再試行してください。Hugging Face のダウンロードが制限されている場合は、オプションの HuggingFace トークンも役立つことがあります。"
+          }
+        }
+      }
+    },
     "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again.": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.0.1",
-    "minHostVersion": "1.4.0",
+    "version": "1.1.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [
         "arm64"

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -539,6 +539,26 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.modelState, .notLoaded)
     }
 
+    func testGemma4RestoreClearsStaleLoadedModelWhenDownloadsAreDisabled() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let modelDirectory = gemmaModelDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writePartialGemmaCache(at: modelDirectory)
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: ["loadedModel": model.id]
+        )
+        let plugin = Gemma4Plugin()
+        plugin.activate(host: host)
+
+        await plugin.restoreLoadedModel(allowDownloads: false)
+
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+    }
+
     func testGemma4CancelModelLoadResetsProgressAndState() throws {
         let plugin = Gemma4Plugin()
         let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
@@ -592,7 +612,7 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertFalse(plugin.downloadedModels.contains { $0.id == model.id })
     }
 
-    func testGemma4HubCacheOnlyIsNotDownloadedButCanBeRemoved() throws {
+    func testGemma4HubCacheOnlyIsNotDownloadedButCanBeRemoved() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
@@ -607,6 +627,11 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertTrue(plugin.hasCachedModelFiles(model))
         XCTAssertFalse(plugin.isModelDownloaded(model))
         XCTAssertFalse(plugin.downloadedModels.contains { $0.id == model.id })
+
+        try await plugin.deleteDownloadedModel(model.id)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hubCacheDirectory.path))
+        XCTAssertFalse(plugin.hasCachedModelFiles(model))
     }
 
     func testGemma4ValidMinimalCacheIsTreatedAsDownloaded() throws {
@@ -636,7 +661,12 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
 
         plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
-        try await Task.sleep(for: .milliseconds(80))
+        try await waitUntil("Gemma 4 timeout error") {
+            if case .error = plugin.modelState {
+                return true
+            }
+            return false
+        }
 
         guard case .error(let message) = plugin.modelState else {
             return XCTFail("Expected Gemma 4 load timeout to set an error state")
@@ -663,11 +693,10 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
 
         plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
-        plugin.beginModelLoad(for: model, isAlreadyDownloaded: false)
-        plugin.startModelLoadTimeoutForTesting(modelName: model.displayName)
+        let generation = plugin.startModelLoadTimeoutForTesting(modelName: model.displayName)
         plugin.cancelModelLoad()
-        try await Task.sleep(for: .milliseconds(80))
 
+        XCTAssertFalse(plugin.isCurrentModelLoadForTesting(generation))
         XCTAssertEqual(plugin.modelState, .notLoaded)
         XCTAssertEqual(plugin.currentDownloadProgress, 0)
     }
@@ -749,13 +778,14 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         try FileManager.default.createDirectory(at: hubLockDirectory, withIntermediateDirectories: true)
 
         plugin.activate(host: host)
-        try await Task.sleep(nanoseconds: 10_000_000)
         host.setUserDefault(model.id, forKey: "loadedModel")
         plugin.beginModelLoad(for: model, isAlreadyDownloaded: true)
 
         plugin.resetCachedModel(model)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hubCacheDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hubLockDirectory.path))
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
         XCTAssertEqual(plugin.modelState, .notLoaded)
         XCTAssertEqual(plugin.currentDownloadProgress, 0)
@@ -818,6 +848,26 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertNil(host.userDefault(forKey: "selectedLLMModel"))
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    private struct WaitUntilTimeout: Error {}
+
+    private func waitUntil(
+        _ description: String,
+        timeout: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(5),
+        condition: @escaping () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while !condition() {
+            guard clock.now < deadline else {
+                XCTFail("Timed out waiting for \(description)")
+                throw WaitUntilTimeout()
+            }
+            try await Task.sleep(for: pollInterval)
+        }
     }
 
     private func gemmaModelDirectory(appSupportDirectory: URL, model: Gemma4ModelDef) -> URL {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -695,6 +695,7 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
         let generation = plugin.startModelLoadTimeoutForTesting(modelName: model.displayName)
         plugin.cancelModelLoad()
+        try await Task.sleep(for: .milliseconds(40))
 
         XCTAssertFalse(plugin.isCurrentModelLoadForTesting(generation))
         XCTAssertEqual(plugin.modelState, .notLoaded)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -105,7 +105,6 @@ final class PluginManifestValidationTests: XCTestCase {
 
     func testDownloadedModelManagingPluginReleasesRequireHost14() throws {
         let manifestPaths = [
-            "TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json",
             "TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json",
             "TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json",
             "TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json",
@@ -118,6 +117,14 @@ final class PluginManifestValidationTests: XCTestCase {
             let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
             XCTAssertEqual(manifest.minHostVersion, "1.4.0", relativePath)
         }
+    }
+
+    func testGemma4PluginReleaseRequiresHost15() throws {
+        let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json")
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
     }
 
     func testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement() throws {
@@ -544,6 +551,127 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.selectedLLMModelId, model.id)
     }
 
+    func testGemma4DownloadActivityIsIndeterminateUntilVisibleProgress() throws {
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+
+        plugin.beginModelLoad(for: model, isAlreadyDownloaded: false)
+
+        let activity = try XCTUnwrap(plugin.currentSettingsActivity)
+        XCTAssertEqual(activity.message, "Downloading model")
+        XCTAssertNil(activity.progress)
+        XCTAssertFalse(plugin.hasVisibleDownloadProgress)
+    }
+
+    func testGemma4DownloadActivityReportsVisibleProgress() throws {
+        let plugin = Gemma4Plugin()
+        let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E2B")
+
+        plugin.recordModelLoadProgressForTesting(fraction: 0.5, generation: generation)
+
+        let activity = try XCTUnwrap(plugin.currentSettingsActivity)
+        XCTAssertEqual(activity.message, "Downloading model")
+        XCTAssertEqual(activity.progress ?? 0, 0.39, accuracy: 0.001)
+        XCTAssertTrue(plugin.hasVisibleDownloadProgress)
+    }
+
+    func testGemma4PartialCacheIsNotTreatedAsDownloaded() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let modelDirectory = gemmaModelDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writePartialGemmaCache(at: modelDirectory)
+
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.hasCachedModelFiles(model))
+        XCTAssertFalse(plugin.isModelDownloaded(model))
+        XCTAssertFalse(plugin.downloadedModels.contains { $0.id == model.id })
+    }
+
+    func testGemma4HubCacheOnlyIsNotDownloadedButCanBeRemoved() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let hubCacheDirectory = gemmaHubCacheDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writeHubGemmaCache(at: hubCacheDirectory)
+
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.hasCachedModelFiles(model))
+        XCTAssertFalse(plugin.isModelDownloaded(model))
+        XCTAssertFalse(plugin.downloadedModels.contains { $0.id == model.id })
+    }
+
+    func testGemma4ValidMinimalCacheIsTreatedAsDownloaded() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e4b-it-4bit"))
+        let modelDirectory = gemmaModelDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writeUsableGemmaCache(at: modelDirectory)
+
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.hasCachedModelFiles(model))
+        XCTAssertTrue(plugin.isModelDownloaded(model))
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+    }
+
+    func testGemma4ModelLoadTimeoutSetsErrorAndResetsProgress() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        plugin.activate(host: host)
+        plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
+
+        plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
+        try await Task.sleep(for: .milliseconds(80))
+
+        guard case .error(let message) = plugin.modelState else {
+            return XCTFail("Expected Gemma 4 load timeout to set an error state")
+        }
+        XCTAssertTrue(message.contains("Gemma 4 E4B"))
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    func testGemma4LateProgressFromInvalidatedLoadIsIgnored() throws {
+        let plugin = Gemma4Plugin()
+        let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
+
+        plugin.invalidateModelLoadForTesting()
+        plugin.recordModelLoadProgressForTesting(fraction: 1.0, generation: generation)
+
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+        XCTAssertEqual(plugin.modelState, .downloading)
+    }
+
+    func testGemma4CancelInvalidatesPendingTimeout() async throws {
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+
+        plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
+        plugin.beginModelLoad(for: model, isAlreadyDownloaded: false)
+        plugin.startModelLoadTimeoutForTesting(modelName: model.displayName)
+        plugin.cancelModelLoad()
+        try await Task.sleep(for: .milliseconds(80))
+
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+    }
+
     func testGemma4UnsupportedModelTypeErrorsUseFriendlyMessage() throws {
         let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-26b-a4b-it-4bit"))
         let error = NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Model type gemma4 not supported"])
@@ -614,8 +742,11 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         let modelDirectory = appSupportDirectory
             .appendingPathComponent("models", isDirectory: true)
             .appendingPathComponent(model.repoId, isDirectory: true)
-        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
-        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+        let hubCacheDirectory = gemmaHubCacheDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        let hubLockDirectory = gemmaHubLockDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writeUsableGemmaCache(at: modelDirectory)
+        try writeHubGemmaCache(at: hubCacheDirectory)
+        try FileManager.default.createDirectory(at: hubLockDirectory, withIntermediateDirectories: true)
 
         plugin.activate(host: host)
         try await Task.sleep(nanoseconds: 10_000_000)
@@ -631,6 +762,30 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 2)
     }
 
+    func testGemma4UnloadModelPreservesDownloadedCache() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let modelDirectory = gemmaModelDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writeUsableGemmaCache(at: modelDirectory)
+
+        plugin.activate(host: host)
+        try await Task.sleep(nanoseconds: 10_000_000)
+        host.setUserDefault(model.id, forKey: "loadedModel")
+        plugin.beginModelLoad(for: model, isAlreadyDownloaded: true)
+
+        plugin.unloadModel()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertTrue(plugin.isModelDownloaded(model))
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+    }
+
     func testGemma4DeleteDownloadedModelClearsSelectionAndCache() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -641,11 +796,12 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
             defaults: ["selectedLLMModel": model.id]
         )
         let plugin = Gemma4Plugin()
-        let modelDirectory = appSupportDirectory
-            .appendingPathComponent("models", isDirectory: true)
-            .appendingPathComponent(model.repoId, isDirectory: true)
-        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
-        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+        let modelDirectory = gemmaModelDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        let hubCacheDirectory = gemmaHubCacheDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        let hubLockDirectory = gemmaHubLockDirectory(appSupportDirectory: appSupportDirectory, model: model)
+        try writeUsableGemmaCache(at: modelDirectory)
+        try writeHubGemmaCache(at: hubCacheDirectory)
+        try FileManager.default.createDirectory(at: hubLockDirectory, withIntermediateDirectories: true)
 
         plugin.activate(host: host)
         try await Task.sleep(nanoseconds: 10_000_000)
@@ -656,10 +812,51 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         try await plugin.deleteDownloadedModel(model.id)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hubCacheDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hubLockDirectory.path))
         XCTAssertNil(plugin.selectedLLMModelId)
         XCTAssertNil(host.userDefault(forKey: "selectedLLMModel"))
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    private func gemmaModelDirectory(appSupportDirectory: URL, model: Gemma4ModelDef) -> URL {
+        appSupportDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(model.repoId, isDirectory: true)
+    }
+
+    private func gemmaHubCacheDirectory(appSupportDirectory: URL, model: Gemma4ModelDef) -> URL {
+        appSupportDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("models--" + model.repoId.replacingOccurrences(of: "/", with: "--"), isDirectory: true)
+    }
+
+    private func gemmaHubLockDirectory(appSupportDirectory: URL, model: Gemma4ModelDef) -> URL {
+        appSupportDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(".locks", isDirectory: true)
+            .appendingPathComponent("models--" + model.repoId.replacingOccurrences(of: "/", with: "--"), isDirectory: true)
+    }
+
+    private func writePartialGemmaCache(at modelDirectory: URL) throws {
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+    }
+
+    private func writeUsableGemmaCache(at modelDirectory: URL) throws {
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: modelDirectory.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: modelDirectory.appendingPathComponent("tokenizer.json"))
+        try Data("weights".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+    }
+
+    private func writeHubGemmaCache(at cacheDirectory: URL) throws {
+        let snapshotDirectory = cacheDirectory
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("revision", isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshotDirectory, withIntermediateDirectories: true)
+        try Data("hub weights".utf8).write(to: snapshotDirectory.appendingPathComponent("model.safetensors"))
     }
 
     func testGemma4ValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {


### PR DESCRIPTION
## Summary
- Fixes the Gemma 4 E4B download stall from #705 by adding WhisperKit-style load generation guards and stale callback protection.
- Replaces optimistic cache detection with Gemma-specific usable-cache validation, including config/tokenizer files and safetensors weights.
- Adds model-load watchdog recovery so stalled downloads reset progress and move into an actionable error state instead of sitting at 2% or 0% forever.
- Extends Gemma 4 model management with reliable unload/delete behavior across local model directories, Hugging Face cache folders, and lock folders.
- Raises the Gemma 4 plugin release line to `1.1.0` and requires TypeWhisper `1.5.0+` for this plugin release.

Closes #705

## Issue Context
Issue #705 reports the bundled Gemma 4 E4B 4-bit MLX plugin getting stuck at 2% indefinitely on TypeWhisper 1.4.0, with CPU activity but no network traffic. This PR makes the Gemma 4 loader fail and recover deterministically when a download/load makes no real progress, and avoids treating incomplete cache directories as downloaded models.

## Release Plan
After this lands, publish the official Gemma 4 plugin release as:

- `plugin-gemma4-v1.1.0`
- `plugin_name=gemma4`
- `plugin_version=1.1.0`
- `distribution_source=official`

## Test Plan
- [x] `git diff --check`
- [x] `jq empty TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/PluginManifestValidationTests test`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests test`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run Gemma4Plugin /Users/marco/.codex/worktrees/2a5f/typewhisper-mac`
- [x] Local dev app smoke: `GET /v1/status` returned `status: ready`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer download progress behavior: determinate percent shown only when ready to be visible, otherwise indeterminate.
  * Refined model actions and labels to distinguish fully downloaded models from cached-only models (Load vs. Download & Load), with updated Load/Unload/Remove wiring.
* **Bug Fixes**
  * Strengthened cache validity checks to avoid treating partial caches as downloaded.
  * Improved stalled download timeout handling and reduced stale state after cancellation, unload, or errors.
  * Enhanced cleanup when removing models and recovering from failures.
* **Documentation**
  * Updated localized “stalled download/preparation” guidance message.
* **Chores**
  * Raised Gemma 4 plugin minimum host/SDK compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->