### PR TITLE
Fix CoreAudio HAL teardown race

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		A10000000000000000000005 /* SpeechFeedbackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000004 /* SpeechFeedbackServiceTests.swift */; };
 		A10000000000000000000006 /* WorkflowServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000005 /* WorkflowServiceTests.swift */; };
 		AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000351 /* ObjCExceptionCatcher.m */; };
+		C85600000000000000000001 /* CoreAudioHALCallbackContext.c in Sources */ = {isa = PBXBuildFile; fileRef = C85600000000000000000003 /* CoreAudioHALCallbackContext.c */; };
 		AA00000000000000000353 /* PostUpdatePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */; };
 		AA00000000000000000354 /* SettingsNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000354 /* SettingsNavigationCoordinator.swift */; };
 		AA00000000000000000355 /* PostUpdateLicensePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000355 /* PostUpdateLicensePromptView.swift */; };
@@ -593,6 +594,8 @@
 		BB00000000000000000033 /* DictationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationViewModel.swift; sourceTree = "<group>"; };
 		BB00000000000000000350 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		BB00000000000000000351 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
+		C85600000000000000000002 /* CoreAudioHALCallbackContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreAudioHALCallbackContext.h; sourceTree = "<group>"; };
+		C85600000000000000000003 /* CoreAudioHALCallbackContext.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CoreAudioHALCallbackContext.c; sourceTree = "<group>"; };
 		BB00000000000000000352 /* TypeWhisper-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TypeWhisper-Bridging-Header.h"; sourceTree = "<group>"; };
 		BB00000000000000000353 /* PostUpdatePromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUpdatePromptCoordinator.swift; sourceTree = "<group>"; };
 		BB00000000000000000354 /* SettingsNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationCoordinator.swift; sourceTree = "<group>"; };
@@ -1491,6 +1494,8 @@
 				533A00000000000000000003 /* DictationRecoveryAudioStore.swift */,
 				BB00000000000000000350 /* ObjCExceptionCatcher.h */,
 				BB00000000000000000351 /* ObjCExceptionCatcher.m */,
+				C85600000000000000000002 /* CoreAudioHALCallbackContext.h */,
+				C85600000000000000000003 /* CoreAudioHALCallbackContext.c */,
 				BB00000000000000000220 /* AudioPlaybackService.swift */,
 				BB00000000000000000031 /* HotkeyService.swift */,
 				BB00000000000000000362 /* SecureInputDiagnostics.swift */,
@@ -3885,6 +3890,7 @@
 				AA00000000000000000030 /* AudioRecordingService.swift in Sources */,
 				533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */,
 				AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */,
+				C85600000000000000000001 /* CoreAudioHALCallbackContext.c in Sources */,
 				AA00000000000000000230 /* AudioPlaybackService.swift in Sources */,
 				AA00000000000000000031 /* HotkeyService.swift in Sources */,
 				AA00000000000000000362 /* SecureInputDiagnostics.swift in Sources */,

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -2337,11 +2337,106 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
         }
     }
 
-    private let audioUnit: AudioUnit
-    private let operations: CoreAudioHALInputOperating
-    private let renderState: RenderState
-    private let lock = NSLock()
-    private var isStopped = false
+    private final class CallbackLifetime: @unchecked Sendable {
+        private static let teardownQueue = DispatchQueue(
+            label: "com.typewhisper.coreaudio-hal-teardown",
+            qos: .utility
+        )
+        private static let quiescenceInterval: TimeInterval = 0.3
+        private static let drainRetryInterval: TimeInterval = 0.01
+
+        let audioUnit: AudioUnit
+        let operations: CoreAudioHALInputOperating
+        let renderState: RenderState
+        let callbackContext: OpaquePointer
+
+        private let lifecycleLock = NSLock()
+        private var teardownStarted = false
+        private var disposalStarted = false
+        private var finalized = false
+
+        init(
+            audioUnit: AudioUnit,
+            operations: CoreAudioHALInputOperating,
+            renderState: RenderState,
+            callbackContext: OpaquePointer
+        ) {
+            self.audioUnit = audioUnit
+            self.operations = operations
+            self.renderState = renderState
+            self.callbackContext = callbackContext
+        }
+
+        func openCallbackGate() -> Bool {
+            let canOpen = lifecycleLock.withLock { !teardownStarted }
+            guard canOpen else { return false }
+            return CoreAudioHALCallbackContextOpen(callbackContext)
+        }
+
+        func stop() {
+            let shouldStartTeardown = lifecycleLock.withLock { () -> Bool in
+                guard !teardownStarted else { return false }
+                teardownStarted = true
+                return true
+            }
+            guard shouldStartTeardown else { return }
+
+            // The C context is the only state the real-time callback may touch before
+            // this closes. From this point on, late callbacks return without allocating
+            // a buffer or rendering from the AudioUnit.
+            guard CoreAudioHALCallbackContextBeginTeardown(callbackContext) else { return }
+            operations.stop(audioUnit)
+            scheduleFinalization()
+        }
+
+        private func scheduleFinalization() {
+            Self.teardownQueue.asyncAfter(deadline: .now() + Self.quiescenceInterval) { [self] in
+                finalizeWhenDrained()
+            }
+        }
+
+        private func finalizeWhenDrained() {
+            guard CoreAudioHALCallbackContextIsDrained(callbackContext) else {
+                Self.teardownQueue.asyncAfter(deadline: .now() + Self.drainRetryInterval) { [self] in
+                    finalizeWhenDrained()
+                }
+                return
+            }
+
+            let shouldStartDisposal = lifecycleLock.withLock { () -> Bool in
+                guard teardownStarted, !disposalStarted else { return false }
+                disposalStarted = true
+                return true
+            }
+            guard shouldStartDisposal else { return }
+
+            operations.uninitialize(audioUnit)
+            operations.dispose(audioUnit)
+            // AudioUnitDispose prevents new native callbacks. Wait once more for a
+            // rejected callback that was already inspecting the C gate.
+            destroyCallbackContextWhenDrained()
+        }
+
+        private func destroyCallbackContextWhenDrained() {
+            guard CoreAudioHALCallbackContextIsDrained(callbackContext) else {
+                Self.teardownQueue.asyncAfter(deadline: .now() + Self.drainRetryInterval) { [self] in
+                    destroyCallbackContextWhenDrained()
+                }
+                return
+            }
+
+            let shouldFinalize = lifecycleLock.withLock { () -> Bool in
+                guard disposalStarted, !finalized else { return false }
+                finalized = true
+                return true
+            }
+            guard shouldFinalize else { return }
+
+            CoreAudioHALCallbackContextDestroy(callbackContext)
+        }
+    }
+
+    private let callbackLifetime: CallbackLifetime
 
     init(
         deviceID: AudioDeviceID,
@@ -2351,8 +2446,6 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
         operations: CoreAudioHALInputOperating,
         onBuffer: @escaping (AVAudioPCMBuffer) -> Void
     ) throws {
-        self.operations = operations
-
         let audioUnit: AudioUnit
         do {
             audioUnit = try operations.makeInputUnit()
@@ -2365,36 +2458,20 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
             )
             throw error
         }
