### PR TITLE
Fix Groq M4A upload fallback

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -187,10 +187,9 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         prompt: String?,
         speakerDiarizationEnabled: Bool
     ) async throws -> PluginStructuredTranscriptionResult {
-        let uploadURL = try await uploadAudio(
-            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
-            apiKey: apiKey
-        )
+        let uploadURL = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            try await uploadAudio(uploadFile: uploadFile, apiKey: apiKey)
+        }
         let transcriptId = try await submitTranscription(
             audioURL: uploadURL,
             modelId: modelId,

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
@@ -132,6 +132,59 @@ final class AssemblyAIPluginTests: XCTestCase {
         XCTAssertNotEqual(uploadBody, audio.wavData)
     }
 
+    func testRESTTranscriptionRetriesUploadWithWavWhenM4ARejected() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "assembly-key"])
+        let plugin = AssemblyAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"could not process file - is it a valid media file?"}}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/upload", statusCode: 400)
+                ),
+                .success(
+                    Data(#"{"upload_url":"https://cdn.example.test/audio.wav"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/upload", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"id":"transcript_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/transcript", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"status":"completed","text":"hello wav","language_code":"de"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/transcript/transcript_123", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: "de", translate: false, prompt: "TypeWhisper")
+
+        XCTAssertEqual(result.text, "hello wav")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v2/upload",
+            "/v2/upload",
+            "/v2/transcript",
+            "/v2/transcript/transcript_123",
+        ])
+
+        let firstUploadBody = try XCTUnwrap(requests[0].httpBody)
+        XCTAssertTrue(String(decoding: firstUploadBody.prefix(64), as: UTF8.self).contains("ftyp"))
+        let retryUploadBody = try XCTUnwrap(requests[1].httpBody)
+        XCTAssertEqual(retryUploadBody, audio.wavData)
+
+        let submitBody = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try XCTUnwrap(requests[2].httpBody)) as? [String: Any]
+        )
+        XCTAssertEqual(submitBody["audio_url"] as? String, "https://cdn.example.test/audio.wav")
+        XCTAssertEqual(submitBody["language_code"] as? String, "de")
+        XCTAssertEqual(submitBody["keyterms_prompt"] as? [String], ["TypeWhisper"])
+    }
+
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: URL(string: url)!,

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -399,21 +399,21 @@ final class CartesiaPlugin: NSObject,
             languageHints: languageHints,
             configuredLanguage: _transcriptionLanguage
         )
-        let uploadFile = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
-            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
-        let request = try Self.makeTranscriptionRequest(
-            uploadFile: uploadFile,
-            apiKey: apiKey,
-            modelId: Self.sttModelId,
-            language: resolvedLanguage
-        )
+        return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            let request = try Self.makeTranscriptionRequest(
+                uploadFile: uploadFile,
+                apiKey: apiKey,
+                modelId: Self.sttModelId,
+                language: resolvedLanguage
+            )
 
-        let (data, response) = try await PluginHTTPClient.data(for: request)
-        try Self.validateHTTPResponse(data: data, response: response)
-        return try Self.parseTranscriptionResponse(
-            data,
-            fallbackLanguage: resolvedLanguage
-        )
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            try Self.validateHTTPResponse(data: data, response: response)
+            return try Self.parseTranscriptionResponse(
+                data,
+                fallbackLanguage: resolvedLanguage
+            )
+        }
     }
 
     // MARK: - TTSProviderPlugin
@@ -779,11 +779,11 @@ extension CartesiaPlugin {
     private static func errorMessage(from data: Data, statusCode: Int) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let message = json["message"] as? String {
-                return message
+                return "HTTP \(statusCode): \(message)"
             }
             if let error = json["error"] as? [String: Any],
                let message = error["message"] as? String {
-                return message
+                return "HTTP \(statusCode): \(message)"
             }
         }
         if let body = String(data: data, encoding: .utf8), !body.isEmpty {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -368,6 +368,50 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(body.contains("fallback-wav"))
     }
 
