### PR TITLE
fix: place active-screen indicators on the correct display

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -782,6 +782,87 @@ struct IndicatorRectDiagnostics: Encodable, Equatable, Sendable {
     }
 }
 
+struct IndicatorScreenGeometry: Equatable {
+    enum CoordinateSpace {
+        case quartz
+        case appKit
+    }
+
+    let identifier: CGDirectDisplayID
+    let appKitFrame: CGRect
+    let quartzDisplayBounds: CGRect?
+
+    init(
+        identifier: CGDirectDisplayID,
+        appKitFrame: CGRect,
+        quartzDisplayBounds: CGRect?
+    ) {
+        self.identifier = identifier
+        self.appKitFrame = appKitFrame
+        self.quartzDisplayBounds = quartzDisplayBounds
+    }
+
+    init?(screen: NSScreen) {
+        guard let screenNumber = screen.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? NSNumber else {
+            return nil
+        }
+
+        let displayID = CGDirectDisplayID(screenNumber.uint32Value)
+        let quartzDisplayBounds = CGDisplayBounds(displayID)
+        self.init(
+            identifier: displayID,
+            appKitFrame: screen.frame,
+            quartzDisplayBounds: quartzDisplayBounds.isNull || quartzDisplayBounds.isEmpty
+                ? nil
+                : quartzDisplayBounds.standardized
+        )
+    }
+
+    static func displayIdentifier(
+        containing point: CGPoint,
+        among displays: [IndicatorScreenGeometry],
+        in coordinateSpace: CoordinateSpace
+    ) -> CGDirectDisplayID? {
+        displays.first { display in
+            guard let frame = display.frame(in: coordinateSpace) else { return false }
+            return frame.contains(point)
+        }?.identifier
+    }
+
+    static func displayIdentifier(
+        intersecting frame: CGRect,
+        among displays: [IndicatorScreenGeometry],
+        in coordinateSpace: CoordinateSpace
+    ) -> CGDirectDisplayID? {
+        let bestDisplay = displays
+            .compactMap { display -> (display: IndicatorScreenGeometry, area: CGFloat)? in
+                guard let displayFrame = display.frame(in: coordinateSpace) else { return nil }
+                let intersection = frame.intersection(displayFrame)
+                let area = intersection.isNull ? 0 : intersection.width * intersection.height
+                return (display, area)
+            }
+            .max(by: { $0.area < $1.area })
+
+        if let bestDisplay, bestDisplay.area > 0 {
+            return bestDisplay.display.identifier
+        }
+
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        return displayIdentifier(containing: center, among: displays, in: coordinateSpace)
+    }
+
+    private func frame(in coordinateSpace: CoordinateSpace) -> CGRect? {
+        switch coordinateSpace {
+        case .quartz:
+            quartzDisplayBounds
+        case .appKit:
+            appKitFrame
+        }
+    }
+}
+
 @MainActor
 final class IndicatorScreenResolver {
     typealias FocusedElementPositionProvider = () -> CGPoint?
@@ -799,6 +880,11 @@ final class IndicatorScreenResolver {
     private let screensProvider: ScreensProvider
     private let mainScreenProvider: MainScreenProvider
     private let windowFrameProvider: WindowFrameProvider
+
+    private struct ScreenDescriptor {
+        let screen: NSScreen
+        let geometry: IndicatorScreenGeometry
+    }
 
     init(
         focusedElementPositionProvider: @escaping FocusedElementPositionProvider = {
@@ -828,22 +914,36 @@ final class IndicatorScreenResolver {
 
         switch displayMode {
         case .activeScreen:
-            if let screen = screen(containing: focusedElementPositionProvider()) {
+            let displayDescriptors = screens.compactMap { screen -> ScreenDescriptor? in
+                guard let geometry = IndicatorScreenGeometry(screen: screen) else { return nil }
+                return ScreenDescriptor(screen: screen, geometry: geometry)
+            }
+
+            if let screen = screen(
+                containingQuartzPoint: focusedElementPositionProvider(),
+                displayDescriptors: displayDescriptors
+            ) {
                 return screen
             }
 
             if let focusedWindowFrame = focusedWindowFrameProvider(),
-               let screen = screen(intersecting: focusedWindowFrame) {
+               let screen = screen(
+                   intersectingQuartzFrame: focusedWindowFrame,
+                   displayDescriptors: displayDescriptors
+               ) {
                 return screen
             }
 
             if let application = frontmostApplicationProvider(),
                let windowFrame = windowFrameProvider(application.processIdentifier),
-               let screen = screen(intersecting: windowFrame) {
+               let screen = screen(
+                   intersectingQuartzFrame: windowFrame,
+                   displayDescriptors: displayDescriptors
+               ) {
                 return screen
             }
 
-            if let screen = screen(containing: mouseLocationProvider()) {
+            if let screen = screen(containingAppKitPoint: mouseLocationProvider(), screens: screens) {
                 return screen
             }
 
@@ -855,27 +955,39 @@ final class IndicatorScreenResolver {
         }
     }
 
-    private func screen(containing point: CGPoint?) -> NSScreen? {
+    private func screen(
+        containingQuartzPoint point: CGPoint?,
+        displayDescriptors: [ScreenDescriptor]
+    ) -> NSScreen? {
         guard let point else { return nil }
-        return screensProvider().first { $0.frame.contains(point) }
-    }
-
-    private func screen(intersecting frame: CGRect) -> NSScreen? {
-        let screens = screensProvider()
-        let bestScreen = screens
-            .map { screen in
-                let intersection = frame.intersection(screen.frame)
-                let area = intersection.isNull ? 0 : intersection.width * intersection.height
-                return (screen, area)
-            }
-            .max(by: { $0.1 < $1.1 })
-
-        if let bestScreen, bestScreen.1 > 0 {
-            return bestScreen.0
+        guard let displayIdentifier = IndicatorScreenGeometry.displayIdentifier(
+            containing: point,
+            among: displayDescriptors.map(\.geometry),
+            in: .quartz
+        ) else {
+            return nil
         }
 
-        let center = CGPoint(x: frame.midX, y: frame.midY)
-        return screen(containing: center)
+        return displayDescriptors.first { $0.geometry.identifier == displayIdentifier }?.screen
+    }
+
+    private func screen(
+        intersectingQuartzFrame frame: CGRect,
+        displayDescriptors: [ScreenDescriptor]
+    ) -> NSScreen? {
+        guard let displayIdentifier = IndicatorScreenGeometry.displayIdentifier(
+            intersecting: frame,
+            among: displayDescriptors.map(\.geometry),
+            in: .quartz
+        ) else {
+            return nil
+        }
+
+        return displayDescriptors.first { $0.geometry.identifier == displayIdentifier }?.screen
+    }
+
+    private func screen(containingAppKitPoint point: CGPoint, screens: [NSScreen]) -> NSScreen? {
+        screens.first { $0.frame.contains(point) }
     }
 
 }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1,6 +1,18 @@
 import XCTest
 import AppKit
+import CoreGraphics
 @testable import TypeWhisper
+
+@MainActor
+private func quartzDisplayBounds(for screen: NSScreen) -> CGRect? {
+    guard let screenNumber = screen.deviceDescription[
+        NSDeviceDescriptionKey("NSScreenNumber")
+    ] as? NSNumber else {
+        return nil
+    }
+
+    return CGDisplayBounds(CGDirectDisplayID(screenNumber.uint32Value))
+}
 
 final class DictationViewModelIndicatorSettingsTests: XCTestCase {
     private var defaults: UserDefaults!
@@ -130,11 +142,12 @@ final class IndicatorScreenResolverTests: XCTestCase {
     @MainActor
     func testActiveScreenPrefersFocusedElementBeforeWindowLookup() throws {
         let screen = try XCTUnwrap(NSScreen.screens.first)
+        let quartzBounds = try XCTUnwrap(quartzDisplayBounds(for: screen))
         var windowLookupCalled = false
         var mouseLookupCalled = false
 
         let resolver = IndicatorScreenResolver(
-            focusedElementPositionProvider: { CGPoint(x: screen.frame.midX, y: screen.frame.midY) },
+            focusedElementPositionProvider: { CGPoint(x: quartzBounds.midX, y: quartzBounds.midY) },
             frontmostApplicationProvider: { NSRunningApplication.current },
             mouseLocationProvider: {
                 mouseLookupCalled = true
@@ -144,7 +157,7 @@ final class IndicatorScreenResolverTests: XCTestCase {
             mainScreenProvider: { screen },
             windowFrameProvider: { _ in
                 windowLookupCalled = true
-                return screen.frame
+                return quartzBounds
             }
         )
 
@@ -158,6 +171,7 @@ final class IndicatorScreenResolverTests: XCTestCase {
     @MainActor
     func testActiveScreenUsesWindowFrameBeforeMouseFallback() throws {
         let screen = try XCTUnwrap(NSScreen.screens.first)
+        let quartzBounds = try XCTUnwrap(quartzDisplayBounds(for: screen))
         var mouseLookupCalled = false
 
         let resolver = IndicatorScreenResolver(
@@ -170,7 +184,7 @@ final class IndicatorScreenResolverTests: XCTestCase {
             },
             screensProvider: { [screen] },
             mainScreenProvider: { screen },
-            windowFrameProvider: { _ in screen.frame }
+            windowFrameProvider: { _ in quartzBounds }
         )
 
         let resolvedScreen = resolver.resolveScreen(for: .activeScreen)
@@ -182,12 +196,13 @@ final class IndicatorScreenResolverTests: XCTestCase {
     @MainActor
     func testActiveScreenUsesFocusedWindowBeforeFrontmostApplicationFallback() throws {
         let screen = try XCTUnwrap(NSScreen.screens.first)
+        let quartzBounds = try XCTUnwrap(quartzDisplayBounds(for: screen))
         var frontmostWindowLookupCalled = false
         var mouseLookupCalled = false
 
         let resolver = IndicatorScreenResolver(
             focusedElementPositionProvider: { nil },
-            focusedWindowFrameProvider: { screen.frame },
+            focusedWindowFrameProvider: { quartzBounds },
             frontmostApplicationProvider: { NSRunningApplication.current },
             mouseLocationProvider: {
                 mouseLookupCalled = true
@@ -230,6 +245,149 @@ final class IndicatorScreenResolverTests: XCTestCase {
 
         XCTAssertTrue(resolvedScreen === screen)
         XCTAssertTrue(mouseLookupCalled)
+    }
+
+    @MainActor
+    func testActiveScreenFallsBackToMainScreenWhenNoSourceResolves() throws {
+        let screen = try XCTUnwrap(NSScreen.screens.first)
+        var mouseLookupCalled = false
+        var mainScreenProviderCalled = false
+
+        let resolver = IndicatorScreenResolver(
+            focusedElementPositionProvider: { nil },
+            focusedWindowFrameProvider: { nil },
+            frontmostApplicationProvider: { nil },
+            mouseLocationProvider: {
+                mouseLookupCalled = true
+                return CGPoint(x: screen.frame.maxX + 10_000, y: screen.frame.maxY + 10_000)
+            },
+            screensProvider: { [screen] },
+            mainScreenProvider: {
+                mainScreenProviderCalled = true
+                return screen
+            },
+            windowFrameProvider: { _ in nil }
+        )
+
+        let resolvedScreen = resolver.resolveScreen(for: .activeScreen)
+
+        XCTAssertTrue(resolvedScreen === screen)
+        XCTAssertTrue(mouseLookupCalled)
+        XCTAssertTrue(mainScreenProviderCalled)
+    }
+}
+
+final class IndicatorScreenGeometryTests: XCTestCase {
+    func testQuartzPointUsesQuartzBoundsForVerticallyStackedDisplays() {
+        let displays = verticallyStackedDisplays()
+        let point = CGPoint(x: 960, y: -540)
+
+        XCTAssertEqual(
+            IndicatorScreenGeometry.displayIdentifier(
+                containing: point,
+                among: [displays.primary, displays.top, displays.bottom],
+                in: .quartz
+            ),
+            displays.top.identifier
+        )
+        XCTAssertEqual(
+            IndicatorScreenGeometry.displayIdentifier(
+                containing: point,
+                among: [displays.primary, displays.top, displays.bottom],
+                in: .appKit
+            ),
+            displays.bottom.identifier
+        )
+    }
+
+    func testQuartzWindowFrameUsesLargestIntersection() {
+        let displays = verticallyStackedDisplays()
+        let frame = CGRect(x: 100, y: -1_000, width: 1_000, height: 1_100)
+
+        XCTAssertEqual(
+            IndicatorScreenGeometry.displayIdentifier(
+                intersecting: frame,
+                among: [displays.primary, displays.top, displays.bottom],
+                in: .quartz
+            ),
+            displays.top.identifier
+        )
+        XCTAssertEqual(
+            IndicatorScreenGeometry.displayIdentifier(
+                intersecting: frame,
+                among: [displays.primary, displays.top, displays.bottom],
+                in: .appKit
+            ),
+            displays.bottom.identifier
+        )
+    }
+
+    func testQuartzWindowFrameFallsBackToItsCenter() {
+        let displays = verticallyStackedDisplays()
+        let frame = CGRect(x: 960, y: -540, width: 0, height: 0)
+
+        XCTAssertEqual(
+            IndicatorScreenGeometry.displayIdentifier(
+                intersecting: frame,
+                among: [displays.primary, displays.top, displays.bottom],
+                in: .quartz
+            ),
+            displays.top.identifier
+        )
+    }
+
+    func testAppKitMousePointUsesAppKitFrames() {
+        let displays = verticallyStackedDisplays()
+        let point = CGPoint(x: 960, y: -540)
+
+        XCTAssertEqual(
+            IndicatorScreenGeometry.displayIdentifier(
+                containing: point,
+                among: [displays.primary, displays.top, displays.bottom],
+                in: .appKit
+            ),
+            displays.bottom.identifier
+        )
+    }
+
+    func testQuartzLookupSkipsDisplaysWithoutQuartzBounds() {
+        let displays = verticallyStackedDisplays()
+        let unavailableTop = IndicatorScreenGeometry(
+            identifier: displays.top.identifier,
+            appKitFrame: displays.top.appKitFrame,
+            quartzDisplayBounds: nil
+        )
+
+        XCTAssertNil(
+            IndicatorScreenGeometry.displayIdentifier(
+                containing: CGPoint(x: 960, y: 1_440),
+                among: [unavailableTop],
+                in: .quartz
+            )
+        )
+    }
+
+    private func verticallyStackedDisplays() -> (
+        primary: IndicatorScreenGeometry,
+        top: IndicatorScreenGeometry,
+        bottom: IndicatorScreenGeometry
+    ) {
+        let primary = IndicatorScreenGeometry(
+            identifier: 1,
+            appKitFrame: CGRect(x: 0, y: 0, width: 1_440, height: 900),
+            quartzDisplayBounds: CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        )
+        let top = IndicatorScreenGeometry(
+            identifier: 2,
+            appKitFrame: CGRect(x: 0, y: 900, width: 1_920, height: 1_080),
+            quartzDisplayBounds: CGRect(x: 0, y: -1_080, width: 1_920, height: 1_080)
+        )
+        let bottom = IndicatorScreenGeometry(
+            identifier: 3,
+            appKitFrame: CGRect(x: 0, y: -1_080, width: 1_920, height: 1_080),
+            quartzDisplayBounds: CGRect(x: 0, y: 900, width: 1_920, height: 1_080)
+        )
+        return (primary, top, bottom)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the active-screen placement regression reported in #854.

- Maps AX caret points and Quartz window frames through the matching display's Quartz bounds.
- Keeps the existing resolution order: caret → focused window → external app window → mouse → main screen.
- Retains the AppKit coordinate space specifically for the mouse fallback.
- Adds synthetic multi-display coordinate-space coverage without changing fullscreen, Space, or settings behavior.

Closes #854

## Test Coverage

All newly introduced coordinate-space paths are covered by XCTest, including Quartz-vs-AppKit point matching, largest window intersection, center fallback, missing Quartz bounds, resolver precedence, and main-screen fallback.

## Pre-Landing Review

No issues found.

## Scope Drift

Scope check: CLEAN. This PR is limited to active-screen indicator display resolution and its regression tests.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/6059/typewhisper-mac`
- [x] Local dual-display smoke: overlay top/bottom, minimal top/bottom, and notch all resolved to the built-in display while the mouse remained on the external display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indicator placement across multiple displays, including vertically stacked monitors.
  * Increased accuracy when positioning indicators around focused elements and application windows.
  * Added more reliable fallback behavior when display information is unavailable.
  * Improved handling of different screen coordinate systems and zero-size window frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->