### PR TITLE
Prevent managed windows from restoring after login

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -41,6 +41,152 @@ enum DockIconVisibility {
     }
 }
 
+@MainActor
+enum ManagedAppWindowRestoration {
+    static func disable(for window: NSWindow) {
+        window.isRestorable = false
+    }
+}
+
+private final class ManagedAppWindowRestorationView: NSView {
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard let window else { return }
+        ManagedAppWindowRestoration.disable(for: window)
+    }
+}
+
+private struct ManagedAppWindowRestorationAccessor: NSViewRepresentable {
+    func makeNSView(context: Context) -> ManagedAppWindowRestorationView {
+        ManagedAppWindowRestorationView()
+    }
+
+    func updateNSView(_ nsView: ManagedAppWindowRestorationView, context: Context) {
+        guard let window = nsView.window else { return }
+        ManagedAppWindowRestoration.disable(for: window)
+    }
+}
+
+private extension View {
+    func disablesManagedAppWindowRestoration() -> some View {
+        background(ManagedAppWindowRestorationAccessor().frame(width: 0, height: 0))
+    }
+}
+
+struct SettingsManagedAppWindowScene: Scene {
+    let content: AnyView
+
+    var body: some Scene {
+        Window(String(localized: "Settings"), id: "settings") {
+            content
+                .disablesManagedAppWindowRestoration()
+        }
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 1050, height: 600)
+    }
+}
+
+struct SetupManagedAppWindowScene: Scene {
+    let content: AnyView
+
+    var body: some Scene {
+        Window(String(localized: "TypeWhisper Setup"), id: "setup") {
+            content
+                .disablesManagedAppWindowRestoration()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 820, height: 560)
+    }
+}
+
+struct HistoryManagedAppWindowScene: Scene {
+    let content: AnyView
+
+    var body: some Scene {
+        Window(String(localized: "History"), id: "history") {
+            content
+                .disablesManagedAppWindowRestoration()
+        }
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 900, height: 500)
+    }
+}
+
+struct ErrorLogManagedAppWindowScene: Scene {
+    let content: AnyView
+
+    var body: some Scene {
+        Window(String(localized: "Error Log"), id: "errors") {
+            content
+                .disablesManagedAppWindowRestoration()
+        }
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 500, height: 400)
+    }
+}
+
+@MainActor
+protocol ManagedAppWindowSceneConfiguration {
+    associatedtype SettingsScene: Scene
+    associatedtype SetupScene: Scene
+    associatedtype HistoryScene: Scene
+    associatedtype ErrorLogScene: Scene
+
+    static func settings(content: AnyView) -> SettingsScene
+    static func setup(content: AnyView) -> SetupScene
+    static func history(content: AnyView) -> HistoryScene
+    static func errorLog(content: AnyView) -> ErrorLogScene
+}
+
+enum LegacyManagedAppWindowSceneConfiguration: ManagedAppWindowSceneConfiguration {
+    static func settings(content: AnyView) -> some Scene {
+        SettingsManagedAppWindowScene(content: content)
+    }
+
+    static func setup(content: AnyView) -> some Scene {
+        SetupManagedAppWindowScene(content: content)
+    }
+
+    static func history(content: AnyView) -> some Scene {
+        HistoryManagedAppWindowScene(content: content)
+    }
+
+    static func errorLog(content: AnyView) -> some Scene {
+        ErrorLogManagedAppWindowScene(content: content)
+    }
+}
+
+@available(macOS 15.0, *)
+struct SuppressedManagedAppWindowScene<Content: Scene>: Scene {
+    let content: Content
+
+    var body: some Scene {
+        content
+            .defaultLaunchBehavior(.suppressed)
+            .restorationBehavior(.disabled)
+    }
+}
+
+@available(macOS 15.0, *)
+enum SuppressedManagedAppWindowSceneConfiguration: ManagedAppWindowSceneConfiguration {
+    static func settings(content: AnyView) -> some Scene {
+        SuppressedManagedAppWindowScene(content: SettingsManagedAppWindowScene(content: content))
+    }
+
+    static func setup(content: AnyView) -> some Scene {
+        SuppressedManagedAppWindowScene(content: SetupManagedAppWindowScene(content: content))
+    }
+
+    static func history(content: AnyView) -> some Scene {
+        SuppressedManagedAppWindowScene(content: HistoryManagedAppWindowScene(content: content))
+    }
+
+    static func errorLog(content: AnyView) -> some Scene {
+        SuppressedManagedAppWindowScene(content: ErrorLogManagedAppWindowScene(content: content))
+    }
+}
+
 enum MenuBarIconState {
     static func isRecordingActive(
         dictationState: DictationViewModel.State,
@@ -147,7 +293,7 @@ enum MenuBarLogoMarkImage {
     }
 }
 
-struct TypeWhisperApp: App {
+struct TypeWhisperApp<WindowConfiguration: ManagedAppWindowSceneConfiguration>: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @AppStorage(UserDefaultsKeys.showMenuBarIcon) private var showMenuBarIcon = true
     @State private var startupSheet: StartupSheetRoute?
@@ -179,34 +325,10 @@ struct TypeWhisperApp: App {
             }
         }
 
-        settingsScene
-
-        Window(String(localized: "TypeWhisper Setup"), id: "setup") {
-            setupContent
-        }
-        .windowStyle(.hiddenTitleBar)
-        .windowResizability(.contentSize)
-        .defaultSize(width: 820, height: 560)
-
-        Window(String(localized: "History"), id: "history") {
-            historyContent
-        }
-        .windowResizability(.contentMinSize)
-        .defaultSize(width: 900, height: 500)
-
-        Window(String(localized: "Error Log"), id: "errors") {
-            errorLogContent
-        }
-        .windowResizability(.contentMinSize)
-        .defaultSize(width: 500, height: 400)
-    }
-
-    private var settingsScene: some Scene {
-        Window(String(localized: "Settings"), id: "settings") {
-            settingsContent
-        }
-        .windowResizability(.contentMinSize)
-        .defaultSize(width: 1050, height: 600)
+        WindowConfiguration.settings(content: AnyView(settingsContent))
+        WindowConfiguration.setup(content: AnyView(setupContent))
+        WindowConfiguration.history(content: AnyView(historyContent))
+        WindowConfiguration.errorLog(content: AnyView(errorLogContent))
     }
 
     @ViewBuilder

