### PR TITLE
Fix Parakeet vocabulary download repair

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -661,18 +661,21 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
         }
 
         let fileManager = FileManager.default
+        var installFailureURL = directory
         do {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
             let temporaryURL = directory.appendingPathComponent(
                 ".\(Self.vocabularyAssetFileName).\(UUID().uuidString).tmp",
                 isDirectory: false
             )
+            installFailureURL = temporaryURL
             do {
                 try data.write(to: temporaryURL, options: .atomic)
                 if Self.vocabularyAssetExists(at: targetURL) {
                     try? fileManager.removeItem(at: temporaryURL)
                     return
                 }
+                installFailureURL = targetURL
                 if fileManager.fileExists(atPath: targetURL.path) {
                     try fileManager.removeItem(at: targetURL)
                 }
@@ -684,7 +687,7 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
         } catch {
             throw ParakeetVocabularyAssetError.installFailed(
                 version: version,
-                path: targetURL,
+                path: installFailureURL,
                 underlying: error
             )
         }

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -42,10 +42,12 @@ private actor AsyncTranscriptionGate {
 final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
+    static let vocabularyAssetFileName = "parakeet_vocab.json"
     private static let logger = Logger(subsystem: "com.typewhisper.plugin.parakeet", category: "Transcription")
     private static let shortClipConfidenceThreshold: Float = 0.55
     private static let shortClipConfidenceGateDuration: TimeInterval = 1.0
     private static let fluidAudioProgressMinimumSampleCount = 240_000
+    typealias VocabularyAssetFetcher = @Sendable (_ url: URL, _ description: String) async throws -> Data
 
     fileprivate var host: HostServices?
     fileprivate var asrManager: AsrManager?
@@ -589,6 +591,7 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
 
         do {
             applyHuggingFaceTokenToEnvironment()
+            try await ensureVocabularyAsset(for: selectedVersion)
             let models = try await AsrModels.downloadAndLoad(version: selectedVersion.asrModelVersion)
             downloadProgress = 0.7
 
@@ -617,6 +620,82 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
             modelState = .error(error.localizedDescription)
             downloadProgress = 0
         }
+    }
+
+    static func vocabularyAssetURL(for version: ParakeetVersion) -> URL {
+        let repo: String
+        switch version {
+        case .v2:
+            repo = "FluidInference/parakeet-tdt-0.6b-v2-coreml"
+        case .v3:
+            repo = "FluidInference/parakeet-tdt-0.6b-v3-coreml"
+        }
+        return URL(string: "https://huggingface.co/\(repo)/resolve/main/\(vocabularyAssetFileName)")!
+    }
+
+    static func vocabularyAssetDirectory(for version: ParakeetVersion) -> URL {
+        AsrModels.defaultCacheDirectory(for: version.asrModelVersion)
+    }
+
+    func ensureVocabularyAsset(
+        for version: ParakeetVersion,
+        targetDirectory: URL? = nil,
+        fetcher: VocabularyAssetFetcher = { url, description in
+            try await DownloadUtils.fetchHuggingFaceFile(from: url, description: description)
+        }
+    ) async throws {
+        let directory = targetDirectory ?? Self.vocabularyAssetDirectory(for: version)
+        let targetURL = directory.appendingPathComponent(Self.vocabularyAssetFileName, isDirectory: false)
+        guard !Self.vocabularyAssetExists(at: targetURL) else { return }
+
+        let vocabularyURL = Self.vocabularyAssetURL(for: version)
+        let description = "\(version.modelDef.displayName) vocabulary"
+        let data: Data
+        do {
+            data = try await fetcher(vocabularyURL, description)
+        } catch {
+            throw ParakeetVocabularyAssetError.downloadFailed(version: version, underlying: error)
+        }
+        guard !data.isEmpty else {
+            throw ParakeetVocabularyAssetError.emptyDownload(version: version)
+        }
+
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            let temporaryURL = directory.appendingPathComponent(
+                ".\(Self.vocabularyAssetFileName).\(UUID().uuidString).tmp",
+                isDirectory: false
+            )
+            do {
+                try data.write(to: temporaryURL, options: .atomic)
+                if Self.vocabularyAssetExists(at: targetURL) {
+                    try? fileManager.removeItem(at: temporaryURL)
+                    return
+                }
+                if fileManager.fileExists(atPath: targetURL.path) {
+                    try fileManager.removeItem(at: targetURL)
+                }
+                try fileManager.moveItem(at: temporaryURL, to: targetURL)
+            } catch {
+                try? fileManager.removeItem(at: temporaryURL)
+                throw error
+            }
+        } catch {
+            throw ParakeetVocabularyAssetError.installFailed(
+                version: version,
+                path: targetURL,
+                underlying: error
+            )
+        }
+    }
+
+    private static func vocabularyAssetExists(at url: URL) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attributes[.size] as? NSNumber else {
+            return false
+        }
+        return size.intValue > 0
     }
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
@@ -790,6 +869,23 @@ enum CtcModelState: Equatable {
     case downloading
     case ready
     case error(String)
+}
+
+private enum ParakeetVocabularyAssetError: LocalizedError {
+    case downloadFailed(version: ParakeetVersion, underlying: Error)
+    case emptyDownload(version: ParakeetVersion)
+    case installFailed(version: ParakeetVersion, path: URL, underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .downloadFailed(let version, let underlying):
+            return "Failed to download Parakeet vocabulary file for \(version.modelDef.displayName): \(underlying.localizedDescription)"
+        case .emptyDownload(let version):
+            return "Failed to download Parakeet vocabulary file for \(version.modelDef.displayName): downloaded file was empty"
+        case .installFailed(let version, let path, let underlying):
+            return "Failed to install Parakeet vocabulary file for \(version.modelDef.displayName) at \(path.path): \(underlying.localizedDescription)"
+        }
+    }
 }
 
 // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -16,10 +16,166 @@ final class ParakeetPluginTests: XCTestCase {
         }
     }
 
