### PR TITLE
Fix Gemma 4 4-bit MLX loading

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -7244,7 +7244,7 @@
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.31.3;
+				version = 3.31.4;
 			};
 		};
 		RR00000000000000000009 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7c66048b411ed2317343aef0981b2f3eb75034329630d9ce205815131e0176cd",
+  "originHash" : "aec9768d6289d796c6b63043c09aea36e7c8c9432265cb60676be6042accaa29",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
-        "version" : "0.31.6"
+        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
+        "version" : "0.31.4"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/FluidInference/FluidAudio.git", branch: "main"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.6"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.4"),
         .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
     ],
     targets: [

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/FluidInference/FluidAudio.git", branch: "main"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.4"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.6"),
         .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
     ],
     targets: [

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/FluidInference/FluidAudio.git", branch: "main"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.3"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.4"),
         .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
     ],
     targets: [

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -839,7 +839,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             )
         }
 
-        let rawMessage = String(describing: error).lowercased()
+        let rawMessage = "\(String(describing: error))\n\(error.localizedDescription)".lowercased()
         if isRecoverableCacheError(rawMessage) {
             let bundle = Bundle(for: Gemma4Plugin.self)
             return String(

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -439,6 +439,13 @@ final class PluginDownloadedModelManagementTests: XCTestCase {
 
 @MainActor
 final class Gemma4PluginModelPolicyTests: XCTestCase {
+    private struct LocalizedOnlyError: LocalizedError, CustomStringConvertible {
+        let message: String
+
+        var errorDescription: String? { message }
+        var description: String { "LocalizedOnlyError" }
+    }
+
     private actor RequestRecorder {
         private var request: URLRequest?
 
@@ -796,6 +803,20 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
             userInfo: [
                 NSLocalizedDescriptionKey: "Mismatched parameter language_model.model.per_layer_model_projection.weight in Gemma4.Gemma4TextLanguageModel.Gemma4TextBackbone.Gemma4ScaledLinear shape. Actual [10752, 320], expected [10752, 2560]"
             ]
+        )
+
+        let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)
+
+        XCTAssertEqual(
+            message,
+            "The downloaded Gemma model cache appears incomplete or incompatible. Delete the cached model and download it again."
+        )
+    }
+
+    func testGemma4LocalizedOnlyMismatchedParameterShapeErrorsUseCacheRecoveryMessage() throws {
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let error = LocalizedOnlyError(
+            message: "Mismatched parameter language_model.model.per_layer_model_projection.weight in Gemma4Model.Gemma4TextModel.Gemma4TextModelInner.ScaledLinear shape. Actual [8960, 192], expected [8960, 1536]"
         )
 
         let message = Gemma4Plugin.userFacingLoadErrorMessage(for: error, modelDef: model)


### PR DESCRIPTION
## Summary
- Fixes the remaining Gemma 4 4-bit load failure reported in the #847 follow-up comments.
- Bumps `mlx-swift-lm` from `3.31.3` to `3.31.4`, which changes Gemma 4 `per_layer_model_projection` to a quantizable `Linear` layer instead of `ScaledLinear`.
- Locks `mlx-swift` at `0.31.4` so the PR remains compatible with the current GitHub Actions Xcode 26.3 runner while satisfying `mlx-swift-lm` `3.31.4`.
- Bumps `Gemma4Plugin` to `1.1.2` and preserves the existing Gemma 4 LLM loader path.
- Includes `localizedDescription` in cache-recovery error classification so MLX shape mismatches surfaced only through localized errors still map to the friendly cache message.

## Issue Context
The reporter's latest diagnostics show TypeWhisper `1.5.1` with `Gemma4Plugin` `1.1.1` actually runtime-loaded, but the model still failed with:

```text
Mismatched parameter language_model.model.per_layer_model_projection.weight in Gemma4Model.Gemma4TextModel.Gemma4TextModelInner.ScaledLinear shape. Actual [8960, 192], expected [8960, 1536]
```

That means the `1.1.1` loader-path fix was active, but the remaining failure came from the MLX Swift Gemma 4 model definition. The public 4-bit weights store `per_layer_model_projection` as packed quantized weights; `mlx-swift-lm` `3.31.3` models that layer as `ScaledLinear`, which expects the uncompressed shape. `mlx-swift-lm` `3.31.4` switches that layer to `Linear`, allowing quantized loading.

Closes #847

## Test Plan
- `git diff --check`
- `xcodebuild -resolvePackageDependencies -project TypeWhisper.xcodeproj`
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests CODE_SIGNING_ALLOWED=NO -skipPackagePluginValidation`
- `xcodebuild -project /Users/marco/.codex/worktrees/fb74/typewhisper-mac/TypeWhisper.xcodeproj -scheme Gemma4Plugin -configuration Debug -derivedDataPath /Users/marco/Projects/typewhisper-mac-dev/DerivedData CONFIGURATION_BUILD_DIR=/Users/marco/Projects/typewhisper-mac-dev/PluginBuild -skipPackagePluginValidation build`
- Installed the built `Gemma4Plugin.bundle` into `/Users/marco/Library/Application Support/TypeWhisper-Dev/Plugins/Gemma4Plugin.bundle`, signed it with the local Apple Development identity, and verified the installed manifest reports `1.1.2`.
- Local-only smoke before removing the temporary test harness from the commit: downloaded and loaded `gemma-4-e2b-it-4bit` into the TypeWhisper-Dev plugin data directory with `mlx-swift-lm` `3.31.4`; the selected test passed in 129.473 seconds.
- Final local-only smoke after pinning `mlx-swift` to `0.31.4`: loaded the cached `gemma-4-e2b-it-4bit` model with `mlx-swift-lm` `3.31.4`; the selected test passed in 5.066 seconds.
- Attempted the dev helper command from the original plan, but local Xcode rejected the new `mlx-swift` `CudaBuild` package plugin without `-skipPackagePluginValidation`:
  `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --clean --run Gemma4Plugin /Users/marco/.codex/worktrees/fb74/typewhisper-mac`
