### PR TITLE
Fix WhisperKit restore wait for long model loads

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -95,6 +95,18 @@ final class ModelManagerService: ObservableObject {
         }
     }
 
+    private enum PluginRestoreResult {
+        case unavailable
+        case configured
+        case failed(String)
+    }
+
+    private enum PluginRestoreWaitResult {
+        case configured
+        case failed(String)
+        case timedOut(activity: PluginSettingsActivity?)
+    }
+
     @Published private(set) var selectedProviderId: String?
 
     @Published var autoUnloadSeconds: Int {
@@ -109,6 +121,9 @@ final class ModelManagerService: ObservableObject {
     private var autoUnloadTargets: [ObjectIdentifier: AutoUnloadTarget] = [:]
     private var autoUnloadDiagnostics: [ObjectIdentifier: ModelAutoUnloadDiagnosticsSnapshot.Entry] = [:]
     private var cancellables = Set<AnyCancellable>()
+    private var pluginConfiguredWaitAttempts = 300
+    private var pluginRestoreBusyWaitAttempts = 5_700
+    private var pluginConfiguredPollInterval: Duration = .milliseconds(100)
 
     private let providerKey = UserDefaultsKeys.selectedEngine
     private let modelKey = UserDefaultsKeys.selectedModelId
@@ -117,6 +132,18 @@ final class ModelManagerService: ObservableObject {
         self.autoUnloadSeconds = ModelAutoUnloadPolicy.effectiveSeconds()
         self.selectedProviderId = UserDefaults.standard.string(forKey: providerKey)
     }
+
+    #if DEBUG
+    func setPluginRestoreWaitConfigurationForTesting(
+        initialAttempts: Int,
+        busyAttempts: Int,
+        pollInterval: Duration
+    ) {
+        pluginConfiguredWaitAttempts = max(0, initialAttempts)
+        pluginRestoreBusyWaitAttempts = max(0, busyAttempts)
+        pluginConfiguredPollInterval = pollInterval
+    }
+    #endif
 
     // MARK: - Public API
 
@@ -1302,7 +1329,10 @@ final class ModelManagerService: ObservableObject {
                 throw modelNotLoadedError(for: plugin)
             }
         } else if !plugin.isConfigured {
-            await triggerRestoreModel(plugin)
+            let restoreResult = await triggerRestoreModel(plugin)
+            if case .failed(let message) = restoreResult {
+                throw TranscriptionEngineError.modelLoadFailed(message)
+            }
         }
 
         return overrideRestoreId
@@ -1356,11 +1386,23 @@ final class ModelManagerService: ObservableObject {
 
     /// Trigger model restore via ObjC dispatch (avoids Swift protocol witness table issues
     /// with dynamically loaded plugin bundles) and poll until ready.
-    private func triggerRestoreModel(_ plugin: TranscriptionEnginePlugin) async {
+    private func triggerRestoreModel(_ plugin: TranscriptionEnginePlugin) async -> PluginRestoreResult {
+        let restoreSelector = NSSelectorFromString("triggerRestoreModel")
         guard let nsPlugin = plugin as? NSObject,
-              nsPlugin.responds(to: NSSelectorFromString("triggerRestoreModel")) else { return }
-        _ = nsPlugin.perform(NSSelectorFromString("triggerRestoreModel"))
-        _ = await waitForPluginConfigured(plugin)
+              nsPlugin.responds(to: restoreSelector) else {
+            return .unavailable
+        }
+        _ = nsPlugin.perform(restoreSelector)
+
+        switch await waitForPluginRestoreConfigured(plugin) {
+        case .configured:
+            return .configured
+        case .failed(let message):
+            return .failed(message)
+        case .timedOut(let activity):
+            guard let activity else { return .unavailable }
+            return .failed(Self.restoreTimeoutMessage(activity: activity))
+        }
     }
 
     private func waitForPluginConfigured(
@@ -1368,14 +1410,82 @@ final class ModelManagerService: ObservableObject {
         selectedModelId: String? = nil,
         stopOnMismatchedSelection: Bool = false
     ) async -> Bool {
-        for _ in 0..<300 {
-            try? await Task.sleep(for: .milliseconds(100))
-            guard plugin.isConfigured else { continue }
-            guard let selectedModelId else { return true }
-            let currentModelId = plugin.selectedModelId
-            if currentModelId == selectedModelId { return true }
-            if stopOnMismatchedSelection, currentModelId != nil { return false }
+        for _ in 0..<pluginConfiguredWaitAttempts {
+            if let configured = pluginConfiguredState(
+                plugin,
+                selectedModelId: selectedModelId,
+                stopOnMismatchedSelection: stopOnMismatchedSelection
+            ) {
+                return configured
+            }
+            try? await Task.sleep(for: pluginConfiguredPollInterval)
         }
-        return false
+
+        return pluginConfiguredState(
+            plugin,
+            selectedModelId: selectedModelId,
+            stopOnMismatchedSelection: stopOnMismatchedSelection
+        ) ?? false
+    }
+
+    private func waitForPluginRestoreConfigured(_ plugin: TranscriptionEnginePlugin) async -> PluginRestoreWaitResult {
+        var latestActivity: PluginSettingsActivity?
+
+        for _ in 0..<pluginConfiguredWaitAttempts {
+            if plugin.isConfigured { return .configured }
+            if let activity = pluginSettingsActivity(plugin) {
+                latestActivity = activity
+                if activity.isError {
+                    return .failed(activity.message)
+                }
+            }
+            try? await Task.sleep(for: pluginConfiguredPollInterval)
+        }
+
+        if plugin.isConfigured { return .configured }
+
+        guard latestActivity != nil else {
+            return .timedOut(activity: nil)
+        }
+
+        for _ in 0..<pluginRestoreBusyWaitAttempts {
+            if plugin.isConfigured { return .configured }
+            guard let activity = pluginSettingsActivity(plugin) else {
+                return .timedOut(activity: latestActivity)
+            }
+            latestActivity = activity
+            if activity.isError {
+                return .failed(activity.message)
+            }
+            try? await Task.sleep(for: pluginConfiguredPollInterval)
+        }
+
+        if plugin.isConfigured { return .configured }
+        return .timedOut(activity: latestActivity)
+    }
+
+    private func pluginConfiguredState(
+        _ plugin: TranscriptionEnginePlugin,
+        selectedModelId: String?,
+        stopOnMismatchedSelection: Bool
+    ) -> Bool? {
+        guard plugin.isConfigured else { return nil }
+        guard let selectedModelId else { return true }
+        let currentModelId = plugin.selectedModelId
+        if currentModelId == selectedModelId { return true }
+        if stopOnMismatchedSelection, currentModelId != nil { return false }
+        return nil
+    }
+
+    private func pluginSettingsActivity(_ plugin: TranscriptionEnginePlugin) -> PluginSettingsActivity? {
+        (plugin as? any PluginSettingsActivityReporting)?.currentSettingsActivity
+    }
+
+    private static func restoreTimeoutMessage(activity: PluginSettingsActivity) -> String {
+        let message = activity.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else {
+            return "Timed out while restoring the selected model."
+        }
+        return "Timed out while restoring the selected model: \(message)."
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -17,6 +17,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     fileprivate var host: HostServices?
     fileprivate var whisperKit: WhisperKit?
     fileprivate var loadedModelId: String?
+    fileprivate var loadingModelId: String?
     fileprivate var _selectedModelId: String?
     fileprivate var _hfToken: String?
     fileprivate var modelState: WhisperModelState = .notLoaded
@@ -52,6 +53,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         releaseWhisperKitResources()
         whisperKit = nil
         loadedModelId = nil
+        loadingModelId = nil
         modelState = .notLoaded
         downloadProgress = 0
         _hfToken = nil
@@ -93,6 +95,15 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         generation == modelLoadGeneration
     }
 
+    private func isModelLoadInProgress(for modelId: String) -> Bool {
+        loadingModelId == modelId
+    }
+
+    private func clearLoadingModelIfCurrent(_ modelId: String, generation: Int) {
+        guard isCurrentModelLoad(generation), loadingModelId == modelId else { return }
+        loadingModelId = nil
+    }
+
     private func startModelLoadTimeout(generation: Int, modelName: String) {
         let timeout = modelLoadTimeoutDuration
         Task { [weak self] in
@@ -109,6 +120,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
                 self.releaseWhisperKitResources()
                 self.whisperKit = nil
                 self.loadedModelId = nil
+                self.loadingModelId = nil
                 self.downloadProgress = 0
                 self.modelState = .error(
                     "Model load is taking too long while macOS compiles \(modelName) for the Neural Engine. Try again, or remove and re-download the model."
@@ -469,6 +481,10 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     fileprivate func loadModel(_ modelDef: WhisperModelDef) async {
+        guard !(isConfigured && loadedModelId == modelDef.id) else { return }
+        guard !isModelLoadInProgress(for: modelDef.id) else { return }
+
+        loadingModelId = modelDef.id
         let loadGeneration = beginModelLoad()
         do {
             // Migrate old models if they exist
@@ -557,6 +573,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
             whisperKit = kit
             loadedModelId = modelDef.id
+            loadingModelId = nil
             _selectedModelId = modelDef.id
             downloadProgress = 1.0
             modelState = .ready(modelDef.id)
@@ -569,6 +586,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             releaseWhisperKitResources()
             whisperKit = nil
             loadedModelId = nil
+            clearLoadingModelIfCurrent(modelDef.id, generation: loadGeneration)
             modelState = .error(error.localizedDescription)
             downloadProgress = 0
             host?.setUserDefault(nil, forKey: "loadedModel")
@@ -584,6 +602,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         releaseWhisperKitResources()
         whisperKit = nil
         loadedModelId = nil
+        loadingModelId = nil
         modelState = .notLoaded
         downloadProgress = 0
         if clearPersistence {
@@ -593,9 +612,26 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     #if DEBUG
+    var modelLoadGenerationForTesting: Int {
+        modelLoadGeneration
+    }
+
+    var loadingModelIdForTesting: String? {
+        loadingModelId
+    }
+
     func setModelStateForTesting(_ state: WhisperModelState, loadedModelId: String? = nil) {
         self.loadedModelId = loadedModelId
         modelState = state
+    }
+
+    func setLoadingModelForTesting(_ modelId: String, phase: String = "compiling") {
+        whisperKit = nil
+        loadedModelId = nil
+        loadingModelId = modelId
+        _selectedModelId = modelId
+        downloadProgress = 0.80
+        modelState = .loading(phase: phase)
     }
 
     func setModelLoadTimeoutForTesting(_ timeout: Duration) {
@@ -604,6 +640,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
     func startModelLoadTimeoutForTesting(modelName: String) {
         let generation = beginModelLoad()
+        loadingModelId = selectedModelId
         modelState = .loading(phase: "compiling")
         startModelLoadTimeout(generation: generation, modelName: modelName)
     }

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -528,6 +528,77 @@ final class APIRouterAndHandlersTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterRestoringTranscriptionPlugin)
+    private final class RestoringTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.restoring-transcription" }
+        static var pluginName: String { "Restoring Mock Transcription" }
+
+        private let stateLock = NSLock()
+        private var _configured = false
+        private var _currentModelId: String?
+        private var _currentSettingsActivity: PluginSettingsActivity?
+        private var _restoreCount = 0
+
+        var restoreDelay: Duration = .milliseconds(0)
+        var restoreShouldConfigure = true
+
+        var configured: Bool {
+            get { stateLock.withLock { _configured } }
+            set { stateLock.withLock { _configured = newValue } }
+        }
+
+        var currentModelId: String? {
+            get { stateLock.withLock { _currentModelId } }
+            set { stateLock.withLock { _currentModelId = newValue } }
+        }
+
+        var activity: PluginSettingsActivity? {
+            get { stateLock.withLock { _currentSettingsActivity } }
+            set { stateLock.withLock { _currentSettingsActivity = newValue } }
+        }
+
+        var restoreCount: Int {
+            stateLock.withLock { _restoreCount }
+        }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "restoring-mock" }
+        var providerDisplayName: String { "Restoring Mock" }
+        var isConfigured: Bool { configured }
+        var transcriptionModels: [PluginModelInfo] { [PluginModelInfo(id: "tiny", displayName: "Tiny")] }
+        var selectedModelId: String? { currentModelId }
+        var currentSettingsActivity: PluginSettingsActivity? { activity }
+        func selectModel(_ modelId: String) {
+            currentModelId = modelId
+        }
+        var supportsTranslation: Bool { false }
+
+        @objc func triggerRestoreModel() {
+            let delay = restoreDelay
+            let shouldConfigure = restoreShouldConfigure
+            stateLock.withLock {
+                _restoreCount += 1
+            }
+
+            Task { [weak self] in
+                try? await Task.sleep(for: delay)
+                guard let self, shouldConfigure else { return }
+                self.stateLock.withLock {
+                    self._configured = true
+                    self._currentSettingsActivity = nil
+                }
+            }
+        }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
     @objc(APIRouterCatalogTranscriptionPlugin)
     private final class CatalogTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.catalog-transcription" }
@@ -6862,6 +6933,136 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
 
         XCTAssertEqual(plugin.selectedModelId, "alpha", "cloudModelOverride must not persist the plugin's default model")
+    }
+
+    @MainActor
+    func testModelManagerWaitsForBusyTranscriptionRestorePastInitialTimeout() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = RestoringTranscriptionPlugin()
+        plugin.currentModelId = "tiny"
+        plugin.configured = false
+        plugin.activity = PluginSettingsActivity(message: "Optimizing model")
+        plugin.restoreDelay = .milliseconds(60)
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.restoring-transcription",
+                    name: "Restoring Mock Transcription",
+                    version: "1.0.0",
+                    principalClass: "APIRouterRestoringTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.setPluginRestoreWaitConfigurationForTesting(
+            initialAttempts: 1,
+            busyAttempts: 20,
+            pollInterval: .milliseconds(10)
+        )
+        modelManager.selectProvider(plugin.providerId)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            language: nil,
+            task: .transcribe,
+            engineOverrideId: nil,
+            cloudModelOverride: nil,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "transcribed")
+        XCTAssertEqual(plugin.restoreCount, 1)
+    }
+
+    @MainActor
+    func testModelManagerReportsBusyRestoreTimeoutInsteadOfGenericNoModelLoaded() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = RestoringTranscriptionPlugin()
+        plugin.currentModelId = "tiny"
+        plugin.configured = false
+        plugin.activity = PluginSettingsActivity(message: "Optimizing model")
+        plugin.restoreShouldConfigure = false
+
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.restoring-transcription",
+                    name: "Restoring Mock Transcription",
+                    version: "1.0.0",
+                    principalClass: "APIRouterRestoringTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.setPluginRestoreWaitConfigurationForTesting(
+            initialAttempts: 1,
+            busyAttempts: 2,
+            pollInterval: .milliseconds(10)
+        )
+        modelManager.selectProvider(plugin.providerId)
+
+        do {
+            _ = try await modelManager.transcribe(
+                audioSamples: [Float](repeating: 0, count: 16_000),
+                language: nil,
+                task: .transcribe,
+                engineOverrideId: nil,
+                cloudModelOverride: nil,
+                prompt: nil
+            )
+            XCTFail("Expected restore timeout")
+        } catch let error as TranscriptionEngineError {
+            guard case .modelLoadFailed(let detail) = error else {
+                return XCTFail("Expected modelLoadFailed, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("Optimizing model"), "Expected activity in detail, got \(detail)")
+            XCTAssertFalse(error.localizedDescription.contains("No model loaded"))
+        }
+
+        XCTAssertEqual(plugin.restoreCount, 1)
     }
 
     @MainActor

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -144,6 +144,33 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         #endif
     }
 
+    func testRestoreWhileSameModelLoadingDoesNotStartAnotherLoad() async throws {
+        let modelId = "openai_whisper-large-v3_turbo"
+        let host = try makeHost(
+            defaults: [
+                "selectedModel": modelId,
+                "loadedModel": modelId,
+            ],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        plugin.setLoadingModelForTesting(modelId)
+
+        let generation = plugin.modelLoadGenerationForTesting
+
+        await plugin.restoreLoadedModel(allowDownloads: true)
+
+        XCTAssertEqual(plugin.modelLoadGenerationForTesting, generation)
+        XCTAssertEqual(plugin.loadingModelIdForTesting, modelId)
+        XCTAssertEqual(plugin.currentSettingsActivity?.message, "Optimizing model")
+        #if DEBUG
+        XCTAssertEqual(plugin.restoreLoadedModelInvocationCountForTesting, 1)
+        #endif
+    }
+
     func testUnloadWithoutClearingPersistenceKeepsLoadedModelMarker() throws {
         let host = try makeHost(defaults: [
             "selectedModel": "openai_whisper-tiny",
@@ -279,6 +306,7 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(plugin.currentSettingsActivity?.isError, true)
         XCTAssertEqual(host.capabilitiesChangedCount, 1)
         XCTAssertTrue(plugin.currentSettingsActivity?.message.contains("Large v3 Turbo") == true)
+        XCTAssertNil(plugin.loadingModelIdForTesting)
     }
 
     func testActivationDoesNotMarkPluginConfiguredBeforeRestoreSucceeds() async throws {


### PR DESCRIPTION
## Summary

This fixes the remaining WhisperKit restore path behind #829 after releasing WhisperKitPlugin 1.1.0.

- Extend the host-side explicit `triggerRestoreModel` wait while a plugin reports active settings work such as loading or optimizing a model.
- Return activity-aware restore failures/timeouts instead of falling through to the generic "No model loaded" error.
- Make WhisperKit's same-model restore idempotent while that model is already loading, so repeated restores do not restart or cancel the in-flight load.
- Bump the WhisperKitPlugin manifest to 1.1.1 for the follow-up plugin release.

## Issue Context

Issue #829 reports TypeWhisper 1.5.0 with WhisperKit getting stuck on long model restore/optimization and then ending with "No model loaded" even though the selected and stored loaded model IDs still point to `openai_whisper-large-v3_turbo`.

The first follow-up was to release the already-prepared WhisperKitPlugin 1.1.0. The reporter confirmed that update installed, but the issue persisted. The fresh diagnostics showed the host still considered the plugin unconfigured while the plugin was actively loading or optimizing the selected model. The host restore wait was too short for this long Core ML restore path, and repeated restores could overlap the same selected model load.

Closes #829

## Test Plan

```bash
git diff --check
```

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testModelManagerWaitsForBusyTranscriptionRestorePastInitialTimeout -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testModelManagerReportsBusyRestoreTimeoutInsteadOfGenericNoModelLoaded -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests/testRestoreWhileSameModelLoadingDoesNotStartAnotherLoad
```

```bash
swift test --package-path TypeWhisperPluginSDK
```

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests
```

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/4617/typewhisper-mac
```

Also attempted the full app test suite:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

That run was interrupted because `TypeWhisperTests/AudioRecorderViewModelTests/testDefaultEngineModelOverrideClearsWhenGlobalProviderChanges` hung. The same test also hangs when run alone and does not exercise this WhisperKit restore path.