### PR TITLE
Forward-port WhisperKit slow model loading fix

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "TypeWhisperPluginSDKTesting", targets: ["TypeWhisperPluginSDKTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", branch: "main"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "2ea0727541135c34189194084531337a3518e1bf"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
         // swift-transformers 1.3.3 is incompatible with swift-jinja 2.4's ObjectKey API.

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -12,7 +12,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     private static let maxConditioningPromptChars = 500
     private static let modelRepo = "argmaxinc/whisperkit-coreml"
     private static let modelEndpoint = "https://huggingface.co"
-    private static let defaultModelLoadTimeoutDuration: Duration = .seconds(600)
+    private static let defaultSlowModelLoadWarningDuration: Duration = .seconds(600)
 
     fileprivate var host: HostServices?
     fileprivate var whisperKit: WhisperKit?
@@ -23,7 +23,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     fileprivate var modelState: WhisperModelState = .notLoaded
     fileprivate var downloadProgress: Double = 0
     private var modelLoadGeneration = 0
-    fileprivate var modelLoadTimeoutDuration = WhisperKitPlugin.defaultModelLoadTimeoutDuration
+    fileprivate var slowModelLoadWarningDuration = WhisperKitPlugin.defaultSlowModelLoadWarningDuration
     #if DEBUG
     private(set) var restoreLoadedModelInvocationCountForTesting = 0
     #endif
@@ -104,10 +104,10 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         loadingModelId = nil
     }
 
