### PR TITLE
Fix Right Option hybrid single-tap toggle

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -922,7 +922,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     }
 
     private func shouldDelayHybridModifierHold(for slotType: HotkeySlotType, hotkey: UnifiedHotkey) -> Bool {
-        slotType == .hybrid && hotkey.kind == .modifierOnly && !hotkey.isDoubleTap
+        guard slotType == .hybrid, hotkey.kind == .modifierOnly, !hotkey.isDoubleTap else {
+            return false
+        }
+        return Self.modifierFlagForKeyCode(hotkey.keyCode) == .control
     }
 
     private func scheduleDelayedHybridModifierHoldStart(for hotkey: UnifiedHotkey) {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -8374,6 +8374,32 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testHybridRightOptionSingleTapStillTogglesDictation() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(rightOptionModifierHotkey(), for: .hybrid)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeRightOptionModifierEvent(isDown: true)
+        let keyUp = try makeRightOptionModifierEvent(isDown: false)
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .eventTap))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .eventTap))
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .toggle)
+    }
+
+    @MainActor
     func testHybridModifierShortcutCancelsPendingHold() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -9458,6 +9484,15 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         )
     }
 
+    @MainActor
+    private func rightOptionModifierHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x3D,
+            modifierFlags: 0,
+            isFn: false
+        )
+    }
+
     private func makeKeyboardEvent(
         keyCode: UInt16,
         keyDown: Bool,
@@ -9512,6 +9547,13 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         try makeFlagsChangedEvent(
             keyCode: 0x3B,
             modifierFlags: isDown ? [.control] : []
+        )
+    }
+
+    private func makeRightOptionModifierEvent(isDown: Bool) throws -> NSEvent {
+        try makeFlagsChangedEvent(
+            keyCode: 0x3D,
+            modifierFlags: isDown ? [.option] : []
         )
     }
 


### PR DESCRIPTION
## Issue Context

#805 was reopened after build 921 still reproduced the Hybrid hotkey regression with Right Option. #806 fixed the delayed-hold release path, but the remaining regression came from #793 applying the #782 Control-intent delay to every modifier-only Hybrid hotkey. That made a normal Right Option single tap cancel before Hybrid could toggle.

Closes #805

## Changes

- Limit the delayed Hybrid modifier hold path to Control-only modifier hotkeys.
- Preserve the existing 350 ms intent delay for Control-based Hybrid hotkeys from #782.
- Restore immediate Hybrid handling for non-Control modifier-only hotkeys such as Right Option, so release before the Hybrid threshold toggles dictation as before.
- Add a regression test for Right Option single-tap Hybrid toggle behavior.

## Test Plan

- `git diff --check`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests/testHybridRightOptionSingleTapStillTogglesDictation -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests/testHybridModifierShortTapDoesNotToggleDictation -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests/testHybridModifierHoldStartsAfterDelayAndShortReleaseTogglesDictation -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests/testHybridModifierLongHoldStopsAfterRelease test`\n- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests test`\n- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' test`\n- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/fc93/typewhisper-mac`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of hybrid hotkey handling so modifier-only shortcuts behave more consistently.
  * Fixed a dictation mode toggle issue for right Option single-tap actions in hybrid mode, ensuring it switches correctly on key press and release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->