### PR TITLE
docs: prepare 1.5.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Speech-to-text and AI text processing for macOS. Transcribe audio using on-device AI models or cloud APIs (Groq, OpenAI, xAI/Grok), then transform the result with reusable workflows. Your voice data stays on your Mac with local models - or use cloud APIs for faster processing.
 
-TypeWhisper `1.4` is the current stable release for macOS. It includes system-wide dictation, file transcription, unified workflows, history, dictionary, snippets, bundled integrations, the community plugin registry, and local automation APIs. Advanced surfaces like the HTTP API, CLI, widgets, watch folders, and the plugin SDK remain supported for power users and automation.
+TypeWhisper `1.5` is the current stable release for macOS. It includes system-wide dictation, file transcription, unified workflows, history, dictionary, snippets, bundled integrations, the community plugin registry, local automation APIs, app-aware insertion, expanded provider support, and local-model reliability improvements. Advanced surfaces like the HTTP API, CLI, widgets, watch folders, and the plugin SDK remain supported for power users and automation.
 
 See the [release readiness guide](docs/release-readiness.md), [support matrix](docs/support-matrix.md), and [release checklist](docs/release-checklist.md) for the current release definition and ship gates.
 
@@ -50,15 +50,15 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 
 <!-- readme-screenshots:end -->
 
-## What's New in 1.4
+## What's New in 1.5
 
-- **Redesigned Integrations** - Installed, Discover, and Manual tabs now group built-in, marketplace, community, and manually installed plugins with clearer source, hosting, and capability metadata
-- **Community plugin registry** - `1.4` builds can discover community plugins through the new registry feed while older `1.3.x` builds stay on the official marketplace feed
-- **Model download controls** - Local model plugins now have clearer downloaded model management, host-version gates, Hugging Face token support, and license acceptance flows where required
-- **New bundled providers** - xAI/Grok, Smallest AI Pulse, Supertonic TTS, refreshed OpenAI voices, Qwen3 ASR, Granite, Voxtral, and Gemma 4 expand the bundled plugin set
-- **Local automation APIs** - Recorder and dictionary HTTP endpoints, watch-folder file jobs, per-request STT engine/model overrides, and CLI/API improvements give power users more automation surface
-- **Workflow and hotkey polish** - Workflow drag reordering, multiple global hotkeys per action, prompt-boundary hardening, direct text hotkeys, and safer Apple Intelligence handling improve day-to-day dictation flows
-- **Dictation reliability pass** - Live transcript, recording indicators, fullscreen/fixed-display handling, USB and multichannel audio capture, route-change recovery, and hotkey startup latency all received focused fixes
+- **App-aware dictation insertion** - Dictation output now better respects sentence position, trailing spaces, terminal paste behavior, rich-text targets, and target-app context
+- **Expanded speech and AI providers** - Gemini speech transcription, Cartesia speech transcription, Sber SaluteSpeech, OpenRouter speech-to-text, Reson8, Mistral AI, Soniox regions and TTS, and OpenAI-compatible profiles broaden the bundled provider set
+- **Local model reliability** - MLX memory-footprint controls, idle auto-unload behavior, stalled Gemma 4 download recovery, and Parakeet vocabulary repair improve local model setup and day-to-day stability
+- **Dictionary learning and normalization** - Auto-learned corrections, target-app correction learning, per-term CTC tuning plumbing, multilingual number-word normalization, English ordinals, digit sequences, and French decimal cleanup improve recognition output
+- **Workflow and hotkey reliability** - Hybrid modifier timing, non-Control modifier taps, global push-to-talk, Pages workflow hotkeys, menu-based dictation pause, Esc confirmation, and automatic workflow output resolution all received targeted fixes
+- **Recording and indicator polish** - Virtual audio input support, media pause/resume hardening, fullscreen indicator fixes, recorder final-failure surfacing, FaceTime built-in microphone capture, and TaskForge insertion fallback improve real-world capture and insertion flows
+- **Release and plugin metadata cleanup** - Cloud ASR upload fallback handling, plugin host-compatibility metadata, plugin uninstall cleanup, and GitHub Latest protection keep the 1.5 distribution path clean
 
 ## Features
 
