### PR TITLE
Improve webhook settings layout

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Localizable.xcstrings
@@ -1,22 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "Active for all transcriptions.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktiv für alle Transkriptionen."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべての文字起こしにアクティブ。"
-          }
-        }
-      }
-    },
     "Add a webhook to send transcription data to external services.": {
       "localizations": {
         "de": {
@@ -45,6 +29,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Webhookを追加"
+          }
+        }
+      }
+    },
+    "All transcriptions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Transkriptionen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての文字起こし"
           }
         }
       }
@@ -161,22 +161,6 @@
         }
       }
     },
-    "No profiles configured.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine Profile konfiguriert."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "構成されたプロファイルはありません。"
-          }
-        }
-      }
-    },
     "No Webhooks": {
       "localizations": {
         "de": {
@@ -193,34 +177,18 @@
         }
       }
     },
-    "Only active for selected profiles.": {
+    "No workflows configured.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nur aktiv für ausgewählte Profile."
+            "value": "Keine Workflows konfiguriert."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "選択したプロファイルのみでアクティブ。"
-          }
-        }
-      }
-    },
-    "Profiles": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profile"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイル"
+            "value": "ワークフローが設定されていません。"
           }
         }
       }
@@ -237,6 +205,86 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存"
+          }
+        }
+      }
+    },
+    "Select at least one workflow.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle mindestens einen Workflow aus."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1つ以上のワークフローを選択してください。"
+          }
+        }
+      }
+    },
+    "Selected workflows": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Workflows"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したワークフロー"
+          }
+        }
+      }
+    },
+    "Send webhook for": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webhook senden für"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webhookの送信対象"
+          }
+        }
+      }
+    },
+    "The webhook is sent after every transcription, including transcriptions without a workflow.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Webhook wird nach jeder Transkription gesendet, auch wenn kein Workflow verwendet wird."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークフローを使用しない場合も含め、すべての文字起こし後にWebhookを送信します。"
+          }
+        }
+      }
+    },
+    "The webhook is sent only for the selected workflows.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Webhook wird nur für die ausgewählten Workflows gesendet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したワークフローに対してのみWebhookを送信します。"
           }
         }
       }
@@ -269,6 +317,38 @@
           "stringUnit": {
             "state": "translated",
             "value": "Webhook通知"
+          }
+        }
+      }
+    },
+    "Workflows": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workflows"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークフロー"
+          }
+        }
+      }
+    },
+    "Workflows: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workflows: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークフロー：%@"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
@@ -102,6 +102,72 @@ final class WebhookPluginTests: XCTestCase {
         XCTAssertEqual(presentation.editingWebhook?.id, existingWebhook.id)
     }
 