+    private actor VocabularyFetchRecorder {
+        private var requests: [(url: URL, description: String)] = []
+        private let data: Data?
+        private let error: Error?
+
+        init(data: Data) {
+            self.data = data
+            self.error = nil
+        }
+
+        init(error: Error) {
+            self.data = nil
+            self.error = error
+        }
+
+        func fetch(url: URL, description: String) async throws -> Data {
+            requests.append((url: url, description: description))
+            if let data {
+                return data
+            }
+            throw error ?? URLError(.unknown)
+        }
+
+        func requestCount() -> Int {
+            requests.count
+        }
+
+        func firstRequest() -> (url: URL, description: String)? {
+            requests.first
+        }
+    }
+
     private func makePlugin(restoresModelOnActivate: Bool = false) -> ParakeetPlugin {
         let plugin = ParakeetPlugin()
         plugin.restoresModelOnActivate = restoresModelOnActivate
         return plugin
+    }
+
+    private func makeTemporaryDirectory(prefix: String = "ParakeetPluginTests") throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "\(prefix)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    func testVocabularyAssetURLsMapToVersionRepositories() {
+        XCTAssertEqual(
+            ParakeetPlugin.vocabularyAssetURL(for: .v2).absoluteString,
+            "https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v2-coreml/resolve/main/parakeet_vocab.json"
+        )
+        XCTAssertEqual(
+            ParakeetPlugin.vocabularyAssetURL(for: .v3).absoluteString,
+            "https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/main/parakeet_vocab.json"
+        )
+    }
+
+    func testEnsureVocabularyAssetSkipsExistingFile() async throws {
+        let directory = try makeTemporaryDirectory()
+        let targetURL = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)
+        let existingData = Data(#"{"0":"existing"}"#.utf8)
+        try existingData.write(to: targetURL)
+        let recorder = VocabularyFetchRecorder(data: Data(#"{"0":"downloaded"}"#.utf8))
+        let plugin = makePlugin()
+
+        try await plugin.ensureVocabularyAsset(
+            for: .v3,
+            targetDirectory: directory,
+            fetcher: { url, description in
+                try await recorder.fetch(url: url, description: description)
+            }
+        )
+
+        let requestCount = await recorder.requestCount()
+        XCTAssertEqual(requestCount, 0)
+        XCTAssertEqual(try Data(contentsOf: targetURL), existingData)
+    }
+
+    func testEnsureVocabularyAssetRepairsEmptyExistingFile() async throws {
+        let directory = try makeTemporaryDirectory()
+        let targetURL = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)
+        try Data().write(to: targetURL)
+        let downloadedData = Data(#"{"0":"downloaded"}"#.utf8)
+        let recorder = VocabularyFetchRecorder(data: downloadedData)
+        let plugin = makePlugin()
+
+        try await plugin.ensureVocabularyAsset(
+            for: .v3,
+            targetDirectory: directory,
+            fetcher: { url, description in
+                try await recorder.fetch(url: url, description: description)
+            }
+        )
+
+        XCTAssertEqual(try Data(contentsOf: targetURL), downloadedData)
+        let requestCount = await recorder.requestCount()
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testEnsureVocabularyAssetDownloadsMissingFile() async throws {
+        let directory = try makeTemporaryDirectory()
+        let targetURL = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)
+        let downloadedData = Data(#"{"0":"<blank>"}"#.utf8)
+        let recorder = VocabularyFetchRecorder(data: downloadedData)
+        let plugin = makePlugin()
+
+        try await plugin.ensureVocabularyAsset(
+            for: .v3,
+            targetDirectory: directory,
+            fetcher: { url, description in
+                try await recorder.fetch(url: url, description: description)
+            }
+        )
+
+        XCTAssertEqual(try Data(contentsOf: targetURL), downloadedData)
+        let requestCount = await recorder.requestCount()
+        XCTAssertEqual(requestCount, 1)
+        let recordedRequest = await recorder.firstRequest()
+        let request = try XCTUnwrap(recordedRequest)
+        XCTAssertEqual(request.url, ParakeetPlugin.vocabularyAssetURL(for: .v3))
+        XCTAssertEqual(request.description, "Parakeet TDT v3 vocabulary")
+    }
+
+    func testEnsureVocabularyAssetSurfacesFailedFetch() async throws {
+        let directory = try makeTemporaryDirectory()
+        let targetURL = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)
+        let recorder = VocabularyFetchRecorder(
+            error: NSError(
+                domain: "ParakeetVocabularyAssetTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "network unavailable"]
+            )
+        )
+        let plugin = makePlugin()
+
+        do {
+            try await plugin.ensureVocabularyAsset(
+                for: .v2,
+                targetDirectory: directory,
+                fetcher: { url, description in
+                    try await recorder.fetch(url: url, description: description)
+                }
+            )
+            XCTFail("Expected vocabulary download to fail")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains(
+                    "Failed to download Parakeet vocabulary file for Parakeet TDT v2"
+                )
+            )
+            XCTAssertTrue(error.localizedDescription.contains("network unavailable"))
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: targetURL.path))
+        let requestCount = await recorder.requestCount()
+        XCTAssertEqual(requestCount, 1)
     }
 
     func testActivationPromotesPersistedLoadedModelToSelectedModelWhenSelectionMissing() throws {

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -143,6 +143,33 @@ final class ParakeetPluginTests: XCTestCase {
         XCTAssertEqual(request.description, "Parakeet TDT v3 vocabulary")
     }
 
+    func testEnsureVocabularyAssetCreatesMissingTargetDirectory() async throws {
+        let parentDirectory = try makeTemporaryDirectory()
+        let directory = parentDirectory.appendingPathComponent("missing-cache", isDirectory: true)
+        let targetURL = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)
+        let downloadedData = Data(#"{"0":"created-directory"}"#.utf8)
+        let recorder = VocabularyFetchRecorder(data: downloadedData)
+        let plugin = makePlugin()
+
+        try await plugin.ensureVocabularyAsset(
+            for: .v2,
+            targetDirectory: directory,
+            fetcher: { url, description in
+                try await recorder.fetch(url: url, description: description)
+            }
+        )
+
+        var isDirectory = ObjCBool(false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+        XCTAssertEqual(try Data(contentsOf: targetURL), downloadedData)
+        let requestCount = await recorder.requestCount()
+        XCTAssertEqual(requestCount, 1)
+        let recordedRequest = await recorder.firstRequest()
+        let request = try XCTUnwrap(recordedRequest)
+        XCTAssertEqual(request.url, ParakeetPlugin.vocabularyAssetURL(for: .v2))
+    }
+
     func testEnsureVocabularyAssetSurfacesFailedFetch() async throws {
         let directory = try makeTemporaryDirectory()
         let targetURL = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)


### PR DESCRIPTION
## Summary
- repair missing `parakeet_vocab.json` before Parakeet v2/v3 model loading
- map v2/v3 vocabulary asset URLs and write the file into FluidAudio's expected cache directory
- cover existing-file skip, empty-file repair, missing-file repair, and failed fetch paths in Parakeet tests

## Issue Context
Issue #819 reports Parakeet install failures on TypeWhisper 1.4 with `ASR model 'parakeet_vocab.json' not found`.

The Hugging Face model repositories contain the vocabulary file, but the pinned FluidAudio downloader can miss that auxiliary JSON on clean caches. This TypeWhisper-side repair path downloads the vocabulary before calling `AsrModels.downloadAndLoad(version:)` so affected users do not have to wait on an upstream FluidAudio fix.

Closes #819

## Test Plan
- `swift test --package-path TypeWhisperPluginSDK --filter ParakeetPluginTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run ParakeetPlugin --enable-plugin com.typewhisper.parakeet /Users/marco/.codex/worktrees/aea8/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech model loading by automatically checking, preparing, and installing required vocabulary files before the model loads.
  * Added safer handling for missing, empty, or failed vocabulary downloads, with clearer, user-friendly error messages.
  * Reuses existing valid vocabulary assets to avoid unnecessary downloads.
* **Tests**
  * Expanded coverage for vocabulary URL generation, caching/re-download behavior, directory creation, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->