### PR TITLE
feat: persist aggregate usage statistics

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -105,6 +105,10 @@
 			533C00000000000000000002 /* DictationRecoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C00000000000000000001 /* DictationRecoveryViewModel.swift */; };
 			533C00000000000000000004 /* DictationRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C00000000000000000003 /* DictationRecoveryView.swift */; };
 			6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */; };
+		AA8390000000000000000001 /* UsageStatisticsDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8390000000000000000001 /* UsageStatisticsDay.swift */; };
+		AA8390000000000000000002 /* UsageStatisticsMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8390000000000000000002 /* UsageStatisticsMetadata.swift */; };
+		AA8390000000000000000003 /* UsageStatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8390000000000000000003 /* UsageStatisticsService.swift */; };
+		AA8390000000000000000004 /* UsageStatisticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8390000000000000000004 /* UsageStatisticsServiceTests.swift */; };
 		A91F00000000000000000001 /* SelectionPalettePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000001 /* SelectionPalettePanel.swift */; };
 		A91F00000000000000000002 /* RecentTranscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000002 /* RecentTranscriptionStore.swift */; };
 		A91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */; };
@@ -544,6 +548,7 @@
 			5A6490000000000000000001 /* ModelManagerAppleSpeechModelSelectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelManagerAppleSpeechModelSelectionTests.swift; sourceTree = "<group>"; };
 			5A6500000000000000000001 /* ModelManagerLiveSessionModelOverrideTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelManagerLiveSessionModelOverrideTests.swift; sourceTree = "<group>"; };
 			3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryServiceTests.swift; sourceTree = "<group>"; };
+		BB8390000000000000000004 /* UsageStatisticsServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsageStatisticsServiceTests.swift; sourceTree = "<group>"; };
 		B91F00000000000000000001 /* SelectionPalettePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPalettePanel.swift; sourceTree = "<group>"; };
 		B91F00000000000000000002 /* RecentTranscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionStore.swift; sourceTree = "<group>"; };
 		B91F00000000000000000003 /* RecentTranscriptionPaletteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTranscriptionPaletteHandler.swift; sourceTree = "<group>"; };
@@ -609,7 +614,10 @@
 		B40800000000000000000001 /* LanguageSelectionEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSelectionEditor.swift; sourceTree = "<group>"; };
 		BB00000000000000000052 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000060 /* TranscriptionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecord.swift; sourceTree = "<group>"; };
+		BB8390000000000000000001 /* UsageStatisticsDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatisticsDay.swift; sourceTree = "<group>"; };
+		BB8390000000000000000002 /* UsageStatisticsMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatisticsMetadata.swift; sourceTree = "<group>"; };
 		BB00000000000000000061 /* HistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryService.swift; sourceTree = "<group>"; };
+		BB8390000000000000000003 /* UsageStatisticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatisticsService.swift; sourceTree = "<group>"; };
 		BB00000000000000000062 /* TextDiffService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDiffService.swift; sourceTree = "<group>"; };
 		BB7080000000000000000001 /* TargetAppCorrectionLearningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetAppCorrectionLearningService.swift; sourceTree = "<group>"; };
 		BB00000000000000000063 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
@@ -1458,6 +1466,8 @@
 				BB00000000000000000331 /* PunctuationRules.swift */,
 				BB00000000000000000332 /* DictationRuntimeContext.swift */,
 				BB00000000000000000060 /* TranscriptionRecord.swift */,
+				BB8390000000000000000001 /* UsageStatisticsDay.swift */,
+				BB8390000000000000000002 /* UsageStatisticsMetadata.swift */,
 				BB00000000000000000065 /* Profile.swift */,
 				BB00000000000000000356 /* Workflow.swift */,
 				BB00000000000000000077 /* DictionaryEntry.swift */,
@@ -1490,6 +1500,7 @@
 				BB00000000000000000050 /* SubtitleExporter.swift */,
 				BB00000000000000000148 /* HistoryExporter.swift */,
 				BB00000000000000000061 /* HistoryService.swift */,
+				BB8390000000000000000003 /* UsageStatisticsService.swift */,
 				B91F00000000000000000002 /* RecentTranscriptionStore.swift */,
 				BB00000000000000000062 /* TextDiffService.swift */,
 				BB7080000000000000000001 /* TargetAppCorrectionLearningService.swift */,
@@ -2277,6 +2288,7 @@
 				A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */,
 				8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */,
 				3F476E4F05313F6BF4E696A5 /* HistoryServiceTests.swift */,
+				BB8390000000000000000004 /* UsageStatisticsServiceTests.swift */,
 				B91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift */,
 				B91F00000000000000000004 /* RecentTranscriptionStoreTests.swift */,
 				C50700000000000000000002 /* MemoryServiceTests.swift */,
@@ -3789,6 +3801,7 @@
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
 				6A9D1EE0C163693B1A798779 /* HistoryServiceTests.swift in Sources */,
+				AA8390000000000000000004 /* UsageStatisticsServiceTests.swift in Sources */,
 				A91F00000000000000000005 /* RecentTranscriptionPaletteHandlerTests.swift in Sources */,
 				A91F00000000000000000004 /* RecentTranscriptionStoreTests.swift in Sources */,
 				A1F000000000000000000102 /* PostUpdatePromptCoordinatorTests.swift in Sources */,
@@ -3901,8 +3914,11 @@
 				AA00000000000000000051 /* GeneralSettingsView.swift in Sources */,
 				A40800000000000000000001 /* LanguageSelectionEditor.swift in Sources */,
 				AA00000000000000000060 /* TranscriptionRecord.swift in Sources */,
+				AA8390000000000000000001 /* UsageStatisticsDay.swift in Sources */,
+				AA8390000000000000000002 /* UsageStatisticsMetadata.swift in Sources */,
 				AA00000000000000000332 /* DictationRuntimeContext.swift in Sources */,
 				AA00000000000000000061 /* HistoryService.swift in Sources */,
