### PR TITLE
fix: lazy-load local models when auto-unload is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Hotkeys are direct workflow shortcuts, not context conditions in the app/URL mat
 
 The active workflow name is shown as a badge in the indicator, together with a short explanation of why it matched.
 
-Multiple engines can be loaded simultaneously for instant switching between workflows. Note that loading multiple local models increases memory usage. Cloud engines (Groq, OpenAI, xAI/Grok) have negligible memory overhead.
+Multiple engines can be loaded simultaneously during a session for instant switching between workflows. Note that loading multiple local models increases memory usage. Set `Auto-unload model` to `Never` if you want TypeWhisper to restore previously loaded local models at launch; any active auto-unload policy keeps startup lazy and reloads the selected/downloaded model on first real use. Cloud engines (Groq, OpenAI, xAI/Grok) have negligible memory overhead.
 
 ## Plugins
 

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -4,6 +4,27 @@ import TypeWhisperPluginSDK
 
 private enum PassiveLoadedModelRestoreContext {
     @TaskLocal static var suppressLoadedModelDefault = false
+
+    private static let synchronousActivationAccessKey = "com.typewhisper.host.loadedModel.synchronousActivationAccess"
+
+    static var allowsLoadedModelDefaultInCurrentCallStack: Bool {
+        Thread.current.threadDictionary[synchronousActivationAccessKey] as? Bool == true
+    }
+
+    static func withSynchronousLoadedModelDefaultAccess(_ body: () -> Void) {
+        let threadDictionary = Thread.current.threadDictionary
+        let previousValue = threadDictionary[synchronousActivationAccessKey]
+        threadDictionary[synchronousActivationAccessKey] = true
+        defer {
+            if let previousValue {
+                threadDictionary[synchronousActivationAccessKey] = previousValue
+            } else {
+                threadDictionary.removeObject(forKey: synchronousActivationAccessKey)
+            }
+        }
+
+        body()
+    }
 }
 
 final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
@@ -12,8 +33,6 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
     let eventBus: EventBusProtocol
     private let ruleNamesProvider: @MainActor () -> [String]
     private let workflowProvider: @MainActor () -> [PluginWorkflowInfo]
