### PR TITLE
fix: macOS Secure Input hotkey handling

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		AA00000000000000000017 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000017 /* SettingsView.swift */; };
 		AA00000000000000000030 /* AudioRecordingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000030 /* AudioRecordingService.swift */; };
 		AA00000000000000000031 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000031 /* HotkeyService.swift */; };
+		AA00000000000000000362 /* SecureInputDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000362 /* SecureInputDiagnostics.swift */; };
 		AA00000000000000000361 /* ClipboardContentFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000361 /* ClipboardContentFormatter.swift */; };
 		AA00000000000000000032 /* TextInsertionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000032 /* TextInsertionService.swift */; };
 		AA00000000000000000033 /* DictationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000033 /* DictationViewModel.swift */; };
@@ -581,6 +582,7 @@
 		BB00000000000000000019 /* TypeWhisper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TypeWhisper.entitlements; sourceTree = "<group>"; };
 		BB00000000000000000030 /* AudioRecordingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecordingService.swift; sourceTree = "<group>"; };
 		BB00000000000000000031 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
+		BB00000000000000000362 /* SecureInputDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureInputDiagnostics.swift; sourceTree = "<group>"; };
 		BB00000000000000000361 /* ClipboardContentFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentFormatter.swift; sourceTree = "<group>"; };
 		BB00000000000000000032 /* TextInsertionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInsertionService.swift; sourceTree = "<group>"; };
 		BB00000000000000000033 /* DictationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationViewModel.swift; sourceTree = "<group>"; };
@@ -1481,6 +1483,7 @@
 				BB00000000000000000351 /* ObjCExceptionCatcher.m */,
 				BB00000000000000000220 /* AudioPlaybackService.swift */,
 				BB00000000000000000031 /* HotkeyService.swift */,
+				BB00000000000000000362 /* SecureInputDiagnostics.swift */,
 				BB00000000000000000196 /* IndicatorCoordinator.swift */,
 				BB00000000000000000361 /* ClipboardContentFormatter.swift */,
 				BB00000000000000000032 /* TextInsertionService.swift */,
@@ -3871,6 +3874,7 @@
 				AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */,
 				AA00000000000000000230 /* AudioPlaybackService.swift in Sources */,
 				AA00000000000000000031 /* HotkeyService.swift in Sources */,
