### PR TITLE
feat: add microphone priority list

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -122,7 +122,9 @@ final class ServiceContainer: ObservableObject {
         punctuationRulesLoader = PunctuationRulesLoader()
         punctuationStrategyResolver = PunctuationStrategyResolver(profileStore: dictationPunctuationProfileStore)
         punctuationVerificationService = PunctuationVerificationService(rulesLoader: punctuationRulesLoader)
-        audioRecorderService = AudioRecorderService()
+        audioRecorderService = AudioRecorderService(
+            inputActivationGuard: inputActivationGuard
+        )
         promptProcessingService.memoryService = memoryService
         promptProcessingService.modelManagerService = modelManagerService
         watchFolderService = WatchFolderService(audioFileService: audioFileService, modelManagerService: modelManagerService)
@@ -189,7 +191,8 @@ final class ServiceContainer: ObservableObject {
         audioRecorderViewModel = AudioRecorderViewModel(
             recorderService: audioRecorderService,
             modelManager: modelManagerService,
-            dictionaryService: dictionaryService
+            dictionaryService: dictionaryService,
+            audioDeviceService: audioDeviceService
         )
 
 

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -58,6 +58,7 @@ enum UserDefaultsKeys {
 
     // MARK: - Audio Device
     static let selectedInputDeviceUID = "selectedInputDeviceUID"
+    static let inputDevicePriorityList = "inputDevicePriorityList"
 
     // MARK: - Home / Setup
     static let setupWizardCompleted = "setupWizardCompleted"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1021,6 +1021,22 @@
         }
       }
     },
+    "Add Microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon hinzufügen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイクを追加"
+          }
+        }
+      }
+    },
     "Add Correction": {
       "localizations": {
         "de": {
@@ -3680,6 +3696,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "メニューバーアイコン非表示時にDockアイコンを表示"
+          }
+        }
+      }
+    },
+    "Disconnected": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Getrennt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続解除"
           }
         }
       }
@@ -6351,6 +6383,22 @@
         }
       }
     },
+    "Microphone Priority": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon-Priorität"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイクの優先順位"
+          }
+        }
+      }
+    },
     "Microphone access is required for dictation.": {
       "extractionState": "stale",
       "localizations": {
@@ -7047,6 +7095,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "マイクが認識されていません。"
+          }
+        }
+      }
+    },
+    "No more microphones": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine weiteren Mikrofone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加できるマイクはありません"
           }
         }
       }
@@ -21293,6 +21357,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "削除"
+          }
+        }
+      }
+    },
+    "Remove microphone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイクを削除"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -6693,6 +6693,38 @@
         }
       }
     },
