### PR TITLE
Add search to Dictionary settings

### DIFF
--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -76,6 +76,7 @@ class DictionaryViewModel: ObservableObject {
     }
 
     @Published var filterTab: FilterTab = .all
+    @Published var searchQuery = ""
 
     // Editor state
     @Published var isEditing = false
@@ -103,22 +104,37 @@ class DictionaryViewModel: ObservableObject {
     private var selectedEntry: DictionaryEntry?
 
     var filteredEntries: [DictionaryEntry] {
+        let entriesForSelectedFilter: [DictionaryEntry]
         switch filterTab {
         case .all:
-            return entries
+            entriesForSelectedFilter = entries
         case .terms:
-            return entries.filter { $0.type == .term }
+            entriesForSelectedFilter = entries.filter { $0.type == .term }
         case .corrections:
-            return entries.filter { $0.type == .correction }
+            entriesForSelectedFilter = entries.filter { $0.type == .correction }
         case .autoLearned:
-            return entries.filter { $0.type == .correction && $0.source == .autoLearned }
+            entriesForSelectedFilter = entries.filter {
+                $0.type == .correction && $0.source == .autoLearned
+            }
         case .termPacks:
             return []
+        }
+
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return entriesForSelectedFilter }
+
+        return entriesForSelectedFilter.filter { entry in
+            entry.original.localizedCaseInsensitiveContains(query) ||
+                (entry.replacement?.localizedCaseInsensitiveContains(query) ?? false)
         }
     }
 
     var filteredEntryRows: [DictionaryEntryRow] {
         filteredEntries.map(row)
+    }
+
+    var hasActiveSearch: Bool {
+        !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var termsCount: Int { dictionaryService.termsCount }

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -25,6 +25,7 @@ struct DictionarySettingsView: View {
                 if viewModel.filterTab == .termPacks {
                     termPacksView
                 } else {
+                    dictionarySearchField
                     dictionaryEntriesView
                 }
             }
@@ -103,6 +104,32 @@ struct DictionarySettingsView: View {
         .padding(.bottom, 4)
     }
 
+    private var dictionarySearchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+
+            TextField(String(localized: "Search..."), text: $viewModel.searchQuery)
+                .textFieldStyle(.plain)
+
+            if !viewModel.searchQuery.isEmpty {
+                Button {
+                    viewModel.searchQuery = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Clear search"))
+            }
+        }
+        .padding(8)
+        .background(.bar)
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .padding(.horizontal, 2)
+        .padding(.bottom, 6)
+    }
+
     private var dictionaryEntriesView: some View {
         ScrollView {
             LazyVStack(spacing: 8) {
@@ -111,15 +138,7 @@ struct DictionarySettingsView: View {
                 }
 
                 if viewModel.filteredEntryRows.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "line.3.horizontal.decrease.circle")
-                            .font(.system(size: 32))
-                            .foregroundStyle(.secondary)
-                        Text(String(localized: "No entries for this filter"))
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 48)
+                    dictionaryEntriesEmptyState
                 } else {
                     ForEach(viewModel.filteredEntryRows) { row in
                         DictionaryCardView(
@@ -133,6 +152,31 @@ struct DictionarySettingsView: View {
             }
             .padding(.horizontal, 2)
         }
+    }
+
+    private var dictionaryEntriesEmptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: viewModel.hasActiveSearch
+                ? "magnifyingglass"
+                : "line.3.horizontal.decrease.circle")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+
+            if viewModel.hasActiveSearch {
+                Text(localizedAppText("No search results", de: "Keine Suchergebnisse"))
+                    .font(.headline)
+                Text(localizedAppText(
+                    "Try a different search term or filter.",
+                    de: "Versuche einen anderen Suchbegriff oder Filter."
+                ))
+                .font(.caption)
+            } else {
+                Text(String(localized: "No entries for this filter"))
+            }
+        }
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 48)
     }
 
     private var emptyState: some View {

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -554,6 +554,18 @@ final class DictionaryServiceTests: XCTestCase {
         XCTAssertEqual(correctionRows.first { $0.original == "empty-replacement" }?.replacementDisplayText, "\"\"")
 
         let correctionIDs = correctionRows.map(\.id)
+        let searchedOriginalID = try XCTUnwrap(
+            correctionRows.first { $0.original == "Wrong-042" }?.id
+        )
+        viewModel.searchQuery = "WRONG-042"
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.id), [searchedOriginalID])
+
+        viewModel.searchQuery = "correct-042"
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.id), [searchedOriginalID])
+
+        viewModel.searchQuery = ""
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.id), correctionIDs)
+
         viewModel.filterTab = .all
         let allCorrectionIDs = viewModel.filteredEntryRows
             .filter { $0.type == .correction }
