### PR TITLE
Add configurable Obsidian daily note append format

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
@@ -33,6 +33,22 @@
         }
       }
     },
+    "Append format:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anhangsformat:"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追記形式:"
+          }
+        }
+      }
+    },
     "Auto-Export": {
       "localizations": {
         "de": {
@@ -113,6 +129,38 @@
         }
       }
     },
+    "Bullet list": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufzählung"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "箇条書き"
+          }
+        }
+      }
+    },
+    "Custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム"
+          }
+        }
+      }
+    },
     "Daily Note Mode": {
       "localizations": {
         "de": {
@@ -177,6 +225,22 @@
         }
       }
     },
+    "Plain append": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfach anhängen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "そのまま追記"
+          }
+        }
+      }
+    },
     "No vault selected": {
       "localizations": {
         "de": {
@@ -205,6 +269,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "プレースホルダー: {{DATE}}, {{TIME}}, {{APP}}, {{LANG}}"
+          }
+        }
+      }
+    },
+    "Placeholders: {{TEXT}}, {{TIME}}, {{DATE}}, {{APP}}, {{LANGUAGE}}, {{URL}}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Platzhalter: {{TEXT}}, {{TIME}}, {{DATE}}, {{APP}}, {{LANGUAGE}}, {{URL}}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレースホルダー: {{TEXT}}, {{TIME}}, {{DATE}}, {{APP}}, {{LANGUAGE}}, {{URL}}"
           }
         }
       }
@@ -301,6 +381,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "タグ:"
+          }
+        }
+      }
+    },
+    "Timestamp section": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitstempelabschnitt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時刻付きセクション"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
@@ -257,18 +257,18 @@
         }
       }
     },
