### PR TITLE
Preserve file transcription languages across engine switches

### DIFF
--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -101,7 +101,6 @@ final class FileTranscriptionViewModel: ObservableObject {
             defaults.set(selectedEngine, forKey: UserDefaultsKeys.fileTranscriptionEngine)
             guard isInitialized, oldValue != selectedEngine else { return }
             selectedModel = nil
-            normalizeLanguageSelectionForResolvedEngine()
         }
     }
     @Published var selectedModel: String? {
@@ -533,15 +532,6 @@ final class FileTranscriptionViewModel: ObservableObject {
            pluginManager.transcriptionEngine(for: selectedEngine) == nil {
             self.selectedEngine = nil
             selectedModel = nil
-        }
-        normalizeLanguageSelectionForResolvedEngine()
-    }
-
-    private func normalizeLanguageSelectionForResolvedEngine() {
-        guard let engine = resolvedEngine else { return }
-        let normalized = languageSelection.normalizedForSupportedLanguages(engine.supportedLanguages)
-        if normalized != languageSelection {
-            languageSelection = normalized
         }
     }
 

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -5,6 +5,57 @@ import XCTest
 
 @MainActor
 final class FileTranscriptionViewModelTests: XCTestCase {
+    func testEngineSwitchPreservesFullLanguageSelectionAndPersistence() throws {
+        let previousPluginManager = PluginManager.shared
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer {
+            PluginManager.shared = previousPluginManager
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        let soniox = FileTranscriptionLanguageSelectionPlugin(
+            providerId: "soniox",
+            providerDisplayName: "Soniox",
+            supportedLanguages: ["es", "en", "uk"]
+        )
+        let assemblyAI = FileTranscriptionLanguageSelectionPlugin(
+            providerId: "assemblyai",
+            providerDisplayName: "AssemblyAI",
+            supportedLanguages: ["es", "en"]
+        )
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            loadedPlugin(for: soniox, appSupportDirectory: appSupportDirectory),
+            loadedPlugin(for: assemblyAI, appSupportDirectory: appSupportDirectory),
+        ]
+
+        let defaults = try makeDefaults()
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
+            defaults: defaults
+        )
+        let fullSelection = LanguageSelection.hints(["es", "en", "uk"])
+
+        viewModel.selectedEngine = soniox.providerId
+        viewModel.languageSelection = fullSelection
+        viewModel.selectedEngine = assemblyAI.providerId
+
+        XCTAssertEqual(viewModel.languageSelection, fullSelection)
+        XCTAssertEqual(
+            LanguageSelection(
+                storedValue: defaults.string(forKey: UserDefaultsKeys.fileTranscriptionLanguage),
+                nilBehavior: .auto
+            ),
+            fullSelection
+        )
+
+        viewModel.selectedEngine = soniox.providerId
+
+        XCTAssertEqual(viewModel.languageSelection, fullSelection)
+    }
+
     func testFileTranscriptionCanStartWithPrepareableAppleSpeechCatalog() async throws {
         let previousPluginManager = PluginManager.shared
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
@@ -818,6 +869,24 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         PluginManager.shared = pluginManager
     }
 
+    private func loadedPlugin(
+        for plugin: FileTranscriptionLanguageSelectionPlugin,
+        appSupportDirectory: URL
+    ) -> LoadedPlugin {
+        LoadedPlugin(
+            manifest: PluginManifest(
+                id: "com.typewhisper.mock.\(plugin.providerId)",
+                name: plugin.providerDisplayName,
+                version: "1.0.0",
+                principalClass: "FileTranscriptionLanguageSelectionPlugin"
+            ),
+            instance: plugin,
+            bundle: Bundle.main,
+            sourceURL: appSupportDirectory,
+            isEnabled: true
+        )
+    }
+
     private func waitForBatchToFinish(_ viewModel: FileTranscriptionViewModel) async throws {
         for _ in 0..<50 {
             if viewModel.batchState == .done {
@@ -872,6 +941,44 @@ private actor AsyncGate {
 }
 
 private struct UnknownTranscriptionError: Error {}
+
+private final class FileTranscriptionLanguageSelectionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.file-transcription-language-selection"
+    static let pluginName = "File Transcription Language Selection"
+
+    private(set) var providerId = "file-transcription-language-selection"
+    private(set) var providerDisplayName = "File Transcription Language Selection"
+    private(set) var supportedLanguages: [String] = []
+    let isConfigured = true
+    let transcriptionModels: [PluginModelInfo] = []
+    let selectedModelId: String? = nil
+    let supportsTranslation = false
+    let supportsStreaming = false
+
+    required override init() {
+        super.init()
+    }
+
+    convenience init(providerId: String, providerDisplayName: String, supportedLanguages: [String]) {
+        self.init()
+        self.providerId = providerId
+        self.providerDisplayName = providerDisplayName
+        self.supportedLanguages = supportedLanguages
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func selectModel(_ modelId: String) {}
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+    }
+}
 
 private final class FileTranscriptionAppleSpeechCatalogPlugin: NSObject, TranscriptionModelCatalogProviding, @unchecked Sendable {
     static let pluginId = AppleSpeechModelSelection.manifestId


### PR DESCRIPTION
## Summary

- preserve the full File Transcription language preference when switching engines
- keep engine-specific filtering at the existing runtime boundary in `ModelManagerService`
- add regression coverage for a Soniox → AssemblyAI → Soniox round trip

## Issue context

File Transcription previously removed languages from the persisted selection when the active engine supported only a subset. Switching from Soniox to AssemblyAI therefore dropped Ukrainian permanently instead of restoring it after switching back.

## Root cause

`FileTranscriptionViewModel` normalized `languageSelection` against the resolved engine and assigned the filtered value back to the persisted property. The runtime path already derives an engine-compatible selection before invoking a plugin, so this view-model mutation was unnecessary and destructive.

## User impact

Users can move between transcription engines without silently losing language hints. Unsupported languages remain in the stored preference while the active engine receives only its supported effective selection.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Closes #911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected language when switching between transcription engines.
  * Improved plugin selection handling when an unavailable engine is detected.

* **Tests**
  * Added coverage verifying language selections remain unchanged and persist across engine switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->