### PR TITLE
Improve search field visibility

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 			AA00000000000000000206 /* OverlayIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000195 /* OverlayIndicatorView.swift */; };
 			AA00000000000000000207 /* IndicatorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000196 /* IndicatorCoordinator.swift */; };
 			AA00000000000000000208 /* SharedIndicatorComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000197 /* SharedIndicatorComponents.swift */; };
+			4E5353420000000000000001 /* NativeSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5353460000000000000001 /* NativeSearchField.swift */; };
 			AA00000000000000000321 /* MinimalIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000309 /* MinimalIndicatorView.swift */; };
 			AA00000000000000000322 /* MinimalIndicatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000310 /* MinimalIndicatorPanel.swift */; };
 			AA00000000000000000209 /* DeepgramPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000200 /* DeepgramPlugin.swift */; };
@@ -759,6 +760,7 @@
 			BB00000000000000000195 /* OverlayIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorView.swift; sourceTree = "<group>"; };
 			BB00000000000000000196 /* IndicatorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorCoordinator.swift; sourceTree = "<group>"; };
 			BB00000000000000000197 /* SharedIndicatorComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedIndicatorComponents.swift; sourceTree = "<group>"; };
+			4E5353460000000000000001 /* NativeSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSearchField.swift; sourceTree = "<group>"; };
 			BB00000000000000000198 /* OverlayIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayIndicatorPanel.swift; sourceTree = "<group>"; };
 			BB00000000000000000309 /* MinimalIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalIndicatorView.swift; sourceTree = "<group>"; };
 			BB00000000000000000310 /* MinimalIndicatorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalIndicatorPanel.swift; sourceTree = "<group>"; };
@@ -1614,6 +1616,7 @@
 				BB00000000000000000309 /* MinimalIndicatorView.swift */,
 				6C7D8E9F0A1B2C3D4E5F6071 /* FloatingPanelSpacePolicy.swift */,
 				BB00000000000000000197 /* SharedIndicatorComponents.swift */,
+				4E5353460000000000000001 /* NativeSearchField.swift */,
 				BB00000000000000000014 /* MenuBarView.swift */,
 				BB00000000000000000016 /* FileTranscriptionView.swift */,
 				533C00000000000000000003 /* DictationRecoveryView.swift */,
@@ -3992,6 +3995,7 @@
 					AA00000000000000000322 /* MinimalIndicatorPanel.swift in Sources */,
 					AA00000000000000000321 /* MinimalIndicatorView.swift in Sources */,
 					AA00000000000000000208 /* SharedIndicatorComponents.swift in Sources */,
+					4E5353420000000000000001 /* NativeSearchField.swift in Sources */,
 					AA00000000000000000126 /* PostProcessingPipeline.swift in Sources */,
 				AA00000000000000000127 /* PluginSettingsView.swift in Sources */,
 				AA00000000000000000152 /* AppConstants.swift in Sources */,

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -105,29 +105,13 @@ struct DictionarySettingsView: View {
     }
 
     private var dictionarySearchField: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-
-            TextField(String(localized: "Search..."), text: $viewModel.searchQuery)
-                .textFieldStyle(.plain)
-
-            if !viewModel.searchQuery.isEmpty {
-                Button {
-                    viewModel.searchQuery = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "Clear search"))
-            }
-        }
-        .padding(8)
-        .background(.bar)
-        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        NativeSearchField(
+            text: $viewModel.searchQuery,
+            placeholder: String(localized: "Search...")
+        )
+        .frame(height: 32)
         .padding(.horizontal, 2)
-        .padding(.bottom, 6)
+        .padding(.vertical, 6)
     }
 
     private var dictionaryEntriesView: some View {

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -109,6 +109,7 @@ struct DictionarySettingsView: View {
             text: $viewModel.searchQuery,
             placeholder: String(localized: "Search...")
         )
+        .frame(maxWidth: .infinity)
         .frame(height: 32)
         .padding(.horizontal, 2)
         .padding(.vertical, 6)

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -36,6 +36,7 @@ struct HistoryView: View {
                 text: $viewModel.searchQuery,
                 placeholder: String(localized: "Search...")
             )
+            .frame(maxWidth: .infinity)
             .frame(height: 32)
             .padding(.horizontal, 8)
             .padding(.vertical, 6)

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -32,23 +32,13 @@ struct HistoryView: View {
     private var listPanel: some View {
         VStack(spacing: 0) {
             // Search
-            HStack {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField(String(localized: "Search..."), text: $viewModel.searchQuery)
-                    .textFieldStyle(.plain)
-                if !viewModel.searchQuery.isEmpty {
-                    Button {
-                        viewModel.searchQuery = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(localized: "Clear search"))
-                }
-            }
-            .padding(8)
+            NativeSearchField(
+                text: $viewModel.searchQuery,
+                placeholder: String(localized: "Search...")
+            )
+            .frame(height: 32)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
             .background(.bar)
 
             // Filter pickers

--- a/TypeWhisper/Views/NativeSearchField.swift
+++ b/TypeWhisper/Views/NativeSearchField.swift
@@ -1,0 +1,47 @@
+import AppKit
+import SwiftUI
+
+/// A shared, native macOS search field with the system focus ring and clear button.
+struct NativeSearchField: NSViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let searchField = NSSearchField()
+        searchField.placeholderString = placeholder
+        searchField.controlSize = .large
+        searchField.bezelStyle = .roundedBezel
+        searchField.focusRingType = .default
+        searchField.sendsSearchStringImmediately = true
+        searchField.sendsWholeSearchString = false
+        searchField.delegate = context.coordinator
+        return searchField
+    }
+
+    func updateNSView(_ searchField: NSSearchField, context: Context) {
+        context.coordinator.text = $text
+        searchField.placeholderString = placeholder
+
+        if searchField.stringValue != text {
+            searchField.stringValue = text
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let searchField = notification.object as? NSSearchField else { return }
+            text.wrappedValue = searchField.stringValue
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -13,6 +13,8 @@ let package = Package(
         .package(url: "https://github.com/FluidInference/FluidAudio.git", branch: "main"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
+        // swift-transformers 1.3.3 is incompatible with swift-jinja 2.4's ObjectKey API.
+        .package(url: "https://github.com/huggingface/swift-jinja.git", exact: "2.3.6"),
         .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.4"),
         .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
     ],


### PR DESCRIPTION
## Context

Follow-up to #869: the new Dictionary search worked correctly, but its flat styling was difficult to distinguish from the surrounding dark background. History used the same low-contrast search treatment.

During verification, the newly published `swift-jinja` 2.4.0 also broke the unchanged Plugin SDK dependency graph through `swift-transformers` 1.3.3. The manifest now constrains the compatible 2.3.6 release.

## Summary

- add a shared AppKit-backed `NativeSearchField`
- use the native macOS bezel, focus ring, search icon, and clear button
- adopt the shared full-width field in Dictionary and History
- keep all existing search/filter behavior unchanged
- constrain `swift-jinja` to 2.3.6 until `swift-transformers` supports the 2.4 ObjectKey API

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7752/typewhisper-mac`
- [x] Manually verified Dictionary and History in dark mode, including idle contrast, focus ring, filtering, the native clear button, and full-width layout