-    private func startModelLoadTimeout(generation: Int, modelName: String) {
-        let timeout = modelLoadTimeoutDuration
+    private func startSlowModelLoadWarning(generation: Int) {
+        let warningDelay = slowModelLoadWarningDuration
         Task { [weak self] in
-            try? await Task.sleep(for: timeout)
+            try? await Task.sleep(for: warningDelay)
             guard let self,
                   self.isCurrentModelLoad(generation),
                   self.loadedModelId == nil else {
@@ -116,16 +116,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
             switch self.modelState {
             case .loading:
-                self.invalidateModelLoad()
-                self.releaseWhisperKitResources()
-                self.whisperKit = nil
-                self.loadedModelId = nil
-                self.loadingModelId = nil
-                self.downloadProgress = 0
-                self.modelState = .error(
-                    "Model load is taking too long while macOS compiles \(modelName) for the Neural Engine. Try again, or remove and re-download the model."
-                )
-                self.host?.setUserDefault(nil, forKey: "loadedModel")
+                self.modelState = .loading(phase: "slow")
                 self.host?.notifyCapabilitiesChanged()
             default:
                 break
@@ -521,7 +512,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             // Load
             modelState = .loading(phase: "compiling")
             downloadProgress = 0.80
-            startModelLoadTimeout(generation: loadGeneration, modelName: modelDef.displayName)
+            startSlowModelLoadWarning(generation: loadGeneration)
 
             let config = WhisperKitConfig(
                 downloadBase: downloadBase,
@@ -634,15 +625,15 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         modelState = .loading(phase: phase)
     }
 
-    func setModelLoadTimeoutForTesting(_ timeout: Duration) {
-        modelLoadTimeoutDuration = timeout
+    func setSlowModelLoadWarningDurationForTesting(_ duration: Duration) {
+        slowModelLoadWarningDuration = duration
     }
 
-    func startModelLoadTimeoutForTesting(modelName: String) {
+    func startSlowModelLoadWarningForTesting() {
         let generation = beginModelLoad()
         loadingModelId = selectedModelId
         modelState = .loading(phase: "compiling")
-        startModelLoadTimeout(generation: generation, modelName: modelName)
+        startSlowModelLoadWarning(generation: generation)
     }
 
     func restoreTargetModelIdForTesting(allowDownloads: Bool = true) -> String? {
@@ -881,6 +872,8 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             switch phase {
             case "compiling", "prewarming":
                 message = "Optimizing model"
+            case "slow":
+                message = "Model optimization is taking longer than expected"
             case "loading":
                 message = "Loading model"
             default:
@@ -1377,6 +1370,8 @@ private struct WhisperKitSettingsView: View {
         switch phase {
         case "compiling", "prewarming":
             String(localized: "Optimizing for Neural Engine...", bundle: bundle)
+        case "slow":
+            String(localized: "Still optimizing for Neural Engine...", bundle: bundle)
         case "loading":
             String(localized: "Loading model...", bundle: bundle)
         default:

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -320,27 +320,34 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(plugin.settingsModelState, .ready("openai_whisper-large-v3_turbo"))
     }
 
-    func testModelLoadTimeoutClearsPersistedLoadedModelAndReportsError() async throws {
+    func testSlowModelLoadWarningKeepsLoadActiveAndPreventsRetry() async throws {
         let host = try makeHost(defaults: [
             "selectedModel": "openai_whisper-large-v3_turbo",
             "loadedModel": "openai_whisper-large-v3_turbo",
-        ])
+        ], shouldRestoreLoadedModelsPassively: false)
         defer { TestSupport.remove(host.pluginDataDirectory) }
 
         let plugin = WhisperKitPlugin()
         plugin.activate(host: host)
-        plugin.setModelLoadTimeoutForTesting(.milliseconds(10))
-        plugin.startModelLoadTimeoutForTesting(modelName: "Large v3 Turbo")
+        plugin.setSlowModelLoadWarningDurationForTesting(.milliseconds(10))
+        plugin.startSlowModelLoadWarningForTesting()
+        let generation = plugin.modelLoadGenerationForTesting
 
         try await Task.sleep(for: .milliseconds(50))
 
         XCTAssertFalse(plugin.isConfigured)
-        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-large-v3_turbo")
         XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai_whisper-large-v3_turbo")
-        XCTAssertEqual(plugin.currentSettingsActivity?.isError, true)
+        XCTAssertEqual(plugin.currentSettingsActivity?.isError, false)
+        XCTAssertEqual(plugin.currentSettingsActivity?.message, "Model optimization is taking longer than expected")
         XCTAssertEqual(host.capabilitiesChangedCount, 1)
-        XCTAssertTrue(plugin.currentSettingsActivity?.message.contains("Large v3 Turbo") == true)
-        XCTAssertNil(plugin.loadingModelIdForTesting)
+        XCTAssertEqual(plugin.loadingModelIdForTesting, "openai_whisper-large-v3_turbo")
+        XCTAssertEqual(plugin.modelLoadGenerationForTesting, generation)
+
+        await plugin.restoreLoadedModel(allowDownloads: true)
+
+        XCTAssertEqual(plugin.loadingModelIdForTesting, "openai_whisper-large-v3_turbo")
+        XCTAssertEqual(plugin.modelLoadGenerationForTesting, generation)
     }
 
     func testActivationDoesNotMarkPluginConfiguredBeforeRestoreSucceeds() async throws {


### PR DESCRIPTION
## Issue context

Issue #829's latest diagnostics showed that Large v3 Turbo was still compiling for the Neural Engine when WhisperKitPlugin's own 600-second watchdog marked the load as failed. That discarded a later successful completion and allowed a duplicate retry to overlap.

This forward-ports the release/1.5 fix from #880 to `main`. The slow watchdog now changes the loading phase to an informational warning while preserving the active load, generation, persisted model selection, and duplicate-load guard. It also keeps the FluidAudio dependency deterministic at the revision already used by the app workspace.

WhisperKitPlugin 1.1.3 has already been released from the corresponding release/1.5 merge.

Closes #829

## Test plan

- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning state when model optimization takes longer than expected, while preserving the selected and previously loaded model.
  * Updated settings activity and model status messages to clearly indicate slow optimization.

* **Bug Fixes**
  * Slow model loading no longer incorrectly clears model information or reports a failure.

* **Chores**
  * Pinned the audio dependency to a specific revision.
  * Updated the WhisperKit plugin version to 1.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->