### PR TITLE
chore: prepare 1.6 release line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 Speech-to-text and AI text processing for macOS. Transcribe audio using on-device AI models or cloud APIs (Groq, OpenAI, xAI/Grok), then transform the result with reusable workflows. Your voice data stays on your Mac with local models - or use cloud APIs for faster processing.
 
-TypeWhisper `1.5` is the current stable release for macOS. It includes system-wide dictation, file transcription, unified workflows, history, dictionary, snippets, bundled integrations, the community plugin registry, local automation APIs, app-aware insertion, expanded provider support, and local-model reliability improvements. Advanced surfaces like the HTTP API, CLI, widgets, watch folders, and the plugin SDK remain supported for power users and automation.
+TypeWhisper `1.5` is the current stable release for macOS. It includes system-wide dictation, file transcription, unified workflows, history, dictionary, snippets, bundled integrations, the community plugin registry, local automation APIs, app-aware insertion, expanded provider support, and local-model reliability improvements. The `main` branch is now preparing the `1.6` release-candidate line; `1.5` receives hotfixes only from `release/1.5`.
 
-See the [release readiness guide](docs/release-readiness.md), [support matrix](docs/support-matrix.md), and [release checklist](docs/release-checklist.md) for the current release definition and ship gates.
+See the [release readiness guide](docs/release-readiness.md), [support matrix](docs/support-matrix.md), and [release checklist](docs/release-checklist.md) for the active `1.6` release definition and ship gates.
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/22fe922d-4a4c-47d1-805e-684a148ebd03" autoplay loop muted playsinline width="270"></video>
@@ -130,7 +130,7 @@ brew install --cask typewhisper/tap/typewhisper
 
 Download the latest DMG from [GitHub Releases](https://github.com/TypeWhisper/typewhisper-mac/releases/latest).
 
-Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.5.0-rc*` and daily builds are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
+Stable direct-download releases use the default Sparkle channel. Release candidates such as `1.6.0-rc*` and daily builds such as `v1.6.0-daily.*` are published as GitHub prereleases, update the shared Sparkle appcast on their own channels, and are excluded from Homebrew.
 Installed builds can switch channels in `Settings -> About` via the `Update Channel` picker.
 
 ## Quick Start

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -4582,7 +4582,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
@@ -4611,7 +4611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
@@ -4627,7 +4627,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_NAME = "typewhisper-cli";
 				SWIFT_VERSION = 6.0;
 			};
@@ -4639,7 +4639,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_NAME = "typewhisper-cli";
 				SWIFT_VERSION = 6.0;
 			};
@@ -5217,7 +5217,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -5244,7 +5244,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -9,17 +9,17 @@
 - Review `README.md`, `SECURITY.md`, `docs/support-matrix.md`, `docs/release-readiness.md`, `TypeWhisperPluginSDK/Plugins/README.md`, and `TypeWhisperPluginSDK/README.md`
 - If README screenshots changed, run `scripts/update-readme-screenshots.sh`; otherwise verify the gallery with `scripts/update-readme-screenshots.sh --check`
 - Confirm marketplace plugin manifests and registry releases carry the current `sdkCompatibilityVersion`
-- Confirm `MARKETING_VERSION = 1.5.0` across the app, CLI, and widgets
-- Prepare or refresh `docs/release-notes/1.5.0.md`
-- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.5.0` before pushing the tag
-- Otherwise the release workflow will publish `docs/release-notes/1.5.0.md` automatically when no release already exists
+- Confirm `MARKETING_VERSION = 1.6.0` across the app, CLI, and widgets
+- Prepare or refresh `docs/release-notes/1.6.0.md`
+- If you want to edit the notes directly on GitHub, create or update the draft release for `v1.6.0` before pushing the tag
+- Otherwise the release workflow will publish `docs/release-notes/1.6.0.md` automatically when no release already exists
 
-## Before `1.5.0-rc1`
+## Before `1.6.0-rc1`
 
 - Confirm `1.3.x` builds continue to use `plugins-v1.json`
-- Confirm `1.4.x`, `1.5.0-rc*`, `1.5.0` daily, and `1.5.0` stable builds use `plugins-community-v1.json`
+- Confirm `1.4.x`, `1.5.x`, `1.6.0-rc*`, `1.6.0` daily, and `1.6.0` stable builds use `plugins-community-v1.json`
 - Confirm community registry entries under `PluginRegistry/community-v1/` set `source` to `community`; omitted `source` values in published feeds must remain official marketplace entries
-- Keep community plugin submissions out of the `1.5` release scope unless they are already bundled or first-party
+- Keep community plugin submissions out of the `1.6` release scope unless they are already bundled or first-party
 - Smoke-test the Integrations hub grouped lists for Built-in, Marketplace, Community, and Manual plugin paths
 - Smoke-test the Installed, Discover, and Manual tabs at desktop and compact window sizes
 - Verify Discover search, the Community include/exclude checkbox, and the capability filter menu
@@ -30,7 +30,7 @@
 
 ## RC Smoke Checks
 
-- Publish `1.5.0-rc*` on the `release-candidate` channel and daily builds on the `daily` channel
+- Publish `1.6.0-rc*` on the `release-candidate` channel and daily builds on the `daily` channel
 - Stable builds must use only the default channel
 - Fresh install
 - Permission recovery
@@ -81,13 +81,13 @@
   - Reorder the selected languages and confirm hint-aware engines receive the ordered list
   - Confirm engines without language-hint support use the first selected language
 - Verify CLI and HTTP API locally
-- Upgrade from `1.4.0` with History, legacy prompts/profiles, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
+- Upgrade from `1.5.0` with History, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
 
-## Before `1.5.0`
+## Before `1.6.0`
 
-- Observe the latest `1.5.0-rc*` build on real machines for multiple days
+- Observe the latest `1.6.0-rc*` build on real machines for multiple days
 - No open P0/P1 bugs in the core workflow
 - Finalize release notes
 - RC and daily tags must not update Homebrew or trigger stable website messaging
 - Verify DMG, ZIP, and the `release-candidate` appcast entry with `minimumSystemVersion` set to `14.0`
-- Verify Homebrew and the stable appcast update only at the final `1.5.0`
+- Verify Homebrew and the stable appcast update only at the final `1.6.0`

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,8 +1,8 @@
 # TypeWhisper 1.x Release Readiness
 
-This document defines the release gates for the current `1.x` product path leading into the stable `1.5.0` release.
+This document defines the release gates for the current `1.x` product path leading into the stable `1.6.0` release.
 
-TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac App Store remains out of scope. For `1.5`, the focus is app-aware dictation insertion, expanded bundled providers, local-model memory reliability, dictionary-learning improvements, workflow and hotkey reliability, and stable plugin metadata for the current SDK line.
+TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac App Store remains out of scope. The `main` branch is the `1.6` development line. The `release/1.5` branch is reserved for `1.5.x` hotfixes, and new feature work belongs on `1.6` unless it is explicitly backported.
 
 ## Audience
 
@@ -31,15 +31,13 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Widgets
 - Watch Folder
 
-## `1.5` Focus Areas
+## `1.6` Focus Areas
 
-- App-aware smart insertion for plain text, rich text, terminal paste, sentence-boundary, and target-app contexts
-- Virtual audio input support, recorder-specific engine overrides, source progress for file transcription, and recorder failure surfacing
-- Expanded bundled speech and AI provider support across Gemini, Cartesia, Sber SaluteSpeech, OpenRouter, Reson8, Mistral AI, Soniox regions and TTS, and OpenAI-compatible profiles
-- Local MLX memory-footprint controls, idle local-model auto-unload behavior, Gemma 4 download recovery, and Parakeet vocabulary repair
-- Auto-learned dictionary corrections, target-app correction learning, per-term CTC tuning plumbing, and broader number normalization
-- Workflow, hotkey, indicator, and insertion reliability fixes across Hybrid modifiers, Pages workflows, Esc confirmation, fullscreen indicators, TaskForge, and FaceTime capture
-- Plugin host compatibility metadata, release-channel correctness, and stable GitHub Latest/Homebrew/Appcast behavior
+- Keep `main` on the `1.6.0` version line so daily builds publish as `v1.6.0-daily.*`.
+- Keep `1.5` stable and hotfix-only from `release/1.5`.
+- Preserve the `1.x` stability contracts for the HTTP API, CLI, plugin SDK, widgets, and watch folders.
+- Avoid raising plugin `minHostVersion` values to `1.6.0` unless a plugin genuinely requires new host APIs.
+- Keep release-channel behavior stable: RC and daily builds are prereleases, while Homebrew and stable website messaging update only at the final stable tag.
 
 ## Stability Contracts for `1.x`
 
@@ -70,7 +68,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 
 ## Release Gates
 
-`1.5.0` is only tagged once all of the following conditions are met:
+`1.6.0` is only tagged once all of the following conditions are met:
 
 - `xcodebuild test` for the app scheme passes.
 - `swift test --package-path TypeWhisperPluginSDK` passes.
@@ -78,9 +76,9 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - There are no first-party build warnings.
 - Plugin manifests validate successfully.
 - README, security guidance, support matrix, and plugin documentation are up to date.
-- The `1.5.0-rc*` line ran on real machines for multiple days without P0/P1 blockers before the stable tag.
+- The `1.6.0-rc*` line ran on real machines for multiple days without P0/P1 blockers before the stable tag.
 - The default channel remains `stable`; `release-candidate` and `daily` exist as Sparkle channels for preview builds.
-- `1.5.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
+- `1.6.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
 - The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.
 
 ## Manual Smoke Checks Before Tagging
@@ -110,7 +108,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Dictionary terms streamed through AssemblyAI, Soniox, and SpeechAnalyzer without session breakage
 - Very short speech clips and streaming-preview/no-speech guard behavior
 - Audio preview and recording after device changes, especially AirPods/Bluetooth profile switches; no crash during Bluetooth route changes
-- Upgrade from `1.4.0` with History, legacy prompts/profiles, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
+- Upgrade from `1.5.0` with History, Workflows, Dictionary, Snippets, hotkeys, enabled plugins, and update channel preserved
 
 ## Release Outputs
 


### PR DESCRIPTION
## Summary
- Bump the app, CLI, and widget `MARKETING_VERSION` values from `1.5.0` to `1.6.0`.
- Document `main` as the new 1.6 RC/development line while keeping `1.5` as the current stable line.
- Update release checklist/readiness docs and preview examples for `1.6.0-rc*` and `v1.6.0-daily.*`.

## Issue Context
No GitHub issue. This prepares the post-1.5 release line requested by Marco.

## Scope Notes
- No `v1.6.0-rc1` tag is created in this PR.
- No placeholder 1.6 release notes file is added.
- Plugin bundle versions, `minHostVersion` values, and SDK compatibility floors are intentionally unchanged.
- `.github/workflows/release.yml` is intentionally unchanged.

## Test Plan
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -showBuildSettings | rg 'MARKETING_VERSION|CURRENT_PROJECT_VERSION'`
- [x] `rg -n 'MARKETING_VERSION = 1\.5\.0|1\.5\.0-rc\*|v1\.5\.0-daily' TypeWhisper.xcodeproj/project.pbxproj README.md docs`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes and checklists for the 1.6 release cycle, including revised candidate, daily build, and stable-release guidance.

* **Chores**
  * Bumped the app version to 1.6.0 across all shipped components and aligned release-readiness references to the new release path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->