+    func testTranscribeRetriesWithWavWhenM4AUploadRejected() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "sk_car_live"])
+        let plugin = CartesiaPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"unsupported audio format"}}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 400)
+                ),
+                .success(
+                    Data(#"{"type":"transcript","text":"Hello from wav","language":"de","words":[]}"#.utf8),
+                    Self.httpResponse(url: "https://api.cartesia.ai/stt", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(
+            audio: audio,
+            language: "de-DE",
+            translate: false,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Hello from wav")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"name="file"; filename="audio.m4a""#))
+        XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))
+
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"name="file"; filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nink-whisper"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertEqual(requests[1].timeoutInterval, 600)
+    }
+
     func testTranscribeUsesConfiguredEnglishLanguageWhenSelected() async throws {
         let host = try PluginTestHostServices(
             defaults: ["transcriptionLanguage": "en"],

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -475,34 +475,34 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
         components.queryItems = queryItems
 
-        let uploadFile = try PluginAudioUploadEncoder.compressedM4AUpload(from: audio)
+        return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            var request = URLRequest(url: components.url!)
+            request.httpMethod = "POST"
+            request.setValue(authHeaderValue(apiKey: apiKey), forHTTPHeaderField: effectiveAuthHeader)
+            request.setValue(uploadFile.contentType, forHTTPHeaderField: "Content-Type")
+            request.httpBody = uploadFile.data
+            request.timeoutInterval = 60
 
-        var request = URLRequest(url: components.url!)
-        request.httpMethod = "POST"
-        request.setValue(authHeaderValue(apiKey: apiKey), forHTTPHeaderField: effectiveAuthHeader)
-        request.setValue(uploadFile.contentType, forHTTPHeaderField: "Content-Type")
-        request.httpBody = uploadFile.data
-        request.timeoutInterval = 60
+            let (data, response) = try await PluginHTTPClient.data(for: request)
 
-        let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw PluginTranscriptionError.apiError("No HTTP response")
+            }
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw PluginTranscriptionError.apiError("No HTTP response")
+            switch httpResponse.statusCode {
+            case 200: break
+            case 401: throw PluginTranscriptionError.invalidApiKey
+            case 429: throw PluginTranscriptionError.rateLimited
+            default:
+                let body = String(data: data, encoding: .utf8) ?? ""
+                throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
+            }
+
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let transcript = Self.extractTranscript(from: json)
+
+            return PluginTranscriptionResult(text: transcript, detectedLanguage: language)
         }
-
-        switch httpResponse.statusCode {
-        case 200: break
-        case 401: throw PluginTranscriptionError.invalidApiKey
-        case 429: throw PluginTranscriptionError.rateLimited
-        default:
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
-        }
-
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        let transcript = Self.extractTranscript(from: json)
-
-        return PluginTranscriptionResult(text: transcript, detectedLanguage: language)
     }
 
     // MARK: - WebSocket Implementation (Raw RFC 6455)

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -193,53 +193,53 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             throw PluginTranscriptionError.apiError("Invalid ElevenLabs REST URL")
         }
 
-        let boundary = UUID().uuidString
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 120
+        return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            let boundary = UUID().uuidString
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = 120
 
