### PR TITLE
Fix WhisperKit restore when loaded model marker is missing

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -644,6 +644,10 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         modelState = .loading(phase: "compiling")
         startModelLoadTimeout(generation: generation, modelName: modelName)
     }
+
+    func restoreTargetModelIdForTesting(allowDownloads: Bool = true) -> String? {
+        modelDefinitionForRestore(allowDownloads: allowDownloads)?.id
+    }
     #endif
 
     fileprivate func deleteModelFiles(_ modelDef: WhisperModelDef) throws {
@@ -658,12 +662,27 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         restoreLoadedModelInvocationCountForTesting += 1
         #endif
 
-        guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
-              let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
-            return
-        }
-        guard allowDownloads || isModelDownloaded(modelDef) else { return }
+        guard let modelDef = modelDefinitionForRestore(allowDownloads: allowDownloads) else { return }
         await loadModel(modelDef)
+    }
+
+    private func modelDefinitionForRestore(allowDownloads: Bool) -> WhisperModelDef? {
+        let persistedLoadedId = host?.userDefault(forKey: "loadedModel") as? String
+        let candidateIds = [persistedLoadedId, _selectedModelId]
+
+        var seen = Set<String>()
+        for candidateId in candidateIds {
+            guard let modelId = candidateId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !modelId.isEmpty,
+                  seen.insert(modelId).inserted,
+                  let modelDef = Self.availableModels.first(where: { $0.id == modelId }),
+                  allowDownloads || isModelDownloaded(modelDef) else {
+                continue
+            }
+            return modelDef
+        }
+
+        return nil
     }
 
     fileprivate func isModelDownloaded(_ modelDef: WhisperModelDef) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -171,6 +171,40 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         #endif
     }
 
+    func testRestoreFallsBackToSelectedDownloadedModelWhenLoadedMarkerMissing() throws {
+        let modelId = "openai_whisper-tiny"
+        let host = try makeHost(
+            defaults: ["selectedModel": modelId],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        _ = try makeUsableWhisperModelDirectory(host: host, modelId: modelId)
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(plugin.selectedModelId, modelId)
+        XCTAssertEqual(plugin.restoreTargetModelIdForTesting(allowDownloads: false), modelId)
+    }
+
+    func testExplicitRestoreFallsBackToSelectedModelWhenLoadedMarkerMissing() throws {
+        let modelId = "openai_whisper-large-v3_turbo"
+        let host = try makeHost(
+            defaults: ["selectedModel": modelId],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(plugin.selectedModelId, modelId)
+        XCTAssertNil(plugin.restoreTargetModelIdForTesting(allowDownloads: false))
+        XCTAssertEqual(plugin.restoreTargetModelIdForTesting(allowDownloads: true), modelId)
+    }
+
     func testUnloadWithoutClearingPersistenceKeepsLoadedModelMarker() throws {
         let host = try makeHost(defaults: [
             "selectedModel": "openai_whisper-tiny",


### PR DESCRIPTION
## Summary

This fixes the remaining WhisperKit restore failure reported in #829 after TypeWhisper 1.5.1 and WhisperKitPlugin 1.1.1 were installed.

- Let WhisperKit restore fall back from the persisted `loadedModel` marker to the persisted `selectedModel` when the loaded marker is missing.
- Keep passive restore conservative: it only uses the selected-model fallback when the selected model is already downloaded/usable.
- Keep explicit restore able to use the selected model as the restore target, which covers the transcription-time `triggerRestoreModel` path.
- Bump WhisperKitPlugin to 1.1.2.

## Issue Context

The reporter's latest diagnostics from 2026-07-05 confirm TypeWhisper 1.5.1 build 928 and WhisperKitPlugin 1.1.1 are installed. The app still reports "No model loaded", but the diagnostics now show:

- `selectedModelId`: `openai_whisper-large-v3_turbo`
- `storedSelectedModelId`: `openai_whisper-large-v3_turbo`
- `storedLoadedModelId`: `null`
- `currentSettingsActivity`: `null`

That means the prior long-restore wait fix is no longer the active failure. The plugin has a selected model, but `restoreLoadedModel` returned immediately because it only looked at the missing `loadedModel` marker. This PR makes restore recover from that state instead of falling through to the generic host error.

Closes #829

## Test Plan

```bash
git diff --check
```

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests/testRestoreFallsBackToSelectedDownloadedModelWhenLoadedMarkerMissing -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests/testExplicitRestoreFallsBackToSelectedModelWhenLoadedMarkerMissing
```

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests
```

```bash
swift test --package-path TypeWhisperPluginSDK
```