### PR TITLE
Add a guided microphone correction trainer

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		AA00000000000000000077 /* DictionaryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000077 /* DictionaryEntry.swift */; };
 		AA00000000000000000078 /* TermPack.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000078 /* TermPack.swift */; };
 		AA00000000000000000079 /* DictionaryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000079 /* DictionaryService.swift */; };
+		A87000000000000000000001 /* DictionaryTrainingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87000000000000000000001 /* DictionaryTrainingService.swift */; };
+		A87000000000000000000002 /* DictionaryTrainingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87000000000000000000002 /* DictionaryTrainingServiceTests.swift */; };
 		AA00000000000000000080 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000080 /* Snippet.swift */; };
 		AA00000000000000000081 /* SnippetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000081 /* SnippetService.swift */; };
 		C1F000000000000000000011 /* UserDataSyncIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F000000000000000000002 /* UserDataSyncIdentity.swift */; };
@@ -638,6 +640,8 @@
 		BB00000000000000000077 /* DictionaryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryEntry.swift; sourceTree = "<group>"; };
 		BB00000000000000000078 /* TermPack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermPack.swift; sourceTree = "<group>"; };
 		BB00000000000000000079 /* DictionaryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryService.swift; sourceTree = "<group>"; };
+		B87000000000000000000001 /* DictionaryTrainingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryTrainingService.swift; sourceTree = "<group>"; };
+		B87000000000000000000002 /* DictionaryTrainingServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictionaryTrainingServiceTests.swift; sourceTree = "<group>"; };
 		BB7080000000000000000002 /* TargetAppCorrectionLearningServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetAppCorrectionLearningServiceTests.swift; sourceTree = "<group>"; };
 		BB00000000000000000080 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		BB00000000000000000081 /* SnippetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetService.swift; sourceTree = "<group>"; };
@@ -1518,6 +1522,7 @@
 				BB00000000000000000074 /* AudioDuckingService.swift */,
 				BB00000000000000000273 /* MediaPlaybackService.swift */,
 				BB00000000000000000079 /* DictionaryService.swift */,
+				B87000000000000000000001 /* DictionaryTrainingService.swift */,
 				BB00000000000000000271 /* DictionaryExporter.swift */,
 				BB00000000000000000081 /* SnippetService.swift */,
 				C1F000000000000000000001 /* Sync */,
@@ -2292,6 +2297,7 @@
 					5A6500000000000000000001 /* ModelManagerLiveSessionModelOverrideTests.swift */,
 					AA8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift */,
 				D63A42880A0BA4C84F36E873 /* DictionaryServiceTests.swift */,
+				B87000000000000000000002 /* DictionaryTrainingServiceTests.swift */,
 				BB7080000000000000000002 /* TargetAppCorrectionLearningServiceTests.swift */,
 				A8D4F2B6E1C3097B5F8A4E62 /* DictionaryExporterTests.swift */,
 				8E39448D561C47B16EEF4C6B /* HTTPRequestParserTests.swift */,
@@ -3805,6 +3811,7 @@
 					5A6500000000000000000002 /* ModelManagerLiveSessionModelOverrideTests.swift in Sources */,
 					BB8C1D4E5F60718293A4B5C6 /* DictationShortSpeechTests.swift in Sources */,
 				B4CC04DF94001FF7220789BC /* DictionaryServiceTests.swift in Sources */,
+				A87000000000000000000002 /* DictionaryTrainingServiceTests.swift in Sources */,
 				AA7080000000000000000002 /* TargetAppCorrectionLearningServiceTests.swift in Sources */,
 				C7A3E9F1D5B2084A6E9C3D71 /* DictionaryExporterTests.swift in Sources */,
 				F635B3F08018D57E0CB709BF /* HTTPRequestParserTests.swift in Sources */,
@@ -3947,6 +3954,7 @@
 				AA00000000000000000077 /* DictionaryEntry.swift in Sources */,
 				AA00000000000000000078 /* TermPack.swift in Sources */,
 				AA00000000000000000079 /* DictionaryService.swift in Sources */,