-        let uploadFile = try PluginAudioUploadEncoder.compressedM4AUpload(from: audio)
-
-        var body = Data()
-        body.appendMultipartFile(
-            boundary: boundary,
-            name: "file",
-            filename: uploadFile.filename,
-            contentType: uploadFile.contentType,
-            data: uploadFile.data
-        )
-        body.appendMultipartField(boundary: boundary, name: "model_id", value: modelId)
-        if let language, !language.isEmpty {
-            body.appendMultipartField(boundary: boundary, name: "language_code", value: language)
-        }
-        if modelId == "scribe_v2" {
-            for term in PluginDictionaryTerms.terms(fromPrompt: prompt) {
-                body.appendMultipartField(boundary: boundary, name: "keyterms", value: term)
+            var body = Data()
+            body.appendMultipartFile(
+                boundary: boundary,
+                name: "file",
+                filename: uploadFile.filename,
+                contentType: uploadFile.contentType,
+                data: uploadFile.data
+            )
+            body.appendMultipartField(boundary: boundary, name: "model_id", value: modelId)
+            if let language, !language.isEmpty {
+                body.appendMultipartField(boundary: boundary, name: "language_code", value: language)
             }
-        }
-        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
-        request.httpBody = body
+            if modelId == "scribe_v2" {
+                for term in PluginDictionaryTerms.terms(fromPrompt: prompt) {
+                    body.appendMultipartField(boundary: boundary, name: "keyterms", value: term)
+                }
+            }
+            body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+            request.httpBody = body
 
-        let (data, response) = try await PluginHTTPClient.data(for: request)
+            let (data, response) = try await PluginHTTPClient.data(for: request)
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw PluginTranscriptionError.apiError("No HTTP response")
-        }
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw PluginTranscriptionError.apiError("No HTTP response")
+            }
 
-        switch httpResponse.statusCode {
-        case 200:
-            return try Self.parseRESTResponse(data, fallbackLanguage: language)
-        case 401:
-            throw PluginTranscriptionError.invalidApiKey
-        case 413:
-            throw PluginTranscriptionError.fileTooLarge
-        case 429:
-            throw PluginTranscriptionError.rateLimited
-        default:
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
+            switch httpResponse.statusCode {
+            case 200:
+                return try Self.parseRESTResponse(data, fallbackLanguage: language)
+            case 401:
+                throw PluginTranscriptionError.invalidApiKey
+            case 413:
+                throw PluginTranscriptionError.fileTooLarge
+            case 429:
+                throw PluginTranscriptionError.rateLimited
+            default:
+                let body = String(data: data, encoding: .utf8) ?? ""
+                throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
+            }
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -255,10 +255,9 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        let audioURL = try await uploadAudio(
-            try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
-            apiKey: apiKey
-        )
+        let audioURL = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            try await uploadAudio(uploadFile, apiKey: apiKey)
+        }
         let resultURL = try await submitPreRecorded(
             audioURL: audioURL,
             language: language,

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/GroqPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/GroqPlugin.swift
@@ -102,7 +102,7 @@ final class GroqPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapa
             throw PluginTranscriptionError.noModelSelected
         }
 