+    "Move Down": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach unten bewegen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下へ移動"
+          }
+        }
+      }
+    },
+    "Move Up": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach oben bewegen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上へ移動"
+          }
+        }
+      }
+    },
     "Name": {
       "localizations": {
         "de": {

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -101,6 +101,31 @@ struct AudioInputDevice: Identifiable, Equatable, Sendable {
     var id: String { uid }
 }
 
+struct AudioInputDevicePriorityItem: Identifiable, Codable, Equatable, Sendable {
+    let uid: String
+    var name: String
+
+    var id: String { uid }
+}
+
+struct ResolvedRecordingInputSelection: Equatable, Sendable {
+    let deviceUID: String?
+    let deviceID: AudioDeviceID?
+    let deviceName: String?
+    let usesBluetoothTransport: Bool
+
+    var hasExplicitDeviceSelection: Bool {
+        deviceUID != nil && deviceID != nil
+    }
+
+    static let systemDefault = ResolvedRecordingInputSelection(
+        deviceUID: nil,
+        deviceID: nil,
+        deviceName: nil,
+        usesBluetoothTransport: false
+    )
+}
+
 struct AudioInputDiagnosticsReport: Encodable, Equatable, Sendable {
     struct Device: Encodable, Equatable, Sendable {
         let deviceID: UInt32
@@ -232,6 +257,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             handleSelectedDeviceSelectionChange(from: oldValue, to: selectedDeviceUID)
         }
     }
+    @Published private(set) var inputDevicePriorityList: [AudioInputDevicePriorityItem] = []
     @Published var disconnectedDeviceName: String?
     @Published var isPreviewActive: Bool = false
     @Published var previewAudioLevel: Float = 0
@@ -250,6 +276,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     var selectedDeviceID: AudioDeviceID? {
         guard let uid = selectedDeviceUID else { return nil }
+        if let device = inputDevices.first(where: { $0.uid == uid }) {
+            return resolvedAudioDeviceID(for: device)
+        }
         if let audioDeviceIDResolverOverride {
             return audioDeviceIDResolverOverride(uid)
         }
@@ -287,6 +316,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private var compatibilityCache: [String: AudioInputDeviceCompatibility] = [:]
     private var isApplyingValidatedSelection = false
     private var isInitializingSelection = false
+    private var isSynchronizingSelectionFromPriorityList = false
+    private var pendingPrimaryPriorityReplacementUID: String?
     private static let bluetoothPreviewConfigurationChangeIgnoreWindow: TimeInterval = 3.0
 
     private var hasMicrophonePermission: Bool {
@@ -384,6 +415,10 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         isInitializingSelection = true
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         inputDevices = applyCompatibilityCache(to: initialInputDevices ?? listInputDevices())
+        inputDevicePriorityList = initialInputDevicePriorityList(
+            savedSelectionUID: selectedDeviceUID,
+            devices: inputDevices
+        )
         if monitorDeviceChanges {
             installDeviceListener()
         }
@@ -408,6 +443,91 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         stopPreview()
     }
 
+    var inputDevicePriorityCandidates: [AudioInputDevice] {
+        let prioritizedUIDs = Set(inputDevicePriorityList.map(\.uid))
+        return inputDevices.filter { !prioritizedUIDs.contains($0.uid) }
+    }
+
+    func displayName(for priorityItem: AudioInputDevicePriorityItem) -> String {
+        if let device = inputDevices.first(where: { $0.uid == priorityItem.uid }) {
+            return displayName(for: device)
+        }
+        return priorityItem.name
+    }
+
+    func isInputDevicePriorityItemAvailable(_ item: AudioInputDevicePriorityItem) -> Bool {
+        inputDevices.contains(where: { $0.uid == item.uid })
+    }
+
+    func addInputDeviceToPriorityList(_ device: AudioInputDevice) {
+        var items = inputDevicePriorityList
+        guard !items.contains(where: { $0.uid == device.uid }) else { return }
+        items.append(AudioInputDevicePriorityItem(uid: device.uid, name: device.name))
+        setInputDevicePriorityList(items)
+    }
+
+    func removeInputDevicePriorityItem(_ item: AudioInputDevicePriorityItem) {
+        setInputDevicePriorityList(inputDevicePriorityList.filter { $0.uid != item.uid })
+    }
+
+    func moveInputDevicePriorityItems(from source: IndexSet, to destination: Int) {
+        guard !source.isEmpty else { return }
+
+        var items = inputDevicePriorityList
+        let validSource = source.filter { items.indices.contains($0) }.sorted()
+        guard !validSource.isEmpty else { return }
+
+        let movingItems = validSource.map { items[$0] }
+        for index in validSource.reversed() {
+            items.remove(at: index)
+        }
+
+        let removedBeforeDestination = validSource.filter { $0 < destination }.count
+        let adjustedDestination = max(0, min(items.count, destination - removedBeforeDestination))
+        items.insert(contentsOf: movingItems, at: adjustedDestination)
+        setInputDevicePriorityList(items)
+    }
+
+    func clearInputDevicePriorityList() {
+        setInputDevicePriorityList([])
+    }
+
+    func selectInputDeviceAsPrimary(_ uid: String) {
+        pendingPrimaryPriorityReplacementUID = uid
+        if selectedDeviceUID == uid {
+            replaceInputDevicePriorityListWithDevice(uid: uid)
+            pendingPrimaryPriorityReplacementUID = nil
+            return
+        }
+
+        selectedDeviceUID = uid
+        if selectedDeviceUID != uid {
+            pendingPrimaryPriorityReplacementUID = nil
+        }
+    }
+
+    func resolvedRecordingInputSelection() -> ResolvedRecordingInputSelection {
+        var candidateUIDs = inputDevicePriorityList.map(\.uid)
+        if candidateUIDs.isEmpty, let selectedDeviceUID {
+            candidateUIDs = [selectedDeviceUID]
+        }
+
+        for uid in candidateUIDs {
+            guard let device = inputDevices.first(where: { $0.uid == uid }) else { continue }
+            guard let deviceID = resolvedAudioDeviceID(for: device) else { continue }
+            let usesBluetoothTransport = transportType(for: deviceID)
+                .map(Self.isBluetoothTransportType) ?? false
+            return ResolvedRecordingInputSelection(
+                deviceUID: uid,
+                deviceID: deviceID,
+                deviceName: device.name,
+                usesBluetoothTransport: usesBluetoothTransport
+            )
+        }
+
+        return .systemDefault
+    }
+
     // MARK: - Audio Preview
 
     func startPreview() {
@@ -418,13 +538,14 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             return
         }
 
-        let preferredDeviceID = selectedDeviceID
-        if let selectionError = selectedInputDeviceError(for: preferredDeviceID) {
+        let resolvedInputSelection = resolvedRecordingInputSelection()
+        let preferredDeviceID = resolvedInputSelection.deviceID
+        if let selectionError = selectedInputDeviceError(for: resolvedInputSelection) {
             previewError = selectionError
             return
         }
 
-        let usesBluetoothPreviewInput = previewInputUsesBluetoothTransport(preferredDeviceID)
+        let usesBluetoothPreviewInput = resolvedInputSelection.usesBluetoothTransport
         let captureRoute = AudioInputCaptureRoute.selectedRoute(
             selectedDeviceID: preferredDeviceID,
             usesBluetoothTransport: usesBluetoothPreviewInput
@@ -477,7 +598,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 }
                 outputVolumeGuard.restoreIfRaised(reason: "preview-start-override-failed")
                 outputVolumeGuard.clear()
-                previewError = selectedDeviceUID == nil ? nil : .incompatible(.engineStartFailed)
+                previewError = resolvedInputSelection.hasExplicitDeviceSelection ? .incompatible(.engineStartFailed) : nil
                 isPreviewActive = false
             }
             return
@@ -486,22 +607,24 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         if case .inputOnlyDevice(let inputOnlyDeviceID) = captureRoute {
             do {
                 try startInputOnlyPreviewCapture(deviceID: inputOnlyDeviceID, label: "preview")
-                if selectedDeviceUID != nil {
-                    markSelectedDeviceCompatibility(.compatible)
+                if let uid = resolvedInputSelection.deviceUID {
+                    markInputDeviceCompatibility(.compatible, uid: uid)
                 }
                 outputVolumeGuard.restoreIfRaised(reason: "preview-start")
                 outputVolumeGuard.clear()
                 isPreviewActive = true
             } catch let error as SelectedInputDeviceError {
                 if case .incompatible(let issue) = error {
-                    markSelectedDeviceCompatibility(.incompatible(issue))
+                    if let uid = resolvedInputSelection.deviceUID {
+                        markInputDeviceCompatibility(.incompatible(issue), uid: uid)
+                    }
                 }
                 previewError = error
                 cleanupAfterFailedInputOnlyPreviewStart()
             } catch {
                 logger.error("Failed to start input-only preview capture: \(error.localizedDescription)")
-                if selectedDeviceUID != nil {
-                    markSelectedDeviceCompatibility(.incompatible(.engineStartFailed))
+                if let uid = resolvedInputSelection.deviceUID {
+                    markInputDeviceCompatibility(.incompatible(.engineStartFailed), uid: uid)
                     previewError = .incompatible(.engineStartFailed)
                 }
                 cleanupAfterFailedInputOnlyPreviewStart()
@@ -526,8 +649,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         do {
             try startPreviewEngineWithRecovery(engine, preferredDeviceID: enginePreferredDeviceID, label: "preview")
-            if selectedDeviceUID != nil {
-                markSelectedDeviceCompatibility(.compatible)
+            if let uid = resolvedInputSelection.deviceUID {
+                markInputDeviceCompatibility(.compatible, uid: uid)
             }
 
             let startupRecoveryAction = previewRecoveryCoordinator.finishStartingSuccessfully()
@@ -545,14 +668,16 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             isPreviewActive = true
         } catch let error as SelectedInputDeviceError {
             if case .incompatible(let issue) = error {
-                markSelectedDeviceCompatibility(.incompatible(issue))
+                if let uid = resolvedInputSelection.deviceUID {
+                    markInputDeviceCompatibility(.incompatible(issue), uid: uid)
+                }
             }
             previewError = error
             cleanupAfterFailedPreviewStart(engine)
         } catch {
             logger.error("Failed to start preview engine: \(error.localizedDescription)")
-            if selectedDeviceUID != nil {
-                markSelectedDeviceCompatibility(.incompatible(.engineStartFailed))
+            if let uid = resolvedInputSelection.deviceUID {
+                markInputDeviceCompatibility(.incompatible(.engineStartFailed), uid: uid)
                 previewError = .incompatible(.engineStartFailed)
             }
             cleanupAfterFailedPreviewStart(engine)
@@ -1428,6 +1553,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             newDevices.contains(where: { $0.uid == uid })
         }
         inputDevices = applyCompatibilityCache(to: newDevices)
+        refreshInputDevicePriorityNames()
 
         if let uid = selectedDeviceUID,
            !newDevices.contains(where: { $0.uid == uid }) {
@@ -1448,9 +1574,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 if refreshedDevices.contains(where: { $0.uid == uid }) {
                     logger.info("Device reappeared after reconfiguration: \(deviceName ?? uid)")
                     self.inputDevices = refreshedDevices
+                    self.refreshInputDevicePriorityNames()
                 } else {
                     logger.info("Selected device confirmed disconnected: \(deviceName ?? uid)")
                     self.inputDevices = refreshedDevices
+                    self.refreshInputDevicePriorityNames()
                     if self.isPreviewActive { self.stopPreview() }
                     self.selectedDeviceUID = nil
                     self.disconnectedDeviceName = deviceName
@@ -1473,12 +1601,29 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     func markSelectedDeviceCompatibility(_ compatibility: AudioInputDeviceCompatibility) {
         guard let selectedDeviceUID else { return }
-        compatibilityCache[selectedDeviceUID] = compatibility
+        markInputDeviceCompatibility(compatibility, uid: selectedDeviceUID)
+    }
+
+    func markRecordingInputSelectionCompatibility(
+        _ compatibility: AudioInputDeviceCompatibility,
+        selection: ResolvedRecordingInputSelection
+    ) {
+        guard let uid = selection.deviceUID else { return }
+        markInputDeviceCompatibility(compatibility, uid: uid)
+    }
+
+    private func markInputDeviceCompatibility(_ compatibility: AudioInputDeviceCompatibility, uid: String) {
+        compatibilityCache[uid] = compatibility
         inputDevices = applyCompatibilityCache(to: inputDevices)
     }
 
     private func handleSelectedDeviceSelectionChange(from oldValue: String?, to newValue: String?) {
         if isInitializingSelection {
+            return
+        }
+
+        if isSynchronizingSelectionFromPriorityList {
+            persistSelectedDeviceUID()
             return
         }
 
@@ -1503,6 +1648,12 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             compatibilityCache[newValue] = .compatible
             inputDevices = applyCompatibilityCache(to: inputDevices)
             persistSelectedDeviceUID()
+            if pendingPrimaryPriorityReplacementUID == newValue {
+                replaceInputDevicePriorityListWithDevice(uid: newValue)
+                pendingPrimaryPriorityReplacementUID = nil
+            } else {
+                promoteInputDeviceToPriorityList(uid: newValue)
+            }
 
             if isPreviewActive {
                 stopPreview()
@@ -1514,17 +1665,29 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 inputDevices = applyCompatibilityCache(to: inputDevices)
             }
             previewError = error
+            if pendingPrimaryPriorityReplacementUID == newValue {
+                pendingPrimaryPriorityReplacementUID = nil
+            }
             revertSelectedDeviceUID(to: oldValue)
         } catch {
             compatibilityCache[newValue] = .incompatible(.engineStartFailed)
             inputDevices = applyCompatibilityCache(to: inputDevices)
             previewError = .incompatible(.engineStartFailed)
+            if pendingPrimaryPriorityReplacementUID == newValue {
+                pendingPrimaryPriorityReplacementUID = nil
+            }
             revertSelectedDeviceUID(to: oldValue)
         }
     }
 
     private func validateDeviceSelection(uid: String) throws {
-        guard let deviceID = audioDeviceIDResolverOverride?(uid) ?? Self.audioDeviceID(fromUID: uid) else {
+        let deviceID: AudioDeviceID?
+        if let device = inputDevices.first(where: { $0.uid == uid }) {
+            deviceID = resolvedAudioDeviceID(for: device)
+        } else {
+            deviceID = audioDeviceIDResolverOverride?(uid) ?? Self.audioDeviceID(fromUID: uid)
+        }
+        guard let deviceID else {
             throw SelectedInputDeviceError.unavailable
         }
 
@@ -1654,6 +1817,113 @@ final class AVAudioInputSelectionEngineValidator: AudioInputSelectionEngineValid
 }
 
 extension AudioDeviceService {
+    private static func loadInputDevicePriorityList() -> [AudioInputDevicePriorityItem] {
+        guard let data = UserDefaults.standard.data(forKey: UserDefaultsKeys.inputDevicePriorityList) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([AudioInputDevicePriorityItem].self, from: data)) ?? []
+    }
+
+    private static func persistInputDevicePriorityList(_ items: [AudioInputDevicePriorityItem]) {
+        if items.isEmpty {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.inputDevicePriorityList)
+            return
+        }
+        guard let data = try? JSONEncoder().encode(items) else { return }
+        UserDefaults.standard.set(data, forKey: UserDefaultsKeys.inputDevicePriorityList)
+    }
+
+    private func initialInputDevicePriorityList(
+        savedSelectionUID: String?,
+        devices: [AudioInputDevice]
+    ) -> [AudioInputDevicePriorityItem] {
+        let savedItems = Self.normalizedInputDevicePriorityList(
+            Self.loadInputDevicePriorityList(),
+            devices: devices
+        )
+        if !savedItems.isEmpty {
+            Self.persistInputDevicePriorityList(savedItems)
+            return savedItems
+        }
+
+        guard let savedSelectionUID else { return [] }
+        let item = AudioInputDevicePriorityItem(
+            uid: savedSelectionUID,
+            name: devices.first(where: { $0.uid == savedSelectionUID })?.name ?? savedSelectionUID
+        )
+        Self.persistInputDevicePriorityList([item])
+        return [item]
+    }
+
+    private static func normalizedInputDevicePriorityList(
+        _ items: [AudioInputDevicePriorityItem],
+        devices: [AudioInputDevice]
+    ) -> [AudioInputDevicePriorityItem] {
+        var seenUIDs = Set<String>()
+        var normalized: [AudioInputDevicePriorityItem] = []
+
+        for item in items {
+            let uid = item.uid.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !uid.isEmpty, !seenUIDs.contains(uid) else { continue }
+            seenUIDs.insert(uid)
+
+            let name = devices.first(where: { $0.uid == uid })?.name
+                ?? item.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            normalized.append(AudioInputDevicePriorityItem(
+                uid: uid,
+                name: name.isEmpty ? uid : name
+            ))
+        }
+
+        return normalized
+    }
+
+    private func setInputDevicePriorityList(_ items: [AudioInputDevicePriorityItem]) {
+        let previousSelectedDeviceUID = selectedDeviceUID
+        let normalized = Self.normalizedInputDevicePriorityList(items, devices: inputDevices)
+        inputDevicePriorityList = normalized
+        Self.persistInputDevicePriorityList(normalized)
+        synchronizeSelectedDeviceUIDFromPriorityList()
+
+        if isPreviewActive, previousSelectedDeviceUID != selectedDeviceUID {
+            stopPreview()
+            startPreview()
+        }
+    }
+
+    private func synchronizeSelectedDeviceUIDFromPriorityList() {
+        isSynchronizingSelectionFromPriorityList = true
+        selectedDeviceUID = inputDevicePriorityList.first?.uid
+        isSynchronizingSelectionFromPriorityList = false
+        persistSelectedDeviceUID()
+    }
+
+    private func promoteInputDeviceToPriorityList(uid: String) {
+        guard let device = inputDevices.first(where: { $0.uid == uid }) else { return }
+        let promotedItem = AudioInputDevicePriorityItem(uid: device.uid, name: device.name)
+        let remainingItems = inputDevicePriorityList.filter { $0.uid != uid }
+        setInputDevicePriorityList([promotedItem] + remainingItems)
+    }
+
+    private func replaceInputDevicePriorityListWithDevice(uid: String) {
+        guard let device = inputDevices.first(where: { $0.uid == uid }) else { return }
+        setInputDevicePriorityList([AudioInputDevicePriorityItem(uid: device.uid, name: device.name)])
+    }
+
+    private func refreshInputDevicePriorityNames() {
+        let normalized = Self.normalizedInputDevicePriorityList(inputDevicePriorityList, devices: inputDevices)
+        guard normalized != inputDevicePriorityList else { return }
+        inputDevicePriorityList = normalized
+        Self.persistInputDevicePriorityList(normalized)
+    }
+
+    private func resolvedAudioDeviceID(for device: AudioInputDevice) -> AudioDeviceID? {
+        if let audioDeviceIDResolverOverride {
+            return audioDeviceIDResolverOverride(device.uid)
+        }
+        return Self.audioDeviceID(fromUID: device.uid) ?? device.deviceID
+    }
+
     private func revertSelectedDeviceUID(to value: String?) {
         isApplyingValidatedSelection = true
         selectedDeviceUID = value
@@ -1664,11 +1934,12 @@ extension AudioDeviceService {
         UserDefaults.standard.set(selectedDeviceUID, forKey: UserDefaultsKeys.selectedInputDeviceUID)
     }
 
-    private func selectedInputDeviceError(for preferredDeviceID: AudioDeviceID?) -> SelectedInputDeviceError? {
-        guard let selectedDeviceUID else { return nil }
-        guard preferredDeviceID != nil else { return .unavailable }
+    private func selectedInputDeviceError(for selection: ResolvedRecordingInputSelection) -> SelectedInputDeviceError? {
+        guard let deviceUID = selection.deviceUID else { return nil }
+        guard selection.deviceID != nil else { return .unavailable }
 
-        switch compatibilityCache[selectedDeviceUID] ?? selectedDevice?.compatibility ?? .unknown {
+        let deviceCompatibility = inputDevices.first(where: { $0.uid == deviceUID })?.compatibility
+        switch compatibilityCache[deviceUID] ?? deviceCompatibility ?? .unknown {
         case .incompatible(let issue):
             return .incompatible(issue)
         case .unknown, .compatible:

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -456,13 +456,23 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     @Published private(set) var systemLevel: Float = 0
     @Published private(set) var systemAudioWarningMessage: String?
     var recordingsDirectoryOverride: URL?
-    var startRecordingOverride: ((_ micEnabled: Bool, _ systemAudioEnabled: Bool, _ format: OutputFormat, _ outputURL: URL) async throws -> URL)?
+    var startRecordingOverride: ((
+        _ micEnabled: Bool,
+        _ systemAudioEnabled: Bool,
+        _ format: OutputFormat,
+        _ outputURL: URL,
+        _ microphoneSelection: ResolvedRecordingInputSelection
+    ) async throws -> URL)?
     var stopRecordingOverride: ((_ outputURL: URL) async throws -> URL?)?
     var currentBufferOverride: (() -> [Float])?
 
     private var audioEngine: AVAudioEngine?
+    private var micInputCaptureSession: AudioInputCaptureSession?
     private let micDefaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController()
     private let micTransportResolver: AudioDeviceTransportResolving = CoreAudioDeviceTransportResolver()
+    private let micBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing
+    private let micInputCaptureFactory: AudioInputCaptureFactory
+    private let micInputActivationGuard: AudioInputDeviceActivating
     private let micFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
     private var scStream: SCStream?
     private var streamOutput: SystemAudioStreamOutput?
@@ -493,6 +503,16 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     private static let systemAudioNonSilentThreshold: Float = 0.0001
 
     static let recordingsDirectoryName = "TypeWhisper Recordings"
+
+    init(
+        inputActivationGuard: AudioInputDeviceActivating = AudioInputDeviceActivationGuard(),
+        bluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
+        inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory()
+    ) {
+        self.micInputActivationGuard = inputActivationGuard
+        self.micBluetoothInputRouteStabilizer = bluetoothInputRouteStabilizer
+        self.micInputCaptureFactory = inputCaptureFactory
+    }
 
     var recordingsDirectory: URL {
         if let recordingsDirectoryOverride {
@@ -593,7 +613,12 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         }
     }
 
-    func startRecording(micEnabled: Bool, systemAudioEnabled: Bool, format: OutputFormat) async throws -> URL {
+    func startRecording(
+        micEnabled: Bool,
+        systemAudioEnabled: Bool,
+        format: OutputFormat,
+        microphoneSelection: ResolvedRecordingInputSelection = .systemDefault
+    ) async throws -> URL {
         guard micEnabled || systemAudioEnabled else {
             throw RecorderError.noSourceEnabled
         }
@@ -619,7 +644,13 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
         if let startRecordingOverride {
             do {
-                self.finalOutputURL = try await startRecordingOverride(micEnabled, systemAudioEnabled, format, outputURL)
+                self.finalOutputURL = try await startRecordingOverride(
+                    micEnabled,
+                    systemAudioEnabled,
+                    format,
+                    outputURL,
+                    microphoneSelection
+                )
             } catch {
                 await rollbackFailedStart()
                 throw error
@@ -638,7 +669,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
                     let micURL = tempDir.appendingPathComponent("mic-\(sessionId).wav")
                     self.micTempURL = micURL
-                    try startMicRecording(outputURL: micURL)
+                    try startMicRecording(outputURL: micURL, microphoneSelection: microphoneSelection)
                 }
 
                 // Start system audio recording
@@ -725,6 +756,14 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             streamOutput = nil
         }
 
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        micInputCaptureSession?.stop()
+        micInputCaptureSession = nil
+        micInputActivationGuard.restore(reason: "recorder-mic-stop")
+        micFileLock.withLock { $0 = nil }
+
         var completedURL = finalOutputURL
 
         // Mix or copy to final output
@@ -765,7 +804,36 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     // MARK: - Microphone Recording
 
-    private func startMicRecording(outputURL: URL) throws {
+    private func startMicRecording(
+        outputURL: URL,
+        microphoneSelection: ResolvedRecordingInputSelection
+    ) throws {
+        if microphoneSelection.hasExplicitDeviceSelection,
+           !microphoneSelection.usesBluetoothTransport,
+           let deviceID = microphoneSelection.deviceID {
+            try startInputOnlyMicRecording(deviceID: deviceID, outputURL: outputURL)
+            return
+        }
+
+        if microphoneSelection.hasExplicitDeviceSelection,
+           microphoneSelection.usesBluetoothTransport {
+            guard micInputActivationGuard.activateIfNeeded(
+                deviceID: microphoneSelection.deviceID,
+                usesBluetoothTransport: true,
+                reason: "recorder-mic-start"
+            ) else {
+                throw RecorderError.engineStartFailed("Selected microphone conflicts with the current audio route.")
+            }
+
+            guard micBluetoothInputRouteStabilizer.waitForActivatedDefaultInput(
+                deviceID: microphoneSelection.deviceID,
+                reason: "recorder-mic-start"
+            ) else {
+                micInputActivationGuard.restore(reason: "recorder-mic-route-stabilization-failed")
+                throw RecorderError.engineStartFailed("Selected microphone did not become the active input route.")
+            }
+        }
+
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         var inputFormat = inputNode.outputFormat(forBus: 0)
@@ -904,6 +972,94 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
         try engine.start()
         audioEngine = engine
+    }
+
+    private func startInputOnlyMicRecording(deviceID: AudioDeviceID, outputURL: URL) throws {
+        let inputFormat = try micInputCaptureFactory.inputOnlyCaptureFormat(deviceID: deviceID)
+        guard let monoFormat = AudioInputBufferNormalizer.monoFloatFormat(for: inputFormat) else {
+            throw RecorderError.engineStartFailed("Cannot create input-only microphone format")
+        }
+
+        let audioFile = try AVAudioFile(
+            forWriting: outputURL,
+            settings: [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: monoFormat.sampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false,
+            ]
+        )
+
+        guard let transcriptionFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.transcriptionSampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw RecorderError.engineStartFailed("Cannot create transcription format")
+        }
+        let transcriptionConverter = AVAudioConverter(from: monoFormat, to: transcriptionFormat)
+
+        micFileLock.withLock { $0 = audioFile }
+
+        let session = try micInputCaptureFactory.startInputOnlyCapture(
+            deviceID: deviceID,
+            label: "recorder-mic",
+            bufferSize: 4096
+        ) { [weak self] buffer in
+            guard let self,
+                  let writeBuffer = AudioInputBufferNormalizer.monoFloatBuffer(from: buffer) else { return }
+
+            if let channelData = writeBuffer.floatChannelData?[0] {
+                let samples = UnsafeBufferPointer(start: channelData, count: Int(writeBuffer.frameLength))
+                let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
+                let level = min(1.0, rms * 5)
+                DispatchQueue.main.async {
+                    self.micLevel = level
+                }
+            }
+
+            self.micFileLock.withLock { file in
+                guard let file else { return }
+                do {
+                    try file.write(from: writeBuffer)
+                } catch {
+                    logger.error("Failed to write input-only mic audio: \(error.localizedDescription)")
+                }
+            }
+
+            if let transcriptionConverter {
+                let targetFrameCount = AVAudioFrameCount(
+                    Double(writeBuffer.frameLength) * Self.transcriptionSampleRate / monoFormat.sampleRate
+                )
+                guard targetFrameCount > 0,
+                      let convertedBuffer = AVAudioPCMBuffer(pcmFormat: transcriptionFormat, frameCapacity: targetFrameCount) else { return }
+                var convError: NSError?
+                let convConsumed = OSAllocatedUnfairLock(initialState: false)
+                transcriptionConverter.convert(to: convertedBuffer, error: &convError) { _, outStatus in
+                    let wasConsumed = convConsumed.withLock { flag in
+                        let prev = flag
+                        flag = true
+                        return prev
+                    }
+                    if wasConsumed {
+                        outStatus.pointee = .noDataNow
+                        return nil
+                    }
+                    outStatus.pointee = .haveData
+                    return writeBuffer
+                }
+                if convError == nil, convertedBuffer.frameLength > 0,
+                   let data = convertedBuffer.floatChannelData?[0] {
+                    let samples = Array(UnsafeBufferPointer(start: data, count: Int(convertedBuffer.frameLength)))
+                    self.appendMicTranscriptionSamples(samples)
+                }
+            }
+        }
+
+        micInputCaptureSession = session
     }
 
     private func enableMicVoiceProcessingIfNeeded(
@@ -1504,6 +1660,9 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         audioEngine?.inputNode.removeTap(onBus: 0)
         audioEngine?.stop()
         audioEngine = nil
+        micInputCaptureSession?.stop()
+        micInputCaptureSession = nil
+        micInputActivationGuard.restore(reason: "recorder-mic-rollback")
         micFileLock.withLock { $0 = nil }
 
         cleanupTempFile(micTempURL)

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -187,6 +187,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let configLock = NSLock()
     private let stopStateLock = NSLock()
     private let engineLock = NSLock()
+    private let audioLevelPublishLock = NSLock()
     private let processingQueue = DispatchQueue(label: "com.typewhisper.audio-processing", qos: .userInteractive)
     private let recoveryQueue = DispatchQueue(label: "com.typewhisper.audio-recovery", qos: .userInitiated)
     private let engineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.audio-engine-teardown")
@@ -203,9 +204,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private var _lastStopGraceCaptureApplied = false
     private var recordingRequestUptimeNanoseconds: UInt64?
     private var hasLoggedFirstConvertedSample = false
+    private var lastAudioLevelPublishUptimeNanoseconds: UInt64 = 0
+    private var pendingAudioLevelUpdate: (level: Float, rms: Float)?
+    private var isAudioLevelPublishScheduled = false
 
     static let targetSampleRate: Double = 16000
     private static let captureTapFrames: AVAudioFrameCount = 256
+    private static let audioLevelPublishIntervalNanoseconds: UInt64 = 33_333_333
     private static let engineTeardownRetentionInterval: TimeInterval = 0.3
 
     init(
@@ -456,6 +461,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             }
 
             setLastStopGraceCaptureApplied(false)
+            resetAudioLevelPublishing()
             DispatchQueue.main.async { [weak self] in
                 self?.isRecording = false
                 self?.audioLevel = normalizedLevel
@@ -498,9 +504,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
             let samples = drainSampleBuffer()
 
+            resetAudioLevelPublishing()
             DispatchQueue.main.async { [weak self] in
                 self?.isRecording = false
                 self?.audioLevel = 0
+                self?.rawAudioLevel = 0
             }
 
             return samples
@@ -542,9 +550,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         let samples = drainSampleBuffer()
 
+        resetAudioLevelPublishing()
         DispatchQueue.main.async { [weak self] in
             self?.isRecording = false
             self?.audioLevel = 0
+            self?.rawAudioLevel = 0
         }
 
         return samples
@@ -928,6 +938,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         outputVolumeGuard.restoreIfRaised(reason: "recording-start-failed")
         outputVolumeGuard.clear()
         inputActivationGuard.restore(reason: "recording-start-failed")
+        resetAudioLevelPublishing()
         DispatchQueue.main.async { [weak self] in
             self?.isRecording = false
             self?.audioLevel = 0
@@ -961,6 +972,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         hasLoggedFirstConvertedSample = false
         bufferLock.unlock()
         initialInputTapSeenLock.withLock { $0 = false }
+        resetAudioLevelPublishing()
     }
 
     private func markInitialInputTapSeenIfNeeded(_ buffer: AVAudioPCMBuffer) {
@@ -1110,6 +1122,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         outputVolumeGuard.restoreIfRaised(reason: "recording-start-failed")
         outputVolumeGuard.clear()
         inputActivationGuard.restore(reason: "recording-start-failed")
+        resetAudioLevelPublishing()
         DispatchQueue.main.async { [weak self] in
             self?.isRecording = false
             self?.audioLevel = 0
@@ -1145,14 +1158,71 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             )
         }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.audioLevel = normalizedLevel
-            self.rawAudioLevel = rms
-            if didReceiveFirstBuffer {
-                self.onFirstRecordingAudioBuffer?()
+        publishAudioLevel(normalizedLevel, rms: rms, force: didReceiveFirstBuffer)
+        if didReceiveFirstBuffer {
+            DispatchQueue.main.async { [weak self] in
+                self?.onFirstRecordingAudioBuffer?()
             }
         }
+    }
+
+    private func publishAudioLevel(_ level: Float, rms: Float, force: Bool = false) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        var shouldPublishNow = false
+        var publishDelayNanoseconds: UInt64?
+
+        audioLevelPublishLock.lock()
+        let elapsed = now &- lastAudioLevelPublishUptimeNanoseconds
+        if force || lastAudioLevelPublishUptimeNanoseconds == 0 || elapsed >= Self.audioLevelPublishIntervalNanoseconds {
+            lastAudioLevelPublishUptimeNanoseconds = now
+            pendingAudioLevelUpdate = nil
+            shouldPublishNow = true
+        } else {
+            pendingAudioLevelUpdate = (level, rms)
+            if !isAudioLevelPublishScheduled {
+                isAudioLevelPublishScheduled = true
+                publishDelayNanoseconds = Self.audioLevelPublishIntervalNanoseconds - elapsed
+            }
+        }
+        audioLevelPublishLock.unlock()
+
+        if shouldPublishNow {
+            DispatchQueue.main.async { [weak self] in
+                self?.audioLevel = level
+                self?.rawAudioLevel = rms
+            }
+        }
+
+        if let publishDelayNanoseconds {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .nanoseconds(Int(publishDelayNanoseconds))) { [weak self] in
+                self?.flushPendingAudioLevelUpdate()
+            }
+        }
+    }
+
+    private func flushPendingAudioLevelUpdate() {
+        let update: (level: Float, rms: Float)?
+
+        audioLevelPublishLock.lock()
+        update = pendingAudioLevelUpdate
+        pendingAudioLevelUpdate = nil
+        isAudioLevelPublishScheduled = false
+        if update != nil {
+            lastAudioLevelPublishUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+        }
+        audioLevelPublishLock.unlock()
+
+        guard let update else { return }
+        audioLevel = update.level
+        rawAudioLevel = update.rms
+    }
+
+    private func resetAudioLevelPublishing() {
+        audioLevelPublishLock.lock()
+        lastAudioLevelPublishUptimeNanoseconds = 0
+        pendingAudioLevelUpdate = nil
+        isAudioLevelPublishScheduled = false
+        audioLevelPublishLock.unlock()
     }
 
 #if DEBUG
@@ -1415,6 +1485,14 @@ extension AudioRecordingService {
 
     func testingProcessConvertedSamples(_ samples: [Float]) {
         processConvertedSamples(samples)
+    }
+
+    func testingMarkAudioLevelPublishedNow() {
+        audioLevelPublishLock.lock()
+        lastAudioLevelPublishUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+        pendingAudioLevelUpdate = nil
+        isAudioLevelPublishScheduled = false
+        audioLevelPublishLock.unlock()
     }
 
     func testingFailActiveRecordingDueToRecovery(_ error: AudioRecordingError) {

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -1037,6 +1037,9 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
         logger.warning("CGEventTap was disabled by system, re-enabling")
+        DispatchQueue.main.async { [weak self] in
+            self?.recoverReleasedActiveHotkeyAfterEventTapDisable()
+        }
     }
 
     private func handleEventTapCallback(_ event: CGEvent) -> Bool {
@@ -1063,7 +1066,9 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
                 hotkey: Self.escapeHotkey,
                 source: source
             ) {
-                onCancelPressed?()
+                performHotkeyAction(source: source) { [weak self] in
+                    self?.onCancelPressed?()
+                }
             }
             return false
         }
@@ -1368,14 +1373,18 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             if source != .eventTap {
                 logFallbackMatchIfNeeded(hotkey: hotkey, source: source)
             }
-            handleKeyDown(slotType: slotType, hotkey: hotkey)
+            performHotkeyAction(source: source) { [weak self] in
+                self?.handleKeyDown(slotType: slotType, hotkey: hotkey)
+            }
         } else if keyUp, shouldDispatch(
             target: .slot(slotType),
             phase: .up,
             hotkey: hotkey,
             source: source
         ) {
-            handleKeyUp(slotType: slotType)
+            performHotkeyAction(source: source) { [weak self] in
+                self?.handleKeyUp(slotType: slotType)
+            }
         }
     }
 
@@ -1395,14 +1404,18 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             if source != .eventTap {
                 logFallbackMatchIfNeeded(hotkey: hotkey, source: source)
             }
-            handleProfileKeyDown(profileId: profileId)
+            performHotkeyAction(source: source) { [weak self] in
+                self?.handleProfileKeyDown(profileId: profileId)
+            }
         } else if keyUp, shouldDispatch(
             target: .profile(profileId),
             phase: .up,
             hotkey: hotkey,
             source: source
         ) {
-            handleProfileKeyUp(profileId: profileId)
+            performHotkeyAction(source: source) { [weak self] in
+                self?.handleProfileKeyUp(profileId: profileId)
+            }
         }
     }
 
@@ -1428,14 +1441,30 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             if source != .eventTap {
                 logFallbackMatchIfNeeded(hotkey: hotkey, source: source)
             }
-            handleWorkflowKeyDown(workflowId: workflowId, behavior: behavior)
+            performHotkeyAction(source: source) { [weak self] in
+                self?.handleWorkflowKeyDown(workflowId: workflowId, behavior: behavior)
+            }
         } else if keyUp, !isTextProcessingModifierRelease, shouldDispatch(
             target: .workflow(workflowId),
             phase: .up,
             hotkey: hotkey,
             source: source
         ) {
-            handleWorkflowKeyUp(workflowId: workflowId, behavior: behavior)
+            performHotkeyAction(source: source) { [weak self] in
+                self?.handleWorkflowKeyUp(workflowId: workflowId, behavior: behavior)
+            }
+        }
+    }
+
+    private func performHotkeyAction(
+        source: HotkeyEventSource,
+        _ action: @escaping @Sendable () -> Void
+    ) {
+        switch source {
+        case .eventTap:
+            DispatchQueue.main.async(execute: action)
+        case .monitor, .carbon:
+            action()
         }
     }
 
@@ -1493,6 +1522,46 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         logger.info("Matched hotkey via NSEvent compatibility fallback: \(Self.displayName(for: hotkey), privacy: .public)")
     }
 
+    private func recoverReleasedActiveHotkeyAfterEventTapDisable() {
+        guard isActive,
+              currentMode == .pushToTalk,
+              activeProfileId == nil,
+              activeWorkflowId == nil,
+              let slotType = activeSlotType,
+              let hotkey = activeGlobalHotkey,
+              !isHotkeyPhysicallyPressed(hotkey) else {
+            return
+        }
+
+        logger.warning(
+            "Recovering active dictation after CGEventTap disable; hotkey is no longer pressed: \(Self.displayName(for: hotkey), privacy: .public)"
+        )
+        handleKeyUp(slotType: slotType)
+    }
+
+    private func isHotkeyPhysicallyPressed(_ hotkey: UnifiedHotkey) -> Bool {
+        switch hotkey.kind {
+        case .fn:
+            return modifierFlagsStateProvider().contains(.function)
+        case .modifierOnly:
+            guard let flag = Self.modifierFlagForKeyCode(hotkey.keyCode) else { return false }
+            return modifierFlagsStateProvider().contains(flag)
+        case .modifierCombo:
+            let flags = modifierFlagsStateProvider()
+            if !hotkey.modifierKeyCodes.isEmpty {
+                let activeModifierKeyCodes = Self.modifierKeyCodes(from: flags)
+                return hotkey.modifierKeyCodes.isSubset(of: activeModifierKeyCodes)
+            }
+            let requiredFlags = NSEvent.ModifierFlags(rawValue: hotkey.modifierFlags)
+            let relevantMask: NSEvent.ModifierFlags = [.command, .option, .control, .shift, .function]
+            return flags.intersection(relevantMask).isSuperset(of: requiredFlags)
+        case .keyWithModifiers, .bareKey:
+            return keyStateProvider(hotkey.keyCode)
+        case .mouseButton:
+            return true
+        }
+    }
+
     private nonisolated static func supportsCarbonHotkey(_ hotkey: UnifiedHotkey) -> Bool {
         hotkey.kind == .keyWithModifiers
             && !hotkey.isDoubleTap
@@ -1529,6 +1598,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     @discardableResult
     func processEventForTesting(_ event: NSEvent, source: HotkeyEventSource) -> Bool {
         handleEvent(event, source: source)
+    }
+
+    func recoverReleasedActiveHotkeyAfterEventTapDisableForTesting() {
+        recoverReleasedActiveHotkeyAfterEventTapDisable()
     }
 
     func needsMouseEventMonitoringForTesting() -> Bool {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -207,6 +207,7 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     private let recorderService: AudioRecorderService
+    private let audioDeviceService: AudioDeviceService
     private let modelManager: ModelManagerService
     private let dictionaryService: DictionaryService
     private let defaults: UserDefaults
@@ -223,10 +224,12 @@ final class AudioRecorderViewModel: ObservableObject {
         recorderService: AudioRecorderService,
         modelManager: ModelManagerService,
         dictionaryService: DictionaryService,
+        audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
         defaults: UserDefaults = .standard,
         livePreviewStartObserver: (() -> Void)? = nil
     ) {
         self.recorderService = recorderService
+        self.audioDeviceService = audioDeviceService
         self.modelManager = modelManager
         self.dictionaryService = dictionaryService
         self.defaults = defaults
@@ -460,15 +463,26 @@ final class AudioRecorderViewModel: ObservableObject {
         partialText = ""
         reconcileSelectionWithAvailablePlugins()
         state = .recording
+        let microphoneSelection = requestedMicEnabled
+            ? audioDeviceService.resolvedRecordingInputSelection()
+            : .systemDefault
 
         let url: URL
         do {
             url = try await recorderService.startRecording(
                 micEnabled: requestedMicEnabled,
                 systemAudioEnabled: requestedSystemAudioEnabled,
-                format: outputFormat
+                format: outputFormat,
+                microphoneSelection: microphoneSelection
             )
         } catch {
+            if let selectionError = error as? SelectedInputDeviceError,
+               case .incompatible(let issue) = selectionError {
+                audioDeviceService.markRecordingInputSelectionCompatibility(
+                    .incompatible(issue),
+                    selection: microphoneSelection
+                )
+            }
             state = .idle
             currentOutputURL = nil
             if let apiSessionID {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1046,12 +1046,14 @@ final class DictationViewModel: ObservableObject {
             return
         }
 
+        let resolvedInputSelection = audioDeviceService.resolvedRecordingInputSelection()
+
         do {
             let initialForcedWorkflow = forcedWorkflow(for: forcedWorkflowId)
             audioRecordingService.microphoneBoostEnabled = microphoneBoostEnabled(for: initialForcedWorkflow)
-            audioRecordingService.selectedDeviceID = audioDeviceService.selectedDeviceID
-            audioRecordingService.hasExplicitDeviceSelection = audioDeviceService.selectedDeviceUID != nil
-            let selectedInputUsesBluetooth = audioDeviceService.selectedDeviceUsesBluetoothTransport
+            audioRecordingService.selectedDeviceID = resolvedInputSelection.deviceID
+            audioRecordingService.hasExplicitDeviceSelection = resolvedInputSelection.hasExplicitDeviceSelection
+            let selectedInputUsesBluetooth = resolvedInputSelection.usesBluetoothTransport
             audioRecordingService.selectedInputDeviceUsesBluetoothTransport = selectedInputUsesBluetooth
             prepareRecordingStartCue(playsSound: !selectedInputUsesBluetooth)
             let audioStartTimestamp = DispatchTime.now().uptimeNanoseconds
@@ -1126,7 +1128,10 @@ final class DictationViewModel: ObservableObject {
                 errorMessage = String(localized: "No mic detected.")
             } else if let recordingError = error as? AudioRecordingService.AudioRecordingError,
                       case .selectedInputDeviceIncompatible(let issue) = recordingError {
-                audioDeviceService.markSelectedDeviceCompatibility(.incompatible(issue))
+                audioDeviceService.markRecordingInputSelectionCompatibility(
+                    .incompatible(issue),
+                    selection: resolvedInputSelection
+                )
                 errorMessage = recordingError.localizedDescription
             } else {
                 errorMessage = error.localizedDescription

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -151,7 +151,7 @@ struct NotchIndicatorView: View {
         .animation(.easeOut(duration: 0.24), value: currentWidth)
         .animation(.easeOut(duration: 0.24), value: expandedBodyHeight)
         .animation(.easeInOut(duration: 0.18), value: presentation.state)
-        .animation(.easeOut(duration: 0.08), value: presentation.audioLevel)
+        .animation(.linear(duration: 0.025), value: presentation.audioLevel)
         .onChange(of: presentation.partialText) {
             if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
                 withAnimation(.easeOut(duration: 0.24)) {

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -120,7 +120,7 @@ struct OverlayIndicatorView: View {
         .preferredColorScheme(.dark)
         .animation(.easeInOut(duration: 0.3), value: textExpanded)
         .animation(.easeInOut(duration: 0.2), value: presentation.state)
-        .animation(.easeOut(duration: 0.08), value: presentation.audioLevel)
+        .animation(.linear(duration: 0.025), value: presentation.audioLevel)
         .onChange(of: presentation.partialText) {
             expandTranscriptPreviewIfNeeded()
         }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -512,6 +512,8 @@ struct RecordingSettingsView: View {
 
     private func microphonePriorityRow(index: Int, item: AudioInputDevicePriorityItem) -> some View {
         let isAvailable = audioDevice.isInputDevicePriorityItemAvailable(item)
+        let canMoveUp = index > 0
+        let canMoveDown = index < audioDevice.inputDevicePriorityList.count - 1
 
         return HStack(spacing: 8) {
             Image(systemName: "line.3.horizontal")
@@ -550,6 +552,41 @@ struct RecordingSettingsView: View {
         .padding(.vertical, 3)
         .frame(minHeight: 24)
         .contentShape(Rectangle())
+        .contextMenu {
+            Button {
+                moveMicrophonePriorityItemUp(item)
+            } label: {
+                Label(String(localized: "Move Up"), systemImage: "chevron.up")
+            }
+            .disabled(!canMoveUp)
+
+            Button {
+                moveMicrophonePriorityItemDown(item)
+            } label: {
+                Label(String(localized: "Move Down"), systemImage: "chevron.down")
+            }
+            .disabled(!canMoveDown)
+        }
+        .modifier(MicrophonePriorityAccessibilityActions(
+            canMoveUp: canMoveUp,
+            canMoveDown: canMoveDown,
+            moveUp: { moveMicrophonePriorityItemUp(item) },
+            moveDown: { moveMicrophonePriorityItemDown(item) }
+        ))
+    }
+
+    private func moveMicrophonePriorityItemUp(_ item: AudioInputDevicePriorityItem) {
+        guard let index = audioDevice.inputDevicePriorityList.firstIndex(of: item),
+              index > 0 else { return }
+
+        audioDevice.moveInputDevicePriorityItems(from: IndexSet(integer: index), to: index - 1)
+    }
+
+    private func moveMicrophonePriorityItemDown(_ item: AudioInputDevicePriorityItem) {
+        guard let index = audioDevice.inputDevicePriorityList.firstIndex(of: item),
+              index < audioDevice.inputDevicePriorityList.count - 1 else { return }
+
+        audioDevice.moveInputDevicePriorityItems(from: IndexSet(integer: index), to: index + 2)
     }
 
     var body: some View {
@@ -884,6 +921,30 @@ private struct SoundEventPicker: View {
             selection = SoundChoice.custom(filename).storageKey
         } catch {
             // File copy failed - silently ignore
+        }
+    }
+}
+
+private struct MicrophonePriorityAccessibilityActions: ViewModifier {
+    let canMoveUp: Bool
+    let canMoveDown: Bool
+    let moveUp: () -> Void
+    let moveDown: () -> Void
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if canMoveUp && canMoveDown {
+            content
+                .accessibilityAction(named: Text(String(localized: "Move Up")), moveUp)
+                .accessibilityAction(named: Text(String(localized: "Move Down")), moveDown)
+        } else if canMoveUp {
+            content
+                .accessibilityAction(named: Text(String(localized: "Move Up")), moveUp)
+        } else if canMoveDown {
+            content
+                .accessibilityAction(named: Text(String(localized: "Move Down")), moveDown)
+        } else {
+            content
         }
     }
 }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -391,6 +391,7 @@ struct RecordingSettingsView: View {
     @ObservedObject private var modelManager = ServiceContainer.shared.modelManagerService
     @State private var selectedProvider: String?
     @State private var customSounds: [String] = SoundChoice.installedCustomSounds()
+    @State private var draggedInputDevicePriorityItem: AudioInputDevicePriorityItem?
     private let soundService = ServiceContainer.shared.soundService
 
     private var needsPermissions: Bool {
@@ -417,6 +418,138 @@ struct RecordingSettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
+    }
+
+    private var inputDeviceSelectionBinding: Binding<String?> {
+        Binding(
+            get: { audioDevice.selectedDeviceUID },
+            set: { newValue in
+                if let newValue {
+                    audioDevice.selectInputDeviceAsPrimary(newValue)
+                } else {
+                    audioDevice.clearInputDevicePriorityList()
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var microphonePriorityEditor: some View {
+        if shouldShowMicrophonePriorityList {
+            LabeledContent(String(localized: "Microphone Priority")) {
+                VStack(alignment: .trailing, spacing: 6) {
+                    microphonePriorityList
+                        .frame(maxWidth: 560, alignment: .leading)
+
+                    microphonePriorityAddMenu
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            HStack {
+                Spacer()
+                microphonePriorityAddMenu
+            }
+        }
+    }
+
+    private var shouldShowMicrophonePriorityList: Bool {
+        let priorityList = audioDevice.inputDevicePriorityList
+        guard priorityList.count == 1, let item = priorityList.first else {
+            return priorityList.count > 1
+        }
+
+        return !audioDevice.isInputDevicePriorityItemAvailable(item)
+    }
+
+    @ViewBuilder
+    private var microphonePriorityList: some View {
+        if !audioDevice.inputDevicePriorityList.isEmpty {
+            VStack(spacing: 0) {
+                ForEach(Array(audioDevice.inputDevicePriorityList.enumerated()), id: \.element.id) { index, item in
+                    microphonePriorityRow(index: index, item: item)
+                        .onDrag {
+                            draggedInputDevicePriorityItem = item
+                            return NSItemProvider(object: item.uid as NSString)
+                        }
+                        .onDrop(
+                            of: ["public.text"],
+                            delegate: MicrophonePriorityDropDelegate(
+                                item: item,
+                                audioDevice: audioDevice,
+                                draggedItem: $draggedInputDevicePriorityItem
+                            )
+                        )
+
+                    if index < audioDevice.inputDevicePriorityList.count - 1 {
+                        Divider()
+                            .padding(.leading, 40)
+                    }
+                }
+            }
+        }
+    }
+
+    private var microphonePriorityAddMenu: some View {
+        Menu {
+            if audioDevice.inputDevicePriorityCandidates.isEmpty {
+                Text(String(localized: "No more microphones"))
+            } else {
+                ForEach(audioDevice.inputDevicePriorityCandidates) { device in
+                    Button(audioDevice.displayName(for: device)) {
+                        audioDevice.addInputDeviceToPriorityList(device)
+                    }
+                }
+            }
+        } label: {
+            Label(String(localized: "Add Microphone"), systemImage: "plus")
+                .font(.callout)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.small)
+        .help(String(localized: "Add Microphone"))
+    }
+
+    private func microphonePriorityRow(index: Int, item: AudioInputDevicePriorityItem) -> some View {
+        let isAvailable = audioDevice.isInputDevicePriorityItemAvailable(item)
+
+        return HStack(spacing: 8) {
+            Image(systemName: "line.3.horizontal")
+                .foregroundStyle(.tertiary)
+                .font(.system(size: 11, weight: .semibold))
+                .frame(width: 12)
+
+            Text("\(index + 1).")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 20, alignment: .trailing)
+
+            Text(audioDevice.displayName(for: item))
+                .font(.callout)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            if !isAvailable {
+                Text(String(localized: "Disconnected"))
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+
+            Spacer(minLength: 8)
+
+            Button {
+                audioDevice.removeInputDevicePriorityItem(item)
+            } label: {
+                Image(systemName: "minus.circle")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .font(.system(size: 13))
+            .help(String(localized: "Remove microphone"))
+        }
+        .padding(.vertical, 3)
+        .frame(minHeight: 24)
+        .contentShape(Rectangle())
     }
 
     var body: some View {
@@ -484,13 +617,15 @@ struct RecordingSettingsView: View {
             }
 
             Section(String(localized: "Microphone")) {
-                Picker(String(localized: "Input Device"), selection: $audioDevice.selectedDeviceUID) {
+                Picker(String(localized: "Input Device"), selection: inputDeviceSelectionBinding) {
                     Text(String(localized: "System Default")).tag(nil as String?)
                     Divider()
                     ForEach(audioDevice.inputDevices) { device in
                         Text(audioDevice.displayName(for: device)).tag(device.uid as String?)
                     }
                 }
+
+                microphonePriorityEditor
 
                 if let message = audioDevice.selectedDeviceStatusMessage {
                     Label(message, systemImage: "exclamationmark.triangle")
@@ -504,18 +639,12 @@ struct RecordingSettingsView: View {
                             .foregroundStyle(.secondary)
                             .font(.caption)
 
-                        GeometryReader { geo in
-                            ZStack(alignment: .leading) {
-                                RoundedRectangle(cornerRadius: 3)
-                                    .fill(.quaternary)
-
-                                RoundedRectangle(cornerRadius: 3)
-                                    .fill(Color.green.gradient)
-                                    .frame(width: max(0, geo.size.width * CGFloat(audioDevice.previewAudioLevel)))
-                                    .animation(.easeOut(duration: 0.08), value: audioDevice.previewAudioLevel)
-                            }
-                        }
-                        .frame(height: 6)
+                        AudioWaveformView(
+                            audioLevel: audioDevice.previewAudioLevel,
+                            isSetup: false,
+                            compact: true
+                        )
+                        .foregroundStyle(.green)
                     }
                     .padding(.vertical, 4)
                 }
@@ -756,6 +885,27 @@ private struct SoundEventPicker: View {
         } catch {
             // File copy failed - silently ignore
         }
+    }
+}
+
+private struct MicrophonePriorityDropDelegate: DropDelegate {
+    let item: AudioInputDevicePriorityItem
+    let audioDevice: AudioDeviceService
+    @Binding var draggedItem: AudioInputDevicePriorityItem?
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedItem,
+              draggedItem != item,
+              let fromIndex = audioDevice.inputDevicePriorityList.firstIndex(of: draggedItem),
+              let toIndex = audioDevice.inputDevicePriorityList.firstIndex(of: item) else { return }
+
+        let destination = toIndex > fromIndex ? toIndex + 1 : toIndex
+        audioDevice.moveInputDevicePriorityItems(from: IndexSet(integer: fromIndex), to: destination)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedItem = nil
+        return true
     }
 }
 

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -2601,7 +2601,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         await MainActor.run {
             apiContext.audioRecorderService.recordingsDirectoryOverride = recordingsDirectory
-            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL in
+            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL, _ in
                 try Data("placeholder".utf8).write(to: outputURL)
                 return outputURL
             }
@@ -2685,7 +2685,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         await MainActor.run {
             apiContext.audioRecorderService.recordingsDirectoryOverride = recordingsDirectory
-            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL in
+            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL, _ in
                 try Data("placeholder".utf8).write(to: outputURL)
                 return outputURL
             }
@@ -2755,7 +2755,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         await MainActor.run {
             apiContext.audioRecorderService.recordingsDirectoryOverride = recordingsDirectory
-            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL in
+            apiContext.audioRecorderService.startRecordingOverride = { _, _, _, outputURL, _ in
                 try Data("placeholder".utf8).write(to: outputURL)
                 let entry = await gate.enter()
                 if entry == 1 {
@@ -3389,6 +3389,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
         service.focusedTextElementOverride = { element }
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
         service.pasteVerificationAttempts = 0
         service.defaultPasteFallbackRestoreDelay = .milliseconds(1)
         service.focusedTextStateOverride = { _ in
@@ -3425,6 +3426,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
         service.focusedTextElementOverride = { element }
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
         service.verifiedRestoreGraceDelay = .milliseconds(1)
 
         var didAttemptDirectAXInsertion = false
@@ -3513,6 +3515,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
         service.focusedTextElementOverride = { element }
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
 
         var stateReadCount = 0
         service.focusedTextStateOverride = { _ in
@@ -3552,6 +3555,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
         service.focusedTextElementOverride = { element }
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
 
         var stateReadCount = 0
         service.focusedTextStateOverride = { _ in
@@ -4623,6 +4627,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testApiStartRecording_skipsStartSoundForBluetoothInput() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
         let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
         let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
         var events: [String] = []
@@ -4657,6 +4662,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictationContext = nil
             TestSupport.remove(appSupportDirectory)
             Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
             Self.restoreUserDefault(originalAudioDuckingEnabled, forKey: UserDefaultsKeys.audioDuckingEnabled)
             Self.restoreUserDefault(originalAudioDuckingLevel, forKey: UserDefaultsKeys.audioDuckingLevel)
         }
@@ -4707,6 +4713,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testApiStartRecording_keepsStartSoundForUSBInputAfterInputIsReady() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
         var events: [String] = []
         let usbDeviceID = AudioDeviceID(410)
         let soundService = MockSoundService { event, enabled in
@@ -4726,6 +4733,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictationContext = nil
             TestSupport.remove(appSupportDirectory)
             Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
         }
 
         dictationContext = Self.makeDictationContext(
@@ -4762,6 +4770,92 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         XCTAssertEqual(events, ["start_audio", "start_sound"])
         XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+    }
+
+    @MainActor
+    func testApiStartRecordingUsesNextAvailablePriorityMicrophone() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        let usbDeviceID = AudioDeviceID(510)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "missing-primary", name: "Desk Mic"),
+                AudioInputDevicePriorityItem(uid: "usb-input", name: "USB Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let transportResolver = FakeAudioDeviceTransportResolver(
+            transports: [usbDeviceID: kAudioDeviceTransportTypeUSB]
+        )
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDeviceTransportResolver: transportResolver
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.audioDeviceService.inputDevices = [
+            AudioInputDevice(deviceID: usbDeviceID, name: "USB Mic", uid: "usb-input")
+        ]
+        context.audioDeviceService.audioDeviceIDResolverOverride = { uid in
+            uid == "usb-input" ? usbDeviceID : nil
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertEqual(selectedDeviceID, usbDeviceID)
+            return true
+        }
+        context.audioRecordingService.startRecordingOverride = {
+            XCTAssertEqual(context.audioRecordingService.selectedDeviceID, usbDeviceID)
+        }
+
+        _ = context.dictationViewModel.apiStartRecording()
+
+        XCTAssertTrue(context.audioRecordingService.hasExplicitDeviceSelection)
+    }
+
+    @MainActor
+    func testApiStartRecordingFallsBackToSystemDefaultWhenPriorityMicrophonesUnavailable() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "missing-primary", name: "Desk Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.audioDeviceService.inputDevices = []
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertNil(selectedDeviceID)
+            return true
+        }
+        context.audioRecordingService.startRecordingOverride = {
+            XCTAssertNil(context.audioRecordingService.selectedDeviceID)
+            XCTAssertFalse(context.audioRecordingService.hasExplicitDeviceSelection)
+        }
+
+        _ = context.dictationViewModel.apiStartRecording()
     }
 
     #if !APPSTORE
@@ -5197,6 +5291,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testApiStartRecording_showsNoMicDetectedErrorWhenSelectedInputUnavailable() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
         let deviceID = AudioDeviceID(42)
         let transportResolver = FakeAudioDeviceTransportResolver(
             transports: [deviceID: kAudioDeviceTransportTypeUSB]
@@ -5211,6 +5306,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictationContext = nil
             TestSupport.remove(appSupportDirectory)
             Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
         }
 
         dictationContext = Self.makeDictationContext(
@@ -5579,7 +5675,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let audioRecorderViewModel = AudioRecorderViewModel(
             recorderService: audioRecorderService,
             modelManager: modelManager,
-            dictionaryService: dictionaryService
+            dictionaryService: dictionaryService,
+            audioDeviceService: audioDeviceService
         )
 
         let router = APIRouter()
@@ -8272,6 +8369,56 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testEventTapDefersDictationStartOutOfCallback() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .toggle)
+
+        var startCount = 0
+        service.onDictationStart = { _ in
+            startCount += 1
+        }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .eventTap))
+        XCTAssertEqual(startCount, 0)
+
+        await Task.yield()
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testEventTapDisableRecoversReleasedPushToTalkHotkey() async throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(spaceHotkey(), for: .pushToTalk)
+
+        var physicalKeyIsDown = true
+        service.keyStateProvider = { keyCode in
+            keyCode == 0x31 && physicalKeyIsDown
+        }
+
+        var startCount = 0
+        var stopCount = 0
+        service.onDictationStart = { _ in startCount += 1 }
+        service.onDictationStop = { stopCount += 1 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true)
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .eventTap))
+        await Task.yield()
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(service.currentMode, .pushToTalk)
+
+        physicalKeyIsDown = false
+        service.recoverReleasedActiveHotkeyAfterEventTapDisableForTesting()
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
     func testSuppressingEventTapMaskOnlyIncludesMouseEventsWhenRequested() {
         let keyboardOnlyMask = HotkeyService.suppressingEventTapMaskForTesting(includeMouse: false)
 
@@ -8624,7 +8771,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testMiddleMouseHotkeyPassesThroughEvenWhenSideMouseHotkeyUsesSuppressingTap() throws {
+    func testMiddleMouseHotkeyPassesThroughEvenWhenSideMouseHotkeyUsesSuppressingTap() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
         service.setHotkeysForTesting([
@@ -8642,11 +8789,12 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(service.needsMouseEventMonitoringForTesting())
         XCTAssertTrue(service.needsSuppressingMouseEventTapForTesting())
         XCTAssertFalse(service.processEventForTesting(middleMouseDown, source: .eventTap))
+        await Task.yield()
         XCTAssertEqual(startCount, 1)
     }
 
     @MainActor
-    func testMatchingSideMouseHotkeyDispatchesAndSuppressesClick() throws {
+    func testMatchingSideMouseHotkeyDispatchesAndSuppressesClick() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
         service.setHotkeyForTesting(UnifiedHotkey(mouseButton: 3), for: .toggle)
@@ -8662,6 +8810,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(service.needsMouseEventMonitoringForTesting())
         XCTAssertTrue(service.needsSuppressingMouseEventTapForTesting())
         XCTAssertTrue(service.processEventForTesting(sideMouseDown, source: .eventTap))
+        await Task.yield()
         XCTAssertEqual(startCount, 1)
         XCTAssertTrue(service.processEventForTesting(sideMouseUp, source: .eventTap))
     }
@@ -9283,7 +9432,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testHybridRightOptionSingleTapStillTogglesDictation() throws {
+    func testHybridRightOptionSingleTapStillTogglesDictation() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
 
@@ -9298,11 +9447,13 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         let keyUp = try makeRightOptionModifierEvent(isDown: false)
 
         XCTAssertTrue(service.processEventForTesting(keyDown, source: .eventTap))
+        await Task.yield()
         XCTAssertEqual(startCount, 1)
         XCTAssertEqual(stopCount, 0)
         XCTAssertEqual(service.currentMode, .pushToTalk)
 
         XCTAssertTrue(service.processEventForTesting(keyUp, source: .eventTap))
+        await Task.yield()
         XCTAssertEqual(startCount, 1)
         XCTAssertEqual(stopCount, 0)
         XCTAssertEqual(service.currentMode, .toggle)
@@ -10171,13 +10322,13 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
             restoredService.onDictationStop = { stopCount += 1 }
 
             let oldKeyDown = try makeKeyboardEvent(keyCode: 0x31, keyDown: true, flags: [.maskControl])
-            XCTAssertFalse(restoredService.processEventForTesting(oldKeyDown, source: .eventTap))
+            XCTAssertFalse(restoredService.processEventForTesting(oldKeyDown, source: .monitor))
             XCTAssertEqual(startCount, 0)
 
             let newKeyDown = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [.maskCommand, .maskAlternate])
             let newKeyUp = try makeKeyboardEvent(keyCode: 0x00, keyDown: false, flags: [.maskCommand, .maskAlternate])
-            XCTAssertTrue(restoredService.processEventForTesting(newKeyDown, source: .eventTap))
-            XCTAssertTrue(restoredService.processEventForTesting(newKeyUp, source: .eventTap))
+            XCTAssertTrue(restoredService.processEventForTesting(newKeyDown, source: .monitor))
+            XCTAssertTrue(restoredService.processEventForTesting(newKeyUp, source: .monitor))
             XCTAssertEqual(startCount, 1)
             XCTAssertEqual(stopCount, 1)
         }

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1,11 +1,35 @@
 import AudioToolbox
 import AudioUnit
 import AVFoundation
+import Combine
 import XCTest
 @testable import TypeWhisper
 
 private final class TestClock: @unchecked Sendable {
     var now: TimeInterval = 0
+}
+
+private final class AudioLevelUpdateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var levels: [Float] = []
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return levels.count
+    }
+
+    var last: Float? {
+        lock.lock()
+        defer { lock.unlock() }
+        return levels.last
+    }
+
+    func append(_ level: Float) {
+        lock.lock()
+        levels.append(level)
+        lock.unlock()
+    }
 }
 
 private func makeMonoBuffer(samples: [Float]) throws -> AVAudioPCMBuffer {
@@ -40,6 +64,38 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
 
         XCTAssertGreaterThan(level, 0.65)
         XCTAssertLessThan(level, 0.9)
+    }
+
+    @MainActor
+    func testAudioLevelPublishingCoalescesRapidBufferUpdates() async throws {
+        let service = AudioRecordingService()
+        let recorder = AudioLevelUpdateRecorder()
+        let firstUpdate = expectation(description: "first audio level update")
+
+        let cancellable = service.$audioLevel
+            .dropFirst()
+            .sink { level in
+                recorder.append(level)
+                if recorder.count == 1 {
+                    firstUpdate.fulfill()
+                }
+            }
+
+        service.testingProcessConvertedSamples(Array(repeating: 0.25 as Float, count: 160))
+        await fulfillment(of: [firstUpdate], timeout: 1.0)
+
+        service.testingMarkAudioLevelPublishedNow()
+        service.testingProcessConvertedSamples(Array(repeating: 0.10 as Float, count: 160))
+        service.testingProcessConvertedSamples(Array(repeating: 0.20 as Float, count: 160))
+
+        try await Task.sleep(for: .milliseconds(5))
+        XCTAssertEqual(recorder.count, 1)
+
+        try await Task.sleep(for: .milliseconds(45))
+        XCTAssertEqual(recorder.count, 2)
+        XCTAssertEqual(recorder.last ?? -1, AudioLevelMeter.normalizedLevel(rms: 0.20), accuracy: 0.0001)
+
+        cancellable.cancel()
     }
 
     func testAudioInputSignalRejectsZeroFilledBluetoothTapBuffer() throws {
@@ -520,11 +576,14 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
 
 final class AudioDeviceServiceCompatibilityTests: XCTestCase {
     private var originalSelectedDeviceUID: Any?
+    private var originalInputDevicePriorityList: Any?
 
     override func setUp() {
         super.setUp()
         originalSelectedDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        originalInputDevicePriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.inputDevicePriorityList)
     }
 
     override func tearDown() {
@@ -533,7 +592,17 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         } else {
             UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         }
+        if let originalInputDevicePriorityList {
+            UserDefaults.standard.set(originalInputDevicePriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        }
         super.tearDown()
+    }
+
+    private func savedInputDevicePriorityList() throws -> [AudioInputDevicePriorityItem] {
+        let data = try XCTUnwrap(UserDefaults.standard.data(forKey: UserDefaultsKeys.inputDevicePriorityList))
+        return try JSONDecoder().decode([AudioInputDevicePriorityItem].self, from: data)
     }
 
     func testStartPreview_selectedIncompatibleDeviceDoesNotActivatePreview() {
@@ -805,6 +874,173 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(service.selectedDeviceUID, "display-mic")
         XCTAssertEqual(service.selectedDevice?.uid, "display-mic")
         XCTAssertNotNil(service.selectedDeviceStatusMessage)
+    }
+
+    func testMigratesSavedSelectedInputDeviceToPriorityList() throws {
+        UserDefaults.standard.set("usb-input", forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let device = AudioInputDevice(
+            deviceID: AudioDeviceID(42),
+            name: "USB Mic",
+            uid: "usb-input"
+        )
+
+        let service = AudioDeviceService(
+            initialInputDevices: [device],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+
+        XCTAssertEqual(service.inputDevicePriorityList, [
+            AudioInputDevicePriorityItem(uid: "usb-input", name: "USB Mic")
+        ])
+        XCTAssertEqual(try savedInputDevicePriorityList(), service.inputDevicePriorityList)
+    }
+
+    func testMovingInputDevicePriorityUpdatesSelectedDeviceAndPersistsDeduplicatedList() throws {
+        let builtIn = AudioInputDevice(deviceID: AudioDeviceID(1), name: "Built-in Mic", uid: "built-in")
+        let usb = AudioInputDevice(deviceID: AudioDeviceID(2), name: "USB Mic", uid: "usb-input")
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "built-in", name: "Built-in Mic"),
+                AudioInputDevicePriorityItem(uid: "usb-input", name: "USB Mic"),
+                AudioInputDevicePriorityItem(uid: "built-in", name: "Built-in Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [builtIn, usb],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+
+        XCTAssertEqual(service.inputDevicePriorityList.map(\.uid), ["built-in", "usb-input"])
+
+        service.moveInputDevicePriorityItems(from: IndexSet(integer: 1), to: 0)
+
+        XCTAssertEqual(service.inputDevicePriorityList.map(\.uid), ["usb-input", "built-in"])
+        XCTAssertEqual(service.selectedDeviceUID, "usb-input")
+        XCTAssertEqual(try savedInputDevicePriorityList().map(\.uid), ["usb-input", "built-in"])
+    }
+
+    func testSelectingPrimaryInputDeviceReplacesMigratedFallbackList() throws {
+        let builtIn = AudioInputDevice(deviceID: AudioDeviceID(1), name: "Built-in Mic", uid: "built-in")
+        let usb = AudioInputDevice(deviceID: AudioDeviceID(2), name: "USB Mic", uid: "usb-input")
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "built-in", name: "Built-in Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        UserDefaults.standard.set("built-in", forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let service = AudioDeviceService(
+            initialInputDevices: [builtIn, usb],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    AudioDeviceID(1): kAudioDeviceTransportTypeBuiltIn,
+                    AudioDeviceID(2): kAudioDeviceTransportTypeUSB
+                ]
+            ),
+            inputActivationGuard: FakeAudioInputDeviceActivator()
+        )
+
+        service.selectInputDeviceAsPrimary("usb-input")
+
+        XCTAssertEqual(service.selectedDeviceUID, "usb-input")
+        XCTAssertEqual(service.inputDevicePriorityList.map(\.uid), ["usb-input"])
+        XCTAssertEqual(try savedInputDevicePriorityList().map(\.uid), ["usb-input"])
+    }
+
+    func testResolvedRecordingInputSelectionSkipsDisconnectedPrimaryDevice() throws {
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "missing-primary", name: "Desk Mic"),
+                AudioInputDevicePriorityItem(uid: "usb-input", name: "USB Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let usbDeviceID = AudioDeviceID(42)
+        let transportResolver = FakeAudioDeviceTransportResolver(
+            transports: [usbDeviceID: kAudioDeviceTransportTypeUSB]
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: usbDeviceID, name: "USB Mic", uid: "usb-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: transportResolver
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            uid == "usb-input" ? usbDeviceID : nil
+        }
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "usb-input")
+        XCTAssertEqual(selection.deviceID, usbDeviceID)
+        XCTAssertTrue(selection.hasExplicitDeviceSelection)
+    }
+
+    func testResolvedRecordingInputSelectionKeepsAvailablePrimaryWhenFallbackExists() throws {
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "hyperx-input", name: "HyperX QuadCast 2"),
+                AudioInputDevicePriorityItem(uid: "built-in", name: "MacBook Pro Microphone")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let hyperxDeviceID = AudioDeviceID(42)
+        let builtInDeviceID = AudioDeviceID(43)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: hyperxDeviceID, name: "HyperX QuadCast 2", uid: "hyperx-input"),
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "built-in")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    hyperxDeviceID: kAudioDeviceTransportTypeUSB,
+                    builtInDeviceID: kAudioDeviceTransportTypeBuiltIn
+                ]
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "hyperx-input": return hyperxDeviceID
+            case "built-in": return builtInDeviceID
+            default: return nil
+            }
+        }
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "hyperx-input")
+        XCTAssertEqual(selection.deviceID, hyperxDeviceID)
+        XCTAssertEqual(selection.deviceName, "HyperX QuadCast 2")
+        XCTAssertTrue(selection.hasExplicitDeviceSelection)
+    }
+
+    func testResolvedRecordingInputSelectionFallsBackToSystemDefaultWhenPriorityListUnavailable() throws {
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "missing-primary", name: "Desk Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertNil(selection.deviceUID)
+        XCTAssertNil(selection.deviceID)
+        XCTAssertFalse(selection.hasExplicitDeviceSelection)
     }
 
     func testPreviewRecoveryEngineSwap_replacesStoredEngineInstance() {

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -1,3 +1,4 @@
+import AudioToolbox
 import XCTest
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
@@ -126,6 +127,79 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(disabledCount, 0)
         XCTAssertEqual(transcriptOnlyCount, 0)
         XCTAssertEqual(splitEnabledCount, 1)
+    }
+
+    func testRecorderStartPassesResolvedMicrophonePrioritySelection() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let usbDeviceID = AudioDeviceID(620)
+        let usbDevice = AudioInputDevice(deviceID: usbDeviceID, name: "USB Mic", uid: "usb-input")
+        let audioDeviceService = AudioDeviceService(
+            initialInputDevices: [usbDevice],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+        audioDeviceService.audioDeviceIDResolverOverride = { uid in
+            uid == "usb-input" ? usbDeviceID : nil
+        }
+        audioDeviceService.addInputDeviceToPriorityList(usbDevice)
+
+        let recorderService = AudioRecorderService()
+        recorderService.recordingsDirectoryOverride = recordingsDirectory
+        var capturedSelection: ResolvedRecordingInputSelection?
+        recorderService.startRecordingOverride = { _, _, _, outputURL, microphoneSelection in
+            capturedSelection = microphoneSelection
+            try Data("placeholder".utf8).write(to: outputURL)
+            return outputURL
+        }
+
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            recorderService: recorderService,
+            audioDeviceService: audioDeviceService
+        )
+
+        _ = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+
+        XCTAssertEqual(capturedSelection?.deviceUID, "usb-input")
+        XCTAssertEqual(capturedSelection?.deviceID, usbDeviceID)
+        XCTAssertTrue(capturedSelection?.hasExplicitDeviceSelection == true)
+    }
+
+    func testRecorderStartIgnoresMicrophonePriorityWhenMicDisabled() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let usbDeviceID = AudioDeviceID(621)
+        let usbDevice = AudioInputDevice(deviceID: usbDeviceID, name: "USB Mic", uid: "usb-input")
+        let audioDeviceService = AudioDeviceService(
+            initialInputDevices: [usbDevice],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false
+        )
+        audioDeviceService.addInputDeviceToPriorityList(usbDevice)
+
+        let recorderService = AudioRecorderService()
+        recorderService.recordingsDirectoryOverride = recordingsDirectory
+        var capturedSelection: ResolvedRecordingInputSelection?
+        recorderService.startRecordingOverride = { _, _, _, outputURL, microphoneSelection in
+            capturedSelection = microphoneSelection
+            try Data("placeholder".utf8).write(to: outputURL)
+            return outputURL
+        }
+
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            recorderService: recorderService,
+            audioDeviceService: audioDeviceService
+        )
+
+        _ = try await viewModel.apiStartRecording(micEnabled: false, systemAudioEnabled: true)
+
+        XCTAssertNil(capturedSelection?.deviceUID)
+        XCTAssertNil(capturedSelection?.deviceID)
+        XCTAssertFalse(capturedSelection?.hasExplicitDeviceSelection == true)
     }
 
     func testFinalTranscriptionFailurePersistsRecorderFailureAndFailsAPISession() async throws {
@@ -266,6 +340,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         defaults: UserDefaults,
         modelManager: ModelManagerService = ModelManagerService(),
         recorderService: AudioRecorderService = AudioRecorderService(),
+        audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
         livePreviewStartObserver: (() -> Void)? = nil
     ) -> AudioRecorderViewModel {
         setupEventBus()
@@ -273,6 +348,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             recorderService: recorderService,
             modelManager: modelManager,
             dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
+            audioDeviceService: audioDeviceService,
             defaults: defaults,
             livePreviewStartObserver: livePreviewStartObserver
         )
@@ -299,7 +375,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
     ) -> AudioRecorderService {
         let recorderService = AudioRecorderService()
         recorderService.recordingsDirectoryOverride = recordingsDirectory
-        recorderService.startRecordingOverride = { _, _, _, proposedOutputURL in
+        recorderService.startRecordingOverride = { _, _, _, proposedOutputURL, _ in
             let resolvedOutputURL = outputURL ?? proposedOutputURL
             try FileManager.default.createDirectory(
                 at: resolvedOutputURL.deletingLastPathComponent(),
@@ -327,7 +403,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let defaults = try makeDefaults()
         let recorderService = AudioRecorderService()
         recorderService.recordingsDirectoryOverride = makeTemporaryDirectory()
-        recorderService.startRecordingOverride = { _, _, _, outputURL in
+        recorderService.startRecordingOverride = { _, _, _, outputURL, _ in
             try Data("placeholder".utf8).write(to: outputURL)
             return outputURL
         }
@@ -435,7 +511,9 @@ final class AudioRecorderViewModelTests: XCTestCase {
     private func preserveStandardDefaults() throws {
         let keys = [
             UserDefaultsKeys.selectedEngine,
-            UserDefaultsKeys.selectedModelId
+            UserDefaultsKeys.selectedModelId,
+            UserDefaultsKeys.selectedInputDeviceUID,
+            UserDefaultsKeys.inputDevicePriorityList
         ]
         let originals = Dictionary(uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) })
         for key in keys {


### PR DESCRIPTION
## Summary
Implements the microphone priority list requested in #844. The previous behavior allowed one explicit microphone or System Default; this adds a shared ordered list for dictation and recorder starts so TypeWhisper uses the first currently available microphone and falls back to System Default when no priority entry is available.

Closes #844

## Changes
- Add a persisted input device priority list with migration from `selectedInputDeviceUID`.
- Resolve dictation, microphone preview/test, recorder UI starts, and recorder API starts through the same microphone selection path.
- Keep disconnected saved devices visible in Settings so users do not lose their order, and support add/remove/drag reorder in the Recording tab.
- Reuse the existing CoreAudio input-only path for explicit non-Bluetooth selections while keeping Bluetooth and System Default behavior unchanged.
- Cap waveform audio-level publishing at 30 FPS and defer event-tap hotkey actions out of the tap callback based on local testing during this work.
- Stabilize clipboard insertion tests by isolating direct-AX assertions from whichever terminal app is frontmost during the test run.

## Test Plan
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/adc5/typewhisper-mac`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added microphone priority management in Settings (add/remove, move up/down, drag-and-drop reorder) and improved “Input Device” selection behavior.
  * Recording now supports explicit microphone selection, including Bluetooth-aware routing.

* **Bug Fixes**
  * More reliable microphone fallback when the preferred device is disconnected or unavailable.
  * Compatibility updates now track by the effective input selection.
  * Hotkey handling and release behavior improved when the event tap is disabled.

* **Documentation / Localization**
  * Updated microphone-related UI strings for German and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->