### PR TITLE
Fix Gemma 4 model loading

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 import MLX
-import MLXVLM
+import MLXLLM
 import MLXLMCommon
 import HuggingFace
 import Hub
@@ -479,7 +479,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                     extraEOSTokens: ["<turn|>"]
                 )
             let loadTask = Task<ModelContainer, Error> {
-                try await VLMModelFactory.shared.loadContainer(
+                try await LLMModelFactory.shared.loadContainer(
                     from: downloader,
                     using: Gemma4TokenizerLoader(),
                     configuration: configuration
@@ -871,6 +871,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             || rawMessage.contains("missing weight")
             || rawMessage.contains("shape mismatch")
             || rawMessage.contains("size mismatch")
+            || (rawMessage.contains("mismatched parameter") && rawMessage.contains("shape"))
             || (rawMessage.contains("checkpoint")
                 && (rawMessage.contains("not found")
                     || rawMessage.contains("missing")

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -641,7 +641,7 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
         for version: ParakeetVersion,
         targetDirectory: URL? = nil,
         fetcher: VocabularyAssetFetcher = { url, description in
-            try await DownloadUtils.fetchHuggingFaceFile(from: url, description: description)
+            try await ParakeetPlugin.downloadVocabularyAsset(from: url, description: description)
         }
     ) async throws {
         let directory = targetDirectory ?? Self.vocabularyAssetDirectory(for: version)
@@ -699,6 +699,36 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
             return false
         }
         return size.intValue > 0
+    }
+
+    private static func downloadVocabularyAsset(from url: URL, description: String) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 600
+        if let token = currentHuggingFaceToken() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: 600)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ParakeetVocabularyAssetHTTPError(description: description, statusCode: nil)
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw ParakeetVocabularyAssetHTTPError(
+                description: description,
+                statusCode: httpResponse.statusCode
+            )
+        }
+        return data
+    }
+
+    private static func currentHuggingFaceToken() -> String? {
+        for key in PluginHuggingFaceTokenHelper.environmentKeys {
+            if let token = PluginHuggingFaceTokenHelper.normalizedToken(ProcessInfo.processInfo.environment[key]) {
+                return token
+            }
+        }
+        return nil
     }
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
@@ -872,6 +902,18 @@ enum CtcModelState: Equatable {
     case downloading
     case ready
     case error(String)
+}
+
+private struct ParakeetVocabularyAssetHTTPError: LocalizedError, Sendable {
+    let description: String
+    let statusCode: Int?
+
+    var errorDescription: String? {
+        guard let statusCode else {
+            return "Invalid HTTP response while downloading \(description)"
+        }
+        return "HTTP \(statusCode) while downloading \(description)"
+    }
 }
 
 private enum ParakeetVocabularyAssetError: LocalizedError {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -788,6 +788,24 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         )
     }
 
+    func testGemma4MismatchedParameterShapeErrorsUseCacheRecoveryMessage() throws {
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e4b-it-4bit"))
+        let error = NSError(
+            domain: "Test",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Mismatched parameter language_model.model.per_layer_model_projection.weight in Gemma4.Gemma4TextLanguageModel.Gemma4TextBackbone.Gemma4ScaledLinear shape. Actual [10752, 320], expected [10752, 2560]"
+            ]
+        )
+
+        let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)
+
+        XCTAssertEqual(
+            message,
+            "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again."
+        )
+    }
+
     func testGemma4ResetCachedModelDeletesCacheAndClearsLoadedState() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary
- Fixes Gemma 4 E2B/E4B 4-bit loading by using the MLX text LLM loader path instead of the VLM loader path.
- Bumps Gemma4Plugin to 1.1.1.
- Maps the reported mismatched-parameter shape error to the existing friendly cache recovery message.
- Restores the Parakeet SwiftPM package build by replacing a stale `DownloadUtils` reference with a package-local vocabulary asset download path.

## Issue context
Issue #847 reports that Gemma4Plugin 1.1.0 cannot load Gemma 4 E2B/E4B 4-bit and surfaces MLX missing-weight / mismatched-shape failures such as `Mismatched parameter ... shape. Actual ..., expected ...`.

Closes #847

## Test plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --clean --run Gemma4Plugin /Users/marco/.codex/worktrees/fb74/typewhisper-mac`

The local dev plugin bundle was installed and its manifest reports `version` 1.1.1. I did not claim live Gemma E2B/E4B model-load verification because that requires the model cache or a multi-GB download window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery during model loading for additional cache-related issues, including certain mismatched-parameter and shape cases.
  * Enhanced vocabulary asset downloading with better handling of HTTP failures and clearer, status-aware error messages.
* **Tests**
  * Added coverage for the “mismatched parameter” user-facing error message so users receive cache-retry guidance.
* **Chores**
  * Updated the Gemma 4 plugin version to **1.1.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->