### PR TITLE
Fix local MLX memory footprint control

### DIFF
--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import CryptoKit
+import Darwin
 import Foundation
 import os.log
 import TypeWhisperPluginSDK
@@ -215,6 +216,35 @@ enum PluginDiagnosticsSupport {
     }
 }
 
+private enum DiagnosticProcessMemorySupport {
+    static func snapshot() -> DiagnosticsReport.ProcessMemoryInfo {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundPointer in
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(TASK_VM_INFO),
+                    reboundPointer,
+                    &count
+                )
+            }
+        }
+
+        guard result == KERN_SUCCESS else {
+            return DiagnosticsReport.ProcessMemoryInfo(
+                residentSizeBytes: nil,
+                physicalFootprintBytes: nil
+            )
+        }
+
+        return DiagnosticsReport.ProcessMemoryInfo(
+            residentSizeBytes: UInt64(info.resident_size),
+            physicalFootprintBytes: UInt64(info.phys_footprint)
+        )
+    }
+}
+
 private struct DiagnosticsReport: Encodable {
     struct AppInfo: Encodable {
         let version: String
@@ -256,6 +286,23 @@ private struct DiagnosticsReport: Encodable {
         let remoteAccessAllowed: Bool
     }
 
+    struct ProcessMemoryInfo: Encodable, Equatable {
+        let residentSizeBytes: UInt64?
+        let physicalFootprintBytes: UInt64?
+    }
+
+    struct PluginRuntimeMemoryInfo: Encodable, Equatable {
+        let activeMemoryBytes: Int
+        let cacheMemoryBytes: Int
+        let peakMemoryBytes: Int
+
+        init(_ snapshot: PluginRuntimeMemorySnapshot) {
+            self.activeMemoryBytes = snapshot.activeMemoryBytes
+            self.cacheMemoryBytes = snapshot.cacheMemoryBytes
+            self.peakMemoryBytes = snapshot.peakMemoryBytes
+        }
+    }
+
     struct AudioOutputInfo: Encodable {
         let deviceID: UInt32
         let uid: String?
@@ -292,6 +339,7 @@ private struct DiagnosticsReport: Encodable {
         let storedSelectedVersion: String?
         let source: DiagnosticPluginSourceInfo
         let currentSettingsActivity: DiagnosticPluginActivityInfo?
+        let runtimeMemory: PluginRuntimeMemoryInfo?
         let registryVersion: String?
         let registrySource: String?
         let externalBundleNotice: String?
@@ -364,6 +412,9 @@ private struct DiagnosticsReport: Encodable {
     let permissions: PermissionsInfo
     let model: ModelInfo
     let api: APIInfo
+    let processMemory: ProcessMemoryInfo
+    let modelAutoUnload: ModelAutoUnloadDiagnosticsSnapshot
+    let memoryExtraction: MemoryExtractionDiagnosticsSnapshot
     let audio: AudioInfo
     let plugins: [PluginInfo]
     let skippedExternalBundles: [SkippedExternalBundleInfo]
@@ -437,6 +488,7 @@ final class ErrorLogService: ObservableObject {
                 nil
             }
             let activity = (loadedPlugin.instance as? any PluginSettingsActivityReporting)?.currentSettingsActivity
+            let runtimeMemory = (loadedPlugin.instance as? any PluginRuntimeMemoryDiagnosticsReporting)?.runtimeMemorySnapshot
             let registryEntry = container.pluginRegistryService.registry.first { $0.id == loadedPlugin.manifest.id }
             let externalNotice = pluginManager.externalBundleNotice(
                 for: loadedPlugin.manifest.id,
@@ -467,6 +519,7 @@ final class ErrorLogService: ObservableObject {
                 storedSelectedVersion: defaults.string(forKey: Self.pluginDefaultKey(pluginId: loadedPlugin.manifest.id, key: "selectedVersion")),
                 source: pluginSource,
                 currentSettingsActivity: activity.map(DiagnosticPluginActivityInfo.init),
+                runtimeMemory: runtimeMemory.map(DiagnosticsReport.PluginRuntimeMemoryInfo.init),
                 registryVersion: registryEntry?.version,
                 registrySource: registryEntry?.source.rawValue,
                 externalBundleNotice: externalNotice?.diagnosticsValue
@@ -499,7 +552,7 @@ final class ErrorLogService: ObservableObject {
         }
 
         return DiagnosticsReport(
-            schemaVersion: 6,
+            schemaVersion: 7,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,
@@ -538,6 +591,9 @@ final class ErrorLogService: ObservableObject {
                 loopbackOnly: true,
                 remoteAccessAllowed: false
             ),
+            processMemory: DiagnosticProcessMemorySupport.snapshot(),
+            modelAutoUnload: container.modelManagerService.autoUnloadDiagnosticsSnapshot(),
+            memoryExtraction: container.memoryService.extractionDiagnosticsSnapshot(),
             audio: .init(
                 selectedInputDeviceUID: defaults.string(forKey: UserDefaultsKeys.selectedInputDeviceUID),
                 selectedInputDeviceName: container.audioDeviceService.selectedDevice?.name,

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -292,11 +292,13 @@ private struct DiagnosticsReport: Encodable {
     }
 
     struct PluginRuntimeMemoryInfo: Encodable, Equatable {
+        let runtimeIdentifier: String
         let activeMemoryBytes: Int
         let cacheMemoryBytes: Int
         let peakMemoryBytes: Int
 
         init(_ snapshot: PluginRuntimeMemorySnapshot) {
+            self.runtimeIdentifier = snapshot.runtimeIdentifier
             self.activeMemoryBytes = snapshot.activeMemoryBytes
             self.cacheMemoryBytes = snapshot.cacheMemoryBytes
             self.peakMemoryBytes = snapshot.peakMemoryBytes

--- a/TypeWhisper/Services/MemoryService.swift
+++ b/TypeWhisper/Services/MemoryService.swift
@@ -108,6 +108,7 @@ Return ONLY the JSON array, nothing else.
     private var lastExtractionTime: Date = .distantPast
     private var extractionCooldown: TimeInterval = 30
     private var extractionTask: Task<Void, Never>?
+    private var activeExtractionID: UUID?
     private var skippedWhileBusy = 0
     private var totalStarted = 0
     private var totalCompleted = 0
@@ -160,6 +161,7 @@ Return ONLY the JSON array, nothing else.
             eventSubscriptionId = nil
         }
         extractionTask?.cancel()
+        activeExtractionID = nil
         extractionTask = nil
     }
 
@@ -212,23 +214,26 @@ Return ONLY the JSON array, nothing else.
         // Capture all MainActor properties before detaching
         let prompt = extractionPrompt
         let model = extractionModel
+        let extractionID = UUID()
+        activeExtractionID = extractionID
 
         extractionTask = Task { [weak self] in
             guard let self else { return }
             do {
                 try Task.checkCancellation()
                 try await self.extractAndStore(payload: payload, providerId: providerId, prompt: prompt, model: model)
-                self.finishExtraction(didFail: false)
+                self.finishExtraction(extractionID: extractionID, didFail: false)
             } catch is CancellationError {
-                self.finishExtraction(didFail: false)
+                self.finishExtraction(extractionID: extractionID, didFail: false)
             } catch {
-                self.finishExtraction(didFail: true)
+                self.finishExtraction(extractionID: extractionID, didFail: true)
                 logger.error("Memory extraction failed: \(error.localizedDescription)")
             }
         }
     }
 
-    private func finishExtraction(didFail: Bool) {
+    private func finishExtraction(extractionID: UUID, didFail: Bool) {
+        guard activeExtractionID == extractionID else { return }
         if didFail {
             totalFailed += 1
         } else {
@@ -236,6 +241,7 @@ Return ONLY the JSON array, nothing else.
         }
         lastFinishedAt = Date()
         extractionTask = nil
+        activeExtractionID = nil
     }
 
     private func extractAndStore(payload: TranscriptionCompletedPayload, providerId: String, prompt: String, model: String) async throws {
@@ -245,6 +251,7 @@ Return ONLY the JSON array, nothing else.
             providerId,
             model.isEmpty ? nil : model
         )
+        try Task.checkCancellation()
 
         let entries = parseExtractedMemories(result, source: MemorySource(
             appName: payload.appName,
@@ -264,6 +271,7 @@ Return ONLY the JSON array, nothing else.
         }
 
         let deduped = await deduplicate(entries: entries, using: plugins)
+        try Task.checkCancellation()
         guard !deduped.isEmpty else {
             logger.info("Memory extraction produced only duplicate entries")
             return
@@ -271,6 +279,7 @@ Return ONLY the JSON array, nothing else.
 
         var storedInReadyPlugin = false
         for plugin in plugins where plugin.isReady {
+            try Task.checkCancellation()
             do {
                 try await plugin.store(deduped)
                 storedInReadyPlugin = true

--- a/TypeWhisper/Services/MemoryService.swift
+++ b/TypeWhisper/Services/MemoryService.swift
@@ -39,6 +39,23 @@ enum MemoryCaptureScope: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
+struct MemoryExtractionDiagnosticsSnapshot: Encodable, Equatable, Sendable {
+    let inFlight: Bool
+    let skippedWhileBusy: Int
+    let totalStarted: Int
+    let totalCompleted: Int
+    let totalFailed: Int
+    let lastStartedAt: Date?
+    let lastFinishedAt: Date?
+}
+
+typealias MemoryExtractionPromptProcessor = @MainActor (
+    _ prompt: String,
+    _ text: String,
+    _ providerId: String,
+    _ model: String?
+) async throws -> String
+
 @MainActor
 final class MemoryService: ObservableObject, MemoryRetrieving {
     nonisolated static let rawMemoryTypeMetadataKey = "rawMemoryType"
@@ -85,18 +102,36 @@ Return ONLY the JSON array, nothing else.
 """
 
     private let promptProcessingService: PromptProcessingService
+    private let promptProcessor: MemoryExtractionPromptProcessor
     private let workflowNameProvider: @MainActor () -> [String]
     private var eventSubscriptionId: UUID?
     private var lastExtractionTime: Date = .distantPast
-    private let extractionCooldown: TimeInterval = 30
+    private var extractionCooldown: TimeInterval = 30
+    private var extractionTask: Task<Void, Never>?
+    private var skippedWhileBusy = 0
+    private var totalStarted = 0
+    private var totalCompleted = 0
+    private var totalFailed = 0
+    private var lastStartedAt: Date?
+    private var lastFinishedAt: Date?
 
     init(
         promptProcessingService: PromptProcessingService,
+        promptProcessor: MemoryExtractionPromptProcessor? = nil,
         workflowNameProvider: @escaping @MainActor () -> [String] = {
             ServiceContainer.shared.workflowService.workflows.map(\.name)
         }
     ) {
         self.promptProcessingService = promptProcessingService
+        self.promptProcessor = promptProcessor ?? { prompt, text, providerId, model in
+            try await promptProcessingService.process(
+                prompt: prompt,
+                text: text,
+                providerOverride: providerId,
+                cloudModelOverride: model,
+                skipMemoryInjection: true
+            )
+        }
         self.workflowNameProvider = workflowNameProvider
         self.isEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.memoryEnabled)
         self.extractionProviderId = UserDefaults.standard.string(forKey: UserDefaultsKeys.memoryExtractionProvider) ?? ""
@@ -124,6 +159,8 @@ Return ONLY the JSON array, nothing else.
             EventBus.shared.unsubscribe(id: id)
             eventSubscriptionId = nil
         }
+        extractionTask?.cancel()
+        extractionTask = nil
     }
 
     // MARK: - Extraction
@@ -159,32 +196,54 @@ Return ONLY the JSON array, nothing else.
         let providerId = extractionProviderId
         guard !providerId.isEmpty else { return }
 
+        if extractionTask != nil {
+            skippedWhileBusy += 1
+            logger.info("Memory extraction skipped because a previous extraction is still running")
+            return
+        }
+
         // Cooldown
         let now = Date()
         guard now.timeIntervalSince(lastExtractionTime) >= extractionCooldown else { return }
         lastExtractionTime = now
+        totalStarted += 1
+        lastStartedAt = now
 
         // Capture all MainActor properties before detaching
         let prompt = extractionPrompt
         let model = extractionModel
 
-        Task { [weak self] in
+        extractionTask = Task { [weak self] in
             guard let self else { return }
             do {
+                try Task.checkCancellation()
                 try await self.extractAndStore(payload: payload, providerId: providerId, prompt: prompt, model: model)
+                self.finishExtraction(didFail: false)
+            } catch is CancellationError {
+                self.finishExtraction(didFail: false)
             } catch {
+                self.finishExtraction(didFail: true)
                 logger.error("Memory extraction failed: \(error.localizedDescription)")
             }
         }
     }
 
+    private func finishExtraction(didFail: Bool) {
+        if didFail {
+            totalFailed += 1
+        } else {
+            totalCompleted += 1
+        }
+        lastFinishedAt = Date()
+        extractionTask = nil
+    }
+
     private func extractAndStore(payload: TranscriptionCompletedPayload, providerId: String, prompt: String, model: String) async throws {
-        let result = try await promptProcessingService.process(
-            prompt: prompt,
-            text: payload.finalText,
-            providerOverride: providerId,
-            cloudModelOverride: model.isEmpty ? nil : model,
-            skipMemoryInjection: true
+        let result = try await promptProcessor(
+            prompt,
+            payload.finalText,
+            providerId,
+            model.isEmpty ? nil : model
         )
 
         let entries = parseExtractedMemories(result, source: MemorySource(
@@ -262,6 +321,28 @@ Return ONLY the JSON array, nothing else.
             return MemoryEntry(content: item.content, type: type, source: source, metadata: metadata, confidence: conf)
         }
     }
+
+    func extractionDiagnosticsSnapshot() -> MemoryExtractionDiagnosticsSnapshot {
+        MemoryExtractionDiagnosticsSnapshot(
+            inFlight: extractionTask != nil,
+            skippedWhileBusy: skippedWhileBusy,
+            totalStarted: totalStarted,
+            totalCompleted: totalCompleted,
+            totalFailed: totalFailed,
+            lastStartedAt: lastStartedAt,
+            lastFinishedAt: lastFinishedAt
+        )
+    }
+
+    #if DEBUG
+    func handleTranscriptionForTesting(_ payload: TranscriptionCompletedPayload) {
+        handleTranscription(payload)
+    }
+
+    func setExtractionCooldownForTesting(_ cooldown: TimeInterval) {
+        extractionCooldown = cooldown
+    }
+    #endif
 
     // MARK: - Deduplication
 

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -766,7 +766,9 @@ final class ModelManagerService: ObservableObject {
             scheduleAutoUnloadIfNeeded(for: plugin, scheduledKeys: &scheduledKeys)
         }
 
-        let existingKeys = Set(autoUnloadTasks.keys).union(autoUnloadTargets.keys)
+        let existingKeys = Set(autoUnloadTasks.keys)
+            .union(autoUnloadTargets.keys)
+            .union(autoUnloadDiagnostics.keys)
         for key in existingKeys.subtracting(scheduledKeys) {
             autoUnloadTasks[key]?.cancel()
             autoUnloadTasks[key] = nil

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -58,6 +58,22 @@ enum ModelAutoUnloadPolicy {
     }
 }
 
+struct ModelAutoUnloadDiagnosticsSnapshot: Encodable, Equatable, Sendable {
+    struct Entry: Encodable, Equatable, Sendable {
+        let pluginClassName: String
+        let pluginObjectIdentifier: String
+        let policySeconds: Int
+        let scheduledAt: Date?
+        let dueAt: Date?
+        let lastFiredAt: Date?
+        let lastSelectorResponded: Bool?
+    }
+
+    let policySeconds: Int
+    let policyName: String
+    let entries: [Entry]
+}
+
 @MainActor
 final class ModelManagerService: ObservableObject {
     struct LiveTranscriptionSessionHandle: Sendable {
@@ -87,6 +103,7 @@ final class ModelManagerService: ObservableObject {
 
     private var autoUnloadTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     private var autoUnloadTargets: [ObjectIdentifier: AutoUnloadTarget] = [:]
+    private var autoUnloadDiagnostics: [ObjectIdentifier: ModelAutoUnloadDiagnosticsSnapshot.Entry] = [:]
     private var cancellables = Set<AnyCancellable>()
 
     private let providerKey = UserDefaultsKeys.selectedEngine
@@ -754,6 +771,7 @@ final class ModelManagerService: ObservableObject {
             autoUnloadTasks[key]?.cancel()
             autoUnloadTasks[key] = nil
             autoUnloadTargets[key] = nil
+            autoUnloadDiagnostics[key] = nil
         }
     }
 
@@ -788,10 +806,24 @@ final class ModelManagerService: ObservableObject {
         autoUnloadTasks[key]?.cancel()
         autoUnloadTasks[key] = nil
         autoUnloadTargets[key] = nil
+        autoUnloadDiagnostics[key] = nil
 
         let seconds = autoUnloadSeconds
         guard seconds != 0 else { return }
 
+        let scheduledAt = Date()
+        let dueAt = seconds == -1
+            ? scheduledAt.addingTimeInterval(0.1)
+            : scheduledAt.addingTimeInterval(TimeInterval(seconds))
+        autoUnloadDiagnostics[key] = ModelAutoUnloadDiagnosticsSnapshot.Entry(
+            pluginClassName: String(describing: type(of: nsPlugin)),
+            pluginObjectIdentifier: Self.diagnosticIdentifier(for: key),
+            policySeconds: seconds,
+            scheduledAt: scheduledAt,
+            dueAt: dueAt,
+            lastFiredAt: nil,
+            lastSelectorResponded: nil
+        )
         autoUnloadTargets[key] = AutoUnloadTarget(plugin: nsPlugin)
         autoUnloadTasks[key] = Task { [weak self] in
             if seconds == -1 {
@@ -812,6 +844,7 @@ final class ModelManagerService: ObservableObject {
         }
         autoUnloadTasks.removeAll()
         autoUnloadTargets.removeAll()
+        autoUnloadDiagnostics.removeAll()
     }
 
     private func performAutoUnload(for key: ObjectIdentifier) {
@@ -820,10 +853,49 @@ final class ModelManagerService: ObservableObject {
             autoUnloadTargets[key] = nil
         }
 
-        guard let nsPlugin = autoUnloadTargets[key]?.plugin else { return }
+        guard let nsPlugin = autoUnloadTargets[key]?.plugin else {
+            recordAutoUnloadFired(for: key, plugin: nil, selectorResponded: false)
+            return
+        }
         let sel = NSSelectorFromString("triggerAutoUnload")
-        guard nsPlugin.responds(to: sel) else { return }
+        let selectorResponded = nsPlugin.responds(to: sel)
+        recordAutoUnloadFired(for: key, plugin: nsPlugin, selectorResponded: selectorResponded)
+        guard selectorResponded else { return }
         nsPlugin.perform(sel)
+    }
+
+    private func recordAutoUnloadFired(
+        for key: ObjectIdentifier,
+        plugin: NSObject?,
+        selectorResponded: Bool
+    ) {
+        let previous = autoUnloadDiagnostics[key]
+        autoUnloadDiagnostics[key] = ModelAutoUnloadDiagnosticsSnapshot.Entry(
+            pluginClassName: plugin.map { String(describing: type(of: $0)) } ?? previous?.pluginClassName ?? "unknown",
+            pluginObjectIdentifier: previous?.pluginObjectIdentifier ?? Self.diagnosticIdentifier(for: key),
+            policySeconds: previous?.policySeconds ?? autoUnloadSeconds,
+            scheduledAt: nil,
+            dueAt: nil,
+            lastFiredAt: Date(),
+            lastSelectorResponded: selectorResponded
+        )
+    }
+
+    func autoUnloadDiagnosticsSnapshot() -> ModelAutoUnloadDiagnosticsSnapshot {
+        ModelAutoUnloadDiagnosticsSnapshot(
+            policySeconds: autoUnloadSeconds,
+            policyName: ModelAutoUnloadPolicy.policyName(seconds: autoUnloadSeconds),
+            entries: autoUnloadDiagnostics.values.sorted {
+                if $0.pluginClassName == $1.pluginClassName {
+                    return $0.pluginObjectIdentifier < $1.pluginObjectIdentifier
+                }
+                return $0.pluginClassName < $1.pluginClassName
+            }
+        )
+    }
+
+    private static func diagnosticIdentifier(for key: ObjectIdentifier) -> String {
+        String(describing: key)
     }
 
     private func runtimeLanguageSelection(

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -127,6 +127,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     private var lastModelLoadProgressInstant = ContinuousClock().now
     private var lastModelLoadProgressFraction = 0.0
     private var activeModelLoadTask: (generation: Int, task: Task<ModelContainer, Error>)?
+    private var restoreModelTask: Task<Void, Never>?
 
     private func modelsDirectory() -> URL {
         host?.pluginDataDirectory.appendingPathComponent("models")
@@ -174,8 +175,17 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         }
 
         let persistedLoadedModel = host.userDefault(forKey: "loadedModel") as? String
-        if let persistedLoadedModel, !Self.canRestoreLoadedModel(persistedLoadedModel) {
-            host.setUserDefault(nil, forKey: "loadedModel")
+        let shouldAutoRestoreLoadedModel: Bool
+        if let persistedLoadedModel {
+            if Self.canRestoreLoadedModel(persistedLoadedModel),
+               let modelDef = Self.modelDefinition(for: persistedLoadedModel) {
+                shouldAutoRestoreLoadedModel = isModelDownloaded(modelDef)
+            } else {
+                host.setUserDefault(nil, forKey: "loadedModel")
+                shouldAutoRestoreLoadedModel = false
+            }
+        } else {
+            shouldAutoRestoreLoadedModel = false
         }
 
         _generationTemperature = host.userDefault(forKey: "generationTemperature") as? Double
@@ -184,7 +194,14 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             ?? PluginLLMTemperatureMode.custom.rawValue
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
-        Task { await restoreLoadedModel(allowDownloads: false) }
+        restoreModelTask?.cancel()
+        if shouldAutoRestoreLoadedModel {
+            restoreModelTask = Task { [weak self] in
+                await self?.restoreLoadedModel(allowDownloads: false)
+            }
+        } else {
+            restoreModelTask = nil
+        }
     }
 
     func deactivate() {
@@ -193,7 +210,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         loadedModelId = nil
         downloadProgress = 0
         modelState = .notLoaded
-        Self.clearRuntimeCache()
+        Self.scheduleRuntimeCacheClearWhenInferenceIsIdle()
         host = nil
     }
 
@@ -234,7 +251,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             loadedModelId = nil
             downloadProgress = 0
             modelState = .notLoaded
-            Self.clearRuntimeCache()
+            await Self.clearRuntimeCacheWhenInferenceIsIdle()
         }
         if _selectedLLMModelId == modelId {
             _selectedLLMModelId = nil
@@ -524,7 +541,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         loadedModelId = nil
         downloadProgress = 0
         modelState = .notLoaded
-        Self.clearRuntimeCache()
+        Self.scheduleRuntimeCacheClearWhenInferenceIsIdle()
         if clearPersistence {
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
@@ -551,7 +568,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         loadedModelId = nil
         downloadProgress = 0
         modelState = .notLoaded
-        Self.clearRuntimeCache()
+        Self.scheduleRuntimeCacheClearWhenInferenceIsIdle()
         host?.setUserDefault(nil, forKey: "loadedModel")
         try? deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
@@ -559,6 +576,18 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     private static func clearRuntimeCache() {
         Memory.clearCache()
+    }
+
+    private static func clearRuntimeCacheWhenInferenceIsIdle() async {
+        try? await PluginLocalInferenceGate.shared.withLock {
+            Memory.clearCache()
+        }
+    }
+
+    private static func scheduleRuntimeCacheClearWhenInferenceIsIdle() {
+        Task {
+            await clearRuntimeCacheWhenInferenceIsIdle()
+        }
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -584,6 +613,8 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     private func invalidateModelLoad() {
         modelLoadGeneration += 1
+        restoreModelTask?.cancel()
+        restoreModelTask = nil
         activeModelLoadTask?.task.cancel()
         activeModelLoadTask = nil
     }

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import MLX
 import MLXVLM
 import MLXLMCommon
 import HuggingFace
@@ -90,7 +91,7 @@ private struct Gemma4TokenizerLoader: TokenizerLoader {
 // MARK: - Plugin Entry Point
 
 @objc(Gemma4Plugin)
-final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PluginRuntimeMemoryDiagnosticsReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gemma4"
     static let pluginName = "Gemma 4"
     static let defaultGenerationTemperature = 0.1
@@ -192,6 +193,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         loadedModelId = nil
         downloadProgress = 0
         modelState = .notLoaded
+        Self.clearRuntimeCache()
         host = nil
     }
 
@@ -232,6 +234,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             loadedModelId = nil
             downloadProgress = 0
             modelState = .notLoaded
+            Self.clearRuntimeCache()
         }
         if _selectedLLMModelId == modelId {
             _selectedLLMModelId = nil
@@ -260,48 +263,52 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         model: String?,
         temperatureDirective: PluginLLMTemperatureDirective
     ) async throws -> String {
-        guard let modelContainer else {
-            throw PluginChatError.notConfigured
-        }
-
         let trimmedUserText = userText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedUserText.isEmpty else {
             throw Gemma4PluginError.noInputText
         }
 
-        let combinedPrompt = """
-        Follow these instructions exactly:
-        \(systemPrompt)
-
-        Input text:
-        \(trimmedUserText)
-        """
-
-        let chat: [Chat.Message] = [
-            .user(combinedPrompt),
-        ]
-        let userInput = UserInput(chat: chat)
-        let input = try await modelContainer.prepare(input: userInput)
         let resolvedTemperature = providerTemperatureDirective
             .resolvedTemperature(applying: temperatureDirective) ?? Self.defaultGenerationTemperature
 
-        let parameters = Self.promptGenerationParameters(
-            temperature: resolvedTemperature,
-            modelId: model ?? loadedModelId
-        )
-
-        let stream = try await modelContainer.generate(input: input, parameters: parameters)
-        var result = ""
-        for await generation in stream {
-            switch generation {
-            case .chunk(let text):
-                result += text
-            case .info, .toolCall:
-                break
+        return try await PluginLocalInferenceGate.shared.withLock { [self] in
+            guard let modelContainer else {
+                throw PluginChatError.notConfigured
             }
-        }
+            defer { Self.clearRuntimeCache() }
 
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+            let combinedPrompt = """
+            Follow these instructions exactly:
+            \(systemPrompt)
+
+            Input text:
+            \(trimmedUserText)
+            """
+
+            let chat: [Chat.Message] = [
+                .user(combinedPrompt),
+            ]
+            let userInput = UserInput(chat: chat)
+            let input = try await modelContainer.prepare(input: userInput)
+
+            let parameters = Self.promptGenerationParameters(
+                temperature: resolvedTemperature,
+                modelId: model ?? loadedModelId
+            )
+
+            let stream = try await modelContainer.generate(input: input, parameters: parameters)
+            var result = ""
+            for await generation in stream {
+                switch generation {
+                case .chunk(let text):
+                    result += text
+                case .info, .toolCall:
+                    break
+                }
+            }
+
+            return result.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 
     // MARK: - LLMModelSelectable
@@ -345,6 +352,15 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         return String(
             localized: "Load a Gemma 4 model in Integrations before using it for prompts.",
             bundle: bundle
+        )
+    }
+
+    var runtimeMemorySnapshot: PluginRuntimeMemorySnapshot? {
+        let snapshot = Memory.snapshot()
+        return PluginRuntimeMemorySnapshot(
+            activeMemoryBytes: snapshot.activeMemory,
+            cacheMemoryBytes: snapshot.cacheMemory,
+            peakMemoryBytes: snapshot.peakMemory
         )
     }
 
@@ -508,6 +524,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         loadedModelId = nil
         downloadProgress = 0
         modelState = .notLoaded
+        Self.clearRuntimeCache()
         if clearPersistence {
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
@@ -534,9 +551,14 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         loadedModelId = nil
         downloadProgress = 0
         modelState = .notLoaded
+        Self.clearRuntimeCache()
         host?.setUserDefault(nil, forKey: "loadedModel")
         try? deleteModelFiles(modelDef)
         host?.notifyCapabilitiesChanged()
+    }
+
+    private static func clearRuntimeCache() {
+        Memory.clearCache()
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PluginRuntimeMemoryDiagnosticsReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 
@@ -54,6 +54,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
+        Self.clearRuntimeCache()
         host = nil
     }
 
@@ -137,58 +138,61 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        guard let model else {
-            throw PluginTranscriptionError.notConfigured
-        }
+        try await PluginLocalInferenceGate.shared.withLock { [self] in
+            guard let model else {
+                throw PluginTranscriptionError.notConfigured
+            }
+            defer { Self.clearRuntimeCache() }
 
-        let audioArray = MLXArray(audio.samples)
-        let languageName = Self.resolveLanguageName(language)
-        let context = Self.contextBiasString(from: prompt)
+            let audioArray = MLXArray(audio.samples)
+            let languageName = Self.resolveLanguageName(language)
+            let context = Self.contextBiasString(from: prompt)
 
-        let primaryOutput = Self.generate(
-            model: model,
-            audio: audioArray,
-            params: Self.primaryParams,
-            context: context,
-            language: languageName
-        )
-        let primaryText = Self.normalizeTranscript(primaryOutput.text)
-        let text: String
-        let outputLanguageName: String?
-
-        if QwenTranscriptGuard.isLikelyLooped(primaryText) {
-            let fallbackOutput = Self.generate(
+            let primaryOutput = Self.generate(
                 model: model,
                 audio: audioArray,
-                params: Self.fallbackParams,
-                context: "",
+                params: Self.primaryParams,
+                context: context,
                 language: languageName
             )
-            let fallbackText = Self.normalizeTranscript(fallbackOutput.text)
+            let primaryText = Self.normalizeTranscript(primaryOutput.text)
+            let text: String
+            let outputLanguageName: String?
 
-            if fallbackText.isEmpty {
+            if QwenTranscriptGuard.isLikelyLooped(primaryText) {
+                let fallbackOutput = Self.generate(
+                    model: model,
+                    audio: audioArray,
+                    params: Self.fallbackParams,
+                    context: "",
+                    language: languageName
+                )
+                let fallbackText = Self.normalizeTranscript(fallbackOutput.text)
+
+                if fallbackText.isEmpty {
+                    text = primaryText
+                    outputLanguageName = primaryOutput.language
+                } else if QwenTranscriptGuard.isLikelyLooped(fallbackText) {
+                    text = QwenTranscriptGuard.preferredTranscript(primary: primaryText, fallback: fallbackText)
+                    outputLanguageName = primaryOutput.language ?? fallbackOutput.language
+                } else {
+                    text = fallbackText
+                    outputLanguageName = fallbackOutput.language
+                }
+            } else {
                 text = primaryText
                 outputLanguageName = primaryOutput.language
-            } else if QwenTranscriptGuard.isLikelyLooped(fallbackText) {
-                text = QwenTranscriptGuard.preferredTranscript(primary: primaryText, fallback: fallbackText)
-                outputLanguageName = primaryOutput.language ?? fallbackOutput.language
-            } else {
-                text = fallbackText
-                outputLanguageName = fallbackOutput.language
             }
-        } else {
-            text = primaryText
-            outputLanguageName = primaryOutput.language
+
+            let resultLanguageName = outputLanguageName ?? languageName
+            let cleanedText = QwenTranscriptGuard.removingLikelyTrailingArtifact(
+                from: text,
+                languageName: resultLanguageName
+            )
+            let detectedLanguage = Self.languageCode(forQwenLanguageName: resultLanguageName) ?? language
+
+            return PluginTranscriptionResult(text: cleanedText, detectedLanguage: detectedLanguage)
         }
-
-        let resultLanguageName = outputLanguageName ?? languageName
-        let cleanedText = QwenTranscriptGuard.removingLikelyTrailingArtifact(
-            from: text,
-            languageName: resultLanguageName
-        )
-        let detectedLanguage = Self.languageCode(forQwenLanguageName: resultLanguageName) ?? language
-
-        return PluginTranscriptionResult(text: cleanedText, detectedLanguage: detectedLanguage)
     }
 
     // MARK: - Model Management
@@ -224,6 +228,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
+        Self.clearRuntimeCache()
         if clearPersistence {
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
@@ -273,6 +278,19 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         case .error(let message):
             return PluginSettingsActivity(message: message, isError: true)
         }
+    }
+
+    var runtimeMemorySnapshot: PluginRuntimeMemorySnapshot? {
+        let snapshot = Memory.snapshot()
+        return PluginRuntimeMemorySnapshot(
+            activeMemoryBytes: snapshot.activeMemory,
+            cacheMemoryBytes: snapshot.cacheMemory,
+            peakMemoryBytes: snapshot.peakMemory
+        )
+    }
+
+    private static func clearRuntimeCache() {
+        Memory.clearCache()
     }
 
     var settingsView: AnyView? {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -54,7 +54,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
-        Self.clearRuntimeCache()
+        Self.scheduleRuntimeCacheClearWhenInferenceIsIdle()
         host = nil
     }
 
@@ -104,7 +104,11 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else { return }
 
         if loadedModelId == modelId {
-            unloadModel(clearPersistence: true)
+            model = nil
+            loadedModelId = nil
+            modelState = .notLoaded
+            host?.setUserDefault(nil, forKey: "loadedModel")
+            await Self.clearRuntimeCacheWhenInferenceIsIdle()
         }
         if _selectedModelId == modelId {
             _selectedModelId = nil
@@ -228,7 +232,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
-        Self.clearRuntimeCache()
+        Self.scheduleRuntimeCacheClearWhenInferenceIsIdle()
         if clearPersistence {
             host?.setUserDefault(nil, forKey: "loadedModel")
         }
@@ -291,6 +295,18 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
     private static func clearRuntimeCache() {
         Memory.clearCache()
+    }
+
+    private static func clearRuntimeCacheWhenInferenceIsIdle() async {
+        try? await PluginLocalInferenceGate.shared.withLock {
+            Memory.clearCache()
+        }
+    }
+
+    private static func scheduleRuntimeCacheClearWhenInferenceIsIdle() {
+        Task {
+            await clearRuntimeCacheWhenInferenceIsIdle()
+        }
     }
 
     var settingsView: AnyView? {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginRuntimeDiagnostics.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginRuntimeDiagnostics.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public struct PluginRuntimeMemorySnapshot: Sendable, Equatable, Codable {
+    public let activeMemoryBytes: Int
+    public let cacheMemoryBytes: Int
+    public let peakMemoryBytes: Int
+
+    public init(activeMemoryBytes: Int, cacheMemoryBytes: Int, peakMemoryBytes: Int) {
+        self.activeMemoryBytes = activeMemoryBytes
+        self.cacheMemoryBytes = cacheMemoryBytes
+        self.peakMemoryBytes = peakMemoryBytes
+    }
+}
+
+public protocol PluginRuntimeMemoryDiagnosticsReporting: TypeWhisperPlugin {
+    var runtimeMemorySnapshot: PluginRuntimeMemorySnapshot? { get }
+}
+
+public actor PluginLocalInferenceGate {
+    public static let shared = PluginLocalInferenceGate()
+
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    public init() {}
+
+    public func withLock<T: Sendable>(
+        _ operation: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        await acquire()
+        defer { release() }
+        return try await operation()
+    }
+
+    private func acquire() async {
+        if !isLocked {
+            isLocked = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if waiters.isEmpty {
+            isLocked = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginRuntimeDiagnostics.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginRuntimeDiagnostics.swift
@@ -75,7 +75,6 @@ public actor PluginLocalInferenceGate {
             release()
             throw CancellationError()
         }
-        try Task.checkCancellation()
     }
 
     private func cancelWaiter(id: UUID) {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginRuntimeDiagnostics.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginRuntimeDiagnostics.swift
@@ -1,11 +1,20 @@
 import Foundation
 
 public struct PluginRuntimeMemorySnapshot: Sendable, Equatable, Codable {
+    public static let sharedMLXRuntimeIdentifier = "shared-mlx-runtime"
+
+    public let runtimeIdentifier: String
     public let activeMemoryBytes: Int
     public let cacheMemoryBytes: Int
     public let peakMemoryBytes: Int
 
-    public init(activeMemoryBytes: Int, cacheMemoryBytes: Int, peakMemoryBytes: Int) {
+    public init(
+        runtimeIdentifier: String = Self.sharedMLXRuntimeIdentifier,
+        activeMemoryBytes: Int,
+        cacheMemoryBytes: Int,
+        peakMemoryBytes: Int
+    ) {
+        self.runtimeIdentifier = runtimeIdentifier
         self.activeMemoryBytes = activeMemoryBytes
         self.cacheMemoryBytes = cacheMemoryBytes
         self.peakMemoryBytes = peakMemoryBytes
@@ -19,35 +28,67 @@ public protocol PluginRuntimeMemoryDiagnosticsReporting: TypeWhisperPlugin {
 public actor PluginLocalInferenceGate {
     public static let shared = PluginLocalInferenceGate()
 
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
     private var isLocked = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [Waiter] = []
 
     public init() {}
 
     public func withLock<T: Sendable>(
         _ operation: @Sendable () async throws -> T
-    ) async rethrows -> T {
-        await acquire()
+    ) async throws -> T {
+        try Task.checkCancellation()
+        try await acquire()
         defer { release() }
+        try Task.checkCancellation()
         return try await operation()
     }
 
-    private func acquire() async {
+    private func acquire() async throws {
         if !isLocked {
             isLocked = true
             return
         }
 
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
+        let waiterID = UUID()
+        let didAcquire = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else {
+                    waiters.append(Waiter(id: waiterID, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(id: waiterID)
+            }
         }
+        guard didAcquire else {
+            throw CancellationError()
+        }
+        if Task.isCancelled {
+            release()
+            throw CancellationError()
+        }
+        try Task.checkCancellation()
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
     }
 
     private func release() {
         if waiters.isEmpty {
             isLocked = false
         } else {
-            waiters.removeFirst().resume()
+            waiters.removeFirst().continuation.resume(returning: true)
         }
     }
 }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -346,14 +346,21 @@ private actor GateConcurrencyState {
 
 private actor GateLockRelease {
     private var continuation: CheckedContinuation<Void, Never>?
+    private var isReleased = false
 
     func wait() async {
+        guard !isReleased else { return }
         await withCheckedContinuation { continuation in
-            self.continuation = continuation
+            if isReleased {
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+            }
         }
     }
 
     func release() {
+        isReleased = true
         continuation?.resume()
         continuation = nil
     }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -330,6 +330,20 @@ private final class MockTTSPlaybackSession: TTSPlaybackSession, @unchecked Senda
     }
 }
 
+private actor GateConcurrencyState {
+    private var currentCount = 0
+    private(set) var maxConcurrent = 0
+
+    func enter() {
+        currentCount += 1
+        maxConcurrent = max(maxConcurrent, currentCount)
+    }
+
+    func leave() {
+        currentCount -= 1
+    }
+}
+
 @objc(MockTTSPlugin)
 private final class MockTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.tts"
@@ -366,6 +380,28 @@ private final class MockTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Senda
 }
 
 final class ProtocolContractTests: XCTestCase {
+    func testLocalInferenceGateSerializesConcurrentOperations() async throws {
+        let gate = PluginLocalInferenceGate()
+        let state = GateConcurrencyState()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    try await gate.withLock {
+                        await state.enter()
+                        try await Task.sleep(for: .milliseconds(20))
+                        await state.leave()
+                    }
+                }
+            }
+
+            try await group.waitForAll()
+        }
+
+        let maxConcurrent = await state.maxConcurrent
+        XCTAssertEqual(maxConcurrent, 1)
+    }
+
     func testPluginAuthRolesExposeStableRawValues() {
         XCTAssertEqual(PluginAuthRole.transcription.rawValue, "transcription")
         XCTAssertEqual(PluginAuthRole.llm.rawValue, "llm")

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -344,6 +344,33 @@ private actor GateConcurrencyState {
     }
 }
 
+private actor GateLockRelease {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor GateOperationState {
+    private(set) var didRun = false
+
+    func markRan() {
+        didRun = true
+    }
+
+    func value() -> Bool {
+        didRun
+    }
+}
+
 @objc(MockTTSPlugin)
 private final class MockTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.tts"
@@ -400,6 +427,45 @@ final class ProtocolContractTests: XCTestCase {
 
         let maxConcurrent = await state.maxConcurrent
         XCTAssertEqual(maxConcurrent, 1)
+    }
+
+    func testLocalInferenceGateDoesNotRunCancelledWaiter() async throws {
+        let gate = PluginLocalInferenceGate()
+        let release = GateLockRelease()
+        let cancelledOperation = GateOperationState()
+        let holderStarted = expectation(description: "holder acquired inference gate")
+
+        let holder = Task {
+            try await gate.withLock {
+                holderStarted.fulfill()
+                await release.wait()
+            }
+        }
+        await fulfillment(of: [holderStarted], timeout: 1.0)
+
+        let waiter = Task {
+            try await gate.withLock {
+                await cancelledOperation.markRan()
+            }
+        }
+        waiter.cancel()
+
+        try await Task.sleep(for: .milliseconds(20))
+        await release.release()
+        try await holder.value
+
+        do {
+            try await waiter.value
+            XCTFail("Cancelled waiter should throw before running gated operation")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let cancelledOperationRan = await cancelledOperation.value()
+        XCTAssertFalse(cancelledOperationRan)
+
+        let followerRan = try await gate.withLock { true }
+        XCTAssertTrue(followerRan)
     }
 
     func testPluginAuthRolesExposeStableRawValues() {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -6475,7 +6475,24 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let modelManager = ModelManagerService()
         modelManager.scheduleAutoUnloadIfNeeded()
 
+        let scheduledSnapshot = modelManager.autoUnloadDiagnosticsSnapshot()
+        let scheduledEntry = try XCTUnwrap(scheduledSnapshot.entries.first)
+        XCTAssertEqual(scheduledSnapshot.policySeconds, -1)
+        XCTAssertEqual(scheduledSnapshot.policyName, "immediate")
+        XCTAssertEqual(scheduledEntry.pluginClassName, "MockLLMProviderPlugin")
+        XCTAssertNotNil(scheduledEntry.scheduledAt)
+        XCTAssertNotNil(scheduledEntry.dueAt)
+        XCTAssertNil(scheduledEntry.lastFiredAt)
+        XCTAssertNil(scheduledEntry.lastSelectorResponded)
+
         await waitForAutoUnloadCount(plugin, toBecome: 1)
+
+        let firedSnapshot = modelManager.autoUnloadDiagnosticsSnapshot()
+        let firedEntry = try XCTUnwrap(firedSnapshot.entries.first)
+        XCTAssertNil(firedEntry.scheduledAt)
+        XCTAssertNil(firedEntry.dueAt)
+        XCTAssertNotNil(firedEntry.lastFiredAt)
+        XCTAssertEqual(firedEntry.lastSelectorResponded, true)
     }
 
     @MainActor

--- a/TypeWhisperTests/MemoryServiceTests.swift
+++ b/TypeWhisperTests/MemoryServiceTests.swift
@@ -114,6 +114,101 @@ final class MemoryServiceTests: XCTestCase {
         ))
     }
 
+    @MainActor
+    func testExtractionSkipsWhilePreviousExtractionIsInFlight() async throws {
+        let originalEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.memoryEnabled)
+        let originalProvider = UserDefaults.standard.object(forKey: UserDefaultsKeys.memoryExtractionProvider)
+        let originalMinimumLength = UserDefaults.standard.object(forKey: UserDefaultsKeys.memoryMinTextLength)
+        defer {
+            restoreUserDefault(originalEnabled, forKey: UserDefaultsKeys.memoryEnabled)
+            restoreUserDefault(originalProvider, forKey: UserDefaultsKeys.memoryExtractionProvider)
+            restoreUserDefault(originalMinimumLength, forKey: UserDefaultsKeys.memoryMinTextLength)
+        }
+
+        var processCallCount = 0
+        var firstCallRelease: CheckedContinuation<Void, Never>?
+        let firstCallStarted = expectation(description: "first memory extraction started")
+
+        let service = MemoryService(
+            promptProcessingService: PromptProcessingService(),
+            promptProcessor: { _, _, _, _ in
+                processCallCount += 1
+                if processCallCount == 1 {
+                    firstCallStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        firstCallRelease = continuation
+                    }
+                }
+                return "[]"
+            }
+        )
+        service.isEnabled = true
+        service.extractionProviderId = "test-provider"
+        service.minimumTextLength = 1
+        service.setExtractionCooldownForTesting(0)
+
+        service.handleTranscriptionForTesting(makePayload(finalText: "remember this first fact", ruleName: nil))
+        await fulfillment(of: [firstCallStarted], timeout: 1.0)
+
+        service.handleTranscriptionForTesting(makePayload(finalText: "remember this second fact", ruleName: nil))
+
+        var busySnapshot = service.extractionDiagnosticsSnapshot()
+        XCTAssertTrue(busySnapshot.inFlight)
+        XCTAssertEqual(busySnapshot.totalStarted, 1)
+        XCTAssertEqual(busySnapshot.skippedWhileBusy, 1)
+        XCTAssertEqual(processCallCount, 1)
+
+        firstCallRelease?.resume()
+        try await waitUntilMemoryExtractionFinishes(service)
+
+        service.handleTranscriptionForTesting(makePayload(finalText: "remember this third fact", ruleName: nil))
+        try await waitUntilProcessCallCount(2, currentCount: { processCallCount })
+        busySnapshot = service.extractionDiagnosticsSnapshot()
+
+        XCTAssertEqual(processCallCount, 2)
+        XCTAssertEqual(busySnapshot.totalStarted, 2)
+        XCTAssertEqual(busySnapshot.skippedWhileBusy, 1)
+    }
+
+    @MainActor
+    private func waitUntilMemoryExtractionFinishes(
+        _ service: MemoryService,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<40 {
+            if !service.extractionDiagnosticsSnapshot().inFlight {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("Timed out waiting for memory extraction to finish", file: file, line: line)
+    }
+
+    @MainActor
+    private func waitUntilProcessCallCount(
+        _ expectedCount: Int,
+        currentCount: @MainActor () -> Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<40 {
+            if currentCount() == expectedCount {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("Timed out waiting for process call count \(expectedCount)", file: file, line: line)
+    }
+
+    private func restoreUserDefault(_ value: Any?, forKey key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
     private func makePayload(finalText: String, ruleName: String?) -> TranscriptionCompletedPayload {
         TranscriptionCompletedPayload(
             rawText: finalText,


### PR DESCRIPTION
## Issue Context
Issue #800 reports that TypeWhisper 1.5.0-daily.20260627 still holds about 50 GB of RAM after the idle auto-unload fix from #788/#789. That daily already includes the timer-based auto-unload work, so this follow-up targets the remaining local MLX footprint path: Qwen3 ASR plus Gemma 4 memory extraction on all dictations.

Closes #800

## Changes
- Add a shared SDK local inference gate so heavy local MLX providers serialize Qwen3/Gemma work instead of running concurrently.
- Clear the MLX runtime cache after Qwen3/Gemma inference and when those local models unload/deactivate.
- Make MemoryService extraction single-flight and expose busy/skipped diagnostics instead of spawning unbounded extraction tasks.
- Extend diagnostics with process memory, auto-unload timer state, MemoryService extraction state, and optional plugin MLX runtime memory snapshots.

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter ProtocolContractTests/testLocalInferenceGateSerializesConcurrentOperations`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/MemoryServiceTests test`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/APIRouterAndHandlersTests test`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' build`
- `git diff --check`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7d5e/typewhisper-mac`

Note: the dev build/run smoke completed and launched the development app from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`. A manual long-running Qwen3 + Gemma 4 memory-pressure session should still be run before marking this ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expanded diagnostics for current process memory, per-plugin runtime memory, and memory extraction workflow status.
  * Enhanced auto-unload diagnostics with scheduling details and last trigger outcomes.
* **Bug Fixes**
  * Prevented overlapping memory extraction runs and improved extraction cancellation/finish handling under load.
  * Improved local inference behavior by serializing concurrent work and clearing model runtime cache only when inference is idle.
* **Tests**
  * Added/updated tests for inference serialization, extraction skip-while-busy, and auto-unload diagnostics snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->