### PR TITLE
Add safe dictionary reset actions

### DIFF
--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -317,7 +317,22 @@ final class DictionaryService: ObservableObject {
 
     /// Batch delete multiple entries
     func deleteEntries(_ entriesToDelete: [DictionaryEntry]) {
-        guard let context = modelContext, !entriesToDelete.isEmpty else { return }
+        do {
+            try deleteEntries(ids: Set(entriesToDelete.map(\.id)))
+        } catch {
+            logger.error("Failed to batch delete entries: \(error.localizedDescription)")
+        }
+    }
+
+    /// Batch delete entries by stable IDs and report persistence failures to the caller.
+    func deleteEntries(ids: Set<UUID>) throws {
+        guard !ids.isEmpty else { return }
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
+
+        let entriesToDelete = entries.filter { ids.contains($0.id) }
+        guard !entriesToDelete.isEmpty else { return }
 
         for entry in entriesToDelete {
             context.delete(entry)
@@ -327,7 +342,10 @@ final class DictionaryService: ObservableObject {
             try context.save()
             loadEntries()
         } catch {
+            context.rollback()
+            loadEntries()
             logger.error("Failed to batch delete entries: \(error.localizedDescription)")
+            throw DictionaryServiceMutationError.saveFailed(error)
         }
     }
 

--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -34,6 +34,37 @@ struct DictionaryEntryRow: Identifiable, Equatable {
     }
 }
 
+enum DictionaryResetAction: String, Identifiable, Equatable {
+    case clearAutoLearnedCorrections
+    case resetCustomDictionary
+    case deactivateAllTermPacks
+
+    var id: String { rawValue }
+}
+
+struct DictionaryResetRequest: Identifiable, Equatable {
+    let action: DictionaryResetAction
+    let termCount: Int
+    let manualCorrectionCount: Int
+    let autoLearnedCorrectionCount: Int
+    let activePackCount: Int
+
+    var id: String { action.id }
+    var correctionCount: Int { manualCorrectionCount + autoLearnedCorrectionCount }
+    var entryCount: Int { termCount + correctionCount }
+
+    var canPerform: Bool {
+        switch action {
+        case .clearAutoLearnedCorrections:
+            return autoLearnedCorrectionCount > 0
+        case .resetCustomDictionary:
+            return entryCount > 0
+        case .deactivateAllTermPacks:
+            return activePackCount > 0
+        }
+    }
+}
+
 // MARK: - Dictionary ViewModel
 
 @MainActor
@@ -49,6 +80,7 @@ class DictionaryViewModel: ObservableObject {
     @Published var entries: [DictionaryEntry] = []
     @Published var error: String?
     @Published var importMessage: String?
+    @Published private(set) var pendingResetRequest: DictionaryResetRequest?
 
     // Filter
     enum FilterTab: Int, CaseIterable {
@@ -100,6 +132,7 @@ class DictionaryViewModel: ObservableObject {
     private let dictionaryService: DictionaryService
     private let licenseService: LicenseService?
     private let termPackRegistryService: TermPackRegistryService?
+    private let defaults: UserDefaults
     private var cancellables = Set<AnyCancellable>()
     private var selectedEntry: DictionaryEntry?
 
@@ -172,11 +205,13 @@ class DictionaryViewModel: ObservableObject {
     init(
         dictionaryService: DictionaryService,
         licenseService: LicenseService? = nil,
-        termPackRegistryService: TermPackRegistryService? = nil
+        termPackRegistryService: TermPackRegistryService? = nil,
+        defaults: UserDefaults = .standard
     ) {
         self.dictionaryService = dictionaryService
         self.licenseService = licenseService
         self.termPackRegistryService = termPackRegistryService
+        self.defaults = defaults
         self.entries = dictionaryService.entries
         migrateLegacyActivatedPacks()
         loadActivatedPackStates()
@@ -320,6 +355,90 @@ class DictionaryViewModel: ObservableObject {
         importMessage = nil
     }
 
+    // MARK: - Reset Actions
+
+    func resetRequest(for action: DictionaryResetAction) -> DictionaryResetRequest {
+        switch action {
+        case .clearAutoLearnedCorrections:
+            let autoLearnedCorrections = dictionaryService.entries.filter {
+                $0.type == .correction && $0.source == .autoLearned
+            }
+            return DictionaryResetRequest(
+                action: action,
+                termCount: 0,
+                manualCorrectionCount: 0,
+                autoLearnedCorrectionCount: autoLearnedCorrections.count,
+                activePackCount: 0
+            )
+
+        case .resetCustomDictionary:
+            let packEntryIDs = managedPackEntryIDs()
+            let customEntries = dictionaryService.entries.filter { !packEntryIDs.contains($0.id) }
+            return DictionaryResetRequest(
+                action: action,
+                termCount: customEntries.filter { $0.type == .term }.count,
+                manualCorrectionCount: customEntries.filter {
+                    $0.type == .correction && $0.source == .manual
+                }.count,
+                autoLearnedCorrectionCount: customEntries.filter {
+                    $0.type == .correction && $0.source == .autoLearned
+                }.count,
+                activePackCount: activatedPackStates.count
+            )
+
+        case .deactivateAllTermPacks:
+            let packEntryIDs = managedPackEntryIDs()
+            let packEntries = dictionaryService.entries.filter { packEntryIDs.contains($0.id) }
+            return DictionaryResetRequest(
+                action: action,
+                termCount: packEntries.filter { $0.type == .term }.count,
+                manualCorrectionCount: packEntries.filter { $0.type == .correction }.count,
+                autoLearnedCorrectionCount: 0,
+                activePackCount: activatedPackStates.count
+            )
+        }
+    }
+
+    func requestReset(_ action: DictionaryResetAction) {
+        let request = resetRequest(for: action)
+        guard request.canPerform else { return }
+        pendingResetRequest = request
+    }
+
+    func cancelReset() {
+        pendingResetRequest = nil
+    }
+
+    func confirmReset() {
+        guard let action = pendingResetRequest?.action else { return }
+        pendingResetRequest = nil
+
+        do {
+            switch action {
+            case .clearAutoLearnedCorrections:
+                let ids = Set(dictionaryService.entries.filter {
+                    $0.type == .correction && $0.source == .autoLearned
+                }.map(\.id))
+                try dictionaryService.deleteEntries(ids: ids)
+
+            case .resetCustomDictionary:
+                let packEntryIDs = managedPackEntryIDs()
+                let ids = Set(dictionaryService.entries.filter {
+                    !packEntryIDs.contains($0.id)
+                }.map(\.id))
+                try dictionaryService.deleteEntries(ids: ids)
+
+            case .deactivateAllTermPacks:
+                let ids = managedPackEntryIDs()
+                try dictionaryService.deleteEntries(ids: ids)
+                activatedPackStates = [:]
+                saveActivatedPackStates()
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
     func termBoostingLabel(for threshold: Float?) -> String {
         termBoostingMode(for: threshold).displayName
     }
@@ -458,7 +577,7 @@ class DictionaryViewModel: ObservableObject {
     }
 
     func applyIndustryPreset(_ preset: IndustryPreset) {
-        UserDefaults.standard.set(preset.rawValue, forKey: UserDefaultsKeys.selectedIndustryPreset)
+        defaults.set(preset.rawValue, forKey: UserDefaultsKeys.selectedIndustryPreset)
 
         guard let packID = preset.termPackID,
               hasCommercialLicense,
@@ -549,10 +668,20 @@ class DictionaryViewModel: ObservableObject {
     }
 
     private func removeSnapshotEntries(from states: [String: ActivatedTermPackState]) {
+        let ids = managedPackEntryIDs(from: states)
+        guard !ids.isEmpty else { return }
+
+        let entriesToDelete = dictionaryService.entries.filter { ids.contains($0.id) }
+        dictionaryService.deleteEntries(entriesToDelete)
+    }
+
+    private func managedPackEntryIDs(
+        from states: [String: ActivatedTermPackState]? = nil
+    ) -> Set<UUID> {
         var termsToRemove = Set<String>()
         var correctionsToRemove = Set<String>() // "original|replacement" keys
 
-        for state in states.values {
+        for state in (states ?? activatedPackStates).values {
             for term in state.installedTerms {
                 termsToRemove.insert(term.lowercased())
             }
@@ -561,18 +690,15 @@ class DictionaryViewModel: ObservableObject {
             }
         }
 
-        let entriesToDelete = dictionaryService.entries.filter { entry in
+        return Set(dictionaryService.entries.compactMap { entry -> UUID? in
             if entry.type == .term {
-                return termsToRemove.contains(entry.original.lowercased())
+                return termsToRemove.contains(entry.original.lowercased()) ? entry.id : nil
             } else if entry.type == .correction, let replacement = entry.replacement {
-                return correctionsToRemove.contains("\(entry.original.lowercased())|\(replacement.lowercased())")
+                let key = "\(entry.original.lowercased())|\(replacement.lowercased())"
+                return correctionsToRemove.contains(key) ? entry.id : nil
             }
-            return false
-        }
-
-        if !entriesToDelete.isEmpty {
-            dictionaryService.deleteEntries(entriesToDelete)
-        }
+            return nil
+        })
     }
 
     /// Adds term entries, skipping any that already exist. Returns the terms that were actually added.
@@ -616,7 +742,7 @@ class DictionaryViewModel: ObservableObject {
     // MARK: - Persistence
 
     private func loadActivatedPackStates() {
-        guard let data = UserDefaults.standard.data(forKey: UserDefaultsKeys.activatedTermPackStates) else { return }
+        guard let data = defaults.data(forKey: UserDefaultsKeys.activatedTermPackStates) else { return }
         do {
             let states = try JSONDecoder().decode([ActivatedTermPackState].self, from: data)
             activatedPackStates = Dictionary(uniqueKeysWithValues: states.map { ($0.packID, $0) })
@@ -629,7 +755,7 @@ class DictionaryViewModel: ObservableObject {
     private func saveActivatedPackStates() {
         let states = Array(activatedPackStates.values)
         if let data = try? JSONEncoder().encode(states) {
-            UserDefaults.standard.set(data, forKey: UserDefaultsKeys.activatedTermPackStates)
+            defaults.set(data, forKey: UserDefaultsKeys.activatedTermPackStates)
         }
     }
 
@@ -637,8 +763,8 @@ class DictionaryViewModel: ObservableObject {
     /// Does NOT auto-reactivate packs - just cleans up the old key. Entries remain in dictionary.
     private func migrateLegacyActivatedPacks() {
         let legacyKey = UserDefaultsKeys.activatedTermPacks
-        guard UserDefaults.standard.stringArray(forKey: legacyKey) != nil else { return }
+        guard defaults.stringArray(forKey: legacyKey) != nil else { return }
         // Clear legacy key - packs will need to be re-activated
-        UserDefaults.standard.removeObject(forKey: legacyKey)
+        defaults.removeObject(forKey: legacyKey)
     }
 }

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -17,17 +17,15 @@ struct DictionarySettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if viewModel.entries.isEmpty && viewModel.filterTab != .termPacks {
+            dictionaryHeader
+
+            if viewModel.filterTab == .termPacks {
+                termPacksView
+            } else if viewModel.entries.isEmpty {
                 emptyState
             } else {
-                dictionaryHeader
-
-                if viewModel.filterTab == .termPacks {
-                    termPacksView
-                } else {
-                    dictionarySearchField
-                    dictionaryEntriesView
-                }
+                dictionarySearchField
+                dictionaryEntriesView
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -51,6 +49,26 @@ struct DictionarySettingsView: View {
             Button(String(localized: "OK")) { viewModel.clearImportMessage() }
         } message: {
             Text(viewModel.importMessage ?? "")
+        }
+        .alert(
+            resetConfirmationTitle,
+            isPresented: Binding(
+                get: { viewModel.pendingResetRequest != nil },
+                set: { if !$0 { viewModel.cancelReset() } }
+            )
+        ) {
+            if let request = viewModel.pendingResetRequest {
+                Button(resetConfirmationButtonTitle(for: request.action), role: .destructive) {
+                    viewModel.confirmReset()
+                }
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                viewModel.cancelReset()
+            }
+        } message: {
+            if let request = viewModel.pendingResetRequest {
+                Text(resetConfirmationMessage(for: request))
+            }
         }
     }
 
@@ -94,6 +112,12 @@ struct DictionarySettingsView: View {
                 } label: {
                     Label(String(localized: "Import..."), systemImage: "square.and.arrow.down")
                 }
+
+                Divider()
+
+                resetMenuButton(.clearAutoLearnedCorrections)
+                resetMenuButton(.resetCustomDictionary)
+                resetMenuButton(.deactivateAllTermPacks)
             } label: {
                 Image(systemName: "ellipsis.circle")
             }
@@ -102,6 +126,100 @@ struct DictionarySettingsView: View {
         }
         .padding(.horizontal, 4)
         .padding(.bottom, 4)
+    }
+
+    @ViewBuilder
+    private func resetMenuButton(_ action: DictionaryResetAction) -> some View {
+        let request = viewModel.resetRequest(for: action)
+        Button(role: .destructive) {
+            viewModel.requestReset(action)
+        } label: {
+            Label(resetMenuTitle(for: action), systemImage: resetMenuIcon(for: action))
+        }
+        .disabled(!request.canPerform)
+    }
+
+    private func resetMenuTitle(for action: DictionaryResetAction) -> String {
+        switch action {
+        case .clearAutoLearnedCorrections:
+            return localizedAppText(
+                "Clear Auto-Learned Corrections...",
+                de: "Automatisch gelernte Korrekturen löschen..."
+            )
+        case .resetCustomDictionary:
+            return localizedAppText(
+                "Reset Custom Dictionary...",
+                de: "Eigenes Dictionary zurücksetzen..."
+            )
+        case .deactivateAllTermPacks:
+            return localizedAppText(
+                "Deactivate All Term Packs...",
+                de: "Alle Begriff-Pakete deaktivieren..."
+            )
+        }
+    }
+
+    private func resetMenuIcon(for action: DictionaryResetAction) -> String {
+        switch action {
+        case .clearAutoLearnedCorrections:
+            return "wand.and.stars"
+        case .resetCustomDictionary:
+            return "trash"
+        case .deactivateAllTermPacks:
+            return "shippingbox.and.arrow.backward"
+        }
+    }
+
+    private var resetConfirmationTitle: String {
+        guard let action = viewModel.pendingResetRequest?.action else { return "" }
+        switch action {
+        case .clearAutoLearnedCorrections:
+            return localizedAppText(
+                "Clear Auto-Learned Corrections?",
+                de: "Automatisch gelernte Korrekturen löschen?"
+            )
+        case .resetCustomDictionary:
+            return localizedAppText(
+                "Reset Custom Dictionary?",
+                de: "Eigenes Dictionary zurücksetzen?"
+            )
+        case .deactivateAllTermPacks:
+            return localizedAppText(
+                "Deactivate All Term Packs?",
+                de: "Alle Begriff-Pakete deaktivieren?"
+            )
+        }
+    }
+
+    private func resetConfirmationButtonTitle(for action: DictionaryResetAction) -> String {
+        switch action {
+        case .clearAutoLearnedCorrections:
+            return localizedAppText("Clear Corrections", de: "Korrekturen löschen")
+        case .resetCustomDictionary:
+            return localizedAppText("Reset Dictionary", de: "Dictionary zurücksetzen")
+        case .deactivateAllTermPacks:
+            return localizedAppText("Deactivate Packs", de: "Pakete deaktivieren")
+        }
+    }
+
+    private func resetConfirmationMessage(for request: DictionaryResetRequest) -> String {
+        switch request.action {
+        case .clearAutoLearnedCorrections:
+            return localizedAppText(
+                "This deletes \(request.autoLearnedCorrectionCount) auto-learned corrections. Manual entries and term packs remain unchanged. This cannot be undone.",
+                de: "Dadurch werden \(request.autoLearnedCorrectionCount) automatisch gelernte Korrekturen gelöscht. Manuelle Einträge und Begriff-Pakete bleiben unverändert. Dies kann nicht rückgängig gemacht werden."
+            )
+        case .resetCustomDictionary:
+            return localizedAppText(
+                "This deletes \(request.termCount) custom terms, \(request.manualCorrectionCount) manual corrections, and \(request.autoLearnedCorrectionCount) auto-learned corrections. \(request.activePackCount) active term packs and their entries remain unchanged. This cannot be undone.",
+                de: "Dadurch werden \(request.termCount) eigene Begriffe, \(request.manualCorrectionCount) manuelle Korrekturen und \(request.autoLearnedCorrectionCount) automatisch gelernte Korrekturen gelöscht. \(request.activePackCount) aktive Begriff-Pakete und deren Einträge bleiben unverändert. Dies kann nicht rückgängig gemacht werden."
+            )
+        case .deactivateAllTermPacks:
+            return localizedAppText(
+                "This deactivates \(request.activePackCount) term packs and removes \(request.termCount) pack terms and \(request.correctionCount) pack corrections. Custom and auto-learned entries remain unchanged.",
+                de: "Dadurch werden \(request.activePackCount) Begriff-Pakete deaktiviert sowie \(request.termCount) Paket-Begriffe und \(request.correctionCount) Paket-Korrekturen entfernt. Eigene und automatisch gelernte Einträge bleiben unverändert."
+            )
+        }
     }
 
     private var dictionarySearchField: some View {

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -496,6 +496,57 @@ final class CloudFolderSyncTests: XCTestCase {
     }
 
     @MainActor
+    func testDictionaryResetActionsKeepHostSnapshotConsistent() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncDictionaryReset")
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let suiteName = "CloudFolderSyncDictionaryReset-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        dictionaryService.addEntry(type: .term, original: "ManualBeforeReset")
+        dictionaryService.learnCorrection(original: "recieve", replacement: "receive")
+
+        let viewModel = DictionaryViewModel(dictionaryService: dictionaryService, defaults: defaults)
+        let pack = TermPack(
+            id: "sync-reset-pack",
+            name: "Sync Reset Pack",
+            description: "Sync reset test pack",
+            icon: "shippingbox",
+            terms: ["ManagedPackTerm"],
+            corrections: [],
+            version: "1.0.0",
+            author: "Tests",
+            localizedNames: nil,
+            localizedDescriptions: nil
+        )
+        viewModel.activatePack(pack)
+
+        let store = TypeWhisperUserDataSyncStore(
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            defaults: defaults
+        )
+
+        viewModel.requestReset(.resetCustomDictionary)
+        viewModel.confirmReset()
+        XCTAssertTrue(store.snapshot().dictionaryEntries.isEmpty)
+        XCTAssertEqual(dictionaryService.entries.map(\.original), ["ManagedPackTerm"])
+
+        dictionaryService.addEntry(type: .term, original: "ManualAfterReset")
+        dictionaryService.learnCorrection(original: "langauge", replacement: "language")
+        viewModel.requestReset(.deactivateAllTermPacks)
+        viewModel.confirmReset()
+
+        let snapshot = store.snapshot()
+        XCTAssertEqual(Set(snapshot.dictionaryEntries.map(\.original)), ["ManualAfterReset", "langauge"])
+        XCTAssertFalse(dictionaryService.entries.contains { $0.original == "ManagedPackTerm" })
+        XCTAssertTrue(viewModel.activatedPackStates.isEmpty)
+    }
+
+    @MainActor
     func testHostApplyMergesDuplicateNaturalKeys() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncMerge")
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -737,6 +737,192 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testClearAutoLearnedResetRequiresConfirmationAndPreservesOtherEntries() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .term, original: "ManualTerm")
+        service.addEntry(type: .correction, original: "teh", replacement: "the")
+        service.learnCorrection(original: "recieve", replacement: "receive")
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+
+        let summary = viewModel.resetRequest(for: .clearAutoLearnedCorrections)
+        XCTAssertEqual(summary.entryCount, 1)
+        XCTAssertEqual(summary.autoLearnedCorrectionCount, 1)
+        XCTAssertTrue(summary.canPerform)
+
+        let originalIDs = service.entries.map(\.id)
+        viewModel.requestReset(.clearAutoLearnedCorrections)
+        XCTAssertNotNil(viewModel.pendingResetRequest)
+        XCTAssertEqual(service.entries.map(\.id), originalIDs)
+
+        viewModel.cancelReset()
+        XCTAssertNil(viewModel.pendingResetRequest)
+        XCTAssertEqual(service.entries.map(\.id), originalIDs)
+
+        viewModel.requestReset(.clearAutoLearnedCorrections)
+        viewModel.confirmReset()
+
+        XCTAssertEqual(Set(service.entries.map(\.original)), ["ManualTerm", "teh"])
+        XCTAssertFalse(service.entries.contains { $0.source == .autoLearned })
+        XCTAssertNil(viewModel.pendingResetRequest)
+        XCTAssertFalse(viewModel.resetRequest(for: .clearAutoLearnedCorrections).canPerform)
+    }
+
+    @MainActor
+    func testResetCustomDictionaryPreservesActivePackEntriesSnapshotsAndExport() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let suiteName = "DictionaryResetCustom-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .term, original: "ManualTerm")
+        service.addEntry(type: .correction, original: "teh", replacement: "the")
+        service.learnCorrection(original: "recieve", replacement: "receive")
+        let viewModel = DictionaryViewModel(dictionaryService: service, defaults: defaults)
+        let pack = TermPack(
+            id: "reset-pack",
+            name: "Reset Pack",
+            description: "Reset test pack",
+            icon: "shippingbox",
+            terms: ["PackTerm"],
+            corrections: [TermPackCorrection(original: "pakc", replacement: "pack")],
+            version: "1.0.0",
+            author: "Tests",
+            localizedNames: nil,
+            localizedDescriptions: nil
+        )
+        viewModel.activatePack(pack)
+
+        let summary = viewModel.resetRequest(for: .resetCustomDictionary)
+        XCTAssertEqual(summary.termCount, 1)
+        XCTAssertEqual(summary.manualCorrectionCount, 1)
+        XCTAssertEqual(summary.autoLearnedCorrectionCount, 1)
+        XCTAssertEqual(summary.activePackCount, 1)
+
+        viewModel.requestReset(.resetCustomDictionary)
+        viewModel.confirmReset()
+
+        XCTAssertEqual(Set(service.entries.map(\.original)), ["PackTerm", "pakc"])
+        XCTAssertNotNil(viewModel.activatedPackStates[pack.id])
+
+        let persistedStatesData = try XCTUnwrap(
+            defaults.data(forKey: UserDefaultsKeys.activatedTermPackStates)
+        )
+        let persistedStates = try JSONDecoder().decode([ActivatedTermPackState].self, from: persistedStatesData)
+        XCTAssertEqual(persistedStates.map(\.packID), [pack.id])
+
+        let exported = DictionaryExporter.exportJSON(service.entries)
+        XCTAssertTrue(exported.contains("PackTerm"))
+        XCTAssertTrue(exported.contains("pakc"))
+        XCTAssertFalse(exported.contains("ManualTerm"))
+        XCTAssertFalse(exported.contains("recieve"))
+
+        let reloadedViewModel = DictionaryViewModel(dictionaryService: service, defaults: defaults)
+        XCTAssertNotNil(reloadedViewModel.activatedPackStates[pack.id])
+    }
+
+    @MainActor
+    func testDeactivateAllPacksRemovesOnlyTrackedEntriesAndPersistsEmptySnapshots() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let suiteName = "DictionaryDeactivatePacks-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .term, original: "ManualTerm")
+        service.addEntry(type: .correction, original: "teh", replacement: "the")
+        service.learnCorrection(original: "recieve", replacement: "receive")
+        let viewModel = DictionaryViewModel(dictionaryService: service, defaults: defaults)
+        let firstPack = TermPack(
+            id: "first-reset-pack",
+            name: "First Reset Pack",
+            description: "First reset test pack",
+            icon: "shippingbox",
+            terms: ["ManualTerm", "FirstPackTerm"],
+            corrections: [TermPackCorrection(original: "frist", replacement: "first")],
+            version: "1.0.0",
+            author: "Tests",
+            localizedNames: nil,
+            localizedDescriptions: nil
+        )
+        let secondPack = TermPack(
+            id: "second-reset-pack",
+            name: "Second Reset Pack",
+            description: "Second reset test pack",
+            icon: "shippingbox",
+            terms: ["SecondPackTerm"],
+            corrections: [],
+            version: "1.0.0",
+            author: "Tests",
+            localizedNames: nil,
+            localizedDescriptions: nil
+        )
+        viewModel.activatePack(firstPack)
+        viewModel.activatePack(secondPack)
+
+        let summary = viewModel.resetRequest(for: .deactivateAllTermPacks)
+        XCTAssertEqual(summary.activePackCount, 2)
+        XCTAssertEqual(summary.termCount, 2)
+        XCTAssertEqual(summary.correctionCount, 1)
+
+        viewModel.requestReset(.deactivateAllTermPacks)
+        viewModel.confirmReset()
+
+        XCTAssertEqual(Set(service.entries.map(\.original)), ["ManualTerm", "teh", "recieve"])
+        XCTAssertTrue(viewModel.activatedPackStates.isEmpty)
+        let persistedStatesData = try XCTUnwrap(
+            defaults.data(forKey: UserDefaultsKeys.activatedTermPackStates)
+        )
+        XCTAssertTrue(try JSONDecoder().decode([ActivatedTermPackState].self, from: persistedStatesData).isEmpty)
+        XCTAssertFalse(viewModel.resetRequest(for: .deactivateAllTermPacks).canPerform)
+        XCTAssertTrue(DictionaryExporter.exportJSON(service.entries).contains("recieve"))
+    }
+
+    @MainActor
+    func testResetActionsAreDisabledForEmptyCategoriesIncludingPackWithNoInstalledEntries() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+
+        XCTAssertFalse(viewModel.resetRequest(for: .clearAutoLearnedCorrections).canPerform)
+        XCTAssertFalse(viewModel.resetRequest(for: .resetCustomDictionary).canPerform)
+        XCTAssertFalse(viewModel.resetRequest(for: .deactivateAllTermPacks).canPerform)
+        viewModel.requestReset(.clearAutoLearnedCorrections)
+        XCTAssertNil(viewModel.pendingResetRequest)
+
+        service.addEntry(type: .term, original: "ExistingTerm")
+        let pack = TermPack(
+            id: "duplicate-only-pack",
+            name: "Duplicate Only",
+            description: "Installs no entries",
+            icon: "shippingbox",
+            terms: ["ExistingTerm"],
+            corrections: [],
+            version: "1.0.0",
+            author: "Tests",
+            localizedNames: nil,
+            localizedDescriptions: nil
+        )
+        viewModel.activatePack(pack)
+
+        let packSummary = viewModel.resetRequest(for: .deactivateAllTermPacks)
+        XCTAssertTrue(packSummary.canPerform)
+        XCTAssertEqual(packSummary.activePackCount, 1)
+        XCTAssertEqual(packSummary.entryCount, 0)
+
+        viewModel.requestReset(.deactivateAllTermPacks)
+        viewModel.confirmReset()
+        XCTAssertEqual(service.entries.map(\.original), ["ExistingTerm"])
+        XCTAssertTrue(viewModel.activatedPackStates.isEmpty)
+    }
+
+    @MainActor
     func testCommercialIndustryPacksAreHiddenWithoutCommercialLicense() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Context

The dictionary needs safe, explicit reset actions for clearing learned corrections, resetting custom entries, and deactivating term packs without accidentally deleting unrelated data.

Closes #868

## What changed

- add confirmation-based reset actions for auto-learned corrections, the custom dictionary, and all active term packs
- preserve entries managed by active term packs when resetting the custom dictionary
- remove tracked term-pack entries and persisted activation state when deactivating all packs
- execute stable-ID batch deletion with a single save/reload and rollback on failure
- keep the dictionary header and reset menu available in empty states
- add regression coverage for cancellation, preservation, persistence, export, cloud sync, and empty-pack edge cases

## Test plan

- [x] Dictionary service tests:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests
```

- [x] Cloud folder sync tests:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/CloudFolderSyncTests
```

- [x] Signed development build and launch:

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7752/typewhisper-mac
```

- [x] Manual macOS smoke test across all three reset actions, including confirmation/cancellation, active term-pack preservation, empty states, and persistence after relaunch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dictionary reset options for clearing auto-learned corrections, resetting custom entries, and deactivating all term packs.
  * Added confirmation prompts and summaries before destructive reset actions.
  * Reset actions are automatically disabled when there is nothing to reset.

* **Bug Fixes**
  * Improved dictionary reset error handling and recovery when saving fails.
  * Ensured dictionary and term-pack changes remain consistent after resets.

* **Tests**
  * Added coverage for reset workflows, persistence, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->