-        return try await transcriptionHelper.transcribeCompressedAudio(
+        return try await transcriptionHelper.transcribeCompressedAudioWithWavFallback(
             audio: audio,
             apiKey: apiKey,
             modelName: modelId,

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/Tests/GroqPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/Tests/GroqPluginTests.swift
@@ -46,6 +46,68 @@ final class GroqPluginTests: XCTestCase {
         XCTAssertFalse(bodyText.contains(#"filename="audio.wav""#))
     }
 
+    func testTranscribeRetriesWithWavWhenGroqRejectsM4AUpload() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "whisper-large-v3"],
+            secrets: ["api-key": "groq-key"]
+        )
+        let plugin = GroqPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"could not process file - is it a valid media file?","type":"invalid_request_error"}}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.groq.com/openai/v1/audio/transcriptions",
+                        statusCode: 400
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"hello","language":"de"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.groq.com/openai/v1/audio/transcriptions",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+        let result = try await plugin.transcribe(
+            audio: audio,
+            language: "de",
+            translate: false,
+            prompt: "TypeWhisper"
+        )
+
+        XCTAssertEqual(result.text, "hello")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(store.sessions[0].requestedPaths, [
+            "/openai/v1/audio/transcriptions",
+            "/openai/v1/audio/transcriptions",
+        ])
+
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))
+
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nwhisper-large-v3"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
+        XCTAssertEqual(requests[1].timeoutInterval, 600)
+    }
+
     func testPreferredModelIdReflectsSelectedLLMModel() throws {
         let host = try PluginTestHostServices()
         let plugin = GroqPlugin()

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -996,10 +996,9 @@ final class SonioxPlugin: NSObject,
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        let fileId = try await uploadFile(
-            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
-            apiKey: apiKey
-        )
+        let fileId = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { upload in
+            try await uploadFile(uploadFile: upload, apiKey: apiKey)
+        }
         let transcriptionId = try await createTranscription(
             fileId: fileId,
             language: language,

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -273,6 +273,74 @@ final class SonioxPluginTests: XCTestCase {
         XCTAssertEqual(body["language_hints"] as? [String], ["en", "de"])
     }
 
+    func testSourceProgressTranscriptionRetriesUploadWithWavWhenM4ARejected() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"could not process file - is it a valid media file?"}}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 400)
+                ),
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"text":"WAV retry transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(
+            audio: audio,
+            languageSelection: PluginLanguageSelection(languageHints: ["en", "de"]),
+            translate: false,
+            prompt: "TypeWhisper",
+            onProgress: { _ in true },
+            onSourceProgress: { _ in true }
+        )
+
+        XCTAssertEqual(result.text, "WAV retry transcript")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v1/files",
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_123",
+            "/v1/transcriptions/transcription_123/transcript",
+        ])
+
+        let firstUploadBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstUploadBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstUploadBody.contains("Content-Type: audio/mp4"))
+
+        let retryUploadBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryUploadBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryUploadBody.contains("Content-Type: audio/wav"))
+
+        let createBody = try Self.jsonBody(from: requests[2])
+        XCTAssertEqual(createBody["file_id"] as? String, "file_123")
+        XCTAssertEqual(createBody["model"] as? String, "stt-async-v5")
+        XCTAssertEqual(createBody["language_hints"] as? [String], ["en", "de"])
+        let context = try XCTUnwrap(createBody["context"] as? [String: Any])
+        XCTAssertEqual(context["terms"] as? [String], ["TypeWhisper"])
+    }
+
     func testSourceProgressTranscriptionUsesSelectedRegionalRESTPath() async throws {
         let host = try PluginTestHostServices(
             defaults: ["selectedRegion": "eu"],

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -182,13 +182,15 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        let jobId = try await submitJob(
-            uploadFile: try PluginAudioUploadEncoder.compressedM4AUpload(from: audio),
-            language: language,
-            modelId: modelId,
-            apiKey: apiKey,
-            prompt: prompt
-        )
+        let jobId = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            try await submitJob(
+                uploadFile: uploadFile,
+                language: language,
+                modelId: modelId,
+                apiKey: apiKey,
+                prompt: prompt
+            )
+        }
         return try await pollJob(jobId: jobId, apiKey: apiKey)
     }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -330,10 +330,12 @@ public enum PluginAudioUploadEncoder {
         let lowercased = message.lowercased()
         let rejectionTerms = [
             "unsupported", "not supported", "does not support", "invalid", "unrecognized", "unknown",
+            "could not process", "failed to process", "corrupt",
         ]
         let mediaTerms = [
             "format", "media", "mime", "content-type", "content type",
-            "codec", "container", "file type", "m4a", "mp4", "aac", "wav",
+            "codec", "container", "file type", "audio", "file", "data",
+            "m4a", "mp4", "aac", "wav",
         ]
         return rejectionTerms.contains { lowercased.contains($0) }
             && mediaTerms.contains { lowercased.contains($0) }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -303,7 +303,8 @@ public enum PluginAudioUploadEncoder {
         guard statusCode != 415 else { return true }
 
         let message = String(data: responseData, encoding: .utf8) ?? ""
-        return indicatesUnsupportedAudioUpload(message)
+        return audioUploadErrorMessageCandidates(from: message)
+            .contains { indicatesUnsupportedAudioUpload($0) }
     }
 
     public static func shouldRetryWithWavUpload(error: Error) -> Bool {
@@ -323,7 +324,44 @@ public enum PluginAudioUploadEncoder {
             return false
         }
 
-        return indicatesUnsupportedAudioUpload(message)
+        return audioUploadErrorMessageCandidates(from: message)
+            .contains { indicatesUnsupportedAudioUpload($0) }
+    }
+
+    private static func audioUploadErrorMessageCandidates(from responseText: String) -> [String] {
+        let trimmed = responseText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let jsonStart = trimmed.firstIndex(where: { $0 == "{" || $0 == "[" }) else {
+            return [trimmed]
+        }
+
+        let jsonText = String(trimmed[jsonStart...])
+        guard let data = jsonText.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) else {
+            return [trimmed]
+        }
+
+        return extractAudioUploadErrorMessages(from: object)
+    }
+
+    private static func extractAudioUploadErrorMessages(from object: Any) -> [String] {
+        let messageKeys = ["error", "message", "err_msg", "error_message", "detail", "description"]
+
+        if let message = object as? String {
+            return [message]
+        }
+
+        if let dictionary = object as? [String: Any] {
+            return messageKeys.flatMap { key -> [String] in
+                guard let value = dictionary[key] else { return [] }
+                return extractAudioUploadErrorMessages(from: value)
+            }
+        }
+
+        if let array = object as? [Any] {
+            return array.flatMap { extractAudioUploadErrorMessages(from: $0) }
+        }
+
+        return []
     }
 
     private static func indicatesUnsupportedAudioUpload(_ message: String) -> Bool {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -372,7 +372,7 @@ public enum PluginAudioUploadEncoder {
         ]
         let mediaTerms = [
             "format", "media", "mime", "content-type", "content type",
-            "codec", "container", "file type", "audio", "file", "data",
+            "codec", "container", "file type", "audio",
             "m4a", "mp4", "aac", "wav",
         ]
         return rejectionTerms.contains { lowercased.contains($0) }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -262,7 +262,25 @@ public struct PluginAudioUploadFile: Sendable, Equatable {
 
 public enum PluginAudioUploadEncoder {
     public static let sampleRate = 16_000
+    public static let minimumUploadDuration: TimeInterval = 1.0
     private static let compressedUploadChunkFrames = 16_000 * 30
+
+    public static func normalizedAudioForUpload(_ audio: AudioData) -> AudioData {
+        guard audio.duration < minimumUploadDuration else { return audio }
+
+        let paddedSamples = PluginAudioUtils.paddedSamples(
+            audio.samples,
+            minimumDuration: minimumUploadDuration,
+            sampleRate: sampleRate
+        )
+        guard paddedSamples.count != audio.samples.count else { return audio }
+
+        return AudioData(
+            samples: paddedSamples,
+            wavData: PluginWavEncoder.encode(paddedSamples, sampleRate: sampleRate),
+            duration: Double(paddedSamples.count) / Double(sampleRate)
+        )
+    }
 
     public static func wavUpload(from audio: AudioData) -> PluginAudioUploadFile {
         PluginAudioUploadFile(
@@ -293,6 +311,28 @@ public enum PluginAudioUploadEncoder {
             contentType: "audio/mp4",
             format: "m4a"
         )
+    }
+
+    public static func withCompressedM4AUploadWavFallback<Result>(
+        from audio: AudioData,
+        operation: (PluginAudioUploadFile) async throws -> Result
+    ) async throws -> Result {
+        let uploadAudio = normalizedAudioForUpload(audio)
+        let preferredUpload: PluginAudioUploadFile
+        do {
+            preferredUpload = try compressedM4AUpload(from: uploadAudio)
+        } catch {
+            return try await operation(wavUpload(from: uploadAudio))
+        }
+
+        do {
+            return try await operation(preferredUpload)
+        } catch {
+            guard shouldRetryWithWavUpload(error: error) else {
+                throw error
+            }
+            return try await operation(wavUpload(from: uploadAudio))
+        }
     }
 
     public static func shouldRetryWithWavUpload(statusCode: Int, responseData: Data) -> Bool {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -170,6 +170,12 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
                 responseData: Data(#"{"error":"audio too short"}"#.utf8)
             )
         )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"error":{"message":"audio too short","type":"invalid_request_error"}}"#.utf8)
+            )
+        )
     }
 
     func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -142,6 +142,18 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         )
         XCTAssertTrue(
             PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"error":{"message":"could not process file - is it a valid media file?","type":"invalid_request_error"}}"#.utf8)
