### PR TITLE
Fix fullscreen indicator menu bar strip

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -549,6 +549,9 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         if let focusedWindowIsFullscreen {
             guard focusedWindowIsFullscreen else { return false }
+            // Tahoe fullscreen windows can report a content frame below the notch
+            // strip while auxiliary panels still affect the top menu-bar strip.
+            return true
         } else if !isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
             return false
         }

--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -4,7 +4,8 @@ import CoreGraphics
 enum FloatingPanelSpacePolicy {
     // Passive indicator panels should stay above the menu bar on normal spaces
     // without remaining at the shielding level used by system lock overlays.
-    static let indicatorWindowLevel = NSWindow.Level.screenSaver
+    static let notchIndicatorWindowLevel = NSWindow.Level.screenSaver
+    static let floatingIndicatorWindowLevel = NSWindow.Level.floating
 
     private static let activeSpaceIndicatorCollectionBehavior: NSWindow.CollectionBehavior = [
         .moveToActiveSpace,
@@ -35,8 +36,12 @@ enum FloatingPanelSpacePolicy {
     }
 
     @MainActor
-    static func applyIndicatorPolicy(to panel: NSPanel, displayMode: NotchIndicatorDisplay) {
-        panel.level = indicatorWindowLevel
+    static func applyIndicatorPolicy(
+        to panel: NSPanel,
+        displayMode: NotchIndicatorDisplay,
+        windowLevel: NSWindow.Level = notchIndicatorWindowLevel
+    ) {
+        panel.level = windowLevel
         panel.collectionBehavior = indicatorCollectionBehavior(for: displayMode)
         // Best-effort: keep passive indicators visible locally while excluding the
         // window from capture APIs that honor AppKit sharing policy.
@@ -44,8 +49,12 @@ enum FloatingPanelSpacePolicy {
     }
 
     @MainActor
-    static func orderIndicatorFront(_ panel: NSPanel, displayMode: NotchIndicatorDisplay) {
-        applyIndicatorPolicy(to: panel, displayMode: displayMode)
+    static func orderIndicatorFront(
+        _ panel: NSPanel,
+        displayMode: NotchIndicatorDisplay,
+        windowLevel: NSWindow.Level = notchIndicatorWindowLevel
+    ) {
+        applyIndicatorPolicy(to: panel, displayMode: displayMode, windowLevel: windowLevel)
         panel.orderFrontRegardless()
     }
 }

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -34,7 +34,8 @@ class MinimalIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
         )
 
         let hostingView = MinimalFirstMouseHostingView(rootView: MinimalIndicatorView())
@@ -147,7 +148,8 @@ class MinimalIndicatorPanel: NSPanel {
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
         )
     }
 

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -65,7 +65,8 @@ class NotchIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
         )
 
         let hostingView = FirstMouseHostingView(rootView: NotchIndicatorView(geometry: notchGeometry))
@@ -169,7 +170,8 @@ class NotchIndicatorPanel: NSPanel {
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
         )
 
         guard !wasVisible else {

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -34,7 +34,8 @@ class OverlayIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
         )
 
         let hostingView = OverlayFirstMouseHostingView(rootView: OverlayIndicatorView())
@@ -148,7 +149,8 @@ class OverlayIndicatorPanel: NSPanel {
         setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay
+            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
         )
     }
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -265,6 +265,38 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testSuppressesForeignAXFullscreenContentWindowBelowNotchStripForNotchPlacement() {
+        let fullscreenContentWindowBelowNotchStrip = CGRect(x: 0, y: 0, width: 3024, height: 1890)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenContentWindowBelowNotchStrip,
+                focusedWindowIsFullscreen: true,
+                frontmostBundleIdentifier: "com.google.Chrome",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .notchStrip
+            )
+        )
+    }
+
+    func testDoesNotSuppressForeignAXFullscreenContentWindowBelowNotchStripForNonNotchPlacement() {
+        let fullscreenContentWindowBelowNotchStrip = CGRect(x: 0, y: 0, width: 3024, height: 1890)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: notchedScreenFrame,
+                safeAreaTopInset: 74,
+                windowFrame: fullscreenContentWindowBelowNotchStrip,
+                focusedWindowIsFullscreen: true,
+                frontmostBundleIdentifier: "com.google.Chrome",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea
+            )
+        )
+    }
+
     func testDoesNotSuppressForeignMaximizedWindowWhenAXReportsNotFullscreen() {
         let maximizedWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
 

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -41,16 +41,23 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
         )
     }
 
