### PR TITLE
Apply dictionary corrections to file transcriptions

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -142,7 +142,8 @@ final class ServiceContainer: ObservableObject {
         // ViewModels (created before HTTP API so DictationViewModel is available)
         fileTranscriptionViewModel = FileTranscriptionViewModel(
             modelManager: modelManagerService,
-            audioFileService: audioFileService
+            audioFileService: audioFileService,
+            dictionaryService: dictionaryService
         )
         let recoveryViewModel = DictationRecoveryViewModel(
             audioRecordingService: audioRecordingService,

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -573,16 +573,25 @@ final class DictionaryService: ObservableObject {
 
     /// Apply all enabled corrections to the given text
     func applyCorrections(to text: String) -> String {
-        var result = text
+        applyCorrections(to: [text]).first ?? text
+    }
+
+    /// Apply all enabled corrections to related text fields while counting each correction once.
+    func applyCorrections(to texts: [String]) -> [String] {
+        var results = texts
         var needsSave = false
 
         for correction in corrections {
             guard let replacement = correction.replacement else { continue }
 
-            let before = result
-            result = applyCorrection(correction, to: result, replacement: replacement)
+            var correctionWasApplied = false
+            for index in results.indices {
+                let before = results[index]
+                results[index] = applyCorrection(correction, to: before, replacement: replacement)
+                correctionWasApplied = correctionWasApplied || results[index] != before
+            }
 
-            if result != before {
+            if correctionWasApplied {
                 correction.usageCount += 1
                 needsSave = true
             }
@@ -596,7 +605,7 @@ final class DictionaryService: ObservableObject {
             }
         }
 
-        return result
+        return results
     }
 
     private func applyCorrection(_ correction: DictionaryEntry, to text: String, replacement: String) -> String {

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -110,6 +110,7 @@ final class FileTranscriptionViewModel: ObservableObject {
 
     private let modelManager: ModelManagerService
     private let audioFileService: AudioFileService
+    private let dictionaryService: DictionaryService
     private let defaults: UserDefaults
     private let audioSamplesLoader: AudioSamplesLoader
     private let transcriptionRunner: TranscriptionRunner
@@ -130,6 +131,7 @@ final class FileTranscriptionViewModel: ObservableObject {
     init(
         modelManager: ModelManagerService,
         audioFileService: AudioFileService,
+        dictionaryService: DictionaryService,
         defaults: UserDefaults = .standard,
         audioSamplesLoader: AudioSamplesLoader? = nil,
         transcriptionRunner: TranscriptionRunner? = nil,
@@ -139,6 +141,7 @@ final class FileTranscriptionViewModel: ObservableObject {
     ) {
         self.modelManager = modelManager
         self.audioFileService = audioFileService
+        self.dictionaryService = dictionaryService
         self.defaults = defaults
         self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url, onProgress, isCancelled in
             try await audioFileService.loadAudioSamples(from: url) { progress in
@@ -423,7 +426,7 @@ final class FileTranscriptionViewModel: ObservableObject {
                 throw CancellationError()
             }
 
-            files[index].result = result
+            files[index].result = result.applyingCorrections(using: dictionaryService)
             files[index].state = .done
             files[index].phaseDescription = String(localized: "Done")
             files[index].progressFraction = 1.0
@@ -613,5 +616,32 @@ final class FileTranscriptionViewModel: ObservableObject {
         elapsedTimerTask?.cancel()
         elapsedTimerTask = nil
         elapsedRefreshDate = Date()
+    }
+}
+
+private extension TranscriptionResult {
+    @MainActor
+    func applyingCorrections(using dictionaryService: DictionaryService) -> TranscriptionResult {
+        let correctedTexts = dictionaryService.applyCorrections(
+            to: [text] + segments.map(\.text)
+        )
+        let correctedSegments = zip(segments, correctedTexts.dropFirst()).map { segment, correctedText in
+            TranscriptionSegment(
+                text: correctedText,
+                start: segment.start,
+                end: segment.end,
+                speakerLabel: segment.speakerLabel,
+                speakerConfidence: segment.speakerConfidence
+            )
+        }
+
+        return TranscriptionResult(
+            text: correctedTexts.first ?? text,
+            detectedLanguage: detectedLanguage,
+            duration: duration,
+            processingTime: processingTime,
+            engineUsed: engineUsed,
+            segments: correctedSegments
+        )
     }
 }

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -142,7 +142,8 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         let modelManager = ModelManagerService()
         let fileTranscriptionViewModel = FileTranscriptionViewModel(
             modelManager: modelManager,
-            audioFileService: AudioFileService()
+            audioFileService: AudioFileService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory)
         )
         FileTranscriptionViewModel._shared = fileTranscriptionViewModel
         let navigationCoordinator = SettingsNavigationCoordinator()

--- a/TypeWhisperTests/DictionaryServiceTests.swift
+++ b/TypeWhisperTests/DictionaryServiceTests.swift
@@ -114,6 +114,27 @@ final class DictionaryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testBatchCorrectionsUpdateRelatedTextsAndCountEachCorrectionOnce() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let service = DictionaryService(appSupportDirectory: appSupportDirectory)
+        service.addEntry(type: .correction, original: "teh", replacement: "the")
+
+        XCTAssertEqual(
+            service.applyCorrections(to: ["teh TypeWhisper", "teh first segment", "unchanged"]),
+            ["the TypeWhisper", "the first segment", "unchanged"]
+        )
+        XCTAssertEqual(service.corrections.first?.usageCount, 1)
+
+        XCTAssertEqual(
+            service.applyCorrections(to: ["already correct", "still unchanged"]),
+            ["already correct", "still unchanged"]
+        )
+        XCTAssertEqual(service.corrections.first?.usageCount, 1)
+    }
+
+    @MainActor
     func testBatchLearningSkipsDuplicatesAndUndoDeletesOnlyMatchingCreatedEntries() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -35,6 +35,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults
         )
 
@@ -56,6 +57,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             audioSamplesLoader: { url, _, _ in
                 XCTAssertEqual(url, fileURL)
@@ -98,6 +100,70 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.files.first?.result?.text, "Recovered text")
     }
 
+    func testTranscribeAllAppliesDictionaryCorrectionsToTextAndSegmentsPreservingMetadata() async throws {
+        let defaults = try makeDefaults()
+        let fileURL = makeTemporaryFile(named: "corrected-transcript.wav")
+        let dictionaryService = makeDictionaryService()
+        dictionaryService.addEntry(type: .correction, original: "teh", replacement: "the")
+        dictionaryService.addEntry(type: .correction, original: "cross segment", replacement: "joined")
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: dictionaryService,
+            defaults: defaults,
+            audioSamplesLoader: { _, _, _ in [0.1, -0.1] },
+            transcriptionRunner: { _, _, _, engineOverrideId, _, _, _, _ in
+                TranscriptionResult(
+                    text: "teh cross segment",
+                    detectedLanguage: "en",
+                    duration: 4.5,
+                    processingTime: 0.25,
+                    engineUsed: engineOverrideId ?? "default",
+                    segments: [
+                        TranscriptionSegment(
+                            text: "teh cross",
+                            start: 0.25,
+                            end: 2,
+                            speakerLabel: "Speaker 1",
+                            speakerConfidence: 0.9
+                        ),
+                        TranscriptionSegment(
+                            text: "segment",
+                            start: 2,
+                            end: 4.25,
+                            speakerLabel: "Speaker 2",
+                            speakerConfidence: 0.8
+                        )
+                    ]
+                )
+            },
+            engineReadinessChecker: { _ in true }
+        )
+
+        viewModel.addFiles([fileURL])
+        viewModel.selectedEngine = "whisper"
+        viewModel.transcribeAll()
+        try await waitForBatchToFinish(viewModel)
+
+        let result = try XCTUnwrap(viewModel.files.first?.result)
+        XCTAssertEqual(result.text, "the joined")
+        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.duration, 4.5)
+        XCTAssertEqual(result.processingTime, 0.25)
+        XCTAssertEqual(result.engineUsed, "whisper")
+        XCTAssertEqual(result.segments.map(\.text), ["the cross", "segment"])
+        XCTAssertEqual(result.segments.map(\.start), [0.25, 2])
+        XCTAssertEqual(result.segments.map(\.end), [2, 4.25])
+        XCTAssertEqual(result.segments.map(\.speakerLabel), ["Speaker 1", "Speaker 2"])
+        XCTAssertEqual(result.segments.map(\.speakerConfidence), [0.9, 0.8])
+        XCTAssertEqual(dictionaryService.corrections.map(\.usageCount), [1, 1])
+        XCTAssertEqual(
+            SubtitleExporter.exportContent(for: result, format: .vtt),
+            "WEBVTT\n\n1\n00:00:00.250 --> 00:00:02.000\nSpeaker 1: the cross\n\n2\n00:00:02.000 --> 00:00:04.250\nSpeaker 2: segment\n"
+        )
+    }
+
     func testTranscribeAllExposesLoadingProgressAndElapsedTime() async throws {
         let defaults = try makeDefaults()
         let fileURL = makeTemporaryFile(named: "long-video.mp4")
@@ -107,6 +173,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             audioSamplesLoader: { url, onProgress, _ in
                 XCTAssertEqual(url, fileURL)
@@ -157,6 +224,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             audioSamplesLoader: { _, _, isCancelled in
                 await started.open()
@@ -203,6 +271,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             audioSamplesLoader: { _, _, _ in [0.1, -0.1] },
             transcriptionRunner: { _, _, _, engineOverrideId, _, onProgress, _, _ in
@@ -244,6 +313,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             audioSamplesLoader: { _, _, _ in [0.1, -0.1] },
             transcriptionRunner: { _, _, _, engineOverrideId, _, _, onSourceProgress, _ in
@@ -294,6 +364,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             subtitleFileSaver: { content, format, suggestedName in
                 savedContent = content
@@ -330,6 +401,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             subtitleFileSaver: { _, _, _ in
                 XCTFail("Multi-file export should use the folder export path")
@@ -370,6 +442,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             subtitleFileSaver: { content, _, _ in
                 savedContent = content
@@ -438,6 +511,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         let viewModel = FileTranscriptionViewModel(
             modelManager: ModelManagerService(),
             audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
             defaults: defaults,
             audioSamplesLoader: { _, onProgress, isCancelled in
                 while !isCancelled() {
@@ -658,6 +732,10 @@ final class FileTranscriptionViewModelTests: XCTestCase {
             defaults.removePersistentDomain(forName: name)
         }
         return defaults
+    }
+
+    private func makeDictionaryService() -> DictionaryService {
+        DictionaryService(appSupportDirectory: makeTemporaryDirectory())
     }
 
     private func makeTemporaryFile(named name: String) -> URL {


### PR DESCRIPTION
## Summary

- apply enabled dictionary corrections to file transcription text and timestamped segments
- preserve language, timing, engine, and speaker metadata while correcting subtitle output
- count each dictionary correction once per file even when it appears in multiple related text fields

## Issue context

File Transcription stored the raw `TranscriptionResult` returned by the engine. Unlike normal dictation and API transcription, it never passed the result through `DictionaryService`, so configured word replacements were missing from copied text and subtitle exports.

This change injects the shared dictionary service into `FileTranscriptionViewModel` and corrects the aggregate text and each segment after transcription. Multi-word corrections that span a segment boundary still apply to the aggregate text without changing segment boundaries or timing.

Closes #897

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictionaryServiceTests -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests` (61 passed)
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` (1,188 passed)
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically applies enabled dictionary corrections to transcribed file text and individual segments.
  * Corrected text is reflected in exported VTT captions while preserving transcription metadata.

* **Bug Fixes**
  * Batch corrections now track usage once per correction rather than once per affected field.
  * Dictionary correction data is saved when corrections are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->