-    "Placeholders: {{DATE}}, {{TIME}}, {{APP}}, {{LANG}}": {
+    "Placeholders: {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Platzhalter: {{DATE}}, {{TIME}}, {{APP}}, {{LANG}}"
+            "value": "Platzhalter: {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "プレースホルダー: {{DATE}}, {{TIME}}, {{APP}}, {{LANG}}"
+            "value": "プレースホルダー: {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -22,6 +22,7 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     fileprivate var _filenameTemplate: String = "{{DATE}} {{TIME}} {{APP}}"
     fileprivate var _dailyNoteEnabled: Bool = false
     fileprivate var _dailyNoteFormat: String = "{{DATE}}"
+    fileprivate var _dailyNoteAppendTemplate: String = "## {{TIME}}\n\n{{TEXT}}"
     fileprivate var _frontmatterEnabled: Bool = true
     fileprivate var _frontmatterTags: [String] = ["typewhisper"]
     fileprivate var _autoExportEnabled: Bool = false
@@ -56,6 +57,7 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         _filenameTemplate = host?.userDefault(forKey: "filenameTemplate") as? String ?? "{{DATE}} {{TIME}} {{APP}}"
         _dailyNoteEnabled = host?.userDefault(forKey: "dailyNoteEnabled") as? Bool ?? false
         _dailyNoteFormat = host?.userDefault(forKey: "dailyNoteFormat") as? String ?? "{{DATE}}"
+        _dailyNoteAppendTemplate = host?.userDefault(forKey: "dailyNoteAppendTemplate") as? String ?? DailyNoteAppendPreset.timestamp.template
         _frontmatterEnabled = host?.userDefault(forKey: "frontmatterEnabled") as? Bool ?? true
         _frontmatterTags = host?.userDefault(forKey: "frontmatterTags") as? [String] ?? ["typewhisper"]
         _autoExportEnabled = host?.userDefault(forKey: "autoExportEnabled") as? Bool ?? false
@@ -121,18 +123,26 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
 
     // MARK: - File Writing
 
-    private func resolveTemplate(_ template: String, appName: String?, language: String?) -> String {
+    private func resolveTemplate(_ template: String, appName: String?, language: String?, timeFormat: String = "HH-mm-ss") -> String {
         let now = Date()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let timeFormatter = DateFormatter()
-        timeFormatter.dateFormat = "HH-mm-ss"
+        timeFormatter.dateFormat = timeFormat
 
         var result = template
         result = result.replacingOccurrences(of: "{{DATE}}", with: dateFormatter.string(from: now))
         result = result.replacingOccurrences(of: "{{TIME}}", with: timeFormatter.string(from: now))
         result = result.replacingOccurrences(of: "{{APP}}", with: appName ?? "Unknown")
         result = result.replacingOccurrences(of: "{{LANG}}", with: language ?? "unknown")
+        return result
+    }
+
+    private func resolveDailyNoteAppendTemplate(_ template: String, text: String, appName: String?, url: String?, language: String?) -> String {
+        var result = resolveTemplate(template, appName: appName, language: language, timeFormat: "HH:mm")
+        result = result.replacingOccurrences(of: "{{TEXT}}", with: text)
+        result = result.replacingOccurrences(of: "{{URL}}", with: url ?? "")
+        result = result.replacingOccurrences(of: "{{LANGUAGE}}", with: language ?? "unknown")
         return result
     }
 
@@ -210,15 +220,27 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         let filePath = (folderPath as NSString).appendingPathComponent("\(filename).md")
 
         let fm = FileManager.default
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateFormat = "HH:mm"
-        let timeString = timeFormatter.string(from: Date())
+        let appendContent = resolveDailyNoteAppendTemplate(
+            _dailyNoteAppendTemplate,
+            text: text,
+            appName: appName,
+            url: url,
+            language: language
+        )
 
         if fm.fileExists(atPath: filePath) {
             // Append to existing daily note
             let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: filePath))
             handle.seekToEndOfFile()
-            let separator = "\n\n---\n\n## \(timeString)\n\n\(text)"
+            let separator: String
+            if _dailyNoteAppendTemplate == DailyNoteAppendPreset.timestamp.template {
+                // Preserve the legacy timestamp-section layout for existing daily notes.
+                separator = "\n\n---\n\n\(appendContent)"
+            } else if _dailyNoteAppendTemplate == DailyNoteAppendPreset.bullet.template {
+                separator = "\n\(appendContent)"
+            } else {
+                separator = "\n\n\(appendContent)"
+            }
             if let data = separator.data(using: .utf8) {
                 handle.write(data)
             }
@@ -236,7 +258,7 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
                 )
                 content += "\n\n"
             }
-            content += "## \(timeString)\n\n\(text)"
+            content += appendContent
             try content.write(toFile: filePath, atomically: true, encoding: .utf8)
         }
 
@@ -324,6 +346,7 @@ private struct ObsidianSettingsView: View {
     @State private var filenameTemplate: String = "{{DATE}} {{TIME}} {{APP}}"
     @State private var dailyNoteEnabled: Bool = false
     @State private var dailyNoteFormat: String = "{{DATE}}"
+    @State private var dailyNoteAppendTemplate: String = DailyNoteAppendPreset.timestamp.template
     @State private var frontmatterEnabled: Bool = true
     @State private var tagsInput: String = "typewhisper"
     @State private var autoExportEnabled: Bool = false
@@ -444,6 +467,34 @@ private struct ObsidianSettingsView: View {
                                     plugin.saveSetting(newValue, forKey: "dailyNoteFormat")
                                 }
                         }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text("Append format:", bundle: bundle)
