### PR TITLE
Keep login launches windowless

### DIFF
--- a/TypeWhisper/App/PostUpdatePromptCoordinator.swift
+++ b/TypeWhisper/App/PostUpdatePromptCoordinator.swift
@@ -8,6 +8,28 @@ enum StartupSheetRoute: String, Identifiable {
     var id: String { rawValue }
 }
 
+enum InitialWindowPresentation: Equatable {
+    case setup
+    case none
+}
+
+enum InitialWindowPresentationPolicy {
+    static func presentation(
+        setupWizardRequired: Bool,
+        postUpdatePromptPending: Bool
+    ) -> InitialWindowPresentation {
+        switch (setupWizardRequired, postUpdatePromptPending) {
+        case (true, _):
+            return .setup
+        case (false, true):
+            // Keep background launches windowless; the prompt remains available in Settings.
+            return .none
+        case (false, false):
+            return .none
+        }
+    }
+}
+
 @MainActor
 final class PostUpdatePromptCoordinator {
     nonisolated(unsafe) static var shared: PostUpdatePromptCoordinator!
@@ -41,10 +63,6 @@ final class PostUpdatePromptCoordinator {
         }
 
         return acknowledgedReleaseFingerprint != currentReleaseFingerprint
-    }
-
-    var shouldAutoOpenSettingsOnLaunch: Bool {
-        shouldPresentPrompt
     }
 
     var activeSheetRoute: StartupSheetRoute? {

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -546,17 +546,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             AudioRecorderViewModel.shared.toggleRecording()
         }
 
-        // Auto-open the standalone setup assistant while first-run setup is incomplete.
-        if HomeViewModel.shared.showSetupWizard {
+        let initialWindowPresentation = InitialWindowPresentationPolicy.presentation(
+            setupWizardRequired: HomeViewModel.shared.showSetupWizard,
+            postUpdatePromptPending: PostUpdatePromptCoordinator.shared.shouldPresentPrompt
+        )
+
+        // Auto-open only the standalone setup assistant while first-run setup is incomplete.
+        // Post-update prompts wait until the user opens Settings interactively.
+        if initialWindowPresentation == .setup {
             UserDefaults.standard.set(false, forKey: UserDefaultsKeys.setupWizardCompleted)
             HomeViewModel.shared.showSetupWizard = true
             NSApp.setActivationPolicy(.regular)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.openSetupWindow()
-            }
-        } else if PostUpdatePromptCoordinator.shared.shouldAutoOpenSettingsOnLaunch {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                self.openSettingsWindow()
             }
         }
 

--- a/TypeWhisperTests/PostUpdatePromptCoordinatorTests.swift
+++ b/TypeWhisperTests/PostUpdatePromptCoordinatorTests.swift
@@ -3,6 +3,67 @@ import XCTest
 
 @MainActor
 final class PostUpdatePromptCoordinatorTests: XCTestCase {
+    func testInitialWindowPolicyOpensSetupWhenRequired() {
+        XCTAssertEqual(
+            InitialWindowPresentationPolicy.presentation(
+                setupWizardRequired: true,
+                postUpdatePromptPending: false
+            ),
+            .setup
+        )
+        XCTAssertEqual(
+            InitialWindowPresentationPolicy.presentation(
+                setupWizardRequired: true,
+                postUpdatePromptPending: true
+            ),
+            .setup
+        )
+    }
+
+    func testInitialWindowPolicyKeepsCompletedSetupWindowlessWithPendingPrompt() {
+        XCTAssertEqual(
+            InitialWindowPresentationPolicy.presentation(
+                setupWizardRequired: false,
+                postUpdatePromptPending: true
+            ),
+            .none
+        )
+    }
+
+    func testInitialWindowPolicyKeepsCompletedSetupWindowlessWithoutPrompt() {
+        XCTAssertEqual(
+            InitialWindowPresentationPolicy.presentation(
+                setupWizardRequired: false,
+                postUpdatePromptPending: false
+            ),
+            .none
+        )
+    }
+
+    func testPendingPromptRemainsAvailableForInteractiveSettingsPresentation() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsKeys.welcomeSheetShown)
+        defaults.set("1.2.9+99@stable", forKey: UserDefaultsKeys.lastSeenReleaseFingerprint)
+
+        let license = LicenseService(defaults: defaults)
+        let coordinator = PostUpdatePromptCoordinator(
+            defaults: defaults,
+            licenseService: license,
+            currentReleaseFingerprint: "1.3.0+123@stable"
+        )
+
+        XCTAssertEqual(
+            InitialWindowPresentationPolicy.presentation(
+                setupWizardRequired: false,
+                postUpdatePromptPending: coordinator.shouldPresentPrompt
+            ),
+            .none
+        )
+        XCTAssertEqual(coordinator.activeSheetRoute, .postUpdateLicensing)
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.lastAcknowledgedPostUpdatePromptRelease))
+    }
+
     func testMissingVersionMarkerAndPendingWelcomeSeedsCurrentReleaseWithoutPrompting() throws {
         let (defaults, suiteName) = try makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }


### PR DESCRIPTION
## Summary

- keep login and other background launches windowless when a post-update licensing prompt is pending
- continue opening the setup assistant automatically when first-run setup is incomplete
- preserve interactive Settings reopening and keep pending prompts available there
- add regression coverage for every initial-window policy state

## Issue context

Issue #877 reports that TypeWhisper opens Settings after every macOS login instead of starting silently in the menu bar.

The root cause was that `applicationDidFinishLaunching` treated a pending post-update licensing prompt as a reason to open Settings on every process launch. That path also runs when macOS starts the app through its registered login item.

This change limits automatic initial-window presentation to the incomplete setup assistant. A pending post-update prompt remains available and unacknowledged until the user opens Settings interactively.

Closes #877

## Test plan

- Targeted tests:

  ```sh
  xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/PostUpdatePromptCoordinatorTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
  ```

- Full test suite:

  ```sh
  xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
  ```

- Signed development build:

  ```sh
  /Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/9391/typewhisper-mac
  ```

- Manual startup smoke with a pending prompt:
  - background launch: 0 visible windows, app not activated
  - interactive reopen: 1 visible Settings window
  - prompt remained unacknowledged
  - restored the original development preferences afterward


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved launch behavior by automatically opening the setup wizard when setup is required.
  * Post-update licensing prompts are now presented when Settings is opened, rather than opening Settings automatically.
* **Bug Fixes**
  * Prevented unnecessary Settings windows from appearing during launch after updates.
* **Tests**
  * Added coverage for setup presentation and interactive post-update prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->