### PR TITLE
Fix compressed M4A upload finalization

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/Tests/CartesiaPluginTests.swift
@@ -182,7 +182,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertTrue(request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data; boundary=") == true)
         XCTAssertEqual(request.timeoutInterval, 600)
 
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains(#"name="file"; filename="audio.m4a""#))
         XCTAssertTrue(body.contains("Content-Type: audio/mp4"))
         XCTAssertTrue(body.contains("name=\"model\"\r\n\r\nink-whisper"))
@@ -305,7 +305,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertEqual(request.url?.path, "/stt")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Cartesia-Version"), CartesiaPlugin.apiVersion)
 
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
     }
 
@@ -334,7 +334,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertEqual(result.text, "Hello, how are you?")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 
@@ -362,7 +362,7 @@ final class CartesiaPluginTests: XCTestCase {
 
         XCTAssertEqual(result.text, "Hello from wav")
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains(#"name="file"; filename="audio.wav""#))
         XCTAssertTrue(body.contains("Content-Type: audio/wav"))
         XCTAssertTrue(body.contains("fallback-wav"))
@@ -438,7 +438,7 @@ final class CartesiaPluginTests: XCTestCase {
         )
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 
@@ -467,7 +467,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertEqual(result.text, "Привет, как дела?")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
     }
 
@@ -501,7 +501,7 @@ final class CartesiaPluginTests: XCTestCase {
         XCTAssertEqual(result.detectedLanguage, "ru")
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nru"))
     }
 
@@ -528,7 +528,7 @@ final class CartesiaPluginTests: XCTestCase {
         )
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        let body = try XCTUnwrap(String(data: try XCTUnwrap(request.httpBody), encoding: .utf8))
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nen"))
     }
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -260,6 +260,48 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
     }
 