-        self.audioUnit = audioUnit
 
-        do {
-            let disabled: UInt32 = 0
-            let enabled: UInt32 = 1
-            try operations.setEnableIO(disabled, scope: kAudioUnitScope_Output, element: 0, audioUnit: audioUnit, label: label)
-            try operations.setEnableIO(enabled, scope: kAudioUnitScope_Input, element: 1, audioUnit: audioUnit, label: label)
-            try operations.setCurrentDevice(deviceID, audioUnit: audioUnit, label: label)
-
-            var streamDescription = try Self.streamDescription(for: format)
-            try operations.setStreamFormat(&streamDescription, audioUnit: audioUnit, label: label)
-
-            let renderState = RenderState(
-                audioUnit: audioUnit,
-                operations: operations,
-                format: format,
-                onBuffer: onBuffer
+        let renderState = RenderState(
+            audioUnit: audioUnit,
+            operations: operations,
+            format: format,
+            onBuffer: onBuffer
+        )
+        guard let callbackContext = CoreAudioHALCallbackContextCreate(
+            Unmanaged.passUnretained(renderState).toOpaque()
+        ) else {
+            let error = CoreAudioHALInputOperationError(
+                operation: "\(label) create HAL callback context",
+                status: -1
             )
-            self.renderState = renderState
-            var callback = AURenderCallbackStruct(
-                inputProc: coreAudioHALInputRenderCallback,
-                inputProcRefCon: Unmanaged.passUnretained(renderState).toOpaque()
-            )
-            try operations.setInputCallback(&callback, audioUnit: audioUnit, label: label)
-            try operations.initialize(audioUnit, label: label)
-            try operations.start(audioUnit, label: label)
-
-            AudioInputCaptureDiagnosticsStore.clear()
-            deviceHelperLogger.info("[\(label)] Started input-only HAL capture for device \(deviceID), sampleRate=\(format.sampleRate), channels=\(format.channelCount), bufferSize=\(bufferSize)")
-        } catch {
             operations.stop(audioUnit)
             operations.uninitialize(audioUnit)
             operations.dispose(audioUnit)
@@ -2406,6 +2483,53 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
             )
             throw error
         }
+        self.callbackLifetime = CallbackLifetime(
+            audioUnit: audioUnit,
+            operations: operations,
+            renderState: renderState,
+            callbackContext: callbackContext
+        )
+
+        do {
+            let disabled: UInt32 = 0
+            let enabled: UInt32 = 1
+            try operations.setEnableIO(disabled, scope: kAudioUnitScope_Output, element: 0, audioUnit: audioUnit, label: label)
+            try operations.setEnableIO(enabled, scope: kAudioUnitScope_Input, element: 1, audioUnit: audioUnit, label: label)
+            try operations.setCurrentDevice(deviceID, audioUnit: audioUnit, label: label)
+
+            var streamDescription = try Self.streamDescription(for: format)
+            try operations.setStreamFormat(&streamDescription, audioUnit: audioUnit, label: label)
+
+            var callback = AURenderCallbackStruct(
+                inputProc: coreAudioHALInputRenderCallback,
+                inputProcRefCon: UnsafeMutableRawPointer(callbackContext)
+            )
+            try operations.setInputCallback(&callback, audioUnit: audioUnit, label: label)
+            try operations.initialize(audioUnit, label: label)
+            guard callbackLifetime.openCallbackGate() else {
+                throw CoreAudioHALInputOperationError(
+                    operation: "\(label) open HAL callback gate",
+                    status: -1
+                )
+            }
+            try operations.start(audioUnit, label: label)
+
+            AudioInputCaptureDiagnosticsStore.clear()
+            deviceHelperLogger.info("[\(label)] Started input-only HAL capture for device \(deviceID), sampleRate=\(format.sampleRate), channels=\(format.channelCount), bufferSize=\(bufferSize)")
+        } catch {
+            callbackLifetime.stop()
+            AudioInputCaptureDiagnosticsStore.recordFailure(
+                label: label,
+                deviceID: deviceID,
+                format: format,
+                error: error
+            )
+            throw error
+        }
+    }
+
+    deinit {
+        callbackLifetime.stop()
     }
 
     static func captureFormat(for deviceID: AudioDeviceID) throws -> AVAudioFormat {
@@ -2426,15 +2550,7 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
     }
 
     func stop() {
-        let shouldStop = lock.withLock { () -> Bool in
-            guard !isStopped else { return false }
-            isStopped = true
-            return true
-        }
-        guard shouldStop else { return }
-        operations.stop(audioUnit)
-        operations.uninitialize(audioUnit)
-        operations.dispose(audioUnit)
+        callbackLifetime.stop()
     }
 
     private static func streamDescription(for format: AVAudioFormat) throws -> AudioStreamBasicDescription {
@@ -2456,8 +2572,16 @@ private func coreAudioHALInputRenderCallback(
     inNumberFrames: UInt32,
     ioData: UnsafeMutablePointer<AudioBufferList>?
 ) -> OSStatus {
+    let callbackContext = OpaquePointer(inRefCon)
+    var renderStatePointer: UnsafeMutableRawPointer?
+    guard CoreAudioHALCallbackContextEnter(callbackContext, &renderStatePointer) else {
+        return noErr
+    }
+    defer { CoreAudioHALCallbackContextLeave(callbackContext) }
+    guard let renderStatePointer else { return noErr }
+
     let renderState = Unmanaged<CoreAudioHALInputCaptureSession.RenderState>
-        .fromOpaque(inRefCon)
+        .fromOpaque(renderStatePointer)
         .takeUnretainedValue()
 
     guard let buffer = AVAudioPCMBuffer(

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -2318,6 +2318,9 @@ final class CoreAudioHALInputOperations: CoreAudioHALInputOperating {
 }
 
 final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecked Sendable {
+    private static let callbackQuiescenceInterval: TimeInterval = 0.3
+    private static let callbackDrainRetryInterval: TimeInterval = 0.01
+
     final class RenderState: @unchecked Sendable {
         let audioUnit: AudioUnit
         let operations: CoreAudioHALInputOperating
@@ -2342,9 +2345,6 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
             label: "com.typewhisper.coreaudio-hal-teardown",
             qos: .utility
         )
-        private static let quiescenceInterval: TimeInterval = 0.3
-        private static let drainRetryInterval: TimeInterval = 0.01
-
         let audioUnit: AudioUnit
         let operations: CoreAudioHALInputOperating
         let renderState: RenderState
@@ -2390,14 +2390,18 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
         }
 
         private func scheduleFinalization() {
-            Self.teardownQueue.asyncAfter(deadline: .now() + Self.quiescenceInterval) { [self] in
+            Self.teardownQueue.asyncAfter(
+                deadline: .now() + CoreAudioHALInputCaptureSession.callbackQuiescenceInterval
+            ) { [self] in
                 finalizeWhenDrained()
             }
         }
 
         private func finalizeWhenDrained() {
             guard CoreAudioHALCallbackContextIsDrained(callbackContext) else {
-                Self.teardownQueue.asyncAfter(deadline: .now() + Self.drainRetryInterval) { [self] in
+                Self.teardownQueue.asyncAfter(
+                    deadline: .now() + CoreAudioHALInputCaptureSession.callbackDrainRetryInterval
+                ) { [self] in
                     finalizeWhenDrained()
                 }
                 return
@@ -2412,19 +2416,31 @@ final class CoreAudioHALInputCaptureSession: AudioInputCaptureSession, @unchecke
 
             operations.uninitialize(audioUnit)
             operations.dispose(audioUnit)
-            // AudioUnitDispose prevents new native callbacks. Wait once more for a
-            // rejected callback that was already inspecting the C gate.
-            destroyCallbackContextWhenDrained()
+            sealCallbackContextWhenDrained()
         }
 
-        private func destroyCallbackContextWhenDrained() {
-            guard CoreAudioHALCallbackContextIsDrained(callbackContext) else {
-                Self.teardownQueue.asyncAfter(deadline: .now() + Self.drainRetryInterval) { [self] in
-                    destroyCallbackContextWhenDrained()
+        private func sealCallbackContextWhenDrained() {
+            // The seal atomically verifies the last admitted callback has left and
+            // prevents another callback from entering the final drain-to-destroy gap.
+            guard CoreAudioHALCallbackContextSealForDestruction(callbackContext) else {
+                Self.teardownQueue.asyncAfter(
+                    deadline: .now() + CoreAudioHALInputCaptureSession.callbackDrainRetryInterval
+                ) { [self] in
+                    sealCallbackContextWhenDrained()
                 }
                 return
             }
 
+            // Keep the sealed refCon alive for one more quiescence window so a native
+            // callback that had not yet touched the atomic state can still reject safely.
+            Self.teardownQueue.asyncAfter(
+                deadline: .now() + CoreAudioHALInputCaptureSession.callbackQuiescenceInterval
+            ) { [self] in
+                destroySealedCallbackContext()
+            }
+        }
+
+        private func destroySealedCallbackContext() {
             let shouldFinalize = lifecycleLock.withLock { () -> Bool in
                 guard disposalStarted, !finalized else { return false }
                 finalized = true
@@ -3240,6 +3256,53 @@ extension AudioDeviceService {
 extension CoreAudioHALInputCaptureSession {
     static func testingInputOnlyCaptureChannelCount(for hardwareChannelCount: AVAudioChannelCount) -> AVAudioChannelCount {
         inputOnlyCaptureChannelCount(for: hardwareChannelCount)
+    }
+
+    static var testingCallbackQuiescenceInterval: TimeInterval {
+        callbackQuiescenceInterval
+    }
+
+    static func testingCallbackContextSealTransitions() -> (
+        sealedWhileInFlight: Bool,
+        sealedAfterDrain: Bool,
+        enteredAfterSeal: Bool,
+        payloadAfterSealWasNil: Bool
+    ) {
+        var payloadStorage: UInt8 = 0
+        return withUnsafeMutablePointer(to: &payloadStorage) { payloadPointer in
+            guard let callbackContext = CoreAudioHALCallbackContextCreate(
+                UnsafeMutableRawPointer(payloadPointer)
+            ) else {
+                return (false, false, true, false)
+            }
+            defer { CoreAudioHALCallbackContextDestroy(callbackContext) }
+
+            guard CoreAudioHALCallbackContextOpen(callbackContext) else {
+                return (false, false, true, false)
+            }
+
+            var admittedPayload: UnsafeMutableRawPointer?
+            guard CoreAudioHALCallbackContextEnter(callbackContext, &admittedPayload) else {
+                return (false, false, true, false)
+            }
+            guard CoreAudioHALCallbackContextBeginTeardown(callbackContext) else {
+                CoreAudioHALCallbackContextLeave(callbackContext)
+                return (false, false, true, false)
+            }
+
+            let sealedWhileInFlight = CoreAudioHALCallbackContextSealForDestruction(callbackContext)
+            CoreAudioHALCallbackContextLeave(callbackContext)
+            let sealedAfterDrain = CoreAudioHALCallbackContextSealForDestruction(callbackContext)
+
+            var payloadAfterSeal: UnsafeMutableRawPointer?
+            let enteredAfterSeal = CoreAudioHALCallbackContextEnter(callbackContext, &payloadAfterSeal)
+            return (
+                sealedWhileInFlight,
+                sealedAfterDrain,
+                enteredAfterSeal,
+                payloadAfterSeal == nil
+            )
+        }
     }
 }
 #endif

--- a/TypeWhisper/Services/CoreAudioHALCallbackContext.c
+++ b/TypeWhisper/Services/CoreAudioHALCallbackContext.c
@@ -8,15 +8,14 @@ struct CoreAudioHALCallbackContext {
     void *payload;
 };
 
-_Static_assert(sizeof(unsigned long long) >= sizeof(void *),
-               "CoreAudio callback context requires a 64-bit platform");
 _Static_assert(ATOMIC_LLONG_LOCK_FREE == 2,
                "CoreAudio callback context requires a lock-free C11 atomic word");
 
 #define CORE_AUDIO_HAL_CALLBACK_CLOSED ((unsigned long long)1)
 #define CORE_AUDIO_HAL_CALLBACK_TEARDOWN_CLAIMED ((unsigned long long)2)
-#define CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_INCREMENT ((unsigned long long)4)
-#define CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK (~((unsigned long long)3))
+#define CORE_AUDIO_HAL_CALLBACK_DESTROY_SEALED ((unsigned long long)4)
+#define CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_INCREMENT ((unsigned long long)8)
+#define CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK (~((unsigned long long)7))
 
 CoreAudioHALCallbackContext *CoreAudioHALCallbackContextCreate(void *payload) {
     if (payload == NULL) {
@@ -47,6 +46,8 @@ bool CoreAudioHALCallbackContextOpen(CoreAudioHALCallbackContext *context) {
         if ((observed & CORE_AUDIO_HAL_CALLBACK_CLOSED) == 0) {
             return true;
         }
+        // Defensively prevent future callers from reopening a reused context
+        // while a callback is still observing its closed state.
         if ((observed & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) != 0) {
             return false;
         }
@@ -70,6 +71,11 @@ bool CoreAudioHALCallbackContextEnter(
     unsigned long long observed = atomic_load_explicit(&context->state, memory_order_acquire);
 
     for (;;) {
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_DESTROY_SEALED) != 0) {
+            *payload = NULL;
+            return false;
+        }
+
         // Rejected callbacks count too: they still dereference this context while
         // observing the closed gate and must finish before it is destroyed.
         if ((observed & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) == CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) {
@@ -123,4 +129,30 @@ bool CoreAudioHALCallbackContextBeginTeardown(CoreAudioHALCallbackContext *conte
 bool CoreAudioHALCallbackContextIsDrained(CoreAudioHALCallbackContext *context) {
     const unsigned long long state = atomic_load_explicit(&context->state, memory_order_acquire);
     return (state & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) == 0;
+}
+
+bool CoreAudioHALCallbackContextSealForDestruction(CoreAudioHALCallbackContext *context) {
+    unsigned long long observed = atomic_load_explicit(&context->state, memory_order_acquire);
+
+    for (;;) {
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_TEARDOWN_CLAIMED) == 0) {
+            return false;
+        }
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_DESTROY_SEALED) != 0) {
+            return true;
+        }
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) != 0) {
+            return false;
+        }
+
+        const unsigned long long desired = observed | CORE_AUDIO_HAL_CALLBACK_DESTROY_SEALED;
+        if (atomic_compare_exchange_weak_explicit(
+                &context->state,
+                &observed,
+                desired,
+                memory_order_acq_rel,
+                memory_order_acquire)) {
+            return true;
+        }
+    }
 }

--- a/TypeWhisper/Services/CoreAudioHALCallbackContext.c
+++ b/TypeWhisper/Services/CoreAudioHALCallbackContext.c
@@ -1,0 +1,126 @@
+#include "CoreAudioHALCallbackContext.h"
+
+#include <stdatomic.h>
+#include <stdlib.h>
+
+struct CoreAudioHALCallbackContext {
+    _Atomic(unsigned long long) state;
+    void *payload;
+};
+
+_Static_assert(sizeof(unsigned long long) >= sizeof(void *),
+               "CoreAudio callback context requires a 64-bit platform");
+_Static_assert(ATOMIC_LLONG_LOCK_FREE == 2,
+               "CoreAudio callback context requires a lock-free C11 atomic word");
+
+#define CORE_AUDIO_HAL_CALLBACK_CLOSED ((unsigned long long)1)
+#define CORE_AUDIO_HAL_CALLBACK_TEARDOWN_CLAIMED ((unsigned long long)2)
+#define CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_INCREMENT ((unsigned long long)4)
+#define CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK (~((unsigned long long)3))
+
+CoreAudioHALCallbackContext *CoreAudioHALCallbackContextCreate(void *payload) {
+    if (payload == NULL) {
+        return NULL;
+    }
+
+    CoreAudioHALCallbackContext *context = calloc(1, sizeof(*context));
+    if (context == NULL) {
+        return NULL;
+    }
+
+    atomic_init(&context->state, CORE_AUDIO_HAL_CALLBACK_CLOSED);
+    context->payload = payload;
+    return context;
+}
+
+void CoreAudioHALCallbackContextDestroy(CoreAudioHALCallbackContext *context) {
+    free(context);
+}
+
+bool CoreAudioHALCallbackContextOpen(CoreAudioHALCallbackContext *context) {
+    unsigned long long observed = atomic_load_explicit(&context->state, memory_order_acquire);
+
+    for (;;) {
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_TEARDOWN_CLAIMED) != 0) {
+            return false;
+        }
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_CLOSED) == 0) {
+            return true;
+        }
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) != 0) {
+            return false;
+        }
+
+        const unsigned long long desired = observed & ~CORE_AUDIO_HAL_CALLBACK_CLOSED;
+        if (atomic_compare_exchange_weak_explicit(
+                &context->state,
+                &observed,
+                desired,
+                memory_order_release,
+                memory_order_acquire)) {
+            return true;
+        }
+    }
+}
+
+bool CoreAudioHALCallbackContextEnter(
+    CoreAudioHALCallbackContext *context,
+    void **payload
+) {
+    unsigned long long observed = atomic_load_explicit(&context->state, memory_order_acquire);
+
+    for (;;) {
+        // Rejected callbacks count too: they still dereference this context while
+        // observing the closed gate and must finish before it is destroyed.
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) == CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) {
+            *payload = NULL;
+            return false;
+        }
+
+        const unsigned long long desired = observed + CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_INCREMENT;
+        if (atomic_compare_exchange_weak_explicit(
+                &context->state,
+                &observed,
+                desired,
+                memory_order_acq_rel,
+                memory_order_acquire)) {
+            *payload = (observed & CORE_AUDIO_HAL_CALLBACK_CLOSED) == 0 ? context->payload : NULL;
+            return true;
+        }
+    }
+}
+
+void CoreAudioHALCallbackContextLeave(CoreAudioHALCallbackContext *context) {
+    atomic_fetch_sub_explicit(
+        &context->state,
+        CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_INCREMENT,
+        memory_order_release
+    );
+}
+
+bool CoreAudioHALCallbackContextBeginTeardown(CoreAudioHALCallbackContext *context) {
+    unsigned long long observed = atomic_load_explicit(&context->state, memory_order_acquire);
+
+    for (;;) {
+        if ((observed & CORE_AUDIO_HAL_CALLBACK_TEARDOWN_CLAIMED) != 0) {
+            return false;
+        }
+
+        const unsigned long long desired = observed |
+            CORE_AUDIO_HAL_CALLBACK_CLOSED |
+            CORE_AUDIO_HAL_CALLBACK_TEARDOWN_CLAIMED;
+        if (atomic_compare_exchange_weak_explicit(
+                &context->state,
+                &observed,
+                desired,
+                memory_order_acq_rel,
+                memory_order_acquire)) {
+            return true;
+        }
+    }
+}
+
+bool CoreAudioHALCallbackContextIsDrained(CoreAudioHALCallbackContext *context) {
+    const unsigned long long state = atomic_load_explicit(&context->state, memory_order_acquire);
+    return (state & CORE_AUDIO_HAL_CALLBACK_IN_FLIGHT_MASK) == 0;
+}

--- a/TypeWhisper/Services/CoreAudioHALCallbackContext.h
+++ b/TypeWhisper/Services/CoreAudioHALCallbackContext.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CoreAudioHALCallbackContext CoreAudioHALCallbackContext;
+
+CoreAudioHALCallbackContext * _Nullable CoreAudioHALCallbackContextCreate(void * _Nonnull payload);
+void CoreAudioHALCallbackContextDestroy(CoreAudioHALCallbackContext * _Nonnull context);
+
+bool CoreAudioHALCallbackContextOpen(CoreAudioHALCallbackContext * _Nonnull context);
+/// Marks a callback in flight. `payload` is NULL when the gate is closed.
+/// A successful caller must always invoke `CoreAudioHALCallbackContextLeave`.
+bool CoreAudioHALCallbackContextEnter(
+    CoreAudioHALCallbackContext * _Nonnull context,
+    void * _Nullable * _Nonnull payload
+);
+void CoreAudioHALCallbackContextLeave(CoreAudioHALCallbackContext * _Nonnull context);
+
+/// Atomically closes the callback gate and claims teardown. Only the first caller succeeds.
+bool CoreAudioHALCallbackContextBeginTeardown(CoreAudioHALCallbackContext * _Nonnull context);
+bool CoreAudioHALCallbackContextIsDrained(CoreAudioHALCallbackContext * _Nonnull context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/TypeWhisper/Services/CoreAudioHALCallbackContext.h
+++ b/TypeWhisper/Services/CoreAudioHALCallbackContext.h
@@ -23,6 +23,8 @@ void CoreAudioHALCallbackContextLeave(CoreAudioHALCallbackContext * _Nonnull con
 /// Atomically closes the callback gate and claims teardown. Only the first caller succeeds.
 bool CoreAudioHALCallbackContextBeginTeardown(CoreAudioHALCallbackContext * _Nonnull context);
 bool CoreAudioHALCallbackContextIsDrained(CoreAudioHALCallbackContext * _Nonnull context);
+/// Atomically verifies the context is drained and prevents future callback admission.
+bool CoreAudioHALCallbackContextSealForDestruction(CoreAudioHALCallbackContext * _Nonnull context);
 
 #ifdef __cplusplus
 }

--- a/TypeWhisper/TypeWhisper-Bridging-Header.h
+++ b/TypeWhisper/TypeWhisper-Bridging-Header.h
@@ -1,1 +1,2 @@
 #import "Services/ObjCExceptionCatcher.h"
+#import "Services/CoreAudioHALCallbackContext.h"

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1819,9 +1819,284 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
         XCTAssertEqual(receivedBuffers.first?.format.sampleRate, 96_000)
         XCTAssertEqual(receivedBuffers.first?.format.channelCount, 2)
 
+        let disposed = expectation(description: "HAL session finalizes after quiescence")
+        operations.disposeHook = { disposed.fulfill() }
         session.stop()
 
         XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testStopClosesCallbackGateBeforeHALStopAndDropsLateCallback() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        var receivedBufferCount = 0
+        let session = try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(903),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations
+        ) { _ in
+            receivedBufferCount += 1
+        }
+
+        var lateCallbackStatus: OSStatus?
+        operations.stopHook = {
+            lateCallbackStatus = operations.invokeStoredCallback()
+        }
+        let disposed = expectation(description: "late-callback session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
+
+        session.stop()
+
+        XCTAssertEqual(try XCTUnwrap(lateCallbackStatus), noErr)
+        XCTAssertEqual(operations.invokeStoredCallback(), noErr)
+        XCTAssertTrue(operations.renderCalls.isEmpty)
+        XCTAssertEqual(receivedBufferCount, 0)
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testStartFailureClosesOpenedCallbackGateBeforeHALStop() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        operations.startError = CoreAudioHALInputOperationError(
+            operation: "test-hal start",
+            status: -50
+        )
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        var lateCallbackStatus: OSStatus?
+        operations.stopHook = {
+            lateCallbackStatus = operations.invokeStoredCallback()
+        }
+        let disposed = expectation(description: "start failure session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
+
+        XCTAssertThrowsError(try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(907),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )) { error in
+            XCTAssertTrue(error is CoreAudioHALInputOperationError)
+        }
+
+        XCTAssertEqual(operations.startCalls, 1)
+        XCTAssertEqual(try XCTUnwrap(lateCallbackStatus), noErr)
+        XCTAssertEqual(operations.invokeStoredCallback(), noErr)
+        XCTAssertTrue(operations.renderCalls.isEmpty)
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testDeinitStopsAndFinalizesHALUnitWithoutExplicitStop() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let disposed = expectation(description: "deinitialized session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
+
+        var session: CoreAudioHALInputCaptureSession? = try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(908),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )
+        XCTAssertNotNil(session)
+
+        session = nil
+
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testStopIsIdempotentWhileHALFinalizationIsPending() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let session = try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(904),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )
+        let disposed = expectation(description: "idempotent session finalizes once")
+        operations.disposeHook = { disposed.fulfill() }
+
+        session.stop()
+        session.stop()
+
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testSessionWaitsForAdmittedCallbackBeforeFinalizingHALUnit() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let renderStarted = expectation(description: "render callback started")
+        let callbackFinished = expectation(description: "render callback finished")
+        let disposed = expectation(description: "drained session finalizes")
+        let releaseRender = DispatchSemaphore(value: 0)
+        operations.renderHook = {
+            renderStarted.fulfill()
+            _ = releaseRender.wait(timeout: .now() + 2.0)
+        }
+        operations.disposeHook = { disposed.fulfill() }
+        let session = try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(905),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )
+
+        DispatchQueue.global().async {
+            _ = operations.invokeStoredCallback()
+            callbackFinished.fulfill()
+        }
+        wait(for: [renderStarted], timeout: 1.0)
+
+        session.stop()
+        XCTAssertEqual(operations.stopCalls, 1)
+
+        Thread.sleep(forTimeInterval: 0.35)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+
+        releaseRender.signal()
+        wait(for: [callbackFinished, disposed], timeout: 2.0)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testCallbackRegistrationFailureClosesStoredCallbackBeforeHALStop() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        operations.inputCallbackError = CoreAudioHALInputOperationError(
+            operation: "test-hal set callback",
+            status: -50
+        )
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        var lateCallbackStatus: OSStatus?
+        operations.stopHook = {
+            lateCallbackStatus = operations.invokeStoredCallback()
+        }
+        let disposed = expectation(description: "failed session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
+
+        XCTAssertThrowsError(try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(906),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )) { error in
+            XCTAssertTrue(error is CoreAudioHALInputOperationError)
+        }
+
+        XCTAssertEqual(try XCTUnwrap(lateCallbackStatus), noErr)
+        XCTAssertTrue(operations.renderCalls.isEmpty)
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.uninitializeCalls, 1)
+        XCTAssertEqual(operations.disposeCalls, 1)
+    }
+
+    func testInitializationFailureClosesStoredCallbackBeforeHALStop() throws {
+        let operations = FakeCoreAudioHALInputOperations()
+        operations.initializeError = CoreAudioHALInputOperationError(
+            operation: "test-hal initialize",
+            status: -50
+        )
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        var lateCallbackStatus: OSStatus?
+        operations.stopHook = {
+            lateCallbackStatus = operations.invokeStoredCallback()
+        }
+        let disposed = expectation(description: "initialization failure session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
+
+        XCTAssertThrowsError(try CoreAudioHALInputCaptureSession(
+            deviceID: AudioDeviceID(909),
+            format: format,
+            bufferSize: 128,
+            label: "test-hal",
+            operations: operations,
+            onBuffer: { _ in }
+        )) { error in
+            XCTAssertTrue(error is CoreAudioHALInputOperationError)
+        }
+
+        XCTAssertEqual(operations.initializeCalls, 1)
+        XCTAssertEqual(try XCTUnwrap(lateCallbackStatus), noErr)
+        XCTAssertTrue(operations.renderCalls.isEmpty)
+        XCTAssertEqual(operations.stopCalls, 1)
+        XCTAssertEqual(operations.uninitializeCalls, 0)
+        XCTAssertEqual(operations.disposeCalls, 0)
+        wait(for: [disposed], timeout: 1.0)
         XCTAssertEqual(operations.uninitializeCalls, 1)
         XCTAssertEqual(operations.disposeCalls, 1)
     }
@@ -1835,6 +2110,8 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
             channels: 1,
             interleaved: false
         ))
