### PR TITLE
Fix notch indicator dismissal race

### DIFF
--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -40,14 +40,28 @@ class NotchIndicatorPanel: NSPanel {
     private static let presentationAnimationDuration: Duration = .milliseconds(220)
 
     private let screenResolver: IndicatorScreenResolver
+    private let displayModeProvider: () -> NotchIndicatorDisplay
     private let notchGeometry = NotchGeometry()
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
     private var showTask: Task<Void, Never>?
     private var dismissTask: Task<Void, Never>?
 
-    init(screenResolver: IndicatorScreenResolver) {
+    convenience init(screenResolver: IndicatorScreenResolver) {
+        self.init(
+            screenResolver: screenResolver,
+            displayModeProvider: { DictationViewModel.shared.notchIndicatorDisplay },
+            content: { NotchIndicatorView(geometry: $0) }
+        )
+    }
+
+    init<Content: View>(
+        screenResolver: IndicatorScreenResolver,
+        displayModeProvider: @escaping () -> NotchIndicatorDisplay,
+        @ViewBuilder content: (NotchGeometry) -> Content
+    ) {
         self.screenResolver = screenResolver
+        self.displayModeProvider = displayModeProvider
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -65,11 +79,11 @@ class NotchIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            displayMode: displayModeProvider(),
             windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
         )
 
-        let hostingView = FirstMouseHostingView(rootView: NotchIndicatorView(geometry: notchGeometry))
+        let hostingView = FirstMouseHostingView(rootView: content(notchGeometry))
         hostingView.sizingOptions = []
         contentView = hostingView
     }
@@ -147,27 +161,8 @@ class NotchIndicatorPanel: NSPanel {
         showTask?.cancel()
         dismissTask?.cancel()
 
-        let screen: NSScreen
-        if let cached = cachedScreen, isVisible {
-            screen = cached
-        } else {
-            screen = resolveScreen()
-            cachedScreen = screen
-        }
-
-        notchGeometry.update(for: screen)
-
-        let screenFrame = screen.frame
-        let x = screenFrame.midX - Self.panelWidth / 2
-        let y = screenFrame.origin.y + screenFrame.height - Self.panelHeight
-
         let wasVisible = isVisible
-        setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
-        FloatingPanelSpacePolicy.orderIndicatorFront(
-            self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
-            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
-        )
+        placePanel()
 
         guard !wasVisible else {
             if !notchGeometry.isPresented {
@@ -189,16 +184,39 @@ class NotchIndicatorPanel: NSPanel {
         }
     }
 
+    private func placePanel() {
+        let screen: NSScreen
+        if let cached = cachedScreen, isVisible {
+            screen = cached
+        } else {
+            screen = resolveScreen()
+            cachedScreen = screen
+        }
+
+        notchGeometry.update(for: screen)
+
+        let screenFrame = screen.frame
+        let x = screenFrame.midX - Self.panelWidth / 2
+        let y = screenFrame.origin.y + screenFrame.height - Self.panelHeight
+
+        setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
+        FloatingPanelSpacePolicy.orderIndicatorFront(
+            self,
+            displayMode: displayModeProvider(),
+            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
+        )
+    }
+
     private func resolveScreen() -> NSScreen {
-        screenResolver.resolveScreen(for: DictationViewModel.shared.notchIndicatorDisplay)
+        screenResolver.resolveScreen(for: displayModeProvider())
     }
 
     func refreshPlacementForActiveContextChange() {
-        guard isVisible else { return }
-        if DictationViewModel.shared.notchIndicatorDisplay == .activeScreen {
+        guard isVisible, notchGeometry.isPresented else { return }
+        if displayModeProvider() == .activeScreen {
             cachedScreen = nil
         }
-        show()
+        placePanel()
     }
 
     func dismiss() {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 import CoreGraphics
+import SwiftUI
 @testable import TypeWhisper
 
 @MainActor
@@ -971,6 +972,60 @@ final class IndicatorPresentationStateTests: XCTestCase {
             visibility: .never,
             presentation: recorderPresentation
         ))
+    }
+}
+
+@MainActor
+final class NotchIndicatorPanelLifecycleTests: XCTestCase {
+    func testPlacementRefreshDoesNotCancelInFlightDismissal() async throws {
+        let panel = try makePanel()
+        defer { panel.orderOut(nil) }
+
+        panel.show()
+        await Task.yield()
+        XCTAssertTrue(panel.isVisible)
+
+        panel.dismiss()
+        panel.refreshPlacementForActiveContextChange()
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertFalse(panel.isVisible)
+    }
+
+    func testShowCancelsInFlightDismissalForNewActivity() async throws {
+        let panel = try makePanel()
+        defer { panel.orderOut(nil) }
+
+        panel.show()
+        await Task.yield()
+        XCTAssertTrue(panel.isVisible)
+
+        panel.dismiss()
+        panel.show()
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertTrue(panel.isVisible)
+    }
+
+    private func makePanel() throws -> NotchIndicatorPanel {
+        guard let screen = NSScreen.screens.first else {
+            throw XCTSkip("Notch indicator panel tests require an available screen")
+        }
+
+        let resolver = IndicatorScreenResolver(
+            focusedElementPositionProvider: { nil },
+            focusedWindowFrameProvider: { nil },
+            frontmostApplicationProvider: { nil },
+            mouseLocationProvider: { CGPoint(x: screen.frame.midX, y: screen.frame.midY) },
+            screensProvider: { [screen] },
+            mainScreenProvider: { screen },
+            windowFrameProvider: { _ in nil }
+        )
+        return NotchIndicatorPanel(
+            screenResolver: resolver,
+            displayModeProvider: { .activeScreen },
+            content: { _ in EmptyView() }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the intermittent Notch indicator placeholder reported in #857.

- Separates panel placement updates from presentation state changes.
- Prevents active-screen refreshes from cancelling an in-flight dismiss animation.
- Preserves the existing behavior where genuine new activity can cancel dismissal and show the indicator again.
- Adds panel lifecycle regression coverage with isolated display and content dependencies.

## Root cause

The Notch panel remains visible for 220 ms while its dismiss animation completes. During that interval, an active application, Space, or screen refresh could call `show()`, cancel the pending dismiss task, and re-present the otherwise empty black panel. With no later state transition, the placeholder could remain visible indefinitely.

## Impact

The Notch indicator now finishes dismissing after activity ends even when active-screen placement refreshes occur during the animation. Overlay and Minimal indicators, visibility settings, animation timing, and public APIs are unchanged.

Closes #857

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/NotchIndicatorPanelLifecycleTests -only-testing:TypeWhisperTests/IndicatorPresentationStateTests -only-testing:TypeWhisperTests/NotchIndicatorLayoutTests`
- [x] `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 1,143 tests passed
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/a711/typewhisper-mac`
- [x] Local hardware smoke on the built-in Notch display: two dictations longer than 10 seconds, active application changes during recording, and 24 rapid Finder/TextEdit activations around dismissal. LLDB confirmed `NotchIndicatorPanel.isVisible == true` while recording and `false` after dismissal.
- [x] Verified the signed dev app at `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app` and restored the original Dev settings after the smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notch indicator panel placement when the active display context changes.
  * Prevented refreshes from interrupting an in-progress dismissal.
  * Ensured showing the panel again cancels a pending dismissal and keeps it visible.

* **Tests**
  * Added coverage for panel visibility and dismissal lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->