### PR TITLE
Fix webhook editor presentation

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -167,23 +167,51 @@ jobs:
             -project TypeWhisper.xcodeproj \
             -scheme TypeWhisper
 
-      - name: Patch manifest version
+      - name: Validate release manifest
         run: |
           MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
           if [ ! -f "$MANIFEST" ]; then
             echo "Missing manifest for ${TARGET}: $MANIFEST"
             exit 1
           fi
-          python3 -c "
+          export MANIFEST
+          python3 <<'PYEOF'
           import json
-          with open('$MANIFEST', 'r') as f:
-              m = json.load(f)
-          m['version'] = '$PLUGIN_VERSION'
-          with open('$MANIFEST', 'w') as f:
-              json.dump(m, f, indent=4)
-              f.write('\n')
-          "
-          echo "Patched $MANIFEST to version $PLUGIN_VERSION"
+          import os
+          import re
+
+          manifest_path = os.environ["MANIFEST"]
+          expected_version = os.environ["PLUGIN_VERSION"]
+
+          with open(manifest_path) as manifest_file:
+              manifest = json.load(manifest_file)
+
+          actual_version = manifest.get("version")
+          if actual_version != expected_version:
+              raise SystemExit(
+                  f"manifest version {actual_version!r} does not match release version {expected_version!r}"
+              )
+
+          min_host_version = manifest.get("minHostVersion")
+          if not isinstance(min_host_version, str) or not re.fullmatch(
+              r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?",
+              min_host_version,
+          ):
+              raise SystemExit(
+                  f"manifest minHostVersion {min_host_version!r} must be a semantic version"
+              )
+
+          sdk_compatibility_version = manifest.get("sdkCompatibilityVersion")
+          if not isinstance(sdk_compatibility_version, str) or not re.fullmatch(
+              r"v[1-9][0-9]*",
+              sdk_compatibility_version,
+          ):
+              raise SystemExit(
+                  "manifest sdkCompatibilityVersion "
+                  f"{sdk_compatibility_version!r} must use the format vN"
+              )
+          PYEOF
+          echo "Validated $MANIFEST for release $PLUGIN_VERSION"
           cat "$MANIFEST"
 
       - name: Build Plugin

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
@@ -83,6 +83,25 @@ final class WebhookPluginTests: XCTestCase {
         XCTAssertEqual(service.webhooks.first?.url, "https://example.com/updated")
     }
 
