### PR TITLE
fix: restore filler dictionary corrections

### DIFF
--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -602,7 +602,8 @@ final class DictionaryService: ObservableObject {
         with replacement: String,
         caseSensitive: Bool
     ) -> String {
-        guard !original.isEmpty else { return text }
+        let boundaryOriginal = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !original.isEmpty, !boundaryOriginal.isEmpty else { return text }
 
         var result = ""
         var searchStart = text.startIndex
@@ -610,18 +611,100 @@ final class DictionaryService: ObservableObject {
 
         while let range = text.range(of: original, options: options, range: searchStart..<text.endIndex, locale: .current) {
             guard range.lowerBound < range.upperBound else { break }
+            let boundaryRange = boundaryEvaluationRange(for: range, in: text)
 
-            if isBoundaryMatch(range, in: text, original: original) {
-                result += text[searchStart..<range.lowerBound]
-                result += replacement
+            if boundaryRange.lowerBound < boundaryRange.upperBound,
+               isBoundaryMatch(boundaryRange, in: text, original: boundaryOriginal) {
+                let resolvedReplacement = boundaryReplacement(
+                    for: range,
+                    in: text,
+                    replacement: replacement,
+                    lowerLimit: searchStart
+                )
+                result += text[searchStart..<resolvedReplacement.range.lowerBound]
+                result += resolvedReplacement.text
+                searchStart = resolvedReplacement.range.upperBound
             } else {
                 result += text[searchStart..<range.upperBound]
+                searchStart = range.upperBound
             }
-            searchStart = range.upperBound
         }
 
         result += text[searchStart..<text.endIndex]
         return result
+    }
+
+    private func boundaryReplacement(
+        for range: Range<String.Index>,
+        in text: String,
+        replacement: String,
+        lowerLimit: String.Index
+    ) -> (range: Range<String.Index>, text: String) {
+        guard replacement.isEmpty else { return (range, replacement) }
+
+        let deletionRange = emptyBoundaryReplacementRange(for: range, in: text, lowerLimit: lowerLimit)
+        return (deletionRange, separatorAfterDeleting(deletionRange, in: text))
+    }
+
+    private func emptyBoundaryReplacementRange(
+        for range: Range<String.Index>,
+        in text: String,
+        lowerLimit: String.Index
+    ) -> Range<String.Index> {
+        var lowerBound = range.lowerBound
+        var upperBound = range.upperBound
+
+        if upperBound < text.endIndex, text[upperBound].isWhitespace {
+            while upperBound < text.endIndex, text[upperBound].isWhitespace {
+                upperBound = text.index(after: upperBound)
+            }
+        } else if shouldConsumeLeadingWhitespace(for: range, in: text) {
+            while lowerBound > lowerLimit {
+                let previous = text.index(before: lowerBound)
+                guard text[previous].isWhitespace else { break }
+                lowerBound = previous
+            }
+        }
+
+        return lowerBound..<upperBound
+    }
+
+    private func shouldConsumeLeadingWhitespace(for range: Range<String.Index>, in text: String) -> Bool {
+        guard range.lowerBound < range.upperBound else { return false }
+        let lastMatchedIndex = text.index(before: range.upperBound)
+        return !text[lastMatchedIndex].isWhitespace || range.upperBound == text.endIndex
+    }
+
+    private func separatorAfterDeleting(_ range: Range<String.Index>, in text: String) -> String {
+        let previous = range.lowerBound > text.startIndex ? text[text.index(before: range.lowerBound)] : nil
+        let next = range.upperBound < text.endIndex ? text[range.upperBound] : nil
+
+        if previous?.isLatinOrNumber == true && next?.isLatinOrNumber == true {
+            return " "
+        }
+
+        if previous?.keepsFollowingWordSeparatedAfterDeletion == true && next?.isLatinOrNumber == true {
+            return " "
+        }
+
+        return ""
+    }
+
+    private func boundaryEvaluationRange(for range: Range<String.Index>, in text: String) -> Range<String.Index> {
+        var lowerBound = range.lowerBound
+        var upperBound = range.upperBound
+
+        while lowerBound < upperBound, text[lowerBound].isWhitespace {
+            lowerBound = text.index(after: lowerBound)
+        }
+
+        while lowerBound < upperBound {
+            let previous = text.index(before: upperBound)
+            guard text[previous].isWhitespace else { break }
+            upperBound = previous
+        }
+
+        return lowerBound..<upperBound
     }
 
     private func isBoundaryMatch(_ range: Range<String.Index>, in text: String, original: String) -> Bool {
@@ -912,6 +995,15 @@ private extension Character {
             (0xF900...0xFAFF).contains(Int(scalar.value)) ||
             (0x20000...0x323AF).contains(Int(scalar.value)) ||
             (0xFF66...0xFF9D).contains(Int(scalar.value))
+        }
+    }
+
+    var keepsFollowingWordSeparatedAfterDeletion: Bool {
+        switch self {
+        case ",", ".", "!", "?", ";", ":":
+            return true
+        default:
+            return false
         }
     }
 

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -187,7 +187,42 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(learned.count, 1)
         XCTAssertEqual(learned.first?.original, "filler")
         XCTAssertEqual(learned.first?.replacement, "")
-        XCTAssertEqual(service.applyCorrections(to: "drop filler text"), "drop  text")
+        XCTAssertEqual(service.applyCorrections(to: "drop filler text"), "drop text")
+    }
+
+    @MainActor
+    func testWhitespaceBearingLatinFillerCorrectionsStillApplyAtWordBoundaries() throws {
+        let plainDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(plainDirectory) }
+
+        let plainService = DictionaryService(appSupportDirectory: plainDirectory)
+        plainService.addEntry(type: .correction, original: "um", replacement: "")
+
+        XCTAssertEqual(plainService.applyCorrections(to: "Um I think this works"), "I think this works")
+        XCTAssertEqual(plainService.applyCorrections(to: "I said um today"), "I said today")
+
+        let whitespaceDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(whitespaceDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: whitespaceDirectory)
+        service.addEntry(type: .correction, original: "um ", replacement: "")
+        service.addEntry(type: .correction, original: " huh", replacement: "")
+
+        XCTAssertEqual(service.applyCorrections(to: "Um I think this works"), "I think this works")
+        XCTAssertEqual(service.applyCorrections(to: "I said um today"), "I said today")
+        XCTAssertEqual(service.applyCorrections(to: "this was huh"), "this was")
+    }
+
+    @MainActor
+    func testWhitespaceBearingFillerCorrectionsKeepOneSeparatorBetweenWords() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: " um ", replacement: "")
+
+        XCTAssertEqual(service.applyCorrections(to: "I said um today"), "I said today")
+        XCTAssertEqual(service.applyCorrections(to: "I said, um today"), "I said, today")
     }
 
     @MainActor
