### PR TITLE
Make recording cancel confirmation optional

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -18,6 +18,7 @@ enum UserDefaultsKeys {
     static let dictationHotkeysPaused = "dictationHotkeysPaused"
     static let transcribeShortQuietClipsAggressively = "transcribeShortQuietClipsAggressively"
     static let microphoneBoostEnabled = "microphoneBoostEnabled"
+    static let requireSecondEscapeToCancelRecording = "requireSecondEscapeToCancelRecording"
 
     // MARK: - Hotkey (JSON-encoded UnifiedHotkey per slot, legacy mirror for first binding)
     static let hybridHotkey = "hybridHotkey"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -8588,6 +8588,22 @@
         }
       }
     },
+    "Require second Esc press to cancel recording": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zweites Drücken von Esc zum Abbrechen erforderlich"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音のキャンセルにEscキーを2回押す"
+          }
+        }
+      }
+    },
     "Press to start, press again to stop.": {
       "localizations": {
         "de": {
@@ -14232,6 +14248,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "無効にすると、インジケーターは録音状態のみを表示し、背景でのテキスト生成は継続されます。"
+          }
+        }
+      }
+    },
+    "When disabled, pressing Esc once immediately discards the active recording.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn deaktiviert, verwirft ein einmaliges Drücken von Esc die aktive Aufnahme sofort."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効にすると、Escキーを1回押すだけで進行中の録音が直ちに破棄されます。"
           }
         }
       }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -209,6 +209,9 @@ final class DictationViewModel: ObservableObject {
     @Published var transcribeShortQuietClipsAggressively: Bool {
         didSet { Self.persistTranscribeShortQuietClipsAggressively(transcribeShortQuietClipsAggressively) }
     }
+    @Published var requireSecondEscapeToCancelRecording: Bool {
+        didSet { Self.persistRequireSecondEscapeToCancelRecording(requireSecondEscapeToCancelRecording) }
+    }
     @Published var microphoneBoostEnabled: Bool {
         didSet {
             Self.persistMicrophoneBoostEnabled(microphoneBoostEnabled)
@@ -485,6 +488,7 @@ final class DictationViewModel: ObservableObject {
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
         self.transcribeShortQuietClipsAggressively = Self.loadTranscribeShortQuietClipsAggressively()
+        self.requireSecondEscapeToCancelRecording = Self.loadRequireSecondEscapeToCancelRecording()
         self.microphoneBoostEnabled = Self.loadMicrophoneBoostEnabled()
         self.spokenFeedbackEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.spokenFeedbackEnabled)
         self.indicatorStyle = Self.loadIndicatorStyle()
@@ -597,6 +601,14 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistTranscribeShortQuietClipsAggressively(_ enabled: Bool, defaults: UserDefaults = .standard) {
         defaults.set(enabled, forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively)
+    }
+
+    nonisolated static func loadRequireSecondEscapeToCancelRecording(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording) as? Bool ?? true
+    }
+
+    nonisolated static func persistRequireSecondEscapeToCancelRecording(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording)
     }
 
     nonisolated static func loadMicrophoneBoostEnabled(defaults: UserDefaults = .standard) -> Bool {
@@ -934,6 +946,12 @@ final class DictationViewModel: ObservableObject {
 
     func handleCancelHotkey() {
         guard let target = cancelWarningTargetForCurrentState() else { return }
+
+        if target == .recording, !requireSecondEscapeToCancelRecording {
+            clearCancelWarning()
+            cancelCurrentOperation()
+            return
+        }
 
         if cancelWarningTarget == target {
             clearCancelWarning()

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -175,6 +175,13 @@ struct AdvancedSettingsView: View {
                     )
                 }
 
+                Toggle(isOn: $dictation.requireSecondEscapeToCancelRecording) {
+                    SettingsInfoLabel(
+                        title: String(localized: "Require second Esc press to cancel recording"),
+                        info: String(localized: "When disabled, pressing Esc once immediately discards the active recording.")
+                    )
+                }
+
                 Toggle(isOn: $dictation.microphoneBoostEnabled) {
                     SettingsInfoLabel(
                         title: localizedAppText("Whisper Mode (AGC)", de: "Whisper-Modus (AGC)"),

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -8316,6 +8316,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
+        let originalPreference = context.dictationViewModel.requireSecondEscapeToCancelRecording
+        defer { context.dictationViewModel.requireSecondEscapeToCancelRecording = originalPreference }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = true
         context.dictationViewModel.state = .recording
 
         context.dictationViewModel.handleCancelHotkey()
@@ -8339,9 +8342,38 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
+        let originalPreference = context.dictationViewModel.requireSecondEscapeToCancelRecording
+        defer { context.dictationViewModel.requireSecondEscapeToCancelRecording = originalPreference }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = true
         context.dictationViewModel.state = .recording
 
         context.dictationViewModel.handleCancelHotkey()
+        context.dictationViewModel.handleCancelHotkey()
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertNil(context.dictationViewModel.cancelWarningMessage)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            try TestSupport.localizedCatalogValueForCurrentLocale(for: "Cancelled")
+        )
+    }
+
+    @MainActor
+    func testHandleCancelHotkey_firstEscapeDuringRecordingCancelsWhenConfirmationDisabled() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        let originalPreference = context.dictationViewModel.requireSecondEscapeToCancelRecording
+        defer { context.dictationViewModel.requireSecondEscapeToCancelRecording = originalPreference }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = false
+        context.dictationViewModel.state = .recording
+
         context.dictationViewModel.handleCancelHotkey()
 
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
@@ -8377,6 +8409,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
             mediaPlaybackService: mediaPlaybackService
         )
         let context = try XCTUnwrap(dictationContext)
+        let originalPreference = context.dictationViewModel.requireSecondEscapeToCancelRecording
+        defer { context.dictationViewModel.requireSecondEscapeToCancelRecording = originalPreference }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = true
         context.audioRecordingService.stopRecordingOverride = { policy in
             events.append("stop_recording_\(policy.logDescription)")
             stopRecordingCalled.fulfill()
@@ -8406,6 +8441,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
+        let originalPreference = context.dictationViewModel.requireSecondEscapeToCancelRecording
+        defer { context.dictationViewModel.requireSecondEscapeToCancelRecording = originalPreference }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = false
         context.dictationViewModel.state = .processing
 
         context.dictationViewModel.handleCancelHotkey()
@@ -8484,6 +8522,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
 
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
+        let originalPreference = context.dictationViewModel.requireSecondEscapeToCancelRecording
+        defer { context.dictationViewModel.requireSecondEscapeToCancelRecording = originalPreference }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = true
         context.dictationViewModel.state = .recording
 
         context.dictationViewModel.handleCancelHotkey()

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -114,6 +114,30 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
         XCTAssertTrue(DictationViewModel.loadTranscribeShortQuietClipsAggressively(defaults: defaults))
     }
 
+    func testRecordingCancelConfirmationDefaultsToEnabled() {
+        XCTAssertTrue(DictationViewModel.loadRequireSecondEscapeToCancelRecording(defaults: defaults))
+    }
+
+    func testRecordingCancelConfirmationPersistsWhenDisabled() {
+        DictationViewModel.persistRequireSecondEscapeToCancelRecording(false, defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording) as? Bool,
+            false
+        )
+        XCTAssertFalse(DictationViewModel.loadRequireSecondEscapeToCancelRecording(defaults: defaults))
+    }
+
+    func testRecordingCancelConfirmationPersistsWhenEnabled() {
+        DictationViewModel.persistRequireSecondEscapeToCancelRecording(true, defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording) as? Bool,
+            true
+        )
+        XCTAssertTrue(DictationViewModel.loadRequireSecondEscapeToCancelRecording(defaults: defaults))
+    }
+
     func testMicrophoneBoostDefaultsToDisabled() {
         XCTAssertFalse(DictationViewModel.loadMicrophoneBoostEnabled(defaults: defaults))
     }

--- a/docs/specs/2026-07-15-optional-recording-cancel-confirmation-design.md
+++ b/docs/specs/2026-07-15-optional-recording-cancel-confirmation-design.md
@@ -1,0 +1,57 @@
+# Optional Recording Cancel Confirmation
+
+## Context
+
+TypeWhisper intentionally requires two Escape presses before cancelling an active dictation recording. This protects long recordings from accidental global Escape presses. Some users prefer a faster cancellation path and accept the risk of immediately discarding the active recording.
+
+The preference must remain an expert option and must not add more visual weight to the primary Recording or Hotkeys settings.
+
+## Design
+
+Add one toggle to the existing **Advanced > Recording** section:
+
+- Label: **Require second Esc press to cancel recording**
+- Help text: **When disabled, pressing Esc once immediately discards the active recording.**
+- Default: enabled
+
+No new settings page or section is introduced.
+
+## Behavior
+
+- With the preference enabled, the current behavior is unchanged: the first Escape press shows the cancellation warning and the second press cancels the active recording.
+- With the preference disabled, the first Escape press immediately cancels and discards the active recording.
+- The preference applies only while `DictationViewModel` is in the `.recording` state.
+- Cancellation during `.processing` remains unchanged and continues to require two Escape presses.
+- The Audio Recorder feature and its recordings are not affected.
+
+## Persistence and Integration
+
+- Add a boolean `UserDefaultsKeys` entry for the preference.
+- Expose the persisted value through `DictationViewModel`, following its existing load/persist helpers for advanced recording preferences.
+- Default to `true` when the key is absent so existing and upgraded installations retain the safe behavior.
+- Branch in `handleCancelHotkey()` only for the `.recording` target. Reuse the existing immediate cancellation path rather than introducing a second cancellation implementation.
+
+## Localization and Accessibility
+
+- Add English, German, and Japanese localizations for the toggle label and help text.
+- Use the existing `SettingsInfoLabel` pattern so the risk explanation is available consistently and exposed to accessibility clients.
+
+## Verification
+
+Add focused regression coverage proving:
+
+1. The absent preference defaults to requiring confirmation.
+2. The first Escape press during recording only warns when confirmation is enabled.
+3. A second Escape press cancels when confirmation is enabled.
+4. A single Escape press cancels during recording when confirmation is disabled.
+5. Disabling recording confirmation does not change the two-press processing cancellation behavior.
+6. Preference persistence round-trips through `UserDefaults`.
+
+Run the focused `APIRouterAndHandlersTests` cancellation tests and the relevant settings/defaults tests, followed by the normal project build or broader test suite appropriate for the changed files.
+
+## Non-Goals
+
+- Making Escape configurable or removable.
+- Changing cancellation behavior during transcription processing.
+- Adding workflow-specific or profile-specific overrides.
+- Changing Audio Recorder controls.


### PR DESCRIPTION
## Issue context

Issue #905 asks for an option to cancel an active recording with a single Esc press. The two-step confirmation was introduced to prevent accidental global Esc presses from discarding long recordings, so this change keeps that protection enabled by default and adds an explicit expert opt-out.

Closes #905

## Summary

- add a persistent **Require second Esc press to cancel recording** toggle under **Advanced → Recording**
- default the preference to enabled for existing and new installations
- allow a single Esc press to cancel only while dictation is actively recording when the preference is disabled
- keep two-step cancellation during transcription processing unchanged
- add German and Japanese localizations plus focused persistence and cancellation regression tests
- document the accepted design and scope

## Test plan

- `jq empty TypeWhisper/Resources/Localizable.xcstrings`
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_firstEscapeDuringRecordingShowsWarningWithoutCancelling -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_secondEscapeDuringRecordingCancels -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_firstEscapeDuringRecordingCancelsWhenConfirmationDisabled -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_secondEscapeDuringRecordingRestoresAudioThenResumesMediaBeforeImmediateStop -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testHandleCancelHotkey_processingRequiresSecondEscapeToCancel -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testRecordingCancelWarningClearsWhenStateLeavesRecording`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/8e04/typewhisper-mac`

Result: 25 selected tests passed. The signed dev app built and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app` with the validated dev App Group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced > Recording option to control Escape-key cancellation behavior.
  * By default, canceling a recording requires pressing Escape twice.
  * Users can disable the option to cancel immediately with one Escape press.
  * Added German and Japanese localization for the new setting.

* **Documentation**
  * Added specifications covering the setting’s behavior, accessibility, localization, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->