+        let disposed = expectation(description: "failed current-device session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
 
         XCTAssertThrowsError(try CoreAudioHALInputCaptureSession(
             deviceID: AudioDeviceID(901),
@@ -1846,6 +2123,7 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
         )) { error in
             XCTAssertEqual(error as? SelectedInputDeviceError, .incompatible(.cannotSetDevice))
         }
+        wait(for: [disposed], timeout: 1.0)
         XCTAssertEqual(operations.disposeCalls, 1)
     }
 
@@ -1864,6 +2142,8 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
             channels: 1,
             interleaved: false
         ))
+        let disposed = expectation(description: "diagnostic failure session finalizes")
+        operations.disposeHook = { disposed.fulfill() }
 
         XCTAssertThrowsError(try CoreAudioHALInputCaptureSession(
             deviceID: AudioDeviceID(902),
@@ -1885,6 +2165,8 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
         XCTAssertEqual(failure.errorDescription, "test-hal set current input device failed with status -50 (-50)")
         XCTAssertEqual(failure.formatSampleRate, 48_000)
         XCTAssertEqual(failure.formatChannelCount, 1)
+        wait(for: [disposed], timeout: 1.0)
+        XCTAssertEqual(operations.disposeCalls, 1)
     }
 }
 
@@ -2211,7 +2493,7 @@ private final class FakeAudioInputCaptureFactory: AudioInputCaptureFactory {
     }
 }
 
