### PR TITLE
Update Sparkle to 2.9.4 and adopt MainActor updater API

### DIFF
--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {

--- a/TypeWhisper/App/UpdateChecker.swift
+++ b/TypeWhisper/App/UpdateChecker.swift
@@ -1,12 +1,12 @@
-@preconcurrency import Sparkle
+import Sparkle
 
-struct UpdateChecker: Sendable {
-    let canCheckForUpdates: @Sendable () -> Bool
-    let checkForUpdates: @Sendable () -> Void
-    let resetUpdateCycleAfterSettingsChange: @Sendable () -> Void
+@MainActor
+struct UpdateChecker {
+    let canCheckForUpdates: () -> Bool
+    let checkForUpdates: () -> Void
+    let resetUpdateCycleAfterSettingsChange: () -> Void
 
     static func sparkle(_ updater: SPUUpdater) -> UpdateChecker {
-        nonisolated(unsafe) let updater = updater
         return UpdateChecker(
             canCheckForUpdates: { updater.canCheckForUpdates },
             checkForUpdates: { updater.checkForUpdates() },
@@ -14,5 +14,5 @@ struct UpdateChecker: Sendable {
         )
     }
 
-    nonisolated(unsafe) static var shared: UpdateChecker?
+    static var shared: UpdateChecker?
 }


### PR DESCRIPTION
## Summary

- update Sparkle from 2.8.1 to 2.9.4
- adopt Sparkle’s MainActor-isolated updater API in `UpdateChecker`
- remove the now-unnecessary `@preconcurrency`, `Sendable`, and `nonisolated(unsafe)` workarounds

## Issue context

Sparkle 2.9.2 includes two security fixes, while 2.9.4 fixes standard updater window activation for backgrounded and dockless applications. The latter is directly relevant to TypeWhisper’s `LSUIElement` menu bar mode.

This dependency update is intentionally separate from the appcast caching work in #891. Sparkle 2.9.4 does not add the originally proposed feed-request delegate hook.

Closes #893

## Test plan

- [x] `scripts/pr-preflight.sh`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -parallel-testing-enabled NO CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | tee test.log`
- [x] `bash scripts/check_first_party_warnings.sh test.log`
- [x] `$HOME/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --clean --run "$PWD"`
- [x] Verified the launched dev app embeds Sparkle 2.9.4, is Apple Development signed, uses the expected dev App Group, and remains running
- [ ] Manually invoke **Check for Updates** and confirm Sparkle’s standard UI opens from menu bar mode (local UI automation was blocked by ScreenCaptureKit error `-3811`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update-checking reliability and safety when interacting with the app interface.
  * Reduced the risk of concurrency-related issues during update checks and settings changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->