+				AA8390000000000000000003 /* UsageStatisticsService.swift in Sources */,
 				AA00000000000000000062 /* TextDiffService.swift in Sources */,
 				AA7080000000000000000001 /* TargetAppCorrectionLearningService.swift in Sources */,
 				AA00000000000000000063 /* HistoryViewModel.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -12,6 +12,7 @@ final class ServiceContainer: ObservableObject {
     let hotkeyService: HotkeyService
     let textInsertionService: TextInsertionService
     let historyService: HistoryService
+    let usageStatisticsService: UsageStatisticsService
     let recentTranscriptionStore: RecentTranscriptionStore
     let textDiffService: TextDiffService
     let profileService: ProfileService
@@ -75,6 +76,7 @@ final class ServiceContainer: ObservableObject {
         hotkeyService = HotkeyService()
         textInsertionService = TextInsertionService()
         historyService = HistoryService()
+        usageStatisticsService = UsageStatisticsService()
         recentTranscriptionStore = RecentTranscriptionStore()
         textDiffService = TextDiffService()
         profileService = ProfileService()
@@ -110,7 +112,10 @@ final class ServiceContainer: ObservableObject {
         pluginManager = PluginManager()
         pluginRegistryService = PluginRegistryService()
         termPackRegistryService = TermPackRegistryService()
-        widgetDataService = WidgetDataService(historyService: historyService)
+        widgetDataService = WidgetDataService(
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService
+        )
         memoryService = MemoryService(promptProcessingService: promptProcessingService)
         appFormatterService = AppFormatterService()
         dictationPunctuationProfileStore = DictationPunctuationProfileStore()
@@ -141,6 +146,7 @@ final class ServiceContainer: ObservableObject {
             modelManager: modelManagerService,
             historyService: historyService,
             audioFileService: audioFileService,
+            usageStatisticsRecorder: usageStatisticsService,
             licenseService: licenseService
         )
         dictationRecoveryViewModel = recoveryViewModel
@@ -172,6 +178,7 @@ final class ServiceContainer: ObservableObject {
             accessibilityAnnouncementService: accessibilityAnnouncementService,
             errorLogService: errorLogService,
             mediaPlaybackService: mediaPlaybackService,
+            usageStatisticsRecorder: usageStatisticsService,
             recoveryFallbackConfigurationProvider: { [recoveryViewModel] primaryEngineId, task in
                 recoveryViewModel.automaticFallbackConfiguration(
                     excluding: primaryEngineId,
@@ -219,7 +226,10 @@ final class ServiceContainer: ObservableObject {
             termPackRegistryService: termPackRegistryService
         )
         snippetsViewModel = SnippetsViewModel(snippetService: snippetService)
-        homeViewModel = HomeViewModel(historyService: historyService)
+        homeViewModel = HomeViewModel(
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService
+        )
         promptActionsViewModel = PromptActionsViewModel(
             promptActionService: promptActionService,
             promptProcessingService: promptProcessingService,
@@ -269,6 +279,7 @@ final class ServiceContainer: ObservableObject {
 
         hotkeyService.setup()
         dictationViewModel.registerInitialTriggerHotkeys()
+        usageStatisticsService.backfillFromHistoryIfNeeded(historyService.records)
         let retentionDays = UserDefaults.standard.integer(forKey: UserDefaultsKeys.historyRetentionDays)
         if retentionDays > 0 { historyService.purgeOldRecords(retentionDays: retentionDays) }
 

--- a/TypeWhisper/Models/UsageStatisticsDay.swift
+++ b/TypeWhisper/Models/UsageStatisticsDay.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 @Model
 final class UsageStatisticsDay {
+    @Attribute(.unique)
     var day: Date
     var transcriptionCount: Int
     var totalWords: Int

--- a/TypeWhisper/Models/UsageStatisticsDay.swift
+++ b/TypeWhisper/Models/UsageStatisticsDay.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+@Model
+final class UsageStatisticsDay {
+    var day: Date
+    var transcriptionCount: Int
+    var totalWords: Int
+    var totalDurationSeconds: Double
+    var appBundleIdentifiersJSON: String?
+
+    init(
+        day: Date,
+        transcriptionCount: Int = 0,
+        totalWords: Int = 0,
+        totalDurationSeconds: Double = 0,
+        appBundleIdentifiers: Set<String> = []
+    ) {
+        self.day = day
+        self.transcriptionCount = transcriptionCount
+        self.totalWords = totalWords
+        self.totalDurationSeconds = totalDurationSeconds
+        self.appBundleIdentifiersJSON = Self.encode(appBundleIdentifiers)
+    }
+
+    var appBundleIdentifiers: Set<String> {
+        get { Self.decode(appBundleIdentifiersJSON) }
+        set { appBundleIdentifiersJSON = Self.encode(newValue) }
+    }
+
+    func add(wordsCount: Int, durationSeconds: Double, appBundleIdentifier: String?) {
+        transcriptionCount += 1
+        totalWords += wordsCount
+        totalDurationSeconds += durationSeconds
+
+        guard let appBundleIdentifier = appBundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !appBundleIdentifier.isEmpty else {
+            return
+        }
+        var identifiers = appBundleIdentifiers
+        identifiers.insert(appBundleIdentifier)
+        appBundleIdentifiers = identifiers
+    }
+
+    private static func encode(_ identifiers: Set<String>) -> String? {
+        let values = identifiers
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .sorted()
+        guard !values.isEmpty,
+              let data = try? JSONEncoder().encode(values),
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+
+    private static func decode(_ value: String?) -> Set<String> {
+        guard let value,
+              let data = value.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return Set(decoded.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+    }
+}

--- a/TypeWhisper/Models/UsageStatisticsMetadata.swift
+++ b/TypeWhisper/Models/UsageStatisticsMetadata.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 @Model
 final class UsageStatisticsMetadata {
+    @Attribute(.unique)
     var key: String
     var value: String
 

--- a/TypeWhisper/Models/UsageStatisticsMetadata.swift
+++ b/TypeWhisper/Models/UsageStatisticsMetadata.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftData
+
+@Model
+final class UsageStatisticsMetadata {
+    var key: String
+    var value: String
+
+    init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}

--- a/TypeWhisper/Services/UsageStatisticsService.swift
+++ b/TypeWhisper/Services/UsageStatisticsService.swift
@@ -1,0 +1,301 @@
+import Combine
+import Foundation
+import SwiftData
+import os.log
+
+private let usageStatisticsLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper",
+    category: "UsageStatisticsService"
+)
+
+@MainActor
+protocol UsageStatisticsRecording: AnyObject {
+    func recordTranscription(
+        timestamp: Date,
+        wordsCount: Int,
+        durationSeconds: Double,
+        appBundleIdentifier: String?
+    )
+}
+
+struct UsageStatisticsDaySnapshot: Equatable {
+    let day: Date
+    let transcriptionCount: Int
+    let totalWords: Int
+    let totalDurationSeconds: Double
+    let appBundleIdentifiers: Set<String>
+}
+
+struct UsageStatisticsSummary: Equatable {
+    let transcriptionCount: Int
+    let words: Int
+    let durationSeconds: Double
+    let appBundleIdentifiers: Set<String>
+
+    static let empty = UsageStatisticsSummary(
+        transcriptionCount: 0,
+        words: 0,
+        durationSeconds: 0,
+        appBundleIdentifiers: []
+    )
+
+    var rawWPM: Double {
+        let minutes = durationSeconds / 60.0
+        guard minutes > 0, words > 0 else { return 0 }
+        return Double(words) / minutes
+    }
+
+    var rawSavedMinutes: Double {
+        Double(words) / 45.0 - (durationSeconds / 60.0)
+    }
+
+    var appCount: Int { appBundleIdentifiers.count }
+}
+
+@MainActor
+final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
+    @Published private(set) var days: [UsageStatisticsDaySnapshot] = []
+
+    private static let historyBackfillCompletedKey = "historyBackfillCompleted"
+
+    private let modelContainer: ModelContainer
+    private let modelContext: ModelContext
+    private var calendar: Calendar
+
+    init(
+        appSupportDirectory: URL = AppConstants.appSupportDirectory,
+        calendar: Calendar = .current
+    ) {
+        self.calendar = calendar
+
+        do {
+            let (container, context) = try SwiftDataStoreFactory.create(
+                for: [UsageStatisticsDay.self, UsageStatisticsMetadata.self],
+                storeName: "usage-statistics",
+                in: appSupportDirectory
+            )
+            modelContainer = container
+            modelContext = context
+        } catch {
+            fatalError("Failed to initialize usage statistics store: \(error)")
+        }
+
+        fetchDays()
+    }
+
+    var hasAnyStatistics: Bool {
+        days.contains { $0.transcriptionCount > 0 || $0.totalWords > 0 || $0.totalDurationSeconds > 0 }
+    }
+
+    func recordTranscription(
+        timestamp: Date = Date(),
+        wordsCount: Int,
+        durationSeconds: Double,
+        appBundleIdentifier: String?
+    ) {
+        guard wordsCount > 0 else {
+            usageStatisticsLogger.warning("Skipping usage statistics entry: empty word count")
+            return
+        }
+        guard durationSeconds.isFinite, durationSeconds >= 0 else {
+            usageStatisticsLogger.warning("Skipping usage statistics entry: invalid duration \(durationSeconds)")
+            return
+        }
+
+        upsertDay(
+            timestamp: timestamp,
+            wordsCount: wordsCount,
+            durationSeconds: durationSeconds,
+            appBundleIdentifier: appBundleIdentifier
+        )
+        save()
+        fetchDays()
+    }
+
+    func backfillFromHistoryIfNeeded(_ records: [TranscriptionRecord]) {
+        guard !historyBackfillCompleted else { return }
+
+        for record in records {
+            let wordsCount = record.wordsCount > 0
+                ? record.wordsCount
+                : record.finalText.split(separator: " ").count
+            guard wordsCount > 0,
+                  record.durationSeconds.isFinite,
+                  record.durationSeconds >= 0 else {
+                continue
+            }
+            upsertDay(
+                timestamp: record.timestamp,
+                wordsCount: wordsCount,
+                durationSeconds: record.durationSeconds,
+                appBundleIdentifier: record.appBundleIdentifier
+            )
+        }
+        setHistoryBackfillCompleted(true)
+        save()
+        fetchDays()
+    }
+
+    func summary(from start: Date?, to end: Date = Date()) -> UsageStatisticsSummary {
+        let startDay = start.map { calendar.startOfDay(for: $0) }
+        let endDay = calendar.startOfDay(for: end)
+
+        return summarize(days.filter { snapshot in
+            if let startDay, snapshot.day < startDay { return false }
+            return snapshot.day <= endDay
+        })
+    }
+
+    func summary(startDay: Date, endDayExclusive: Date) -> UsageStatisticsSummary {
+        let normalizedStart = calendar.startOfDay(for: startDay)
+        return summarize(days.filter { $0.day >= normalizedStart && $0.day < endDayExclusive })
+    }
+
+    func dailyWordCounts(days count: Int?, endingAt now: Date = Date()) -> [UsageStatisticsDaySnapshot] {
+        let today = calendar.startOfDay(for: now)
+        let requestedDays: Int
+        if let count {
+            requestedDays = max(count, 1)
+        } else if let oldest = days.map(\.day).min() {
+            requestedDays = max(1, (calendar.dateComponents([.day], from: oldest, to: today).day ?? 0) + 1)
+        } else {
+            requestedDays = 30
+        }
+
+        let byDay = Dictionary(uniqueKeysWithValues: days.map { ($0.day, $0) })
+        return (0..<requestedDays).reversed().compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else {
+                return nil
+            }
+            return byDay[day] ?? UsageStatisticsDaySnapshot(
+                day: day,
+                transcriptionCount: 0,
+                totalWords: 0,
+                totalDurationSeconds: 0,
+                appBundleIdentifiers: []
+            )
+        }
+    }
+
+    func previousPeriodSummary(days count: Int, endingAt now: Date = Date()) -> UsageStatisticsSummary {
+        let today = calendar.startOfDay(for: now)
+        guard let currentStart = calendar.date(byAdding: .day, value: -(max(count, 1) - 1), to: today),
+              let previousStart = calendar.date(byAdding: .day, value: -max(count, 1), to: currentStart) else {
+            return .empty
+        }
+        return summary(startDay: previousStart, endDayExclusive: currentStart)
+    }
+
+    func clearUsageStatistics() {
+        do {
+            for day in try modelContext.fetch(FetchDescriptor<UsageStatisticsDay>()) {
+                modelContext.delete(day)
+            }
+            setHistoryBackfillCompleted(true)
+            save()
+            fetchDays()
+        } catch {
+            usageStatisticsLogger.error("Failed to clear usage statistics: \(error.localizedDescription)")
+        }
+    }
+
+    #if DEBUG
+    func replaceWithHistoryRecords(_ records: [TranscriptionRecord]) {
+        do {
+            for day in try modelContext.fetch(FetchDescriptor<UsageStatisticsDay>()) {
+                modelContext.delete(day)
+            }
+            setHistoryBackfillCompleted(false)
+            save()
+            fetchDays()
+            backfillFromHistoryIfNeeded(records)
+        } catch {
+            usageStatisticsLogger.error("Failed to rebuild usage statistics: \(error.localizedDescription)")
+        }
+    }
+    #endif
+
+    private var historyBackfillCompleted: Bool {
+        metadataValue(for: Self.historyBackfillCompletedKey) == "true"
+    }
+
+    private func upsertDay(
+        timestamp: Date,
+        wordsCount: Int,
+        durationSeconds: Double,
+        appBundleIdentifier: String?
+    ) {
+        let dayStart = calendar.startOfDay(for: timestamp)
+        let statisticsDay = findDay(dayStart) ?? {
+            let day = UsageStatisticsDay(day: dayStart)
+            modelContext.insert(day)
+            return day
+        }()
+        statisticsDay.add(
+            wordsCount: wordsCount,
+            durationSeconds: durationSeconds,
+            appBundleIdentifier: appBundleIdentifier
+        )
+    }
+
+    private func summarize(_ snapshots: [UsageStatisticsDaySnapshot]) -> UsageStatisticsSummary {
+        snapshots.reduce(.empty) { partial, snapshot in
+            UsageStatisticsSummary(
+                transcriptionCount: partial.transcriptionCount + snapshot.transcriptionCount,
+                words: partial.words + snapshot.totalWords,
+                durationSeconds: partial.durationSeconds + snapshot.totalDurationSeconds,
+                appBundleIdentifiers: partial.appBundleIdentifiers.union(snapshot.appBundleIdentifiers)
+            )
+        }
+    }
+
+    private func findDay(_ day: Date) -> UsageStatisticsDay? {
+        let descriptor = FetchDescriptor<UsageStatisticsDay>()
+        guard let existing = try? modelContext.fetch(descriptor) else { return nil }
+        return existing.first { $0.day == day }
+    }
+
+    private func fetchDays() {
+        let descriptor = FetchDescriptor<UsageStatisticsDay>(
+            sortBy: [SortDescriptor(\.day, order: .reverse)]
+        )
+        do {
+            days = try modelContext.fetch(descriptor).map {
+                UsageStatisticsDaySnapshot(
+                    day: $0.day,
+                    transcriptionCount: $0.transcriptionCount,
+                    totalWords: $0.totalWords,
+                    totalDurationSeconds: $0.totalDurationSeconds,
+                    appBundleIdentifiers: $0.appBundleIdentifiers
+                )
+            }
+        } catch {
+            days = []
+        }
+    }
+
+    private func metadataValue(for key: String) -> String? {
+        guard let metadata = try? modelContext.fetch(FetchDescriptor<UsageStatisticsMetadata>()) else {
+            return nil
+        }
+        return metadata.first { $0.key == key }?.value
+    }
+
+    private func setHistoryBackfillCompleted(_ completed: Bool) {
+        let value = completed ? "true" : "false"
+        if let existing = try? modelContext.fetch(FetchDescriptor<UsageStatisticsMetadata>())
+            .first(where: { $0.key == Self.historyBackfillCompletedKey }) {
+            existing.value = value
+        } else {
+            modelContext.insert(UsageStatisticsMetadata(key: Self.historyBackfillCompletedKey, value: value))
+        }
+    }
+
+    private func save() {
+        do {
+            try modelContext.save()
+        } catch {
+            usageStatisticsLogger.error("Save failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/TypeWhisper/Services/UsageStatisticsService.swift
+++ b/TypeWhisper/Services/UsageStatisticsService.swift
@@ -102,38 +102,46 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
             return
         }
 
-        upsertDay(
-            timestamp: timestamp,
-            wordsCount: wordsCount,
-            durationSeconds: durationSeconds,
-            appBundleIdentifier: appBundleIdentifier
-        )
-        save()
-        fetchDays()
+        do {
+            try upsertDay(
+                timestamp: timestamp,
+                wordsCount: wordsCount,
+                durationSeconds: durationSeconds,
+                appBundleIdentifier: appBundleIdentifier
+            )
+            save()
+            fetchDays()
+        } catch {
+            usageStatisticsLogger.error("Failed to record usage statistics: \(error.localizedDescription)")
+        }
     }
 
     func backfillFromHistoryIfNeeded(_ records: [TranscriptionRecord]) {
         guard !historyBackfillCompleted else { return }
 
-        for record in records {
-            let wordsCount = record.wordsCount > 0
-                ? record.wordsCount
-                : record.finalText.split(separator: " ").count
-            guard wordsCount > 0,
-                  record.durationSeconds.isFinite,
-                  record.durationSeconds >= 0 else {
-                continue
+        do {
+            for record in records {
+                let wordsCount = record.wordsCount > 0
+                    ? record.wordsCount
+                    : record.finalText.split(separator: " ").count
+                guard wordsCount > 0,
+                      record.durationSeconds.isFinite,
+                      record.durationSeconds >= 0 else {
+                    continue
+                }
+                try upsertDay(
+                    timestamp: record.timestamp,
+                    wordsCount: wordsCount,
+                    durationSeconds: record.durationSeconds,
+                    appBundleIdentifier: record.appBundleIdentifier
+                )
             }
-            upsertDay(
-                timestamp: record.timestamp,
-                wordsCount: wordsCount,
-                durationSeconds: record.durationSeconds,
-                appBundleIdentifier: record.appBundleIdentifier
-            )
+            try setHistoryBackfillCompleted(true)
+            save()
+            fetchDays()
+        } catch {
+            usageStatisticsLogger.error("Failed to backfill usage statistics: \(error.localizedDescription)")
         }
-        setHistoryBackfillCompleted(true)
-        save()
-        fetchDays()
     }
 
     func summary(from start: Date?, to end: Date = Date()) -> UsageStatisticsSummary {
@@ -191,7 +199,7 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
             for day in try modelContext.fetch(FetchDescriptor<UsageStatisticsDay>()) {
                 modelContext.delete(day)
             }
-            setHistoryBackfillCompleted(true)
+            try setHistoryBackfillCompleted(true)
             save()
             fetchDays()
         } catch {
@@ -205,7 +213,7 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
             for day in try modelContext.fetch(FetchDescriptor<UsageStatisticsDay>()) {
                 modelContext.delete(day)
             }
-            setHistoryBackfillCompleted(false)
+            try setHistoryBackfillCompleted(false)
             save()
             fetchDays()
             backfillFromHistoryIfNeeded(records)
@@ -216,7 +224,12 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
     #endif
 
     private var historyBackfillCompleted: Bool {
-        metadataValue(for: Self.historyBackfillCompletedKey) == "true"
+        do {
+            return try metadataValue(for: Self.historyBackfillCompletedKey) == "true"
+        } catch {
+            usageStatisticsLogger.error("Failed to read usage statistics metadata: \(error.localizedDescription)")
+            return true
+        }
     }
 
     private func upsertDay(
@@ -224,13 +237,16 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
         wordsCount: Int,
         durationSeconds: Double,
         appBundleIdentifier: String?
-    ) {
+    ) throws {
         let dayStart = calendar.startOfDay(for: timestamp)
-        let statisticsDay = findDay(dayStart) ?? {
+        let statisticsDay: UsageStatisticsDay
+        if let existingDay = try findDay(dayStart) {
+            statisticsDay = existingDay
+        } else {
             let day = UsageStatisticsDay(day: dayStart)
             modelContext.insert(day)
-            return day
-        }()
+            statisticsDay = day
+        }
         statisticsDay.add(
             wordsCount: wordsCount,
             durationSeconds: durationSeconds,
@@ -249,9 +265,9 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
         }
     }
 
-    private func findDay(_ day: Date) -> UsageStatisticsDay? {
+    private func findDay(_ day: Date) throws -> UsageStatisticsDay? {
         let descriptor = FetchDescriptor<UsageStatisticsDay>()
-        guard let existing = try? modelContext.fetch(descriptor) else { return nil }
+        let existing = try modelContext.fetch(descriptor)
         return existing.first { $0.day == day }
     }
 
@@ -270,20 +286,19 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
                 )
             }
         } catch {
+            usageStatisticsLogger.error("Failed to fetch usage statistics days: \(error.localizedDescription)")
             days = []
         }
     }
 
-    private func metadataValue(for key: String) -> String? {
-        guard let metadata = try? modelContext.fetch(FetchDescriptor<UsageStatisticsMetadata>()) else {
-            return nil
-        }
+    private func metadataValue(for key: String) throws -> String? {
+        let metadata = try modelContext.fetch(FetchDescriptor<UsageStatisticsMetadata>())
         return metadata.first { $0.key == key }?.value
     }
 
-    private func setHistoryBackfillCompleted(_ completed: Bool) {
+    private func setHistoryBackfillCompleted(_ completed: Bool) throws {
         let value = completed ? "true" : "false"
-        if let existing = try? modelContext.fetch(FetchDescriptor<UsageStatisticsMetadata>())
+        if let existing = try modelContext.fetch(FetchDescriptor<UsageStatisticsMetadata>())
             .first(where: { $0.key == Self.historyBackfillCompletedKey }) {
             existing.value = value
         } else {

--- a/TypeWhisper/Services/WidgetDataService.swift
+++ b/TypeWhisper/Services/WidgetDataService.swift
@@ -5,51 +5,48 @@ import WidgetKit
 @MainActor
 final class WidgetDataService {
     private let historyService: HistoryService
+    private let usageStatisticsService: UsageStatisticsService
     private var cancellable: AnyCancellable?
 
-    init(historyService: HistoryService) {
+    init(historyService: HistoryService, usageStatisticsService: UsageStatisticsService) {
         self.historyService = historyService
+        self.usageStatisticsService = usageStatisticsService
 
-        cancellable = historyService.$records
+        cancellable = Publishers.CombineLatest(historyService.$records, usageStatisticsService.$days)
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
-            .sink { [weak self] records in
-                self?.updateWidgetData(records: records)
+            .sink { [weak self] records, _ in
+                self?.updateWidgetData(records: records, now: Date())
             }
     }
 
-    private func updateWidgetData(records: [TranscriptionRecord]) {
-        let data = buildWidgetData(records: records)
+    private func updateWidgetData(records: [TranscriptionRecord], now: Date) {
+        let data = buildWidgetData(records: records, now: now)
         data.save()
         WidgetCenter.shared.reloadAllTimelines()
     }
 
-    private func buildWidgetData(records: [TranscriptionRecord]) -> WidgetData {
+    func buildWidgetData(records: [TranscriptionRecord], now: Date = Date()) -> WidgetData {
         let calendar = Calendar.current
-        let now = Date()
         let startOfToday = calendar.startOfDay(for: now)
-        let startOfWeek = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+        let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? now
+        let startOfWeek = calendar.date(byAdding: .day, value: -6, to: startOfToday) ?? startOfToday
 
-        let todayRecords = records.filter { $0.timestamp >= startOfToday }
-        let weekRecords = records.filter { $0.timestamp >= startOfWeek }
+        let todaySummary = usageStatisticsService.summary(startDay: startOfToday, endDayExclusive: startOfTomorrow)
+        let weekSummary = usageStatisticsService.summary(startDay: startOfWeek, endDayExclusive: startOfTomorrow)
 
         // Stats
-        let wordsToday = todayRecords.reduce(0) { $0 + $1.wordsCount }
-        let wordsThisWeek = weekRecords.reduce(0) { $0 + $1.wordsCount }
+        let wordsToday = todaySummary.words
+        let wordsThisWeek = weekSummary.words
 
-        let totalMinutesWeek = weekRecords.reduce(0.0) { $0 + $1.durationSeconds } / 60.0
         let averageWPM: String
-        if totalMinutesWeek > 0 && wordsThisWeek > 0 {
-            averageWPM = "\(Int(Double(wordsThisWeek) / totalMinutesWeek))"
+        if weekSummary.rawWPM > 0 {
+            averageWPM = "\(Int(weekSummary.rawWPM))"
         } else {
             averageWPM = "-"
         }
 
-        let uniqueApps = Set(weekRecords.compactMap { $0.appBundleIdentifier })
-
         // Time saved today (typing at 45 WPM baseline)
-        let todayMinutes = todayRecords.reduce(0.0) { $0 + $1.durationSeconds } / 60.0
-        let typingMinutes = Double(wordsToday) / 45.0
-        let savedMinutes = typingMinutes - todayMinutes
+        let savedMinutes = todaySummary.rawSavedMinutes
         let timeSavedToday: String
         if savedMinutes > 0 {
             let mins = Int(savedMinutes)
@@ -67,23 +64,18 @@ final class WidgetDataService {
             timeSavedToday: timeSavedToday,
             wordsThisWeek: wordsThisWeek,
             averageWPM: averageWPM,
-            appsUsed: uniqueApps.count
+            appsUsed: weekSummary.appCount
         )
 
         // Chart - 7 days
         var chartPoints: [WidgetChartPoint] = []
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "E"
-        for i in (0..<7).reversed() {
-            guard let day = calendar.date(byAdding: .day, value: -i, to: now) else { continue }
-            let dayStart = calendar.startOfDay(for: day)
-            let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
-            let dayWords = records.filter { $0.timestamp >= dayStart && $0.timestamp < dayEnd }
-                .reduce(0) { $0 + $1.wordsCount }
+        for snapshot in usageStatisticsService.dailyWordCounts(days: 7, endingAt: now) {
             chartPoints.append(WidgetChartPoint(
-                dateLabel: dateFormatter.string(from: day),
-                date: dayStart,
-                wordCount: dayWords
+                dateLabel: dateFormatter.string(from: snapshot.day),
+                date: snapshot.day,
+                wordCount: snapshot.totalWords
             ))
         }
 

--- a/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
@@ -80,6 +80,7 @@ final class DictationRecoveryViewModel: ObservableObject {
     private let audioRecordingService: AudioRecordingService
     private let modelManager: ModelManagerService
     private let historyService: HistoryService
+    private let usageStatisticsRecorder: UsageStatisticsRecording?
     private let licenseService: LicenseService?
     private let audioSamplesLoader: AudioSamplesLoader
     private let transcriptionRunner: TranscriptionRunner
@@ -93,6 +94,7 @@ final class DictationRecoveryViewModel: ObservableObject {
         modelManager: ModelManagerService,
         historyService: HistoryService,
         audioFileService: AudioFileService,
+        usageStatisticsRecorder: UsageStatisticsRecording? = nil,
         licenseService: LicenseService? = nil,
         defaults: UserDefaults = .standard,
         audioSamplesLoader: AudioSamplesLoader? = nil,
@@ -102,6 +104,7 @@ final class DictationRecoveryViewModel: ObservableObject {
         self.audioRecordingService = audioRecordingService
         self.modelManager = modelManager
         self.historyService = historyService
+        self.usageStatisticsRecorder = usageStatisticsRecorder
         self.licenseService = licenseService
         self.defaults = defaults
         self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
@@ -287,6 +290,13 @@ final class DictationRecoveryViewModel: ObservableObject {
                     }
                     return
                 }
+
+                usageStatisticsRecorder?.recordTranscription(
+                    timestamp: Date(),
+                    wordsCount: text.split(separator: " ").count,
+                    durationSeconds: result.duration,
+                    appBundleIdentifier: Bundle.main.bundleIdentifier
+                )
 
                 let historyID = UUID()
                 historyService.addRecord(

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -270,6 +270,7 @@ final class DictationViewModel: ObservableObject {
     private let modelManager: ModelManagerService
     private let settingsViewModel: SettingsViewModel
     private let historyService: HistoryService
+    private let usageStatisticsRecorder: UsageStatisticsRecording?
     private let recentTranscriptionStore: RecentTranscriptionStore
     private let profileService: ProfileService
     private let workflowService: WorkflowService
@@ -380,6 +381,7 @@ final class DictationViewModel: ObservableObject {
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
         errorLogService: ErrorLogService,
         mediaPlaybackService: MediaPlaybackService,
+        usageStatisticsRecorder: UsageStatisticsRecording? = nil,
         recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider? = nil,
         recoveryFallbackRunner: RecoveryFallbackRunner? = nil
     ) {
@@ -389,6 +391,7 @@ final class DictationViewModel: ObservableObject {
         self.modelManager = modelManager
         self.settingsViewModel = settingsViewModel
         self.historyService = historyService
+        self.usageStatisticsRecorder = usageStatisticsRecorder
         self.recentTranscriptionStore = recentTranscriptionStore
         self.profileService = profileService
         self.workflowService = workflowService
@@ -1625,6 +1628,12 @@ final class DictationViewModel: ObservableObject {
                 audioRecordingService.discardActiveRecoveryRecording()
                 soundService.play(.transcriptionSuccess, enabled: soundFeedbackEnabled)
                 let wordCount = text.split(separator: " ").count
+                usageStatisticsRecorder?.recordTranscription(
+                    timestamp: completionTimestamp,
+                    wordsCount: wordCount,
+                    durationSeconds: audioDuration,
+                    appBundleIdentifier: activeApp.bundleId
+                )
                 let detectedLang = result.detectedLanguage ?? language
                 let completedTranscription = DictationSessionTranscription(
                     text: text,

--- a/TypeWhisper/ViewModels/HomeViewModel.swift
+++ b/TypeWhisper/ViewModels/HomeViewModel.swift
@@ -57,11 +57,13 @@ final class HomeViewModel: ObservableObject {
     }
 
     private let historyService: HistoryService
+    private let usageStatisticsService: UsageStatisticsService
     private var cancellables = Set<AnyCancellable>()
     private var refreshWorkItem: DispatchWorkItem?
 
-    init(historyService: HistoryService) {
+    init(historyService: HistoryService, usageStatisticsService: UsageStatisticsService) {
         self.historyService = historyService
+        self.usageStatisticsService = usageStatisticsService
         self.showSetupWizard = !UserDefaults.standard.bool(forKey: UserDefaultsKeys.setupWizardCompleted)
 
         setupBindings()
@@ -70,6 +72,11 @@ final class HomeViewModel: ObservableObject {
 
     private func setupBindings() {
         historyService.$records
+            .dropFirst()
+            .sink { [weak self] _ in self?.scheduleRefresh() }
+            .store(in: &cancellables)
+
+        usageStatisticsService.$days
             .dropFirst()
             .sink { [weak self] _ in self?.scheduleRefresh() }
             .store(in: &cancellables)
@@ -93,19 +100,10 @@ final class HomeViewModel: ObservableObject {
     func refresh() {
         let now = Date()
         let allRecords = historyService.records
-        hasAnyTranscriptions = !allRecords.isEmpty
-
-        // Filter records for current period
-        let filtered: [TranscriptionRecord]
-        if let days = selectedTimePeriod.days {
-            let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
-            filtered = allRecords.filter { $0.timestamp >= cutoff }
-        } else {
-            filtered = allRecords
-        }
+        hasAnyTranscriptions = usageStatisticsService.hasAnyStatistics || !allRecords.isEmpty
 
         // Stats for current period
-        let stats = computeStats(for: filtered)
+        let stats = computeStats(for: currentSummary(now: now))
         wordsCount = stats.words
         averageWPM = stats.wpm
         appsUsed = stats.apps
@@ -113,10 +111,7 @@ final class HomeViewModel: ObservableObject {
 
         // Trends (compare with previous period of same length)
         if let days = selectedTimePeriod.days {
-            let currentCutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
-            let prevCutoff = Calendar.current.date(byAdding: .day, value: -days, to: currentCutoff) ?? currentCutoff
-            let prevFiltered = allRecords.filter { $0.timestamp >= prevCutoff && $0.timestamp < currentCutoff }
-            let prevStats = computeStats(for: prevFiltered)
+            let prevStats = computeStats(for: usageStatisticsService.previousPeriodSummary(days: days, endingAt: now))
 
             wordsTrend = Self.trendPercent(current: Double(stats.words), previous: Double(prevStats.words))
             appsTrend = Self.trendPercent(current: Double(stats.apps), previous: Double(prevStats.apps))
@@ -130,7 +125,7 @@ final class HomeViewModel: ObservableObject {
         }
 
         // Chart data
-        chartData = buildChartData(records: filtered)
+        chartData = buildChartData(now: now)
 
         // Recent transcriptions
         recentTranscriptions = Array(allRecords.prefix(3))
@@ -145,24 +140,34 @@ final class HomeViewModel: ObservableObject {
         let rawSavedMinutes: Double
     }
 
-    private func computeStats(for records: [TranscriptionRecord]) -> PeriodStats {
-        let words = records.reduce(0) { $0 + $1.wordsCount }
-        let totalMinutes = records.reduce(0.0) { $0 + $1.durationSeconds } / 60.0
+    private func currentSummary(now: Date) -> UsageStatisticsSummary {
+        guard let days = selectedTimePeriod.days else {
+            return usageStatisticsService.summary(from: nil, to: now)
+        }
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        guard let startDay = calendar.date(byAdding: .day, value: -(days - 1), to: today),
+              let endDay = calendar.date(byAdding: .day, value: 1, to: today) else {
+            return .empty
+        }
+        return usageStatisticsService.summary(startDay: startDay, endDayExclusive: endDay)
+    }
 
+    private func computeStats(for summary: UsageStatisticsSummary) -> PeriodStats {
+        let words = summary.words
         let rawWPM: Double
         let wpm: String
-        if totalMinutes > 0 && words > 0 {
-            rawWPM = Double(words) / totalMinutes
+        if summary.rawWPM > 0 {
+            rawWPM = summary.rawWPM
             wpm = "\(Int(rawWPM))"
         } else {
             rawWPM = 0
             wpm = "—"
         }
 
-        let apps = Set(records.compactMap { $0.appBundleIdentifier }).count
+        let apps = summary.appCount
 
-        let typingMinutes = Double(words) / 45.0
-        let rawSavedMinutes = typingMinutes - totalMinutes
+        let rawSavedMinutes = summary.rawSavedMinutes
         let timeSaved: String
         if rawSavedMinutes > 0 {
             let mins = Int(rawSavedMinutes)
@@ -183,29 +188,10 @@ final class HomeViewModel: ObservableObject {
         return ((current - previous) / previous) * 100
     }
 
-    private func buildChartData(records: [TranscriptionRecord]) -> [ActivityDataPoint] {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        let days = selectedTimePeriod.days ?? max(1, {
-            guard let oldest = records.last?.timestamp else { return 30 }
-            return calendar.dateComponents([.day], from: oldest, to: today).day.map { $0 + 1 } ?? 30
-        }())
-
-        var dataByDay: [Date: Int] = [:]
-        for i in 0..<days {
-            if let date = calendar.date(byAdding: .day, value: -i, to: today) {
-                dataByDay[date] = 0
-            }
-        }
-
-        for record in records {
-            let day = calendar.startOfDay(for: record.timestamp)
-            dataByDay[day, default: 0] += record.wordsCount
-        }
-
-        return dataByDay
-            .map { ActivityDataPoint(date: $0.key, wordCount: $0.value) }
-            .sorted { $0.date < $1.date }
+    private func buildChartData(now: Date) -> [ActivityDataPoint] {
+        usageStatisticsService
+            .dailyWordCounts(days: selectedTimePeriod.days, endingAt: now)
+            .map { ActivityDataPoint(date: $0.day, wordCount: $0.totalWords) }
     }
 
     func completeSetupWizard() {

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -15,6 +15,7 @@ struct AdvancedSettingsView: View {
     @State private var cliSymlinkTarget = ""
     @State private var raycastInstalled = false
     @State private var showClearMemoryConfirmation = false
+    @State private var showClearUsageStatisticsConfirmation = false
     @State private var showDiagnosticsExportError = false
     @State private var diagnosticsExportErrorMessage = ""
 
@@ -292,6 +293,22 @@ struct AdvancedSettingsView: View {
                             info: String(localized: "Older entries are automatically removed at app launch.")
                         )
                     }
+                }
+
+                Button(role: .destructive) {
+                    showClearUsageStatisticsConfirmation = true
+                } label: {
+                    Label(String(localized: "Clear Usage Statistics"), systemImage: "trash")
+                }
+                .confirmationDialog(
+                    String(localized: "Clear Usage Statistics?"),
+                    isPresented: $showClearUsageStatisticsConfirmation
+                ) {
+                    Button(String(localized: "Clear Statistics"), role: .destructive) {
+                        ServiceContainer.shared.usageStatisticsService.clearUsageStatistics()
+                    }
+                } message: {
+                    Text(String(localized: "This will permanently delete aggregate word, app, time-saved, and activity statistics. Transcription history entries are unchanged."))
                 }
             }
 

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -58,6 +58,7 @@ struct HomeSettingsView: View {
                         Button("Seed Demo Data") {
                             let historyService = ServiceContainer.shared.historyService
                             historyService.seedDemoData()
+                            ServiceContainer.shared.usageStatisticsService.replaceWithHistoryRecords(historyService.records)
                         }
                         .buttonStyle(.plain)
                         .foregroundStyle(.orange)
@@ -65,6 +66,7 @@ struct HomeSettingsView: View {
                         Button("Clear All Data") {
                             let historyService = ServiceContainer.shared.historyService
                             historyService.clearAll()
+                            ServiceContainer.shared.usageStatisticsService.clearUsageStatistics()
                         }
                         .buttonStyle(.plain)
                         .foregroundStyle(.red)

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -229,7 +229,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let didReportProgress = await progressReported.wait()
         XCTAssertTrue(didReportProgress, "Timed out waiting for transcription progress callback")
 
-        XCTAssertEqual(viewModel.files.first?.phaseDescription, "Transcribing")
+        XCTAssertEqual(viewModel.files.first?.phaseDescription, String(localized: "Transcribing"))
         XCTAssertEqual(viewModel.files.first?.progressText, "Partial transcript")
         await finishRunner.open()
         try await waitForBatchToFinish(viewModel)
@@ -275,7 +275,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(didReportProgress, "Timed out waiting for source progress callback")
 
         let item = try XCTUnwrap(viewModel.files.first)
-        XCTAssertEqual(item.phaseDescription, "Transcribing")
+        XCTAssertEqual(item.phaseDescription, String(localized: "Transcribing"))
         XCTAssertEqual(item.progressFraction, 0.25)
         XCTAssertEqual(item.progressText, "Minute one")
         XCTAssertEqual(item.sourceProgress?.processedDuration, 60)

--- a/TypeWhisperTests/HistoryServiceTests.swift
+++ b/TypeWhisperTests/HistoryServiceTests.swift
@@ -9,6 +9,7 @@ final class HistoryServiceTests: XCTestCase {
 
         let service = HistoryService(appSupportDirectory: appSupportDirectory)
         service.clearAll()
+        let usageStatisticsService = UsageStatisticsService(appSupportDirectory: appSupportDirectory)
 
         service.addRecord(
             rawText: "Weekly planning meeting",
@@ -39,11 +40,17 @@ final class HistoryServiceTests: XCTestCase {
         let staleRecord = try XCTUnwrap(service.records.first(where: { $0.finalText == "Older note" }))
         staleRecord.timestamp = Calendar.current.date(byAdding: .day, value: -120, to: Date())!
         service.updateRecord(staleRecord, finalText: staleRecord.finalText)
+        usageStatisticsService.backfillFromHistoryIfNeeded(service.records)
 
         service.purgeOldRecords(retentionDays: 30)
 
         XCTAssertEqual(service.records.count, 1)
         XCTAssertEqual(service.totalRecords, 1)
         XCTAssertEqual(service.totalWords, 3)
+
+        let allTimeUsage = usageStatisticsService.summary(from: nil)
+        XCTAssertEqual(allTimeUsage.transcriptionCount, 2)
+        XCTAssertEqual(allTimeUsage.words, 5)
+        XCTAssertEqual(allTimeUsage.appCount, 2)
     }
 }

--- a/TypeWhisperTests/UsageStatisticsServiceTests.swift
+++ b/TypeWhisperTests/UsageStatisticsServiceTests.swift
@@ -76,8 +76,8 @@ final class UsageStatisticsServiceTests: XCTestCase {
         let directory = try TestSupport.makeTemporaryDirectory(prefix: "UsageStatisticsDashboard")
         defer { TestSupport.remove(directory) }
 
-        let calendar = Self.utcCalendar()
-        let now = Self.date(year: 2026, month: 7, day: 5, hour: 12, calendar: calendar)
+        let calendar = Calendar.current
+        let now = calendar.date(byAdding: .hour, value: 12, to: calendar.startOfDay(for: Date()))!
         let historyService = HistoryService(appSupportDirectory: directory)
         historyService.clearAll()
         historyService.addRecord(

--- a/TypeWhisperTests/UsageStatisticsServiceTests.swift
+++ b/TypeWhisperTests/UsageStatisticsServiceTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import TypeWhisper
+
+final class UsageStatisticsServiceTests: XCTestCase {
+    @MainActor
+    func testRecordsDailyAggregatesAndSummaries() throws {
+        let directory = try TestSupport.makeTemporaryDirectory(prefix: "UsageStatistics")
+        defer { TestSupport.remove(directory) }
+
+        let calendar = Self.utcCalendar()
+        let service = UsageStatisticsService(appSupportDirectory: directory, calendar: calendar)
+        let today = Self.date(year: 2026, month: 7, day: 5, hour: 12, calendar: calendar)
+        let yesterday = Self.date(year: 2026, month: 7, day: 4, hour: 9, calendar: calendar)
+
+        service.recordTranscription(timestamp: today, wordsCount: 90, durationSeconds: 60, appBundleIdentifier: "com.example.editor")
+        service.recordTranscription(timestamp: today, wordsCount: 45, durationSeconds: 60, appBundleIdentifier: "com.example.editor")
+        service.recordTranscription(timestamp: yesterday, wordsCount: 45, durationSeconds: 30, appBundleIdentifier: "com.example.mail")
+
+        let summary = service.summary(from: nil, to: today)
+        XCTAssertEqual(summary.transcriptionCount, 3)
+        XCTAssertEqual(summary.words, 180)
+        XCTAssertEqual(summary.durationSeconds, 150, accuracy: 0.001)
+        XCTAssertEqual(summary.appCount, 2)
+        XCTAssertEqual(summary.rawWPM, 72, accuracy: 0.001)
+        XCTAssertEqual(summary.rawSavedMinutes, 1.5, accuracy: 0.001)
+
+        let daily = service.dailyWordCounts(days: 2, endingAt: today)
+        XCTAssertEqual(daily.map(\.totalWords), [45, 135])
+    }
+
+    @MainActor
+    func testHistoryBackfillIsIdempotentAndClearDoesNotRebackfill() throws {
+        let directory = try TestSupport.makeTemporaryDirectory(prefix: "UsageStatisticsBackfill")
+        defer { TestSupport.remove(directory) }
+
+        let historyService = HistoryService(appSupportDirectory: directory)
+        historyService.clearAll()
+        historyService.addRecord(
+            rawText: "Alpha beta gamma",
+            finalText: "Alpha beta gamma",
+            appName: "Editor",
+            appBundleIdentifier: "com.example.editor",
+            durationSeconds: 30,
+            language: "en",
+            engineUsed: "parakeet"
+        )
+        historyService.addRecord(
+            rawText: "Delta epsilon",
+            finalText: "Delta epsilon",
+            appName: "Mail",
+            appBundleIdentifier: "com.example.mail",
+            durationSeconds: 20,
+            language: "en",
+            engineUsed: "parakeet"
+        )
+
+        let service = UsageStatisticsService(appSupportDirectory: directory)
+        service.backfillFromHistoryIfNeeded(historyService.records)
+        service.backfillFromHistoryIfNeeded(historyService.records)
+
+        var summary = service.summary(from: nil)
+        XCTAssertEqual(summary.transcriptionCount, 2)
+        XCTAssertEqual(summary.words, 5)
+        XCTAssertEqual(summary.appCount, 2)
+
+        service.clearUsageStatistics()
+        service.backfillFromHistoryIfNeeded(historyService.records)
+
+        summary = service.summary(from: nil)
+        XCTAssertEqual(summary.transcriptionCount, 0)
+        XCTAssertEqual(summary.words, 0)
+    }
+
+    @MainActor
+    func testHomeAndWidgetUseUsageStatisticsWhileKeepingRecentHistory() throws {
+        let directory = try TestSupport.makeTemporaryDirectory(prefix: "UsageStatisticsDashboard")
+        defer { TestSupport.remove(directory) }
+
+        let calendar = Self.utcCalendar()
+        let now = Self.date(year: 2026, month: 7, day: 5, hour: 12, calendar: calendar)
+        let historyService = HistoryService(appSupportDirectory: directory)
+        historyService.clearAll()
+        historyService.addRecord(
+            rawText: "Retained history only",
+            finalText: "Retained history only",
+            appName: "Notes",
+            appBundleIdentifier: "com.example.notes",
+            durationSeconds: 10,
+            language: "en",
+            engineUsed: "parakeet"
+        )
+
+        let usageStatisticsService = UsageStatisticsService(appSupportDirectory: directory, calendar: calendar)
+        usageStatisticsService.recordTranscription(
+            timestamp: now,
+            wordsCount: 120,
+            durationSeconds: 60,
+            appBundleIdentifier: "com.example.aggregate"
+        )
+
+        let homeViewModel = HomeViewModel(
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService
+        )
+        homeViewModel.selectedTimePeriod = .week
+        homeViewModel.refresh()
+
+        XCTAssertTrue(homeViewModel.hasAnyTranscriptions)
+        XCTAssertEqual(homeViewModel.wordsCount, 120)
+        XCTAssertEqual(homeViewModel.averageWPM, "120")
+        XCTAssertEqual(homeViewModel.appsUsed, 1)
+        XCTAssertEqual(homeViewModel.recentTranscriptions.count, 1)
+        XCTAssertEqual(homeViewModel.recentTranscriptions.first?.finalText, "Retained history only")
+
+        let widgetDataService = WidgetDataService(
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService
+        )
+        let widgetData = widgetDataService.buildWidgetData(records: historyService.records, now: now)
+
+        XCTAssertEqual(widgetData.stats.wordsToday, 120)
+        XCTAssertEqual(widgetData.stats.wordsThisWeek, 120)
+        XCTAssertEqual(widgetData.stats.averageWPM, "120")
+        XCTAssertEqual(widgetData.stats.appsUsed, 1)
+        XCTAssertEqual(widgetData.recentHistory.first?.preview, "Retained history only")
+    }
+
+    private static func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private static func date(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        calendar: Calendar
+    ) -> Date {
+        DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        ).date!
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a privacy-safe `usage-statistics.store` SwiftData store for daily aggregate usage buckets, separate from transcription history.
- Backfills aggregates once from retained history before retention cleanup, then records new dictation/recovery completions regardless of the Save History setting.
- Updates Home dashboard and widgets to read words, WPM, apps used, time saved, and chart data from aggregates while keeping recent transcription lists tied to retained history.
- Adds an Advanced > History action to clear aggregate usage statistics, and makes DEBUG Clear All Data clear both history and stats.
- Stabilizes file transcription progress tests under localized app languages.

## Issue Context
Issue #839 reports that retention cleanup currently removes history rows that dashboard/widget stats depend on, which makes long-term aggregate usage stats disappear. This PR keeps retention focused on transcript/history content while preserving text-free daily aggregates until the user explicitly clears usage statistics.

Closes #839

## Test Coverage
New usage-statistics coverage includes daily aggregation, unique app unioning, summary math, idempotent history backfill, clearing stats, retention independence, and Home/widget aggregate sourcing.

## Pre-Landing Review
No issues found.

## Design Review
SwiftUI settings change only. Web design review not applicable.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN. Delivered the requested separate aggregate stats store and dashboard/widget aggregate migration; the only extra commit stabilizes localized test assertions required for the full XCTest gate.

## Verification Results
- Full app XCTest passed: `Executed 1095 tests, with 0 failures (0 unexpected)`.
- Dev build passed: `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

## Test plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/HistoryServiceTests -only-testing:TypeWhisperTests/UsageStatisticsServiceTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests/testRunnerProgressUpdatesActiveFileStatus -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests/testRunnerSourceProgressUpdatesActiveFileStatus`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "/Users/marco/.codex/worktrees/fcb5/typewhisper-mac"`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent usage statistics recording for dictations (daily totals, word counts, duration, and app breakdowns).
  * Updated Home and widgets to compute charts and summaries from usage statistics.
  * Added separate “Clear Usage Statistics” option in advanced settings.
* **Bug Fixes**
  * Improved refresh/backfill behavior so usage statistics are reliably kept in sync and backfill is idempotent.
* **Tests**
  * Added end-to-end tests for recording, history backfill, clearing behavior, and Home/widget integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->