@@ -566,6 +578,56 @@ final class DictionaryServiceTests: XCTestCase {
         let autoLearnedRows = autoLearnedViewModel.filteredEntryRows
         XCTAssertEqual(autoLearnedRows.map(\.original), ["autolearned"])
         XCTAssertTrue(autoLearnedRows.allSatisfy { $0.source == .autoLearned })
+    }
+
+    @MainActor
+    func testDictionarySearchMatchesOriginalAndReplacementAndComposesWithFilters() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .term, original: "TypeWhisper")
+        service.addEntry(type: .term, original: "Podcast")
+        service.addEntry(type: .correction, original: "teh", replacement: "the")
+        service.learnCorrection(original: "langauge", replacement: "language")
+
+        let entriesBeforeSearch = service.entries.map {
+            ($0.id, $0.type, $0.original, $0.replacement, $0.source)
+        }
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+
+        viewModel.searchQuery = "TYPEWHISPER"
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.original), ["TypeWhisper"])
+
+        viewModel.filterTab = .corrections
+        viewModel.searchQuery = "THE"
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.original), ["teh"])
+
+        viewModel.filterTab = .autoLearned
+        XCTAssertTrue(viewModel.filteredEntryRows.isEmpty)
+        viewModel.searchQuery = "LANGUAGE"
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.original), ["langauge"])
+
+        viewModel.filterTab = .terms
+        XCTAssertTrue(viewModel.filteredEntryRows.isEmpty)
+        viewModel.searchQuery = "   "
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.original), ["Podcast", "TypeWhisper"])
+        XCTAssertFalse(viewModel.hasActiveSearch)
+
+        viewModel.searchQuery = "podcast"
+        XCTAssertTrue(viewModel.hasActiveSearch)
+        viewModel.filterTab = .termPacks
+        XCTAssertEqual(viewModel.searchQuery, "podcast")
+        XCTAssertTrue(viewModel.filteredEntryRows.isEmpty)
+
+        viewModel.filterTab = .all
+        viewModel.searchQuery = ""
+        XCTAssertEqual(viewModel.filteredEntryRows.count, entriesBeforeSearch.count)
+        XCTAssertEqual(service.entries.map(\.id), entriesBeforeSearch.map { $0.0 })
+        XCTAssertEqual(service.entries.map(\.type), entriesBeforeSearch.map { $0.1 })
+        XCTAssertEqual(service.entries.map(\.original), entriesBeforeSearch.map { $0.2 })
+        XCTAssertEqual(service.entries.map(\.replacement), entriesBeforeSearch.map { $0.3 })
+        XCTAssertEqual(service.entries.map(\.source), entriesBeforeSearch.map { $0.4 })
     }
 
     @MainActor


### PR DESCRIPTION
## Issue context

The Dictionary settings supported type filters but offered no way to search larger dictionaries. This adds local UI-only search without changing persistence, sync, import/export, CLI, or HTTP API behavior.

## Summary

- add a published search query to `DictionaryViewModel`
- apply the selected type filter first, then search `original` and `replacement` case-insensitively
- keep immutable `DictionaryEntryRow` snapshots and stable row IDs
- add a native macOS search field with a clear button, hidden for Term Packs
- preserve the query across filter changes and show a dedicated no-results state
- cover filter composition, clearing, immutability, and large-list row stability

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7752/typewhisper-mac`
- [x] Manually smoke-tested All, Terms, Corrections, Auto-learned, Term Packs, case-insensitive original/replacement matches, clear behavior, query persistence, empty search results, and large-list scrolling

Closes #869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dictionary search to quickly find entries by original or replacement text.
  * Search works alongside existing dictionary filters and is case-insensitive.
  * Added contextual empty states for searches with no matching results.

* **Bug Fixes**
  * Clearing a search now restores the complete filtered dictionary list without altering entry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->