### PR TITLE
fix: remove incorrect fullscreen suppression for notch indicator

### DIFF
--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -155,11 +155,6 @@ class NotchIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
-        if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen, placement: .notchStrip) {
-            suppressForForeignFullscreen()
-            return
-        }
-
         notchGeometry.update(for: screen)
 
         let screenFrame = screen.frame
@@ -192,16 +187,6 @@ class NotchIndicatorPanel: NSPanel {
             }
             self.showTask = nil
         }
-    }
-
-    private func suppressForForeignFullscreen() {
-        cachedScreen = nil
-        showTask?.cancel()
-        showTask = nil
-        dismissTask?.cancel()
-        dismissTask = nil
-        notchGeometry.isPresented = false
-        orderOut(nil)
     }
 
     private func resolveScreen() -> NSScreen {


### PR DESCRIPTION
## Problem

The notch indicator can disappear while dictating in fullscreen apps because `NotchIndicatorPanel.show()` still applies the notch-strip fullscreen suppression policy before it lays out the panel.

## Scope

This retargets the change to `main` instead of `release/1.5`; it is not a 1.5 hotfix. Overlay and Minimal keep their existing fullscreen suppression behavior.

## Fix

Stop applying `IndicatorFullscreenSuppressionPolicy` inside `NotchIndicatorPanel.show()`. The shared suppression policy remains in place for the other indicator placement decisions, and the Notch panel continues to use its existing fullscreen auxiliary window behavior.

## Issue context

This is related to the remaining fullscreen feedback gap described in #602, but it does not re-open or replace the earlier top-strip fixes from #373/#543.

Refs #602

## Testing

```bash
git diff --check
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/26a1/typewhisper-mac
```