### PR TITLE
Add direct Recorder retranscription

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -200,6 +200,7 @@ final class ServiceContainer: ObservableObject {
             recorderService: audioRecorderService,
             modelManager: modelManagerService,
             dictionaryService: dictionaryService,
+            audioFileService: audioFileService,
             audioDeviceService: audioDeviceService
         )
 

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -10094,6 +10094,94 @@
         }
       }
     },
+    "recorder.retranscribe": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneut transkribieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-transcribe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再文字起こし"
+          }
+        }
+      }
+    },
+    "recorder.retranscribeConfirmation.message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Aufnahme „%@“ hat bereits ein Transkript. Es wird erst ersetzt, wenn die erneute Transkription erfolgreich war."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” already has a transcript. It will only be replaced after the new transcription succeeds."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」にはすでに文字起こしがあります。新しい文字起こしが成功した場合にのみ置き換えられます。"
+          }
+        }
+      }
+    },
+    "recorder.retranscribeConfirmation.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorhandenes Transkript ersetzen?"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Replace Existing Transcript?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既存の文字起こしを置き換えますか？"
+          }
+        }
+      }
+    },
+    "recorder.retranscribing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erneute Transkription läuft …"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-transcribing…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再文字起こし中…"
+          }
+        }
+      }
+    },
     "recorder.transcribe": {
       "localizations": {
         "de": {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -9,6 +9,8 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhis
 
 @MainActor
 final class AudioRecorderViewModel: ObservableObject {
+    typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
+
     nonisolated(unsafe) static var _shared: AudioRecorderViewModel?
     static var shared: AudioRecorderViewModel {
         guard let instance = _shared else {
@@ -37,6 +39,7 @@ final class AudioRecorderViewModel: ObservableObject {
         case noSourceEnabled
         case alreadyRecording
         case finalizing
+        case retranscribing
         case notRecording
 
         var errorDescription: String? {
@@ -47,6 +50,8 @@ final class AudioRecorderViewModel: ObservableObject {
                 "Already recording"
             case .finalizing:
                 "Recorder is finalizing"
+            case .retranscribing:
+                "Recorder is transcribing an existing recording"
             case .notRecording:
                 "Not recording"
             }
@@ -166,6 +171,7 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var systemAudioWarningMessage: String?
     @Published var partialText: String = ""
     @Published var isTranscribing: Bool = false
+    @Published private(set) var retranscribingRecordingURL: URL?
 
     var activeEngineName: String? { resolvedEngine?.providerDisplayName }
     var activeModelName: String? {
@@ -199,7 +205,7 @@ final class AudioRecorderViewModel: ObservableObject {
     }
     var selectedLanguage: String? { languageSelection.requestedLanguage }
     var canToggleRecording: Bool {
-        Self.canToggleRecording(
+        retranscribingRecordingURL == nil && Self.canToggleRecording(
             state: state,
             micEnabled: micEnabled,
             systemAudioEnabled: systemAudioEnabled
@@ -210,6 +216,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private let audioDeviceService: AudioDeviceService
     private let modelManager: ModelManagerService
     private let dictionaryService: DictionaryService
+    private let audioSamplesLoader: AudioSamplesLoader
     private let defaults: UserDefaults
     private let streamingHandler: StreamingHandler
     private let livePreviewStartObserver: (() -> Void)?
@@ -224,14 +231,19 @@ final class AudioRecorderViewModel: ObservableObject {
         recorderService: AudioRecorderService,
         modelManager: ModelManagerService,
         dictionaryService: DictionaryService,
+        audioFileService: AudioFileService = AudioFileService(),
         audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
         defaults: UserDefaults = .standard,
+        audioSamplesLoader: AudioSamplesLoader? = nil,
         livePreviewStartObserver: (() -> Void)? = nil
     ) {
         self.recorderService = recorderService
         self.audioDeviceService = audioDeviceService
         self.modelManager = modelManager
         self.dictionaryService = dictionaryService
+        self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
+            try await audioFileService.loadAudioSamples(from: url)
+        }
         self.defaults = defaults
         self.livePreviewStartObserver = livePreviewStartObserver
         self.streamingHandler = StreamingHandler(
@@ -445,6 +457,10 @@ final class AudioRecorderViewModel: ObservableObject {
         systemAudioEnabled requestedSystemAudioEnabled: Bool,
         apiSessionID: UUID?
     ) async throws -> URL {
+        guard retranscribingRecordingURL == nil else {
+            throw RecorderAPIError.retranscribing
+        }
+
         switch state {
         case .idle:
             break
@@ -685,7 +701,58 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     func transcribeRecording(_ item: RecordingItem) {
-        FileTranscriptionViewModel.shared.addFiles([item.url])
+        guard canTranscribeRecording(item) else { return }
+
+        let url = item.url
+        retranscribingRecordingURL = url
+        errorMessage = nil
+
+        Task { [weak self] in
+            guard let self else { return }
+            defer {
+                self.retranscribingRecordingURL = nil
+                self.loadRecordings()
+            }
+
+            let samples: [Float]
+            do {
+                samples = try await self.audioSamplesLoader(url)
+            } catch {
+                self.recordRetranscriptionFailure(
+                    phase: .preparingFinalAudio,
+                    error: error,
+                    for: url
+                )
+                return
+            }
+
+            self.reconcileSelectionWithAvailablePlugins()
+            let providerId = self.effectiveProviderId
+            let request = FinalTranscriptionRequest(
+                outputURL: url,
+                buffer: samples,
+                languageSelection: self.languageSelection,
+                task: self.selectedTask,
+                providerId: providerId,
+                modelOverrideId: self.selectedModel,
+                prompt: self.dictionaryService.getTermsForPrompt(providerId: providerId),
+                dictionaryTermHints: self.dictionaryService.getTermHints(providerId: providerId),
+                liveSessionResult: nil
+            )
+
+            _ = await self.runRetranscription(request)
+        }
+    }
+
+    func isRetranscribing(_ item: RecordingItem) -> Bool {
+        retranscribingRecordingURL?.standardizedFileURL == item.url.standardizedFileURL
+    }
+
+    func canTranscribeRecording(_ item: RecordingItem) -> Bool {
+        guard state == .idle, retranscribingRecordingURL == nil else { return false }
+        guard FileManager.default.fileExists(atPath: item.url.path) else { return false }
+        guard let engine = resolvedEngine else { return false }
+        return modelManager.canPrepareForTranscription(engine)
     }
 
     func openRecordingsFolder() {
@@ -824,16 +891,7 @@ final class AudioRecorderViewModel: ObservableObject {
         }
 
         // Fall back to transcribe if engine doesn't support translation
-        let effectiveTask: TranscriptionTask
-        if request.task == .translate,
-           let providerId = request.providerId,
-           let pluginManager = PluginManager.shared,
-           let plugin = pluginManager.transcriptionEngine(for: providerId),
-           !plugin.supportsTranslation {
-            effectiveTask = .transcribe
-        } else {
-            effectiveTask = request.task
-        }
+        let effectiveTask = resolvedTask(for: request)
 
         do {
             let result = if let liveSessionResult = request.liveSessionResult {
@@ -880,6 +938,84 @@ final class AudioRecorderViewModel: ObservableObject {
             errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
             return .failed(recordedFailure)
         }
+    }
+
+    private func runRetranscription(_ request: FinalTranscriptionRequest) async -> FinalTranscriptionOutcome {
+        let effectiveTask = resolvedTask(for: request)
+
+        do {
+            let result = try await modelManager.transcribe(
+                audioSamples: request.buffer,
+                languageSelection: request.languageSelection,
+                task: effectiveTask,
+                engineOverrideId: request.providerId,
+                cloudModelOverride: request.modelOverrideId,
+                prompt: request.prompt,
+                dictionaryTermHints: request.dictionaryTermHints
+            )
+            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else {
+                let failure = makeTranscriptionFailure(
+                    phase: .emptyResult,
+                    providerError: String(localized: "recorder.emptyFinalTranscriptionError"),
+                    request: request
+                )
+                let recordedFailure = saveTranscriptionFailure(failure, for: request.outputURL)
+                errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
+                return .failed(recordedFailure)
+            }
+
+            return saveTranscriptOutcome(text, for: request.outputURL, request: request)
+        } catch {
+            recordRetranscriptionFailure(
+                phase: .finalTranscription,
+                error: error,
+                for: request.outputURL,
+                request: request
+            )
+            let failure = loadTranscriptionFailure(for: request.outputURL)
+                ?? transientTranscriptionFailures[transcriptionFailureKey(for: request.outputURL)]
+            if let failure {
+                return .failed(failure)
+            }
+            return .skipped
+        }
+    }
+
+    private func resolvedTask(for request: FinalTranscriptionRequest) -> TranscriptionTask {
+        guard request.task == .translate,
+              let providerId = request.providerId,
+              let plugin = PluginManager.shared?.transcriptionEngine(for: providerId),
+              !plugin.supportsTranslation else {
+            return request.task
+        }
+        return .transcribe
+    }
+
+    private func recordRetranscriptionFailure(
+        phase: RecordingTranscriptionFailure.Phase,
+        error: Error,
+        for audioURL: URL,
+        request: FinalTranscriptionRequest? = nil
+    ) {
+        let request = request ?? FinalTranscriptionRequest(
+            outputURL: audioURL,
+            buffer: [],
+            languageSelection: languageSelection,
+            task: selectedTask,
+            providerId: effectiveProviderId,
+            modelOverrideId: selectedModel,
+            prompt: nil,
+            dictionaryTermHints: [],
+            liveSessionResult: nil
+        )
+        let failure = makeTranscriptionFailure(
+            phase: phase,
+            providerError: error.localizedDescription,
+            request: request
+        )
+        let recordedFailure = saveTranscriptionFailure(failure, for: audioURL)
+        errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
     }
 
     // MARK: - Transcript Sidecar

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -684,6 +684,8 @@ final class AudioRecorderViewModel: ObservableObject {
     }
 
     func deleteRecording(_ item: RecordingItem) {
+        guard !isRetranscribing(item) else { return }
+
         do {
             try FileManager.default.removeItem(at: item.url)
             // Also delete sidecar transcript

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -384,6 +384,7 @@ private struct RecordingRow: View {
     let item: AudioRecorderViewModel.RecordingItem
     @ObservedObject var viewModel: AudioRecorderViewModel
     @State private var showTranscript = false
+    @State private var showRetranscriptionConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -423,13 +424,22 @@ private struct RecordingRow: View {
                         .help(String(localized: "recorder.showTranscript"))
                     }
 
-                    Button {
-                        viewModel.transcribeRecording(item)
-                    } label: {
-                        Image(systemName: "text.viewfinder")
+                    if viewModel.isRetranscribing(item) {
+                        ProgressView()
+                            .controlSize(.small)
+                            .help(String(localized: "recorder.retranscribing"))
+                    } else {
+                        Button {
+                            requestTranscription()
+                        } label: {
+                            Image(systemName: item.transcript == nil
+                                ? "text.viewfinder"
+                                : "arrow.triangle.2.circlepath")
+                        }
+                        .buttonStyle(.borderless)
+                        .help(transcriptionActionTitle)
+                        .disabled(!viewModel.canTranscribeRecording(item))
                     }
-                    .buttonStyle(.borderless)
-                    .help(String(localized: "recorder.transcribe"))
 
                     Button {
                         viewModel.revealInFinder(item)
@@ -438,6 +448,7 @@ private struct RecordingRow: View {
                     }
                     .buttonStyle(.borderless)
                     .help(String(localized: "recorder.revealInFinder"))
+                    .disabled(viewModel.isRetranscribing(item))
 
                     Button(role: .destructive) {
                         viewModel.deleteRecording(item)
@@ -446,10 +457,12 @@ private struct RecordingRow: View {
                     }
                     .buttonStyle(.borderless)
                     .help(String(localized: "recorder.delete"))
+                    .disabled(viewModel.isRetranscribing(item))
                 }
             }
 
-            if let failureSummary = viewModel.transcriptionFailureSummary(for: item) {
+            if !viewModel.isRetranscribing(item),
+               let failureSummary = viewModel.transcriptionFailureSummary(for: item) {
                 Label(failureSummary, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)
@@ -485,16 +498,50 @@ private struct RecordingRow: View {
                 }
                 Divider()
             }
-            Button(String(localized: "recorder.transcribe")) {
-                viewModel.transcribeRecording(item)
+            Button(transcriptionActionTitle) {
+                requestTranscription()
             }
+            .disabled(!viewModel.canTranscribeRecording(item))
             Button(String(localized: "recorder.revealInFinder")) {
                 viewModel.revealInFinder(item)
             }
+            .disabled(viewModel.isRetranscribing(item))
             Divider()
             Button(String(localized: "recorder.delete"), role: .destructive) {
                 viewModel.deleteRecording(item)
             }
+            .disabled(viewModel.isRetranscribing(item))
+        }
+        .confirmationDialog(
+            String(localized: "recorder.retranscribeConfirmation.title"),
+            isPresented: $showRetranscriptionConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "recorder.retranscribe"), role: .destructive) {
+                viewModel.transcribeRecording(item)
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: {
+            Text(
+                String(
+                    format: String(localized: "recorder.retranscribeConfirmation.message"),
+                    item.fileName
+                )
+            )
+        }
+    }
+
+    private var transcriptionActionTitle: String {
+        item.transcript == nil
+            ? String(localized: "recorder.transcribe")
+            : String(localized: "recorder.retranscribe")
+    }
+
+    private func requestTranscription() {
+        if item.transcript == nil {
+            viewModel.transcribeRecording(item)
+        } else {
+            showRetranscriptionConfirmation = true
         }
     }
 

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -427,7 +427,9 @@ private struct RecordingRow: View {
                     if viewModel.isRetranscribing(item) {
                         ProgressView()
                             .controlSize(.small)
-                            .help(String(localized: "recorder.retranscribing"))
+                            .help(item.transcript == nil
+                                ? String(localized: "recorder.transcribing")
+                                : String(localized: "recorder.retranscribing"))
                     } else {
                         Button {
                             requestTranscription()

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -590,6 +590,10 @@ final class AudioRecorderViewModelTests: XCTestCase {
         viewModel.transcribeRecording(second)
         XCTAssertEqual(loadCount, 1)
 
+        viewModel.deleteRecording(first)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.url.path))
+        XCTAssertEqual(viewModel.recordings.count, 2)
+
         do {
             _ = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
             XCTFail("Expected recording start to be rejected while retranscribing")

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -377,11 +377,253 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(sidecarValues.isDirectory, true)
     }
 
+    func testRetranscriptionUsesRecorderOverridesAndReplacesTranscriptAfterSuccess() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(
+            groqBehavior: .success("wrong engine"),
+            assemblyAIBehavior: .success("fresh retranscription")
+        )
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.m4a")
+        let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
+        let failureURL = failureSidecarURL(for: audioURL)
+        try Data("audio".utf8).write(to: audioURL)
+        try "old transcript".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let oldFailure = AudioRecorderViewModel.RecordingTranscriptionFailure(
+            phase: .finalTranscription,
+            providerError: "old failure",
+            engineName: "Groq",
+            modelName: "Whisper Large V3",
+            failedAt: .distantPast
+        )
+        try JSONEncoder().encode(oldFailure).write(to: failureURL, options: .atomic)
+
+        let dictionaryService = DictionaryService(appSupportDirectory: makeTemporaryDirectory())
+        dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        var loadedURL: URL?
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            dictionaryService: dictionaryService,
+            audioSamplesLoader: { url in
+                loadedURL = url
+                return [0.25, -0.25]
+            }
+        )
+        viewModel.selectedEngine = "assemblyai"
+        viewModel.selectedModel = "universal-3-pro"
+        viewModel.languageSelection = .exact("de")
+        viewModel.selectedTask = .translate
+        viewModel.loadRecordings()
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        viewModel.transcribeRecording(recording)
+        XCTAssertFalse(viewModel.canToggleRecording)
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertEqual(loadedURL?.standardizedFileURL, audioURL.standardizedFileURL)
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "fresh retranscription")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: failureURL.path))
+        XCTAssertEqual(viewModel.recordings.first?.transcript, "fresh retranscription")
+        XCTAssertNil(viewModel.recordings.first?.transcriptionFailure)
+        XCTAssertTrue(viewModel.canToggleRecording)
+
+        let plugin = try XCTUnwrap(
+            PluginManager.shared.transcriptionEngine(for: "assemblyai") as? AudioRecorderMockTranscriptionPlugin
+        )
+        let request = try XCTUnwrap(plugin.lastRequest)
+        XCTAssertEqual(request.language, "de")
+        XCTAssertTrue(request.translate)
+        XCTAssertTrue(request.prompt?.contains("TypeWhisper") == true)
+        XCTAssertTrue(plugin.selectedModelOverrides.contains("universal-3-pro"))
+    }
+
+    func testRetranscriptionAudioLoadFailurePreservesExistingTranscript() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager()
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.wav")
+        let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
+        try Data("audio".utf8).write(to: audioURL)
+        try "keep me".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in throw AudioFileService.AudioFileError.unsupportedFormat }
+        )
+        viewModel.loadRecordings()
+
+        viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
+        XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .preparingFinalAudio)
+        XCTAssertNil(viewModel.retranscribingRecordingURL)
+    }
+
+    func testRetranscriptionEngineFailurePreservesExistingTranscript() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .failure("provider unavailable"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.wav")
+        let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
+        try Data("audio".utf8).write(to: audioURL)
+        try "keep me".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in [0.25, -0.25] }
+        )
+        viewModel.loadRecordings()
+
+        viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
+        XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .finalTranscription)
+        XCTAssertTrue(viewModel.recordings.first?.transcriptionFailure?.providerError.contains("provider unavailable") == true)
+    }
+
+    func testEmptyRetranscriptionPersistsFailureWithoutTranscript() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .empty)
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.wav")
+        try Data("audio".utf8).write(to: audioURL)
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in [0.25, -0.25] }
+        )
+        viewModel.loadRecordings()
+
+        viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertNil(viewModel.recordings.first?.transcript)
+        XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .emptyResult)
+    }
+
+    func testRetranscriptionSaveFailurePreservesExistingTranscriptAndRecordsFailure() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .success("replacement"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.wav")
+        let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
+        let failureURL = failureSidecarURL(for: audioURL)
+        try Data("audio".utf8).write(to: audioURL)
+        try "keep me".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: transcriptURL.path)
+        defer {
+            try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: transcriptURL.path)
+        }
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in [0.25, -0.25] }
+        )
+        viewModel.loadRecordings()
+
+        viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .savingTranscript)
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failureURL.path))
+    }
+
+    func testRetranscriptionRejectsConcurrentRetryAndRecordingStart() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager()
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let firstURL = recordingsDirectory.appendingPathComponent("First.wav")
+        let secondURL = recordingsDirectory.appendingPathComponent("Second.wav")
+        try Data("first".utf8).write(to: firstURL)
+        try Data("second".utf8).write(to: secondURL)
+        var continuation: CheckedContinuation<[Float], Never>?
+        var loadCount = 0
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in
+                loadCount += 1
+                return await withCheckedContinuation { continuation = $0 }
+            }
+        )
+        viewModel.loadRecordings()
+        XCTAssertEqual(viewModel.recordings.count, 2)
+        let first = try XCTUnwrap(viewModel.recordings.first)
+        let second = try XCTUnwrap(viewModel.recordings.dropFirst().first)
+
+        viewModel.transcribeRecording(first)
+        for _ in 0..<20 where continuation == nil {
+            await Task.yield()
+        }
+        XCTAssertNotNil(continuation)
+        XCTAssertFalse(viewModel.canToggleRecording)
+        XCTAssertFalse(viewModel.canTranscribeRecording(second))
+
+        viewModel.transcribeRecording(second)
+        XCTAssertEqual(loadCount, 1)
+
+        do {
+            _ = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+            XCTFail("Expected recording start to be rejected while retranscribing")
+        } catch let error as AudioRecorderViewModel.RecorderAPIError {
+            guard case .retranscribing = error else {
+                return XCTFail("Expected retranscribing error, got \(error)")
+            }
+        }
+
+        continuation?.resume(returning: [0.25, -0.25])
+        try await waitForRetranscriptionToFinish(viewModel)
+        XCTAssertTrue(viewModel.canToggleRecording)
+    }
+
+    func testRecorderRetranscriptionCopyIsLocalized() throws {
+        for key in [
+            "recorder.retranscribe",
+            "recorder.retranscribing",
+            "recorder.retranscribeConfirmation.title",
+            "recorder.retranscribeConfirmation.message"
+        ] {
+            for language in ["de", "en", "ja"] {
+                XCTAssertFalse(try TestSupport.localizedCatalogValue(for: key, language: language).isEmpty)
+            }
+        }
+    }
+
     private func makeViewModel(
         defaults: UserDefaults,
         modelManager: ModelManagerService = ModelManagerService(),
         recorderService: AudioRecorderService? = nil,
+        dictionaryService: DictionaryService? = nil,
         audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
+        audioSamplesLoader: AudioRecorderViewModel.AudioSamplesLoader? = nil,
         livePreviewStartObserver: (() -> Void)? = nil
     ) -> AudioRecorderViewModel {
         setupEventBus()
@@ -393,9 +635,10 @@ final class AudioRecorderViewModelTests: XCTestCase {
         return AudioRecorderViewModel(
             recorderService: resolvedRecorderService,
             modelManager: modelManager,
-            dictionaryService: DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
+            dictionaryService: dictionaryService ?? DictionaryService(appSupportDirectory: makeTemporaryDirectory()),
             audioDeviceService: audioDeviceService,
             defaults: defaults,
+            audioSamplesLoader: audioSamplesLoader,
             livePreviewStartObserver: livePreviewStartObserver
         )
     }
@@ -440,6 +683,20 @@ final class AudioRecorderViewModelTests: XCTestCase {
 
     private func failureSidecarURL(for audioURL: URL) -> URL {
         audioURL.appendingPathExtension("transcription-failure.json")
+    }
+
+    private func waitForRetranscriptionToFinish(
+        _ viewModel: AudioRecorderViewModel,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<100 {
+            if viewModel.retranscribingRecordingURL == nil {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("Recorder retranscription did not finish", file: file, line: line)
     }
 
     private func livePreviewStartCount(
@@ -598,6 +855,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
 }
 
 private final class AudioRecorderMockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    struct Request: Sendable {
+        let language: String?
+        let translate: Bool
+        let prompt: String?
+    }
+
     enum TranscriptionBehavior {
         case success(String)
         case empty
@@ -614,6 +877,8 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
     var isConfigured = true
     var supportsTranslation = true
     private let behavior: TranscriptionBehavior
+    private(set) var lastRequest: Request?
+    private(set) var selectedModelOverrides: [String] = []
 
     required override init() {
         self.providerId = "mock"
@@ -643,6 +908,7 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
     func deactivate() {}
 
     func selectModel(_ modelId: String) {
+        selectedModelOverrides.append(modelId)
         selectedModelId = modelId
     }
 
@@ -652,7 +918,8 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        switch behavior {
+        lastRequest = Request(language: language, translate: translate, prompt: prompt)
+        return switch behavior {
         case .success(let text):
             PluginTranscriptionResult(text: text)
         case .empty:


### PR DESCRIPTION
## Context

Issue #902 reports that Recorder audio can survive an app or Mac restart while its in-flight transcription is lost, leaving no way to retry inside the Recorder. Users currently have to re-import the recording through File Transcription.

This change adds a direct, manual Recorder retranscription path. Automatic resume after relaunch remains out of scope.

## Changes

- retranscribe Recorder files with the Recorder's current engine, model, language, task, and dictionary settings
- allow immediate transcription for recordings without a transcript and require confirmation before replacing an existing transcript
- limit Recorder retranscription to one file at a time and block recording starts while it runs
- atomically update transcript sidecars on success and clear stale failure metadata
- persist audio-loading, provider, empty-result, and transcript-writing failures without losing an existing transcript
- show per-row progress and disable conflicting actions
- add German, English, and Japanese UI copy
- add focused coverage for success, settings overrides, all failure stages, transcript preservation, and concurrency guards

Recovery behavior is unchanged because that flow handles recovered dictations rather than Recorder files.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `git diff --check`

Closes #902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for re-transcribing existing recordings, including async sample loading and a dedicated in-progress retranscription state.
  * Added a confirmation dialog before replacing an existing transcript and updated the UI to show a retranscription progress indicator and status.
  * While retranscribing, recording toggles, deletion, and file-reveal actions are disabled to prevent conflicting operations.
  * Retranscription now preserves the existing transcript on failure and clears prior failure state on success.
* **Localization**
  * Added new strings for the retranscription confirmation and progress/status messaging.
* **Tests**
  * Added extensive retranscription coverage for success, multiple failure modes, and concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->