### PR TITLE
Fix recorder Apple Speech model restore

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -349,13 +349,14 @@ final class ModelManagerService: ObservableObject {
     ) -> String? {
         guard let override else { return nil }
         let previousId = plugin.selectedModelId
+        if previousId != override || !plugin.isConfigured {
+            plugin.selectModel(override)
+        }
         // If the plugin had no previous selection we can't express "unselect" through the SDK,
         // so the override stays in place. For configured plugins selectedModelId is normally set.
         guard let previousId, previousId != override else {
-            if previousId != override { plugin.selectModel(override) }
             return nil
         }
-        plugin.selectModel(override)
         return previousId
     }
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -59,7 +59,7 @@ final class AudioRecorderViewModel: ObservableObject {
         let languageSelection: LanguageSelection
         let task: TranscriptionTask
         let providerId: String?
-        let resolvedModelId: String?
+        let modelOverrideId: String?
         let prompt: String?
         let dictionaryTermHints: [PluginDictionaryTermHint]
         let liveSessionResult: TranscriptionResult?
@@ -534,7 +534,7 @@ final class AudioRecorderViewModel: ObservableObject {
                     languageSelection: languageSelection,
                     task: selectedTask,
                     providerId: providerId,
-                    resolvedModelId: effectiveModelId,
+                    modelOverrideId: selectedModel,
                     prompt: dictionaryPrompt,
                     dictionaryTermHints: dictionaryTermHints,
                     liveSessionResult: liveSessionResult
@@ -798,7 +798,7 @@ final class AudioRecorderViewModel: ObservableObject {
             selectedProviderId: modelManager.selectedProviderId,
             languageSelection: languageSelection,
             task: task,
-            cloudModelOverride: effectiveModelId,
+            cloudModelOverride: selectedModel,
             allowLiveTranscription: true,
             stateCheck: { [weak self] in self?.state == .recording }
         )
@@ -844,7 +844,7 @@ final class AudioRecorderViewModel: ObservableObject {
                     languageSelection: request.languageSelection,
                     task: effectiveTask,
                     engineOverrideId: request.providerId,
-                    cloudModelOverride: request.resolvedModelId,
+                    cloudModelOverride: request.modelOverrideId,
                     prompt: request.prompt,
                     dictionaryTermHints: request.dictionaryTermHints
                 )
@@ -941,7 +941,7 @@ final class AudioRecorderViewModel: ObservableObject {
             },
             modelName: modelManager.resolvedModelDisplayName(
                 engineOverrideId: request.providerId,
-                cloudModelOverride: request.resolvedModelId
+                cloudModelOverride: request.modelOverrideId
             ),
             failedAt: Date()
         )

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -301,6 +301,47 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertNil(recording.transcriptionFailure)
     }
 
+    func testFinalTranscriptionDoesNotForceGlobalDefaultModelAsRecorderOverride() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let appSupportDirectory = makeTemporaryDirectory()
+        let previousPluginManager = PluginManager.shared
+        addTeardownBlock {
+            PluginManager.shared = previousPluginManager
+        }
+
+        let plugin = RecorderOverrideMarkerTranscriptionPlugin()
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: RecorderOverrideMarkerTranscriptionPlugin.pluginId,
+                    name: RecorderOverrideMarkerTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "RecorderOverrideMarkerTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+        let viewModel = makeFinalTranscriptionViewModel(defaults: defaults, modelManager: modelManager)
+
+        XCTAssertNil(viewModel.selectedModel)
+
+        let sessionID = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
+        XCTAssertEqual(session.text, "unforced whisper-large-v3")
+        XCTAssertEqual(plugin.selectedModelOverrides, [])
+    }
+
     func testFailureSidecarWriteErrorStillShowsRecorderFailure() async throws {
         try preserveStandardDefaults()
         setupPluginManager(groqBehavior: .failure("HTTP 500: provider unavailable"))
@@ -614,5 +655,51 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         case .failure(let message):
             throw PluginTranscriptionError.apiError(message)
         }
