### PR TITLE
Fix webhook creation flow

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
@@ -51,6 +51,58 @@ final class WebhookPluginTests: XCTestCase {
         )
     }
 
+    func testNewDraftIsNotPersistedUntilSaved() throws {
+        let host = try PluginTestHostServices()
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        var draft = ExampleWebhookConfig()
+
+        XCTAssertTrue(service.webhooks.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: configURL(for: host).path))
+
+        draft.name = "New Hook"
+        draft.url = "https://example.com/new"
+        service.saveWebhook(draft)
+
+        XCTAssertEqual(service.webhooks.map(\.id), [draft.id])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: configURL(for: host).path))
+    }
+
+    func testSaveWebhookUpdatesExistingWebhookWithoutDuplicatingIt() throws {
+        let host = try PluginTestHostServices()
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        var webhook = ExampleWebhookConfig(name: "Original", url: "https://example.com/original")
+
+        service.saveWebhook(webhook)
+        webhook.name = "Updated"
+        webhook.url = "https://example.com/updated"
+        service.saveWebhook(webhook)
+
+        XCTAssertEqual(service.webhooks.count, 1)
+        XCTAssertEqual(service.webhooks.first?.id, webhook.id)
+        XCTAssertEqual(service.webhooks.first?.name, "Updated")
+        XCTAssertEqual(service.webhooks.first?.url, "https://example.com/updated")
+    }
+
+    func testLoadRemovesOnlyUnmodifiedDefaultDrafts() throws {
+        let host = try PluginTestHostServices()
+        let emptyDraft = ExampleWebhookConfig()
+        let namedDraft = ExampleWebhookConfig(name: "Keep Me")
+        let configuredWebhook = ExampleWebhookConfig(
+            name: "Configured",
+            url: "https://example.com/configured"
+        )
+        let configData = try JSONEncoder().encode([emptyDraft, namedDraft, configuredWebhook])
+        try configData.write(to: configURL(for: host), options: .atomic)
+
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+
+        XCTAssertEqual(Set(service.webhooks.map(\.id)), Set([namedDraft.id, configuredWebhook.id]))
+
+        let storedData = try Data(contentsOf: configURL(for: host))
+        let persisted = try JSONDecoder().decode([ExampleWebhookConfig].self, from: storedData)
+        XCTAssertEqual(Set(persisted.map(\.id)), Set([namedDraft.id, configuredWebhook.id]))
+    }
+
     func testLoadMigratesLegacyPlaintextSensitiveHeaders() throws {
         let host = try PluginTestHostServices()
         let legacyWebhook = ExampleWebhookConfig(

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -93,6 +93,16 @@ struct ExampleWebhookConfig: Codable, Identifiable {
         self.profileFilter = profileFilter
     }
 
+    var isUnmodifiedDefaultDraft: Bool {
+        name.isEmpty
+            && url.isEmpty
+            && httpMethod == "POST"
+            && headers == ["Content-Type": "application/json"]
+            && secretHeaderNames.isEmpty
+            && isEnabled
+            && profileFilter.isEmpty
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -181,8 +191,11 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
     private func loadConfig() {
         guard let data = try? Data(contentsOf: configURL),
               let config = try? JSONDecoder().decode([ExampleWebhookConfig].self, from: data) else { return }
-        webhooks = config.map(resolveSecretHeaders)
-        if config.contains(where: containsPlaintextSecretHeader) || config.contains(where: containsEmptySensitiveHeader) {
+        let migratedConfig = config.filter { !$0.isUnmodifiedDefaultDraft }
+        webhooks = migratedConfig.map(resolveSecretHeaders)
+        if migratedConfig.count != config.count
+            || migratedConfig.contains(where: containsPlaintextSecretHeader)
+            || migratedConfig.contains(where: containsEmptySensitiveHeader) {
             saveConfig()
         }
     }
@@ -212,6 +225,14 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
         clearSecretsRemoved(from: webhooks[index], next: nextWebhook)
         webhooks[index] = nextWebhook
         saveConfig()
+    }
+
+    func saveWebhook(_ webhook: ExampleWebhookConfig) {
+        if webhooks.contains(where: { $0.id == webhook.id }) {
+            updateWebhook(webhook)
+        } else {
+            addWebhook(webhook)
+        }
     }
 
     static func secretStorageKey(webhookID: UUID, headerName: String) -> String {
@@ -426,7 +447,7 @@ struct ExampleWebhookSettingsView: View {
                     .font(.headline)
                 Spacer()
                 Button {
-                    service.addWebhook(ExampleWebhookConfig())
+                    editingWebhook = ExampleWebhookConfig()
                 } label: {
                     Label(String(localized: "Add Webhook", bundle: bundle), systemImage: "plus")
                 }
@@ -484,7 +505,7 @@ struct ExampleWebhookSettingsView: View {
                 webhook: webhook,
                 availableProfiles: service.host.availableRuleNames,
                 onSave: { updated in
-                    service.updateWebhook(updated)
+                    service.saveWebhook(updated)
                     editingWebhook = nil
                 },
                 onCancel: { editingWebhook = nil }


### PR DESCRIPTION
## Summary

- open the webhook editor when **Add Webhook** is clicked instead of persisting an empty entry immediately
- save new and existing webhooks through a shared upsert path
- remove only exact, unmodified empty drafts left behind by the broken v1.0.13 flow while preserving partially configured webhooks
- add regression coverage for draft persistence, insert/update behavior, and cleanup migration

## Issue context

Webhook Notifications v1.0.13 persisted a blank default webhook when **Add Webhook** was clicked but never assigned a draft to the existing editor sheet. The sheet therefore did not appear, and the update-only save path could not create a new webhook.

Closes #871

## Test plan

```bash
swift test --package-path TypeWhisperPluginSDK --filter WebhookPluginTests
xcodebuild -project TypeWhisper.xcodeproj -scheme WebhookPlugin -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run WebhookPlugin /Users/marco/.codex/worktrees/fa3a/typewhisper-mac
```

The installed development bundle was additionally verified with:

```bash
codesign --verify --deep --strict --verbose=2 "$HOME/Library/Application Support/TypeWhisper-Dev/Plugins/WebhookPlugin.bundle"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook draft handling so new configurations are saved only when explicitly submitted.
  * Saving an existing webhook now updates it without creating duplicates.
  * Added automatic cleanup of unused default drafts when loading webhook settings.

* **Bug Fixes**
  * Improved webhook configuration migration and persistence for sensitive header values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->