+                                    .frame(width: 100, alignment: .trailing)
+                                Picker("Append format:", selection: appendFormatPreset) {
+                                    Text("Timestamp section", bundle: bundle).tag(DailyNoteAppendPreset.timestamp.template)
+                                    Text("Plain append", bundle: bundle).tag(DailyNoteAppendPreset.plain.template)
+                                    Text("Bullet list", bundle: bundle).tag(DailyNoteAppendPreset.bullet.template)
+                                    Text("Custom", bundle: bundle).tag(dailyNoteAppendTemplate)
+                                }
+                                .labelsHidden()
+                            }
+
+                            TextEditor(text: $dailyNoteAppendTemplate)
+                                .font(.system(.body, design: .monospaced))
+                                .frame(height: 84)
+                                .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.25)))
+                                .onChange(of: dailyNoteAppendTemplate) { _, newValue in
+                                    plugin._dailyNoteAppendTemplate = newValue
+                                    plugin.saveSetting(newValue, forKey: "dailyNoteAppendTemplate")
+                                }
+
+                            Text("Placeholders: {{TEXT}}, {{TIME}}, {{DATE}}, {{APP}}, {{LANGUAGE}}, {{URL}}", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                                .padding(.leading, 108)
+                        }
                     }
                 }
 
@@ -539,6 +590,7 @@ private struct ObsidianSettingsView: View {
             filenameTemplate = plugin._filenameTemplate
             dailyNoteEnabled = plugin._dailyNoteEnabled
             dailyNoteFormat = plugin._dailyNoteFormat
+            dailyNoteAppendTemplate = plugin._dailyNoteAppendTemplate
             frontmatterEnabled = plugin._frontmatterEnabled
             tagsInput = plugin._frontmatterTags.joined(separator: ", ")
             autoExportEnabled = plugin._autoExportEnabled
@@ -561,6 +613,13 @@ private struct ObsidianSettingsView: View {
             .replacingOccurrences(of: "{{LANG}}", with: "en")
     }
 
+    private var appendFormatPreset: Binding<String> {
+        Binding(
+            get: { dailyNoteAppendTemplate },
+            set: { dailyNoteAppendTemplate = $0 }
+        )
+    }
+
     private func selectVaultFolder() {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
@@ -572,6 +631,23 @@ private struct ObsidianSettingsView: View {
             plugin._vaultPath = url.path
             plugin.saveSetting(url.path, forKey: "vaultPath")
             plugin.host?.notifyCapabilitiesChanged()
+        }
+    }
+}
+
+private enum DailyNoteAppendPreset {
+    case timestamp
+    case plain
+    case bullet
+
+    var template: String {
+        switch self {
+        case .timestamp:
+            "## {{TIME}}\n\n{{TEXT}}"
+        case .plain:
+            "{{TEXT}}"
+        case .bullet:
+            "- {{TEXT}}"
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -126,14 +126,19 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     private func resolveTemplate(_ template: String, appName: String?, language: String?, timeFormat: String = "HH-mm-ss") -> String {
         let now = Date()
         let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let timeFormatter = DateFormatter()
+        timeFormatter.calendar = Calendar(identifier: .gregorian)
+        timeFormatter.locale = Locale(identifier: "en_US_POSIX")
         timeFormatter.dateFormat = timeFormat
 
         var result = template
         result = result.replacingOccurrences(of: "{{DATE}}", with: dateFormatter.string(from: now))
         result = result.replacingOccurrences(of: "{{TIME}}", with: timeFormatter.string(from: now))
         result = result.replacingOccurrences(of: "{{APP}}", with: appName ?? "Unknown")
+        result = result.replacingOccurrences(of: "{{LANGUAGE}}", with: language ?? "unknown")
         result = result.replacingOccurrences(of: "{{LANG}}", with: language ?? "unknown")
         return result
     }
@@ -142,7 +147,6 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         var result = resolveTemplate(template, appName: appName, language: language, timeFormat: "HH:mm")
         result = result.replacingOccurrences(of: "{{TEXT}}", with: text)
         result = result.replacingOccurrences(of: "{{URL}}", with: url ?? "")
-        result = result.replacingOccurrences(of: "{{LANGUAGE}}", with: language ?? "unknown")
         return result
     }
 
@@ -347,6 +351,7 @@ private struct ObsidianSettingsView: View {
     @State private var dailyNoteEnabled: Bool = false
     @State private var dailyNoteFormat: String = "{{DATE}}"
     @State private var dailyNoteAppendTemplate: String = DailyNoteAppendPreset.timestamp.template
+    @State private var appendFormatSelection: String = DailyNoteAppendPreset.timestamp.template
     @State private var frontmatterEnabled: Bool = true
     @State private var tagsInput: String = "typewhisper"
     @State private var autoExportEnabled: Bool = false
@@ -431,7 +436,7 @@ private struct ObsidianSettingsView: View {
                         .foregroundStyle(.secondary)
                         .padding(.leading, 108)
 
-                    Text("Placeholders: {{DATE}}, {{TIME}}, {{APP}}, {{LANG}}", bundle: bundle)
+                    Text("Placeholders: {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}", bundle: bundle)
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .padding(.leading, 108)
@@ -472,13 +477,17 @@ private struct ObsidianSettingsView: View {
                             HStack {
                                 Text("Append format:", bundle: bundle)
                                     .frame(width: 100, alignment: .trailing)
-                                Picker("Append format:", selection: appendFormatPreset) {
+                                Picker("Append format:", selection: $appendFormatSelection) {
                                     Text("Timestamp section", bundle: bundle).tag(DailyNoteAppendPreset.timestamp.template)
                                     Text("Plain append", bundle: bundle).tag(DailyNoteAppendPreset.plain.template)
                                     Text("Bullet list", bundle: bundle).tag(DailyNoteAppendPreset.bullet.template)
-                                    Text("Custom", bundle: bundle).tag(dailyNoteAppendTemplate)
+                                    Text("Custom", bundle: bundle).tag(DailyNoteAppendPreset.customSelection)
                                 }
                                 .labelsHidden()
+                                .onChange(of: appendFormatSelection) { _, newValue in
+                                    guard newValue != DailyNoteAppendPreset.customSelection else { return }
+                                    dailyNoteAppendTemplate = newValue
+                                }
                             }
 
                             TextEditor(text: $dailyNoteAppendTemplate)
@@ -488,6 +497,7 @@ private struct ObsidianSettingsView: View {
                                 .onChange(of: dailyNoteAppendTemplate) { _, newValue in
                                     plugin._dailyNoteAppendTemplate = newValue
                                     plugin.saveSetting(newValue, forKey: "dailyNoteAppendTemplate")
+                                    appendFormatSelection = DailyNoteAppendPreset.selection(for: newValue)
                                 }
 
                             Text("Placeholders: {{TEXT}}, {{TIME}}, {{DATE}}, {{APP}}, {{LANGUAGE}}, {{URL}}", bundle: bundle)
@@ -591,6 +601,7 @@ private struct ObsidianSettingsView: View {
             dailyNoteEnabled = plugin._dailyNoteEnabled
             dailyNoteFormat = plugin._dailyNoteFormat
             dailyNoteAppendTemplate = plugin._dailyNoteAppendTemplate
+            appendFormatSelection = DailyNoteAppendPreset.selection(for: dailyNoteAppendTemplate)
             frontmatterEnabled = plugin._frontmatterEnabled
             tagsInput = plugin._frontmatterTags.joined(separator: ", ")
             autoExportEnabled = plugin._autoExportEnabled
@@ -601,8 +612,12 @@ private struct ObsidianSettingsView: View {
     private var previewFilename: String {
         let now = Date()
         let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let timeFormatter = DateFormatter()
+        timeFormatter.calendar = Calendar(identifier: .gregorian)
+        timeFormatter.locale = Locale(identifier: "en_US_POSIX")
         timeFormatter.dateFormat = "HH-mm-ss"
 
         let template = dailyNoteEnabled ? dailyNoteFormat : filenameTemplate
@@ -610,14 +625,8 @@ private struct ObsidianSettingsView: View {
             .replacingOccurrences(of: "{{DATE}}", with: dateFormatter.string(from: now))
             .replacingOccurrences(of: "{{TIME}}", with: timeFormatter.string(from: now))
             .replacingOccurrences(of: "{{APP}}", with: "Safari")
+            .replacingOccurrences(of: "{{LANGUAGE}}", with: "en")
             .replacingOccurrences(of: "{{LANG}}", with: "en")
-    }
-
-    private var appendFormatPreset: Binding<String> {
-        Binding(
-            get: { dailyNoteAppendTemplate },
-            set: { dailyNoteAppendTemplate = $0 }
-        )
     }
 
     private func selectVaultFolder() {
@@ -639,6 +648,16 @@ private enum DailyNoteAppendPreset {
     case timestamp
     case plain
     case bullet
+
+    static let customSelection = "custom"
+
+    static var templates: [String] {
+        [timestamp.template, plain.template, bullet.template]
+    }
+
+    static func selection(for template: String) -> String {
+        templates.contains(template) ? template : customSelection
+    }
 
     var template: String {
         switch self {

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -119,6 +119,47 @@ final class ObsidianPluginTests: XCTestCase {
         let content = try String(contentsOf: files[0], encoding: .utf8)
         XCTAssertTrue(content.contains("First entry"))
         XCTAssertTrue(content.contains("Second entry"))
+        XCTAssertTrue(content.contains("---\n\n## "), "The default timestamp-section format should remain unchanged.")
+        XCTAssertNotNil(
+            content.range(of: #"## \d{2}:\d{2}"#, options: .regularExpression),
+            "The default timestamp should retain the legacy HH:mm format."
+        )
+    }
+
+    func testDailyNoteUsesCustomAppendTemplate() async throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultCustomAppend")
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        let host = try PluginTestHostServices(defaults: [
+            "vaultPath": vaultURL.path,
+            "dailyNoteEnabled": true,
+            "dailyNoteAppendTemplate": "- {{TEXT}} ({{APP}} / {{LANGUAGE}} / {{URL}})",
+            "frontmatterEnabled": false,
+        ])
+        let plugin = ObsidianPlugin()
+        plugin.activate(host: host)
+
+        for text in ["First note", "Second note"] {
+            let result = try await plugin.execute(
+                input: text,
+                context: ActionContext(
+                    appName: "Notes",
+                    url: "https://example.com",
+                    language: "en",
+                    originalText: text
+                )
+            )
+            XCTAssertTrue(result.success)
+        }
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: vaultURL.appendingPathComponent("TypeWhisper", isDirectory: true),
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertEqual(files.count, 1)
+
+        let content = try String(contentsOf: files[0], encoding: .utf8)
+        XCTAssertEqual(content, "- First note (Notes / en / https://example.com)\n\n- Second note (Notes / en / https://example.com)")
     }
 
     func testAutoExportDailyNoteOmitsAppMetadataWhenFormatDoesNotContainApp() async throws {


### PR DESCRIPTION
## Summary
- add a configurable daily-note append template to the Obsidian plugin
- provide timestamp-section, plain-append, bullet-list, and editable custom formats
- support `{{TEXT}}`, `{{TIME}}`, `{{DATE}}`, `{{APP}}`, `{{LANGUAGE}}`, and `{{URL}}` placeholders
- preserve the existing timestamp-heading layout and `HH:mm` timestamp format by default

## Issue context
Obsidian daily notes currently add a timestamp heading and separator after workflow output, preventing workflows from controlling the final Markdown shape. This adds a plugin-level append wrapper so users can maintain plain or bullet-list daily captures while keeping workflow prompts responsible for note-body formatting.

Closes #659

## Test plan
- `cd TypeWhisperPluginSDK && swift test --filter ObsidianPluginTests`

Validated locally: 8 Obsidian plugin tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable daily note append formats: timestamp section, plain append, bullet list, and custom templates.
  * Added support for template placeholders including text, URL, language, app, date, and time.
  * Updated the settings UI with “Append format” and improved localized (EN/DE/JA) template guidance.

* **Bug Fixes**
  * Improved daily note appending behavior for both new and existing notes, including correct separators and time formatting.

* **Tests**
  * Added assertions for default timestamp formatting and exact rendering of custom append templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->