+    func testTranscribeRetriesWithWavWhenCompatibleServerReportsFfprobeFailure() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedModel": "large-v3",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":"ffprobe failed: moov atom not found"}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/audio/transcriptions", statusCode: 500)
+                ),
+                .success(
+                    Data(#"{"text":"fallback hello"}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: "de", translate: false, prompt: "TypeWhisper")
+
+        XCTAssertEqual(result.text, "fallback hello")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstBody.contains("Content-Type: audio/mp4"))
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
+        XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nlarge-v3"))
+        XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
+    }
+
     func testProfileSpecificTranscriptionUsesSeparateCredentialsAndURLs() async throws {
         let host = try PluginTestHostServices(
             defaults: [

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -336,15 +336,19 @@ public enum PluginAudioUploadEncoder {
     }
 
     public static func shouldRetryWithWavUpload(statusCode: Int, responseData: Data) -> Bool {
-        guard [400, 415, 422].contains(statusCode) else {
-            return false
-        }
-
         guard statusCode != 415 else { return true }
 
         let message = String(data: responseData, encoding: .utf8) ?? ""
-        return audioUploadErrorMessageCandidates(from: message)
-            .contains { indicatesUnsupportedAudioUpload($0) }
+        let candidates = audioUploadErrorMessageCandidates(from: message)
+        if [400, 422].contains(statusCode) {
+            return candidates.contains { indicatesUnsupportedAudioUpload($0) }
+        }
+
+        if statusCode == 500 {
+            return candidates.contains { indicatesMediaProbeFailure($0) }
+        }
+
+        return false
     }
 
     public static func shouldRetryWithWavUpload(error: Error) -> Bool {
@@ -360,12 +364,14 @@ public enum PluginAudioUploadEncoder {
             return true
         }
 
-        guard message.contains("HTTP 400:") || message.contains("HTTP 422:") else {
-            return false
+        let candidates = audioUploadErrorMessageCandidates(from: message)
+        if message.contains("HTTP 500:") {
+            return candidates.contains { indicatesMediaProbeFailure($0) }
         }
 
-        return audioUploadErrorMessageCandidates(from: message)
-            .contains { indicatesUnsupportedAudioUpload($0) }
+        guard message.contains("HTTP 400:") || message.contains("HTTP 422:") else { return false }
+
+        return candidates.contains { indicatesUnsupportedAudioUpload($0) }
     }
 
     private static func audioUploadErrorMessageCandidates(from responseText: String) -> [String] {
@@ -419,6 +425,18 @@ public enum PluginAudioUploadEncoder {
             && mediaTerms.contains { lowercased.contains($0) }
     }
 
+    private static func indicatesMediaProbeFailure(_ message: String) -> Bool {
+        let lowercased = message.lowercased()
+        let probeFailures = [
+            "ffprobe failed",
+            "ffprobe",
+            "ffmpeg",
+            "moov atom not found",
+            "invalid data found when processing input",
+        ]
+        return probeFailures.contains { lowercased.contains($0) }
+    }
+
     private static func compressedM4AData(from samples: [Float]) throws -> Data {
         guard !samples.isEmpty else {
             throw PluginTranscriptionError.apiError("Cannot encode empty audio upload")
@@ -442,28 +460,30 @@ public enum PluginAudioUploadEncoder {
             throw PluginTranscriptionError.apiError("Failed to create compressed upload format")
         }
 
-        let file = try AVAudioFile(
-            forWriting: url,
-            settings: settings,
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
+        do {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: settings,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
 
-        var offset = 0
-        while offset < samples.count {
-            let count = min(compressedUploadChunkFrames, samples.count - offset)
-            guard let buffer = AVAudioPCMBuffer(
-                pcmFormat: format,
-                frameCapacity: AVAudioFrameCount(count)
-            ) else {
-                throw PluginTranscriptionError.apiError("Failed to create compressed upload buffer")
+            var offset = 0
+            while offset < samples.count {
+                let count = min(compressedUploadChunkFrames, samples.count - offset)
+                guard let buffer = AVAudioPCMBuffer(
+                    pcmFormat: format,
+                    frameCapacity: AVAudioFrameCount(count)
+                ) else {
+                    throw PluginTranscriptionError.apiError("Failed to create compressed upload buffer")
+                }
+                buffer.frameLength = AVAudioFrameCount(count)
+                samples.withUnsafeBufferPointer { pointer in
+                    buffer.floatChannelData?[0].update(from: pointer.baseAddress! + offset, count: count)
+                }
+                try file.write(from: buffer)
+                offset += count
             }
-            buffer.frameLength = AVAudioFrameCount(count)
-            samples.withUnsafeBufferPointer { pointer in
-                buffer.floatChannelData?[0].update(from: pointer.baseAddress! + offset, count: count)
-            }
-            try file.write(from: buffer)
-            offset += count
         }
 
         return try Data(contentsOf: url)

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -429,8 +429,13 @@ public enum PluginAudioUploadEncoder {
         let lowercased = message.lowercased()
         let probeFailures = [
             "ffprobe failed",
-            "ffprobe",
-            "ffmpeg",
+            "ffprobe error",
+            "ffprobe returned",
+            "ffprobe exited",
+            "ffmpeg failed",
+            "ffmpeg error",
+            "ffmpeg returned",
+            "ffmpeg exited",
             "moov atom not found",
             "invalid data found when processing input",
         ]

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -124,10 +124,12 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         XCTAssertEqual(upload.format, "m4a")
         XCTAssertTrue(upload.data.count > 0)
         XCTAssertLessThan(upload.data.count, wavData.count)
-        XCTAssertTrue(String(decoding: upload.data.prefix(64), as: UTF8.self).contains("ftyp"))
+        XCTAssertNotNil(upload.data.range(of: Data("ftyp".utf8)))
+        XCTAssertNotNil(upload.data.range(of: Data("mdat".utf8)))
+        XCTAssertNotNil(upload.data.range(of: Data("moov".utf8)))
     }
 
-    func testWavFallbackRetryClassifierRequiresMediaFormatRejectionFor400And422() {
+    func testWavFallbackRetryClassifierRequiresMediaFormatOrProbeFailure() {
         XCTAssertTrue(
             PluginAudioUploadEncoder.shouldRetryWithWavUpload(
                 statusCode: 400,
@@ -158,6 +160,19 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
                 responseData: Data(#"{"error":"bad upload"}"#.utf8)
             )
         )
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 500,
+                responseData: Data(#"{"error":"ffprobe failed: moov atom not found"}"#.utf8)
+            )
+        )
+        XCTAssertTrue(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                error: PluginTranscriptionError.apiError(
+                    #"HTTP 500: {"error":"Invalid data found when processing input"}"#
+                )
+            )
+        )
         XCTAssertFalse(
             PluginAudioUploadEncoder.shouldRetryWithWavUpload(
                 statusCode: 400,
@@ -186,6 +201,12 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
             PluginAudioUploadEncoder.shouldRetryWithWavUpload(
                 statusCode: 400,
                 responseData: Data(#"{"error":{"message":"corrupt request data","type":"invalid_request_error"}}"#.utf8)
+            )
+        )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 500,
+                responseData: Data(#"{"error":"internal server error"}"#.utf8)
             )
         )
     }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -209,6 +209,12 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
                 responseData: Data(#"{"error":"internal server error"}"#.utf8)
             )
         )
+        XCTAssertFalse(
+            PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+                statusCode: 500,
+                responseData: Data(#"{"error":"ffmpeg worker unavailable"}"#.utf8)
+            )
+        )
     }
 
     func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {


### PR DESCRIPTION
## Summary
- Fixes the shared compressed M4A upload encoder so `AVAudioFile` is finalized before the plugin SDK reads the temporary `.m4a` bytes.
- Adds regression coverage proving compressed uploads now include finalized `ftyp`, `mdat`, and `moov` atoms.
- Extends WAV retry classification for narrow media-probe failures such as `ffprobe failed: moov atom not found` on HTTP 500, while keeping generic 500s non-retriable.
- Adds an OpenAI Compatible regression test for the issue report and updates Cartesia multipart tests to tolerate valid binary M4A payloads.

## Issue Context
Issue #811 reports that OpenAI Compatible plugin v1.1.5 uploads `audio.m4a` files that ffprobe cannot decode because the `moov` atom is missing. Servers that validate audio through ffprobe/ffmpeg return HTTP 500, and the existing WAV fallback does not retry because the response is not a 400/415/422 unsupported-format error.

This fix addresses both sides: the generated M4A bytes are finalized before upload, and the fallback now handles exact media-probe failures from compatible servers.

Closes #811

## Test Coverage
All new code paths have regression coverage:
- M4A encoder output contains `ftyp`, `mdat`, and `moov`.
- HTTP 500 `ffprobe failed: moov atom not found` retries with WAV.
- Generic HTTP 500 remains non-retriable.
- OpenAI Compatible preserves model/language/prompt fields across the WAV retry.

## Pre-Landing Review
No issues found. The diff is limited to the shared SDK encoder/retry classifier and tests. No SQL, LLM trust-boundary, shell, enum, workflow, or distribution-pipeline changes are introduced.

## Release Plan
After this PR lands on `main`, release the affected official plugins with `plugin-release.yml`:

`assemblyai 1.0.13`, `cartesia 1.0.4`, `cloudflare-asr 1.0.6`, `deepgram 1.0.12`, `elevenlabs 1.0.8`, `gemini 1.0.20`, `gladia 1.0.8`, `groq 1.0.23`, `mistral 1.0.3`, `openai 1.2.2`, `openai-compatible 1.1.6`, `openrouter 1.1.3`, `soniox 1.2.4`, `speechmatics 1.0.7`, `xai 1.0.2`.

## Test Plan
- [x] `swift test --package-path TypeWhisperPluginSDK --filter 'OpenAITranscriptionHelperTests|OpenAICompatiblePluginTests'`
- [x] `swift test --package-path TypeWhisperPluginSDK --filter CartesiaPluginTests`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `swift test --package-path TypeWhisperPluginSDK --filter 'OpenAITranscriptionHelperTests|OpenAICompatiblePluginTests|CartesiaPluginTests'`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription reliability by refining when the app retries uploads using a more compatible WAV format, based on clearer server error signals.
  * Better distinguishes unsupported-audio versus media-probe failures to reduce unnecessary retries and failed transcription attempts.
  * Strengthened validation of compressed and multipart audio uploads to ensure correct request content.
* **Tests**
  * Added coverage for WAV retry behavior when servers report missing media metadata, and expanded assertions around upload retry classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->