### PR TITLE
Bump Obsidian plugin to 1.0.7

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.obsidian",
     "name": "Obsidian",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- bump the Obsidian plugin manifest from 1.0.6 to 1.0.7
- prepare the configurable daily-note append formats from #898 for an official plugin release

## Issue context

PR #898 implemented #659 and landed the configurable daily-note append templates on `main`. The plugin release workflow requires the manifest version to exactly match the requested release version, so this follow-up version bump is required before publishing `plugin-obsidian-v1.0.7`.

## Test plan

- `cd TypeWhisperPluginSDK && swift test --filter ObsidianPluginTests`
- `git diff --check origin/main...HEAD`

Validated locally: 8 Obsidian plugin tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Obsidian plugin to version 1.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->