### PR TITLE
fix: make correction learning conservative

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See the [release readiness guide](docs/release-readiness.md), [support matrix](d
 ### Personalization
 
 - **Workflow triggers** - Per-app, per-website, combined app + website, hotkey, global fallback, and manual palette-only triggers for language, task, engine, prompt, and auto-submit behavior. Website matching supports subdomains
-- **Dictionary** - Terms improve cloud recognition accuracy. Corrections fix common transcription mistakes automatically. Auto-learns from manual corrections. Includes importable term packs
+- **Dictionary** - Terms improve cloud recognition accuracy. Corrections fix common transcription mistakes automatically. Auto-learns high-confidence local single-word manual corrections, while broader rewrites and deletions are skipped. Includes importable term packs
 - **Localized term packs** - Built-in term pack names and descriptions are localized in English and German
 - **Snippets** - Text shortcuts with trigger/replacement. Supports placeholders like `{{DATE}}`, `{{TIME}}`, and `{{CLIPBOARD}}`
 - **History** - Searchable transcription history with inline editing, correction detection, app context tracking, timeline grouping, filters, bulk delete, multi-select export, auto-retention, and a standalone window accessible from the tray menu

--- a/TypeWhisper/Services/TextDiffService.swift
+++ b/TypeWhisper/Services/TextDiffService.swift
@@ -136,10 +136,13 @@ final class TextDiffService {
             return []
         }
 
-        var suggestions: [CorrectionSuggestion] = []
-        var seenOriginals = Set<String>()
+        var suggestion: CorrectionSuggestion?
 
         for (originalToken, editedToken) in zip(originalTokens, editedTokens) where originalToken != editedToken {
+            guard suggestion == nil else {
+                return []
+            }
+
             let originalStripped = Self.strippedWordToken(originalToken)
             let editedStripped = Self.strippedWordToken(editedToken)
 
@@ -156,23 +159,14 @@ final class TextDiffService {
                 return []
             }
 
-            let originalKey = originalStripped.lowercased()
-            guard !seenOriginals.contains(originalKey) else {
-                return []
-            }
-
-            seenOriginals.insert(originalKey)
-            suggestions.append(CorrectionSuggestion(
+            suggestion = CorrectionSuggestion(
                 original: originalStripped,
                 replacement: editedStripped
-            ))
-
-            guard suggestions.count <= maxSuggestions else {
-                return []
-            }
+            )
         }
 
-        return suggestions
+        guard let suggestion else { return [] }
+        return [suggestion]
     }
 
     private static func wordTokens(in text: String) -> [String] {

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -229,7 +229,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let didReportProgress = await progressReported.wait()
         XCTAssertTrue(didReportProgress, "Timed out waiting for transcription progress callback")
 
-        XCTAssertEqual(viewModel.files.first?.phaseDescription, "Transcribing")
+        XCTAssertEqual(viewModel.files.first?.phaseDescription, String(localized: "Transcribing"))
         XCTAssertEqual(viewModel.files.first?.progressText, "Partial transcript")
         await finishRunner.open()
         try await waitForBatchToFinish(viewModel)
@@ -275,7 +275,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(didReportProgress, "Timed out waiting for source progress callback")
 
         let item = try XCTUnwrap(viewModel.files.first)
-        XCTAssertEqual(item.phaseDescription, "Transcribing")
+        XCTAssertEqual(item.phaseDescription, String(localized: "Transcribing"))
         XCTAssertEqual(item.progressFraction, 0.25)
         XCTAssertEqual(item.progressText, "Minute one")
         XCTAssertEqual(item.sourceProgress?.processedDuration, 60)

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -52,6 +52,98 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertEqual(dictionaryService.correctionsCount, 1)
     }
 
