### PR TITLE
Require restart after loaded plugin updates

### DIFF
--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -639,7 +639,11 @@ final class PluginManager: ObservableObject {
         return false
     }
 
-    private func makeUnloadedPluginRecord(manifest: PluginManifest, sourceURL: URL) throws -> LoadedPlugin {
+    private func makeUnloadedPluginRecord(
+        manifest: PluginManifest,
+        sourceURL: URL,
+        isEnabled: Bool = false
+    ) throws -> LoadedPlugin {
         guard let bundle = Bundle(url: sourceURL) else {
             throw PluginLoadError.failedToCreateBundle(bundleName: sourceURL.lastPathComponent)
         }
@@ -649,8 +653,22 @@ final class PluginManager: ObservableObject {
             instance: UnloadedPluginPlaceholder(),
             bundle: bundle,
             sourceURL: sourceURL,
-            isEnabled: false
+            isEnabled: isEnabled
         )
+    }
+
+    func registerUnloadedPlugin(manifest: PluginManifest, sourceURL: URL, isEnabled: Bool) throws {
+        if let existingIndex = loadedPlugins.firstIndex(where: { $0.manifest.id == manifest.id }) {
+            loadedPlugins.remove(at: existingIndex)
+        }
+
+        loadedPlugins.append(try makeUnloadedPluginRecord(
+            manifest: manifest,
+            sourceURL: sourceURL,
+            isEnabled: isEnabled
+        ))
+        UserDefaults.standard.set(isEnabled, forKey: "plugin.\(manifest.id).enabled")
+        logger.info("Registered plugin \(manifest.id, privacy: .public) v\(manifest.version, privacy: .public) as restart-required unloaded placeholder")
     }
 
     func setRuleNamesProvider(_ provider: @escaping @MainActor () -> [String]) {

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -487,7 +487,15 @@ final class PluginRegistryService: ObservableObject {
     enum InstallState: Equatable {
         case downloading(Double)
         case extracting
+        case restartRequired
         case error(String)
+
+        var requiresRestart: Bool {
+            if case .restartRequired = self {
+                return true
+            }
+            return false
+        }
     }
 
     // MARK: - Version Comparison
@@ -748,13 +756,17 @@ final class PluginRegistryService: ObservableObject {
                 return false
             }
 
-            _ = try installBundle(
+            let installResult = try installBundle(
                 at: bundleURL,
                 expectedPluginId: plugin.id,
                 copyBundle: false
             )
 
-            installStates.removeValue(forKey: plugin.id)
+            if installResult.requiresRestart {
+                installStates[plugin.id] = .restartRequired
+            } else {
+                installStates.removeValue(forKey: plugin.id)
+            }
             lastFetchDate = nil // invalidate cache so installInfo refreshes
             updateAvailableUpdatesCount()
             logger.info("Installed plugin \(plugin.id) v\(plugin.version)")
@@ -806,7 +818,9 @@ final class PluginRegistryService: ObservableObject {
         let fm = FileManager.default
 
         if url.pathExtension == "bundle" {
-            return try installBundle(at: url, expectedPluginId: nil, copyBundle: true)
+            let result = try installBundle(at: url, expectedPluginId: nil, copyBundle: true)
+            updateInstallState(for: result)
+            return result.manifest
         } else if url.pathExtension == "zip" {
             let tempDir = fm.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -830,17 +844,35 @@ final class PluginRegistryService: ObservableObject {
                               userInfo: [NSLocalizedDescriptionKey: "No .bundle found in ZIP"])
             }
 
-            return try installBundle(at: bundleURL, expectedPluginId: nil, copyBundle: false)
+            let result = try installBundle(at: bundleURL, expectedPluginId: nil, copyBundle: false)
+            updateInstallState(for: result)
+            return result.manifest
         }
 
         throw NSError(domain: "PluginRegistry", code: 5,
                       userInfo: [NSLocalizedDescriptionKey: "Unsupported plugin package"])
     }
 
-    private func installBundle(at bundleURL: URL, expectedPluginId: String?, copyBundle: Bool) throws -> PluginManifest {
+    private struct InstallResult {
+        let manifest: PluginManifest
+        let requiresRestart: Bool
+    }
+
+    private func updateInstallState(for result: InstallResult) {
+        if result.requiresRestart {
+            installStates[result.manifest.id] = .restartRequired
+        } else {
+            installStates.removeValue(forKey: result.manifest.id)
+        }
+    }
+
+    private func installBundle(at bundleURL: URL, expectedPluginId: String?, copyBundle: Bool) throws -> InstallResult {
         let fm = FileManager.default
         let manifest = try readManifest(at: bundleURL)
-        let existingLoadedBundleURL = PluginManager.shared.bundleURL(for: manifest.id)
+        let existingLoadedPlugin = PluginManager.shared.loadedPlugins.first { $0.manifest.id == manifest.id }
+        let existingLoadedBundleURL = existingLoadedPlugin?.sourceURL
+        let replacingRuntimeLoadedPlugin = existingLoadedPlugin?.isRuntimeLoaded == true
+        let shouldEnableAfterRestart = existingLoadedPlugin?.isEnabled == true
 
         guard manifest.isCompatibleWithCurrentEnvironment else {
             let architecture = RuntimeArchitecture.current
@@ -891,7 +923,15 @@ final class PluginRegistryService: ObservableObject {
                 try fm.moveItem(at: bundleURL, to: destinationURL)
             }
 
-            try PluginManager.shared.loadPlugin(at: destinationURL)
+            if replacingRuntimeLoadedPlugin {
+                try PluginManager.shared.registerUnloadedPlugin(
+                    manifest: manifest,
+                    sourceURL: destinationURL,
+                    isEnabled: shouldEnableAfterRestart
+                )
+            } else {
+                try PluginManager.shared.loadPlugin(at: destinationURL)
+            }
             try removeDuplicateBundles(for: manifest.id, keeping: destinationURL)
 
             if hadExistingBundle, fm.fileExists(atPath: backupURL.path) {
@@ -915,7 +955,7 @@ final class PluginRegistryService: ObservableObject {
             throw error
         }
 
-        return manifest
+        return InstallResult(manifest: manifest, requiresRestart: replacingRuntimeLoadedPlugin)
     }
 
     static func validateDownloadedArchiveResponse(_ response: URLResponse) throws {

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1068,6 +1068,9 @@ struct PluginSettingsView: View {
         selectedTab = .installed
 
         let resolvedRegistryPlugin = registryPlugin ?? registryService.registry.first { $0.id == pluginId }
+        if registryService.installStates[pluginId]?.requiresRestart == true {
+            return
+        }
         enableInstalledPluginIfNeeded(pluginId)
 
         guard let installedPlugin = pluginManager.loadedPlugins.first(where: { $0.id == pluginId }),
@@ -1579,7 +1582,7 @@ private struct InstalledPluginRow: View {
                 Spacer(minLength: 12)
 
                 HStack(spacing: 8) {
-                    if plugin.supportsSettingsWindow {
+                    if plugin.supportsSettingsWindow && !restartRequired {
                         Button {
                             PluginSettingsWindowManager.shared.present(plugin)
                         } label: {
@@ -1597,6 +1600,7 @@ private struct InstalledPluginRow: View {
                         }
                     ))
                     .labelsHidden()
+                    .disabled(restartRequired)
                     .accessibilityLabel(String(localized: "Enable \(plugin.manifest.name)"))
 
                     if hasOverflowActions {
@@ -1776,6 +1780,10 @@ private struct InstalledPluginRow: View {
 
     private var hasOverflowActions: Bool {
         detailsURL != nil || homepageURL != nil || canRepairInstallation || !plugin.isBundled
+    }
+
+    private var restartRequired: Bool {
+        installState?.requiresRestart == true
     }
 
     private func downloadedModelCountTitle(_ count: Int) -> String {
@@ -2038,6 +2046,15 @@ private struct PluginInstallStateView: View {
                 Text(String(localized: "Installing..."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+        case .restartRequired:
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.clockwise.circle.fill")
+                    .foregroundStyle(.orange)
+                Text(String(localized: "Restart TypeWhisper to finish updating."))
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
             }
         case .error(let message):
             HStack(spacing: 6) {

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -850,6 +850,8 @@ struct SetupWizardView: View {
                 case .extracting:
                     ProgressView()
                         .controlSize(.small)
+                case .restartRequired:
+                    statusPill(localizedAppText("Restart", de: "Neustart"), systemImage: "arrow.clockwise.circle.fill", color: .orange)
                 case .error:
                     statusPill(localizedAppText("Retry later", de: "Später erneut"), systemImage: "exclamationmark.triangle.fill", color: .orange)
                 }

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -524,6 +524,76 @@ final class PluginRegistryServiceTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testInstallingOverRuntimeLoadedPluginRequiresRestartInsteadOfHotReloading() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRuntimeUpdate")
+        let incomingDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRuntimeUpdateIncoming")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginRuntimeUpdateCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(incomingDirectory)
+            TestSupport.remove(cacheDirectory)
+            UserDefaults.standard.removeObject(forKey: "plugin.com.typewhisper.runtime-update.enabled")
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let pluginId = "com.typewhisper.runtime-update"
+        let existingURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("RuntimeUpdatePlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: existingURL,
+            pluginId: pluginId,
+            pluginName: "Runtime Update Plugin",
+            version: "1.0.0"
+        )
+
+        let existingBundle = try XCTUnwrap(Bundle(url: existingURL))
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: pluginId,
+                    name: "Runtime Update Plugin",
+                    version: "1.0.0",
+                    principalClass: "RuntimeUpdatePlugin"
+                ),
+                instance: MockRuntimeUpdatePlugin(),
+                bundle: existingBundle,
+                sourceURL: existingURL,
+                isEnabled: true
+            ),
+        ]
+
+        let incomingURL = incomingDirectory
+            .appendingPathComponent("RuntimeUpdatePlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: incomingURL,
+            pluginId: pluginId,
+            pluginName: "Runtime Update Plugin",
+            version: "1.0.1"
+        )
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+
+        let manifest = try await service.installFromFile(incomingURL)
+
+        XCTAssertEqual(manifest.version, "1.0.1")
+        XCTAssertEqual(service.installStates[pluginId], .restartRequired)
+
+        let registeredPlugin = try XCTUnwrap(pluginManager.loadedPlugins.first { $0.manifest.id == pluginId })
+        XCTAssertEqual(registeredPlugin.manifest.version, "1.0.1")
+        XCTAssertEqual(registeredPlugin.sourceURL, existingURL)
+        XCTAssertTrue(registeredPlugin.isEnabled)
+        XCTAssertFalse(registeredPlugin.isRuntimeLoaded)
+    }
+
     func testMalformedPluginEntryIsSkippedInsteadOfFailingEntireRegistry() throws {
         // A single bad entry (wrong type on a required field) must not empty
         // the marketplace: the decoder reports the error and keeps the rest.
@@ -1053,5 +1123,52 @@ final class PluginRegistryServiceTests: XCTestCase {
             }
             """.utf8
         )
+    }
+
+    private static func makePluginBundle(
+        at bundleURL: URL,
+        pluginId: String,
+        pluginName: String,
+        version: String
+    ) throws {
+        let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let infoPlist: [String: Any] = [
+            "CFBundleIdentifier": pluginId,
+            "CFBundleName": pluginName,
+            "CFBundlePackageType": "BNDL",
+            "CFBundleShortVersionString": version,
+            "CFBundleVersion": "1",
+        ]
+        let infoData = try PropertyListSerialization.data(
+            fromPropertyList: infoPlist,
+            format: .xml,
+            options: 0
+        )
+        try infoData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+
+        let manifest = PluginManifest(
+            id: pluginId,
+            name: pluginName,
+            version: version,
+            principalClass: "RuntimeUpdatePlugin"
+        )
+        try JSONEncoder()
+            .encode(manifest)
+            .write(to: resourcesURL.appendingPathComponent("manifest.json"))
+    }
+
+    private final class MockRuntimeUpdatePlugin: NSObject, TypeWhisperPlugin, @unchecked Sendable {
+        static let pluginId = "com.typewhisper.runtime-update"
+        static let pluginName = "Runtime Update Plugin"
+
+        required override init() {
+            super.init()
+        }
+
+        func activate(host: any HostServices) {}
+        func deactivate() {}
     }
 }


### PR DESCRIPTION
## Summary
- Treat updates of already runtime-loaded plugins as restart-required instead of attempting an in-process hot reload.
- Register the newly installed bundle as an unloaded placeholder so the installed version is visible, while runtime actions stay blocked until the next app launch.
- Show a restart-required install state in Integrations and the setup wizard.

## Issue context
Follow-up to #847 and [the latest reporter status](https://github.com/TypeWhisper/typewhisper-mac/issues/847#issuecomment-4914263327).

Gemma4Plugin v1.1.1 was published correctly and the reporter's diagnostics show the v1.1.1 executable SHA on disk, but the running process still reported old bundle metadata and surfaced the raw v1.1.0 loader error. That points to the host replacing the bundle files after the old Swift/ObjC plugin class was already loaded. Re-instantiating a plugin with the same principal class in the same process is not a reliable hot reload path.

This patch prevents that misleading state for Gemma4Plugin and future plugin updates.

## Test plan
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryServiceTests -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests CODE_SIGNING_ALLOWED=NO`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin installs that replace a running plugin now clearly show a restart-required state.
  * The setup flow now highlights plugins that need a restart with a dedicated status indicator.

* **Bug Fixes**
  * Prevented post-install actions like auto-opening settings or enabling plugins when a restart is needed.
  * Disabled plugin controls until the app is restarted after an update that can’t be applied live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->