+    func testEditorStateDerivesWorkflowScopeFromExistingConfiguration() {
+        let allTranscriptions = ExampleWebhookEditorState(webhook: ExampleWebhookConfig(
+            name: "All",
+            url: "https://example.com/all"
+        ))
+        let selectedWorkflows = ExampleWebhookEditorState(webhook: ExampleWebhookConfig(
+            name: "Selected",
+            url: "https://example.com/selected",
+            workflowFilter: ["Cleaned Text"]
+        ))
+
+        XCTAssertEqual(allTranscriptions.workflowScope, .allTranscriptions)
+        XCTAssertEqual(selectedWorkflows.workflowScope, .selectedWorkflows)
+        XCTAssertEqual(selectedWorkflows.webhook.workflowFilter, ["Cleaned Text"])
+    }
+
+    func testEditorStatePreservesSelectionWhileTogglingAndClearsItForAllOnSave() {
+        var state = ExampleWebhookEditorState(webhook: ExampleWebhookConfig(
+            name: "Selected",
+            url: "https://example.com/selected",
+            workflowFilter: ["Cleaned Text"]
+        ))
+
+        state.workflowScope = .allTranscriptions
+        XCTAssertEqual(state.webhook.workflowFilter, ["Cleaned Text"])
+        XCTAssertTrue(state.webhookForSaving.workflowFilter.isEmpty)
+
+        state.workflowScope = .selectedWorkflows
+        XCTAssertEqual(state.webhook.workflowFilter, ["Cleaned Text"])
+        XCTAssertEqual(state.webhookForSaving.workflowFilter, ["Cleaned Text"])
+    }
+
+    func testEditorStateRequiresAWorkflowWhenSelectedScopeIsActive() {
+        var state = ExampleWebhookEditorState(webhook: ExampleWebhookConfig(
+            name: "Selected",
+            url: "https://example.com/selected"
+        ))
+
+        state.workflowScope = .selectedWorkflows
+        XCTAssertFalse(state.canSave)
+
+        state.setWorkflow("Translation", isSelected: true)
+        XCTAssertTrue(state.canSave)
+        XCTAssertEqual(state.webhook.workflowFilter, ["Translation"])
+
+        state.setWorkflow("Translation", isSelected: false)
+        XCTAssertFalse(state.canSave)
+        XCTAssertTrue(state.webhook.workflowFilter.isEmpty)
+    }
+
+    func testWorkflowFilterKeepsLegacyProfileFilterStorageKey() throws {
+        let webhook = ExampleWebhookConfig(
+            name: "Compatible",
+            url: "https://example.com/compatible",
+            workflowFilter: ["Product Idea"]
+        )
+
+        let data = try JSONEncoder().encode(webhook)
+        let rawJSON = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(rawJSON.contains("\"profileFilter\""))
+        XCTAssertFalse(rawJSON.contains("\"workflowFilter\""))
+
+        let decoded = try JSONDecoder().decode(ExampleWebhookConfig.self, from: data)
+        XCTAssertEqual(decoded.workflowFilter, ["Product Idea"])
+    }
+
     func testLoadRemovesOnlyUnmodifiedDefaultDrafts() throws {
         let host = try PluginTestHostServices()
         let emptyDraft = ExampleWebhookConfig()
@@ -259,6 +325,50 @@ final class WebhookPluginTests: XCTestCase {
         let request = try XCTUnwrap(sessionStore.sessions.first?.requestedRequests.first)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer restored-token")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testSendHonorsAllAndSelectedWorkflowScopes() async throws {
+        let host = try PluginTestHostServices()
+        let service = ExampleWebhookService(dataDirectory: host.pluginDataDirectory, host: host)
+        var webhook = ExampleWebhookConfig(
+            name: "Scoped Hook",
+            url: "https://example.com/scoped"
+        )
+        service.saveWebhook(webhook)
+
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: URL(string: "https://example.com/scoped")!,
+            statusCode: 204,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let sessionStore = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            sessionStore.makeSession(outcomes: [.success(Data(), response)])
+        }
+
+        await service.sendWebhooks(for: payload(ruleName: nil))
+        XCTAssertEqual(sessionStore.sessions.first?.requestedRequests.count, 1)
+
+        webhook.workflowFilter = ["Cleaned Text"]
+        service.updateWebhook(webhook)
+
+        await service.sendWebhooks(for: payload(ruleName: nil))
+        await service.sendWebhooks(for: payload(ruleName: "Translation"))
+        XCTAssertEqual(sessionStore.sessions.first?.requestedRequests.count, 1)
+
+        await service.sendWebhooks(for: payload(ruleName: "Cleaned Text"))
+        XCTAssertEqual(sessionStore.sessions.first?.requestedRequests.count, 2)
+    }
+
+    private func payload(ruleName: String?) -> TranscriptionCompletedPayload {
+        TranscriptionCompletedPayload(
+            rawText: "raw",
+            finalText: "final",
+            engineUsed: "test",
+            durationSeconds: 1,
+            ruleName: ruleName
+        )
     }
 
     private func configURL(for host: PluginTestHostServices) -> URL {

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -77,12 +77,12 @@ struct ExampleWebhookConfig: Codable, Identifiable {
     var headers: [String: String]
     var secretHeaderNames: [String]
     var isEnabled: Bool
-    var profileFilter: [String]  // Empty = all rules
+    var workflowFilter: [String]  // Empty = all transcriptions
 
     init(name: String = "", url: String = "", httpMethod: String = "POST",
          headers: [String: String] = ["Content-Type": "application/json"],
          secretHeaderNames: [String] = [],
-         isEnabled: Bool = true, profileFilter: [String] = []) {
+         isEnabled: Bool = true, workflowFilter: [String] = []) {
         self.id = UUID()
         self.name = name
         self.url = url
@@ -90,7 +90,7 @@ struct ExampleWebhookConfig: Codable, Identifiable {
         self.headers = headers
         self.secretHeaderNames = secretHeaderNames
         self.isEnabled = isEnabled
-        self.profileFilter = profileFilter
+        self.workflowFilter = workflowFilter
     }
 
     var isUnmodifiedDefaultDraft: Bool {
@@ -100,7 +100,7 @@ struct ExampleWebhookConfig: Codable, Identifiable {
             && headers == ["Content-Type": "application/json"]
             && secretHeaderNames.isEmpty
             && isEnabled
-            && profileFilter.isEmpty
+            && workflowFilter.isEmpty
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -111,7 +111,7 @@ struct ExampleWebhookConfig: Codable, Identifiable {
         case headers
         case secretHeaderNames
         case isEnabled
-        case profileFilter
+        case workflowFilter = "profileFilter"
     }
 
     init(from decoder: Decoder) throws {
@@ -123,7 +123,7 @@ struct ExampleWebhookConfig: Codable, Identifiable {
         headers = try container.decode([String: String].self, forKey: .headers)
         secretHeaderNames = try container.decodeIfPresent([String].self, forKey: .secretHeaderNames) ?? []
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
-        profileFilter = try container.decode([String].self, forKey: .profileFilter)
+        workflowFilter = try container.decode([String].self, forKey: .workflowFilter)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -135,7 +135,7 @@ struct ExampleWebhookConfig: Codable, Identifiable {
         try container.encode(headers, forKey: .headers)
         try container.encode(secretHeaderNames, forKey: .secretHeaderNames)
         try container.encode(isEnabled, forKey: .isEnabled)
-        try container.encode(profileFilter, forKey: .profileFilter)
+        try container.encode(workflowFilter, forKey: .workflowFilter)
     }
 }
 
@@ -368,10 +368,11 @@ final class ExampleWebhookService: ObservableObject, @unchecked Sendable {
 
     func sendWebhooks(for payload: TranscriptionCompletedPayload) async {
         for webhook in webhooks where webhook.isEnabled {
-            // Rule filter: empty = all, otherwise match by name
-            if !webhook.profileFilter.isEmpty {
+            // The event still exposes the legacy ruleName compatibility field.
+            // An empty workflow filter means every completed transcription.
+            if !webhook.workflowFilter.isEmpty {
                 guard let ruleName = payload.ruleName,
-                      webhook.profileFilter.contains(ruleName) else {
+                      webhook.workflowFilter.contains(ruleName) else {
                     continue
                 }
             }
@@ -447,6 +448,42 @@ struct ExampleWebhookEditorPresentation {
     }
 }
 
+enum ExampleWebhookWorkflowScope: String, CaseIterable, Equatable {
+    case allTranscriptions
+    case selectedWorkflows
+}
+
+struct ExampleWebhookEditorState {
+    var webhook: ExampleWebhookConfig
+    var workflowScope: ExampleWebhookWorkflowScope
+
+    init(webhook: ExampleWebhookConfig) {
+        self.webhook = webhook
+        self.workflowScope = webhook.workflowFilter.isEmpty ? .allTranscriptions : .selectedWorkflows
+    }
+
+    var canSave: Bool {
+        guard !webhook.url.isEmpty else { return false }
+        return workflowScope == .allTranscriptions || !webhook.workflowFilter.isEmpty
+    }
+
+    mutating func setWorkflow(_ name: String, isSelected: Bool) {
+        if isSelected {
+            guard !webhook.workflowFilter.contains(name) else { return }
+            webhook.workflowFilter.append(name)
+        } else {
+            webhook.workflowFilter.removeAll { $0 == name }
+        }
+    }
+
+    var webhookForSaving: ExampleWebhookConfig {
+        guard workflowScope == .allTranscriptions else { return webhook }
+        var updated = webhook
+        updated.workflowFilter = []
+        return updated
+    }
+}
+
 struct ExampleWebhookSettingsView: View {
     @ObservedObject var service: ExampleWebhookService
     @Environment(\.dismiss) private var dismiss
@@ -460,7 +497,7 @@ struct ExampleWebhookSettingsView: View {
             if let editingWebhook = editorPresentation.editingWebhook {
                 ExampleWebhookEditView(
                     webhook: editingWebhook,
-                    availableProfiles: service.host.availableRuleNames,
+                    availableWorkflows: service.host.availableRuleNames,
                     onSave: { updated in
                         service.saveWebhook(updated)
                         editorPresentation.dismissEditor()
@@ -472,6 +509,8 @@ struct ExampleWebhookSettingsView: View {
                 webhookOverview
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .containerRelativeFrame(.vertical, alignment: .top)
         .frame(minHeight: 400)
     }
 
@@ -560,11 +599,9 @@ private struct WebhookRow: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
-                if !webhook.profileFilter.isEmpty {
-                    Text("Rules: \(webhook.profileFilter.joined(separator: ", "))")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
+                Text(workflowScopeDescription)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
             }
 
             Spacer()
@@ -594,6 +631,16 @@ private struct WebhookRow: View {
             .buttonStyle(.borderless)
         }
         .padding(.vertical, 4)
+    }
+
+    private var workflowScopeDescription: String {
+        guard !webhook.workflowFilter.isEmpty else {
+            return String(localized: "All transcriptions", bundle: bundle)
+        }
+        return String(
+            format: String(localized: "Workflows: %@", bundle: bundle),
+            webhook.workflowFilter.joined(separator: ", ")
+        )
     }
 }
 
@@ -634,18 +681,30 @@ private struct DeliveryLogRow: View {
 // MARK: - Edit View
 
 private struct ExampleWebhookEditView: View {
-    @State var webhook: ExampleWebhookConfig
-    let availableProfiles: [String]
+    @State private var editorState: ExampleWebhookEditorState
+    let availableWorkflows: [String]
     let onSave: (ExampleWebhookConfig) -> Void
     let onCancel: () -> Void
 
     private let bundle = Bundle(for: ExampleWebhookService.self)
 
+    init(
+        webhook: ExampleWebhookConfig,
+        availableWorkflows: [String],
+        onSave: @escaping (ExampleWebhookConfig) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        _editorState = State(initialValue: ExampleWebhookEditorState(webhook: webhook))
+        self.availableWorkflows = availableWorkflows
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                Text(webhook.name.isEmpty && webhook.url.isEmpty
+                Text(editorState.webhook.name.isEmpty && editorState.webhook.url.isEmpty
                      ? String(localized: "Add Webhook", bundle: bundle)
                      : String(localized: "Edit Webhook", bundle: bundle))
                     .font(.headline)
@@ -655,45 +714,66 @@ private struct ExampleWebhookEditView: View {
 
             Divider()
 
-            Form {
-                Section(String(localized: "General", bundle: bundle)) {
-                    TextField(String(localized: "Name", bundle: bundle), text: $webhook.name)
-                    TextField(String(localized: "URL", bundle: bundle), text: $webhook.url)
-                        .textContentType(.URL)
-                    Picker(String(localized: "Method", bundle: bundle), selection: $webhook.httpMethod) {
-                        Text("POST", bundle: bundle).tag("POST")
-                        Text("PUT", bundle: bundle).tag("PUT")
-                    }
-                }
-
-                Section("Rules") {
-                    if availableProfiles.isEmpty {
-                        Text("No rules configured.")
-                            .foregroundStyle(.secondary)
-                            .font(.caption)
-                    } else {
-                        ForEach(availableProfiles, id: \.self) { name in
-                            Toggle(name, isOn: Binding(
-                                get: { webhook.profileFilter.contains(name) },
-                                set: { selected in
-                                    if selected {
-                                        webhook.profileFilter.append(name)
-                                    } else {
-                                        webhook.profileFilter.removeAll { $0 == name }
-                                    }
-                                }
-                            ))
+            ScrollView(.vertical) {
+                Form {
+                    Section(String(localized: "General", bundle: bundle)) {
+                        TextField(
+                            String(localized: "Name", bundle: bundle),
+                            text: $editorState.webhook.name
+                        )
+                        TextField(
+                            String(localized: "URL", bundle: bundle),
+                            text: $editorState.webhook.url
+                        )
+                            .textContentType(.URL)
+                        Picker(
+                            String(localized: "Method", bundle: bundle),
+                            selection: $editorState.webhook.httpMethod
+                        ) {
+                            Text("POST", bundle: bundle).tag("POST")
+                            Text("PUT", bundle: bundle).tag("PUT")
                         }
                     }
 
-                    Text(webhook.profileFilter.isEmpty
-                         ? String(localized: "Active for all transcriptions.", bundle: bundle)
-                         : "Only active for selected rules.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    Section(String(localized: "Workflows", bundle: bundle)) {
+                        Picker(
+                            String(localized: "Send webhook for", bundle: bundle),
+                            selection: $editorState.workflowScope
+                        ) {
+                            Text("All transcriptions", bundle: bundle)
+                                .tag(ExampleWebhookWorkflowScope.allTranscriptions)
+                            Text("Selected workflows", bundle: bundle)
+                                .tag(ExampleWebhookWorkflowScope.selectedWorkflows)
+                        }
+                        .pickerStyle(.radioGroup)
+
+                        if editorState.workflowScope == .selectedWorkflows {
+                            if availableWorkflows.isEmpty {
+                                Text("No workflows configured.", bundle: bundle)
+                                    .foregroundStyle(.secondary)
+                                    .font(.caption)
+                            } else {
+                                ForEach(availableWorkflows, id: \.self) { name in
+                                    Toggle(name, isOn: Binding(
+                                        get: { editorState.webhook.workflowFilter.contains(name) },
+                                        set: { selected in
+                                            editorState.setWorkflow(name, isSelected: selected)
+                                        }
+                                    ))
+                                }
+                            }
+                        }
+
+                        Text(workflowScopeHelpText)
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                    }
                 }
+                .formStyle(.grouped)
+                .fixedSize(horizontal: false, vertical: true)
             }
-            .formStyle(.grouped)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .layoutPriority(1)
 
             Divider()
 
@@ -703,13 +783,27 @@ private struct ExampleWebhookEditView: View {
                     .keyboardShortcut(.cancelAction)
                 Spacer()
                 Button(String(localized: "Save", bundle: bundle)) {
-                    onSave(webhook)
+                    onSave(editorState.webhookForSaving)
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(webhook.url.isEmpty)
+                .disabled(!editorState.canSave)
             }
             .padding()
         }
-        .frame(width: 480, height: 420)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var workflowScopeHelpText: String {
+        switch editorState.workflowScope {
+        case .allTranscriptions:
+            return String(
+                localized: "The webhook is sent after every transcription, including transcriptions without a workflow.",
+                bundle: bundle
+            )
+        case .selectedWorkflows where editorState.webhook.workflowFilter.isEmpty:
+            return String(localized: "Select at least one workflow.", bundle: bundle)
+        case .selectedWorkflows:
+            return String(localized: "The webhook is sent only for the selected workflows.", bundle: bundle)
+        }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.webhook",
     "name": "Webhook Notifications",
-    "version": "1.0.15",
+    "version": "1.1.0",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

The Webhook Notifications editor used a fixed 480 x 420 frame inside the separately hosted plugin settings window. With the current workflow list, this clipped controls and left unused space at larger window sizes. The editor also mixed the legacy "Rules" and "Profiles" terminology even though the entries represent TypeWhisper workflows.

## Changes

- make the webhook settings content fill the host viewport
- keep the editor header and footer visible while only the form content scrolls
- replace the implicit empty-selection behavior with explicit "All transcriptions" and "Selected workflows" modes
- require at least one workflow when the selected-workflows mode is active
- update overview copy and English, German, and Japanese localizations to workflow terminology
- retain the persisted `profileFilter` key and event `ruleName` compatibility field
- prepare the plugin manifest for version 1.1.0 without publishing a release

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter WebhookPluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme WebhookPlugin -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run WebhookPlugin /Users/marco/.codex/worktrees/b6c0/typewhisper-mac`
- verify the installed bundle is signed and loaded by TypeWhisper-Dev
- verify the manifest and all German/Japanese catalog entries

The automated visual smoke was attempted three times, but ScreenCaptureKit failed with `SCStreamErrorDomain Code=-3811`. The signed 1.1.0 bundle was installed and confirmed loaded in the running dev process.

No plugin release workflow should be dispatched for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow-based webhook filtering, allowing webhooks to apply to all transcriptions or selected workflows.
  * Updated webhook settings and editing screens with workflow selection and clearer guidance.
  * Added localized German and Japanese text for workflow-related labels and instructions.
  * Preserved compatibility with existing webhook configurations during the transition to workflow filtering.

* **Bug Fixes**
  * Prevented saving workflow-scoped webhooks without selecting a workflow.
  * Ensured webhook delivery respects the selected workflow scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->