+    }
+}
+
+private final class RecorderOverrideMarkerTranscriptionPlugin: NSObject, TranscriptionModelCatalogProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.recorder-override-marker"
+    static let pluginName = "Recorder Override Marker"
+
+    private let models = [
+        PluginModelInfo(id: "whisper-large-v3", displayName: "Whisper Large V3"),
+        PluginModelInfo(id: "whisper-small", displayName: "Whisper Small")
+    ]
+    private var selectedModelReadCount = 0
+    private var currentModelId = "whisper-large-v3"
+    private(set) var selectedModelOverrides: [String] = []
+
+    var providerId: String { "recorder-override-marker" }
+    var providerDisplayName: String { Self.pluginName }
+    var isConfigured: Bool { true }
+    var selectedModelId: String? {
+        selectedModelReadCount += 1
+        if selectedModelReadCount == 1 {
+            currentModelId = "whisper-small"
+            return "whisper-large-v3"
+        }
+        return currentModelId
+    }
+    var availableModels: [PluginModelInfo] { models }
+    var transcriptionModels: [PluginModelInfo] { models }
+    var supportsTranslation: Bool { true }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    func selectModel(_ modelId: String) {
+        selectedModelOverrides.append(modelId)
+        currentModelId = modelId
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        let mode = selectedModelOverrides.isEmpty ? "unforced" : "forced"
+        return PluginTranscriptionResult(text: "\(mode) \(currentModelId)")
     }
 }

--- a/TypeWhisperTests/ModelManagerAppleSpeechModelSelectionTests.swift
+++ b/TypeWhisperTests/ModelManagerAppleSpeechModelSelectionTests.swift
@@ -116,6 +116,28 @@ final class ModelManagerAppleSpeechModelSelectionTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelId, "speechanalyzer-en_US")
     }
 
+    func testManualModelOverrideLoadsPersistedAppleSpeechModelWhenRuntimeModelIsUnloaded() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockAppleSpeechTranscriptionPlugin(
+            persistedSelectedModelId: "speechanalyzer-en_US"
+        )
+        let modelManager = installAppleSpeechPlugin(plugin, appSupportDirectory: appSupportDirectory)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            languageSelection: .auto,
+            task: .transcribe,
+            cloudModelOverride: "speechanalyzer-en_US"
+        )
+
+        XCTAssertEqual(result.text, "transcribed with speechanalyzer-en_US")
+        XCTAssertEqual(plugin.requestedLanguagePreparations, [])
+        XCTAssertEqual(plugin.transcribedModelIds, ["speechanalyzer-en_US"])
+        XCTAssertEqual(plugin.selectedModelId, "speechanalyzer-en_US")
+    }
+
     func testAppleSpeechUsesActionableErrorWhenNoModelCanBePrepared() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -178,24 +200,28 @@ private final class MockAppleSpeechTranscriptionPlugin: NSObject, TranscriptionM
     let availableModels: [PluginModelInfo]
     private(set) var requestedLanguagePreparations: [String?] = []
     private(set) var transcribedModelIds: [String] = []
+    private let persistedSelectedModelId: String?
     private var currentModelId: String?
 
     init(
-        availableModels: [PluginModelInfo] = defaultAvailableModels
+        availableModels: [PluginModelInfo] = defaultAvailableModels,
+        persistedSelectedModelId: String? = nil
     ) {
         self.availableModels = availableModels
+        self.persistedSelectedModelId = persistedSelectedModelId
         super.init()
     }
 
     required override init() {
         self.availableModels = Self.defaultAvailableModels
+        self.persistedSelectedModelId = nil
         super.init()
     }
 
     var providerId: String { AppleSpeechModelSelection.providerId }
     var providerDisplayName: String { "Apple Speech" }
     var isConfigured: Bool { currentModelId != nil }
-    var selectedModelId: String? { currentModelId }
+    var selectedModelId: String? { currentModelId ?? persistedSelectedModelId }
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { false }
     var supportedLanguages: [String] {


### PR DESCRIPTION
## Summary
- Stop treating the globally resolved default model as a recorder-specific model override.
- Keep explicit recorder model overrides working for live preview, final transcription, and retry paths.
- Harden model override application so an Apple Speech model with a persisted selected ID but no runtime-loaded locale is selected/restored before transcription.

## Issue context
Issue #850 reports TypeWhisper 1.5.1 showing Apple Speech as ready with English (United States) loaded, while hotkey dictation still failed with "Apple Speech needs a language model." The recorder path was resolving the global Apple Speech `loadedModel` into a `cloudModelOverride`, which could bypass the normal Apple Speech preparation path when no recorder-specific model was selected.

Closes #850

## Test plan
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/ModelManagerAppleSpeechModelSelectionTests -only-testing:TypeWhisperTests/ModelManagerLiveSessionModelOverrideTests -only-testing:TypeWhisperTests/AudioRecorderViewModelTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/426a/typewhisper-mac`

Dev smoke ran on macOS `27.0` (`26A5378j`) and launched `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection handling so the app applies the chosen model more reliably when recording and transcription start or stop.
  * Fixed transcription behavior for model overrides, including cases where a model is not yet loaded or the plugin wasn’t previously configured.
  * Corrected how the app records the active model during transcription failures and session completion.
  * Added coverage for override-related transcription scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->