-private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating {
+private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating, @unchecked Sendable {
     struct EnableIOCall: Equatable {
         let enabled: UInt32
         let scope: AudioUnitScope
@@ -2225,7 +2507,13 @@ private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating 
 
     let audioUnit: AudioUnit = AudioUnit(bitPattern: 0x1)!
     var currentDeviceError: Error?
+    var inputCallbackError: Error?
+    var initializeError: Error?
+    var startError: Error?
     var renderStatus: OSStatus = noErr
+    var stopHook: (() -> Void)?
+    var disposeHook: (() -> Void)?
+    var renderHook: (() -> Void)?
     private(set) var enableIOCalls: [EnableIOCall] = []
     private(set) var currentDeviceCalls: [AudioDeviceID] = []
     private(set) var streamFormatCalls: [AudioStreamBasicDescription] = []
@@ -2262,18 +2550,22 @@ private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating 
 
     func setInputCallback(_ callback: inout AURenderCallbackStruct, audioUnit: AudioUnit, label: String) throws {
         inputCallback = callback
+        if let inputCallbackError { throw inputCallbackError }
     }
 
     func initialize(_ audioUnit: AudioUnit, label: String) throws {
         initializeCalls += 1
+        if let initializeError { throw initializeError }
     }
 
     func start(_ audioUnit: AudioUnit, label: String) throws {
         startCalls += 1
+        if let startError { throw startError }
     }
 
     func stop(_ audioUnit: AudioUnit) {
         stopCalls += 1
+        stopHook?()
     }
 
     func uninitialize(_ audioUnit: AudioUnit) {
@@ -2282,6 +2574,7 @@ private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating 
 
     func dispose(_ audioUnit: AudioUnit) {
         disposeCalls += 1
+        disposeHook?()
     }
 
     func render(
@@ -2292,8 +2585,21 @@ private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating 
         frameCount: UInt32,
         data: UnsafeMutablePointer<AudioBufferList>
     ) -> OSStatus {
+        renderHook?()
         renderCalls.append(.init(busNumber: busNumber, frameCount: frameCount))
         return renderStatus
+    }
+
+    @discardableResult
+    func invokeStoredCallback(frameCount: UInt32 = 64) -> OSStatus? {
+        guard let callback = inputCallback,
+              let inputProc = callback.inputProc,
+              let inputProcRefCon = callback.inputProcRefCon else {
+            return nil
+        }
+        var flags = AudioUnitRenderActionFlags()
+        var timestamp = AudioTimeStamp()
+        return inputProc(inputProcRefCon, &flags, &timestamp, 1, frameCount, nil)
     }
 }
 

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1871,6 +1871,15 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
         XCTAssertEqual(operations.disposeCalls, 1)
     }
 
+    func testCallbackContextSealWaitsForDrainAndRejectsFutureEntries() {
+        let transitions = CoreAudioHALInputCaptureSession.testingCallbackContextSealTransitions()
+
+        XCTAssertFalse(transitions.sealedWhileInFlight)
+        XCTAssertTrue(transitions.sealedAfterDrain)
+        XCTAssertFalse(transitions.enteredAfterSeal)
+        XCTAssertTrue(transitions.payloadAfterSealWasNil)
+    }
+
     func testStartFailureClosesOpenedCallbackGateBeforeHALStop() throws {
         let operations = FakeCoreAudioHALInputOperations()
         operations.startError = CoreAudioHALInputOperationError(
@@ -2010,7 +2019,9 @@ final class CoreAudioHALInputCaptureSessionTests: XCTestCase {
         session.stop()
         XCTAssertEqual(operations.stopCalls, 1)
 
-        Thread.sleep(forTimeInterval: 0.35)
+        Thread.sleep(
+            forTimeInterval: CoreAudioHALInputCaptureSession.testingCallbackQuiescenceInterval + 0.05
+        )
         XCTAssertEqual(operations.uninitializeCalls, 0)
         XCTAssertEqual(operations.disposeCalls, 0)
 

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -380,13 +380,18 @@ final class AudioRecorderViewModelTests: XCTestCase {
     private func makeViewModel(
         defaults: UserDefaults,
         modelManager: ModelManagerService = ModelManagerService(),
-        recorderService: AudioRecorderService = AudioRecorderService(),
+        recorderService: AudioRecorderService? = nil,
         audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
         livePreviewStartObserver: (() -> Void)? = nil
     ) -> AudioRecorderViewModel {
         setupEventBus()
+        let resolvedRecorderService = recorderService ?? {
+            let service = AudioRecorderService()
+            service.recordingsDirectoryOverride = makeTemporaryDirectory()
+            return service
+        }()
         return AudioRecorderViewModel(
-            recorderService: recorderService,
+            recorderService: resolvedRecorderService,
             modelManager: modelManager,
             dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
             audioDeviceService: audioDeviceService,


### PR DESCRIPTION
## Issue context

Issue #856 reports an intermittent `EXC_BAD_ACCESS` on CoreAudio's real-time input callback after rapidly pressing and releasing the dictation hotkey. The crash occurs while the callback constructs an `AVAudioPCMBuffer`, which indicates that a HAL callback can outlive the Swift session/render state it references.

Closes #856

## Summary

- add a small lock-free C11 atomic callback context compatible with the macOS 14 deployment target
- close the callback gate before `AudioUnitStop`, and return late callbacks without allocating a buffer or calling render
- keep the HAL session, render state, and callback context alive for a 300 ms quiescence window and until admitted callbacks drain
- make stop, deinit, failure cleanup, uninitialize, dispose, and context destruction idempotent
- add focused session tests for normal rendering, late callbacks, failure paths, deinit, repeated stop, quiescence, and in-flight callback draining
- isolate recorder view-model tests in a temporary recordings directory so the test host does not request access to the user's Documents folder

No public API changes are included.

## Coverage

```text
CoreAudio HAL session lifecycle
├── normal callback admission and render                TESTED
├── callback gate closes before HAL stop                TESTED
├── late callback skips allocation and render           TESTED
├── repeated stop and deinit teardown                    TESTED
├── callback registration / initialization / start fail TESTED
├── admitted callback blocks disposal until drain       TESTED
├── 300 ms quiescence before uninitialize/dispose       TESTED
└── real rapid-hotkey and preview cycling               MANUAL

AI-assessed coverage: 13/15 paths (87%)
```

Seven focused regression tests were added. The full app suite passes with 1,136 tests and no failures.

## Pre-landing review

- No critical or informational findings.
- Scope check: CLEAN. The production change is limited to the shared CoreAudio HAL session lifecycle; no hotkey debounce or plugin behavior changed.
- No version or release-notes bump: this repository manages those on the release line rather than per bug-fix PR.

## Test plan

Automated:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/CoreAudioHALInputCaptureSessionTests

/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh "$(pwd)"
```

Manual on a Mac with microphone permission and an available input device:

1. Rapidly press and release the dictation hotkey repeatedly; verify there is no crash, hang, or stale callback.
2. Rapidly start and stop microphone preview in Settings.
3. Alternate between preview and dictation and verify both continue to capture normally.
4. Confirm no Documents-folder permission prompt appears while running the test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio capture stop/shutdown reliability, including correct teardown timing.
  * Prevented input callbacks from rendering or accessing audio resources during teardown or final destruction.
  * More robust handling of capture initialization and startup failure scenarios.
* **Tests**
  * Strengthened coverage for callback draining, idempotent stop behavior, shutdown/finalization ordering, and error/failure cases.
  * Enhanced simulated CoreAudio HAL lifecycle to better model real-world callback and disposal timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->