-    func testIndicatorPolicyUsesScreenSaverLevelAboveStatusBarButBelowShielding() {
-        let level = FloatingPanelSpacePolicy.indicatorWindowLevel
+    func testNotchIndicatorPolicyUsesScreenSaverLevelAboveStatusBarButBelowShielding() {
+        let level = FloatingPanelSpacePolicy.notchIndicatorWindowLevel
 
         XCTAssertEqual(level, .screenSaver)
         XCTAssertGreaterThan(level.rawValue, NSWindow.Level.statusBar.rawValue)
         XCTAssertLessThan(level.rawValue, Int(CGShieldingWindowLevel()))
     }
 
+    func testFloatingIndicatorPolicyUsesFloatingLevelBelowStatusBar() {
+        let level = FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+
+        XCTAssertEqual(level, .floating)
+        XCTAssertLessThan(level.rawValue, NSWindow.Level.statusBar.rawValue)
+    }
+
     @MainActor
-    func testIndicatorPolicyExcludesPanelFromScreenCapture() {
+    func testIndicatorPolicyAppliesRequestedWindowLevelAndExcludesPanelFromScreenCapture() {
         let panel = NSPanel(
             contentRect: .zero,
             styleMask: [.borderless],
@@ -58,8 +65,13 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
             defer: false
         )
 
-        FloatingPanelSpacePolicy.applyIndicatorPolicy(to: panel, displayMode: .activeScreen)
+        FloatingPanelSpacePolicy.applyIndicatorPolicy(
+            to: panel,
+            displayMode: .activeScreen,
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+        )
 
+        XCTAssertEqual(panel.level, FloatingPanelSpacePolicy.floatingIndicatorWindowLevel)
         XCTAssertEqual(panel.sharingType, .none)
     }
 }


### PR DESCRIPTION
## Issue context

Issue #808 reports that when TypeWhisper is running with an indicator enabled on macOS Tahoe, the fullscreen menu-bar/notch strip can pick up the wallpaper color instead of staying black. The reporter reproduced it with TypeWhisper 1.4.0 (803), Parakeet v3, and any indicator style.

Closes #808

## Summary

- Split indicator panel window levels so the Notch extension keeps the existing `.screenSaver` level, while Overlay and Minimal indicators use `.floating`, matching the Selection Palette's fullscreen-friendly behavior.
- Keep `.fullScreenAuxiliary`, display-mode collection behavior, and screen-capture exclusion unchanged.
- Treat foreign `AXFullScreen == true` windows as suppressing top/notch-strip indicators even when the focused content frame starts below the notch safe area.
- Preserve bottom Overlay/Minimal fullscreen visibility by leaving `.nonNotchArea` suppression behavior unchanged.

## Test Plan

```bash
git diff --check
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/898b/typewhisper-mac
```

Manual/visual smoke performed locally:

- Verified the dev app was built and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app` with Apple Development signing.
- Temporarily set the dev app to Notch indicator + Always visible, opened TextEdit fullscreen on the notched internal display, captured `/tmp/typewhisper-808-notch-smoke.png`, and confirmed the central top safe-area band was black (`mean/max RGB = 0,0,0`).
- Restored the previous dev app indicator defaults afterward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indicator visibility handling when a full-screen window is active.
  * Refined suppression behavior for notch-area indicators in fullscreen-like scenarios.
  * Ensured panels use the correct window level for notch, floating, and overlay display modes.

* **Tests**
  * Added coverage for fullscreen suppression rules.
  * Expanded window-level tests to verify panel stacking and screen-capture settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->