### PR TITLE
Add iOS platform fields to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,18 @@ name: Bug Report
 description: Report a bug or unexpected behavior
 labels: ["bug"]
 body:
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which TypeWhisper app or surface is affected?
+      options:
+        - macOS
+        - iOS
+        - iOS Keyboard
+        - Cloud Provider
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
@@ -31,10 +43,8 @@ body:
   - type: input
     id: macos-version
     attributes:
-      label: macOS Version
-      placeholder: "e.g. macOS 15.3 Sequoia"
-    validations:
-      required: true
+      label: OS Version
+      placeholder: "e.g. macOS 15.3 Sequoia or iOS 27.0"
   - type: input
     id: app-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,7 +41,7 @@ body:
     validations:
       required: true
   - type: input
-    id: macos-version
+    id: os-version
     attributes:
       label: OS Version
       placeholder: "e.g. macOS 15.3 Sequoia or iOS 27.0"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,18 @@ name: Feature Request
 description: Suggest a new feature or improvement
 labels: ["enhancement"]
 body:
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which TypeWhisper app or surface should this apply to?
+      options:
+        - macOS
+        - iOS
+        - iOS Keyboard
+        - Cloud Provider
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Summary
- add platform selectors to bug and feature issue forms
- allow iOS, iOS Keyboard, and Cloud Provider reports in the public TypeWhisper issue tracker
- make the OS version field platform-neutral

## Verification
- Parsed updated issue form YAML locally with Ruby
- Confirmed transferred iOS issues are now in the public macOS repo with iOS labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated bug report and feature request issue templates to capture a required **Platform** selection (macOS, iOS, iOS Keyboard, Cloud Provider).
  * Renamed the bug report field from **“macOS Version”** to **“OS Version”** for broader clarity.
  * Adjusted the bug report’s **OS Version** requirement so it’s no longer enforced as required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->