### PR TITLE
Surface recorder final transcription failures

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9326,6 +9326,12 @@
             "state": "translated",
             "value": "Final transcription returned no text."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終文字起こしはテキストを返しませんでした。"
+          }
         }
       }
     },
@@ -9341,6 +9347,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "empty result"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空の結果"
           }
         }
       }
@@ -9358,6 +9370,12 @@
             "state": "translated",
             "value": "final transcription"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終文字起こし"
+          }
         }
       }
     },
@@ -9374,6 +9392,12 @@
             "state": "translated",
             "value": "preparing final audio"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終音声の準備"
+          }
         }
       }
     },
@@ -9389,6 +9413,34 @@
           "stringUnit": {
             "state": "translated",
             "value": "saving transcript"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしの保存"
+          }
+        }
+      }
+    },
+    "recorder.failureMetadataSaveError": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Fehler-Metadaten konnten nicht gespeichert werden: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Failed to save failure metadata: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 失敗メタデータを保存できませんでした: %@"
           }
         }
       }
@@ -10025,6 +10077,12 @@
             "state": "translated",
             "value": "Transcription failed"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしに失敗しました"
+          }
         }
       }
     },
@@ -10041,6 +10099,12 @@
             "state": "translated",
             "value": "Transcription failed during %@: %@"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@中に文字起こしに失敗しました: %@"
+          }
         }
       }
     },
@@ -10056,6 +10120,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transcription failed for %@, %@ during %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしに失敗しました（長さ %@、サイズ %@、%@中）: %@"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9313,6 +9313,86 @@
         }
       }
     },
+    "recorder.emptyFinalTranscriptionError": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die finale Transkription hat keinen Text zurueckgegeben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Final transcription returned no text."
+          }
+        }
+      }
+    },
+    "recorder.failurePhase.emptyResult": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "leeres Ergebnis"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "empty result"
+          }
+        }
+      }
+    },
+    "recorder.failurePhase.finalTranscription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "finaler Transkription"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "final transcription"
+          }
+        }
+      }
+    },
+    "recorder.failurePhase.preparingFinalAudio": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereitung des finalen Audios"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "preparing final audio"
+          }
+        }
+      }
+    },
+    "recorder.failurePhase.savingTranscript": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern des Transkripts"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "saving transcript"
+          }
+        }
+      }
+    },
     "recorder.language": {
       "extractionState": "stale",
       "localizations": {
@@ -9928,6 +10008,54 @@
           "stringUnit": {
             "state": "translated",
             "value": "音声認識"
+          }
+        }
+      }
+    },
+    "recorder.transcriptionFailed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription failed"
+          }
+        }
+      }
+    },
+    "recorder.transcriptionFailureAPISummary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen waehrend %@: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription failed during %@: %@"
+          }
+        }
+      }
+    },
+    "recorder.transcriptionFailureSummary": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkription fehlgeschlagen fuer %@, %@ waehrend %@: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transcription failed for %@, %@ during %@: %@"
           }
         }
       }

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -65,6 +65,47 @@ final class AudioRecorderViewModel: ObservableObject {
         let liveSessionResult: TranscriptionResult?
     }
 