+				AA00000000000000000362 /* SecureInputDiagnostics.swift in Sources */,
 				AA00000000000000000361 /* ClipboardContentFormatter.swift in Sources */,
 				AA00000000000000000032 /* TextInsertionService.swift in Sources */,
 				AA00000000000000000033 /* DictationViewModel.swift in Sources */,

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -412,6 +412,7 @@ private struct DiagnosticsReport: Encodable {
     let app: AppInfo
     let system: SystemInfo
     let permissions: PermissionsInfo
+    let secureInput: SecureInputDiagnostics
     let model: ModelInfo
     let api: APIInfo
     let processMemory: ProcessMemoryInfo
@@ -554,7 +555,7 @@ final class ErrorLogService: ObservableObject {
         }
 
         return DiagnosticsReport(
-            schemaVersion: 7,
+            schemaVersion: 8,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,
@@ -577,6 +578,7 @@ final class ErrorLogService: ObservableObject {
                 microphoneGranted: AVAudioApplication.shared.recordPermission == .granted,
                 accessibilityGranted: container.textInsertionService.isAccessibilityGranted
             ),
+            secureInput: SecureInputDiagnosticsProvider.snapshot(),
             model: .init(
                 selectedProviderId: container.modelManagerService.selectedProviderId,
                 selectedModelId: container.modelManagerService.selectedModelId,

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -147,6 +147,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     enum HotkeyEventSource: Sendable {
         case eventTap
         case monitor
+        case carbon
     }
 
     private enum HotkeyDispatchPhase: Hashable {
@@ -165,6 +166,19 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         let target: Target
         let phase: HotkeyDispatchPhase
         let hotkey: UnifiedHotkey
+    }
+
+    private struct CarbonHotkeyRegistration {
+        enum Target {
+            case slot(HotkeySlotType)
+            case profile(UUID)
+            case workflow(UUID, WorkflowHotkeyBehavior)
+        }
+
+        let id: UInt32
+        let target: Target
+        let hotkey: UnifiedHotkey
+        var ref: EventHotKeyRef?
     }
 
     enum HotkeyMode: String {
@@ -226,6 +240,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private static let escapeHotkey = UnifiedHotkey(keyCode: escapeKeyCode, modifierFlags: 0, isFn: false)
     private static let capsLockKeyCode: UInt16 = 0x39
     private static let capsLockSuppressionWindow: TimeInterval = 0.25
+    private static let carbonHotkeySignature: OSType = "tywh".utf16.reduce(0) { ($0 << 8) + OSType($1) }
     private nonisolated static let hotkeyEventTapPlacement: CGEventTapPlacement = .headInsertEventTap
 
     nonisolated static func requestTimestamp() -> UInt64 {
@@ -316,12 +331,18 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private var localMonitor: Any?
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var carbonHotkeyRegistrations: [UInt32: CarbonHotkeyRegistration] = [:]
+    private var carbonHotkeyEventHandlerRef: EventHandlerRef?
     private var recentEventTapDispatches: [HotkeyDispatchKey: Date] = [:]
     private var capsLockOriginSuppressionUntil: Date?
 
     var accessibilityTrustedProvider: () -> Bool = { AXIsProcessTrusted() }
 
     private let logger = Logger(subsystem: AppConstants.loggerSubsystem, category: "HotkeyService")
+
+    deinit {
+        tearDownMonitor()
+    }
 
     // Modifier keyCodes that generate flagsChanged instead of keyDown/keyUp
     nonisolated static let modifierKeyCodes: Set<UInt16> = [
@@ -542,15 +563,18 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private func setupMonitor() {
         tearDownMonitor()
         let includeMouse = needsMouseEventMonitoring
+        let suppressingMouse = needsSuppressingMouseEventTap
+        let accessibilityTrusted = accessibilityTrustedProvider()
+        installCarbonHotkeys()
 
-        guard accessibilityTrustedProvider() else {
+        guard accessibilityTrusted else {
             logger.info("Accessibility permission not granted, installing local hotkey monitor only")
             installLocalEventMonitor(includeMouse: includeMouse)
             return
         }
 
         // Try CGEventTap first - it can suppress hotkey events from reaching other apps
-        if setupEventTap(includeMouse: needsSuppressingMouseEventTap) {
+        if setupEventTap(includeMouse: suppressingMouse) {
             logger.info("Using head-inserted CGEventTap for hotkey monitoring with NSEvent compatibility fallback")
             installEventMonitors(includeMouse: includeMouse)
             return
@@ -615,6 +639,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     private func tearDownMonitor() {
         cancelPendingHybridModifierHold()
+        tearDownCarbonHotkeys()
 
         if let monitor = globalMonitor {
             NSEvent.removeMonitor(monitor)
@@ -651,6 +676,245 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     func resumeMonitoring() {
         setupMonitor()
+    }
+
+    // MARK: - Carbon Hotkeys (works through Secure Input)
+
+    private func installCarbonHotkeys() {
+        tearDownCarbonHotkeys()
+
+        var nextId: UInt32 = 1
+        for slotType in HotkeySlotType.allCases {
+            for state in slots[slotType] ?? [] {
+                guard let hotkey = state.hotkey else { continue }
+                registerCarbonHotkeyIfSupported(
+                    id: nextId,
+                    target: .slot(slotType),
+                    hotkey: hotkey
+                )
+                nextId &+= 1
+            }
+        }
+
+        for (profileId, state) in profileSlots {
+            registerCarbonHotkeyIfSupported(
+                id: nextId,
+                target: .profile(profileId),
+                hotkey: state.hotkey
+            )
+            nextId &+= 1
+        }
+
+        for states in workflowSlots.values {
+            for state in states {
+                registerCarbonHotkeyIfSupported(
+                    id: nextId,
+                    target: .workflow(state.workflowId, state.behavior),
+                    hotkey: state.hotkey
+                )
+                nextId &+= 1
+            }
+        }
+
+        installCarbonEventHandlersIfNeeded()
+    }
+
+    private func registerCarbonHotkeyIfSupported(
+        id: UInt32,
+        target: CarbonHotkeyRegistration.Target,
+        hotkey: UnifiedHotkey
+    ) {
+        guard Self.supportsCarbonHotkey(hotkey) else { return }
+
+        let hotkeyId = EventHotKeyID(signature: Self.carbonHotkeySignature, id: id)
+        let options = UInt32(kEventHotKeyNoOptions)
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(hotkey.keyCode),
+            Self.carbonModifierFlags(for: hotkey),
+            hotkeyId,
+            GetEventDispatcherTarget(),
+            options,
+            &ref
+        )
+
+        guard status == noErr, ref != nil else {
+            logger.warning(
+                "RegisterEventHotKey failed: id=\(id, privacy: .public), status=\(status, privacy: .public), hotkey=\(Self.displayName(for: hotkey), privacy: .public)"
+            )
+            return
+        }
+
+        carbonHotkeyRegistrations[id] = CarbonHotkeyRegistration(
+            id: id,
+            target: target,
+            hotkey: hotkey,
+            ref: ref
+        )
+    }
+
+    private func installCarbonEventHandlersIfNeeded() {
+        guard !carbonHotkeyRegistrations.isEmpty, carbonHotkeyEventHandlerRef == nil else { return }
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+
+        var eventTypes = [
+            EventTypeSpec(
+                eventClass: OSType(kEventClassKeyboard),
+                eventKind: OSType(kEventHotKeyPressed)
+            ),
+            EventTypeSpec(
+                eventClass: OSType(kEventClassKeyboard),
+                eventKind: OSType(kEventHotKeyReleased)
+            ),
+        ]
+        let status = InstallEventHandler(
+            GetEventDispatcherTarget(),
+            Self.carbonHotkeyEventHandler,
+            eventTypes.count,
+            &eventTypes,
+            selfPtr,
+            &carbonHotkeyEventHandlerRef
+        )
+        if status != noErr {
+            logger.warning("InstallEventHandler failed for Carbon hotkey events: status=\(status, privacy: .public)")
+            tearDownCarbonHotkeys()
+        }
+    }
+
+    private static let carbonHotkeyEventHandler: EventHandlerUPP = { _, event, userData in
+        guard let event, let userData else { return noErr }
+        var hotkeyId = EventHotKeyID()
+        let status = GetEventParameter(
+            event,
+            EventParamName(kEventParamDirectObject),
+            EventParamType(typeEventHotKeyID),
+            nil,
+            MemoryLayout<EventHotKeyID>.size,
+            nil,
+            &hotkeyId
+        )
+        guard status == noErr, hotkeyId.signature == carbonHotkeySignature else {
+            return noErr
+        }
+
+        let phase: HotkeyDispatchPhase
+        switch GetEventKind(event) {
+        case UInt32(kEventHotKeyPressed):
+            phase = .down
+        case UInt32(kEventHotKeyReleased):
+            phase = .up
+        default:
+            return noErr
+        }
+
+        let service = Unmanaged<HotkeyService>.fromOpaque(userData).takeUnretainedValue()
+        DispatchQueue.main.async {
+            service.handleCarbonHotkey(id: hotkeyId.id, phase: phase)
+        }
+        return noErr
+    }
+
+    private func handleCarbonHotkey(id: UInt32, phase: HotkeyDispatchPhase) {
+        guard let registration = carbonHotkeyRegistrations[id] else { return }
+        handleCarbonHotkey(registration: registration, phase: phase)
+    }
+
+    private func handleCarbonHotkey(
+        registration: CarbonHotkeyRegistration,
+        phase: HotkeyDispatchPhase
+    ) {
+        switch registration.target {
+        case let .slot(slotType):
+            guard !(dictationHotkeysPaused && slotType.startsDictation) else { return }
+            dispatchCarbonGlobalMatch(
+                slotType: slotType,
+                hotkey: registration.hotkey,
+                phase: phase
+            )
+
+        case let .profile(profileId):
+            guard !dictationHotkeysPaused else { return }
+            dispatchCarbonProfileMatch(
+                profileId: profileId,
+                hotkey: registration.hotkey,
+                phase: phase
+            )
+
+        case let .workflow(workflowId, behavior):
+            guard !(dictationHotkeysPaused && behavior == .startDictation) else { return }
+            dispatchCarbonWorkflowMatch(
+                workflowId: workflowId,
+                hotkey: registration.hotkey,
+                behavior: behavior,
+                phase: phase
+            )
+        }
+    }
+
+    private func dispatchCarbonGlobalMatch(
+        slotType: HotkeySlotType,
+        hotkey: UnifiedHotkey,
+        phase: HotkeyDispatchPhase
+    ) {
+        guard shouldDispatch(target: .slot(slotType), phase: phase, hotkey: hotkey, source: .carbon) else {
+            return
+        }
+
+        switch phase {
+        case .down:
+            handleKeyDown(slotType: slotType, hotkey: hotkey)
+        case .up:
+            handleKeyUp(slotType: slotType)
+        }
+    }
+
+    private func dispatchCarbonProfileMatch(
+        profileId: UUID,
+        hotkey: UnifiedHotkey,
+        phase: HotkeyDispatchPhase
+    ) {
+        guard shouldDispatch(target: .profile(profileId), phase: phase, hotkey: hotkey, source: .carbon) else {
+            return
+        }
+
+        switch phase {
+        case .down:
+            handleProfileKeyDown(profileId: profileId)
+        case .up:
+            handleProfileKeyUp(profileId: profileId)
+        }
+    }
+
+    private func dispatchCarbonWorkflowMatch(
+        workflowId: UUID,
+        hotkey: UnifiedHotkey,
+        behavior: WorkflowHotkeyBehavior,
+        phase: HotkeyDispatchPhase
+    ) {
+        guard shouldDispatch(target: .workflow(workflowId), phase: phase, hotkey: hotkey, source: .carbon) else {
+            return
+        }
+
+        switch phase {
+        case .down:
+            handleWorkflowKeyDown(workflowId: workflowId, behavior: behavior)
+        case .up:
+            handleWorkflowKeyUp(workflowId: workflowId, behavior: behavior)
+        }
+    }
+
+    private func tearDownCarbonHotkeys() {
+        for registration in carbonHotkeyRegistrations.values {
+            if let ref = registration.ref {
+                UnregisterEventHotKey(ref)
+            }
+        }
+        carbonHotkeyRegistrations.removeAll()
+
+        if let handler = carbonHotkeyEventHandlerRef {
+            RemoveEventHandler(handler)
+            carbonHotkeyEventHandlerRef = nil
+        }
     }
 
     // MARK: - CGEventTap (suppresses hotkey events)
@@ -1165,17 +1429,36 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         }
 
         let dispatchKey = HotkeyDispatchKey(target: target, phase: phase, hotkey: hotkey)
-        if source == .eventTap {
-            recentEventTapDispatches[dispatchKey] = now
-            return true
+        if let recentDispatch = recentEventTapDispatches[dispatchKey],
+           now.timeIntervalSince(recentDispatch) < Self.monitorDedupWindow {
+            return false
         }
 
-        return recentEventTapDispatches[dispatchKey] == nil
+        recentEventTapDispatches[dispatchKey] = now
+        return true
     }
 
     private func logFallbackMatchIfNeeded(hotkey: UnifiedHotkey, source: HotkeyEventSource) {
         guard source == .monitor, eventTap != nil, hotkey.mouseButton == nil else { return }
         logger.info("Matched hotkey via NSEvent compatibility fallback: \(Self.displayName(for: hotkey), privacy: .public)")
+    }
+
+    private nonisolated static func supportsCarbonHotkey(_ hotkey: UnifiedHotkey) -> Bool {
+        hotkey.kind == .keyWithModifiers
+            && !hotkey.isDoubleTap
+            && hotkey.mouseButton == nil
+            && carbonModifierFlags(for: hotkey) != 0
+    }
+
+    private nonisolated static func carbonModifierFlags(for hotkey: UnifiedHotkey) -> UInt32 {
+        let flags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
+        var carbonFlags: UInt32 = 0
+        if flags.contains(.command) { carbonFlags |= UInt32(cmdKey) }
+        if flags.contains(.option) { carbonFlags |= UInt32(optionKey) }
+        if flags.contains(.control) { carbonFlags |= UInt32(controlKey) }
+        if flags.contains(.shift) { carbonFlags |= UInt32(shiftKey) }
+        if flags.contains(.function) { carbonFlags |= UInt32(kEventKeyModifierFnMask) }
+        return carbonFlags
     }
 
 #if DEBUG
@@ -1212,6 +1495,28 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     static func eventTapPlacementForTesting() -> CGEventTapPlacement {
         hotkeyEventTapPlacement
+    }
+
+    static func supportsCarbonHotkeyForTesting(_ hotkey: UnifiedHotkey) -> Bool {
+        supportsCarbonHotkey(hotkey)
+    }
+
+    static func carbonModifierFlagsForTesting(_ hotkey: UnifiedHotkey) -> UInt32 {
+        carbonModifierFlags(for: hotkey)
+    }
+
+    func processCarbonHotkeyForTesting(
+        slotType: HotkeySlotType,
+        hotkey: UnifiedHotkey,
+        isPressed: Bool
+    ) {
+        let registration = CarbonHotkeyRegistration(
+            id: 1,
+            target: .slot(slotType),
+            hotkey: hotkey,
+            ref: nil
+        )
+        handleCarbonHotkey(registration: registration, phase: isPressed ? .down : .up)
     }
 #endif
 

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -216,6 +216,9 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     var modifierFlagsStateProvider: () -> NSEvent.ModifierFlags = {
         NSEvent.ModifierFlags(rawValue: UInt(CGEventSource.flagsState(.combinedSessionState).rawValue))
     }
+    var keyStateProvider: (UInt16) -> Bool = { keyCode in
+        CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
+    }
     var workflowTextProcessingModifierPollInterval: TimeInterval = 0.05
     var workflowTextProcessingModifierReleaseTimeout: TimeInterval = 2.0
     var workflowTextProcessingPostReleaseDelay: TimeInterval = 0.15
@@ -891,15 +894,62 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         behavior: WorkflowHotkeyBehavior,
         phase: HotkeyDispatchPhase
     ) {
+        if behavior == .processSelectedText,
+           hotkey.kind == .keyWithModifiers,
+           phase == .up,
+           keyStateProvider(hotkey.keyCode) {
+            dispatchCarbonWorkflowKeyUpWhenPhysicalKeyReleases(
+                workflowId: workflowId,
+                hotkey: hotkey,
+                behavior: behavior
+            )
+            return
+        }
+
         guard shouldDispatch(target: .workflow(workflowId), phase: phase, hotkey: hotkey, source: .carbon) else {
             return
         }
 
         switch phase {
         case .down:
+            if behavior == .processSelectedText, hotkey.kind == .keyWithModifiers {
+                setWorkflowKeyWasDown(workflowId: workflowId, hotkey: hotkey, keyWasDown: true)
+            }
             handleWorkflowKeyDown(workflowId: workflowId, behavior: behavior)
         case .up:
             handleWorkflowKeyUp(workflowId: workflowId, behavior: behavior)
+        }
+    }
+
+    private func setWorkflowKeyWasDown(workflowId: UUID, hotkey: UnifiedHotkey, keyWasDown: Bool) {
+        guard var states = workflowSlots[workflowId],
+              let index = states.firstIndex(where: { $0.hotkey == hotkey }) else {
+            return
+        }
+        states[index].keyWasDown = keyWasDown
+        workflowSlots[workflowId] = states
+    }
+
+    private func dispatchCarbonWorkflowKeyUpWhenPhysicalKeyReleases(
+        workflowId: UUID,
+        hotkey: UnifiedHotkey,
+        behavior: WorkflowHotkeyBehavior
+    ) {
+        guard activeWorkflowId == workflowId else { return }
+        guard keyStateProvider(hotkey.keyCode) else {
+            guard shouldDispatch(target: .workflow(workflowId), phase: .up, hotkey: hotkey, source: .carbon) else {
+                return
+            }
+            handleWorkflowKeyUp(workflowId: workflowId, behavior: behavior)
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + workflowTextProcessingModifierPollInterval) { [weak self] in
+            self?.dispatchCarbonWorkflowKeyUpWhenPhysicalKeyReleases(
+                workflowId: workflowId,
+                hotkey: hotkey,
+                behavior: behavior
+            )
         }
     }
 
@@ -1513,6 +1563,21 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         let registration = CarbonHotkeyRegistration(
             id: 1,
             target: .slot(slotType),
+            hotkey: hotkey,
+            ref: nil
+        )
+        handleCarbonHotkey(registration: registration, phase: isPressed ? .down : .up)
+    }
+
+    func processCarbonWorkflowHotkeyForTesting(
+        workflowId: UUID,
+        hotkey: UnifiedHotkey,
+        behavior: WorkflowHotkeyBehavior,
+        isPressed: Bool
+    ) {
+        let registration = CarbonHotkeyRegistration(
+            id: 1,
+            target: .workflow(workflowId, behavior),
             hotkey: hotkey,
             ref: nil
         )

--- a/TypeWhisper/Services/SecureInputDiagnostics.swift
+++ b/TypeWhisper/Services/SecureInputDiagnostics.swift
@@ -1,0 +1,181 @@
+import AppKit
+import Carbon.HIToolbox
+import Darwin
+import Foundation
+import IOKit
+
+struct SecureInputDiagnostics: Encodable, Equatable, Sendable {
+    let isActive: Bool
+    let carbonSecureInputEnabled: Bool
+    let primarySource: String?
+    let primaryPID: Int32?
+    let primaryAppName: String?
+    let primaryBundleIdentifier: String?
+    let primaryExecutablePath: String?
+    let ioRegistryPID: Int32?
+    let currentSessionPID: Int32?
+
+    var logDescription: String {
+        guard isActive else {
+            let stalePID = ioRegistryPID.map(String.init) ?? "none"
+            return "inactive(carbon=\(carbonSecureInputEnabled), ioRegistryPID=\(stalePID))"
+        }
+
+        let pid = primaryPID.map(String.init) ?? "unknown"
+        let app = primaryAppName ?? "unknown"
+        let source = primarySource ?? "unknown"
+        return "active(source=\(source), pid=\(pid), app=\(app), carbon=\(carbonSecureInputEnabled), ioRegistryPID=\(ioRegistryPID.map(String.init) ?? "none"), currentSessionPID=\(currentSessionPID.map(String.init) ?? "none"))"
+    }
+
+    var userFacingOwner: String {
+        if let primaryAppName, let primaryPID {
+            return "\(primaryAppName) (pid \(primaryPID))"
+        }
+        if let primaryAppName {
+            return primaryAppName
+        }
+        if let primaryPID {
+            return "pid \(primaryPID)"
+        }
+        return "another app"
+    }
+}
+
+struct SecureInputProcessInfo: Equatable, Sendable {
+    let pid: Int32
+    let appName: String?
+    let bundleIdentifier: String?
+    let executablePath: String?
+}
+
+enum SecureInputDiagnosticsProvider {
+    static func snapshot() -> SecureInputDiagnostics {
+        snapshot(
+            consoleUsers: copyConsoleUsers(),
+            currentSessionPID: currentSessionSecureInputPID(),
+            carbonSecureInputEnabled: IsSecureEventInputEnabled(),
+            processResolver: resolveProcess
+        )
+    }
+
+    static func snapshot(
+        consoleUsers: NSArray?,
+        currentSessionPID: Int32?,
+        carbonSecureInputEnabled: Bool,
+        processResolver: (Int32) -> SecureInputProcessInfo?
+    ) -> SecureInputDiagnostics {
+        let ioRegistryPID = secureInputPID(from: consoleUsers)
+        var resolvedCandidate: (String, SecureInputProcessInfo)?
+        if let ioRegistryPID, ioRegistryPID > 0 {
+            if let process = processResolver(ioRegistryPID) {
+                resolvedCandidate = ("ioRegistry", process)
+            }
+        } else if let currentSessionPID, currentSessionPID > 0,
+                  let process = processResolver(currentSessionPID) {
+            resolvedCandidate = ("currentSession", process)
+        }
+
+        let unresolvedPID = ioRegistryPID ?? currentSessionPID
+        let isActive = carbonSecureInputEnabled
+
+        return SecureInputDiagnostics(
+            isActive: isActive,
+            carbonSecureInputEnabled: carbonSecureInputEnabled,
+            primarySource: resolvedCandidate?.0 ?? (isActive ? "unknown" : nil),
+            primaryPID: resolvedCandidate?.1.pid ?? (isActive ? unresolvedPID : nil),
+            primaryAppName: resolvedCandidate?.1.appName,
+            primaryBundleIdentifier: resolvedCandidate?.1.bundleIdentifier,
+            primaryExecutablePath: resolvedCandidate?.1.executablePath,
+            ioRegistryPID: ioRegistryPID,
+            currentSessionPID: currentSessionPID
+        )
+    }
+
+    private static func copyConsoleUsers() -> NSArray? {
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        guard root != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(root) }
+
+        let value = IORegistryEntryCreateCFProperty(
+            root,
+            "IOConsoleUsers" as CFString,
+            kCFAllocatorDefault,
+            0
+        )
+        return value?.takeRetainedValue() as? NSArray
+    }
+
+    private static func secureInputPID(from consoleUsers: NSArray?) -> Int32? {
+        guard let consoleUsers else { return nil }
+
+        var fallbackPID: Int32?
+        for case let session as NSDictionary in consoleUsers {
+            guard let pid = int32Value(session["kCGSSessionSecureInputPID"]), pid > 0 else {
+                continue
+            }
+
+            if fallbackPID == nil {
+                fallbackPID = pid
+            }
+
+            if boolValue(session["kCGSessionOnConsoleKey"]) == true
+                || boolValue(session["kCGSSessionOnConsoleKey"]) == true {
+                return pid
+            }
+        }
+        return fallbackPID
+    }
+
+    private static func currentSessionSecureInputPID() -> Int32? {
+        guard let session = CGSessionCopyCurrentDictionary() as NSDictionary? else { return nil }
+        guard let pid = int32Value(session["kCGSSessionSecureInputPID"]), pid > 0 else { return nil }
+        return pid
+    }
+
+    private static func resolveProcess(pid: Int32) -> SecureInputProcessInfo? {
+        let processID = pid_t(pid)
+        let app = NSRunningApplication(processIdentifier: processID)
+        let executablePath = app?.executableURL?.path ?? executablePath(for: processID)
+        guard app != nil || executablePath != nil else { return nil }
+
+        return SecureInputProcessInfo(
+            pid: pid,
+            appName: app?.localizedName ?? executablePath.map { URL(fileURLWithPath: $0).lastPathComponent },
+            bundleIdentifier: app?.bundleIdentifier,
+            executablePath: executablePath
+        )
+    }
+
+    private static func executablePath(for pid: pid_t) -> String? {
+        var buffer = [CChar](repeating: 0, count: 4096)
+        let result = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard result > 0 else { return nil }
+        let end = buffer.firstIndex(of: 0) ?? buffer.count
+        let bytes = buffer.prefix(end).map { UInt8(bitPattern: $0) }
+        return String(bytes: bytes, encoding: .utf8)
+    }
+
+    private static func int32Value(_ value: Any?) -> Int32? {
+        switch value {
+        case let number as NSNumber:
+            number.int32Value
+        case let value as Int:
+            Int32(value)
+        case let value as Int32:
+            value
+        default:
+            nil
+        }
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let number as NSNumber:
+            number.boolValue
+        case let value as Bool:
+            value
+        default:
+            nil
+        }
+    }
+}

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -1,10 +1,26 @@
+import Combine
 import SwiftUI
 
 struct HotkeySettingsView: View {
     @ObservedObject private var dictation = DictationViewModel.shared
+    @State private var secureInputDiagnostics = SecureInputDiagnosticsProvider.snapshot()
+    private let secureInputRefresh = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
 
     var body: some View {
         Form {
+            if secureInputDiagnostics.isActive {
+                Section {
+                    Label {
+                        Text(String(localized: "Secure Input is active in \(secureInputDiagnostics.userFacingOwner). Standard key+modifier shortcuts should keep working. Fallback-only shortcut types may not work until that app leaves password or sensitive input."))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+
             Section(String(localized: "Hotkeys")) {
                 MultiHotkeySlotRecorder(
                     slot: .hybrid,
@@ -65,6 +81,9 @@ struct HotkeySettingsView: View {
         .formStyle(.grouped)
         .padding()
         .frame(minWidth: 500, minHeight: 300)
+        .onReceive(secureInputRefresh) { _ in
+            secureInputDiagnostics = SecureInputDiagnosticsProvider.snapshot()
+        }
     }
 }
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import CoreAudio
 import Foundation
 import XCTest
@@ -17,6 +18,116 @@ private func rtfAttributedStringContainsFontTrait(
     let font = attributed.attribute(.font, at: range.location, effectiveRange: &effectiveRange) as? NSFont
     guard let font else { return false }
     return NSFontManager.shared.traits(of: font).contains(trait)
+}
+
+final class SecureInputDiagnosticsProviderTests: XCTestCase {
+    func testSnapshotPrefersOnConsoleIORegistryOwner() {
+        let consoleUsers: NSArray = [
+            [
+                "kCGSSessionSecureInputPID": NSNumber(value: 111),
+                "kCGSSessionOnConsoleKey": NSNumber(value: false),
+            ],
+            [
+                "kCGSSessionSecureInputPID": NSNumber(value: 222),
+                "kCGSessionOnConsoleKey": NSNumber(value: true),
+            ],
+        ]
+
+        let snapshot = SecureInputDiagnosticsProvider.snapshot(
+            consoleUsers: consoleUsers,
+            currentSessionPID: 333,
+            carbonSecureInputEnabled: true,
+            processResolver: { pid in
+                SecureInputProcessInfo(
+                    pid: pid,
+                    appName: "App \(pid)",
+                    bundleIdentifier: "test.\(pid)",
+                    executablePath: "/Applications/App\(pid).app"
+                )
+            }
+        )
+
+        XCTAssertTrue(snapshot.isActive)
+        XCTAssertEqual(snapshot.primarySource, "ioRegistry")
+        XCTAssertEqual(snapshot.primaryPID, 222)
+        XCTAssertEqual(snapshot.primaryAppName, "App 222")
+        XCTAssertEqual(snapshot.ioRegistryPID, 222)
+        XCTAssertEqual(snapshot.currentSessionPID, 333)
+    }
+
+    func testSnapshotDoesNotBlameCurrentSessionWhenIORegistryOwnerCannotBeResolved() {
+        let consoleUsers: NSArray = [
+            [
+                "kCGSSessionSecureInputPID": NSNumber(value: 111),
+                "kCGSessionOnConsoleKey": NSNumber(value: true),
+            ],
+        ]
+
+        let snapshot = SecureInputDiagnosticsProvider.snapshot(
+            consoleUsers: consoleUsers,
+            currentSessionPID: 333,
+            carbonSecureInputEnabled: true,
+            processResolver: { pid in
+                guard pid == 333 else { return nil }
+                return SecureInputProcessInfo(
+                    pid: pid,
+                    appName: "Current App",
+                    bundleIdentifier: "test.current",
+                    executablePath: "/Applications/Current.app"
+                )
+            }
+        )
+
+        XCTAssertTrue(snapshot.isActive)
+        XCTAssertEqual(snapshot.primarySource, "unknown")
+        XCTAssertEqual(snapshot.primaryPID, 111)
+        XCTAssertNil(snapshot.primaryAppName)
+        XCTAssertEqual(snapshot.ioRegistryPID, 111)
+        XCTAssertEqual(snapshot.currentSessionPID, 333)
+    }
+
+    func testSnapshotPreservesActiveStateWhenOwnerIsUnknown() {
+        let snapshot = SecureInputDiagnosticsProvider.snapshot(
+            consoleUsers: nil,
+            currentSessionPID: nil,
+            carbonSecureInputEnabled: true,
+            processResolver: { _ in nil }
+        )
+
+        XCTAssertTrue(snapshot.isActive)
+        XCTAssertEqual(snapshot.primarySource, "unknown")
+        XCTAssertNil(snapshot.primaryPID)
+        XCTAssertEqual(snapshot.userFacingOwner, "another app")
+    }
+
+    func testSnapshotDoesNotTreatResolvedStaleOwnerAsActive() {
+        let consoleUsers: NSArray = [
+            [
+                "kCGSSessionSecureInputPID": NSNumber(value: 111),
+                "kCGSessionOnConsoleKey": NSNumber(value: true),
+            ],
+        ]
+
+        let snapshot = SecureInputDiagnosticsProvider.snapshot(
+            consoleUsers: consoleUsers,
+            currentSessionPID: nil,
+            carbonSecureInputEnabled: false,
+            processResolver: { pid in
+                SecureInputProcessInfo(
+                    pid: pid,
+                    appName: "Stale App",
+                    bundleIdentifier: "test.stale",
+                    executablePath: "/Applications/Stale.app"
+                )
+            }
+        )
+
+        XCTAssertFalse(snapshot.isActive)
+        XCTAssertEqual(snapshot.primarySource, "ioRegistry")
+        XCTAssertEqual(snapshot.primaryPID, 111)
+        XCTAssertEqual(snapshot.primaryAppName, "Stale App")
+        XCTAssertEqual(snapshot.ioRegistryPID, 111)
+    }
 }
 
 final class APIRouterAndHandlersTests: XCTestCase {
@@ -7656,6 +7767,121 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testCarbonHotkeySupportIsLimitedToSinglePressKeyWithModifiers() {
+        XCTAssertTrue(HotkeyService.supportsCarbonHotkeyForTesting(commandOptionAHotkey()))
+        XCTAssertTrue(HotkeyService.supportsCarbonHotkeyForTesting(fnF14Hotkey()))
+        XCTAssertEqual(
+            HotkeyService.carbonModifierFlagsForTesting(commandOptionAHotkey()),
+            UInt32(cmdKey) | UInt32(optionKey)
+        )
+        XCTAssertEqual(
+            HotkeyService.carbonModifierFlagsForTesting(fnF14Hotkey()),
+            UInt32(kEventKeyModifierFnMask)
+        )
+
+        XCTAssertFalse(HotkeyService.supportsCarbonHotkeyForTesting(bareSpaceHotkey()))
+        XCTAssertFalse(HotkeyService.supportsCarbonHotkeyForTesting(commandOptionComboHotkey()))
+        XCTAssertFalse(HotkeyService.supportsCarbonHotkeyForTesting(controlModifierHotkey()))
+        XCTAssertFalse(HotkeyService.supportsCarbonHotkeyForTesting(UnifiedHotkey(mouseButton: 3)))
+
+        let doubleTap = UnifiedHotkey(
+            keyCode: 0x00,
+            modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
+            isFn: false,
+            isDoubleTap: true
+        )
+        XCTAssertFalse(HotkeyService.supportsCarbonHotkeyForTesting(doubleTap))
+    }
+
+    @MainActor
+    func testCarbonHotkeyDispatchStartsToggleWithoutKeyboardEvent() {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let hotkey = fnF14Hotkey()
+        service.setHotkeyForTesting(hotkey, for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        service.processCarbonHotkeyForTesting(slotType: .toggle, hotkey: hotkey, isPressed: true)
+
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(service.currentMode, .toggle)
+    }
+
+    @MainActor
+    func testCarbonHotkeyReleaseStopsPushToTalk() {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let hotkey = commandOptionAHotkey()
+        service.setHotkeyForTesting(hotkey, for: .pushToTalk)
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+        service.onDictationStop = {
+            stopCount += 1
+        }
+
+        service.processCarbonHotkeyForTesting(slotType: .pushToTalk, hotkey: hotkey, isPressed: true)
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        service.processCarbonHotkeyForTesting(slotType: .pushToTalk, hotkey: hotkey, isPressed: false)
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
+    func testCarbonHotkeyDispatchDedupesFollowingEventTapDispatch() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let hotkey = commandOptionAHotkey()
+        service.setHotkeyForTesting(hotkey, for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .eventTap))
+        await Task.yield()
+        XCTAssertEqual(startCount, 1)
+
+        service.processCarbonHotkeyForTesting(slotType: .toggle, hotkey: hotkey, isPressed: true)
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testCarbonHotkeyDispatchDedupesFollowingMonitorDispatch() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let hotkey = commandOptionAHotkey()
+        service.setHotkeyForTesting(hotkey, for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(startCount, 1)
+
+        service.processCarbonHotkeyForTesting(slotType: .toggle, hotkey: hotkey, isPressed: true)
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
     func testMiddleMousePassesThroughWhenNoMouseHotkeyIsBound() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -9452,6 +9678,15 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         UnifiedHotkey(
             keyCode: 0x08,
             modifierFlags: NSEvent.ModifierFlags([.command, .shift]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func fnF14Hotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x6B,
+            modifierFlags: NSEvent.ModifierFlags.function.rawValue,
             isFn: false
         )
     }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -7839,6 +7839,160 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testCarbonWorkflowHotkeyStartsDictation() {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        let workflowId = UUID()
+        let hotkey = commandOptionAHotkey()
+        service.registerWorkflowHotkeys([(id: workflowId, hotkey: hotkey, behavior: .startDictation)])
+
+        var startedWorkflowId: UUID?
+        service.onWorkflowDictationStart = { workflowId, _ in startedWorkflowId = workflowId }
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .startDictation,
+            isPressed: true
+        )
+
+        XCTAssertEqual(startedWorkflowId, workflowId)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .startDictation,
+            isPressed: false
+        )
+        XCTAssertEqual(service.currentMode, .toggle)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+    }
+
+    @MainActor
+    func testCarbonWorkflowHotkeyTextProcessingDispatchesOnPhysicalKeyRelease() async {
+        let (service, workflowId, hotkey) = makeCarbonWorkflowTextProcessingService(
+            keyStateProvider: { _ in false }
+        )
+
+        var textWorkflowId: UUID?
+        let textProcessingCallback = expectation(description: "workflow text processing callback")
+        service.onWorkflowTextProcessing = {
+            textWorkflowId = $0
+            textProcessingCallback.fulfill()
+        }
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .processSelectedText,
+            isPressed: true
+        )
+        XCTAssertNil(textWorkflowId)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .processSelectedText,
+            isPressed: false
+        )
+        await fulfillment(of: [textProcessingCallback], timeout: 1.0)
+        XCTAssertEqual(textWorkflowId, workflowId)
+        XCTAssertNil(service.activeWorkflowId)
+    }
+
+    @MainActor
+    func testCarbonWorkflowHotkeyTextProcessingWaitsForPhysicalKeyUpAfterModifierRelease() async throws {
+        let workflowId = UUID()
+        let hotkey = commandOptionAHotkey()
+        var keyIsDown = true
+        let service = makeCarbonWorkflowTextProcessingService(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            keyStateProvider: { keyCode in keyCode == hotkey.keyCode && keyIsDown }
+        ).service
+
+        var textWorkflowId: UUID?
+        let textProcessingCallback = expectation(description: "workflow text processing callback")
+        service.onWorkflowTextProcessing = {
+            textWorkflowId = $0
+            textProcessingCallback.fulfill()
+        }
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .processSelectedText,
+            isPressed: true
+        )
+        XCTAssertNil(textWorkflowId)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .processSelectedText,
+            isPressed: false
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertNil(textWorkflowId)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        keyIsDown = false
+        let physicalKeyUp = try makeKeyboardEvent(keyCode: 0x00, keyDown: false, flags: [])
+        XCTAssertTrue(service.processEventForTesting(physicalKeyUp, source: .monitor))
+        await fulfillment(of: [textProcessingCallback], timeout: 1.0)
+        XCTAssertEqual(textWorkflowId, workflowId)
+        XCTAssertNil(service.activeWorkflowId)
+    }
+
+    @MainActor
+    func testCarbonWorkflowHotkeyTextProcessingCompletesWithoutMonitorKeyUpAfterPhysicalKeyRelease() async throws {
+        let workflowId = UUID()
+        let hotkey = commandOptionAHotkey()
+        var keyIsDown = true
+        let service = makeCarbonWorkflowTextProcessingService(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            keyStateProvider: { keyCode in keyCode == hotkey.keyCode && keyIsDown }
+        ).service
+
+        var textWorkflowId: UUID?
+        let textProcessingCallback = expectation(description: "workflow text processing callback")
+        service.onWorkflowTextProcessing = {
+            textWorkflowId = $0
+            textProcessingCallback.fulfill()
+        }
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .processSelectedText,
+            isPressed: true
+        )
+        XCTAssertNil(textWorkflowId)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        service.processCarbonWorkflowHotkeyForTesting(
+            workflowId: workflowId,
+            hotkey: hotkey,
+            behavior: .processSelectedText,
+            isPressed: false
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertNil(textWorkflowId)
+        XCTAssertEqual(service.activeWorkflowId, workflowId)
+
+        keyIsDown = false
+        await fulfillment(of: [textProcessingCallback], timeout: 1.0)
+        XCTAssertEqual(textWorkflowId, workflowId)
+        XCTAssertNil(service.activeWorkflowId)
+    }
+
+    @MainActor
     func testCarbonHotkeyDispatchDedupesFollowingEventTapDispatch() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -9671,6 +9825,25 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
             modifierFlags: NSEvent.ModifierFlags([.command, .option]).rawValue,
             isFn: false
         )
+    }
+
+    @MainActor
+    private func makeCarbonWorkflowTextProcessingService(
+        workflowId: UUID = UUID(),
+        hotkey: UnifiedHotkey? = nil,
+        keyStateProvider: @escaping (UInt16) -> Bool
+    ) -> (service: HotkeyService, workflowId: UUID, hotkey: UnifiedHotkey) {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.workflowTextProcessingModifierPollInterval = 0.001
+        service.workflowTextProcessingModifierReleaseTimeout = 0.25
+        service.workflowTextProcessingPostReleaseDelay = 0.001
+        service.modifierFlagsStateProvider = { [] }
+        service.keyStateProvider = keyStateProvider
+
+        let hotkey = hotkey ?? commandOptionAHotkey()
+        service.registerWorkflowHotkeys([(id: workflowId, hotkey: hotkey, behavior: .processSelectedText)])
+        return (service, workflowId, hotkey)
     }
 
     @MainActor


### PR DESCRIPTION
> [!NOTE]
> This PR was AI assisted.

## Summary

Fixes key-based global hotkeys getting blocked when macOS Secure Input is active by registering normal key+modifier shortcuts through Carbon `RegisterEventHotKey` / `InstallEventHandler`, matching the approach used by AltTab:
- https://github.com/lwouis/alt-tab-macos/blob/master/src/experimentations/README.md
- https://github.com/lwouis/alt-tab-macos/blob/master/src/events/KeyboardEvents.swift
- https://github.com/lwouis/alt-tab-macos/issues/157
- https://github.com/lwouis/alt-tab-macos/issues/3117

Keeps the existing CGEventTap/NSEvent path for shortcut types Carbon cannot cover, adds Secure Input diagnostics and surfaces Secure Input state in Settings/diagnostic exports:
<img width="1035" height="177" alt="image" src="https://github.com/user-attachments/assets/7f185303-868a-4f9b-9c4e-69d7664882e9" />

(Carbon has been deprecated for a really long time, but it's still there in macOS 27 Beta 2, so should be fine for now: https://developer.apple.com/documentation/coreservices/carbon_core)

## Test Plan

- [x] Ran `scripts/pr-preflight.sh`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added secure-input diagnostics with a live warning banner in Hotkey Settings that refreshes periodically and shows the detected owner when available.
  * Enabled secure-input (system-level/Carbon) hotkey support to improve dictation and workflow triggering.

* **Bug Fixes**
  * Improved coordination and deduplication across hotkey event sources, including consistent behavior for Carbon-triggered actions.
  * Refined secure-input status reporting when owner/process details are incomplete or stale.

* **Tests**
  * Added and expanded test coverage for secure-input diagnostics and Carbon hotkey behavior (press/release, dedupe, workflows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->