+    func testWebhookEditorPresentationHandlesAddEditAndDismiss() throws {
+        var presentation = ExampleWebhookEditorPresentation()
+
+        XCTAssertNil(presentation.editingWebhook)
+
+        presentation.beginAddingWebhook()
+        XCTAssertTrue(try XCTUnwrap(presentation.editingWebhook).isUnmodifiedDefaultDraft)
+
+        presentation.dismissEditor()
+        XCTAssertNil(presentation.editingWebhook)
+
+        let existingWebhook = ExampleWebhookConfig(
+            name: "Existing Hook",
+            url: "https://example.com/existing"
+        )
+        presentation.beginEditingWebhook(existingWebhook)
+        XCTAssertEqual(presentation.editingWebhook?.id, existingWebhook.id)
+    }
+
     func testLoadRemovesOnlyUnmodifiedDefaultDrafts() throws {
         let host = try PluginTestHostServices()
         let emptyDraft = ExampleWebhookConfig()

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -431,15 +431,51 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
 
 // MARK: - Settings View
 
+struct ExampleWebhookEditorPresentation {
+    private(set) var editingWebhook: ExampleWebhookConfig?
+
+    mutating func beginAddingWebhook() {
+        editingWebhook = ExampleWebhookConfig()
+    }
+
+    mutating func beginEditingWebhook(_ webhook: ExampleWebhookConfig) {
+        editingWebhook = webhook
+    }
+
+    mutating func dismissEditor() {
+        editingWebhook = nil
+    }
+}
+
 struct ExampleWebhookSettingsView: View {
     @ObservedObject var service: ExampleWebhookService
     @Environment(\.dismiss) private var dismiss
     @Environment(\.pluginSettingsClose) private var closeSettings
-    @State private var editingWebhook: ExampleWebhookConfig?
+    @State private var editorPresentation = ExampleWebhookEditorPresentation()
 
     private let bundle = Bundle(for: ExampleWebhookService.self)
 
     var body: some View {
+        Group {
+            if let editingWebhook = editorPresentation.editingWebhook {
+                ExampleWebhookEditView(
+                    webhook: editingWebhook,
+                    availableProfiles: service.host.availableRuleNames,
+                    onSave: { updated in
+                        service.saveWebhook(updated)
+                        editorPresentation.dismissEditor()
+                    },
+                    onCancel: { editorPresentation.dismissEditor() }
+                )
+                .id(editingWebhook.id)
+            } else {
+                webhookOverview
+            }
+        }
+        .frame(minHeight: 400)
+    }
+
+    private var webhookOverview: some View {
         VStack(spacing: 0) {
             // Toolbar
             HStack {
@@ -447,7 +483,7 @@ struct ExampleWebhookSettingsView: View {
                     .font(.headline)
                 Spacer()
                 Button {
-                    editingWebhook = ExampleWebhookConfig()
+                    editorPresentation.beginAddingWebhook()
                 } label: {
                     Label(String(localized: "Add Webhook", bundle: bundle), systemImage: "plus")
                 }
@@ -470,7 +506,7 @@ struct ExampleWebhookSettingsView: View {
                 List {
                     ForEach(service.webhooks) { webhook in
                         WebhookRow(webhook: webhook, service: service, onEdit: {
-                            editingWebhook = webhook
+                            editorPresentation.beginEditingWebhook(webhook)
                         })
                     }
 
@@ -499,17 +535,6 @@ struct ExampleWebhookSettingsView: View {
                 .keyboardShortcut(.cancelAction)
             }
             .padding()
-        }
-        .sheet(item: $editingWebhook) { webhook in
-            ExampleWebhookEditView(
-                webhook: webhook,
-                availableProfiles: service.host.availableRuleNames,
-                onSave: { updated in
-                    service.saveWebhook(updated)
-                    editingWebhook = nil
-                },
-                onCancel: { editingWebhook = nil }
-            )
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.webhook",
     "name": "Webhook Notifications",
-    "version": "1.0.9",
+    "version": "1.0.15",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

This is a follow-up to #871. The v1.0.14 fix corrected draft creation and persistence, but the editor was still presented as a nested SwiftUI sheet inside the separately hosted plugin settings window. In practice, clicking **Add Webhook** changed state without showing an editor, so users still could not add a webhook URL.

The release workflow also rewrote only the version in its temporary checkout, which allowed the committed manifest version to drift from released artifacts while host and SDK compatibility continued to come from source metadata.

## What changed

- render the add/edit form inline inside the existing plugin settings window
- keep add, edit, cancel, and save transitions in a dedicated presentation state
- preserve the existing `saveWebhook` upsert and secret-storage behavior
- add regression coverage for add, edit, and dismiss presentation transitions
- bump the source plugin manifest to v1.0.15
- make the release workflow validate, rather than rewrite, manifest metadata
- require the committed manifest version to match the release input
- validate `minHostVersion` and `sdkCompatibilityVersion` before building and publishing

## User impact

Clicking **Add Webhook** now visibly opens the form in the current window, and saved webhook URLs continue through the existing persistence and delivery path. Plugin bundles and registry entries are now guaranteed to use the compatibility metadata from the reviewed source manifest.

## Test plan

- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json`
- `swift test --package-path TypeWhisperPluginSDK --filter WebhookPluginTests`
- `actionlint -ignore 'SC2086' -ignore 'SC2129' .github/workflows/plugin-release.yml`
- execute the extracted `Validate release manifest` step with `PLUGIN_VERSION=1.0.15 TARGET=WebhookPlugin`
- verify the same step rejects `PLUGIN_VERSION=1.0.14`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run WebhookPlugin /Users/marco/.codex/worktrees/b6c0/typewhisper-mac`
- In TypeWhisper-Dev, open Webhook Notifications, click **Add Webhook**, and verify the inline editor appears
- Save a webhook URL and verify the configured webhook appears in the list
- Send a synthetic POST to the provided webhook.site endpoint and verify HTTP 200

## Release

After merge, release the official Webhook plugin as v1.0.15.

Refs #871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook creation and editing now open directly within the settings interface (inline editor).
  - Editing/add actions now follow a unified editor presentation flow.

- **Bug Fixes**
  - Improved webhook editor state handling across add, edit, and dismiss to ensure the correct draft is shown.

- **Tests**
  - Added XCTest coverage for the editor presentation transitions (add, edit, dismiss).

- **Chores**
  - Updated the Webhook plugin version to **1.0.15**.
  - Enhanced the release workflow to validate plugin manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->