### PR TITLE
Fix fullscreen top overlay menu bar strip

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -251,6 +251,26 @@ private enum SafariBundleIdentifiers {
 enum IndicatorWindowFrameLookup {
     @MainActor
     static func safariWindowFrames(intersecting screenFrame: CGRect) -> [CGRect] {
+        windowFrames(intersecting: screenFrame) { ownerPID, _ in
+            guard let application = NSRunningApplication(processIdentifier: ownerPID) else {
+                return false
+            }
+            return isSafariWindowOwner(application.bundleIdentifier)
+        }
+    }
+
+    @MainActor
+    static func applicationWindowFrames(for processIdentifier: pid_t, intersecting screenFrame: CGRect) -> [CGRect] {
+        windowFrames(intersecting: screenFrame) { ownerPID, _ in
+            ownerPID == processIdentifier
+        }
+    }
+
+    @MainActor
+    private static func windowFrames(
+        intersecting screenFrame: CGRect,
+        matchingOwner: (pid_t, [String: Any]) -> Bool
+    ) -> [CGRect] {
         guard let windowList = CGWindowListCopyWindowInfo(
             [.optionOnScreenOnly, .excludeDesktopElements],
             kCGNullWindowID
@@ -262,8 +282,7 @@ enum IndicatorWindowFrameLookup {
         return windowList.compactMap { windowInfo in
             guard let rawBounds = windowInfo[kCGWindowBounds as String],
                   let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
-                  let application = NSRunningApplication(processIdentifier: ownerPID),
-                  isSafariWindowOwner(application.bundleIdentifier) else {
+                  matchingOwner(ownerPID, windowInfo) else {
                 return nil
             }
 
@@ -456,6 +475,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         focusedWindowFullscreenProvider: () -> Bool? = IndicatorWindowFrameLookup.focusedWindowIsFullscreen,
         windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
         safariWindowFramesProvider: @MainActor (CGRect) -> [CGRect] = IndicatorWindowFrameLookup.safariWindowFrames(intersecting:),
+        applicationWindowFramesProvider: @MainActor (pid_t, CGRect) -> [CGRect] = IndicatorWindowFrameLookup.applicationWindowFrames(for:intersecting:),
         appBundleIdentifier: String? = Bundle.main.bundleIdentifier
     ) -> Bool {
         let application = frontmostApplicationProvider()
@@ -469,6 +489,13 @@ enum IndicatorFullscreenSuppressionPolicy {
         }
         let focusedWindowIsFullscreen = focusedWindowFullscreenProvider()
         let safariWindowFrames = safariWindowFramesProvider(screen.frame)
+        let applicationWindowFrames: [CGRect]
+        if let application,
+           !isTypeWhisperBundleIdentifier(application.bundleIdentifier, appBundleIdentifier: appBundleIdentifier) {
+            applicationWindowFrames = applicationWindowFramesProvider(application.processIdentifier, screen.frame)
+        } else {
+            applicationWindowFrames = []
+        }
 
         let shouldSuppress = shouldSuppressIndicator(
             screenFrame: screen.frame,
@@ -478,7 +505,8 @@ enum IndicatorFullscreenSuppressionPolicy {
             frontmostBundleIdentifier: application?.bundleIdentifier,
             appBundleIdentifier: appBundleIdentifier,
             placement: placement,
-            safariWindowFrames: safariWindowFrames
+            safariWindowFrames: safariWindowFrames,
+            applicationWindowFrames: applicationWindowFrames
         )
 
         if shouldSuppress, let application {
@@ -502,7 +530,8 @@ enum IndicatorFullscreenSuppressionPolicy {
         frontmostBundleIdentifier: String?,
         appBundleIdentifier: String?,
         placement: IndicatorPlacement = .notchStrip,
-        safariWindowFrames: [CGRect] = []
+        safariWindowFrames: [CGRect] = [],
+        applicationWindowFrames: [CGRect] = []
     ) -> Bool {
         guard safeAreaTopInset > 0, !screenFrame.isEmpty else {
             return false
@@ -511,7 +540,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         let screenFrame = screenFrame.standardized
 
         if safariWindowFrames.contains(where: {
-            isSafariFullscreenLikeWindow(
+            isFullscreenLikeOrContentWindowBelowNotch(
                 screenFrame: screenFrame,
                 safeAreaTopInset: safeAreaTopInset,
                 windowFrame: $0.standardized
@@ -520,9 +549,37 @@ enum IndicatorFullscreenSuppressionPolicy {
             return true
         }
 
-        guard let candidateWindowFrame = windowFrame,
+        let frontmostIsTypeWhisper = isTypeWhisperBundleIdentifier(
+            frontmostBundleIdentifier,
+            appBundleIdentifier: appBundleIdentifier
+        )
+
+        let candidateWindowFrame = windowFrame?.standardized
+        let focusedWindowIsKnownMainSurface = candidateWindowFrame.map {
+            isFullscreenLikeOrContentWindowBelowNotch(
+                screenFrame: screenFrame,
+                safeAreaTopInset: safeAreaTopInset,
+                windowFrame: $0
+            )
+        } ?? false
+        let focusedWindowExplicitlyNotFullscreen = focusedWindowIsFullscreen == false && focusedWindowIsKnownMainSurface
+
+        if placement == .notchStrip,
+           !frontmostIsTypeWhisper,
+           !focusedWindowExplicitlyNotFullscreen,
+           applicationWindowFrames.contains(where: {
+                isFullscreenLikeOrContentWindowBelowNotch(
+                    screenFrame: screenFrame,
+                    safeAreaTopInset: safeAreaTopInset,
+                    windowFrame: $0.standardized
+                )
+           }) {
+            return true
+        }
+
+        guard let candidateWindowFrame,
               !candidateWindowFrame.isEmpty,
-              !isTypeWhisperBundleIdentifier(frontmostBundleIdentifier, appBundleIdentifier: appBundleIdentifier) else {
+              !frontmostIsTypeWhisper else {
             return false
         }
 
@@ -530,12 +587,12 @@ enum IndicatorFullscreenSuppressionPolicy {
             return false
         }
 
-        let windowFrame = candidateWindowFrame.standardized
+        let windowFrame = candidateWindowFrame
 
         // Safari's hidden fullscreen toolbar can be triggered by auxiliary panels
         // even when the indicator renders away from the notch strip.
         if isSafariBundleIdentifier(frontmostBundleIdentifier),
-           isSafariFullscreenLikeWindow(
+           isFullscreenLikeOrContentWindowBelowNotch(
                 screenFrame: screenFrame,
                 safeAreaTopInset: safeAreaTopInset,
                 windowFrame: windowFrame
@@ -551,6 +608,12 @@ enum IndicatorFullscreenSuppressionPolicy {
             guard focusedWindowIsFullscreen else { return false }
             // Tahoe fullscreen windows can report a content frame below the notch
             // strip while auxiliary panels still affect the top menu-bar strip.
+            return true
+        } else if isFullscreenContentWindowBelowNotch(
+            screenFrame: screenFrame,
+            safeAreaTopInset: safeAreaTopInset,
+            windowFrame: windowFrame
+        ) {
             return true
         } else if !isFullscreenLikeWindow(screenFrame: screenFrame, windowFrame: windowFrame) {
             return false
@@ -573,7 +636,7 @@ enum IndicatorFullscreenSuppressionPolicy {
             && heightCoverage >= minimumFullscreenDimensionCoverage
     }
 
-    private static func isSafariFullscreenLikeWindow(
+    private static func isFullscreenLikeOrContentWindowBelowNotch(
         screenFrame: CGRect,
         safeAreaTopInset: CGFloat,
         windowFrame: CGRect
@@ -582,6 +645,18 @@ enum IndicatorFullscreenSuppressionPolicy {
             return true
         }
 
+        return isFullscreenContentWindowBelowNotch(
+            screenFrame: screenFrame,
+            safeAreaTopInset: safeAreaTopInset,
+            windowFrame: windowFrame
+        )
+    }
+
+    private static func isFullscreenContentWindowBelowNotch(
+        screenFrame: CGRect,
+        safeAreaTopInset: CGFloat,
+        windowFrame: CGRect
+    ) -> Bool {
         let contentHeight = screenFrame.height - safeAreaTopInset
         guard contentHeight > 0 else { return false }
 

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -488,9 +488,12 @@ enum IndicatorFullscreenSuppressionPolicy {
             windowFrame = nil
         }
         let focusedWindowIsFullscreen = focusedWindowFullscreenProvider()
+        let safeAreaTopInset = screen.safeAreaInsets.top
         let safariWindowFrames = safariWindowFramesProvider(screen.frame)
         let applicationWindowFrames: [CGRect]
-        if let application,
+        if placement == .notchStrip,
+           safeAreaTopInset > 0,
+           let application,
            !isTypeWhisperBundleIdentifier(application.bundleIdentifier, appBundleIdentifier: appBundleIdentifier) {
             applicationWindowFrames = applicationWindowFramesProvider(application.processIdentifier, screen.frame)
         } else {
@@ -499,7 +502,7 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         let shouldSuppress = shouldSuppressIndicator(
             screenFrame: screen.frame,
-            safeAreaTopInset: screen.safeAreaInsets.top,
+            safeAreaTopInset: safeAreaTopInset,
             windowFrame: windowFrame,
             focusedWindowIsFullscreen: focusedWindowIsFullscreen,
             frontmostBundleIdentifier: application?.bundleIdentifier,

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -297,6 +297,96 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testSuppressesForeignFullscreenContentWindowBelowNotchStripWhenAXFullscreenIsUnavailable() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let fullscreenContentWindowBelowNotch = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: fullscreenContentWindowBelowNotch,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.brave.Browser",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .notchStrip
+            )
+        )
+    }
+
+    func testDoesNotSuppressForeignFullscreenContentWindowBelowNotchStripForBottomPlacementWhenAXFullscreenIsUnavailable() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let fullscreenContentWindowBelowNotch = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: fullscreenContentWindowBelowNotch,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.brave.Browser",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea
+            )
+        )
+    }
+
+    func testSuppressesWhenFocusedWindowIsTransientButApplicationHasFullscreenContentBelowNotch() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let transientToolbarWindow = CGRect(x: 0, y: 0, width: 1512, height: 41)
+        let fullscreenContentWindowBelowNotch = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: transientToolbarWindow,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.brave.Browser",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .notchStrip,
+                applicationWindowFrames: [fullscreenContentWindowBelowNotch]
+            )
+        )
+    }
+
+    func testDoesNotSuppressBottomPlacementWhenFocusedWindowIsTransientButApplicationHasFullscreenContentBelowNotch() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let transientToolbarWindow = CGRect(x: 0, y: 0, width: 1512, height: 41)
+        let fullscreenContentWindowBelowNotch = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: transientToolbarWindow,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.brave.Browser",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                applicationWindowFrames: [fullscreenContentWindowBelowNotch]
+            )
+        )
+    }
+
+    func testDoesNotSuppressMaximizedMainWindowWhenApplicationWindowScanSeesSameFrameAndAXReportsNotFullscreen() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let maximizedWindowBelowNotch = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: maximizedWindowBelowNotch,
+                focusedWindowIsFullscreen: false,
+                frontmostBundleIdentifier: "com.brave.Browser",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .notchStrip,
+                applicationWindowFrames: [maximizedWindowBelowNotch]
+            )
+        )
+    }
+
     func testDoesNotSuppressForeignMaximizedWindowWhenAXReportsNotFullscreen() {
         let maximizedWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
 


### PR DESCRIPTION
## Summary
- Follow-up to #808 after the June 29 report/video showed the issue still reproducing with `Overlay + Top`: fullscreen Chromium-style apps on notched displays could still get a wallpaper-colored top strip and nearly invisible tab/menu items.
- Extends fullscreen suppression beyond the focused AX window by scanning the visible windows for the frontmost foreign app, so top/notch indicators are suppressed when fullscreen content starts below the notch safe-area strip.
- Keeps the #603 contract intact: bottom `Overlay`/`Minimal` indicators remain allowed over fullscreen apps, and maximized non-fullscreen windows remain allowed when `AXFullScreen == false`.

Closes #808

## Issue Context
The original fix handled the straightforward `AXFullScreen == true` path and Safari's hidden-toolbar behavior. The follow-up video showed a different Chromium-style split-window case: the focused toolbar/window can report `AXFullScreen == false`, while the same app owns a fullscreen content window below the notch strip. That made top-position indicators eligible to join the fullscreen space and affect the menu-bar strip.

## Test Coverage
- Added regression coverage for foreign fullscreen content windows below the notch strip when `AXFullScreen` is unavailable.
- Added regression coverage for transient focused toolbar windows while the same app owns fullscreen content below the notch strip.
- Added negative coverage proving bottom `.nonNotchArea` indicators remain allowed.
- Added negative coverage proving maximized non-fullscreen main windows remain allowed when `AXFullScreen == false`.

## Verification
- [x] `git diff --check`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/898b/typewhisper-mac`

## Manual Verification
- Analyzed the linked YouTube report with `yt-dlp`, `ffmpeg`, and ImageMagick frame/pixel checks. The report's fullscreen top strip was wallpaper-blue in the affected frames.
- Reproduced the Chromium split-window state locally with Brave on the internal notched display and the dev app set to `Overlay + Top + Always`.
- After this patch, the internal fullscreen top strip measured dark/black in the central top band, while bottom-placement behavior remains covered by tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indicator fullscreen suppression when accessibility fullscreen availability is unknown or ambiguous, reducing incorrect hiding/showing across notch-strip and non-notch placements.
  * Enhanced handling for cases where another app has fullscreen-like content near the notch strip, ensuring suppression applies only when appropriate.
  * Refined fullscreen-like/content-below-notch detection logic to better match real window positioning.
* **Tests**
  * Added coverage for transient and maximized window scenarios involving below-notch application windows and nil fullscreen reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->