### PR TITLE
Fix Qwen3 downloaded model restore

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -44,7 +44,6 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     func activate(host: HostServices) {
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
-            ?? Self.availableModels.first?.id
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
 
         if shouldRestoreLoadedModelsPassively {
@@ -135,8 +134,25 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     var selectedModelId: String? { _selectedModelId }
 
     func selectModel(_ modelId: String) {
+        let previousLoadedModelId = loadedModelId
+        let shouldClearLoadedModel = previousLoadedModelId != nil && previousLoadedModelId != modelId
         _selectedModelId = modelId
         host?.setUserDefault(modelId, forKey: "selectedModel")
+
+        if shouldClearLoadedModel {
+            model = nil
+            loadedModelId = nil
+            modelState = .notLoaded
+            host?.setUserDefault(nil, forKey: "loadedModel")
+            Self.scheduleRuntimeCacheClearWhenInferenceIsIdle()
+            host?.notifyCapabilitiesChanged()
+        }
+
+        guard shouldRestoreDownloadedSelection(modelId, previousLoadedModelId: previousLoadedModelId) else {
+            return
+        }
+
+        Task { await restoreLoadedModel(allowDownloads: false, preferredModelId: modelId) }
     }
 
     var supportsTranslation: Bool { false }
@@ -232,7 +248,11 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     }
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
-    @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
+    @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: false) } }
+    @objc(triggerRestoreModelForModel:) func triggerRestoreModel(forModel modelId: NSString?) {
+        let preferredModelId = modelId.map(String.init)
+        Task { await restoreLoadedModel(allowDownloads: false, preferredModelId: preferredModelId) }
+    }
 
     func unloadModel(clearPersistence: Bool = true) {
         model = nil
@@ -256,13 +276,68 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         }
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true) async {
-        guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
-              let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
-            return
+    func restoreLoadedModel(allowDownloads: Bool = false) async {
+        await restoreLoadedModel(allowDownloads: allowDownloads, preferredModelId: nil)
+    }
+
+    func restoreLoadedModel(allowDownloads: Bool = false, preferredModelId: String?) async {
+        for modelId in restoreCandidateModelIds(
+            preferredModelId: preferredModelId,
+            allowDownloads: allowDownloads
+        ) {
+            guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else {
+                continue
+            }
+            do {
+                try await loadModel(modelDef)
+                return
+            } catch {
+                continue
+            }
         }
-        guard allowDownloads || hasDownloadedModel(modelDef) else { return }
-        try? await loadModel(modelDef)
+    }
+
+    func restoreCandidateModelIds(
+        preferredModelId: String? = nil,
+        allowDownloads: Bool = false
+    ) -> [String] {
+        var candidateIds: [String] = []
+
+        func appendCandidate(_ modelId: String?) {
+            guard let modelId, !modelId.isEmpty else { return }
+            guard Self.availableModels.contains(where: { $0.id == modelId }) else { return }
+            guard !candidateIds.contains(modelId) else { return }
+            candidateIds.append(modelId)
+        }
+
+        appendCandidate(preferredModelId)
+        appendCandidate(host?.userDefault(forKey: "loadedModel") as? String)
+        appendCandidate(_selectedModelId)
+
+        let downloadedIds = downloadedModels.map(\.id)
+        if downloadedIds.count == 1 {
+            appendCandidate(downloadedIds[0])
+        }
+
+        guard !allowDownloads else { return candidateIds }
+
+        return candidateIds.filter { modelId in
+            guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else {
+                return false
+            }
+            return hasDownloadedModel(modelDef)
+        }
+    }
+
+    func shouldRestoreDownloadedSelection(
+        _ modelId: String,
+        previousLoadedModelId: String?
+    ) -> Bool {
+        guard previousLoadedModelId != modelId else { return false }
+        guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else {
+            return false
+        }
+        return hasDownloadedModel(modelDef)
     }
 
     private func hasDownloadedModel(_ modelDef: Qwen3ModelDef) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -153,20 +153,87 @@ final class Qwen3PluginTests: XCTestCase {
         )
     }
 