+            )
+        )
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"err_msg":"Bad Request: failed to process audio: corrupt or unsupported data"}"#.utf8)
+            )
+        )
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
                 statusCode: 415,
                 responseData: Data(#"{"error":"bad upload"}"#.utf8)
             )

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -176,6 +176,18 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
                 responseData: Data(#"{"error":{"message":"audio too short","type":"invalid_request_error"}}"#.utf8)
             )
         )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"error":{"message":"invalid file size","type":"invalid_request_error"}}"#.utf8)
+            )
+        )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 400,
+                responseData: Data(#"{"error":{"message":"corrupt request data","type":"invalid_request_error"}}"#.utf8)
+            )
+        )
     }
 
     func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {


### PR DESCRIPTION
## Context
Issue #780 moved REST cloud ASR uploads to compressed M4A to reduce cloud upload latency. After the Groq `1.0.21` plugin release, diagnostics from the TypeWhisper `1.5.0` dev host showed Groq rejecting the M4A upload with HTTP 400:

`could not process file - is it a valid media file?`

The same diagnostics also included a Deepgram-style media rejection:

`failed to process audio: corrupt or unsupported data`

Those are media-format failures, so affected REST upload paths should retry the same request as WAV instead of failing immediately. The fix keeps M4A as the primary upload format and only retries WAV for media-format style 400/415/422 responses.

Closes #780

## Changes
- Switch Groq transcription from M4A-only uploads to the shared M4A-with-WAV-fallback helper.
- Add a shared SDK wrapper for provider-owned REST upload flows: M4A first, WAV retry only on upload media-format rejection.
- Apply the wrapper to M4A-primary REST cloud upload paths that had no server-response WAV retry yet:
  - Deepgram
  - ElevenLabs
  - Speechmatics
  - Gladia
  - AssemblyAI
  - Soniox
  - Cartesia
- Harden retry classification so it reads provider message fields instead of matching raw JSON metadata, and so generic `file` / `data` tokens do not trigger unrelated retries.
- Preserve provider-specific fields, endpoints, auth headers, prompts, language hints, model IDs, polling flows, and timeouts.
- Leave streaming/WebSocket/live-preview and WAV/PCM-only paths unchanged.

## Test Plan
- `cd TypeWhisperPluginSDK && swift test --filter TypeWhisperPluginSDKTests`
- `cd TypeWhisperPluginSDK && swift test --filter GroqPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter AssemblyAIPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter CartesiaPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter SonioxPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter OpenAIPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter OpenAICompatiblePluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter GeminiPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter MistralAIPluginTests`
- `cd TypeWhisperPluginSDK && swift test --filter OpenRouterPluginTests`
- `for plugin in DeepgramPlugin ElevenLabsPlugin GladiaPlugin SpeechmaticsPlugin AssemblyAIPlugin CartesiaPlugin SonioxPlugin GroqPlugin; do /Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh "$plugin" /Users/marco/.codex/worktrees/34ab/typewhisper-mac || exit $?; done`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run GroqPlugin /Users/marco/.codex/worktrees/34ab/typewhisper-mac`
- `for plugin in DeepgramPlugin ElevenLabsPlugin GladiaPlugin SpeechmaticsPlugin AssemblyAIPlugin CartesiaPlugin SonioxPlugin GroqPlugin; do bundle="/Users/marco/Library/Application Support/TypeWhisper-Dev/Plugins/${plugin}.bundle"; binary="$bundle/Contents/MacOS/$plugin"; codesign --verify --deep --strict "$bundle" || exit $?; nm -u "$binary" | rg "withCompressedM4AUploadWavFallback|transcribeCompressedAudioWithWavFallback" || exit $?; done`
- `git diff --check`