+				A87000000000000000000001 /* DictionaryTrainingService.swift in Sources */,
 				AA00000000000000000080 /* Snippet.swift in Sources */,
 				AA00000000000000000081 /* SnippetService.swift in Sources */,
 				C1F000000000000000000011 /* UserDataSyncIdentity.swift in Sources */,

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -21,6 +21,7 @@ final class ServiceContainer: ObservableObject {
     let audioDuckingService: AudioDuckingService
     let mediaPlaybackService: MediaPlaybackService
     let dictionaryService: DictionaryService
+    let dictionaryTrainingService: DictionaryTrainingService
     let targetAppCorrectionLearningService: TargetAppCorrectionLearningService
     let snippetService: SnippetService
     let userDataSyncStore: TypeWhisperUserDataSyncStore
@@ -153,6 +154,12 @@ final class ServiceContainer: ObservableObject {
         )
         dictationRecoveryViewModel = recoveryViewModel
         settingsViewModel = SettingsViewModel(modelManager: modelManagerService)
+        dictionaryTrainingService = DictionaryTrainingService(
+            audioRecordingService: audioRecordingService,
+            modelManager: modelManagerService,
+            settingsViewModel: settingsViewModel,
+            dictionaryService: dictionaryService
+        )
         dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
             textInsertionService: textInsertionService,

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -38,6 +38,13 @@ struct DictionaryCorrectionLearningResult: Equatable, Sendable {
     let failed: Bool
 }
 
+struct DictionaryTrainingCommitResult: Equatable, Sendable {
+    let addedTerm: Bool
+    let addedCorrections: [String]
+    let duplicateCorrections: [String]
+    let conflictingCorrections: [String]
+}
+
 @MainActor
 final class DictionaryService: ObservableObject {
     private var modelContainer: ModelContainer?
@@ -50,6 +57,14 @@ final class DictionaryService: ObservableObject {
     @Published private(set) var correctionsCount: Int = 0
     @Published private(set) var enabledTermsCount: Int = 0
     @Published private(set) var enabledCorrectionsCount: Int = 0
+
+    #if DEBUG
+    private var trainingSaveOverride: (() throws -> Void)?
+
+    func setTrainingSaveOverrideForTesting(_ override: (() throws -> Void)?) {
+        trainingSaveOverride = override
+    }
+    #endif
 
     init(appSupportDirectory: URL = AppConstants.appSupportDirectory) {
         setupModelContainer(appSupportDirectory: appSupportDirectory)
@@ -835,6 +850,127 @@ final class DictionaryService: ObservableObject {
                 duplicateCount: duplicateCount,
                 failed: true
             )
+        }
+    }
+
+    /// Atomically adds a reviewed training term and its flat manual corrections.
+    /// Existing corrections are re-checked immediately before saving and are never overwritten.
+    func applyDictionaryTraining(
+        canonicalWord rawCanonicalWord: String,
+        approvedCandidates rawCandidates: [String]
+    ) throws -> DictionaryTrainingCommitResult {
+        guard let context = modelContext else {
+            throw DictionaryServiceMutationError.unavailable
+        }
+
+        let canonicalWord = rawCanonicalWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !canonicalWord.isEmpty else {
+            return DictionaryTrainingCommitResult(
+                addedTerm: false,
+                addedCorrections: [],
+                duplicateCorrections: [],
+                conflictingCorrections: []
+            )
+        }
+
+        let canonicalKey = canonicalWord.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: .current
+        )
+        let termExists = entries.contains {
+            $0.type == .term &&
+                $0.original.folding(
+                    options: [.caseInsensitive, .diacriticInsensitive],
+                    locale: .current
+                ) == canonicalKey
+        }
+        let addedTerm = !termExists
+        let now = Date()
+
+        if addedTerm {
+            context.insert(DictionaryEntry(
+                type: .term,
+                original: canonicalWord,
+                source: .manual,
+                createdAt: now,
+                updatedAt: now
+            ))
+        }
+
+        let existingCorrections = entries.filter { $0.type == .correction }
+        var seenCandidateKeys = Set<String>()
+        var addedCorrections: [String] = []
+        var duplicateCorrections: [String] = []
+        var conflictingCorrections: [String] = []
+
+        for rawCandidate in rawCandidates {
+            let candidate = rawCandidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            let candidateKey = candidate.folding(
+                options: [.caseInsensitive, .diacriticInsensitive],
+                locale: .current
+            )
+            guard !candidate.isEmpty,
+                  candidateKey != canonicalKey,
+                  seenCandidateKeys.insert(candidateKey).inserted else {
+                continue
+            }
+
+            if let existing = existingCorrections.first(where: {
+                $0.original.folding(
+                    options: [.caseInsensitive, .diacriticInsensitive],
+                    locale: .current
+                ) == candidateKey
+            }) {
+                let existingReplacementKey = (existing.replacement ?? "").folding(
+                    options: [.caseInsensitive, .diacriticInsensitive],
+                    locale: .current
+                )
+                if existingReplacementKey == canonicalKey {
+                    duplicateCorrections.append(candidate)
+                } else {
+                    conflictingCorrections.append(candidate)
+                }
+                continue
+            }
+
+            context.insert(DictionaryEntry(
+                type: .correction,
+                original: candidate,
+                replacement: canonicalWord,
+                caseSensitive: false,
+                source: .manual,
+                createdAt: now,
+                updatedAt: now
+            ))
+            addedCorrections.append(candidate)
+        }
+
+        guard addedTerm || !addedCorrections.isEmpty else {
+            return DictionaryTrainingCommitResult(
+                addedTerm: false,
+                addedCorrections: [],
+                duplicateCorrections: duplicateCorrections,
+                conflictingCorrections: conflictingCorrections
+            )
+        }
+
+        do {
+            #if DEBUG
+            try trainingSaveOverride?()
+            #endif
+            try context.save()
+            loadEntries()
+            return DictionaryTrainingCommitResult(
+                addedTerm: addedTerm,
+                addedCorrections: addedCorrections,
+                duplicateCorrections: duplicateCorrections,
+                conflictingCorrections: conflictingCorrections
+            )
+        } catch {
+            context.rollback()
+            loadEntries()
+            logger.error("Failed to apply dictionary training: \(error.localizedDescription)")
+            throw DictionaryServiceMutationError.saveFailed(error)
         }
     }
 

--- a/TypeWhisper/Services/DictionaryTrainingService.swift
+++ b/TypeWhisper/Services/DictionaryTrainingService.swift
@@ -18,6 +18,7 @@ enum DictionaryTrainingStage: Equatable, Sendable {
 
 enum DictionaryTrainingSampleState: Equatable, Sendable {
     case pending
+    case preparing
     case recording
     case transcribing
     case completed
@@ -172,7 +173,7 @@ final class DictionaryTrainingService: ObservableObject {
 
     var activeSampleID: UUID? {
         samples.first {
-            $0.state == .recording || $0.state == .transcribing
+            $0.state == .preparing || $0.state == .recording || $0.state == .transcribing
         }?.id
     }
 
@@ -242,6 +243,7 @@ final class DictionaryTrainingService: ObservableObject {
 
     func updateSentence(id: UUID, sentence: String) {
         guard let index = samples.firstIndex(where: { $0.id == id }),
+              samples[index].state != .preparing,
               samples[index].state != .recording,
               samples[index].state != .transcribing else {
             return
@@ -266,6 +268,7 @@ final class DictionaryTrainingService: ObservableObject {
             ))
             return
         }
+        samples[index].state = .preparing
         guard await dependencies.requestMicrophonePermission() else {
             guard requestedSessionID == sessionID else { return }
             samples[index].state = .failed(localizedAppText(
@@ -335,7 +338,11 @@ final class DictionaryTrainingService: ObservableObject {
             samples[index].evaluation = evaluation
             samples[index].state = .completed
         } catch is CancellationError {
-            return
+            guard requestedSessionID == sessionID, !isCancelled else { return }
+            samples[index].state = .failed(localizedAppText(
+                "Transcription was cancelled.",
+                de: "Die Transkription wurde abgebrochen."
+            ))
         } catch {
             guard requestedSessionID == sessionID, !isCancelled else { return }
             samples[index].state = .failed(error.localizedDescription)
@@ -344,6 +351,7 @@ final class DictionaryTrainingService: ObservableObject {
 
     func retrySample(id: UUID) {
         guard let index = samples.firstIndex(where: { $0.id == id }),
+              samples[index].state != .preparing,
               samples[index].state != .recording,
               samples[index].state != .transcribing else {
             return

--- a/TypeWhisper/Services/DictionaryTrainingService.swift
+++ b/TypeWhisper/Services/DictionaryTrainingService.swift
@@ -1,0 +1,566 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+struct DictionaryTrainingEngineSnapshot: Equatable, Sendable {
+    let providerID: String
+    let engineName: String
+    let modelID: String?
+    let modelName: String
+    let languageSelection: LanguageSelection
+}
+
+enum DictionaryTrainingStage: Equatable, Sendable {
+    case word
+    case samples
+    case review
+    case summary
+}
+
+enum DictionaryTrainingSampleState: Equatable, Sendable {
+    case pending
+    case recording
+    case transcribing
+    case completed
+    case failed(String)
+}
+
+enum DictionaryTrainingSampleEvaluation: Equatable, Sendable {
+    case correct
+    case candidate(String)
+    case skipped
+}
+
+struct DictionaryTrainingSample: Identifiable, Equatable, Sendable {
+    let id: UUID
+    var sentence: String
+    var transcript: String?
+    var state: DictionaryTrainingSampleState
+    var evaluation: DictionaryTrainingSampleEvaluation?
+}
+
+enum DictionaryTrainingCandidateDisposition: Equatable, Sendable {
+    case available
+    case duplicate
+    case conflict(existingReplacement: String)
+    case invalid
+}
+
+struct DictionaryTrainingCandidate: Identifiable, Equatable, Sendable {
+    let id: UUID
+    var original: String
+    var isSelected: Bool
+    var disposition: DictionaryTrainingCandidateDisposition
+}
+
+struct DictionaryTrainingSummary: Equatable, Sendable {
+    let addedTerm: Bool
+    let addedCorrections: [String]
+    let duplicateCorrections: [String]
+    let conflictingCorrections: [String]
+}
+
+struct DictionaryTrainingTranscriptionRequest: Equatable, Sendable {
+    let audioSamples: [Float]
+    let snapshot: DictionaryTrainingEngineSnapshot
+    let prompt: String?
+    let dictionaryTermHints: [PluginDictionaryTermHint]
+    let normalizeNumbers: Bool
+}
+
+@MainActor
+struct DictionaryTrainingDependencies {
+    var engineSnapshot: () -> DictionaryTrainingEngineSnapshot?
+    var canTranscribe: () -> Bool
+    var requestMicrophonePermission: () async -> Bool
+    var startRecording: () throws -> Void
+    var stopRecording: () async -> [Float]
+    var discardActiveRecording: () -> Void
+    var transcribe: (DictionaryTrainingTranscriptionRequest) async throws -> String
+    var dictionaryEntries: () -> [DictionaryEntry]
+    var commit: (String, [String]) throws -> DictionaryTrainingCommitResult
+
+    static func live(
+        audioRecordingService: AudioRecordingService,
+        modelManager: ModelManagerService,
+        settingsViewModel: SettingsViewModel,
+        dictionaryService: DictionaryService
+    ) -> DictionaryTrainingDependencies {
+        DictionaryTrainingDependencies(
+            engineSnapshot: {
+                guard let providerID = modelManager.selectedProviderId,
+                      let engineName = modelManager.activeEngineName else {
+                    return nil
+                }
+                return DictionaryTrainingEngineSnapshot(
+                    providerID: providerID,
+                    engineName: engineName,
+                    modelID: modelManager.selectedModelId,
+                    modelName: modelManager.activeModelName ?? engineName,
+                    languageSelection: settingsViewModel.languageSelection
+                )
+            },
+            canTranscribe: { modelManager.canTranscribe },
+            requestMicrophonePermission: {
+                await audioRecordingService.requestMicrophonePermission()
+            },
+            startRecording: {
+                try audioRecordingService.startRecording()
+            },
+            stopRecording: {
+                await audioRecordingService.stopRecording(policy: .immediate)
+            },
+            discardActiveRecording: {
+                audioRecordingService.discardActiveRecoveryRecording()
+            },
+            transcribe: { request in
+                let result = try await modelManager.transcribe(
+                    audioSamples: request.audioSamples,
+                    languageSelection: request.snapshot.languageSelection,
+                    task: .transcribe,
+                    engineOverrideId: request.snapshot.providerID,
+                    cloudModelOverride: request.snapshot.modelID,
+                    prompt: request.prompt,
+                    dictionaryTermHints: request.dictionaryTermHints,
+                    normalizeNumbers: request.normalizeNumbers
+                )
+                return result.text
+            },
+            dictionaryEntries: { dictionaryService.entries },
+            commit: { canonicalWord, candidates in
+                try dictionaryService.applyDictionaryTraining(
+                    canonicalWord: canonicalWord,
+                    approvedCandidates: candidates
+                )
+            }
+        )
+    }
+}
+
+@MainActor
+final class DictionaryTrainingService: ObservableObject {
+    static let requiredSampleCount = 3
+
+    @Published private(set) var stage: DictionaryTrainingStage = .word
+    @Published var canonicalWord = ""
+    @Published private(set) var engineSnapshot: DictionaryTrainingEngineSnapshot?
+    @Published private(set) var samples: [DictionaryTrainingSample] = []
+    @Published private(set) var candidates: [DictionaryTrainingCandidate] = []
+    @Published private(set) var summary: DictionaryTrainingSummary?
+    @Published private(set) var errorMessage: String?
+
+    private let dependencies: DictionaryTrainingDependencies
+    private var isCancelled = false
+    private var sessionID = UUID()
+
+    init(dependencies: DictionaryTrainingDependencies) {
+        self.dependencies = dependencies
+    }
+
+    convenience init(
+        audioRecordingService: AudioRecordingService,
+        modelManager: ModelManagerService,
+        settingsViewModel: SettingsViewModel,
+        dictionaryService: DictionaryService
+    ) {
+        self.init(dependencies: .live(
+            audioRecordingService: audioRecordingService,
+            modelManager: modelManager,
+            settingsViewModel: settingsViewModel,
+            dictionaryService: dictionaryService
+        ))
+    }
+
+    var activeSampleID: UUID? {
+        samples.first {
+            $0.state == .recording || $0.state == .transcribing
+        }?.id
+    }
+
+    var canProceedToReview: Bool {
+        samples.count >= Self.requiredSampleCount && samples.allSatisfy {
+            $0.state == .completed
+        }
+    }
+
+    var selectedCandidateCount: Int {
+        candidates.filter {
+            $0.isSelected && $0.disposition == .available
+        }.count
+    }
+
+    func reset() {
+        sessionID = UUID()
+        stage = .word
+        canonicalWord = ""
+        engineSnapshot = nil
+        samples = []
+        candidates = []
+        summary = nil
+        errorMessage = nil
+        isCancelled = false
+        dependencies.discardActiveRecording()
+    }
+
+    func beginTraining(localeIdentifier: String = Locale.current.identifier) {
+        errorMessage = nil
+        let normalizedWord = canonicalWord.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard Self.isValidCanonicalWord(normalizedWord) else {
+            errorMessage = localizedAppText(
+                "Enter exactly one word without punctuation.",
+                de: "Gib genau ein Wort ohne Satzzeichen ein."
+            )
+            return
+        }
+        guard dependencies.canTranscribe(), let snapshot = dependencies.engineSnapshot() else {
+            errorMessage = localizedAppText(
+                "The selected transcription engine or model is unavailable.",
+                de: "Die ausgewählte Transkriptions-Engine oder das Modell ist nicht verfügbar."
+            )
+            return
+        }
+
+        canonicalWord = normalizedWord
+        engineSnapshot = snapshot
+        samples = Self.exampleSentences(
+            for: normalizedWord,
+            localeIdentifier: localeIdentifier
+        ).map {
+            DictionaryTrainingSample(
+                id: UUID(),
+                sentence: $0,
+                transcript: nil,
+                state: .pending,
+                evaluation: nil
+            )
+        }
+        candidates = []
+        summary = nil
+        isCancelled = false
+        stage = .samples
+    }
+
+    func updateSentence(id: UUID, sentence: String) {
+        guard let index = samples.firstIndex(where: { $0.id == id }),
+              samples[index].state != .recording,
+              samples[index].state != .transcribing else {
+            return
+        }
+        samples[index].sentence = sentence
+        samples[index].transcript = nil
+        samples[index].evaluation = nil
+        samples[index].state = .pending
+    }
+
+    func startRecording(sampleID: UUID) async {
+        errorMessage = nil
+        let requestedSessionID = sessionID
+        guard activeSampleID == nil,
+              let index = samples.firstIndex(where: { $0.id == sampleID }) else {
+            return
+        }
+        guard Self.sentenceContainsTargetExactlyOnce(samples[index].sentence, target: canonicalWord) else {
+            samples[index].state = .failed(localizedAppText(
+                "The sentence must contain the target word exactly once.",
+                de: "Der Satz muss das Zielwort genau einmal enthalten."
+            ))
+            return
+        }
+        guard await dependencies.requestMicrophonePermission() else {
+            guard requestedSessionID == sessionID else { return }
+            samples[index].state = .failed(localizedAppText(
+                "Microphone permission is required.",
+                de: "Der Mikrofonzugriff ist erforderlich."
+            ))
+            return
+        }
+
+        do {
+            guard requestedSessionID == sessionID else { return }
+            try dependencies.startRecording()
+            guard requestedSessionID == sessionID, !isCancelled else {
+                _ = await dependencies.stopRecording()
+                dependencies.discardActiveRecording()
+                return
+            }
+            samples[index].transcript = nil
+            samples[index].evaluation = nil
+            samples[index].state = .recording
+        } catch {
+            dependencies.discardActiveRecording()
+            samples[index].state = .failed(error.localizedDescription)
+        }
+    }
+
+    func stopRecordingAndTranscribe(sampleID: UUID) async {
+        guard let index = samples.firstIndex(where: { $0.id == sampleID }),
+              samples[index].state == .recording,
+              let snapshot = engineSnapshot else {
+            return
+        }
+        let requestedSessionID = sessionID
+
+        samples[index].state = .transcribing
+        let sentence = samples[index].sentence
+        let audioSamples = await dependencies.stopRecording()
+        defer { dependencies.discardActiveRecording() }
+
+        guard requestedSessionID == sessionID, !isCancelled else { return }
+        guard !audioSamples.isEmpty else {
+            samples[index].state = .failed(localizedAppText(
+                "No audio was recorded.",
+                de: "Es wurde kein Audio aufgenommen."
+            ))
+            return
+        }
+
+        do {
+            let request = DictionaryTrainingTranscriptionRequest(
+                audioSamples: audioSamples,
+                snapshot: snapshot,
+                prompt: nil,
+                dictionaryTermHints: [],
+                normalizeNumbers: false
+            )
+            let transcript = try await dependencies.transcribe(request)
+            guard !Task.isCancelled,
+                  requestedSessionID == sessionID,
+                  !isCancelled else { return }
+            let evaluation = Self.evaluate(
+                expectedSentence: sentence,
+                rawTranscript: transcript,
+                targetWord: canonicalWord
+            )
+            samples[index].transcript = transcript
+            samples[index].evaluation = evaluation
+            samples[index].state = .completed
+        } catch is CancellationError {
+            return
+        } catch {
+            guard requestedSessionID == sessionID, !isCancelled else { return }
+            samples[index].state = .failed(error.localizedDescription)
+        }
+    }
+
+    func retrySample(id: UUID) {
+        guard let index = samples.firstIndex(where: { $0.id == id }),
+              samples[index].state != .recording,
+              samples[index].state != .transcribing else {
+            return
+        }
+        samples[index].transcript = nil
+        samples[index].evaluation = nil
+        samples[index].state = .pending
+    }
+
+    func proceedToReview() {
+        guard canProceedToReview else { return }
+        candidates = makeCandidates()
+        stage = .review
+    }
+
+    func returnToSamples() {
+        guard stage == .review else { return }
+        stage = .samples
+    }
+
+    func updateCandidate(id: UUID, original: String) {
+        guard let index = candidates.firstIndex(where: { $0.id == id }) else { return }
+        candidates[index].original = original
+        refreshCandidateDispositions(keeping: id)
+    }
+
+    func setCandidateSelected(id: UUID, selected: Bool) {
+        guard let index = candidates.firstIndex(where: { $0.id == id }),
+              candidates[index].disposition == .available else {
+            return
+        }
+        candidates[index].isSelected = selected
+    }
+
+    func confirm() {
+        errorMessage = nil
+        let selected = candidates.compactMap { candidate in
+            candidate.isSelected && candidate.disposition == .available
+                ? candidate.original.trimmingCharacters(in: .whitespacesAndNewlines)
+                : nil
+        }
+
+        do {
+            let result = try dependencies.commit(canonicalWord, selected)
+            summary = DictionaryTrainingSummary(
+                addedTerm: result.addedTerm,
+                addedCorrections: result.addedCorrections,
+                duplicateCorrections: result.duplicateCorrections,
+                conflictingCorrections: result.conflictingCorrections
+            )
+            stage = .summary
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func cancel() async {
+        isCancelled = true
+        if let activeSampleID,
+           let index = samples.firstIndex(where: { $0.id == activeSampleID }),
+           samples[index].state == .recording {
+            _ = await dependencies.stopRecording()
+        }
+        dependencies.discardActiveRecording()
+        reset()
+    }
+
+    static func exampleSentences(for word: String, localeIdentifier: String) -> [String] {
+        let isGerman = localeIdentifier.lowercased().hasPrefix("de")
+        if isGerman {
+            return [
+                "Heute möchte ich \(word) deutlich sagen.",
+                "Bitte schreibe \(word) in diesen Satz.",
+                "Das wichtige Wort ist heute \(word)."
+            ]
+        }
+        return [
+            "Today I want to say \(word) clearly.",
+            "Please write \(word) in this sentence.",
+            "The important word today is \(word)."
+        ]
+    }
+
+    static func isValidCanonicalWord(_ word: String) -> Bool {
+        let tokens = wordTokens(in: word)
+        return tokens.count == 1 && tokens[0] == word
+    }
+
+    static func sentenceContainsTargetExactlyOnce(_ sentence: String, target: String) -> Bool {
+        wordTokens(in: sentence).filter {
+            $0.compare(target, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }.count == 1
+    }
+
+    static func evaluate(
+        expectedSentence: String,
+        rawTranscript: String,
+        targetWord: String
+    ) -> DictionaryTrainingSampleEvaluation {
+        let expectedTokens = wordTokens(in: expectedSentence)
+        let transcriptTokens = wordTokens(in: rawTranscript)
+
+        guard !transcriptTokens.isEmpty,
+              expectedTokens.count == transcriptTokens.count else {
+            return .skipped
+        }
+
+        let differences = zip(expectedTokens, transcriptTokens).enumerated().filter { _, pair in
+            pair.0 != pair.1
+        }
+        guard differences.count == 1,
+              let difference = differences.first else {
+            if expectedTokens == transcriptTokens {
+                return .correct
+            }
+            return .skipped
+        }
+
+        let expectedWord = difference.element.0
+        let candidate = difference.element.1
+        guard expectedWord.compare(
+            targetWord,
+            options: [.caseInsensitive, .diacriticInsensitive]
+        ) == .orderedSame else {
+            return .skipped
+        }
+        guard candidate.compare(
+            targetWord,
+            options: [.caseInsensitive, .diacriticInsensitive]
+        ) != .orderedSame else {
+            return .skipped
+        }
+        guard isValidCanonicalWord(candidate) else { return .skipped }
+        return .candidate(candidate)
+    }
+
+    private func makeCandidates() -> [DictionaryTrainingCandidate] {
+        var seen = Set<String>()
+        return samples.compactMap { sample in
+            guard case .candidate(let original) = sample.evaluation else { return nil }
+            let key = normalizedKey(original)
+            guard seen.insert(key).inserted else { return nil }
+            let disposition = disposition(for: original)
+            return DictionaryTrainingCandidate(
+                id: UUID(),
+                original: original,
+                isSelected: disposition == .available,
+                disposition: disposition
+            )
+        }
+    }
+
+    private func disposition(for rawCandidate: String) -> DictionaryTrainingCandidateDisposition {
+        let candidate = rawCandidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidCanonicalWord(candidate),
+              normalizedKey(candidate) != normalizedKey(canonicalWord) else {
+            return .invalid
+        }
+
+        guard let existing = dependencies.dictionaryEntries().first(where: {
+            $0.type == .correction && normalizedKey($0.original) == normalizedKey(candidate)
+        }) else {
+            return .available
+        }
+
+        if normalizedKey(existing.replacement ?? "") == normalizedKey(canonicalWord) {
+            return .duplicate
+        }
+        return .conflict(existingReplacement: existing.replacement ?? "")
+    }
+
+    private func refreshCandidateDispositions(keeping candidateID: UUID) {
+        for index in candidates.indices {
+            let wasAvailable = candidates[index].disposition == .available
+            candidates[index].disposition = disposition(for: candidates[index].original)
+            if candidates[index].disposition != .available {
+                candidates[index].isSelected = false
+            } else if !wasAvailable || candidates[index].id == candidateID {
+                candidates[index].isSelected = true
+            }
+        }
+
+        var preferredIndexByKey: [String: Int] = [:]
+        for index in candidates.indices where candidates[index].disposition == .available {
+            let key = normalizedKey(candidates[index].original)
+            guard !key.isEmpty else { continue }
+
+            if let existingIndex = preferredIndexByKey[key] {
+                let duplicateIndex: Int
+                if candidates[index].id == candidateID {
+                    duplicateIndex = existingIndex
+                    preferredIndexByKey[key] = index
+                } else {
+                    duplicateIndex = index
+                }
+                candidates[duplicateIndex].disposition = .invalid
+                candidates[duplicateIndex].isSelected = false
+            } else {
+                preferredIndexByKey[key] = index
+            }
+        }
+    }
+
+    private func normalizedKey(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: .current
+        )
+    }
+
+    private static func wordTokens(in text: String) -> [String] {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let pattern = #"[\p{L}\p{N}]+(?:['’_-][\p{L}\p{N}]+)*"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [] }
+        return expression.matches(in: text, range: range).compactMap { match in
+            guard let tokenRange = Range(match.range, in: text) else { return nil }
+            return String(text[tokenRange])
+        }
+    }
+}

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -605,7 +605,11 @@ private struct DictionaryTrainingSheet: View {
                 axis: .vertical
             )
             .textFieldStyle(.roundedBorder)
-            .disabled(sample.state == .recording || sample.state == .transcribing)
+            .disabled(
+                sample.state == .preparing ||
+                    sample.state == .recording ||
+                    sample.state == .transcribing
+            )
 
             if let transcript = sample.transcript {
                 VStack(alignment: .leading, spacing: 3) {
@@ -697,6 +701,10 @@ private struct DictionaryTrainingSheet: View {
                 set: { service.setCandidateSelected(id: candidate.id, selected: $0) }
             ))
             .labelsHidden()
+            .accessibilityLabel(localizedAppText(
+                "Include \(candidate.original) as a correction",
+                de: "\(candidate.original) als Korrektur einschließen"
+            ))
             .disabled(candidate.disposition != .available)
 
             TextField(
@@ -824,6 +832,11 @@ private struct DictionaryTrainingSheet: View {
         case .pending:
             Label(localizedAppText("Ready", de: "Bereit"), systemImage: "circle")
                 .foregroundStyle(.secondary)
+        case .preparing:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text(localizedAppText("Preparing", de: "Vorbereitung"))
+            }
         case .recording:
             Label(localizedAppText("Recording", de: "Aufnahme"), systemImage: "record.circle.fill")
                 .foregroundStyle(.red)

--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -9,7 +9,9 @@ struct DictionarySettingsView: View {
     @ObservedObject private var viewModel = DictionaryViewModel.shared
     @ObservedObject private var termPackRegistryService: TermPackRegistryService
     @ObservedObject private var pluginManager: PluginManager
+    @ObservedObject private var trainingService = ServiceContainer.shared.dictionaryTrainingService
     @State private var expandedCorrectionGroups = Set<String>()
+    @State private var isTrainingPresented = false
 
     init() {
         _termPackRegistryService = ObservedObject(wrappedValue: TermPackRegistryService.shared)
@@ -34,6 +36,14 @@ struct DictionarySettingsView: View {
         .padding(.horizontal, 8)
         .sheet(isPresented: $viewModel.isEditing) {
             DictionaryEditorSheet(viewModel: viewModel)
+        }
+        .sheet(isPresented: $isTrainingPresented, onDismiss: {
+            Task { await trainingService.cancel() }
+        }) {
+            DictionaryTrainingSheet(
+                service: trainingService,
+                dismiss: { isTrainingPresented = false }
+            )
         }
         .alert(String(localized: "Error"), isPresented: Binding(
             get: { viewModel.error != nil },
@@ -88,6 +98,15 @@ struct DictionarySettingsView: View {
             Spacer()
 
             if viewModel.filterTab != .termPacks {
+                Button {
+                    trainingService.reset()
+                    isTrainingPresented = true
+                } label: {
+                    Label(
+                        localizedAppText("Train Word...", de: "Wort trainieren..."),
+                        systemImage: "mic.badge.plus"
+                    )
+                }
                 Button {
                     viewModel.startCreating(type: .correction)
                 } label: {
@@ -468,6 +487,386 @@ struct DictionarySettingsView: View {
                 )
             }
             .sorted { $0.engineName.localizedCaseInsensitiveCompare($1.engineName) == .orderedAscending }
+    }
+}
+
+private struct DictionaryTrainingSheet: View {
+    @ObservedObject var service: DictionaryTrainingService
+    let dismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            trainingHeader
+            Divider()
+            stageContent
+            Divider()
+            trainingFooter
+        }
+        .frame(width: 700, height: 620)
+        .interactiveDismissDisabled(service.activeSampleID != nil)
+    }
+
+    private var trainingHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(
+                    localizedAppText("Train a Word", de: "Wort trainieren"),
+                    systemImage: "waveform.and.mic"
+                )
+                .font(.title2.weight(.semibold))
+                Spacer()
+                Text(stageLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let snapshot = service.engineSnapshot {
+                HStack(spacing: 16) {
+                    Label(snapshot.engineName, systemImage: "cpu")
+                    Label(snapshot.modelName, systemImage: "shippingbox")
+                    Label(languageLabel(snapshot.languageSelection), systemImage: "globe")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(20)
+    }
+
+    @ViewBuilder
+    private var stageContent: some View {
+        switch service.stage {
+        case .word:
+            wordStage
+        case .samples:
+            samplesStage
+        case .review:
+            reviewStage
+        case .summary:
+            summaryStage
+        }
+    }
+
+    private var wordStage: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            ContentUnavailableView(
+                localizedAppText("Choose the target word", de: "Zielwort auswählen"),
+                systemImage: "character.cursor.ibeam",
+                description: Text(localizedAppText(
+                    "TypeWhisper will record three editable example sentences and inspect only the raw transcription. Nothing is saved until you confirm the review.",
+                    de: "TypeWhisper nimmt drei editierbare Beispielsätze auf und prüft nur die rohe Transkription. Bis zur Bestätigung der Prüfung wird nichts gespeichert."
+                ))
+            )
+
+            TextField(
+                localizedAppText("Target word", de: "Zielwort"),
+                text: $service.canonicalWord
+            )
+            .textFieldStyle(.roundedBorder)
+            .font(.title3)
+
+            if let error = service.errorMessage {
+                errorLabel(error)
+            }
+            Spacer()
+        }
+        .padding(24)
+    }
+
+    private var samplesStage: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(service.samples) { sample in
+                    trainingSampleCard(sample)
+                }
+                if let error = service.errorMessage {
+                    errorLabel(error)
+                }
+            }
+            .padding(20)
+        }
+    }
+
+    private func trainingSampleCard(_ sample: DictionaryTrainingSample) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(localizedAppText("Sample", de: "Beispiel") + " \(sampleNumber(sample.id))")
+                    .font(.headline)
+                Spacer()
+                sampleStateLabel(sample.state)
+            }
+
+            TextField(
+                localizedAppText("Example sentence", de: "Beispielsatz"),
+                text: Binding(
+                    get: { sample.sentence },
+                    set: { service.updateSentence(id: sample.id, sentence: $0) }
+                ),
+                axis: .vertical
+            )
+            .textFieldStyle(.roundedBorder)
+            .disabled(sample.state == .recording || sample.state == .transcribing)
+
+            if let transcript = sample.transcript {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(localizedAppText("Raw transcript", de: "Rohtranskript"))
+                        .font(.caption.weight(.semibold))
+                    Text(transcript)
+                        .textSelection(.enabled)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                if sample.state == .recording {
+                    Button {
+                        Task { await service.stopRecordingAndTranscribe(sampleID: sample.id) }
+                    } label: {
+                        Label(localizedAppText("Stop", de: "Stopp"), systemImage: "stop.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+                } else {
+                    Button {
+                        Task { await service.startRecording(sampleID: sample.id) }
+                    } label: {
+                        Label(
+                            sample.state == .completed
+                                ? localizedAppText("Record Again", de: "Erneut aufnehmen")
+                                : localizedAppText("Record", de: "Aufnehmen"),
+                            systemImage: "record.circle"
+                        )
+                    }
+                    .disabled(service.activeSampleID != nil || sample.state == .transcribing)
+                }
+
+                if case .failed = sample.state {
+                    Button(localizedAppText("Retry", de: "Wiederholen")) {
+                        service.retrySample(id: sample.id)
+                    }
+                    .disabled(service.activeSampleID != nil)
+                }
+                Spacer()
+            }
+        }
+        .padding(14)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(.separator, lineWidth: 1)
+        }
+    }
+
+    private var reviewStage: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(localizedAppText(
+                    "Review the unique misrecognitions. Conflicts are never overwritten.",
+                    de: "Prüfe die eindeutigen Fehlerkennungen. Konflikte werden niemals überschrieben."
+                ))
+                .foregroundStyle(.secondary)
+
+                if service.candidates.isEmpty {
+                    ContentUnavailableView(
+                        localizedAppText("No correction candidates", de: "Keine Korrekturkandidaten"),
+                        systemImage: "checkmark.circle",
+                        description: Text(localizedAppText(
+                            "The target word can still be added as a dictionary term.",
+                            de: "Das Zielwort kann trotzdem als Dictionary-Begriff hinzugefügt werden."
+                        ))
+                    )
+                } else {
+                    ForEach(service.candidates) { candidate in
+                        candidateRow(candidate)
+                    }
+                }
+
+                if let error = service.errorMessage {
+                    errorLabel(error)
+                }
+            }
+            .padding(20)
+        }
+    }
+
+    private func candidateRow(_ candidate: DictionaryTrainingCandidate) -> some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(
+                get: { candidate.isSelected },
+                set: { service.setCandidateSelected(id: candidate.id, selected: $0) }
+            ))
+            .labelsHidden()
+            .disabled(candidate.disposition != .available)
+
+            TextField(
+                localizedAppText("Misrecognition", de: "Fehlerkennung"),
+                text: Binding(
+                    get: { candidate.original },
+                    set: { service.updateCandidate(id: candidate.id, original: $0) }
+                )
+            )
+            .textFieldStyle(.roundedBorder)
+
+            Image(systemName: "arrow.right")
+                .foregroundStyle(.secondary)
+            Text(service.canonicalWord)
+                .fontWeight(.medium)
+                .frame(minWidth: 100, alignment: .leading)
+            candidateDispositionLabel(candidate.disposition)
+        }
+        .padding(12)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var summaryStage: some View {
+        VStack(spacing: 18) {
+            ContentUnavailableView(
+                localizedAppText("Training complete", de: "Training abgeschlossen"),
+                systemImage: "checkmark.circle.fill",
+                description: Text(summaryDescription)
+            )
+            if let snapshot = service.engineSnapshot {
+                Text(localizedAppText(
+                    "Candidates were produced by \(snapshot.engineName) / \(snapshot.modelName). Corrections remain global.",
+                    de: "Die Kandidaten wurden von \(snapshot.engineName) / \(snapshot.modelName) erzeugt. Korrekturen bleiben global."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var trainingFooter: some View {
+        HStack {
+            if service.stage == .review {
+                Button(localizedAppText("Back", de: "Zurück")) {
+                    service.returnToSamples()
+                }
+            }
+
+            Spacer()
+
+            Button(service.stage == .summary
+                ? localizedAppText("Done", de: "Fertig")
+                : localizedAppText("Cancel", de: "Abbrechen")) {
+                Task {
+                    await service.cancel()
+                    dismiss()
+                }
+            }
+
+            switch service.stage {
+            case .word:
+                Button(localizedAppText("Continue", de: "Weiter")) {
+                    service.beginTraining()
+                }
+                .buttonStyle(.borderedProminent)
+            case .samples:
+                Button(localizedAppText("Review", de: "Prüfen")) {
+                    service.proceedToReview()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!service.canProceedToReview)
+            case .review:
+                Button(localizedAppText("Add to Dictionary", de: "Zum Dictionary hinzufügen")) {
+                    service.confirm()
+                }
+                .buttonStyle(.borderedProminent)
+            case .summary:
+                EmptyView()
+            }
+        }
+        .padding(16)
+    }
+
+    private var stageLabel: String {
+        switch service.stage {
+        case .word: localizedAppText("1 of 4 · Word", de: "1 von 4 · Wort")
+        case .samples: localizedAppText("2 of 4 · Samples", de: "2 von 4 · Beispiele")
+        case .review: localizedAppText("3 of 4 · Review", de: "3 von 4 · Prüfung")
+        case .summary: localizedAppText("4 of 4 · Summary", de: "4 von 4 · Zusammenfassung")
+        }
+    }
+
+    private var summaryDescription: String {
+        guard let summary = service.summary else { return "" }
+        let termText = summary.addedTerm
+            ? localizedAppText("The target word was added as a term.", de: "Das Zielwort wurde als Begriff hinzugefügt.")
+            : localizedAppText("The target word already existed.", de: "Das Zielwort war bereits vorhanden.")
+        return termText + " " + localizedAppText(
+            "Added \(summary.addedCorrections.count) corrections, skipped \(summary.duplicateCorrections.count) duplicates and \(summary.conflictingCorrections.count) conflicts.",
+            de: "\(summary.addedCorrections.count) Korrekturen hinzugefügt, \(summary.duplicateCorrections.count) Duplikate und \(summary.conflictingCorrections.count) Konflikte übersprungen."
+        )
+    }
+
+    private func sampleNumber(_ id: UUID) -> Int {
+        (service.samples.firstIndex(where: { $0.id == id }) ?? 0) + 1
+    }
+
+    private func languageLabel(_ selection: LanguageSelection) -> String {
+        switch selection {
+        case .auto, .inheritGlobal:
+            return localizedAppText("Automatic language", de: "Automatische Sprache")
+        case .exact(let code):
+            return code
+        case .hints(let codes):
+            return codes.joined(separator: ", ")
+        }
+    }
+
+    @ViewBuilder
+    private func sampleStateLabel(_ state: DictionaryTrainingSampleState) -> some View {
+        switch state {
+        case .pending:
+            Label(localizedAppText("Ready", de: "Bereit"), systemImage: "circle")
+                .foregroundStyle(.secondary)
+        case .recording:
+            Label(localizedAppText("Recording", de: "Aufnahme"), systemImage: "record.circle.fill")
+                .foregroundStyle(.red)
+        case .transcribing:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text(localizedAppText("Transcribing", de: "Transkription"))
+            }
+        case .completed:
+            Label(localizedAppText("Complete", de: "Fertig"), systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .lineLimit(2)
+        }
+    }
+
+    @ViewBuilder
+    private func candidateDispositionLabel(_ disposition: DictionaryTrainingCandidateDisposition) -> some View {
+        switch disposition {
+        case .available:
+            Label(localizedAppText("New", de: "Neu"), systemImage: "plus.circle")
+                .foregroundStyle(.green)
+        case .duplicate:
+            Label(localizedAppText("Duplicate", de: "Duplikat"), systemImage: "equal.circle")
+                .foregroundStyle(.secondary)
+        case .conflict(let replacement):
+            Label(
+                localizedAppText("Conflict: \(replacement)", de: "Konflikt: \(replacement)"),
+                systemImage: "exclamationmark.triangle"
+            )
+            .foregroundStyle(.orange)
+        case .invalid:
+            Label(localizedAppText("Invalid", de: "Ungültig"), systemImage: "xmark.circle")
+                .foregroundStyle(.red)
+        }
+    }
+
+    private func errorLabel(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .foregroundStyle(.red)
+            .font(.callout)
     }
 }
 

--- a/TypeWhisperTests/DictionaryTrainingServiceTests.swift
+++ b/TypeWhisperTests/DictionaryTrainingServiceTests.swift
@@ -207,6 +207,78 @@ final class DictionaryTrainingServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testPreparingSampleRejectsDuplicateRecordingTaskAndEditing() async {
+        let snapshot = makeSnapshot()
+        var permissionContinuation: CheckedContinuation<Bool, Never>?
+        var permissionRequestCount = 0
+        var startCount = 0
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: {
+                permissionRequestCount += 1
+                return await withCheckedContinuation { continuation in
+                    permissionContinuation = continuation
+                }
+            },
+            startRecording: { startCount += 1 },
+            stopRecording: { [0.1] },
+            discardActiveRecording: {},
+            transcribe: { _ in "unused" },
+            dictionaryEntries: { [] },
+            commit: { [self] _, _ in self.emptyCommitResult() }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        let sample = service.samples[0]
+        let firstRecording = Task { @MainActor in
+            await service.startRecording(sampleID: sample.id)
+        }
+        await Task.yield()
+
+        XCTAssertEqual(service.samples[0].state, .preparing)
+        XCTAssertEqual(service.activeSampleID, sample.id)
+        service.updateSentence(id: sample.id, sentence: "Please write TypeWhisper today.")
+        XCTAssertEqual(service.samples[0].sentence, sample.sentence)
+
+        await service.startRecording(sampleID: sample.id)
+        XCTAssertEqual(permissionRequestCount, 1)
+
+        permissionContinuation?.resume(returning: true)
+        await firstRecording.value
+        XCTAssertEqual(startCount, 1)
+        XCTAssertEqual(service.samples[0].state, .recording)
+    }
+
+    @MainActor
+    func testDependencyCancellationMarksCurrentSampleFailed() async {
+        let snapshot = makeSnapshot()
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {},
+            stopRecording: { [0.1] },
+            discardActiveRecording: {},
+            transcribe: { _ in throw CancellationError() },
+            dictionaryEntries: { [] },
+            commit: { [self] _, _ in self.emptyCommitResult() }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        let sampleID = service.samples[0].id
+        await service.startRecording(sampleID: sampleID)
+        await service.stopRecordingAndTranscribe(sampleID: sampleID)
+
+        guard case .failed = service.samples[0].state else {
+            return XCTFail("Expected cancelled transcription to fail the sample")
+        }
+        XCTAssertNil(service.activeSampleID)
+    }
+
+    @MainActor
     func testCancelDuringRecordingDiscardsAudioWithoutDictionaryMutation() async {
         let snapshot = makeSnapshot()
         var stopCount = 0

--- a/TypeWhisperTests/DictionaryTrainingServiceTests.swift
+++ b/TypeWhisperTests/DictionaryTrainingServiceTests.swift
@@ -199,8 +199,8 @@ final class DictionaryTrainingServiceTests: XCTestCase {
 
         shouldFail = false
         service.retrySample(id: second.id)
-        await service.startRecording(sampleID: second.id)
         service.updateSentence(id: second.id, sentence: "Today I want to say TypeWhisper clearly.")
+        await service.startRecording(sampleID: second.id)
         await service.stopRecordingAndTranscribe(sampleID: second.id)
         XCTAssertEqual(service.samples[1].state, .completed)
         XCTAssertEqual(service.samples[0].state, .completed)

--- a/TypeWhisperTests/DictionaryTrainingServiceTests.swift
+++ b/TypeWhisperTests/DictionaryTrainingServiceTests.swift
@@ -1,0 +1,343 @@
+import XCTest
+@testable import TypeWhisper
+
+final class DictionaryTrainingServiceTests: XCTestCase {
+    private enum TestError: Error {
+        case transcriptionFailed
+        case saveFailed
+    }
+
+    @MainActor
+    func testExampleSentencesAreLocalizedDeterministicAndContainTargetOnce() {
+        let english = DictionaryTrainingService.exampleSentences(
+            for: "TypeWhisper",
+            localeIdentifier: "en_US"
+        )
+        let german = DictionaryTrainingService.exampleSentences(
+            for: "TypeWhisper",
+            localeIdentifier: "de_DE"
+        )
+
+        XCTAssertEqual(english.count, DictionaryTrainingService.requiredSampleCount)
+        XCTAssertEqual(german.count, DictionaryTrainingService.requiredSampleCount)
+        XCTAssertEqual(
+            english,
+            DictionaryTrainingService.exampleSentences(for: "TypeWhisper", localeIdentifier: "en_US")
+        )
+        XCTAssertNotEqual(english, german)
+        XCTAssertTrue((english + german).allSatisfy {
+            DictionaryTrainingService.sentenceContainsTargetExactlyOnce($0, target: "TypeWhisper")
+        })
+        XCTAssertTrue(DictionaryTrainingService.isValidCanonicalWord("TypeWhisper"))
+        XCTAssertFalse(DictionaryTrainingService.isValidCanonicalWord("Type Whisper"))
+        XCTAssertFalse(DictionaryTrainingService.isValidCanonicalWord("TypeWhisper!"))
+    }
+
+    @MainActor
+    func testEvaluatorAcceptsOnlyOneUnambiguousTargetWordDifference() {
+        XCTAssertEqual(
+            DictionaryTrainingService.evaluate(
+                expectedSentence: "Please write TypeWhisper today.",
+                rawTranscript: "Please write TypeWisper today.",
+                targetWord: "TypeWhisper"
+            ),
+            .candidate("TypeWisper")
+        )
+        XCTAssertEqual(
+            DictionaryTrainingService.evaluate(
+                expectedSentence: "Please write TypeWhisper today.",
+                rawTranscript: "Please write TypeWhisper today!",
+                targetWord: "TypeWhisper"
+            ),
+            .correct
+        )
+        XCTAssertEqual(
+            DictionaryTrainingService.evaluate(
+                expectedSentence: "Please write TypeWhisper today.",
+                rawTranscript: "Please write typewhisper today.",
+                targetWord: "TypeWhisper"
+            ),
+            .skipped
+        )
+        XCTAssertEqual(
+            DictionaryTrainingService.evaluate(
+                expectedSentence: "Please write TypeWhisper today.",
+                rawTranscript: "Please now write TypeWisper today.",
+                targetWord: "TypeWhisper"
+            ),
+            .skipped
+        )
+        XCTAssertEqual(
+            DictionaryTrainingService.evaluate(
+                expectedSentence: "Please write TypeWhisper today.",
+                rawTranscript: "Please type TypeWisper today.",
+                targetWord: "TypeWhisper"
+            ),
+            .skipped
+        )
+        XCTAssertEqual(
+            DictionaryTrainingService.evaluate(
+                expectedSentence: "Please write TypeWhisper today.",
+                rawTranscript: "",
+                targetWord: "TypeWhisper"
+            ),
+            .skipped
+        )
+    }
+
+    @MainActor
+    func testThreeSamplesUseRawSnapshotTranscriptionAndDeduplicateCandidates() async throws {
+        let snapshot = makeSnapshot()
+        var requests: [DictionaryTrainingTranscriptionRequest] = []
+        var transcriptIndex = 0
+        var commitWord: String?
+        var commitCandidates: [String] = []
+        let transcripts = [
+            "Today I want to say TypeWisper clearly.",
+            "Please write TypeWisper in this sentence.",
+            "The important word today is TypeWhispr."
+        ]
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {},
+            stopRecording: { [0.1, 0.2] },
+            discardActiveRecording: {},
+            transcribe: { request in
+                requests.append(request)
+                defer { transcriptIndex += 1 }
+                return transcripts[transcriptIndex]
+            },
+            dictionaryEntries: { [] },
+            commit: { word, candidates in
+                commitWord = word
+                commitCandidates = candidates
+                return DictionaryTrainingCommitResult(
+                    addedTerm: true,
+                    addedCorrections: candidates,
+                    duplicateCorrections: [],
+                    conflictingCorrections: []
+                )
+            }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        XCTAssertEqual(service.engineSnapshot, snapshot)
+
+        for sample in service.samples {
+            await service.startRecording(sampleID: sample.id)
+            await service.stopRecordingAndTranscribe(sampleID: sample.id)
+        }
+
+        XCTAssertTrue(service.canProceedToReview)
+        XCTAssertEqual(requests.count, 3)
+        XCTAssertTrue(requests.allSatisfy {
+            $0.snapshot == snapshot &&
+                $0.prompt == nil &&
+                $0.dictionaryTermHints.isEmpty &&
+                !$0.normalizeNumbers
+        })
+
+        service.proceedToReview()
+        XCTAssertEqual(service.candidates.map(\.original), ["TypeWisper", "TypeWhispr"])
+        XCTAssertEqual(service.selectedCandidateCount, 2)
+
+        let firstCandidateID = service.candidates[0].id
+        let secondCandidateID = service.candidates[1].id
+        service.updateCandidate(id: secondCandidateID, original: "TypeWisper")
+        XCTAssertEqual(service.selectedCandidateCount, 1)
+        XCTAssertEqual(service.candidates[0].disposition, .invalid)
+        service.updateCandidate(id: secondCandidateID, original: "TypeWhispr")
+        XCTAssertEqual(service.selectedCandidateCount, 2)
+        XCTAssertEqual(service.candidates[0].disposition, .available)
+        XCTAssertEqual(service.candidates[0].id, firstCandidateID)
+
+        service.confirm()
+        XCTAssertEqual(commitWord, "TypeWhisper")
+        XCTAssertEqual(commitCandidates, ["TypeWisper", "TypeWhispr"])
+        XCTAssertEqual(service.stage, .summary)
+    }
+
+    @MainActor
+    func testFailedSampleCanRetryWithoutLosingCompletedSamples() async {
+        let snapshot = makeSnapshot()
+        var shouldFail = false
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {},
+            stopRecording: { [0.1] },
+            discardActiveRecording: {},
+            transcribe: { request in
+                if shouldFail { throw TestError.transcriptionFailed }
+                return request.snapshot.providerID == snapshot.providerID
+                    ? "Today I want to say TypeWhisper clearly."
+                    : ""
+            },
+            dictionaryEntries: { [] },
+            commit: { [self] _, _ in self.emptyCommitResult() }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        let first = service.samples[0]
+        await service.startRecording(sampleID: first.id)
+        await service.stopRecordingAndTranscribe(sampleID: first.id)
+        XCTAssertEqual(service.samples[0].state, .completed)
+
+        shouldFail = true
+        let second = service.samples[1]
+        await service.startRecording(sampleID: second.id)
+        await service.stopRecordingAndTranscribe(sampleID: second.id)
+        guard case .failed = service.samples[1].state else {
+            return XCTFail("Expected failed sample")
+        }
+        XCTAssertEqual(service.samples[0].state, .completed)
+
+        shouldFail = false
+        service.retrySample(id: second.id)
+        await service.startRecording(sampleID: second.id)
+        service.updateSentence(id: second.id, sentence: "Today I want to say TypeWhisper clearly.")
+        await service.stopRecordingAndTranscribe(sampleID: second.id)
+        XCTAssertEqual(service.samples[1].state, .completed)
+        XCTAssertEqual(service.samples[0].state, .completed)
+    }
+
+    @MainActor
+    func testCancelDuringRecordingDiscardsAudioWithoutDictionaryMutation() async {
+        let snapshot = makeSnapshot()
+        var stopCount = 0
+        var discardCount = 0
+        var commitCount = 0
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {},
+            stopRecording: {
+                stopCount += 1
+                return [0.1]
+            },
+            discardActiveRecording: { discardCount += 1 },
+            transcribe: { _ in "unused" },
+            dictionaryEntries: { [] },
+            commit: { _, _ in
+                commitCount += 1
+                return self.emptyCommitResult()
+            }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        await service.startRecording(sampleID: service.samples[0].id)
+        await service.cancel()
+
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertGreaterThanOrEqual(discardCount, 1)
+        XCTAssertEqual(commitCount, 0)
+        XCTAssertEqual(service.stage, .word)
+    }
+
+    @MainActor
+    func testLateTranscriptionResultCannotMutateCancelledSession() async {
+        let snapshot = makeSnapshot()
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {},
+            stopRecording: { [0.1] },
+            discardActiveRecording: {},
+            transcribe: { _ in
+                try await Task.sleep(for: .milliseconds(30))
+                return "Today I want to say TypeWisper clearly."
+            },
+            dictionaryEntries: { [] },
+            commit: { [self] _, _ in self.emptyCommitResult() }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        let sampleID = service.samples[0].id
+        await service.startRecording(sampleID: sampleID)
+        let transcription = Task { @MainActor in
+            await service.stopRecordingAndTranscribe(sampleID: sampleID)
+        }
+        await Task.yield()
+        await service.cancel()
+        await transcription.value
+
+        XCTAssertEqual(service.stage, .word)
+        XCTAssertTrue(service.samples.isEmpty)
+        XCTAssertTrue(service.candidates.isEmpty)
+    }
+
+    @MainActor
+    func testDictionaryCommitAddsManualFlatEntriesAndSkipsDuplicateAndConflict() throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(directory) }
+        let dictionary = DictionaryService(appSupportDirectory: directory)
+        dictionary.addEntry(type: .correction, original: "TypeWisper", replacement: "TypeWhisper")
+        dictionary.addEntry(type: .correction, original: "TypeWhispr", replacement: "Other")
+
+        let result = try dictionary.applyDictionaryTraining(
+            canonicalWord: "TypeWhisper",
+            approvedCandidates: ["TypeWisper", "TypeWhispr", "TypeWhispper", "typewhispper"]
+        )
+
+        XCTAssertTrue(result.addedTerm)
+        XCTAssertEqual(result.addedCorrections, ["TypeWhispper"])
+        XCTAssertEqual(result.duplicateCorrections, ["TypeWisper"])
+        XCTAssertEqual(result.conflictingCorrections, ["TypeWhispr"])
+        XCTAssertTrue(dictionary.entries.contains {
+            $0.type == .term && $0.original == "TypeWhisper" && $0.source == .manual
+        })
+        XCTAssertTrue(dictionary.entries.contains {
+            $0.type == .correction &&
+                $0.original == "TypeWhispper" &&
+                $0.replacement == "TypeWhisper" &&
+                $0.source == .manual
+        })
+        XCTAssertEqual(
+            dictionary.entries.first { $0.original == "TypeWhispr" }?.replacement,
+            "Other"
+        )
+    }
+
+    @MainActor
+    func testDictionaryCommitRollsBackTermAndCorrectionsOnSaveFailure() throws {
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(directory) }
+        let dictionary = DictionaryService(appSupportDirectory: directory)
+        dictionary.setTrainingSaveOverrideForTesting { throw TestError.saveFailed }
+
+        XCTAssertThrowsError(try dictionary.applyDictionaryTraining(
+            canonicalWord: "TypeWhisper",
+            approvedCandidates: ["TypeWisper"]
+        ))
+        XCTAssertTrue(dictionary.entries.isEmpty)
+    }
+
+    private func makeSnapshot() -> DictionaryTrainingEngineSnapshot {
+        DictionaryTrainingEngineSnapshot(
+            providerID: "mock-engine",
+            engineName: "Mock Engine",
+            modelID: "mock-model",
+            modelName: "Mock Model",
+            languageSelection: .exact("en")
+        )
+    }
+
+    @MainActor
+    private func emptyCommitResult() -> DictionaryTrainingCommitResult {
+        DictionaryTrainingCommitResult(
+            addedTerm: false,
+            addedCorrections: [],
+            duplicateCorrections: [],
+            conflictingCorrections: []
+        )
+    }
+}


### PR DESCRIPTION
## Issue context

Issue #870 asks for a guided microphone flow that captures real ASR misrecognitions for one canonical word, while keeping the process conservative and review-driven. The trainer must use raw transcription output, avoid model fine-tuning and cloud-generated sentences, leave no dictionary changes before confirmation, and never overwrite conflicting corrections.

Closes #870

## What changed

- add a native four-stage Dictionary training sheet for choosing a word, recording three editable localized samples, reviewing candidates, and showing the commit summary
- snapshot the selected engine, model, and language for the session and transcribe through the existing microphone path without prompts, dictionary hints, number normalization, or normal post-processing
- accept only a single unambiguous target-word difference, skip correct or ambiguous results, and deduplicate candidates case- and diacritic-insensitively
- allow candidates to be edited and selected while clearly showing duplicates, invalid values, and existing replacement conflicts
- atomically add the canonical term and approved flat manual corrections, rechecking duplicates/conflicts immediately before save and rolling back the whole mutation on failure
- clean up active recording state on retry, cancellation, dismissal, and late transcription completion
- add focused coverage for sentence generation, conservative comparison, snapshot/raw transcription inputs, retries, cancellation races, candidate deduplication, conflict handling, and rollback

## User impact

Users can teach TypeWhisper a difficult word from actual microphone samples without predicting spelling variants manually. Nothing is persisted until the review is confirmed, and existing conflicting corrections are preserved.

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryTrainingServiceTests -only-testing:TypeWhisperTests/DictionaryServiceTests
```

Result: 46 tests passed with 0 failures.

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/7752/typewhisper-mac
```

Result: signed development build succeeded, signature and development App Group were verified, and the app launched for manual testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided “Train Word…” flow in Dictionary Settings, including localized example generation.
  * Record and transcribe example sentences to generate suggested candidate corrections.
  * Review, edit, and commit approved candidates to the dictionary, with an end-of-training summary.
  * Integrated a dictionary training service and supporting unit test coverage.
* **Bug Fixes**
  * Prevented cancelled or outdated training results from mutating the current training session.
  * Ensured dictionary training commits roll back if saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->