### PR TITLE
Group dictionary correction variants

### DIFF
--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -34,6 +34,47 @@ struct DictionaryEntryRow: Identifiable, Equatable {
     }
 }
 
+enum DictionaryListRowID: Hashable {
+    case entry(UUID)
+    case correctionGroup(String)
+}
+
+struct DictionaryCorrectionGroupRow: Identifiable, Equatable {
+    let replacement: String
+    let aliases: [DictionaryEntryRow]
+
+    var id: DictionaryListRowID {
+        .correctionGroup(replacement)
+    }
+
+    var replacementDisplayText: String {
+        dictionaryReplacementDisplayText(replacement)
+    }
+}
+
+enum DictionaryListRow: Identifiable, Equatable {
+    case entry(DictionaryEntryRow)
+    case correctionGroup(DictionaryCorrectionGroupRow)
+
+    var id: DictionaryListRowID {
+        switch self {
+        case .entry(let row):
+            return .entry(row.id)
+        case .correctionGroup(let group):
+            return group.id
+        }
+    }
+
+    var entryRows: [DictionaryEntryRow] {
+        switch self {
+        case .entry(let row):
+            return [row]
+        case .correctionGroup(let group):
+            return group.aliases
+        }
+    }
+}
+
 enum DictionaryResetAction: String, Identifiable, Equatable {
     case clearAutoLearnedCorrections
     case resetCustomDictionary
@@ -119,6 +160,7 @@ class DictionaryViewModel: ObservableObject {
     @Published var editCaseSensitive = false
     @Published var editTermBoostingMode: TermBoostingMode = .automatic
     @Published var editAdvancedCtcMinSimilarity: Double = 0.65
+    @Published private(set) var lockedCorrectionReplacement: String?
 
     // Term Packs
     @Published var activatedPackStates: [String: ActivatedTermPackState] = [:]
@@ -136,34 +178,47 @@ class DictionaryViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var selectedEntry: DictionaryEntry?
 
-    var filteredEntries: [DictionaryEntry] {
-        let entriesForSelectedFilter: [DictionaryEntry]
+    private var entriesForSelectedFilter: [DictionaryEntry] {
         switch filterTab {
         case .all:
-            entriesForSelectedFilter = entries
+            return entries
         case .terms:
-            entriesForSelectedFilter = entries.filter { $0.type == .term }
+            return entries.filter { $0.type == .term }
         case .corrections:
-            entriesForSelectedFilter = entries.filter { $0.type == .correction }
+            return entries.filter { $0.type == .correction }
         case .autoLearned:
-            entriesForSelectedFilter = entries.filter {
+            return entries.filter {
                 $0.type == .correction && $0.source == .autoLearned
             }
         case .termPacks:
             return []
         }
+    }
+
+    var filteredListRows: [DictionaryListRow] {
+        let listRows = groupedListRows(from: entriesForSelectedFilter.map(row))
 
         let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return entriesForSelectedFilter }
+        guard !query.isEmpty else { return listRows }
 
-        return entriesForSelectedFilter.filter { entry in
-            entry.original.localizedCaseInsensitiveContains(query) ||
-                (entry.replacement?.localizedCaseInsensitiveContains(query) ?? false)
+        return listRows.filter { listRow in
+            switch listRow {
+            case .entry(let row):
+                return rowMatchesSearch(row, query: query)
+            case .correctionGroup(let group):
+                return group.replacement.localizedCaseInsensitiveContains(query) ||
+                    group.aliases.contains { rowMatchesSearch($0, query: query) }
+            }
         }
     }
 
     var filteredEntryRows: [DictionaryEntryRow] {
-        filteredEntries.map(row)
+        filteredListRows.flatMap(\.entryRows)
+    }
+
+    var filteredEntries: [DictionaryEntry] {
+        let visibleIDs = Set(filteredEntryRows.map(\.id))
+        return entriesForSelectedFilter.filter { visibleIDs.contains($0.id) }
     }
 
     var hasActiveSearch: Bool {
@@ -260,6 +315,7 @@ class DictionaryViewModel: ObservableObject {
         selectedEntry = nil
         isCreatingNew = true
         isEditing = true
+        lockedCorrectionReplacement = nil
         editType = type
         editOriginal = ""
         editReplacement = ""
@@ -267,10 +323,18 @@ class DictionaryViewModel: ObservableObject {
         resetTermBoostingEditor()
     }
 
+    func startCreatingCorrectionAlias(replacement: String) {
+        guard !replacement.isEmpty else { return }
+        startCreating(type: .correction)
+        lockedCorrectionReplacement = replacement
+        editReplacement = replacement
+    }
+
     func startEditing(_ entry: DictionaryEntry) {
         selectedEntry = entry
         isCreatingNew = false
         isEditing = true
+        lockedCorrectionReplacement = nil
         editType = entry.type
         editOriginal = entry.original
         editReplacement = entry.replacement ?? ""
@@ -291,6 +355,7 @@ class DictionaryViewModel: ObservableObject {
         editOriginal = ""
         editReplacement = ""
         editCaseSensitive = false
+        lockedCorrectionReplacement = nil
         resetTermBoostingEditor()
     }
 
@@ -300,7 +365,9 @@ class DictionaryViewModel: ObservableObject {
             return
         }
 
-        let replacement = editType == .correction ? editReplacement : nil
+        let replacement = editType == .correction
+            ? (lockedCorrectionReplacement ?? editReplacement)
+            : nil
         let ctcMinSimilarity = editType == .term ? editCtcMinSimilarity : nil
 
         if isCreatingNew {
@@ -460,6 +527,41 @@ class DictionaryViewModel: ObservableObject {
             termBoostingLabel: termBoostingLabel(for: entry.ctcMinSimilarity),
             formattedCtcMinSimilarity: formattedCtcMinSimilarity(entry.ctcMinSimilarity)
         )
+    }
+
+    private func groupedListRows(from rows: [DictionaryEntryRow]) -> [DictionaryListRow] {
+        var listRows: [DictionaryListRow] = []
+        var groupIndexes: [String: Int] = [:]
+
+        for row in rows {
+            guard row.type == .correction,
+                  let replacement = row.replacement,
+                  !replacement.isEmpty else {
+                listRows.append(.entry(row))
+                continue
+            }
+
+            if let groupIndex = groupIndexes[replacement],
+               case .correctionGroup(let existingGroup) = listRows[groupIndex] {
+                listRows[groupIndex] = .correctionGroup(DictionaryCorrectionGroupRow(
+                    replacement: replacement,
+                    aliases: existingGroup.aliases + [row]
+                ))
+            } else {
+                groupIndexes[replacement] = listRows.count
+                listRows.append(.correctionGroup(DictionaryCorrectionGroupRow(
+                    replacement: replacement,
+                    aliases: [row]
+                )))
+            }
+        }
+
+        return listRows
+    }
+
+    private func rowMatchesSearch(_ row: DictionaryEntryRow, query: String) -> Bool {
+        row.original.localizedCaseInsensitiveContains(query) ||
+            (row.replacement?.localizedCaseInsensitiveContains(query) ?? false)
     }
 
     private func entry(withID id: UUID) -> DictionaryEntry? {

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -9,6 +9,7 @@ struct DictionarySettingsView: View {
     @ObservedObject private var viewModel = DictionaryViewModel.shared
     @ObservedObject private var termPackRegistryService: TermPackRegistryService
     @ObservedObject private var pluginManager: PluginManager
+    @State private var expandedCorrectionGroups = Set<String>()
 
     init() {
         _termPackRegistryService = ObservedObject(wrappedValue: TermPackRegistryService.shared)
@@ -240,21 +241,66 @@ struct DictionarySettingsView: View {
                     DictionaryEngineSupportSection(rows: engineSupportRows)
                 }
 
-                if viewModel.filteredEntryRows.isEmpty {
+                if viewModel.filteredListRows.isEmpty {
                     dictionaryEntriesEmptyState
                 } else {
-                    ForEach(viewModel.filteredEntryRows) { row in
-                        DictionaryCardView(
-                            row: row,
-                            setEntryEnabled: { viewModel.setEntryEnabled(id: row.id, enabled: $0) },
-                            editEntry: { viewModel.startEditingEntry(id: row.id) },
-                            deleteEntry: { viewModel.deleteEntry(id: row.id) }
-                        )
+                    ForEach(viewModel.filteredListRows) { listRow in
+                        dictionaryListRow(listRow)
                     }
                 }
             }
             .padding(.horizontal, 2)
         }
+    }
+
+    @ViewBuilder
+    private func dictionaryListRow(_ listRow: DictionaryListRow) -> some View {
+        switch listRow {
+        case .entry(let row):
+            DictionaryCardView(
+                row: row,
+                setEntryEnabled: { viewModel.setEntryEnabled(id: row.id, enabled: $0) },
+                editEntry: { viewModel.startEditingEntry(id: row.id) },
+                deleteEntry: { viewModel.deleteEntry(id: row.id) }
+            )
+
+        case .correctionGroup(let group):
+            if group.aliases.count == 1, let row = group.aliases.first {
+                DictionaryCardView(
+                    row: row,
+                    setEntryEnabled: { viewModel.setEntryEnabled(id: row.id, enabled: $0) },
+                    editEntry: { viewModel.startEditingEntry(id: row.id) },
+                    deleteEntry: { viewModel.deleteEntry(id: row.id) },
+                    addAlias: { viewModel.startCreatingCorrectionAlias(replacement: group.replacement) }
+                )
+            } else {
+                DictionaryCorrectionGroupCardView(
+                    group: group,
+                    isExpanded: correctionGroupExpansionBinding(for: group.replacement),
+                    setEntryEnabled: { id, enabled in
+                        viewModel.setEntryEnabled(id: id, enabled: enabled)
+                    },
+                    editEntry: { viewModel.startEditingEntry(id: $0) },
+                    deleteEntry: { viewModel.deleteEntry(id: $0) },
+                    addAlias: { viewModel.startCreatingCorrectionAlias(replacement: group.replacement) }
+                )
+            }
+        }
+    }
+
+    private func correctionGroupExpansionBinding(for replacement: String) -> Binding<Bool> {
+        Binding(
+            get: {
+                viewModel.hasActiveSearch || expandedCorrectionGroups.contains(replacement)
+            },
+            set: { isExpanded in
+                if isExpanded {
+                    expandedCorrectionGroups.insert(replacement)
+                } else {
+                    expandedCorrectionGroups.remove(replacement)
+                }
+            }
+        )
     }
 
     private var dictionaryEntriesEmptyState: some View {
@@ -681,6 +727,7 @@ private struct DictionaryCardView: View {
     let setEntryEnabled: (Bool) -> Void
     let editEntry: () -> Void
     let deleteEntry: () -> Void
+    var addAlias: (() -> Void)? = nil
 
     var body: some View {
         HStack(spacing: 10) {
@@ -733,6 +780,17 @@ private struct DictionaryCardView: View {
 
             Spacer()
 
+            if let addAlias, row.type == .correction, !(row.replacement?.isEmpty ?? true) {
+                Button {
+                    addAlias()
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(.borderless)
+                .help(localizedAppText("Add alias", de: "Variante hinzufügen"))
+                .accessibilityLabel(localizedAppText("Add alias", de: "Variante hinzufügen"))
+            }
+
             Toggle("", isOn: Binding(
                 get: { row.isEnabled },
                 set: { setEntryEnabled($0) }
@@ -757,6 +815,155 @@ private struct DictionaryCardView: View {
             editEntry()
         }
         .accessibilityElement(children: .combine)
+        .contextMenu {
+            Button(String(localized: "Edit")) {
+                editEntry()
+            }
+            if let addAlias {
+                Button(localizedAppText("Add Alias", de: "Variante hinzufügen")) {
+                    addAlias()
+                }
+            }
+            Divider()
+            Button(String(localized: "Delete"), role: .destructive) {
+                deleteEntry()
+            }
+        }
+    }
+}
+
+private struct DictionaryCorrectionGroupCardView: View {
+    let group: DictionaryCorrectionGroupRow
+    @Binding var isExpanded: Bool
+    let setEntryEnabled: (UUID, Bool) -> Void
+    let editEntry: (UUID) -> Void
+    let deleteEntry: (UUID) -> Void
+    let addAlias: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                VStack(spacing: 0) {
+                    ForEach(Array(group.aliases.enumerated()), id: \.element.id) { index, alias in
+                        if index > 0 {
+                            Divider()
+                                .padding(.leading, 28)
+                        }
+
+                        DictionaryCorrectionAliasRow(
+                            row: alias,
+                            setEntryEnabled: { setEntryEnabled(alias.id, $0) },
+                            editEntry: { editEntry(alias.id) },
+                            deleteEntry: { deleteEntry(alias.id) }
+                        )
+                    }
+                }
+                .padding(.top, 8)
+            } label: {
+                HStack(spacing: 8) {
+                    Text(String(localized: "Correction"))
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(Color.orange)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.orange.opacity(0.12))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+
+                    Text(group.replacementDisplayText)
+                        .font(.callout)
+                        .fontWeight(.semibold)
+                        .lineLimit(1)
+
+                    Text(localizedAppText(
+                        "\(group.aliases.count) variants",
+                        de: "\(group.aliases.count) Varianten"
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.10))
+                    .clipShape(Capsule())
+                }
+            }
+
+            Button {
+                addAlias()
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.borderless)
+            .help(localizedAppText("Add alias", de: "Variante hinzufügen"))
+            .accessibilityLabel(localizedAppText("Add alias", de: "Variante hinzufügen"))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(NSColor.controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+        )
+        .contextMenu {
+            Button(localizedAppText("Add Alias", de: "Variante hinzufügen")) {
+                addAlias()
+            }
+        }
+    }
+}
+
+private struct DictionaryCorrectionAliasRow: View {
+    let row: DictionaryEntryRow
+    let setEntryEnabled: (Bool) -> Void
+    let editEntry: () -> Void
+    let deleteEntry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.turn.down.right")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .frame(width: 18)
+
+            Text(row.original)
+                .font(.callout)
+                .strikethrough()
+                .foregroundStyle(row.isEnabled ? .primary : .secondary)
+
+            if row.caseSensitive {
+                Text("Aa")
+                    .font(.caption2)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.12))
+                    .foregroundStyle(.secondary)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+
+            if row.source == .autoLearned {
+                DictionarySourceBadge()
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { row.isEnabled },
+                set: { setEntryEnabled($0) }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .accessibilityLabel(String(localized: "Enable \(row.original)"))
+            .onTapGesture {}
+        }
+        .padding(.leading, 8)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            editEntry()
+        }
         .contextMenu {
             Button(String(localized: "Edit")) {
                 editEntry()
@@ -813,12 +1020,24 @@ private struct DictionaryEditorSheet: View {
         case original, replacement
     }
 
+    private var title: String {
+        if viewModel.lockedCorrectionReplacement != nil {
+            return localizedAppText("Add Correction Alias", de: "Korrekturvariante hinzufügen")
+        }
+        if viewModel.isCreatingNew {
+            return viewModel.editType == .term
+                ? String(localized: "New Term")
+                : String(localized: "New Correction")
+        }
+        return viewModel.editType == .term
+            ? String(localized: "Edit Term")
+            : String(localized: "Edit Correction")
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text(viewModel.isCreatingNew
-                     ? (viewModel.editType == .term ? String(localized: "New Term") : String(localized: "New Correction"))
-                     : (viewModel.editType == .term ? String(localized: "Edit Term") : String(localized: "Edit Correction")))
+                Text(title)
                     .font(.headline)
                 Spacer()
             }
@@ -858,6 +1077,16 @@ private struct DictionaryEditorSheet: View {
                                 TextField(String(localized: "e.g. Kubernetes"), text: $viewModel.editReplacement)
                                     .textFieldStyle(.roundedBorder)
                                     .focused($focusedField, equals: .replacement)
+                                    .disabled(viewModel.lockedCorrectionReplacement != nil)
+
+                                if viewModel.lockedCorrectionReplacement != nil {
+                                    Text(localizedAppText(
+                                        "The correct text is fixed by the selected group.",
+                                        de: "Der korrekte Text wird von der ausgewählten Gruppe vorgegeben."
+                                    ))
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                }
                             }
                         }
 

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -548,8 +548,10 @@ final class DictionaryServiceTests: XCTestCase {
         let viewModel = DictionaryViewModel(dictionaryService: service)
         viewModel.filterTab = .corrections
         let correctionRows = viewModel.filteredEntryRows
+        let correctionListRowIDs = viewModel.filteredListRows.map(\.id)
 
         XCTAssertEqual(correctionRows.count, 121)
+        XCTAssertEqual(correctionListRowIDs.count, 121)
         XCTAssertTrue(correctionRows.allSatisfy { $0.type == .correction })
         XCTAssertEqual(correctionRows.first { $0.original == "empty-replacement" }?.replacementDisplayText, "\"\"")
 
@@ -565,6 +567,7 @@ final class DictionaryServiceTests: XCTestCase {
 
         viewModel.searchQuery = ""
         XCTAssertEqual(viewModel.filteredEntryRows.map(\.id), correctionIDs)
+        XCTAssertEqual(viewModel.filteredListRows.map(\.id), correctionListRowIDs)
 
         viewModel.filterTab = .all
         let allCorrectionIDs = viewModel.filteredEntryRows
@@ -578,6 +581,177 @@ final class DictionaryServiceTests: XCTestCase {
         let autoLearnedRows = autoLearnedViewModel.filteredEntryRows
         XCTAssertEqual(autoLearnedRows.map(\.original), ["autolearned"])
         XCTAssertTrue(autoLearnedRows.allSatisfy { $0.source == .autoLearned })
+    }
+
+    @MainActor
+    func testDictionaryCorrectionGroupsUseExactNonEmptyReplacementAndPreserveAliasState() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(
+            type: .correction,
+            original: "type wisper",
+            replacement: "TypeWhisper",
+            caseSensitive: true
+        )
+        service.addEntry(
+            type: .correction,
+            original: "type whisper",
+            replacement: "TypeWhisper"
+        )
+        service.addEntry(
+            type: .correction,
+            original: "typewhisper lower",
+            replacement: "typewhisper"
+        )
+        service.addEntry(
+            type: .correction,
+            original: "remove filler",
+            replacement: ""
+        )
+
+        let disabledAlias = try XCTUnwrap(service.entries.first { $0.original == "type whisper" })
+        service.setEntryEnabled(disabledAlias, enabled: false)
+
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+        viewModel.filterTab = .corrections
+
+        let listRows = viewModel.filteredListRows
+        let groups = listRows.compactMap { listRow -> DictionaryCorrectionGroupRow? in
+            guard case .correctionGroup(let group) = listRow else { return nil }
+            return group
+        }
+        let standaloneRows = listRows.compactMap { listRow -> DictionaryEntryRow? in
+            guard case .entry(let row) = listRow else { return nil }
+            return row
+        }
+
+        XCTAssertEqual(groups.map(\.replacement), ["TypeWhisper", "typewhisper"])
+        XCTAssertNotEqual(groups[0].id, groups[1].id)
+        XCTAssertEqual(groups[0].aliases.map(\.original), ["type whisper", "type wisper"])
+        XCTAssertEqual(groups[0].aliases.map(\.isEnabled), [false, true])
+        XCTAssertEqual(groups[0].aliases.map(\.caseSensitive), [false, true])
+        XCTAssertEqual(groups[1].aliases.map(\.original), ["typewhisper lower"])
+        XCTAssertEqual(standaloneRows.map(\.original), ["remove filler"])
+        XCTAssertEqual(standaloneRows.first?.replacementDisplayText, "\"\"")
+    }
+
+    @MainActor
+    func testDictionaryCorrectionGroupSearchReturnsWholeGroupAndComposesWithFilters() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .term, original: "TypeWhisper")
+        service.addEntry(type: .correction, original: "type wisper", replacement: "TypeWhisper")
+        service.addEntry(type: .correction, original: "type whisper", replacement: "TypeWhisper")
+        service.learnCorrection(original: "taipwhisper", replacement: "TypeWhisper")
+
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+        viewModel.filterTab = .all
+        viewModel.searchQuery = "typewhisper"
+        XCTAssertEqual(viewModel.filteredListRows.count, 2)
+        XCTAssertTrue(viewModel.filteredListRows.contains {
+            if case .entry(let row) = $0 { return row.type == .term }
+            return false
+        })
+
+        viewModel.filterTab = .corrections
+
+        viewModel.searchQuery = "TYPE WISPER"
+        guard case .correctionGroup(let aliasMatchGroup) = try XCTUnwrap(viewModel.filteredListRows.first) else {
+            return XCTFail("Expected a correction group for an alias match")
+        }
+        XCTAssertEqual(aliasMatchGroup.aliases.count, 3)
+
+        viewModel.searchQuery = "typewhisper"
+        guard case .correctionGroup(let replacementMatchGroup) = try XCTUnwrap(viewModel.filteredListRows.first) else {
+            return XCTFail("Expected a correction group for a replacement match")
+        }
+        XCTAssertEqual(replacementMatchGroup.aliases.count, 3)
+
+        viewModel.filterTab = .autoLearned
+        guard case .correctionGroup(let autoLearnedGroup) = try XCTUnwrap(viewModel.filteredListRows.first) else {
+            return XCTFail("Expected an auto-learned correction group")
+        }
+        XCTAssertEqual(autoLearnedGroup.aliases.map(\.original), ["taipwhisper"])
+        XCTAssertTrue(autoLearnedGroup.aliases.allSatisfy { $0.source == .autoLearned })
+
+        viewModel.filterTab = .terms
+        XCTAssertEqual(viewModel.filteredEntryRows.map(\.original), ["TypeWhisper"])
+        XCTAssertTrue(viewModel.filteredListRows.allSatisfy {
+            if case .entry = $0 { return true }
+            return false
+        })
+    }
+
+    @MainActor
+    func testAddingCorrectionAliasCreatesFlatEntryWithLockedReplacement() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "type wisper", replacement: "TypeWhisper")
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+
+        viewModel.startCreatingCorrectionAlias(replacement: "TypeWhisper")
+        XCTAssertTrue(viewModel.isCreatingNew)
+        XCTAssertTrue(viewModel.isEditing)
+        XCTAssertEqual(viewModel.editType, .correction)
+        XCTAssertEqual(viewModel.lockedCorrectionReplacement, "TypeWhisper")
+
+        viewModel.editOriginal = "type whisper"
+        viewModel.editReplacement = "Changed outside the group"
+        viewModel.editCaseSensitive = true
+        viewModel.saveEditing()
+
+        let addedAlias = try XCTUnwrap(service.entries.first { $0.original == "type whisper" })
+        XCTAssertEqual(addedAlias.replacement, "TypeWhisper")
+        XCTAssertTrue(addedAlias.caseSensitive)
+        XCTAssertEqual(addedAlias.source, .manual)
+        XCTAssertNil(viewModel.lockedCorrectionReplacement)
+
+        let reloadedViewModel = DictionaryViewModel(dictionaryService: service)
+        reloadedViewModel.filterTab = .corrections
+        guard case .correctionGroup(let group) = try XCTUnwrap(reloadedViewModel.filteredListRows.first) else {
+            return XCTFail("Expected the added alias to remain a flat entry in one derived group")
+        }
+        XCTAssertEqual(group.aliases.map(\.original), ["type whisper", "type wisper"])
+        XCTAssertEqual(service.entries.filter { $0.type == .correction }.count, 2)
+    }
+
+    @MainActor
+    func testCorrectionGroupAliasActionsChangeOnlySelectedFlatEntry() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "type wisper", replacement: "TypeWhisper")
+        service.addEntry(type: .correction, original: "type whisper", replacement: "TypeWhisper")
+        let viewModel = DictionaryViewModel(dictionaryService: service)
+        viewModel.filterTab = .corrections
+
+        guard case .correctionGroup(let group) = try XCTUnwrap(viewModel.filteredListRows.first) else {
+            return XCTFail("Expected a correction group")
+        }
+        let selectedAlias = try XCTUnwrap(group.aliases.first { $0.original == "type wisper" })
+        let untouchedAlias = try XCTUnwrap(group.aliases.first { $0.original == "type whisper" })
+
+        viewModel.setEntryEnabled(id: selectedAlias.id, enabled: false)
+        XCTAssertFalse(try XCTUnwrap(service.entries.first { $0.id == selectedAlias.id }).isEnabled)
+        XCTAssertTrue(try XCTUnwrap(service.entries.first { $0.id == untouchedAlias.id }).isEnabled)
+
+        viewModel.startEditingEntry(id: selectedAlias.id)
+        viewModel.editOriginal = "typewhispr"
+        viewModel.saveEditing()
+        XCTAssertEqual(service.entries.first { $0.id == selectedAlias.id }?.original, "typewhispr")
+        XCTAssertEqual(service.entries.first { $0.id == untouchedAlias.id }?.original, "type whisper")
+
+        let refreshedViewModel = DictionaryViewModel(dictionaryService: service)
+        refreshedViewModel.deleteEntry(id: selectedAlias.id)
+        XCTAssertFalse(service.entries.contains { $0.id == selectedAlias.id })
+        XCTAssertTrue(service.entries.contains { $0.id == untouchedAlias.id })
     }
 
     @MainActor


### PR DESCRIPTION
## Context

Dictionary corrections with the same replacement were previously rendered as unrelated rows. This made spelling variants repetitive and difficult to scan as dictionaries grew.

Closes #867

## What changed

- derive immutable correction-group snapshots in `DictionaryViewModel` without changing persistence
- group corrections only when their non-empty replacement strings match exactly, including casing
- keep empty-replacement corrections as standalone rows
- render multi-alias groups with a native macOS disclosure UI while keeping single-correction groups compact
- preserve per-alias editing, enable/disable, deletion, case-sensitivity, and source state
- add aliases through the existing correction editor with the selected group replacement locked
- match search queries against group replacements and every alias while composing with all existing filters
- retain stable group and alias identities for large-list rendering

## Compatibility

The underlying entries remain flat `DictionaryEntry` records. There are no storage schema, sync, import/export, CLI, or HTTP API changes.

## Test plan

- [x] Dictionary service and view-model tests (38 tests, 0 failures):

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests
```

- [x] Signed development build and launch:

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7752/typewhisper-mac
```

- [x] Manual macOS smoke test covering exact/case-sensitive grouping, empty replacements, mixed alias state, search and filters, direct alias creation, per-alias actions, and persistence after relaunch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Correction entries with the same replacement are now grouped for a clearer dictionary view.
  * Groups can be expanded to view and manage individual aliases.
  * Added support for creating aliases from correction groups.
  * Correction values remain protected while creating or editing aliases.
  * Search now matches and displays complete correction groups.

* **Bug Fixes**
  * Editing, enabling, disabling, or deleting an alias now affects only the selected entry.
  * Group expansion and filtering remain consistent when searches are cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->