+    struct RecordingTranscriptionFailure: Codable, Equatable, Sendable {
+        enum Phase: String, Codable, Equatable, Sendable {
+            case preparingFinalAudio
+            case finalTranscription
+            case emptyResult
+            case savingTranscript
+
+            var displayName: String {
+                switch self {
+                case .preparingFinalAudio:
+                    String(localized: "recorder.failurePhase.preparingFinalAudio")
+                case .finalTranscription:
+                    String(localized: "recorder.failurePhase.finalTranscription")
+                case .emptyResult:
+                    String(localized: "recorder.failurePhase.emptyResult")
+                case .savingTranscript:
+                    String(localized: "recorder.failurePhase.savingTranscript")
+                }
+            }
+        }
+
+        let phase: Phase
+        let providerError: String
+        let engineName: String?
+        let modelName: String?
+        let failedAt: Date
+    }
+
+    private enum FinalTranscriptionOutcome {
+        case skipped
+        case transcriptSaved
+        case failed(RecordingTranscriptionFailure)
+
+        var failure: RecordingTranscriptionFailure? {
+            if case .failed(let failure) = self {
+                return failure
+            }
+            return nil
+        }
+    }
+
     struct RecordingItem: Identifiable {
         let id = UUID()
         let url: URL
@@ -72,6 +113,7 @@ final class AudioRecorderViewModel: ObservableObject {
         let duration: TimeInterval
         let fileSize: Int64
         let transcript: String?
+        let transcriptionFailure: RecordingTranscriptionFailure?
         var fileName: String { url.lastPathComponent }
     }
 
@@ -494,9 +536,12 @@ final class AudioRecorderViewModel: ObservableObject {
 
             EventBus.shared.emit(.recordingStopped(RecordingStoppedPayload(durationSeconds: recordingDuration)))
 
+            let finalTranscriptionOutcome: FinalTranscriptionOutcome
             if let request = finalTranscriptionRequest {
-                await runFinalTranscription(request)
+                finalTranscriptionOutcome = await runFinalTranscription(request)
                 state = .idle
+            } else {
+                finalTranscriptionOutcome = .skipped
             }
 
             // Emit final transcript to LiveTranscriptPlugin
@@ -512,7 +557,15 @@ final class AudioRecorderViewModel: ObservableObject {
 
             if let apiSessionID {
                 if let url {
-                    completeRecorderAPISession(id: apiSessionID, outputURL: url)
+                    if let failure = finalTranscriptionOutcome.failure {
+                        failRecorderAPISession(
+                            id: apiSessionID,
+                            outputURL: url,
+                            error: recorderTranscriptionFailureAPISummary(failure)
+                        )
+                    } else {
+                        completeRecorderAPISession(id: apiSessionID, outputURL: url)
+                    }
                 } else {
                     failRecorderAPISession(id: apiSessionID, error: "Failed to finalize recording")
                 }
@@ -585,8 +638,8 @@ final class AudioRecorderViewModel: ObservableObject {
         }
     }
 
-    private func failRecorderAPISession(id: UUID, error: String) {
-        let outputFile = recorderAPISessions[id]?.outputFile
+    private func failRecorderAPISession(id: UUID, outputURL: URL? = nil, error: String) {
+        let outputFile = outputURL?.path ?? recorderAPISessions[id]?.outputFile
         storeRecorderAPISession(RecorderAPISessionSnapshot(
             id: id,
             status: .failed,
@@ -605,6 +658,7 @@ final class AudioRecorderViewModel: ObservableObject {
             // Also delete sidecar transcript
             let txtURL = item.url.deletingPathExtension().appendingPathExtension("txt")
             try? FileManager.default.removeItem(at: txtURL)
+            try? FileManager.default.removeItem(at: transcriptionFailureURL(for: item.url))
             recordings.removeAll { $0.id == item.id }
         } catch {
             errorMessage = error.localizedDescription
@@ -654,7 +708,15 @@ final class AudioRecorderViewModel: ObservableObject {
                     let size = (attrs[.size] as? Int64) ?? 0
                     let duration = audioDuration(for: url)
                     let transcript = loadTranscript(for: url)
-                    return RecordingItem(url: url, date: date, duration: duration, fileSize: size, transcript: transcript)
+                    let transcriptionFailure = loadTranscriptionFailure(for: url)
+                    return RecordingItem(
+                        url: url,
+                        date: date,
+                        duration: duration,
+                        fileSize: size,
+                        transcript: transcript,
+                        transcriptionFailure: transcriptionFailure
+                    )
                 }
                 .sorted { $0.date > $1.date }
 
@@ -686,6 +748,17 @@ final class AudioRecorderViewModel: ObservableObject {
         return formatter.string(fromByteCount: bytes)
     }
 
+    func transcriptionFailureSummary(for item: RecordingItem) -> String? {
+        guard let failure = item.transcriptionFailure else { return nil }
+        return String(
+            format: String(localized: "recorder.transcriptionFailureSummary"),
+            formattedDuration(item.duration),
+            formattedFileSize(item.fileSize),
+            failure.phase.displayName,
+            failure.providerError
+        )
+    }
+
     // MARK: - Streaming Transcription
 
     private func startStreamingTranscription() {
@@ -715,7 +788,7 @@ final class AudioRecorderViewModel: ObservableObject {
         )
     }
 
-    private func runFinalTranscription(_ request: FinalTranscriptionRequest) async {
+    private func runFinalTranscription(_ request: FinalTranscriptionRequest) async -> FinalTranscriptionOutcome {
         isTranscribing = true
         defer { isTranscribing = false }
 
@@ -723,15 +796,15 @@ final class AudioRecorderViewModel: ObservableObject {
         guard buffer.count > 8000 else { // At least 0.5s of audio
             // Use streaming result as final if buffer too short
             if !partialText.isEmpty {
-                saveTranscript(partialText, for: request.outputURL)
+                return saveTranscriptOutcome(partialText, for: request.outputURL, request: request)
             } else if let liveSessionResult = request.liveSessionResult {
                 let text = liveSessionResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !text.isEmpty {
                     partialText = text
-                    saveTranscript(text, for: request.outputURL)
+                    return saveTranscriptOutcome(text, for: request.outputURL, request: request)
                 }
             }
-            return
+            return .skipped
         }
 
         // Fall back to transcribe if engine doesn't support translation
@@ -763,16 +836,33 @@ final class AudioRecorderViewModel: ObservableObject {
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !text.isEmpty {
                 partialText = text
-                saveTranscript(text, for: request.outputURL)
+                return saveTranscriptOutcome(text, for: request.outputURL, request: request)
             } else if !partialText.isEmpty {
-                saveTranscript(partialText, for: request.outputURL)
+                return saveTranscriptOutcome(partialText, for: request.outputURL, request: request)
+            } else {
+                let failure = makeTranscriptionFailure(
+                    phase: .emptyResult,
+                    providerError: String(localized: "recorder.emptyFinalTranscriptionError"),
+                    request: request
+                )
+                saveTranscriptionFailure(failure, for: request.outputURL)
+                errorMessage = recorderTranscriptionFailureAPISummary(failure)
+                return .failed(failure)
             }
         } catch {
             logger.error("Final transcription failed: \(error.localizedDescription)")
             // Fall back to streaming result
             if !partialText.isEmpty {
-                saveTranscript(partialText, for: request.outputURL)
+                return saveTranscriptOutcome(partialText, for: request.outputURL, request: request)
             }
+            let failure = makeTranscriptionFailure(
+                phase: .finalTranscription,
+                providerError: error.localizedDescription,
+                request: request
+            )
+            saveTranscriptionFailure(failure, for: request.outputURL)
+            errorMessage = recorderTranscriptionFailureAPISummary(failure)
+            return .failed(failure)
         }
     }
 
@@ -782,17 +872,86 @@ final class AudioRecorderViewModel: ObservableObject {
         audioURL.deletingPathExtension().appendingPathExtension("txt")
     }
 
-    private func saveTranscript(_ text: String, for audioURL: URL) {
+    private func saveTranscript(_ text: String, for audioURL: URL) throws {
         let txtURL = transcriptURL(for: audioURL)
-        do {
-            try text.write(to: txtURL, atomically: true, encoding: .utf8)
-        } catch {
-            logger.error("Failed to save transcript: \(error.localizedDescription)")
-        }
+        try text.write(to: txtURL, atomically: true, encoding: .utf8)
+        clearTranscriptionFailure(for: audioURL)
     }
 
     private func loadTranscript(for audioURL: URL) -> String? {
         let txtURL = transcriptURL(for: audioURL)
         return try? String(contentsOf: txtURL, encoding: .utf8)
+    }
+
+    private func saveTranscriptOutcome(
+        _ text: String,
+        for audioURL: URL,
+        request: FinalTranscriptionRequest
+    ) -> FinalTranscriptionOutcome {
+        do {
+            try saveTranscript(text, for: audioURL)
+            return .transcriptSaved
+        } catch {
+            logger.error("Failed to save transcript: \(error.localizedDescription)")
+            let failure = makeTranscriptionFailure(
+                phase: .savingTranscript,
+                providerError: error.localizedDescription,
+                request: request
+            )
+            saveTranscriptionFailure(failure, for: audioURL)
+            errorMessage = recorderTranscriptionFailureAPISummary(failure)
+            return .failed(failure)
+        }
+    }
+
+    private func transcriptionFailureURL(for audioURL: URL) -> URL {
+        audioURL.deletingPathExtension().appendingPathExtension("transcription-failure.json")
+    }
+
+    private func makeTranscriptionFailure(
+        phase: RecordingTranscriptionFailure.Phase,
+        providerError: String,
+        request: FinalTranscriptionRequest
+    ) -> RecordingTranscriptionFailure {
+        RecordingTranscriptionFailure(
+            phase: phase,
+            providerError: providerError,
+            engineName: request.providerId.flatMap { providerId in
+                PluginManager.shared?.transcriptionEngine(for: providerId)?.providerDisplayName
+            },
+            modelName: modelManager.resolvedModelDisplayName(
+                engineOverrideId: request.providerId,
+                cloudModelOverride: request.resolvedModelId
+            ),
+            failedAt: Date()
+        )
+    }
+
+    private func saveTranscriptionFailure(_ failure: RecordingTranscriptionFailure, for audioURL: URL) {
+        let url = transcriptionFailureURL(for: audioURL)
+        do {
+            let data = try JSONEncoder().encode(failure)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            logger.error("Failed to save recorder transcription failure: \(error.localizedDescription)")
+        }
+    }
+
+    private func loadTranscriptionFailure(for audioURL: URL) -> RecordingTranscriptionFailure? {
+        let url = transcriptionFailureURL(for: audioURL)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(RecordingTranscriptionFailure.self, from: data)
+    }
+
+    private func clearTranscriptionFailure(for audioURL: URL) {
+        try? FileManager.default.removeItem(at: transcriptionFailureURL(for: audioURL))
+    }
+
+    private func recorderTranscriptionFailureAPISummary(_ failure: RecordingTranscriptionFailure) -> String {
+        String(
+            format: String(localized: "recorder.transcriptionFailureAPISummary"),
+            failure.phase.displayName,
+            failure.providerError
+        )
     }
 }

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -216,6 +216,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private var currentOutputURL: URL?
     private var activeRecorderAPISessionID: UUID?
     private var recorderAPISessions: [UUID: RecorderAPISessionSnapshot] = [:]
+    private var transientTranscriptionFailures: [String: RecordingTranscriptionFailure] = [:]
     private var isInitialized = false
 
     init(
@@ -658,7 +659,7 @@ final class AudioRecorderViewModel: ObservableObject {
             // Also delete sidecar transcript
             let txtURL = item.url.deletingPathExtension().appendingPathExtension("txt")
             try? FileManager.default.removeItem(at: txtURL)
-            try? FileManager.default.removeItem(at: transcriptionFailureURL(for: item.url))
+            clearTranscriptionFailure(for: item.url)
             recordings.removeAll { $0.id == item.id }
         } catch {
             errorMessage = error.localizedDescription
@@ -709,6 +710,7 @@ final class AudioRecorderViewModel: ObservableObject {
                     let duration = audioDuration(for: url)
                     let transcript = loadTranscript(for: url)
                     let transcriptionFailure = loadTranscriptionFailure(for: url)
+                        ?? transientTranscriptionFailures[transcriptionFailureKey(for: url)]
                     return RecordingItem(
                         url: url,
                         date: date,
@@ -845,9 +847,9 @@ final class AudioRecorderViewModel: ObservableObject {
                     providerError: String(localized: "recorder.emptyFinalTranscriptionError"),
                     request: request
                 )
-                saveTranscriptionFailure(failure, for: request.outputURL)
-                errorMessage = recorderTranscriptionFailureAPISummary(failure)
-                return .failed(failure)
+                let recordedFailure = saveTranscriptionFailure(failure, for: request.outputURL)
+                errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
+                return .failed(recordedFailure)
             }
         } catch {
             logger.error("Final transcription failed: \(error.localizedDescription)")
@@ -860,9 +862,9 @@ final class AudioRecorderViewModel: ObservableObject {
                 providerError: error.localizedDescription,
                 request: request
             )
-            saveTranscriptionFailure(failure, for: request.outputURL)
-            errorMessage = recorderTranscriptionFailureAPISummary(failure)
-            return .failed(failure)
+            let recordedFailure = saveTranscriptionFailure(failure, for: request.outputURL)
+            errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
+            return .failed(recordedFailure)
         }
     }
 
@@ -898,14 +900,18 @@ final class AudioRecorderViewModel: ObservableObject {
                 providerError: error.localizedDescription,
                 request: request
             )
-            saveTranscriptionFailure(failure, for: audioURL)
-            errorMessage = recorderTranscriptionFailureAPISummary(failure)
-            return .failed(failure)
+            let recordedFailure = saveTranscriptionFailure(failure, for: audioURL)
+            errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
+            return .failed(recordedFailure)
         }
     }
 
     private func transcriptionFailureURL(for audioURL: URL) -> URL {
-        audioURL.deletingPathExtension().appendingPathExtension("transcription-failure.json")
+        audioURL.appendingPathExtension("transcription-failure.json")
+    }
+
+    private func transcriptionFailureKey(for audioURL: URL) -> String {
+        audioURL.resolvingSymlinksInPath().path
     }
 
     private func makeTranscriptionFailure(
@@ -927,13 +933,33 @@ final class AudioRecorderViewModel: ObservableObject {
         )
     }
 
-    private func saveTranscriptionFailure(_ failure: RecordingTranscriptionFailure, for audioURL: URL) {
+    @discardableResult
+    private func saveTranscriptionFailure(
+        _ failure: RecordingTranscriptionFailure,
+        for audioURL: URL
+    ) -> RecordingTranscriptionFailure {
         let url = transcriptionFailureURL(for: audioURL)
+        let key = transcriptionFailureKey(for: audioURL)
         do {
             let data = try JSONEncoder().encode(failure)
             try data.write(to: url, options: .atomic)
+            transientTranscriptionFailures.removeValue(forKey: key)
+            return failure
         } catch {
             logger.error("Failed to save recorder transcription failure: \(error.localizedDescription)")
+            let surfacedFailure = RecordingTranscriptionFailure(
+                phase: failure.phase,
+                providerError: String(
+                    format: String(localized: "recorder.failureMetadataSaveError"),
+                    failure.providerError,
+                    error.localizedDescription
+                ),
+                engineName: failure.engineName,
+                modelName: failure.modelName,
+                failedAt: failure.failedAt
+            )
+            transientTranscriptionFailures[key] = surfacedFailure
+            return surfacedFailure
         }
     }
 
@@ -944,6 +970,7 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     private func clearTranscriptionFailure(for audioURL: URL) {
+        transientTranscriptionFailures.removeValue(forKey: transcriptionFailureKey(for: audioURL))
         try? FileManager.default.removeItem(at: transcriptionFailureURL(for: audioURL))
     }
 

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -400,6 +400,10 @@ private struct RecordingRow: View {
                         if item.transcript != nil {
                             Label(String(localized: "recorder.hasTranscript"), systemImage: "text.quote")
                         }
+                        if item.transcriptionFailure != nil {
+                            Label(String(localized: "recorder.transcriptionFailed"), systemImage: "exclamationmark.triangle")
+                                .foregroundStyle(.red)
+                        }
                     }
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -443,6 +447,14 @@ private struct RecordingRow: View {
                     .buttonStyle(.borderless)
                     .help(String(localized: "recorder.delete"))
                 }
+            }
+
+            if let failureSummary = viewModel.transcriptionFailureSummary(for: item) {
+                Label(failureSummary, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             // Expandable transcript

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -197,7 +197,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         modelManager.selectProvider("groq")
         let recordingsDirectory = makeTemporaryDirectory()
         let outputURL = recordingsDirectory.appendingPathComponent("Recording success.wav")
-        let failureURL = outputURL.deletingPathExtension().appendingPathExtension("transcription-failure.json")
+        let failureURL = failureSidecarURL(for: outputURL)
         let oldFailure = AudioRecorderViewModel.RecordingTranscriptionFailure(
             phase: .finalTranscription,
             providerError: "old error",
@@ -225,6 +225,41 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let recording = try XCTUnwrap(viewModel.recordings.first)
         XCTAssertEqual(recording.transcript, "fresh transcript")
         XCTAssertNil(recording.transcriptionFailure)
+    }
+
+    func testFailureSidecarWriteErrorStillShowsRecorderFailure() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .failure("HTTP 500: provider unavailable"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let outputURL = recordingsDirectory.appendingPathComponent("Recording write-error.wav")
+        let failureURL = failureSidecarURL(for: outputURL)
+        try FileManager.default.createDirectory(at: failureURL, withIntermediateDirectories: true)
+
+        let recorderService = makeRecorderService(
+            recordingsDirectory: recordingsDirectory,
+            outputURL: outputURL
+        )
+        let viewModel = makeViewModel(defaults: defaults, modelManager: modelManager, recorderService: recorderService)
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let sessionID = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .failed)
+        XCTAssertTrue(session.error?.contains("HTTP 500") == true)
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertNil(recording.transcript)
+        let failure = try XCTUnwrap(recording.transcriptionFailure)
+        XCTAssertEqual(failure.phase, .finalTranscription)
+        XCTAssertTrue(failure.providerError.contains("HTTP 500"))
+        XCTAssertGreaterThan(failure.providerError.count, "API error: HTTP 500: provider unavailable".count)
+        let sidecarValues = try failureURL.resourceValues(forKeys: [.isDirectoryKey])
+        XCTAssertEqual(sidecarValues.isDirectory, true)
     }
 
     private func makeViewModel(
@@ -279,6 +314,10 @@ final class AudioRecorderViewModelTests: XCTestCase {
         }
         recorderService.currentBufferOverride = { samples }
         return recorderService
+    }
+
+    private func failureSidecarURL(for audioURL: URL) -> URL {
+        audioURL.appendingPathExtension("transcription-failure.json")
     }
 
     private func livePreviewStartCount(

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -128,19 +128,157 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(splitEnabledCount, 1)
     }
 
+    func testFinalTranscriptionFailurePersistsRecorderFailureAndFailsAPISession() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .failure("HTTP 413: payload too large"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let viewModel = makeFinalTranscriptionViewModel(defaults: defaults, modelManager: modelManager)
+
+        let sessionID = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+        XCTAssertEqual(try viewModel.apiStopRecording(), sessionID)
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .failed)
+        let outputFile = try XCTUnwrap(session.outputFile)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputFile))
+        XCTAssertNil(session.text)
+        XCTAssertTrue(session.error?.contains("HTTP 413") == true)
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertEqual(
+            recording.url.resolvingSymlinksInPath().path,
+            URL(fileURLWithPath: outputFile).resolvingSymlinksInPath().path
+        )
+        XCTAssertNil(recording.transcript)
+        let failure = try XCTUnwrap(recording.transcriptionFailure)
+        XCTAssertEqual(failure.phase, .finalTranscription)
+        XCTAssertEqual(failure.engineName, "Groq")
+        XCTAssertEqual(failure.modelName, "Whisper Large V3")
+        XCTAssertTrue(failure.providerError.contains("HTTP 413"))
+        XCTAssertTrue(session.error?.contains(failure.phase.displayName) == true)
+
+        let summary = try XCTUnwrap(viewModel.transcriptionFailureSummary(for: recording))
+        XCTAssertTrue(summary.contains(viewModel.formattedDuration(recording.duration)))
+        XCTAssertTrue(summary.contains(viewModel.formattedFileSize(recording.fileSize)))
+        XCTAssertTrue(summary.contains(failure.phase.displayName))
+        XCTAssertTrue(summary.contains("HTTP 413"))
+    }
+
+    func testEmptyFinalTranscriptionPersistsRecorderFailure() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .empty)
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let viewModel = makeFinalTranscriptionViewModel(defaults: defaults, modelManager: modelManager)
+
+        let sessionID = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .failed)
+        XCTAssertNotNil(session.outputFile)
+        XCTAssertNil(session.text)
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertNil(recording.transcript)
+        let failure = try XCTUnwrap(recording.transcriptionFailure)
+        XCTAssertEqual(failure.phase, .emptyResult)
+        XCTAssertFalse(failure.providerError.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        XCTAssertTrue(session.error?.contains(failure.phase.displayName) == true)
+        XCTAssertTrue(session.error?.contains(failure.providerError) == true)
+    }
+
+    func testSuccessfulTranscriptSaveClearsPriorRecorderFailure() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .success("fresh transcript"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let outputURL = recordingsDirectory.appendingPathComponent("Recording success.wav")
+        let failureURL = outputURL.deletingPathExtension().appendingPathExtension("transcription-failure.json")
+        let oldFailure = AudioRecorderViewModel.RecordingTranscriptionFailure(
+            phase: .finalTranscription,
+            providerError: "old error",
+            engineName: "Groq",
+            modelName: "Whisper Large V3",
+            failedAt: Date.distantPast
+        )
+        try JSONEncoder().encode(oldFailure).write(to: failureURL, options: .atomic)
+
+        let recorderService = makeRecorderService(
+            recordingsDirectory: recordingsDirectory,
+            outputURL: outputURL
+        )
+        let viewModel = makeViewModel(defaults: defaults, modelManager: modelManager, recorderService: recorderService)
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let sessionID = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
+        XCTAssertEqual(session.text, "fresh transcript")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: failureURL.path))
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertEqual(recording.transcript, "fresh transcript")
+        XCTAssertNil(recording.transcriptionFailure)
+    }
+
     private func makeViewModel(
         defaults: UserDefaults,
         modelManager: ModelManagerService = ModelManagerService(),
         recorderService: AudioRecorderService = AudioRecorderService(),
         livePreviewStartObserver: (() -> Void)? = nil
     ) -> AudioRecorderViewModel {
-        AudioRecorderViewModel(
+        setupEventBus()
+        return AudioRecorderViewModel(
             recorderService: recorderService,
             modelManager: modelManager,
             dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
             defaults: defaults,
             livePreviewStartObserver: livePreviewStartObserver
         )
+    }
+
+    private func makeFinalTranscriptionViewModel(
+        defaults: UserDefaults,
+        modelManager: ModelManagerService,
+        recordingsDirectory: URL? = nil
+    ) -> AudioRecorderViewModel {
+        let recorderService = makeRecorderService(
+            recordingsDirectory: recordingsDirectory ?? makeTemporaryDirectory()
+        )
+        let viewModel = makeViewModel(defaults: defaults, modelManager: modelManager, recorderService: recorderService)
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+        return viewModel
+    }
+
+    private func makeRecorderService(
+        recordingsDirectory: URL,
+        outputURL: URL? = nil,
+        samples: [Float] = Array(repeating: 0.25, count: Int(AudioRecorderService.transcriptionSampleRate))
+    ) -> AudioRecorderService {
+        let recorderService = AudioRecorderService()
+        recorderService.recordingsDirectoryOverride = recordingsDirectory
+        recorderService.startRecordingOverride = { _, _, _, proposedOutputURL in
+            let resolvedOutputURL = outputURL ?? proposedOutputURL
+            try FileManager.default.createDirectory(
+                at: resolvedOutputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("placeholder".utf8).write(to: resolvedOutputURL)
+            return resolvedOutputURL
+        }
+        recorderService.stopRecordingOverride = { resolvedOutputURL in
+            try Data("recorded".utf8).write(to: resolvedOutputURL)
+            return resolvedOutputURL
+        }
+        recorderService.currentBufferOverride = { samples }
+        return recorderService
     }
 
     private func livePreviewStartCount(
@@ -171,7 +309,36 @@ final class AudioRecorderViewModelTests: XCTestCase {
         return startCount
     }
 
-    private func setupPluginManager() {
+    private func waitForRecorderSession(
+        _ viewModel: AudioRecorderViewModel,
+        id: UUID,
+        status: AudioRecorderViewModel.RecorderAPISessionStatus,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> AudioRecorderViewModel.RecorderAPISessionSnapshot {
+        for _ in 0..<40 {
+            if let session = viewModel.apiRecorderSession(id: id), session.status == status {
+                return session
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        let session = viewModel.apiRecorderSession(id: id)
+        XCTFail("Recorder session \(id) did not reach \(status.rawValue). Current status: \(session?.status.rawValue ?? "missing")", file: file, line: line)
+        return try XCTUnwrap(session, file: file, line: line)
+    }
+
+    private func setupEventBus() {
+        let previousEventBus: EventBus? = EventBus.shared
+        EventBus.shared = EventBus()
+        addTeardownBlock {
+            EventBus.shared = previousEventBus
+        }
+    }
+
+    private func setupPluginManager(
+        groqBehavior: AudioRecorderMockTranscriptionPlugin.TranscriptionBehavior = .success("mock transcription"),
+        assemblyAIBehavior: AudioRecorderMockTranscriptionPlugin.TranscriptionBehavior = .success("mock transcription")
+    ) {
         let previousPluginManager = PluginManager.shared
         addTeardownBlock {
             PluginManager.shared = previousPluginManager
@@ -194,7 +361,8 @@ final class AudioRecorderViewModelTests: XCTestCase {
                         PluginModelInfo(id: "whisper-large-v3", displayName: "Whisper Large V3"),
                         PluginModelInfo(id: "whisper-small", displayName: "Whisper Small")
                     ],
-                    selectedModelId: "whisper-large-v3"
+                    selectedModelId: "whisper-large-v3",
+                    behavior: groqBehavior
                 ),
                 bundle: Bundle.main,
                 sourceURL: appSupportDirectory,
@@ -214,7 +382,8 @@ final class AudioRecorderViewModelTests: XCTestCase {
                         PluginModelInfo(id: "universal-3-pro", displayName: "Universal-3 Pro"),
                         PluginModelInfo(id: "universal-2", displayName: "Universal-2")
                     ],
-                    selectedModelId: "universal-2"
+                    selectedModelId: "universal-2",
+                    behavior: assemblyAIBehavior
                 ),
                 bundle: Bundle.main,
                 sourceURL: appSupportDirectory,
@@ -266,6 +435,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
 }
 
 private final class AudioRecorderMockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    enum TranscriptionBehavior {
+        case success(String)
+        case empty
+        case failure(String)
+    }
+
     static let pluginId = "com.typewhisper.mock.audio-recorder"
     static let pluginName = "Audio Recorder Mock"
 
@@ -275,12 +450,14 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
     var selectedModelId: String?
     var isConfigured = true
     var supportsTranslation = true
+    private let behavior: TranscriptionBehavior
 
     required override init() {
         self.providerId = "mock"
         self.providerDisplayName = "Mock"
         self.transcriptionModels = []
         self.selectedModelId = nil
+        self.behavior = .success("mock transcription")
         super.init()
     }
 
@@ -288,12 +465,14 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         providerId: String,
         displayName: String,
         models: [PluginModelInfo],
-        selectedModelId: String?
+        selectedModelId: String?,
+        behavior: TranscriptionBehavior = .success("mock transcription")
     ) {
         self.providerId = providerId
         self.providerDisplayName = displayName
         self.transcriptionModels = models
         self.selectedModelId = selectedModelId
+        self.behavior = behavior
         super.init()
     }
 
@@ -310,6 +489,13 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        PluginTranscriptionResult(text: "mock transcription")
+        switch behavior {
+        case .success(let text):
+            PluginTranscriptionResult(text: text)
+        case .empty:
+            PluginTranscriptionResult(text: "")
+        case .failure(let message):
+            throw PluginTranscriptionError.apiError(message)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Persist Recorder final-transcription failures in a sidecar next to the saved recording, including phase, provider error, engine/model, and timestamp.
- Show Recorder rows a persistent red terminal failure state with the saved file duration, file size, failure phase, and provider error while keeping retry/reveal/delete actions available.
- Return a final transcription outcome from the Recorder stop flow so API sessions with saved audio and terminal transcription failures end as `failed` with `output_file` retained.

## Issue Context
Issue #661 reports Recorder-tab sessions where the recording is still saved, but the final transcript never appears and no clear terminal error is shown. #676 improved the File Transcription path, but the Recorder tab finalization flow is separate and still needed its own failure surface.

Closes #661

## Test Plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visible transcription failure details for recordings, including a clear failed status and a longer error summary.
  * Recording history now preserves transcription failure information alongside each audio item.

* **Bug Fixes**
  * Improved final transcription handling so empty or failed results are reported more accurately.
  * Deleting a recording now also removes its saved failure details.

* **Tests**
  * Expanded automated coverage for successful, empty, and failed transcription outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->