### PR TITLE
Fix trailing space after dictation

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2388,7 +2388,7 @@ enum DictationInsertionTextFormatter {
         contextualInsertionEnabled: Bool = true
     ) -> String {
         guard contextualInsertionEnabled, let insertionContext else {
-            return textWithTrailingSpaceIfNeeded(text)
+            return text
         }
 
         let boundaries = insertionBoundaries(for: insertionContext)
@@ -2411,17 +2411,9 @@ enum DictationInsertionTextFormatter {
                shouldInsertSpace(between: last, and: next) {
                 result += " "
             }
-        } else {
-            result = textWithTrailingSpaceIfNeeded(result)
         }
 
         return result
-    }
-
-    private static func textWithTrailingSpaceIfNeeded(_ text: String) -> String {
-        guard let lastScalar = text.unicodeScalars.last else { return text }
-        guard !CharacterSet.whitespacesAndNewlines.contains(lastScalar) else { return text }
-        return text + " "
     }
 
     private struct InsertionBoundaries {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -4211,7 +4211,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testDictationDirectInsertionAddsTrailingSpaceWithoutMutatingStoredTranscription() async throws {
+    func testDictationDirectInsertionDoesNotAddTrailingSpace() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let historyEnabledKey = UserDefaultsKeys.historyEnabled
         let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
@@ -4266,7 +4266,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         let session = try XCTUnwrap(context.dictationViewModel.apiDictationSession(id: sessionID))
         XCTAssertEqual(session.status, .completed)
-        XCTAssertEqual(pasteboard.string(forType: .string), "transcribed ")
+        XCTAssertEqual(pasteboard.string(forType: .string), "transcribed")
         XCTAssertEqual(session.transcription?.text, "transcribed")
         XCTAssertEqual(context.historyService.records.first?.finalText, "transcribed")
         XCTAssertEqual(

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -227,8 +227,8 @@ final class MicrophoneBoostProcessorTests: XCTestCase {
 }
 
 final class DictationInsertionTextFormatterTests: XCTestCase {
-    func testAddsTrailingSpaceToNonEmptyTextWithoutTrailingWhitespace() {
-        XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion("Hello"), "Hello ")
+    func testDoesNotAddTrailingSpaceToNonEmptyText() {
+        XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion("Hello"), "Hello")
     }
 
     func testLeavesExistingTrailingSpaceUntouched() {
@@ -243,7 +243,7 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
         XCTAssertEqual(DictationInsertionTextFormatter.textForInsertion(""), "")
     }
 
-    func testDisabledContextualInsertionKeepsTrailingSpaceOnlyBehavior() {
+    func testDisabledContextualInsertionDoesNotAddTrailingSpace() {
         let context = TextInsertionService.InsertionContext(
             value: "coffeemachine",
             selectedRange: NSRange(location: 6, length: 0),
@@ -258,14 +258,14 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
                 insertionContext: context,
                 contextualInsertionEnabled: false
             ),
-            "Strong. "
+            "Strong."
         )
     }
 
-    func testMissingContextKeepsTrailingSpaceOnlyBehavior() {
+    func testMissingContextDoesNotAddTrailingSpace() {
         XCTAssertEqual(
             DictationInsertionTextFormatter.textForInsertion("Strong."),
-            "Strong. "
+            "Strong."
         )
     }
 
@@ -418,7 +418,7 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
 
         XCTAssertEqual(
             DictationInsertionTextFormatter.textForInsertion("NASA tools.", insertionContext: context),
-            " NASA tools. "
+            " NASA tools."
         )
     }
 
@@ -433,7 +433,7 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
 
         XCTAssertEqual(
             DictationInsertionTextFormatter.textForInsertion("TypeWhisper", insertionContext: context),
-            " TypeWhisper "
+            " TypeWhisper"
         )
     }
 


### PR DESCRIPTION
## Summary

- Stop appending a synthetic trailing space after direct dictation insertion.
- Preserve context-aware spacing when existing text follows the insertion point.
- Keep session, history, recent transcription, action plugin, and event text unchanged.

## Issue Context

Issue #862 reports that every inserted transcription ends with an extra space regardless of transcription model or post-processing prompt. The trailing space was added by `DictationInsertionTextFormatter` as a fallback, not by the selected model. Direct insertion now leaves text unchanged when cursor context is unavailable or app-aware formatting is disabled, and it no longer appends whitespace at the end of a text field.

Closes #862

## Test Plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/DictationInsertionTextFormatterTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testDictationDirectInsertionDoesNotAddTrailingSpace -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testDictationDirectInsertionUsesContextWhenAppAwareFormattingIsEnabled`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dictation text insertion no longer adds an unwanted trailing space.
  * Direct insertion now preserves the transcribed text exactly when contextual formatting is unavailable.
  * Smart insertion continues to handle punctuation and casing without appending extra spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->