### PR TITLE
Improve correction learning reliability and visibility

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -70,6 +70,7 @@ enum UserDefaultsKeys {
     static let termPackRegistryLastUpdateCheck = "termPackRegistryLastUpdateCheck"
     static let selectedIndustryPreset = "selectedIndustryPreset"
     static let targetAppCorrectionLearningEnabled = "targetAppCorrectionLearningEnabled"
+    static let targetAppCorrectionLearningLatestAttempt = "targetAppCorrectionLearningLatestAttempt"
 
     // MARK: - History
     static let historyEnabled = "historyEnabled"

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -32,6 +32,12 @@ struct LearnedDictionaryCorrection: Identifiable, Equatable, Sendable {
     let replacement: String
 }
 
+struct DictionaryCorrectionLearningResult: Equatable, Sendable {
+    let learnedCorrections: [LearnedDictionaryCorrection]
+    let duplicateCount: Int
+    let failed: Bool
+}
+
 @MainActor
 final class DictionaryService: ObservableObject {
     private var modelContainer: ModelContainer?
@@ -752,7 +758,17 @@ final class DictionaryService: ObservableObject {
     /// Batch add corrections learned from user edits. Existing corrections are never overwritten.
     @discardableResult
     func learnCorrections(_ suggestions: [CorrectionSuggestion]) -> [LearnedDictionaryCorrection] {
-        guard let context = modelContext, !suggestions.isEmpty else { return [] }
+        learnCorrectionsWithResult(suggestions).learnedCorrections
+    }
+
+    /// Typed variant used by automatic learning to distinguish duplicates from storage failures.
+    func learnCorrectionsWithResult(_ suggestions: [CorrectionSuggestion]) -> DictionaryCorrectionLearningResult {
+        guard !suggestions.isEmpty else {
+            return DictionaryCorrectionLearningResult(learnedCorrections: [], duplicateCount: 0, failed: false)
+        }
+        guard let context = modelContext else {
+            return DictionaryCorrectionLearningResult(learnedCorrections: [], duplicateCount: 0, failed: true)
+        }
 
         var existingOriginals = Set(
             entries
@@ -761,6 +777,7 @@ final class DictionaryService: ObservableObject {
         )
         let now = Date()
         var learned: [LearnedDictionaryCorrection] = []
+        var duplicateCount = 0
 
         for suggestion in suggestions {
             let original = suggestion.original.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -768,8 +785,11 @@ final class DictionaryService: ObservableObject {
             let originalKey = original.lowercased()
 
             guard !original.isEmpty,
-                  originalKey != replacement.lowercased(),
-                  !existingOriginals.contains(originalKey) else {
+                  originalKey != replacement.lowercased() else {
+                continue
+            }
+            guard !existingOriginals.contains(originalKey) else {
+                duplicateCount += 1
                 continue
             }
 
@@ -791,15 +811,30 @@ final class DictionaryService: ObservableObject {
             ))
         }
 
-        guard !learned.isEmpty else { return [] }
+        guard !learned.isEmpty else {
+            return DictionaryCorrectionLearningResult(
+                learnedCorrections: [],
+                duplicateCount: duplicateCount,
+                failed: false
+            )
+        }
 
         do {
             try context.save()
             loadEntries()
-            return learned
+            return DictionaryCorrectionLearningResult(
+                learnedCorrections: learned,
+                duplicateCount: duplicateCount,
+                failed: false
+            )
         } catch {
+            context.rollback()
             logger.error("Failed to learn corrections: \(error.localizedDescription)")
-            return []
+            return DictionaryCorrectionLearningResult(
+                learnedCorrections: [],
+                duplicateCount: duplicateCount,
+                failed: true
+            )
         }
     }
 

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -76,6 +76,11 @@ struct DiagnosticWorkflowInfo: Encodable, Equatable {
     let usesAppleTranslate: Bool
 }
 
+struct DiagnosticCorrectionLearningInfo: Encodable, Equatable, Sendable {
+    let enabled: Bool
+    let lastAttempt: TargetAppCorrectionLearningAttemptSnapshot?
+}
+
 enum PluginDiagnosticsSupport {
     static func appBundlePathKind(
         for bundleURL: URL,
@@ -422,6 +427,7 @@ private struct DiagnosticsReport: Encodable {
     let plugins: [PluginInfo]
     let skippedExternalBundles: [SkippedExternalBundleInfo]
     let workflows: DiagnosticWorkflowSnapshot
+    let correctionLearning: DiagnosticCorrectionLearningInfo
     let settings: SettingsSnapshot
     let lastIndicatorFullscreenSuppression: IndicatorFullscreenSuppressionDiagnostics?
     let counts: Counts
@@ -555,7 +561,7 @@ final class ErrorLogService: ObservableObject {
         }
 
         return DiagnosticsReport(
-            schemaVersion: 8,
+            schemaVersion: 9,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,
@@ -620,6 +626,10 @@ final class ErrorLogService: ObservableObject {
             workflows: Self.workflowDiagnosticsSnapshot(
                 from: container.workflowService,
                 promptProcessingService: container.promptProcessingService
+            ),
+            correctionLearning: DiagnosticCorrectionLearningInfo(
+                enabled: defaults.bool(forKey: UserDefaultsKeys.targetAppCorrectionLearningEnabled),
+                lastAttempt: container.targetAppCorrectionLearningService.latestAttempt
             ),
             settings: .init(
                 bundledReleaseChannel: AppConstants.releaseChannel.rawValue,

--- a/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
+++ b/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
@@ -1,10 +1,60 @@
 import AppKit
+import Combine
 import Foundation
 
-enum TargetAppCorrectionCommitSignal: Equatable, Sendable {
+enum TargetAppCorrectionCommitSignal: String, Codable, Equatable, Sendable {
     case returnKey
+    case keypadEnterKey
     case tabKey
+    case focusChanged
     case activeApplicationChanged
+}
+
+enum TargetAppCorrectionLearningOutcome: String, Codable, Equatable, Sendable {
+    case learned
+    case unsupportedTextObservation
+    case noEdit
+    case ambiguousEdit
+    case noCommitBeforeTimeout
+    case duplicateCorrection
+    case cancelled
+    case failed
+}
+
+struct TargetAppCorrectionLearningAttemptSnapshot: Codable, Equatable, Sendable {
+    let outcome: TargetAppCorrectionLearningOutcome
+    let timestamp: Date
+    let commitSignal: TargetAppCorrectionCommitSignal?
+    let learnedCorrectionCount: Int
+}
+
+struct TargetAppCorrectionLearningResult: Equatable, Sendable {
+    let snapshot: TargetAppCorrectionLearningAttemptSnapshot
+    let learnedCorrections: [LearnedDictionaryCorrection]
+}
+
+private func targetAppCorrectionCommitSignal(forKeyCode keyCode: UInt16) -> TargetAppCorrectionCommitSignal? {
+    switch keyCode {
+    case 0x24:
+        return .returnKey
+    case 0x4C:
+        return .keypadEnterKey
+    case 0x30:
+        return .tabKey
+    default:
+        return nil
+    }
+}
+
+private func installGlobalTargetAppCorrectionKeyMonitor(
+    onCommit: @escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void
+) -> Any? {
+    NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+        guard let signal = targetAppCorrectionCommitSignal(forKeyCode: event.keyCode) else { return }
+        Task { @MainActor in
+            onCommit(signal)
+        }
+    }
 }
 
 @MainActor
@@ -15,10 +65,6 @@ protocol TargetAppCorrectionCommitObserving: AnyObject {
 
 @MainActor
 final class TargetAppCorrectionCommitObserver: TargetAppCorrectionCommitObserving {
-    private static let returnKeyCode: UInt16 = 0x24
-    private static let keypadEnterKeyCode: UInt16 = 0x4C
-    private static let tabKeyCode: UInt16 = 0x30
-
     private let onCommit: @MainActor (TargetAppCorrectionCommitSignal) -> Void
     private var globalKeyMonitor: Any?
     private var localKeyMonitor: Any?
@@ -31,9 +77,7 @@ final class TargetAppCorrectionCommitObserver: TargetAppCorrectionCommitObservin
     func start() {
         stop()
 
-        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            self?.handleKeyEvent(event)
-        }
+        globalKeyMonitor = installGlobalTargetAppCorrectionKeyMonitor(onCommit: onCommit)
         localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.handleKeyEvent(event)
             return event
@@ -70,14 +114,7 @@ final class TargetAppCorrectionCommitObserver: TargetAppCorrectionCommitObservin
     }
 
     static func commitSignal(forKeyCode keyCode: UInt16) -> TargetAppCorrectionCommitSignal? {
-        switch keyCode {
-        case returnKeyCode, keypadEnterKeyCode:
-            return .returnKey
-        case tabKeyCode:
-            return .tabKey
-        default:
-            return nil
-        }
+        targetAppCorrectionCommitSignal(forKeyCode: keyCode)
     }
 }
 
@@ -154,15 +191,21 @@ private final class TargetAppCorrectionWakeCoordinator: @unchecked Sendable {
 }
 
 @MainActor
-final class TargetAppCorrectionLearningService {
+final class TargetAppCorrectionLearningService: ObservableObject {
     private static let defaultPollSchedule: [Duration] = (1...30).map { .seconds($0) }
 
     private let textInsertionService: TextInsertionService
     private let textDiffService: TextDiffService
-    private let dictionaryService: DictionaryService
+    private let learnCorrections: @MainActor ([CorrectionSuggestion]) -> DictionaryCorrectionLearningResult
     private let pollSchedule: [Duration]
     private let sleep: @MainActor (Duration) async -> Void
     private let makeCommitObserver: (@escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void) -> TargetAppCorrectionCommitObserving
+    private let defaults: UserDefaults
+    private let shouldPersistLatestAttempt: Bool
+    private let now: @MainActor () -> Date
+    private var activeAttemptID: UUID?
+
+    @Published private(set) var latestAttempt: TargetAppCorrectionLearningAttemptSnapshot?
 
     init(
         textInsertionService: TextInsertionService,
@@ -174,22 +217,47 @@ final class TargetAppCorrectionLearningService {
         },
         makeCommitObserver: @escaping (@escaping @MainActor (TargetAppCorrectionCommitSignal) -> Void) -> TargetAppCorrectionCommitObserving = {
             TargetAppCorrectionCommitObserver(onCommit: $0)
-        }
+        },
+        learnCorrections: (@MainActor ([CorrectionSuggestion]) -> DictionaryCorrectionLearningResult)? = nil,
+        defaults: UserDefaults = .standard,
+        persistLatestAttempt: Bool = !AppConstants.isRunningTests,
+        now: @escaping @MainActor () -> Date = Date.init
     ) {
         self.textInsertionService = textInsertionService
         self.textDiffService = textDiffService
-        self.dictionaryService = dictionaryService
+        self.learnCorrections = learnCorrections ?? { suggestions in
+            dictionaryService.learnCorrectionsWithResult(suggestions)
+        }
         self.pollSchedule = pollSchedule ?? Self.defaultPollSchedule
         self.sleep = sleep
         self.makeCommitObserver = makeCommitObserver
+        self.defaults = defaults
+        self.shouldPersistLatestAttempt = persistLatestAttempt
+        self.now = now
+        self.latestAttempt = Self.loadLatestAttempt(from: defaults)
     }
 
     func trackInsertion(
         insertedText: String,
         baseline: TextInsertionService.FocusedTextObservation
-    ) async -> [LearnedDictionaryCorrection] {
+    ) async -> TargetAppCorrectionLearningResult {
+        let attemptID = UUID()
+        activeAttemptID = attemptID
         let insertedText = insertedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !insertedText.isEmpty, !pollSchedule.isEmpty else { return [] }
+        guard !insertedText.isEmpty else {
+            return completeAttempt(
+                id: attemptID,
+                outcome: .unsupportedTextObservation,
+                commitSignal: nil
+            )
+        }
+        guard !pollSchedule.isEmpty else {
+            return completeAttempt(
+                id: attemptID,
+                outcome: .noCommitBeforeTimeout,
+                commitSignal: nil
+            )
+        }
 
         var commitSignal: TargetAppCorrectionCommitSignal?
         let wakeCoordinator = TargetAppCorrectionWakeCoordinator()
@@ -201,6 +269,7 @@ final class TargetAppCorrectionLearningService {
         defer { commitObserver.stop() }
 
         var latestSuggestions: [CorrectionSuggestion] = []
+        var latestNonConfidentOutcome: TargetAppCorrectionLearningOutcome = .unsupportedTextObservation
         var elapsed: Duration = .seconds(0)
         for pollOffset in pollSchedule {
             let waitDuration: Duration
@@ -217,14 +286,33 @@ final class TargetAppCorrectionLearningService {
                     await sleep(.seconds(0))
                 }
             }
-            guard !Task.isCancelled else { return [] }
+            guard !Task.isCancelled else {
+                return completeAttempt(
+                    id: attemptID,
+                    outcome: .cancelled,
+                    commitSignal: commitSignal
+                )
+            }
 
             guard let observation = textInsertionService.recaptureFocusedTextObservation(matching: baseline) else {
                 switch textInsertionService.focusedTextElementMatch(baseline) {
                 case .same, .unavailable:
-                    return []
+                    if let commitSignal {
+                        return completeCommittedAttempt(
+                            id: attemptID,
+                            suggestions: latestSuggestions,
+                            fallbackOutcome: latestNonConfidentOutcome,
+                            commitSignal: commitSignal
+                        )
+                    }
+                    continue
                 case .different:
-                    return dictionaryService.learnCorrections(latestSuggestions)
+                    return completeCommittedAttempt(
+                        id: attemptID,
+                        suggestions: latestSuggestions,
+                        fallbackOutcome: latestNonConfidentOutcome,
+                        commitSignal: commitSignal ?? .focusChanged
+                    )
                 }
             }
 
@@ -237,14 +325,100 @@ final class TargetAppCorrectionLearningService {
                 latestSuggestions = suggestions
             } else {
                 latestSuggestions = []
+                latestNonConfidentOutcome = observation.value == baseline.value ? .noEdit : .ambiguousEdit
             }
 
-            if commitSignal != nil {
-                return dictionaryService.learnCorrections(latestSuggestions)
+            if let commitSignal {
+                return completeCommittedAttempt(
+                    id: attemptID,
+                    suggestions: latestSuggestions,
+                    fallbackOutcome: latestNonConfidentOutcome,
+                    commitSignal: commitSignal
+                )
             }
         }
 
-        return []
+        if Task.isCancelled {
+            return completeAttempt(
+                id: attemptID,
+                outcome: .cancelled,
+                commitSignal: commitSignal
+            )
+        }
+        return completeAttempt(
+            id: attemptID,
+            outcome: .noCommitBeforeTimeout,
+            commitSignal: nil
+        )
+    }
+
+    private func completeCommittedAttempt(
+        id: UUID,
+        suggestions: [CorrectionSuggestion],
+        fallbackOutcome: TargetAppCorrectionLearningOutcome,
+        commitSignal: TargetAppCorrectionCommitSignal
+    ) -> TargetAppCorrectionLearningResult {
+        guard !suggestions.isEmpty else {
+            return completeAttempt(
+                id: id,
+                outcome: fallbackOutcome,
+                commitSignal: commitSignal
+            )
+        }
+
+        let dictionaryResult = learnCorrections(suggestions)
+        let outcome: TargetAppCorrectionLearningOutcome
+        if dictionaryResult.failed {
+            outcome = .failed
+        } else if !dictionaryResult.learnedCorrections.isEmpty {
+            outcome = .learned
+        } else if dictionaryResult.duplicateCount > 0 {
+            outcome = .duplicateCorrection
+        } else {
+            outcome = .failed
+        }
+        return completeAttempt(
+            id: id,
+            outcome: outcome,
+            commitSignal: commitSignal,
+            learnedCorrections: dictionaryResult.learnedCorrections
+        )
+    }
+
+    private func completeAttempt(
+        id: UUID,
+        outcome: TargetAppCorrectionLearningOutcome,
+        commitSignal: TargetAppCorrectionCommitSignal?,
+        learnedCorrections: [LearnedDictionaryCorrection] = []
+    ) -> TargetAppCorrectionLearningResult {
+        let snapshot = TargetAppCorrectionLearningAttemptSnapshot(
+            outcome: outcome,
+            timestamp: now(),
+            commitSignal: commitSignal,
+            learnedCorrectionCount: learnedCorrections.count
+        )
+        if activeAttemptID == id {
+            activeAttemptID = nil
+            latestAttempt = snapshot
+            persistLatestAttempt(snapshot)
+        }
+        return TargetAppCorrectionLearningResult(
+            snapshot: snapshot,
+            learnedCorrections: learnedCorrections
+        )
+    }
+
+    private func persistLatestAttempt(_ snapshot: TargetAppCorrectionLearningAttemptSnapshot) {
+        guard shouldPersistLatestAttempt else { return }
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        defaults.set(data, forKey: UserDefaultsKeys.targetAppCorrectionLearningLatestAttempt)
+    }
+
+    private static func loadLatestAttempt(from defaults: UserDefaults) -> TargetAppCorrectionLearningAttemptSnapshot? {
+        guard let data = defaults.data(forKey: UserDefaultsKeys.targetAppCorrectionLearningLatestAttempt) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(TargetAppCorrectionLearningAttemptSnapshot.self, from: data)
     }
 
     func highConfidenceCorrectionSuggestions(

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2240,14 +2240,14 @@ final class DictationViewModel: ObservableObject {
 
         targetAppCorrectionLearningTask = Task { @MainActor [weak self, baseline, insertedText] in
             guard let self else { return }
-            let learned = await self.targetAppCorrectionLearningService.trackInsertion(
+            let result = await self.targetAppCorrectionLearningService.trackInsertion(
                 insertedText: insertedText,
                 baseline: baseline
             )
             guard !Task.isCancelled else { return }
             self.targetAppCorrectionLearningTask = nil
-            guard !learned.isEmpty else { return }
-            self.showLearnedCorrectionsFeedback(learned)
+            guard !result.learnedCorrections.isEmpty else { return }
+            self.showLearnedCorrectionsFeedback(result.learnedCorrections)
         }
     }
 

--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PremiumSettingsView: View {
     @ObservedObject private var license: LicenseService
     @ObservedObject private var syncController: CloudFolderSyncController
+    @ObservedObject private var correctionLearningService: TargetAppCorrectionLearningService
     @AppStorage(UserDefaultsKeys.targetAppCorrectionLearningEnabled) private var targetAppCorrectionLearningEnabled = false
 
     private let settingsNavigation: SettingsNavigationCoordinator
@@ -11,10 +12,12 @@ struct PremiumSettingsView: View {
     init(
         licenseService: LicenseService = LicenseService.shared,
         syncController: CloudFolderSyncController = ServiceContainer.shared.cloudFolderSyncController,
+        correctionLearningService: TargetAppCorrectionLearningService = ServiceContainer.shared.targetAppCorrectionLearningService,
         settingsNavigation: SettingsNavigationCoordinator = .shared
     ) {
         self.license = licenseService
         self.syncController = syncController
+        self.correctionLearningService = correctionLearningService
         self.settingsNavigation = settingsNavigation
     }
 
@@ -348,6 +351,50 @@ struct PremiumSettingsView: View {
             )
             .toggleStyle(.switch)
 
+            if let attempt = correctionLearningService.latestAttempt {
+                Divider()
+
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: correctionLearningOutcomeIcon(attempt.outcome))
+                        .foregroundStyle(correctionLearningOutcomeColor(attempt.outcome))
+                        .frame(width: 18)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(correctionLearningOutcomeText(attempt.outcome))
+                            .font(.callout.weight(.medium))
+
+                        HStack(spacing: 4) {
+                            Text(localizedAppText("Last attempt", de: "Letzter Versuch"))
+                            Text(attempt.timestamp, style: .relative)
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                        if attempt.learnedCorrectionCount > 0 {
+                            Text(String.localizedStringWithFormat(
+                                localizedAppText("%d corrections learned", de: "%d Korrekturen gelernt"),
+                                attempt.learnedCorrectionCount
+                            ))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Spacer(minLength: 8)
+
+                    if let commitSignal = attempt.commitSignal {
+                        Text(correctionLearningCommitSignalText(commitSignal))
+                            .font(.caption2.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(Color.secondary.opacity(0.12)))
+                    }
+                }
+                .accessibilityElement(children: .combine)
+            }
+
             VStack(alignment: .leading, spacing: 7) {
                 Text(String(localized: "Correction examples"))
                     .font(.caption.weight(.semibold))
@@ -356,6 +403,68 @@ struct PremiumSettingsView: View {
                 correctionExampleRow(PremiumCorrectionExample(before: "teh", after: "the"))
                 correctionExampleRow(PremiumCorrectionExample(before: "recieve", after: "receive"))
             }
+        }
+    }
+
+    private func correctionLearningOutcomeText(_ outcome: TargetAppCorrectionLearningOutcome) -> String {
+        switch outcome {
+        case .learned:
+            localizedAppText("Correction learned", de: "Korrektur gelernt")
+        case .unsupportedTextObservation:
+            localizedAppText("Text could not be observed", de: "Text konnte nicht beobachtet werden")
+        case .noEdit:
+            localizedAppText("No edit detected", de: "Keine Bearbeitung erkannt")
+        case .ambiguousEdit:
+            localizedAppText("Ambiguous edit skipped", de: "Mehrdeutige Bearbeitung übersprungen")
+        case .noCommitBeforeTimeout:
+            localizedAppText("No completion signal detected", de: "Kein Abschlusssignal erkannt")
+        case .duplicateCorrection:
+            localizedAppText("Correction already exists", de: "Korrektur ist bereits vorhanden")
+        case .cancelled:
+            localizedAppText("Learning attempt cancelled", de: "Lernversuch abgebrochen")
+        case .failed:
+            localizedAppText("Correction could not be saved", de: "Korrektur konnte nicht gespeichert werden")
+        }
+    }
+
+    private func correctionLearningOutcomeIcon(_ outcome: TargetAppCorrectionLearningOutcome) -> String {
+        switch outcome {
+        case .learned:
+            "checkmark.circle.fill"
+        case .failed:
+            "exclamationmark.triangle.fill"
+        case .unsupportedTextObservation, .ambiguousEdit, .noCommitBeforeTimeout:
+            "info.circle.fill"
+        case .noEdit, .duplicateCorrection, .cancelled:
+            "minus.circle.fill"
+        }
+    }
+
+    private func correctionLearningOutcomeColor(_ outcome: TargetAppCorrectionLearningOutcome) -> Color {
+        switch outcome {
+        case .learned:
+            .green
+        case .failed:
+            .red
+        case .unsupportedTextObservation, .ambiguousEdit, .noCommitBeforeTimeout:
+            .yellow
+        case .noEdit, .duplicateCorrection, .cancelled:
+            .secondary
+        }
+    }
+
+    private func correctionLearningCommitSignalText(_ signal: TargetAppCorrectionCommitSignal) -> String {
+        switch signal {
+        case .returnKey:
+            localizedAppText("Return", de: "Return")
+        case .keypadEnterKey:
+            localizedAppText("Enter", de: "Enter")
+        case .tabKey:
+            localizedAppText("Tab", de: "Tab")
+        case .focusChanged:
+            localizedAppText("Focus changed", de: "Fokuswechsel")
+        case .activeApplicationChanged:
+            localizedAppText("App changed", de: "App-Wechsel")
         }
     }
 

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -722,8 +722,11 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
             selectedText: nil,
             selectedRange: NSRange(location: 3, length: 0)
         )
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+        textInsertionService.focusedTextStateOverride = { _ in nil }
         let service = TargetAppCorrectionLearningService(
-            textInsertionService: TextInsertionService(),
+            textInsertionService: textInsertionService,
             textDiffService: TextDiffService(),
             dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
             pollSchedule: [.seconds(60)],

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -46,9 +46,11 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         commitEmitter.emit(.returnKey)
         let learned = await task.value
 
-        XCTAssertEqual(learned.count, 1)
-        XCTAssertEqual(learned.first?.original, "teh")
-        XCTAssertEqual(learned.first?.replacement, "the")
+        XCTAssertEqual(learned.snapshot.outcome, .learned)
+        XCTAssertEqual(learned.snapshot.commitSignal, .returnKey)
+        XCTAssertEqual(learned.learnedCorrections.count, 1)
+        XCTAssertEqual(learned.learnedCorrections.first?.original, "teh")
+        XCTAssertEqual(learned.learnedCorrections.first?.replacement, "the")
         XCTAssertEqual(dictionaryService.correctionsCount, 1)
     }
 
@@ -94,7 +96,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         commitEmitter.emit(.returnKey)
         let learned = await task.value
 
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .ambiguousEdit)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
@@ -140,7 +143,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         commitEmitter.emit(.returnKey)
         let learned = await task.value
 
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .ambiguousEdit)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
@@ -178,7 +182,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
 
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .noCommitBeforeTimeout)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
@@ -222,8 +227,10 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
 
-        XCTAssertEqual(learned.first?.original, "teh")
-        XCTAssertEqual(learned.first?.replacement, "the")
+        XCTAssertEqual(learned.snapshot.outcome, .learned)
+        XCTAssertEqual(learned.snapshot.commitSignal, .focusChanged)
+        XCTAssertEqual(learned.learnedCorrections.first?.original, "teh")
+        XCTAssertEqual(learned.learnedCorrections.first?.replacement, "the")
         XCTAssertEqual(dictionaryService.correctionsCount, 1)
     }
 
@@ -262,7 +269,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
 
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .noCommitBeforeTimeout)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
@@ -305,7 +313,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
 
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .noCommitBeforeTimeout)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
@@ -337,7 +346,9 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         )
 
         let changedFocusLearned = await changedFocusService.trackInsertion(insertedText: "teh", baseline: baseline)
-        XCTAssertTrue(changedFocusLearned.isEmpty)
+        XCTAssertEqual(changedFocusLearned.snapshot.outcome, .unsupportedTextObservation)
+        XCTAssertEqual(changedFocusLearned.snapshot.commitSignal, .focusChanged)
+        XCTAssertTrue(changedFocusLearned.learnedCorrections.isEmpty)
 
         let missingStateInsertionService = TextInsertionService()
         missingStateInsertionService.focusedTextElementOverride = { baselineElement }
@@ -352,7 +363,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         )
 
         let missingStateLearned = await missingStateService.trackInsertion(insertedText: "teh", baseline: baseline)
-        XCTAssertTrue(missingStateLearned.isEmpty)
+        XCTAssertEqual(missingStateLearned.snapshot.outcome, .noCommitBeforeTimeout)
+        XCTAssertTrue(missingStateLearned.learnedCorrections.isEmpty)
     }
 
     func testClearsStaleSuggestionsWhenEditIsUndoneBeforeCommit() async throws {
@@ -398,7 +410,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
 
         let learned = await service.trackInsertion(insertedText: "teh", baseline: baseline)
 
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .noEdit)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
@@ -470,7 +483,8 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         )
 
         let duplicateLearned = await duplicateService.trackInsertion(insertedText: "teh", baseline: baseline)
-        XCTAssertTrue(duplicateLearned.isEmpty)
+        XCTAssertEqual(duplicateLearned.snapshot.outcome, .duplicateCorrection)
+        XCTAssertTrue(duplicateLearned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 1)
     }
 
@@ -507,13 +521,232 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         task.cancel()
 
         let learned = await task.value
-        XCTAssertTrue(learned.isEmpty)
+        XCTAssertEqual(learned.snapshot.outcome, .cancelled)
+        XCTAssertTrue(learned.learnedCorrections.isEmpty)
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
+    func testLearnsSafeCandidateWhenTextObservationDisappearsAtCommit() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+        var captureCount = 0
+        textInsertionService.focusedTextStateOverride = { _ in
+            captureCount += 1
+            guard captureCount == 1 else { return nil }
+            let value = "Please use the word"
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        var sleepCount = 0
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            sleep: { _ in
+                sleepCount += 1
+                if sleepCount == 2 {
+                    commitEmitter.emit(.tabKey)
+                }
+            },
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let result = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
+        XCTAssertEqual(result.snapshot.outcome, .learned)
+        XCTAssertEqual(result.snapshot.commitSignal, .tabKey)
+        XCTAssertEqual(result.learnedCorrections.first?.replacement, "the")
+    }
+
+    func testLearnsForKeypadEnterTabAndActiveApplicationCommitSignals() async throws {
+        let rootDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(rootDirectory) }
+
+        for signal in [
+            TargetAppCorrectionCommitSignal.keypadEnterKey,
+            .tabKey,
+            .activeApplicationChanged
+        ] {
+            let element = AXUIElementCreateSystemWide()
+            let textInsertionService = TextInsertionService()
+            textInsertionService.focusedTextElementOverride = { element }
+            textInsertionService.focusedTextStateOverride = { _ in
+                let value = "Please use the word"
+                return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+            }
+
+            let commitEmitter = CommitEmitterBox()
+            let dictionaryService = DictionaryService(
+                appSupportDirectory: rootDirectory.appendingPathComponent(signal.rawValue)
+            )
+            let service = TargetAppCorrectionLearningService(
+                textInsertionService: textInsertionService,
+                textDiffService: TextDiffService(),
+                dictionaryService: dictionaryService,
+                pollSchedule: [.milliseconds(0)],
+                sleep: { _ in commitEmitter.emit(signal) },
+                makeCommitObserver: commitObserver(capturing: commitEmitter)
+            )
+            let baseline = TextInsertionService.FocusedTextObservation(
+                element: element,
+                value: "Please use teh word",
+                selectedText: nil,
+                selectedRange: NSRange(location: 19, length: 0)
+            )
+
+            let result = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
+            XCTAssertEqual(result.snapshot.outcome, .learned, "Unexpected outcome for \(signal)")
+            XCTAssertEqual(result.snapshot.commitSignal, signal)
+            XCTAssertEqual(result.learnedCorrections.count, 1)
+        }
+    }
+
+    func testReportsFailedWhenDictionaryStorageFails() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+        textInsertionService.focusedTextStateOverride = { _ in
+            let value = "Please use the word"
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+        let commitEmitter = CommitEmitterBox()
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
+            pollSchedule: [.milliseconds(0)],
+            sleep: { _ in commitEmitter.emit(.returnKey) },
+            makeCommitObserver: commitObserver(capturing: commitEmitter),
+            learnCorrections: { _ in
+                DictionaryCorrectionLearningResult(
+                    learnedCorrections: [],
+                    duplicateCount: 0,
+                    failed: true
+                )
+            }
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Please use teh word",
+            selectedText: nil,
+            selectedRange: NSRange(location: 19, length: 0)
+        )
+
+        let result = await service.trackInsertion(insertedText: "teh", baseline: baseline)
+
+        XCTAssertEqual(result.snapshot.outcome, .failed)
+        XCTAssertTrue(result.learnedCorrections.isEmpty)
+    }
+
+    func testLatestAttemptPersistsWithoutTextContent() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let suiteName = "TargetAppCorrectionLearningServiceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let timestamp = Date(timeIntervalSince1970: 1_750_000_000)
+
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: TextInsertionService(),
+            textDiffService: TextDiffService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
+            pollSchedule: [],
+            makeCommitObserver: noopCommitObserver,
+            defaults: defaults,
+            persistLatestAttempt: true,
+            now: { timestamp }
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: AXUIElementCreateSystemWide(),
+            value: "private baseline phrase",
+            selectedText: nil,
+            selectedRange: NSRange(location: 23, length: 0)
+        )
+
+        let result = await service.trackInsertion(insertedText: "private insertion", baseline: baseline)
+        let storedData = try XCTUnwrap(defaults.data(
+            forKey: UserDefaultsKeys.targetAppCorrectionLearningLatestAttempt
+        ))
+        let storedJSON = try XCTUnwrap(String(data: storedData, encoding: .utf8))
+
+        XCTAssertEqual(result.snapshot.outcome, .noCommitBeforeTimeout)
+        XCTAssertFalse(storedJSON.contains("private"))
+        XCTAssertFalse(storedJSON.contains("bundle"))
+
+        let reloadedService = TargetAppCorrectionLearningService(
+            textInsertionService: TextInsertionService(),
+            textDiffService: TextDiffService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
+            pollSchedule: [],
+            makeCommitObserver: noopCommitObserver,
+            defaults: defaults
+        )
+        XCTAssertEqual(reloadedService.latestAttempt, result.snapshot)
+
+        let diagnosticData = try JSONEncoder().encode(DiagnosticCorrectionLearningInfo(
+            enabled: true,
+            lastAttempt: result.snapshot
+        ))
+        let diagnosticJSON = try XCTUnwrap(String(data: diagnosticData, encoding: .utf8))
+        XCTAssertFalse(diagnosticJSON.contains("private"))
+        XCTAssertFalse(diagnosticJSON.contains("bundle"))
+    }
+
+    func testCancelledOlderAttemptDoesNotOverwriteNewerOutcome() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "teh",
+            selectedText: nil,
+            selectedRange: NSRange(location: 3, length: 0)
+        )
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: TextInsertionService(),
+            textDiffService: TextDiffService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
+            pollSchedule: [.seconds(60)],
+            makeCommitObserver: noopCommitObserver
+        )
+
+        let olderTask = Task { @MainActor in
+            await service.trackInsertion(insertedText: "teh", baseline: baseline)
+        }
+        await Task.yield()
+
+        let newerResult = await service.trackInsertion(insertedText: "", baseline: baseline)
+        olderTask.cancel()
+        let olderResult = await olderTask.value
+
+        XCTAssertEqual(newerResult.snapshot.outcome, .unsupportedTextObservation)
+        XCTAssertEqual(olderResult.snapshot.outcome, .cancelled)
+        XCTAssertEqual(service.latestAttempt, newerResult.snapshot)
     }
 
     func testCommitObserverMapsReturnEnterAndTabKeys() {
         XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x24), .returnKey)