@@ -197,11 +232,15 @@ final class DictionaryServiceTests: XCTestCase {
 
         let service = DictionaryService(appSupportDirectory: appSupportDirectory)
         service.addEntry(type: .correction, original: "rake", replacement: "RAKE")
+        service.addEntry(type: .correction, original: "um", replacement: "")
+        service.addEntry(type: .correction, original: "um ", replacement: "")
 
         XCTAssertEqual(service.applyCorrections(to: "rake"), "RAKE")
         XCTAssertEqual(service.applyCorrections(to: "Rake"), "RAKE")
         XCTAssertEqual(service.applyCorrections(to: "brake rakes"), "brake rakes")
         XCTAssertEqual(service.applyCorrections(to: "Use rake, rake/brake, and (rake)."), "Use RAKE, RAKE/brake, and (RAKE).")
+        XCTAssertEqual(service.applyCorrections(to: "umbrella stand"), "umbrella stand")
+        XCTAssertEqual(service.applyCorrections(to: "album art"), "album art")
     }
 
     @MainActor

--- a/TypeWhisperTests/SpeechPunctuationServiceTests.swift
+++ b/TypeWhisperTests/SpeechPunctuationServiceTests.swift
@@ -333,6 +333,42 @@ final class SpeechPunctuationServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testPipelineAppliesWhitespaceFillerCorrections() async throws {
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        let profileStore = DictationPunctuationProfileStore(defaults: UserDefaults(suiteName: #function)!, storageKey: #function)
+        let strategyResolver = PunctuationStrategyResolver(profileStore: profileStore)
+        dictionaryService.addEntry(type: .correction, original: "um", replacement: "")
+
+        let pipeline = PostProcessingPipeline(
+            snippetService: SnippetService(),
+            dictionaryService: dictionaryService,
+            appFormatterService: nil,
+            speechPunctuationService: SpeechPunctuationService(rulesLoader: makeRulesLoader()),
+            punctuationStrategyResolver: strategyResolver
+        )
+
+        let result = try await pipeline.process(
+            text: "Um this still works",
+            context: PostProcessingContext(language: "en"),
+            dictationContext: DictationRuntimeContext(
+                engineId: "parakeet",
+                modelId: "parakeet-v3",
+                configuredLanguage: "en",
+                detectedLanguage: nil
+            )
+        )
+
+        XCTAssertEqual(result.text, "this still works")
+        XCTAssertEqual(result.appliedSteps, ["Corrections"])
+    }
+
+    @MainActor
     func testPipelineNormalizesNumbersBeforeLaterPostProcessing() async throws {
         let previousDefault = UserDefaults.standard.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)


### PR DESCRIPTION
## Summary

Fixes the Dictionary Corrections regression reported in #853. The reporter had saved corrections for filler words such as `um` and `huh`; after TypeWhisper 1.5.1 those saved corrections no longer behaved like the pre-1.5.x flow.

This keeps the `Filler Words` plugin as the purpose-built filler-removal extension, but saved Dictionary Corrections remain supported:

- Preserve whole-word protection from PR #749 so corrections still do not replace inside longer words such as `umbrella` or `album`.
- Allow whitespace-bearing legacy corrections such as `um `, ` huh`, and ` um ` to match using their trimmed word core for boundary checks.
- Clean adjacent whitespace for empty correction replacements so `um -> ""` removes the filler without leaving leading/double spaces or joining words.
- Add a pipeline regression test proving Dictionary Corrections still run as the `Corrections` post-processing step.

Closes #853

## Verification

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests -only-testing:TypeWhisperTests/SpeechPunctuationServiceTests`
  - Passed: 47 tests, 0 failures
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
  - Passed: 1123 tests, 0 failures
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"`
  - Passed: `** BUILD SUCCEEDED **`, app built at `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`

## Review Notes

Pre-landing review found no issues. No schema, storage/import/export, localization, CLI, HTTP, sync, or public API changes.

Version and changelog bump are not included because this repository does not have root-level `VERSION` or `CHANGELOG.md` files, and recent TypeWhisper app bugfix PRs land without adding synthetic release metadata files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how empty correction replacements behave at word boundaries, preserving clean spacing and avoiding extra gaps or awkward joins.
  * Better handles filler-word removal in whitespace-sensitive text, including cases with punctuation and surrounding spaces.

* **Tests**
  * Expanded coverage for whole-word correction behavior and spacing edge cases.
  * Added a pipeline test confirming filler-word corrections are applied end-to-end as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->