-    private let activationContextLock = NSLock()
-    private var synchronousActivationDepth = 0
 
     init(
         pluginId: String,
@@ -55,7 +74,7 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
     func userDefault(forKey key: String) -> Any? {
         if key == "loadedModel",
            PassiveLoadedModelRestoreContext.suppressLoadedModelDefault,
-           !isInSynchronousPluginActivation,
+           !PassiveLoadedModelRestoreContext.allowsLoadedModelDefaultInCurrentCallStack,
            !shouldRestoreLoadedModelsPassively {
             return nil
         }
@@ -78,7 +97,7 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
         _ body: @escaping () -> Void
     ) {
         let activation = {
-            self.withSynchronousPluginActivation(body)
+            PassiveLoadedModelRestoreContext.withSynchronousLoadedModelDefaultAccess(body)
         }
 
         guard suppressPassiveLoadedModelRestore else {
@@ -89,25 +108,6 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
         PassiveLoadedModelRestoreContext.$suppressLoadedModelDefault.withValue(true) {
             activation()
         }
-    }
-
-    private var isInSynchronousPluginActivation: Bool {
-        activationContextLock.withLock {
-            synchronousActivationDepth > 0
-        }
-    }
-
-    private func withSynchronousPluginActivation(_ body: () -> Void) {
-        activationContextLock.withLock {
-            synchronousActivationDepth += 1
-        }
-        defer {
-            activationContextLock.withLock {
-                synchronousActivationDepth -= 1
-            }
-        }
-
-        body()
     }
 
     // MARK: - App Context

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -2,12 +2,18 @@ import AppKit
 import Foundation
 import TypeWhisperPluginSDK
 
-final class HostServicesImpl: HostServices, @unchecked Sendable {
+private enum PassiveLoadedModelRestoreContext {
+    @TaskLocal static var suppressLoadedModelDefault = false
+}
+
+final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
     let pluginId: String
     let pluginDataDirectory: URL
     let eventBus: EventBusProtocol
     private let ruleNamesProvider: @MainActor () -> [String]
     private let workflowProvider: @MainActor () -> [PluginWorkflowInfo]
+    private let activationContextLock = NSLock()
+    private var synchronousActivationDepth = 0
 
     init(
         pluginId: String,
@@ -47,11 +53,61 @@ final class HostServicesImpl: HostServices, @unchecked Sendable {
     // MARK: - UserDefaults (plugin-scoped)
 
     func userDefault(forKey key: String) -> Any? {
-        UserDefaults.standard.object(forKey: "plugin.\(pluginId).\(key)")
+        if key == "loadedModel",
+           PassiveLoadedModelRestoreContext.suppressLoadedModelDefault,
+           !isInSynchronousPluginActivation,
+           !shouldRestoreLoadedModelsPassively {
+            return nil
+        }
+
+        return UserDefaults.standard.object(forKey: "plugin.\(pluginId).\(key)")
     }
 
     func setUserDefault(_ value: Any?, forKey key: String) {
         UserDefaults.standard.set(value, forKey: "plugin.\(pluginId).\(key)")
+    }
+
+    // MARK: - Model Lifecycle Policy
+
+    var shouldRestoreLoadedModelsPassively: Bool {
+        ModelAutoUnloadPolicy.shouldRestoreLoadedModelsPassively()
+    }
+
+    func performPluginActivation(
+        suppressPassiveLoadedModelRestore: Bool,
+        _ body: @escaping () -> Void
+    ) {
+        let activation = {
+            self.withSynchronousPluginActivation(body)
+        }
+
+        guard suppressPassiveLoadedModelRestore else {
+            activation()
+            return
+        }
+
+        PassiveLoadedModelRestoreContext.$suppressLoadedModelDefault.withValue(true) {
+            activation()
+        }
+    }
+
+    private var isInSynchronousPluginActivation: Bool {
+        activationContextLock.withLock {
+            synchronousActivationDepth > 0
+        }
+    }
+
+    private func withSynchronousPluginActivation(_ body: () -> Void) {
+        activationContextLock.withLock {
+            synchronousActivationDepth += 1
+        }
+        defer {
+            activationContextLock.withLock {
+                synchronousActivationDepth -= 1
+            }
+        }
+
+        body()
     }
 
     // MARK: - App Context

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -46,6 +46,10 @@ enum ModelAutoUnloadPolicy {
         return defaults.integer(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
     }
 
+    static func shouldRestoreLoadedModelsPassively(defaults: UserDefaults = .standard) -> Bool {
+        effectiveSeconds(defaults: defaults) == 0
+    }
+
     static func policyName(seconds: Int) -> String {
         switch seconds {
         case 0:

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -668,7 +668,9 @@ final class PluginManager: ObservableObject {
             ruleNamesProvider: ruleNamesProvider,
             workflowProvider: workflowProvider
         )
-        plugin.instance.activate(host: host)
+        host.performPluginActivation(suppressPassiveLoadedModelRestore: !plugin.isBundled) {
+            plugin.instance.activate(host: host)
+        }
         logger.info("Activated plugin: \(plugin.manifest.id)")
     }
 

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -668,10 +668,15 @@ final class PluginManager: ObservableObject {
             ruleNamesProvider: ruleNamesProvider,
             workflowProvider: workflowProvider
         )
-        host.performPluginActivation(suppressPassiveLoadedModelRestore: !plugin.isBundled) {
+        host.performPluginActivation(suppressPassiveLoadedModelRestore: shouldSuppressPassiveLoadedModelRestore(for: plugin)) {
             plugin.instance.activate(host: host)
         }
         logger.info("Activated plugin: \(plugin.manifest.id)")
+    }
+
+    func shouldSuppressPassiveLoadedModelRestore(for plugin: LoadedPlugin) -> Bool {
+        guard !plugin.isBundled else { return false }
+        return !(plugin.instance is any HostModelLifecyclePolicyAwarePlugin)
     }
 
     @available(*, deprecated, renamed: "setRuleNamesProvider")

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -174,9 +174,9 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             host.setUserDefault(sanitizedSelection, forKey: "selectedLLMModel")
         }
 
-        let persistedLoadedModel = host.userDefault(forKey: "loadedModel") as? String
         let shouldAutoRestoreLoadedModel: Bool
-        if let persistedLoadedModel {
+        if host.shouldRestoreLoadedModelsPassively,
+           let persistedLoadedModel = host.userDefault(forKey: "loadedModel") as? String {
             if Self.canRestoreLoadedModel(persistedLoadedModel),
                let modelDef = Self.modelDefinition(for: persistedLoadedModel) {
                 shouldAutoRestoreLoadedModel = isModelDownloaded(modelDef)
@@ -220,6 +220,10 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     var isAvailable: Bool {
         modelContainer != nil && loadedModelId != nil
+    }
+
+    var shouldRestoreLoadedModelsPassively: Bool {
+        host?.shouldRestoreLoadedModelsPassively ?? true
     }
 
     var supportedModels: [PluginModelInfo] {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -176,7 +176,7 @@ struct Gemma4SettingsView: View {
             }
         }
         .task {
-            if case .notLoaded = plugin.modelState {
+            if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
                 await plugin.restoreLoadedModel(allowDownloads: false)
                 isPolling = false

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -31,7 +31,9 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             ?? Self.availableModels.first?.id
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
-        Task { await restoreLoadedModel(allowDownloads: false) }
+        if shouldRestoreLoadedModelsPassively {
+            Task { await restoreLoadedModel(allowDownloads: false) }
+        }
     }
 
     func deactivate() {
@@ -48,6 +50,10 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     var isConfigured: Bool {
         model != nil && loadedModelId != nil
+    }
+
+    var shouldRestoreLoadedModelsPassively: Bool {
+        host?.shouldRestoreLoadedModelsPassively ?? true
     }
 
     var transcriptionModels: [PluginModelInfo] {
@@ -491,7 +497,7 @@ private struct GraniteSettingsView: View {
             }
         }
         .task {
-            if case .notLoaded = plugin.modelState {
+            if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
                 await plugin.restoreLoadedModel(allowDownloads: false)
                 isPolling = false

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -95,7 +95,7 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
                 selectedVersion = version
             }
         }
-        if restoresModelOnActivate {
+        if restoresModelOnActivate, host.shouldRestoreLoadedModelsPassively {
             Task { await restoreLoadedModel(allowDownloads: false) }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -47,7 +47,9 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             ?? Self.availableModels.first?.id
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
-        Task { await restoreLoadedModel(allowDownloads: false) }
+        if shouldRestoreLoadedModelsPassively {
+            Task { await restoreLoadedModel(allowDownloads: false) }
+        }
     }
 
     func deactivate() {
@@ -65,6 +67,10 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
     var isConfigured: Bool {
         model != nil && loadedModelId != nil
+    }
+
+    var shouldRestoreLoadedModelsPassively: Bool {
+        host?.shouldRestoreLoadedModelsPassively ?? true
     }
 
     var transcriptionModels: [PluginModelInfo] {
@@ -849,7 +855,7 @@ private struct Qwen3SettingsView: View {
         }
         .task {
             // Auto-restore previously loaded model
-            if case .notLoaded = plugin.modelState {
+            if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
                 await plugin.restoreLoadedModel(allowDownloads: false)
                 isPolling = false

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -32,7 +32,9 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
         Task {
             await populateModels()
             host.notifyCapabilitiesChanged()
-            await restoreLoadedModel(allowDownloads: false)
+            if host.shouldRestoreLoadedModelsPassively {
+                await restoreLoadedModel(allowDownloads: false)
+            }
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -47,7 +47,9 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             ?? Self.availableModels.first?.id
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
-        Task { await restoreLoadedModel(allowDownloads: false) }
+        if shouldRestoreLoadedModelsPassively {
+            Task { await restoreLoadedModel(allowDownloads: false) }
+        }
     }
 
     func deactivate() {
@@ -64,6 +66,10 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     var isConfigured: Bool {
         model != nil && loadedModelId != nil
+    }
+
+    var shouldRestoreLoadedModelsPassively: Bool {
+        host?.shouldRestoreLoadedModelsPassively ?? true
     }
 
     var transcriptionModels: [PluginModelInfo] {
@@ -497,7 +503,7 @@ private struct VoxtralSettingsView: View {
             }
         }
         .task {
-            if case .notLoaded = plugin.modelState {
+            if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
                 await plugin.restoreLoadedModel(allowDownloads: false)
                 isPolling = false

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -23,6 +23,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     fileprivate var downloadProgress: Double = 0
     private var modelLoadGeneration = 0
     fileprivate var modelLoadTimeoutDuration = WhisperKitPlugin.defaultModelLoadTimeoutDuration
+    #if DEBUG
+    private(set) var restoreLoadedModelInvocationCountForTesting = 0
+    #endif
 
     required override init() {
         super.init()
@@ -614,6 +617,10 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
+        #if DEBUG
+        restoreLoadedModelInvocationCountForTesting += 1
+        #endif
+
         guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
               let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
             return

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -39,7 +39,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
                 host.setUserDefault(persistedLoadedModel, forKey: "selectedModel")
             }
         }
-        Task { await restoreLoadedModel(allowDownloads: false) }
+        if shouldRestoreLoadedModelsPassively {
+            Task { await restoreLoadedModel(allowDownloads: false) }
+        }
     }
 
     func deactivate() {
@@ -123,6 +125,10 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
     var isConfigured: Bool {
         whisperKit != nil && loadedModelId != nil
+    }
+
+    var shouldRestoreLoadedModelsPassively: Bool {
+        host?.shouldRestoreLoadedModelsPassively ?? true
     }
 
     var settingsModelState: WhisperModelState {
@@ -1141,6 +1147,7 @@ private struct WhisperKitSettingsView: View {
             if plugin.whisperKit == nil,
                plugin.loadedModelId == nil,
                plugin.modelState == .notLoaded,
+               plugin.shouldRestoreLoadedModelsPassively,
                let persistedLoadedModelId,
                !persistedLoadedModelId.isEmpty {
                 activeModelId = persistedLoadedModelId

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -355,6 +355,8 @@ func activate(host: HostServices) {
 
 `availableWorkflows` exposes read-only `PluginWorkflowInfo` snapshots. Plugins can inspect workflow names, templates, enabled state, trigger metadata, behavior settings, LLM provider/model choices, temperature directives, and output routing without depending on TypeWhisper's internal SwiftData models.
 
+Local model plugins that restore a previously loaded model during activation should first check `host.shouldRestoreLoadedModelsPassively`. Rebuilt plugins that already honor that policy can adopt `HostModelLifecyclePolicyAwarePlugin` so TypeWhisper does not apply the legacy external-plugin `loadedModel` masking shim during `activate(host:)`.
+
 ---
 
 ## Event Bus

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -37,7 +37,15 @@ public protocol HostServices: Sendable {
     func setStreamingDisplayActive(_ active: Bool)
 }
 
+public protocol HostModelLifecyclePolicyProviding: Sendable {
+    var shouldRestoreLoadedModelsPassively: Bool { get }
+}
+
 public extension HostServices {
+    var shouldRestoreLoadedModelsPassively: Bool {
+        (self as? any HostModelLifecyclePolicyProviding)?.shouldRestoreLoadedModelsPassively ?? true
+    }
+
     var availableWorkflows: [PluginWorkflowInfo] { [] }
 
     @available(*, deprecated, renamed: "availableRuleNames")

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -18,6 +18,8 @@ public extension TypeWhisperPlugin {
     var settingsView: AnyView? { nil }
 }
 
+public protocol HostModelLifecyclePolicyAwarePlugin: TypeWhisperPlugin {}
+
 // MARK: - Shared Settings Activity
 
 public struct PluginSettingsActivity: Sendable, Equatable {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDKTesting/PluginTestSupport.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDKTesting/PluginTestSupport.swift
@@ -37,7 +37,7 @@ public final class PluginTestEventBus: EventBusProtocol, @unchecked Sendable {
     }
 }
 
-public final class PluginTestHostServices: HostServices, @unchecked Sendable {
+public final class PluginTestHostServices: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
     private struct AnySendable: @unchecked Sendable {
         let value: Any
     }
@@ -58,6 +58,7 @@ public final class PluginTestHostServices: HostServices, @unchecked Sendable {
     public var activeAppName: String?
     public var availableRuleNames: [String]
     public var availableWorkflows: [PluginWorkflowInfo]
+    public var shouldRestoreLoadedModelsPassively: Bool
 
     public init(
         defaults: [String: Any] = [:],
@@ -67,7 +68,8 @@ public final class PluginTestHostServices: HostServices, @unchecked Sendable {
         activeAppBundleId: String? = nil,
         activeAppName: String? = nil,
         availableRuleNames: [String] = [],
-        availableWorkflows: [PluginWorkflowInfo] = []
+        availableWorkflows: [PluginWorkflowInfo] = [],
+        shouldRestoreLoadedModelsPassively: Bool = true
     ) throws {
         self.state = State(
             defaults: defaults.mapValues(AnySendable.init(value:)),
@@ -78,6 +80,7 @@ public final class PluginTestHostServices: HostServices, @unchecked Sendable {
         self.activeAppName = activeAppName
         self.availableRuleNames = availableRuleNames
         self.availableWorkflows = availableWorkflows
+        self.shouldRestoreLoadedModelsPassively = shouldRestoreLoadedModelsPassively
 
         if let pluginDataDirectory {
             self.pluginDataDirectory = pluginDataDirectory

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginManifestTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import TypeWhisperPluginSDK
 
 final class PluginManifestTests: XCTestCase {
+    func testPluginSDKCompatibilityLineRemainsV1ForAdditiveHostPolicies() {
+        XCTAssertEqual(PluginSDKCompatibility.currentVersion, "v1")
+    }
+
     func testPluginManifestDecodesOptionalCompatibilityFields() throws {
         let data = Data(
             """

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -79,6 +79,22 @@ private struct MockHostServices: HostServices {
     func setStreamingDisplayActive(_ active: Bool) {}
 }
 
+private struct PolicyAwareMockHostServices: HostServices, HostModelLifecyclePolicyProviding {
+    let pluginDataDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let activeAppBundleId: String? = nil
+    let activeAppName: String? = nil
+    let eventBus: EventBusProtocol = MockEventBus()
+    let availableRuleNames: [String] = []
+    let shouldRestoreLoadedModelsPassively: Bool
+
+    func storeSecret(key: String, value: String) throws {}
+    func loadSecret(key: String) -> String? { nil }
+    func userDefault(forKey key: String) -> Any? { nil }
+    func setUserDefault(_ value: Any?, forKey key: String) {}
+    func notifyCapabilitiesChanged() {}
+    func setStreamingDisplayActive(_ active: Bool) {}
+}
+
 @objc(MockTranscriptionPlugin)
 private final class MockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.transcription"
@@ -514,6 +530,14 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertEqual(host.availableRuleNames, ["Work", "Docs"])
         XCTAssertEqual(host.availableProfileNames, ["Work", "Docs"])
         XCTAssertEqual(host.activeAppName, "Notes")
+    }
+
+    func testHostServicesPassiveRestorePolicyDefaultsForLegacyHosts() {
+        let legacyHost = MockHostServices(eventBus: MockEventBus(), availableRuleNames: [])
+        XCTAssertTrue(legacyHost.shouldRestoreLoadedModelsPassively)
+
+        let policyAwareHost = PolicyAwareMockHostServices(shouldRestoreLoadedModelsPassively: false)
+        XCTAssertFalse(policyAwareHost.shouldRestoreLoadedModelsPassively)
     }
 
     func testHostServicesExposeWorkflowSnapshots() throws {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -5114,6 +5114,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let audioFileService = AudioFileService()
         let audioRecordingService = AudioRecordingService()
         let audioRecorderService = AudioRecorderService()
+        audioRecorderService.recordingsDirectoryOverride = appSupportDirectory.appendingPathComponent("recordings")
         let hotkeyService = HotkeyService()
         let textInsertionService = TextInsertionService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
@@ -6433,6 +6434,101 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(ModelAutoUnloadPolicy.effectiveSeconds(), 0)
         XCTAssertEqual(modelManager.autoUnloadSeconds, 0)
         XCTAssertEqual(ModelAutoUnloadPolicy.policyName(seconds: modelManager.autoUnloadSeconds), "never")
+    }
+
+    @MainActor
+    func testModelAutoUnloadPolicyOnlyNeverAllowsPassiveStartupRestore() throws {
+        let suiteName = "ModelAutoUnloadPolicyTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        defaults.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        XCTAssertFalse(ModelAutoUnloadPolicy.shouldRestoreLoadedModelsPassively(defaults: defaults))
+
+        defaults.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        XCTAssertTrue(ModelAutoUnloadPolicy.shouldRestoreLoadedModelsPassively(defaults: defaults))
+
+        for activePolicySeconds in [-1, 120, 300, 600, 1800, 3600] {
+            defaults.set(activePolicySeconds, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            XCTAssertFalse(
+                ModelAutoUnloadPolicy.shouldRestoreLoadedModelsPassively(defaults: defaults),
+                "Policy \(activePolicySeconds) should lazy-load models after startup"
+            )
+        }
+    }
+
+    @MainActor
+    func testHostServicesSuppressesInheritedPassiveLoadedModelRestoreForLegacyPluginActivation() async throws {
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        let pluginId = "com.typewhisper.tests.legacy.\(UUID().uuidString)"
+        let loadedModelKey = "plugin.\(pluginId).loadedModel"
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+            UserDefaults.standard.removeObject(forKey: loadedModelKey)
+        }
+
+        UserDefaults.standard.set(600, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        UserDefaults.standard.set("legacy-loaded-model", forKey: loadedModelKey)
+        let host = HostServicesImpl(
+            pluginId: pluginId,
+            eventBus: MockEventBus(),
+            ruleNamesProvider: { [] }
+        )
+        defer { try? FileManager.default.removeItem(at: host.pluginDataDirectory) }
+
+        var inheritedRestoreTask: Task<String?, Never>?
+        host.performPluginActivation(suppressPassiveLoadedModelRestore: true) {
+            XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "legacy-loaded-model")
+            inheritedRestoreTask = Task {
+                host.userDefault(forKey: "loadedModel") as? String
+            }
+        }
+
+        let task = try XCTUnwrap(inheritedRestoreTask)
+        let observedLoadedModel = await task.value
+        XCTAssertNil(observedLoadedModel)
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "legacy-loaded-model")
+    }
+
+    @MainActor
+    func testHostServicesAllowsInheritedPassiveLoadedModelRestoreWhenAutoUnloadIsNever() async throws {
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        let pluginId = "com.typewhisper.tests.never.\(UUID().uuidString)"
+        let loadedModelKey = "plugin.\(pluginId).loadedModel"
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+            UserDefaults.standard.removeObject(forKey: loadedModelKey)
+        }
+
+        UserDefaults.standard.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        UserDefaults.standard.set("legacy-loaded-model", forKey: loadedModelKey)
+        let host = HostServicesImpl(
+            pluginId: pluginId,
+            eventBus: MockEventBus(),
+            ruleNamesProvider: { [] }
+        )
+        defer { try? FileManager.default.removeItem(at: host.pluginDataDirectory) }
+
+        var inheritedRestoreTask: Task<String?, Never>?
+        host.performPluginActivation(suppressPassiveLoadedModelRestore: true) {
+            inheritedRestoreTask = Task {
+                host.userDefault(forKey: "loadedModel") as? String
+            }
+        }
+
+        let task = try XCTUnwrap(inheritedRestoreTask)
+        let observedLoadedModel = await task.value
+        XCTAssertEqual(observedLoadedModel, "legacy-loaded-model")
     }
 
     @MainActor

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1646,6 +1646,14 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
         }
     }
 
+    private final class MockLifecyclePolicyAwarePlugin: NSObject, TypeWhisperPlugin, HostModelLifecyclePolicyAwarePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.lifecycle-aware" }
+        static var pluginName: String { "Mock Lifecycle Aware" }
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+    }
+
     override func tearDown() {
         RuntimeArchitecture.overrideCurrent = nil
         super.tearDown()
@@ -1701,6 +1709,61 @@ final class PluginArchitectureCompatibilityTests: XCTestCase {
         XCTAssertFalse(manager.isManifestSDKCompatible(missingManifest, isBundled: false))
         XCTAssertFalse(manager.isManifestSDKCompatible(mismatchedManifest, isBundled: false))
         XCTAssertTrue(manager.isManifestSDKCompatible(missingManifest, isBundled: true))
+    }
+
+    func testPassiveRestoreCompatibilityMaskOnlyAppliesToLegacyExternalPlugins() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let externalURL = appSupportDirectory
+            .appendingPathComponent("Plugins", isDirectory: true)
+            .appendingPathComponent("External.bundle", isDirectory: true)
+        let bundledURL = (Bundle.main.builtInPlugInsURL ?? URL(fileURLWithPath: "/Applications/TypeWhisper.app/Contents/PlugIns"))
+            .appendingPathComponent("Bundled.bundle", isDirectory: true)
+
+        let legacyExternalPlugin = LoadedPlugin(
+            manifest: PluginManifest(
+                id: "com.typewhisper.mock.legacy-external",
+                name: "Legacy External",
+                version: "1.0.0",
+                sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                principalClass: "MockTranscriptionPlugin"
+            ),
+            instance: MockTranscriptionPlugin(),
+            bundle: Bundle.main,
+            sourceURL: externalURL,
+            isEnabled: true
+        )
+        let lifecycleAwareExternalPlugin = LoadedPlugin(
+            manifest: PluginManifest(
+                id: "com.typewhisper.mock.lifecycle-aware",
+                name: "Lifecycle Aware",
+                version: "1.0.0",
+                sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                principalClass: "MockLifecyclePolicyAwarePlugin"
+            ),
+            instance: MockLifecyclePolicyAwarePlugin(),
+            bundle: Bundle.main,
+            sourceURL: externalURL,
+            isEnabled: true
+        )
+        let bundledPlugin = LoadedPlugin(
+            manifest: PluginManifest(
+                id: "com.typewhisper.mock.bundled",
+                name: "Bundled",
+                version: "1.0.0",
+                principalClass: "MockTranscriptionPlugin"
+            ),
+            instance: MockTranscriptionPlugin(),
+            bundle: Bundle.main,
+            sourceURL: bundledURL,
+            isEnabled: true
+        )
+
+        XCTAssertTrue(manager.shouldSuppressPassiveLoadedModelRestore(for: legacyExternalPlugin))
+        XCTAssertFalse(manager.shouldSuppressPassiveLoadedModelRestore(for: lifecycleAwareExternalPlugin))
+        XCTAssertFalse(manager.shouldSuppressPassiveLoadedModelRestore(for: bundledPlugin))
     }
 
     func testExternalBundleNoticeShowsBundledFallbackWhenLegacyBundleIsSkipped() throws {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -457,7 +457,7 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         func unsubscribe(id: UUID) {}
     }
 
-    private final class MockHostServices: HostServices, @unchecked Sendable {
+    private final class MockHostServices: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
         private var defaults: [String: Any]
         private var secrets: [String: String]
 
@@ -466,17 +466,20 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         var activeAppBundleId: String?
         var activeAppName: String?
         var availableRuleNames: [String] = []
+        var shouldRestoreLoadedModelsPassively: Bool
         private(set) var capabilitiesChangedCount = 0
         private(set) var streamingDisplayActiveValues: [Bool] = []
 
         init(
             pluginDataDirectory: URL,
             defaults: [String: Any] = [:],
-            secrets: [String: String] = [:]
+            secrets: [String: String] = [:],
+            shouldRestoreLoadedModelsPassively: Bool = true
         ) {
             self.pluginDataDirectory = pluginDataDirectory
             self.defaults = defaults
             self.secrets = secrets
+            self.shouldRestoreLoadedModelsPassively = shouldRestoreLoadedModelsPassively
         }
 
         func storeSecret(key: String, value: String) throws { secrets[key] = value }
@@ -536,6 +539,29 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         plugin.activate(host: host)
 
         XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "gemma-4-26b-a4b-it-4bit")
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+    }
+
+    func testGemma4ActivationSkipsPassiveRestoreWhenHostDisallowsIt() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(
+            pluginDataDirectory: appSupportDirectory,
+            defaults: [
+                "selectedLLMModel": "gemma-4-e2b-it-4bit",
+                "loadedModel": "retired-or-unavailable-model"
+            ],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        let plugin = Gemma4Plugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.shouldRestoreLoadedModelsPassively)
+        XCTAssertEqual(plugin.selectedLLMModelId, "gemma-4-e2b-it-4bit")
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "gemma-4-e2b-it-4bit")
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "retired-or-unavailable-model")
         XCTAssertEqual(plugin.modelState, .notLoaded)
     }
 

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -54,6 +54,26 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         )
     }
 
+    #if DEBUG
+    private func waitForRestoreLoadedModelInvocationCount(
+        _ plugin: WhisperKitPlugin,
+        toBecome expected: Int,
+        timeout: Duration = .seconds(1),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if plugin.restoreLoadedModelInvocationCountForTesting == expected {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(plugin.restoreLoadedModelInvocationCountForTesting, expected, file: file, line: line)
+    }
+    #endif
+
     func testAvailableModelsIncludeDistilLargeV3Turbo() {
         let model = WhisperKitPlugin.availableModels.first {
             $0.id == "distil-whisper_distil-large-v3_turbo"
@@ -102,11 +122,26 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
         XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai_whisper-tiny")
 
-        try await Task.sleep(for: .milliseconds(50))
+        #if DEBUG
+        await waitForRestoreLoadedModelInvocationCount(plugin, toBecome: 0)
+        #endif
 
         XCTAssertFalse(plugin.isConfigured)
         XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
         XCTAssertEqual(host.capabilitiesChangedCount, 0)
+    }
+
+    func testActivationSchedulesPassiveRestoreWhenHostAllowsIt() async throws {
+        let host = try makeHost(defaults: ["loadedModel": "openai_whisper-tiny"])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.shouldRestoreLoadedModelsPassively)
+        #if DEBUG
+        await waitForRestoreLoadedModelInvocationCount(plugin, toBecome: 1)
+        #endif
     }
 
     func testUnloadWithoutClearingPersistenceKeepsLoadedModelMarker() throws {

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -12,7 +12,7 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         func unsubscribe(id: UUID) {}
     }
 
-    private final class MockHostServices: HostServices, @unchecked Sendable {
+    private final class MockHostServices: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
         private var defaults: [String: Any]
         private var secrets: [String: String] = [:]
 
@@ -21,11 +21,17 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         var activeAppBundleId: String?
         var activeAppName: String?
         var availableRuleNames: [String] = []
+        var shouldRestoreLoadedModelsPassively: Bool
         private(set) var capabilitiesChangedCount = 0
 
-        init(pluginDataDirectory: URL, defaults: [String: Any] = [:]) {
+        init(
+            pluginDataDirectory: URL,
+            defaults: [String: Any] = [:],
+            shouldRestoreLoadedModelsPassively: Bool = true
+        ) {
             self.pluginDataDirectory = pluginDataDirectory
             self.defaults = defaults
+            self.shouldRestoreLoadedModelsPassively = shouldRestoreLoadedModelsPassively
         }
 
         func storeSecret(key: String, value: String) throws { secrets[key] = value }
@@ -36,9 +42,16 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         func setStreamingDisplayActive(_ active: Bool) {}
     }
 
-    private func makeHost(defaults: [String: Any] = [:]) throws -> MockHostServices {
+    private func makeHost(
+        defaults: [String: Any] = [:],
+        shouldRestoreLoadedModelsPassively: Bool = true
+    ) throws -> MockHostServices {
         let pluginDataDirectory = try TestSupport.makeTemporaryDirectory(prefix: "WhisperKitLifecycleTests")
-        return MockHostServices(pluginDataDirectory: pluginDataDirectory, defaults: defaults)
+        return MockHostServices(
+            pluginDataDirectory: pluginDataDirectory,
+            defaults: defaults,
+            shouldRestoreLoadedModelsPassively: shouldRestoreLoadedModelsPassively
+        )
     }
 
     func testAvailableModelsIncludeDistilLargeV3Turbo() {
@@ -65,6 +78,27 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         let plugin = WhisperKitPlugin()
         plugin.activate(host: host)
 
+        XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai_whisper-tiny")
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+    }
+
+    func testActivationSkipsPassiveRestoreWhenHostDisallowsIt() async throws {
+        let host = try makeHost(
+            defaults: ["loadedModel": "openai_whisper-tiny"],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.shouldRestoreLoadedModelsPassively)
         XCTAssertEqual(plugin.selectedModelId, "openai_whisper-tiny")
         XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai_whisper-tiny")
 


### PR DESCRIPTION
## Summary
Issue #815 reports that after a Mac restart, a local model can be restored into memory and keep using several GB even when an auto-unload duration is configured. This intentionally does not add a manual eject button; instead, active auto-unload policies now make startup and settings restore lazy.

- Add an additive HostServices lifecycle policy so hosts can opt plugins out of passive loaded-model restore without changing the v1 HostServices contract.
- Map passive restore to `Auto-unload model = Never`; any active auto-unload policy, including the default, skips startup/settings passive restores.
- Gate passive restore in the bundled local model plugins and settings tasks for WhisperKit, Parakeet, SpeechAnalyzer, Gemma 4, Qwen3, Granite, and Voxtral.
- Add a host-side compatibility mask for legacy non-bundled v1 plugins so activation-spawned passive restore tasks do not see `loadedModel` when auto-unload is active, while the persisted marker remains available for explicit restore/use paths.
- Keep selected/downloaded/loaded model state intact unless existing unload/remove/stale-cache/load-failure paths clear it.

Closes #815

## Test Coverage
All new code paths have focused regression coverage:
- policy mapping for `Never` vs active auto-unload values
- HostServices default compatibility for legacy hosts
- legacy plugin activation masking while preserving the loaded model marker
- representative WhisperKit and Gemma 4 passive restore skip behavior
- APIRouter fixture isolation for recorder directory setup

## Documentation
- `README.md`: clarified local model startup restore semantics for `Auto-unload model`.
- Public docs: TypeWhisper/typewhisper.com#99 updates English and German Workflows/Profile copy for the same behavior.

## Pre-Landing Review
No issues found.

## Design Review
No browser frontend files changed in this repo. SwiftUI settings task changes are behavior gates only; no visual design review needed.

## Eval Results
No prompt-related files changed. Evals skipped.

## Plan Completion
Plan implemented with one product-scope adjustment requested in discussion: no manual eject button. The fix makes startup restore lazy whenever auto-unload is active and preserves loaded model markers for first real use.

## Verification Results
TypeWhisper macOS, SDK, and documentation verification passed.

## Test plan
- [x] `git diff --check`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
- [x] `npm run test:i18n` (in `typewhisper.com`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a host/policy-controlled option for passive restoration of previously loaded local models at launch, including proper behavior when auto-unload is set to **Never**.
  * Introduced an SDK plugin marker to opt into the new lifecycle policy behavior.

* **Bug Fixes**
  * Disabled passive model restore for plugins when the host indicates it’s not allowed.
  * Updated activation/startup logic so restore behavior matches the effective auto-unload policy and legacy handling stays consistent.

* **Documentation**
  * Expanded guidance in the Workflows section and SDK Host Services notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->