### PR TITLE
Fix delayed Hybrid hotkey toggle behavior

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -1544,20 +1544,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
         switch slotType {
         case .hybrid:
-            if activeDelayedHybridModifierHold {
-                isActive = false
-                activeSlotType = nil
-                activeGlobalHotkey = nil
-                currentMode = nil
-                keyDownTime = nil
-                pushToTalkInterruptionSignaled = false
-                activeDelayedHybridModifierHold = false
-                onDictationStop?()
-                return
-            }
             guard let downTime = keyDownTime else { return }
             if Date().timeIntervalSince(downTime) < Self.toggleThreshold {
                 currentMode = .toggle
+                activeDelayedHybridModifierHold = false
             } else {
                 isActive = false
                 activeSlotType = nil

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -8435,7 +8435,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testHybridModifierHoldStartsAfterDelayAndStopsOnRelease() async throws {
+    func testHybridModifierHoldStartsAfterDelayAndShortReleaseTogglesDictation() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
         service.hybridModifierHoldActivationDelay = 0.02
@@ -8462,6 +8462,44 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(startCount, 1)
         XCTAssertEqual(stopCount, 0)
         XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        currentFlags = []
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .toggle)
+    }
+
+    @MainActor
+    func testHybridModifierLongHoldStopsAfterRelease() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.hybridModifierHoldActivationDelay = 0.02
+
+        service.setHotkeyForTesting(controlModifierHotkey(), for: .hybrid)
+
+        var currentFlags = NSEvent.ModifierFlags.control
+        service.modifierFlagsStateProvider = { currentFlags }
+
+        var startCount = 0
+        var stopCount = 0
+        let started = expectation(description: "hybrid modifier hold starts after delay")
+        service.onDictationStart = { _ in
+            startCount += 1
+            started.fulfill()
+        }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeControlModifierEvent(isDown: true)
+        let keyUp = try makeControlModifierEvent(isDown: false)
+
+        XCTAssertFalse(service.processEventForTesting(keyDown, source: .monitor))
+        await fulfillment(of: [started], timeout: 1.0)
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        try await Task.sleep(for: .milliseconds(1_050))
 
         currentFlags = []
         XCTAssertTrue(service.processEventForTesting(keyUp, source: .monitor))


### PR DESCRIPTION
## Issue Context

Issue #805 reports that the June 27 daily release regressed Hybrid hotkeys: after configuring Hybrid behavior, the hotkey behaves like Push to Talk and stops as soon as the key is released. This came from the delayed modifier-only Hybrid activation added for issue #782: the delay correctly prevents accidental Control taps, but the delayed active path treated release as pure Push to Talk instead of letting Hybrid choose between short-release toggle and long-hold stop.

Closes #805

## Changes

- Keeps the modifier-only Hybrid activation delay so ordinary Control taps and shortcuts do not immediately start dictation.
- Lets delayed Hybrid activation use the existing Hybrid release threshold after recording starts.
- Adds regression coverage for the short-release Toggle path and keeps long-hold Push-to-Talk stop behavior covered.
- Leaves settings, public APIs, schemas, and UI unchanged.

## Test Plan

- `git diff --check`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests test`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' test`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/fc93/typewhisper-mac`
  - Build and signing succeeded for `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.
  - The script's automatic LaunchServices restart returned `-600`, then the built dev app was launched directly with `open -n /Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app` and confirmed via `pgrep` at `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app/Contents/MacOS/TypeWhisper`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hybrid hotkey behavior now correctly distinguishes short and long key holds.
  * Short releases now toggle dictation without unexpectedly stopping it.
  * Long holds continue to stop dictation as expected after release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->