### PR TITLE
Add privacy-friendly Polar attribution

### DIFF
--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -167,6 +167,35 @@ enum AppConstants {
         static let checkoutURLSupporterBronze = "https://buy.polar.sh/polar_cl_yilyo1V90RnuUX59V2PyLUIg45FpzYI8aMhG824wYn8"
         static let checkoutURLSupporterSilver = "https://buy.polar.sh/polar_cl_lXFAqnanhrrPd1RZ95SCb2L05L3lNrUQIkYVd0ZmK5b"
         static let checkoutURLSupporterGold = "https://buy.polar.sh/polar_cl_FpojMlLmyF73gOqpXLihSE0lNYnoQoaMxGp724IIor4"
+
+        static func attributedCheckoutURL(
+            baseURL: String,
+            source: String,
+            medium: String,
+            content: String
+        ) -> URL? {
+            guard var components = URLComponents(string: baseURL) else { return nil }
+            var queryItems = components.queryItems ?? []
+            queryItems.removeAll { item in
+                ["utm_source", "utm_medium", "utm_content"].contains(item.name)
+            }
+            queryItems.append(contentsOf: [
+                URLQueryItem(name: "utm_source", value: source),
+                URLQueryItem(name: "utm_medium", value: medium),
+                URLQueryItem(name: "utm_content", value: content),
+            ])
+            components.queryItems = queryItems
+            return components.url
+        }
+
+        static func appCheckoutURL(baseURL: String, content: String) -> URL? {
+            attributedCheckoutURL(
+                baseURL: baseURL,
+                source: "typewhisper_mac",
+                medium: "app",
+                content: "mac_\(content)"
+            )
+        }
     }
 
     enum Website {

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -688,6 +688,10 @@ final class LicenseService: ObservableObject {
             "key": key,
             "organization_id": AppConstants.Polar.organizationId,
             "label": deviceLabel,
+            "meta": [
+                "platform": "macos",
+                "app_version": AppConstants.appVersion,
+            ],
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -769,7 +769,10 @@ struct LicenseSettingsView: View {
             AppConstants.Polar.checkoutURLEnterprise
         }
 
-        return URL(string: urlString)
+        return AppConstants.Polar.appCheckoutURL(
+            baseURL: urlString,
+            content: "settings_\(tier.rawValue)_monthly"
+        )
     }
 
     private var selectedCommercialLifetimeURL: URL? {
@@ -784,7 +787,10 @@ struct LicenseSettingsView: View {
             AppConstants.Polar.checkoutURLEnterpriseLifetime
         }
 
-        return URL(string: urlString)
+        return AppConstants.Polar.appCheckoutURL(
+            baseURL: urlString,
+            content: "settings_\(tier.rawValue)_lifetime"
+        )
     }
 
     @MainActor
@@ -867,7 +873,12 @@ struct LicenseSettingsView: View {
             case .silver: AppConstants.Polar.checkoutURLSupporterSilver
             case .gold: AppConstants.Polar.checkoutURLSupporterGold
             }
-            openURL(URL(string: url))
+            openURL(
+                AppConstants.Polar.appCheckoutURL(
+                    baseURL: url,
+                    content: "settings_\(tier.rawValue)_one_time"
+                )
+            )
         } label: {
             VStack(spacing: 6) {
                 Image(systemName: supporterTierIcon(tier))

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -525,6 +525,21 @@ final class CLISupportTests: XCTestCase {
         )
     }
 
+    func testMacCheckoutURLAddsPolarAttribution() throws {
+        let url = try XCTUnwrap(
+            AppConstants.Polar.appCheckoutURL(
+                baseURL: AppConstants.Polar.checkoutURLIndividual,
+                content: "settings_individual_monthly"
+            )
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+
+        XCTAssertEqual(query["utm_source"], "typewhisper_mac")
+        XCTAssertEqual(query["utm_medium"], "app")
+        XCTAssertEqual(query["utm_content"], "mac_settings_individual_monthly")
+    }
+
     @MainActor
     func testActivateAnyKeyRoutesCommercialBenefitIntoCommercialState() async throws {
         let (defaults, suiteName) = try makeIsolatedDefaults()
@@ -542,6 +557,14 @@ final class CLISupportTests: XCTestCase {
             dataTransport: { request in
                 switch request.url?.path {
                 case "/v1/customer-portal/license-keys/activate":
+                    let bodyData = try XCTUnwrap(request.httpBody)
+                    let requestBody = try XCTUnwrap(
+                        JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+                    )
+                    let metadata = try XCTUnwrap(requestBody["meta"] as? [String: String])
+                    XCTAssertEqual(metadata["platform"], "macos")
+                    XCTAssertEqual(metadata["app_version"], AppConstants.appVersion)
+                    XCTAssertNotNil(requestBody["label"] as? String)
                     let body = #"{"id":"activation-123"}"#
                     return (Data(body.utf8), Self.httpResponse(url: request.url!, statusCode: 200))
                 case "/v1/customer-portal/license-keys/validate":


### PR DESCRIPTION
## Context

TypeWhisper needs aggregate attribution from in-app checkout clicks through purchases and license activations without creating persistent user identifiers.

## Changes

- Add shared Polar checkout URL attribution for all commercial and supporter purchase paths.
- Tag Mac checkout traffic with utm_source=typewhisper_mac and utm_medium=app.
- Attach macOS platform and app version metadata to license activations while retaining the readable device label.
- Add coverage for checkout parameters and activation payload metadata.

## User impact

Purchases started in the Mac app can be attributed in Polar, and license activations expose the platform and app version without claiming a distribution channel.

## Test plan

- xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination platform=macOS -only-testing:TypeWhisperTests/CLISupportTests test CODE_SIGNING_ALLOWED=NO
- /Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/2524/typewhisper-mac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attribution tracking to checkout links for monthly, lifetime, and one-time purchases.
  * Added platform and app version details to license activation requests.

* **Bug Fixes**
  * Checkout links now replace existing attribution parameters to prevent stale tracking data.

* **Tests**
  * Added coverage for checkout attribution and license activation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->