+    func testRestoreCandidatesUseDownloadedSelectedModelWithoutLoadedModel() throws {
+        let model = try XCTUnwrap(Qwen3Plugin.availableModels.first { $0.id == "qwen3-asr-1.7b-8bit" })
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": model.id],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        let plugin = Qwen3Plugin()
+
+        plugin.activate(host: host)
+        try makeDownloadedModelDirectory(model, host: host)
+
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(plugin.selectedModelId, model.id)
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+        XCTAssertEqual(plugin.restoreCandidateModelIds(allowDownloads: false), [model.id])
+    }
+
+    func testDownloadedModelSelectionIsRestoreableWithoutDownloadingFallbacks() throws {
+        let model = try XCTUnwrap(Qwen3Plugin.availableModels.first { $0.id == "qwen3-asr-1.7b-8bit" })
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = Qwen3Plugin()
+
+        plugin.activate(host: host)
+        try makeDownloadedModelDirectory(model, host: host)
+
+        XCTAssertTrue(plugin.shouldRestoreDownloadedSelection(model.id, previousLoadedModelId: nil))
+        XCTAssertFalse(plugin.shouldRestoreDownloadedSelection(model.id, previousLoadedModelId: model.id))
+        XCTAssertEqual(plugin.restoreCandidateModelIds(preferredModelId: model.id, allowDownloads: false), [model.id])
+    }
+
+    func testRestoreCandidatesFallBackToSoleDownloadedModelWithoutSelection() throws {
+        let model = try XCTUnwrap(Qwen3Plugin.availableModels.first { $0.id == "qwen3-asr-1.7b-8bit" })
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = Qwen3Plugin()
+
+        plugin.activate(host: host)
+        try makeDownloadedModelDirectory(model, host: host)
+
+        XCTAssertNil(plugin.selectedModelId)
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+        XCTAssertEqual(plugin.restoreCandidateModelIds(allowDownloads: false), [model.id])
+    }
+
+    func testUndownloadedModelSelectionDoesNotRestoreOrDownload() throws {
+        let model = try XCTUnwrap(Qwen3Plugin.availableModels.first { $0.id == "qwen3-asr-1.7b-8bit" })
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = Qwen3Plugin()
+
+        plugin.activate(host: host)
+        plugin.selectModel(model.id)
+
+        XCTAssertEqual(plugin.selectedModelId, model.id)
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, model.id)
+        XCTAssertFalse(plugin.shouldRestoreDownloadedSelection(model.id, previousLoadedModelId: nil))
+        XCTAssertTrue(plugin.restoreCandidateModelIds(preferredModelId: model.id, allowDownloads: false).isEmpty)
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+    }
+
+    func testRestoreCandidatesDoNotDefaultToUndownloadedModel() throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = Qwen3Plugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertNil(plugin.selectedModelId)
+        XCTAssertTrue(plugin.downloadedModels.isEmpty)
+        XCTAssertTrue(plugin.restoreCandidateModelIds(allowDownloads: false).isEmpty)
+    }
+
     func testDeleteDownloadedModelRemovesCacheAndClearsSelection() async throws {
         let model = try XCTUnwrap(Qwen3Plugin.availableModels.first)
-        let host = try PluginTestHostServices(defaults: ["selectedModel": model.id])
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": model.id],
+            shouldRestoreLoadedModelsPassively: false
+        )
         let plugin = Qwen3Plugin()
 
         plugin.activate(host: host)
         host.setUserDefault(model.id, forKey: "loadedModel")
 
-        let modelDirectory = host.pluginDataDirectory
-            .appendingPathComponent("models", isDirectory: true)
-            .appendingPathComponent("mlx-audio", isDirectory: true)
-            .appendingPathComponent(model.repoId.replacingOccurrences(of: "/", with: "_"), isDirectory: true)
-        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
-        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+        let modelDirectory = try makeDownloadedModelDirectory(model, host: host)
 
         XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
 
@@ -176,5 +243,19 @@ final class Qwen3PluginTests: XCTestCase {
         XCTAssertNil(plugin.selectedModelId)
         XCTAssertNil(host.userDefault(forKey: "selectedModel"))
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+    }
+
+    @discardableResult
+    private func makeDownloadedModelDirectory(
+        _ model: Qwen3ModelDef,
+        host: PluginTestHostServices
+    ) throws -> URL {
+        let modelDirectory = host.pluginDataDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("mlx-audio", isDirectory: true)
+            .appendingPathComponent(model.repoId.replacingOccurrences(of: "/", with: "_"), isDirectory: true)
+        try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+        return modelDirectory
     }
 }


### PR DESCRIPTION
## Summary
- Fixes Qwen3 as a plugin-only change; this PR does not modify the app or the SDK contract.
- Restores an existing downloaded Qwen3 model from persisted `loadedModel`, a selected downloaded model, or the only downloaded model.
- When the host selects a downloaded Qwen3 model override, Qwen3 now starts a passive restore for that downloaded model so existing File Transcription / Watch Folder host code can wait for the plugin to become configured.
- Keeps Qwen3 from auto-downloading an arbitrary default model when no downloaded model is available.
- Does not add arbitrary `.gguf` import support; Qwen3 still uses the MLX/HuggingFace cache layout.

## Issue Context
Issue #826 reports that Qwen3 can show a local model selection while File Transcription and Watch Folder fail with `No model loaded`. The existing app path already selects the requested model and waits for the engine to become configured; the missing piece was in Qwen3 itself: it did not restore selected/downloaded models unless `loadedModel` was already persisted. This PR fixes that inside the plugin so it can ship as a plugin update.

Closes #826

## Test Plan
- [x] `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run Qwen3Plugin --enable-plugin com.typewhisper.qwen3 /Users/marco/.codex/worktrees/defb/typewhisper-mac`
- [x] Verified the dev app is running with the signed Qwen3 plugin installed and `/v1/models` exposes Qwen3 catalog entries.
- [ ] Manual File Transcription / Watch Folder Qwen3 transcription smoke with a downloaded ASR model. The local dev environment currently has Qwen3 enabled but no `Qwen3-ASR-*` download, so this PR stays draft until that smoke can be run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for restoring a specific previously selected model.
* **Bug Fixes**
  * Prevented automatic fallback to the first available model when no saved selection exists.
  * Improved model restore to resume the last loaded downloaded model without triggering new downloads.
  * Enhanced restore logic to clear stale in-memory state when switching models and to try alternate candidates after failures.
* **Tests**
  * Expanded coverage to validate restore behavior using filesystem-backed downloaded models and updated restore-candidate scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->