+    func testSkipsSentenceRewriteAfterCommitSignal() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+
+        var observations = [
+            "Rewrite every token now"
+        ]
+        textInsertionService.focusedTextStateOverride = { _ in
+            let value = observations.removeFirst()
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.seconds(5)],
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let task = Task { @MainActor in
+            await service.trackInsertion(insertedText: baseline.value, baseline: baseline)
+        }
+        for _ in 0..<1000 where !commitEmitter.isReady {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(commitEmitter.isReady)
+        commitEmitter.emit(.returnKey)
+        let learned = await task.value
+
+        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
+    func testSkipsInsertedTextRemovalAfterCommitSignal() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+
+        var observations = [
+            "Please use word"
+        ]
+        textInsertionService.focusedTextStateOverride = { _ in
+            let value = observations.removeFirst()
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.seconds(5)],
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let task = Task { @MainActor in
+            await service.trackInsertion(insertedText: "teh", baseline: baseline)
+        }
+        for _ in 0..<1000 where !commitEmitter.isReady {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(commitEmitter.isReady)
+        commitEmitter.emit(.returnKey)
+        let learned = await task.value
+
+        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
     func testTimeoutDoesNotLearnWithoutCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TextDiffServiceTests.swift
+++ b/TypeWhisperTests/TextDiffServiceTests.swift
@@ -26,21 +26,36 @@ final class TextDiffServiceTests: XCTestCase {
         XCTAssertTrue(suggestions.isEmpty)
     }
 
-    func testHighConfidenceExtractionFindsUpToThreeSingleTokenReplacements() {
+    func testHighConfidenceExtractionFindsSingleLocalTokenReplacement() {
         let service = TextDiffService()
 
         let suggestions = service.extractHighConfidenceCorrections(
-            original: "teh langauge recieved",
-            edited: "the language received"
+            original: "please use teh word",
+            edited: "please use the word"
         )
 
-        XCTAssertEqual(suggestions.count, 3)
-        XCTAssertEqual(suggestions.map(\.original), ["teh", "langauge", "recieved"])
-        XCTAssertEqual(suggestions.map(\.replacement), ["the", "language", "received"])
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertEqual(suggestions.first?.original, "teh")
+        XCTAssertEqual(suggestions.first?.replacement, "the")
     }
 
     func testHighConfidenceExtractionSkipsAmbiguousAndLowSignalEdits() {
         let service = TextDiffService()
+
+        XCTAssertTrue(service.extractHighConfidenceCorrections(
+            original: "teh langauge",
+            edited: "the language"
+        ).isEmpty)
+
+        XCTAssertTrue(service.extractHighConfidenceCorrections(
+            original: "remove this sentence",
+            edited: "write new copy"
+        ).isEmpty)
+
+        XCTAssertTrue(service.extractHighConfidenceCorrections(
+            original: "remove this sentence",
+            edited: ""
+        ).isEmpty)
 
         XCTAssertTrue(service.extractHighConfidenceCorrections(
             original: "teh quick fox",


### PR DESCRIPTION
## Summary

This PR makes automatic correction learning conservative:

- Stores auto-learned corrections only when there is exactly one changed word token.
- Rejects multi-word edits, same-token-count sentence rewrites, insertions, and deletions for automatic learning.
- Keeps manual/API dictionary behavior unchanged.
- Makes file transcription progress tests locale-stable by comparing against the localized source string.
- Clarifies the app README so the documented behavior matches the conservative learning scope.

## Test Coverage

CODE PATH COVERAGE
==================
[+] `TextDiffService.extractHighConfidenceCorrections(...)`
    - [TESTED] Single local word replacement, `teh` -> `the`.
    - [TESTED] Multiple changed word positions are rejected.
    - [TESTED] Same-count sentence rewrites are rejected.
    - [TESTED] Token count mismatches and full deletions are rejected.
    - [TESTED] Existing low-signal guards remain covered: case-only, punctuation-only, insertions, repeated ambiguous edits.

[+] Target app correction learning commit flow
    - [TESTED] A local single-word edit after a commit signal still writes one dictionary correction.
    - [TESTED] Whole sentence rewrites after a commit signal write nothing.
    - [TESTED] Removing inserted text after a commit signal writes nothing.

Coverage gate: PASS (100%).

## Pre-Landing Review

No issues found.

## Design Review

Skipped. This PR does not change SwiftUI or visible UI surfaces.

## Scope Drift

Clean. The branch implements conservative auto-learning and includes one unrelated test-stability fix discovered by the full app test suite.

## Plan Completion

All requested implementation and test items are addressed. No schema, API, or UI changes were made.

## Documentation

- `README.md`: clarified that automatic correction learning stores high-confidence local single-word manual corrections and skips broader rewrites or deletions.
- Public website docs were updated separately in TypeWhisper/typewhisper.com PR #103: https://github.com/TypeWhisper/typewhisper.com/pull/103

## Verification

Focused tests:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/TextDiffServiceTests -only-testing:TypeWhisperTests/TargetAppCorrectionLearningServiceTests
```

Result: passed, 16 tests, 0 failures.

Full app test suite:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Result: passed, 1094 tests, 0 failures.

Dev app build:

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"
```

Result: passed, `** BUILD SUCCEEDED **`, app built at `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

Website docs:

```bash
npm run test:i18n
```

Result: passed in `TypeWhisper/typewhisper.com`, `i18n OK: 1063 keys across en, de`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-confidence correction suggestions to show at most one clear single-word match, reducing ambiguous/extra recommendations.
  * Prevented correction learning after commit signals in skip scenarios to reduce incorrect saved corrections.
  * Updated transcription progress checks to use localized status text for more reliable updates.

* **Tests**
  * Strengthened coverage for single-suggestion extraction and clarified “empty result” edge cases.
  * Added async test cases for learning-skip behavior and updated localized assertion expectations.

* **Documentation**
  * Updated Dictionary feature wording to clarify what kinds of edits are used for auto-learning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->