@@ -124,7 +124,7 @@ brew install --cask typewhisper/tap/typewhisper
 
 Download the latest DMG from [GitHub Releases](https://github.com/TypeWhisper/typewhisper-mac/releases/latest).
 
-Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.4.0-rc*` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
+Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.5.0-rc*` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
 Installed builds can switch channels in `Settings -> About` via the `Update Channel` picker.
 
 ## Quick Start

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -9,17 +9,17 @@
 - Review `README.md`, `SECURITY.md`, `docs/support-matrix.md`, `docs/release-readiness.md`, `TypeWhisperPluginSDK/Plugins/README.md`, and `TypeWhisperPluginSDK/README.md`
 - If README screenshots changed, run `scripts/update-readme-screenshots.sh`; otherwise verify the gallery with `scripts/update-readme-screenshots.sh --check`
 - Confirm marketplace plugin manifests and registry releases carry the current `sdkCompatibilityVersion`
-- Confirm `MARKETING_VERSION = 1.4.0` across the app, CLI, and widgets
-- Prepare or refresh `docs/release-notes/1.4.0.md`
-- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.4.0` before pushing the tag
-- Otherwise the release workflow will publish `docs/release-notes/1.4.0.md` automatically when no release already exists
+- Confirm `MARKETING_VERSION = 1.5.0` across the app, CLI, and widgets
+- Prepare or refresh `docs/release-notes/1.5.0.md`
+- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.5.0` before pushing the tag
+- Otherwise the release workflow will publish `docs/release-notes/1.5.0.md` automatically when no release already exists
 
-## Before `1.4.0-rc1`
+## Before `1.5.0-rc1`
 
 - Confirm `1.3.x` builds continue to use `plugins-v1.json`
-- Confirm `1.4.0-rc*`, `1.4.0` daily, and `1.4.0` stable builds use `plugins-community-v1.json`
+- Confirm `1.4.x`, `1.5.0-rc*`, `1.5.0` daily, and `1.5.0` stable builds use `plugins-community-v1.json`
 - Confirm community registry entries under `PluginRegistry/community-v1/` set `source` to `community`; omitted `source` values in published feeds must remain official marketplace entries
-- Keep community plugin submissions out of the `1.3` release scope unless they are already bundled or first-party
+- Keep community plugin submissions out of the `1.5` release scope unless they are already bundled or first-party
 - Smoke-test the Integrations hub grouped lists for Built-in, Marketplace, Community, and Manual plugin paths
 - Smoke-test the Installed, Discover, and Manual tabs at desktop and compact window sizes
 - Verify Discover search, the Community include/exclude checkbox, and the capability filter menu
@@ -30,7 +30,7 @@
 
 ## RC Smoke Checks
 
-- Publish `1.4.0-rc*` on the `release-candidate` channel and daily builds on the `daily` channel
+- Publish `1.5.0-rc*` on the `release-candidate` channel and daily builds on the `daily` channel
 - Stable builds must use only the default channel
 - Fresh install
 - Permission recovery
@@ -81,13 +81,13 @@
   - Reorder the selected languages and confirm hint-aware engines receive the ordered list
   - Confirm engines without language-hint support use the first selected language
 - Verify CLI and HTTP API locally
-- Upgrade from `1.2.2` with 1.4 Workflows available and no Legacy settings page
+- Upgrade from `1.4.0` with Workflows, History, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
 
-## Before `1.4.0`
+## Before `1.5.0`
 
-- Observe the latest `1.4.0-rc*` build on real machines for multiple days
+- Observe the latest `1.5.0-rc*` build on real machines for multiple days
 - No open P0/P1 bugs in the core workflow
 - Finalize release notes
 - RC and daily tags must not update Homebrew or trigger stable website messaging
 - Verify DMG, ZIP, and the `release-candidate` appcast entry with `minimumSystemVersion` set to `14.0`
-- Verify Homebrew and the stable appcast update only at the final `1.4.0`
+- Verify Homebrew and the stable appcast update only at the final `1.5.0`

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -81,7 +81,7 @@
   - Reorder the selected languages and confirm hint-aware engines receive the ordered list
   - Confirm engines without language-hint support use the first selected language
 - Verify CLI and HTTP API locally
-- Upgrade from `1.4.0` with Workflows, History, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
+- Upgrade from `1.4.0` with History, legacy prompts/profiles, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
 
 ## Before `1.5.0`
 

--- a/docs/release-notes/1.5.0.md
+++ b/docs/release-notes/1.5.0.md
@@ -1,0 +1,30 @@
+TypeWhisper `1.5.0` is the stable `1.5` macOS release. It brings app-aware dictation insertion, virtual audio input support, broader number normalization, expanded bundled speech providers, local-model memory controls, dictionary-learning improvements, and a focused reliability pass across hotkeys, workflows, plugins, model handling, and release metadata.
+
+## Highlights
+
+- Added app-aware smart insertion so dictated text better respects surrounding text, sentence position, trailing spaces, terminal paste behavior, and target-app context.
+- Added virtual audio input device support and hardened media pause/resume behavior, recording start feedback, mouse-button shortcuts, and fullscreen indicator handling.
+- Expanded number normalization across generic transcription output, multilingual number words, Dutch number words, English ordinals, English digit sequences, and French decimal phrases.
+- Added and refreshed bundled speech and AI providers, including Gemini speech transcription, Cartesia speech transcription, Sber SaluteSpeech, OpenRouter speech-to-text, Reson8, Mistral AI, OpenAI-compatible profiles, Soniox regions and TTS, and updated cloud ASR providers.
+- Added Japanese localization and dictation support, ordered language hints, recent transcriptions in the workflow palette, source progress for file transcription, recorder-specific engine overrides, and a short-dictation workflow AI-skip setting.
+- Added local MLX memory-footprint controls, idle local-model auto-unload behavior, and recovery for stalled Gemma 4 model downloads.
+- Added pro transcription fallback, auto-learned dictionary corrections, per-term dictionary CTC tuning plumbing, and tighter target-app correction learning.
+
+## Reliability and Fixes
+
+- Fixed delayed Hybrid hotkey behavior, restored non-Control hybrid modifier taps, improved global push-to-talk capture, aligned Pages workflow hotkeys with palette behavior, added menu-based dictation pause, and required confirmation before Esc cancels dictation.
+- Fixed fullscreen indicator menu-bar strip issues and the top overlay menu-bar strip.
+- Fixed Groq and cloud ASR compressed M4A upload handling, including a WAV fallback for incomplete M4A finalization.
+- Fixed Soniox async file transcription routing, region persistence, and realtime model selection.
+- Fixed OpenAI Compatible GPT-5 token parameter handling, host SDK compatibility, and configurable request-timeout behavior.
+- Fixed plugin host compatibility metadata, raised cloud ASR plugin host floors to TypeWhisper 1.5 where required, and prevented plugin releases from taking over the repository-level GitHub Latest marker.
+- Fixed TaskForge preserve-clipboard insertion fallback, dictionary scroll crashes, event tap teardown, FaceTime built-in microphone capture, plugin uninstall keychain cleanup, and development build cleanup scope.
+- Fixed Parakeet v2/v3 model setup by repairing missing vocabulary downloads before model loading.
+- Improved Japanese dictation post-processing and settings localization, Latin word replacement boundaries, terminal clipboard restore verification, and recorder final transcription failure surfacing.
+
+## Developer and Distribution Notes
+
+- Stable `1.5.0` builds use the default Sparkle channel and require macOS 14.0 or later.
+- Release candidates and daily builds remain on their dedicated Sparkle channels and do not update Homebrew.
+- The final stable tag publishes DMG and ZIP assets, updates the stable Sparkle appcast entry, triggers the website release dispatch, and updates the Homebrew cask.
+- The `1.5` plugin line uses the community-capable registry feed and keeps host compatibility metadata aligned with the bundled plugin SDK.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,8 +1,8 @@
 # TypeWhisper 1.x Release Readiness
 
-This document defines the release gates for the current `1.x` product path leading into the stable `1.3.0` release.
+This document defines the release gates for the current `1.x` product path leading into the stable `1.5.0` release.
 
-TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac App Store remains out of scope. For `1.3`, the focus is unified workflows, spoken feedback, per-request engine control, multilingual hints, hotkey robustness, and streaming-dictionary support in plugins.
+TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac App Store remains out of scope. For `1.5`, the focus is app-aware dictation insertion, expanded bundled providers, local-model memory reliability, dictionary-learning improvements, workflow and hotkey reliability, and stable plugin metadata for the current SDK line.
 
 ## Audience
 
@@ -31,17 +31,15 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Widgets
 - Watch Folder
 
-## `1.3` Focus Areas
+## `1.5` Focus Areas
 
-- Spoken feedback (TTS) with a new bundled `System Voice` plugin, scoped to transcription readback
-- Per-request STT engine/model selection through the HTTP API and CLI
-- Multilingual language hints with a multi-select picker and selected-count indicator
-- Fn press-and-release and press-and-hold hotkey strategies
-- GPT-5/Codex compatibility for the bundled OpenAI plugin
-- Dictionary terms forwarded through streaming transcription providers without breaking sessions
-- Qwen3 context-bias formatter refactor
-- Audio recovery hardening around Bluetooth route changes
-- Fixes landed from the 1.2.3 review pass (K1-K4, M1/M7/M8)
+- App-aware smart insertion for plain text, rich text, terminal paste, sentence-boundary, and target-app contexts
+- Virtual audio input support, recorder-specific engine overrides, source progress for file transcription, and recorder failure surfacing
+- Expanded bundled speech and AI provider support across Gemini, Cartesia, Sber SaluteSpeech, OpenRouter, Reson8, Mistral AI, Soniox regions and TTS, and OpenAI-compatible profiles
+- Local MLX memory-footprint controls, idle local-model auto-unload behavior, Gemma 4 download recovery, and Parakeet vocabulary repair
+- Auto-learned dictionary corrections, target-app correction learning, per-term CTC tuning plumbing, and broader number normalization
+- Workflow, hotkey, indicator, and insertion reliability fixes across Hybrid modifiers, Pages workflows, Esc confirmation, fullscreen indicators, TaskForge, and FaceTime capture
+- Plugin host compatibility metadata, release-channel correctness, and stable GitHub Latest/Homebrew/Appcast behavior
 
 ## Stability Contracts for `1.x`
 
@@ -72,7 +70,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 
 ## Release Gates
 
-`1.3.0` is only tagged once all of the following conditions are met:
+`1.5.0` is only tagged once all of the following conditions are met:
 
 - `xcodebuild test` for the app scheme passes.
 - `swift test --package-path TypeWhisperPluginSDK` passes.
@@ -80,9 +78,9 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - There are no first-party build warnings.
 - Plugin manifests validate successfully.
 - README, security guidance, support matrix, and plugin documentation are up to date.
-- The `1.3.0-rc*` line ran on real machines for multiple days without P0/P1 blockers before the stable tag.
+- The `1.5.0-rc*` line ran on real machines for multiple days without P0/P1 blockers before the stable tag.
 - The default channel remains `stable`; `release-candidate` and `daily` exist as Sparkle channels for preview builds.
-- `1.3.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
+- `1.5.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
 - The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.
 
 ## Manual Smoke Checks Before Tagging
@@ -112,7 +110,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Dictionary terms streamed through AssemblyAI, Soniox, and SpeechAnalyzer without session breakage
 - Very short speech clips and streaming-preview/no-speech guard behavior
 - Audio preview and recording after device changes, especially AirPods/Bluetooth profile switches; no crash during Bluetooth route changes
-- Upgrade from `1.2.2` with History, legacy prompts/profiles, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
+- Upgrade from `1.4.0` with History, legacy prompts/profiles, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
 
 ## Release Outputs
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -19,7 +19,7 @@ This matrix describes the officially supported direct-download path for the curr
 | File transcription | Yes | Yes | Yes | Core workflow in the current stable release |
 | Workflow processing | Yes | Yes | Yes | Core workflow in the current stable release |
 | Workflows, History, Dictionary, Snippets | Yes | Yes | Yes | Core workflow in the current stable release |
-| Notch, Overlay, and Minimal indicators | Yes | Yes | Yes | User-facing status surfaces in `1.3` |
+| Notch, Overlay, and Minimal indicators | Yes | Yes | Yes | User-facing status surfaces in the current stable release |
 | Widgets | Yes | Yes | Yes | Supported advanced surface |
 | HTTP API | Yes | Yes | Yes | Loopback-only, disabled by default |
 | CLI | Yes | Yes | Yes | Requires the local API server to be running |


### PR DESCRIPTION
## Summary
- Add curated stable release notes for `v1.5.0` so the release workflow uses reviewed copy instead of generated commit notes.
- Update README stable-release messaging and "What's New" content for the 1.5 release line.
- Refresh release checklist/readiness/support docs from stale 1.3/1.4 stable-target wording to the 1.5 stable release path.

## Test Coverage
Docs-only release preparation. No application code paths changed.

## Pre-Landing Review
No structural issues found in the docs-only diff.

## Scope Drift
Scope Check: CLEAN. The PR only updates release notes and stable-release documentation for the planned `v1.5.0` tag.

## Test plan
- [x] `scripts/update-readme-screenshots.sh --check`
- [x] `git diff --check`
- [x] `bash scripts/pr-preflight.sh origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated TypeWhisper 1.5 release highlights, including app-aware dictation insertion, expanded speech/AI provider support, improved local model reliability, and dictionary learning/normalization enhancements.
* **Bug Fixes**
  * Documented reliability improvements across workflows, hotkeys, recording, and upload/transcription handling, plus stability fixes for plugin behavior and release metadata.
* **Documentation**
  * Refreshed release information, release-readiness and checklist steps, and support guidance to align with the 1.5.0 stable and rc/daily channel cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->