### PR TITLE
docs: add 1.5.0-rc2 release notes

### DIFF
--- a/docs/release-notes/1.5.0-rc2.md
+++ b/docs/release-notes/1.5.0-rc2.md
@@ -1,0 +1,28 @@
+TypeWhisper `1.5.0-rc2` refreshes the `1.5` release-candidate line after `rc1` with tighter local-model memory controls, broader provider reliability fixes, dictionary-learning improvements, and another pass over hotkeys, workflows, plugins, and release infrastructure.
+
+## Highlights
+
+- Added local MLX memory-footprint controls and improved recovery for stalled Gemma 4 model downloads.
+- Added the pro transcription fallback and surfaced auto-learned dictionary corrections so app-specific cleanup can be inspected and reused.
+- Added per-term dictionary CTC tuning plumbing and tightened when target-app corrections are learned.
+- Refined push-to-talk, Hybrid modifier hold activation, Pages workflow hotkeys, menu-based dictation pause, and automatic workflow output format resolution.
+- Added and updated provider paths across Mistral AI, MemPalace, Soniox regions and TTS, OpenAI-compatible thinking and token behavior, cloud ASR providers, and bundled marketplace metadata.
+
+## Reliability and Fixes
+
+- Fixed Groq M4A upload fallback handling and compressed cloud ASR uploads.
+- Raised cloud ASR plugin host floors to TypeWhisper 1.5 and restored plugin host compatibility for older release lines where needed.
+- Fixed TaskForge preserve-clipboard insertion fallback, dictionary scroll crashes, idle local-model auto-unload, event tap teardown, and FaceTime built-in microphone capture.
+- Fixed OpenAI Compatible GPT-5 token parameter handling and host SDK compatibility.
+- Fixed Soniox region persistence, async file transcription routing, and realtime model selection.
+- Improved Japanese dictation post-processing and settings localization, Latin word replacement boundaries, and French decimal normalization.
+- Cleaned up plugin keychain data on uninstall and kept development build cleanup scoped to the TypeWhisper-Dev build.
+
+## Testing Focus
+
+- Verify local MLX memory controls, idle unload behavior, and Gemma 4 stalled-download recovery.
+- Verify pro transcription fallback, dictionary correction learning, per-term CTC tuning, and dictionary scroll behavior.
+- Verify global push-to-talk, Hybrid modifier hold, menu pause, Pages workflow hotkeys, workflow output resolution, and Esc confirmation behavior.
+- Smoke-test Groq, cloud ASR providers, Mistral AI, MemPalace, Soniox STT/TTS, and OpenAI-compatible profile paths.
+- Verify TaskForge preserve-clipboard insertion fallback, FaceTime mic capture, event tap teardown, and plugin uninstall cleanup.
+- Confirm `v1.5.0-rc2` publishes on the `release-candidate` Sparkle channel, remains a GitHub prerelease, and does not update Homebrew or the stable website release path.

--- a/docs/release-notes/1.5.0-rc2.md
+++ b/docs/release-notes/1.5.0-rc2.md
@@ -1,4 +1,4 @@
-TypeWhisper `1.5.0-rc2` refreshes the `1.5` release-candidate line after `rc1` with tighter local-model memory controls, broader provider reliability fixes, dictionary-learning improvements, and another pass over hotkeys, workflows, plugins, and release infrastructure.
+TypeWhisper `v1.5.0-rc2` refreshes the `1.5` release-candidate line after `rc1` with tighter local-model memory controls, broader provider reliability fixes, dictionary-learning improvements, and another pass over hotkeys, workflows, plugins, and release infrastructure.
 
 ## Highlights
 


### PR DESCRIPTION
## Summary
- Adds curated release notes for `v1.5.0-rc2` so the release workflow can publish them from the tagged commit.
- Keeps the RC scope limited to current `main`; no app, SDK, plugin, Homebrew, or stable website release behavior changes.

## Release context
This PR prepares the notes-only commit required before cutting `v1.5.0-rc2` from `main`. The tag and release workflow will run after this PR is merged.

## Test plan
- [x] `git diff --check origin/main...HEAD`
- [x] `git diff --stat origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls to reduce local model memory usage.
  * Improved dictionary learning with auto-corrections and term-level tuning.
  * Added a pro transcription fallback that leverages learned dictionary corrections.

* **Bug Fixes**
  * Improved recovery for stalled Gemma downloads.
  * Refined push-to-talk, modifier-hold behavior, workflow hotkeys, dictation pause, and automatic workflow output formatting.
  * Increased reliability across local and provider workflows, including better mic capture, provider parameter handling, and cleaner uninstall behavior.

* **Chores**
  * Updated release notes and confirmed prerelease publishing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->