--- a/TypeWhisper/App/main.swift
+++ b/TypeWhisper/App/main.swift
@@ -34,4 +34,8 @@ private class OverrideBundle: Bundle, @unchecked Sendable {
 
 object_setClass(Bundle.main, OverrideBundle.self)
 
-TypeWhisperApp.main()
+if #available(macOS 15.0, *) {
+    TypeWhisperApp<SuppressedManagedAppWindowSceneConfiguration>.main()
+} else {
+    TypeWhisperApp<LegacyManagedAppWindowSceneConfiguration>.main()
+}

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -857,6 +857,23 @@ final class DockIconVisibilityTests: XCTestCase {
     }
 }
 
+@MainActor
+final class ManagedAppWindowRestorationTests: XCTestCase {
+    func testManagedWindowIsMarkedNonRestorable() {
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isRestorable = true
+
+        ManagedAppWindowRestoration.disable(for: window)
+
+        XCTAssertFalse(window.isRestorable)
+    }
+}
+
 final class MenuBarGroupingTests: XCTestCase {
     func testMenuBarSectionsUseExpectedOrderAndLocalizedKeys() {
         XCTAssertEqual(


### PR DESCRIPTION
## Issue context

Issue #907 reports that TypeWhisper appears in the Dock after a login launch even though App visibility is set to Menu bar icon. The preference itself remains correct; a SwiftUI-managed window can be launched or restored during startup, which temporarily forces the regular activation policy.

## Summary

- select a macOS 15+ managed-window scene configuration at app entry and suppress automatic launch plus scene restoration
- keep the macOS 14 scene configuration and mark Settings, Setup, History, and Error Log windows as non-restorable through a shared AppKit accessor
- preserve the existing DockIconVisibility behavior and the explicit first-run Setup opening
- add a regression test for the AppKit non-restorable-window fallback

Closes #907

## Test plan

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/DockIconVisibilityTests -only-testing:TypeWhisperTests/PostUpdatePromptCoordinatorTests -only-testing:TypeWhisperTests/ManagedAppWindowRestorationTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
scripts/pr-preflight.sh origin/main
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/f1ee/typewhisper-mac
```

Manual dev-app smoke:

- with Menu bar icon enabled, a background relaunch after quitting with Settings open had no managed windows and used the accessory activation policy
- opening Settings changed to the regular activation policy and showed one managed window; closing it returned to accessory with no managed windows
- Keep Dock Icon Visible remained regular with no windows
- Show Dock Icon Only While a Window Is Open remained accessory with no windows, switched to regular while Settings was open, and returned to accessory after closing it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Managed app windows no longer restore automatically after relaunch, providing a more predictable startup experience.
  * On macOS 15 and later, additional safeguards prevent managed windows from opening unexpectedly during launch.

* **Compatibility**
  * Window behavior is now tailored to the macOS version in use, preserving support for earlier releases.

* **Tests**
  * Added coverage to verify that automatic window restoration is disabled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->