-        XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x4C), .returnKey)
+        XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x4C), .keypadEnterKey)
         XCTAssertEqual(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x30), .tabKey)
         XCTAssertNil(TargetAppCorrectionCommitObserver.commitSignal(forKeyCode: 0x31))
     }


### PR DESCRIPTION
## Issue context

Automatic correction learning could appear unreliable because skipped attempts did not expose whether the target text was inaccessible, the edit was ambiguous, the commit never arrived, or persistence failed. This implements the visibility and reliability work requested in #866 while preserving the conservative single-word learning rules.

Closes #866

## What changed

- add eight stable, text-free learning outcomes and persist the latest attempt snapshot
- track commit signals for Return, keypad Enter, Tab, focus changes, and active-application changes
- retain safe candidates across temporarily unavailable Accessibility observations and guard outcomes with attempt IDs
- distinguish duplicate corrections and persistence failures without changing dictionary storage compatibility
- expose the latest outcome and relative timestamp in Premium settings
- add a text-free `correctionLearning` diagnostics block and bump the diagnostics schema to 9
- preserve existing success feedback and Undo behavior
- expand coverage for outcomes, commit signals, transient AX state, safe skips, persistence privacy, and stale tasks

## Validation

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/TargetAppCorrectionLearningServiceTests -only-testing:TypeWhisperTests/TextDiffServiceTests
```

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7752/typewhisper-mac
```

Manual smoke coverage:

- verified native, browser, and Electron target behavior across supported commit signals
- verified learned feedback, Undo, duplicate, no-edit, ambiguous-edit, and timeout paths
- verified the latest outcome survives relaunch and diagnostics remain text-free
- confirmed Zed's custom editor does not expose an Accessibility text element, so it is handled as a safe unsupported-text-observation case rather than learning from incomplete state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic correction learning now provides richer results, including learned corrections, duplicate suggestions, cancellations, timeouts, and dictionary storage failures.
  * Added support for additional commit signals (keypad Enter and focus changes).
  * Premium settings now shows the latest learning attempt with outcome, relative time, commit signal details, and learned correction count.
  * Diagnostics export now includes a correction-learning section (with an updated schema version).
* **Bug Fixes**
  * Improved handling for canceled attempts, missing/changed observations, focus mismatches, duplicate corrections, and persistence/load reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->