### PR TITLE
Keep unavailable webhook workflows visible

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Localizable.xcstrings
@@ -193,6 +193,22 @@
         }
       }
     },
+    "No longer available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht mehr verfügbar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用できなくなりました"
+          }
+        }
+      }
+    },
     "Save": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/Tests/WebhookPluginTests.swift
@@ -152,6 +152,22 @@ final class WebhookPluginTests: XCTestCase {
         XCTAssertTrue(state.webhook.workflowFilter.isEmpty)
     }
 
+    func testEditorStateKeepsUnavailablePersistedWorkflowsVisibleForDeselection() {
+        var state = ExampleWebhookEditorState(webhook: ExampleWebhookConfig(
+            name: "Selected",
+            url: "https://example.com/selected",
+            workflowFilter: ["Deleted Workflow", "Translation"]
+        ))
+
+        XCTAssertEqual(
+            state.workflowsForSelection(availableWorkflows: ["Translation", "Cleaned Text"]),
+            ["Translation", "Cleaned Text", "Deleted Workflow"]
+        )
+
+        state.setWorkflow("Deleted Workflow", isSelected: false)
+        XCTAssertEqual(state.webhook.workflowFilter, ["Translation"])
+    }
+
     func testWorkflowFilterKeepsLegacyProfileFilterStorageKey() throws {
         let webhook = ExampleWebhookConfig(
             name: "Compatible",

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/WebhookPlugin.swift
@@ -476,6 +476,11 @@ struct ExampleWebhookEditorState {
         }
     }
 
+    func workflowsForSelection(availableWorkflows: [String]) -> [String] {
+        var seen: Set<String> = []
+        return (availableWorkflows + webhook.workflowFilter).filter { seen.insert($0).inserted }
+    }
+
     var webhookForSaving: ExampleWebhookConfig {
         guard workflowScope == .allTranscriptions else { return webhook }
         var updated = webhook
@@ -748,18 +753,27 @@ private struct ExampleWebhookEditView: View {
                         .pickerStyle(.radioGroup)
 
                         if editorState.workflowScope == .selectedWorkflows {
-                            if availableWorkflows.isEmpty {
+                            if workflowsForSelection.isEmpty {
                                 Text("No workflows configured.", bundle: bundle)
                                     .foregroundStyle(.secondary)
                                     .font(.caption)
                             } else {
-                                ForEach(availableWorkflows, id: \.self) { name in
-                                    Toggle(name, isOn: Binding(
+                                ForEach(workflowsForSelection, id: \.self) { name in
+                                    Toggle(isOn: Binding(
                                         get: { editorState.webhook.workflowFilter.contains(name) },
                                         set: { selected in
                                             editorState.setWorkflow(name, isSelected: selected)
                                         }
-                                    ))
+                                    )) {
+                                        HStack {
+                                            Text(name)
+                                            if !availableWorkflows.contains(name) {
+                                                Text("No longer available", bundle: bundle)
+                                                    .foregroundStyle(.secondary)
+                                                    .font(.caption)
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -805,5 +819,9 @@ private struct ExampleWebhookEditView: View {
         case .selectedWorkflows:
             return String(localized: "The webhook is sent only for the selected workflows.", bundle: bundle)
         }
+    }
+
+    private var workflowsForSelection: [String] {
+        editorState.workflowsForSelection(availableWorkflows: availableWorkflows)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #886 and its unresolved CodeRabbit review thread.

Persisted workflow filters can reference workflows that were renamed or deleted. The editor previously rendered only currently available workflows, so stale selections stayed active but invisible and could not be deselected.

- render the union of available workflows and persisted workflow selections
- preserve the host-provided workflow order and append unavailable persisted entries
- label unavailable workflows in English, German, and Japanese
- add a regression test covering visibility, deduplication, and deselection

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter WebhookPluginTests`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme WebhookPlugin -configuration Debug -destination platform=macOS CODE_SIGNING_ALLOWED=NO build`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run WebhookPlugin /Users/marco/.codex/worktrees/b6c0/typewhisper-mac`

This is a follow-up for the still-unreleased Webhook plugin 1.1.0. It does not bump the manifest and must not trigger a plugin release.