### PR TITLE
Fix recorder Stop freeze with bounded streaming finalization

### DIFF
--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -953,7 +953,9 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             }
         } else if let finalURL = completedURL {
             do {
-                try finalizeOutputFile(stoppedRecording)
+                try await Task.detached(priority: .userInitiated) {
+                    try self.finalizeOutputFile(stoppedRecording)
+                }.value
             } catch {
                 logger.error("Failed to finalize recording: \(error.localizedDescription)")
                 cleanupTempFile(finalURL)

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -766,17 +766,16 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
         var completedURL = finalOutputURL
 
-        // Mix or copy to final output
+        // Mix or copy to final output. This is CPU/memory-heavy for long recordings
+        // (whole-file buffers, per-sample loops), so it runs off the calling actor to
+        // avoid freezing the UI when stopRecording() is awaited from the main actor.
         if let finalURL = completedURL {
             do {
-                if micEnabled && systemAudioEnabled,
-                   let micURL = micTempURL, let sysURL = systemTempURL {
-                    try mixAudioFiles(micURL: micURL, systemURL: sysURL, outputURL: finalURL)
-                } else if micEnabled, let micURL = micTempURL {
-                    try copyOrConvert(from: micURL, to: finalURL)
-                } else if systemAudioEnabled, let sysURL = systemTempURL {
-                    try copyOrConvert(from: sysURL, to: finalURL)
-                }
+                try await finalizeOutputFile(
+                    finalURL: finalURL,
+                    micURL: micEnabled ? micTempURL : nil,
+                    sysURL: systemAudioEnabled ? systemTempURL : nil
+                )
             } catch {
                 logger.error("Failed to finalize recording: \(error.localizedDescription)")
                 cleanupTempFile(finalURL)
@@ -1460,6 +1459,18 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     }
 
     // MARK: - Helpers
+
+    private func finalizeOutputFile(finalURL: URL, micURL: URL?, sysURL: URL?) async throws {
+        try await Task.detached(priority: .userInitiated) { [self] in
+            if let micURL, let sysURL {
+                try mixAudioFiles(micURL: micURL, systemURL: sysURL, outputURL: finalURL)
+            } else if let micURL {
+                try copyOrConvert(from: micURL, to: finalURL)
+            } else if let sysURL {
+                try copyOrConvert(from: sysURL, to: finalURL)
+            }
+        }.value
+    }
 
     private func copyOrConvert(from sourceURL: URL, to destinationURL: URL) throws {
         switch outputFormat {

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import AVFoundation
+import AudioToolbox
 import CoreAudio
 import ScreenCaptureKit
 import Combine
@@ -371,6 +372,76 @@ struct SystemAudioCaptureDiagnostics {
     }
 }
 
+private final class AudioFileChunkReader {
+    private let audioFile: ExtAudioFileRef
+    private let buffer: AVAudioPCMBuffer
+
+    init(
+        url: URL,
+        clientFormat: AVAudioFormat,
+        chunkFrameCount: AVAudioFrameCount
+    ) throws {
+        var openedFile: ExtAudioFileRef?
+        let openStatus = ExtAudioFileOpenURL(url as CFURL, &openedFile)
+        guard openStatus == noErr, let openedFile else {
+            throw Self.error(operation: "open", url: url, status: openStatus)
+        }
+
+        var streamDescription = clientFormat.streamDescription.pointee
+        let formatStatus = ExtAudioFileSetProperty(
+            openedFile,
+            kExtAudioFileProperty_ClientDataFormat,
+            UInt32(MemoryLayout<AudioStreamBasicDescription>.size),
+            &streamDescription
+        )
+        guard formatStatus == noErr else {
+            ExtAudioFileDispose(openedFile)
+            throw Self.error(operation: "configure", url: url, status: formatStatus)
+        }
+
+        self.audioFile = openedFile
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: clientFormat,
+            frameCapacity: chunkFrameCount
+        ) else {
+            ExtAudioFileDispose(openedFile)
+            throw NSError(
+                domain: "AudioRecorderService.AudioFileChunkReader",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not allocate an audio finalization buffer."]
+            )
+        }
+        self.buffer = buffer
+    }
+
+    deinit {
+        ExtAudioFileDispose(audioFile)
+    }
+
+    func read() throws -> AVAudioPCMBuffer {
+        var frameCount = buffer.frameCapacity
+        buffer.frameLength = frameCount
+        let readStatus = ExtAudioFileRead(audioFile, &frameCount, buffer.mutableAudioBufferList)
+        guard readStatus == noErr else {
+            throw Self.error(operation: "read", url: nil, status: readStatus)
+        }
+        buffer.frameLength = frameCount
+        return buffer
+    }
+
+    private static func error(operation: String, url: URL?, status: OSStatus) -> NSError {
+        var description = "Could not \(operation) audio during recorder finalization (OSStatus \(status))."
+        if let url {
+            description += " File: \(url.lastPathComponent)"
+        }
+        return NSError(
+            domain: NSOSStatusErrorDomain,
+            code: Int(status),
+            userInfo: [NSLocalizedDescriptionKey: description]
+        )
+    }
+}
+
 /// Records audio from microphone and/or system audio to file.
 /// Uses AVAudioEngine for mic and ScreenCaptureKit for system audio.
 final class AudioRecorderService: ObservableObject, @unchecked Sendable {
@@ -389,6 +460,81 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let envelopeReleaseTime: Double
         let gainAttackTime: Double
         let gainReleaseTime: Double
+    }
+
+    private struct MicDuckingProcessor {
+        private let parameters: MicDuckingParameters
+        private let holdSamples: Int
+        private let envelopeAttack: Float
+        private let envelopeRelease: Float
+        private let gainAttack: Float
+        private let gainRelease: Float
+        private var systemEnvelope: Float = 0
+        private var currentMicGain: Float = 1
+        private var remainingHold = 0
+        private(set) var minimumGain: Float = 1
+        private var gainSum: Float = 0
+        private var processedFrameCount = 0
+        private var duckingEngaged = false
+
+        init(parameters: MicDuckingParameters, sampleRate: Double) {
+            self.parameters = parameters
+            self.holdSamples = max(1, Int(sampleRate * parameters.holdTime))
+            self.envelopeAttack = AudioRecorderService.smoothingCoefficient(
+                timeConstant: parameters.envelopeAttackTime,
+                sampleRate: sampleRate
+            )
+            self.envelopeRelease = AudioRecorderService.smoothingCoefficient(
+                timeConstant: parameters.envelopeReleaseTime,
+                sampleRate: sampleRate
+            )
+            self.gainAttack = AudioRecorderService.smoothingCoefficient(
+                timeConstant: parameters.gainAttackTime,
+                sampleRate: sampleRate
+            )
+            self.gainRelease = AudioRecorderService.smoothingCoefficient(
+                timeConstant: parameters.gainReleaseTime,
+                sampleRate: sampleRate
+            )
+        }
+
+        mutating func gain(for referenceSample: Float) -> Float {
+            let sampleMagnitude = abs(referenceSample)
+            let envelopeCoefficient = sampleMagnitude > systemEnvelope ? envelopeAttack : envelopeRelease
+            systemEnvelope = sampleMagnitude + envelopeCoefficient * (systemEnvelope - sampleMagnitude)
+
+            let targetMicGain: Float
+            if systemEnvelope >= parameters.highThreshold {
+                targetMicGain = parameters.minimumMicGain
+                remainingHold = holdSamples
+                duckingEngaged = true
+            } else if systemEnvelope <= parameters.lowThreshold {
+                if remainingHold > 0 {
+                    remainingHold -= 1
+                    targetMicGain = parameters.minimumMicGain
+                    duckingEngaged = true
+                } else {
+                    targetMicGain = 1
+                }
+            } else {
+                let progress = (systemEnvelope - parameters.lowThreshold)
+                    / (parameters.highThreshold - parameters.lowThreshold)
+                targetMicGain = 1 - progress * (1 - parameters.minimumMicGain)
+                duckingEngaged = true
+            }
+
+            let gainCoefficient = targetMicGain < currentMicGain ? gainAttack : gainRelease
+            currentMicGain = targetMicGain + gainCoefficient * (currentMicGain - targetMicGain)
+            minimumGain = min(minimumGain, currentMicGain)
+            gainSum += currentMicGain
+            processedFrameCount += 1
+            return currentMicGain
+        }
+
+        var summary: (minimumGain: Float, averageGain: Float)? {
+            guard duckingEngaged, minimumGain < 0.99, processedFrameCount > 0 else { return nil }
+            return (minimumGain, gainSum / Float(processedFrameCount))
+        }
     }
 
     enum RecorderError: LocalizedError {
@@ -450,6 +596,17 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    struct StoppedRecording: Sendable {
+        let finalOutputURL: URL?
+        let micTempURL: URL?
+        let systemTempURL: URL?
+        let outputFormat: OutputFormat
+        let trackMode: TrackMode
+        let micDuckingMode: MicDuckingMode
+        let transcriptionSamples: [Float]
+        let usesFinalizationOverride: Bool
+    }
+
     @Published private(set) var isRecording = false
     @Published private(set) var duration: TimeInterval = 0
     @Published private(set) var micLevel: Float = 0
@@ -503,6 +660,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     private static let systemAudioNonSilentThreshold: Float = 0.0001
 
     static let recordingsDirectoryName = "TypeWhisper Recordings"
+    static let finalizationChunkFrameCount: AVAudioFrameCount = 8_192
 
     init(
         inputActivationGuard: AudioInputDeviceActivating = AudioInputDeviceActivationGuard(),
@@ -704,48 +862,36 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     }
 
     func stopRecording() async -> URL? {
+        let stoppedRecording = await stopCapture()
+        return await finalizeRecording(stoppedRecording)
+    }
+
+    func stopCapture(includeTranscriptionSamples: Bool = false) async -> StoppedRecording {
         // Stop timer
         durationTimer?.invalidate()
         durationTimer = nil
         endSystemAudioMonitoring()
 
-        if let stopRecordingOverride, let finalURL = finalOutputURL {
-            let completedURL: URL?
-            do {
-                completedURL = try await stopRecordingOverride(finalURL)
-            } catch {
-                logger.error("Failed to finalize recording with override: \(error.localizedDescription)")
-                cleanupTempFile(finalURL)
-                completedURL = nil
-            }
+        let usesFinalizationOverride = stopRecordingOverride != nil
+        let stoppedMicEnabled = micEnabled
+        let stoppedSystemAudioEnabled = systemAudioEnabled
+        let stoppedMicTempURL = stoppedMicEnabled ? micTempURL : nil
+        let stoppedSystemTempURL = stoppedSystemAudioEnabled ? systemTempURL : nil
+        let stoppedFinalOutputURL = finalOutputURL
+        let stoppedOutputFormat = outputFormat
+        let stoppedTrackMode = trackMode
+        let stoppedMicDuckingMode = micDuckingMode
 
-            cleanupTempFile(micTempURL)
-            cleanupTempFile(systemTempURL)
-            micTempURL = nil
-            systemTempURL = nil
-            finalOutputURL = nil
-            startTime = nil
-
-            DispatchQueue.main.async {
-                self.isRecording = false
-                self.duration = 0
-                self.micLevel = 0
-                self.systemLevel = 0
-            }
-
-            return completedURL
-        }
-
-        // Stop mic
-        if micEnabled {
+        // Test overrides own their capture lifecycle. Production capture must be fully
+        // stopped before any live-session or file finalization work begins.
+        if !usesFinalizationOverride, stoppedMicEnabled {
             audioEngine?.inputNode.removeTap(onBus: 0)
             audioEngine?.stop()
             audioEngine = nil
             micFileLock.withLock { $0 = nil }
         }
 
-        // Stop system audio
-        if systemAudioEnabled, let stream = scStream {
+        if !usesFinalizationOverride, stoppedSystemAudioEnabled, let stream = scStream {
             do {
                 try await stream.stopCapture()
             } catch {
@@ -756,36 +902,18 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             streamOutput = nil
         }
 
-        audioEngine?.inputNode.removeTap(onBus: 0)
-        audioEngine?.stop()
-        audioEngine = nil
-        micInputCaptureSession?.stop()
-        micInputCaptureSession = nil
-        micInputActivationGuard.restore(reason: "recorder-mic-stop")
-        micFileLock.withLock { $0 = nil }
-
-        var completedURL = finalOutputURL
-
-        // Mix or copy to final output. This is CPU/memory-heavy for long recordings
-        // (whole-file buffers, per-sample loops), so it runs off the calling actor to
-        // avoid freezing the UI when stopRecording() is awaited from the main actor.
-        if let finalURL = completedURL {
-            do {
-                try await finalizeOutputFile(
-                    finalURL: finalURL,
-                    micURL: micEnabled ? micTempURL : nil,
-                    sysURL: systemAudioEnabled ? systemTempURL : nil
-                )
-            } catch {
-                logger.error("Failed to finalize recording: \(error.localizedDescription)")
-                cleanupTempFile(finalURL)
-                completedURL = nil
-            }
+        if !usesFinalizationOverride {
+            audioEngine?.inputNode.removeTap(onBus: 0)
+            audioEngine?.stop()
+            audioEngine = nil
+            micInputCaptureSession?.stop()
+            micInputCaptureSession = nil
+            micInputActivationGuard.restore(reason: "recorder-mic-stop")
+            micFileLock.withLock { $0 = nil }
         }
 
-        // Cleanup temp files
-        cleanupTempFile(micTempURL)
-        cleanupTempFile(systemTempURL)
+        let transcriptionSamples = includeTranscriptionSamples ? getCurrentBuffer() : []
+
         micTempURL = nil
         systemTempURL = nil
         finalOutputURL = nil
@@ -797,6 +925,44 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             self.micLevel = 0
             self.systemLevel = 0
         }
+
+        return StoppedRecording(
+            finalOutputURL: stoppedFinalOutputURL,
+            micTempURL: stoppedMicTempURL,
+            systemTempURL: stoppedSystemTempURL,
+            outputFormat: stoppedOutputFormat,
+            trackMode: stoppedTrackMode,
+            micDuckingMode: stoppedMicDuckingMode,
+            transcriptionSamples: transcriptionSamples,
+            usesFinalizationOverride: usesFinalizationOverride
+        )
+    }
+
+    func finalizeRecording(_ stoppedRecording: StoppedRecording) async -> URL? {
+        var completedURL = stoppedRecording.finalOutputURL
+
+        if stoppedRecording.usesFinalizationOverride,
+           let stopRecordingOverride,
+           let finalURL = completedURL {
+            do {
+                completedURL = try await stopRecordingOverride(finalURL)
+            } catch {
+                logger.error("Failed to finalize recording with override: \(error.localizedDescription)")
+                cleanupTempFile(finalURL)
+                completedURL = nil
+            }
+        } else if let finalURL = completedURL {
+            do {
+                try finalizeOutputFile(stoppedRecording)
+            } catch {
+                logger.error("Failed to finalize recording: \(error.localizedDescription)")
+                cleanupTempFile(finalURL)
+                completedURL = nil
+            }
+        }
+
+        cleanupTempFile(stoppedRecording.micTempURL)
+        cleanupTempFile(stoppedRecording.systemTempURL)
 
         return completedURL
     }
@@ -1199,7 +1365,6 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let micFile = try AVAudioFile(forReading: micURL)
         let sysFile = try AVAudioFile(forReading: systemURL)
 
-        // Use the higher sample rate
         let targetSampleRate = max(micFile.processingFormat.sampleRate, sysFile.processingFormat.sampleRate)
         let targetChannels: AVAudioChannelCount = 2
 
@@ -1210,77 +1375,6 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
             interleaved: false
         ) else { return }
 
-        // Determine total length in frames at target sample rate
-        let micDuration = Double(micFile.length) / micFile.processingFormat.sampleRate
-        let sysDuration = Double(sysFile.length) / sysFile.processingFormat.sampleRate
-        let totalDuration = max(micDuration, sysDuration)
-        let totalFrames = AVAudioFrameCount(totalDuration * targetSampleRate)
-
-        guard totalFrames > 0 else { return }
-
-        // Read and convert both sources
-        let micBuffer = try readAndConvert(file: micFile, to: mixFormat, totalFrames: totalFrames)
-        let sysBuffer = try readAndConvert(file: sysFile, to: mixFormat, totalFrames: totalFrames)
-
-        let micDuckingProfile: MicDuckingProfile?
-        if trackMode == .mixed,
-           let systemLeft = sysBuffer.floatChannelData?[0] {
-            let systemRight = sysBuffer.format.channelCount > 1 ? sysBuffer.floatChannelData?[1] : nil
-            micDuckingProfile = Self.buildMicDuckingProfile(
-                frameCount: Int(totalFrames),
-                sampleRate: targetSampleRate,
-                mode: micDuckingMode
-            ) { index in
-                monoSample(left: systemLeft, right: systemRight, index: index)
-            }
-        } else {
-            micDuckingProfile = nil
-        }
-
-        if let micDuckingProfile {
-            logger.info("Applied mic ducking with minimum gain \(micDuckingProfile.minimumGain) and average gain \(micDuckingProfile.averageGain)")
-        }
-
-        // Mix buffers
-        guard let mixedBuffer = AVAudioPCMBuffer(pcmFormat: mixFormat, frameCapacity: totalFrames) else { return }
-        mixedBuffer.frameLength = totalFrames
-
-        if trackMode == .separate {
-            guard let leftData = mixedBuffer.floatChannelData?[0],
-                  let rightData = mixedBuffer.floatChannelData?[1],
-                  let micLeft = micBuffer.floatChannelData?[0],
-                  let systemLeft = sysBuffer.floatChannelData?[0] else { return }
-
-            let micRight = micBuffer.format.channelCount > 1 ? micBuffer.floatChannelData?[1] : nil
-            let systemRight = sysBuffer.format.channelCount > 1 ? sysBuffer.floatChannelData?[1] : nil
-
-            for i in 0..<Int(totalFrames) {
-                leftData[i] = i < Int(micBuffer.frameLength)
-                    ? monoSample(left: micLeft, right: micRight, index: i)
-                    : 0
-            }
-
-            for i in 0..<Int(totalFrames) {
-                rightData[i] = i < Int(sysBuffer.frameLength)
-                    ? monoSample(left: systemLeft, right: systemRight, index: i)
-                    : 0
-            }
-        } else {
-            for ch in 0..<Int(targetChannels) {
-                guard let mixedData = mixedBuffer.floatChannelData?[ch],
-                      let micData = micBuffer.floatChannelData?[ch],
-                      let sysData = sysBuffer.floatChannelData?[ch] else { continue }
-
-                for i in 0..<Int(totalFrames) {
-                    let micSample = i < Int(micBuffer.frameLength) ? micData[i] : 0
-                    let sysSample = i < Int(sysBuffer.frameLength) ? sysData[i] : 0
-                    let micGain = micDuckingProfile?.gains[i] ?? 1
-                    mixedData[i] = (micSample * micGain) + sysSample
-                }
-            }
-        }
-
-        // Write output
         let outputSettings: [String: Any]
         switch outputFormat {
         case .wav:
@@ -1302,82 +1396,71 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         }
 
         let outputFile = try AVAudioFile(forWriting: outputURL, settings: outputSettings)
-        try outputFile.write(from: mixedBuffer)
-    }
+        let micReader = try AudioFileChunkReader(
+            url: micURL,
+            clientFormat: mixFormat,
+            chunkFrameCount: Self.finalizationChunkFrameCount
+        )
+        let systemReader = try AudioFileChunkReader(
+            url: systemURL,
+            clientFormat: mixFormat,
+            chunkFrameCount: Self.finalizationChunkFrameCount
+        )
+        var duckingProcessor = trackMode == .mixed
+            ? Self.makeMicDuckingProcessor(mode: micDuckingMode, sampleRate: targetSampleRate)
+            : nil
 
-    private func readAndConvert(file: AVAudioFile, to targetFormat: AVAudioFormat, totalFrames: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
-        let sourceFormat = file.processingFormat
-        let sourceFrames = AVAudioFrameCount(file.length)
+        while true {
+            let micBuffer = try micReader.read()
+            let systemBuffer = try systemReader.read()
+            let frameCount = max(micBuffer.frameLength, systemBuffer.frameLength)
+            guard frameCount > 0 else { break }
 
-        guard let sourceBuffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: sourceFrames) else {
-            throw RecorderError.engineStartFailed("Cannot create read buffer")
-        }
-        try file.read(into: sourceBuffer)
-
-        // If formats match, just zero-pad to totalFrames
-        if sourceFormat.sampleRate == targetFormat.sampleRate && sourceFormat.channelCount == targetFormat.channelCount {
-            guard let padded = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: totalFrames) else {
-                return sourceBuffer
+            guard let mixedBuffer = AVAudioPCMBuffer(
+                pcmFormat: mixFormat,
+                frameCapacity: frameCount
+            ) else {
+                throw RecorderError.engineStartFailed("Cannot create finalization mix buffer")
             }
-            padded.frameLength = totalFrames
-            for ch in 0..<Int(targetFormat.channelCount) {
-                guard let dst = padded.floatChannelData?[ch],
-                      let src = sourceBuffer.floatChannelData?[ch] else { continue }
-                let copyCount = min(Int(sourceFrames), Int(totalFrames))
-                dst.update(from: src, count: copyCount)
-                if copyCount < Int(totalFrames) {
-                    dst.advanced(by: copyCount).update(repeating: 0, count: Int(totalFrames) - copyCount)
+            mixedBuffer.frameLength = frameCount
+
+            guard let outputLeft = mixedBuffer.floatChannelData?[0],
+                  let outputRight = mixedBuffer.floatChannelData?[1],
+                  let micLeft = micBuffer.floatChannelData?[0],
+                  let micRight = micBuffer.floatChannelData?[1],
+                  let systemLeft = systemBuffer.floatChannelData?[0],
+                  let systemRight = systemBuffer.floatChannelData?[1] else {
+                throw RecorderError.engineStartFailed("Cannot access finalization mix channels")
+            }
+
+            let micFrameCount = Int(micBuffer.frameLength)
+            let systemFrameCount = Int(systemBuffer.frameLength)
+            for index in 0..<Int(frameCount) {
+                let hasMicFrame = index < micFrameCount
+                let hasSystemFrame = index < systemFrameCount
+                if trackMode == .separate {
+                    outputLeft[index] = hasMicFrame ? (micLeft[index] + micRight[index]) * 0.5 : 0
+                    outputRight[index] = hasSystemFrame
+                        ? (systemLeft[index] + systemRight[index]) * 0.5
+                        : 0
+                    continue
                 }
+
+                let systemLeftSample = hasSystemFrame ? systemLeft[index] : 0
+                let systemRightSample = hasSystemFrame ? systemRight[index] : 0
+                let micGain = duckingProcessor?.gain(
+                    for: (systemLeftSample + systemRightSample) * 0.5
+                ) ?? 1
+                outputLeft[index] = (hasMicFrame ? micLeft[index] * micGain : 0) + systemLeftSample
+                outputRight[index] = (hasMicFrame ? micRight[index] * micGain : 0) + systemRightSample
             }
-            return padded
+
+            try outputFile.write(from: mixedBuffer)
         }
 
-        // Convert format
-        guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
-            throw RecorderError.engineStartFailed("Cannot create audio converter for mixing")
+        if let summary = duckingProcessor?.summary {
+            logger.info("Applied mic ducking with minimum gain \(summary.minimumGain) and average gain \(summary.averageGain)")
         }
-
-        let convertedFrames = AVAudioFrameCount(Double(sourceFrames) * targetFormat.sampleRate / sourceFormat.sampleRate)
-        let outputFrames = max(convertedFrames, totalFrames)
-        guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputFrames) else {
-            throw RecorderError.engineStartFailed("Cannot create converted buffer")
-        }
-
-        var error: NSError?
-        let consumed = OSAllocatedUnfairLock(initialState: false)
-        converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
-            let wasConsumed = consumed.withLock { flag in
-                let prev = flag
-                flag = true
-                return prev
-            }
-            if wasConsumed {
-                outStatus.pointee = .noDataNow
-                return nil
-            }
-            outStatus.pointee = .haveData
-            return sourceBuffer
-        }
-
-        if let error { throw error }
-
-        // Zero-pad if needed
-        if convertedBuffer.frameLength < totalFrames {
-            guard let padded = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: totalFrames) else {
-                return convertedBuffer
-            }
-            padded.frameLength = totalFrames
-            for ch in 0..<Int(targetFormat.channelCount) {
-                guard let dst = padded.floatChannelData?[ch],
-                      let src = convertedBuffer.floatChannelData?[ch] else { continue }
-                let copyCount = Int(convertedBuffer.frameLength)
-                dst.update(from: src, count: copyCount)
-                dst.advanced(by: copyCount).update(repeating: 0, count: Int(totalFrames) - copyCount)
-            }
-            return padded
-        }
-
-        return convertedBuffer
     }
 
     // MARK: - Level Update (called from SystemLevelSetter on main queue)
@@ -1467,30 +1550,32 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     // MARK: - Helpers
 
-    private func finalizeOutputFile(finalURL: URL, micURL: URL?, sysURL: URL?) async throws {
-        // Snapshot the current configuration before handing off to the detached task:
-        // these are plain mutable properties on this @unchecked Sendable class, and the
-        // UI can still be running concurrently while this background work is in flight.
-        let trackMode = trackMode
-        let micDuckingMode = micDuckingMode
-        let outputFormat = outputFormat
+    private func finalizeOutputFile(_ stoppedRecording: StoppedRecording) throws {
+        guard let finalURL = stoppedRecording.finalOutputURL else { return }
 
-        try await Task.detached(priority: .userInitiated) { [self] in
-            if let micURL, let sysURL {
-                try mixAudioFiles(
-                    micURL: micURL,
-                    systemURL: sysURL,
-                    outputURL: finalURL,
-                    trackMode: trackMode,
-                    micDuckingMode: micDuckingMode,
-                    outputFormat: outputFormat
-                )
-            } else if let micURL {
-                try copyOrConvert(from: micURL, to: finalURL, outputFormat: outputFormat)
-            } else if let sysURL {
-                try copyOrConvert(from: sysURL, to: finalURL, outputFormat: outputFormat)
-            }
-        }.value
+        if let micURL = stoppedRecording.micTempURL,
+           let systemURL = stoppedRecording.systemTempURL {
+            try mixAudioFiles(
+                micURL: micURL,
+                systemURL: systemURL,
+                outputURL: finalURL,
+                trackMode: stoppedRecording.trackMode,
+                micDuckingMode: stoppedRecording.micDuckingMode,
+                outputFormat: stoppedRecording.outputFormat
+            )
+        } else if let micURL = stoppedRecording.micTempURL {
+            try copyOrConvert(
+                from: micURL,
+                to: finalURL,
+                outputFormat: stoppedRecording.outputFormat
+            )
+        } else if let systemURL = stoppedRecording.systemTempURL {
+            try copyOrConvert(
+                from: systemURL,
+                to: finalURL,
+                outputFormat: stoppedRecording.outputFormat
+            )
+        }
     }
 
     private func copyOrConvert(from sourceURL: URL, to destinationURL: URL, outputFormat: OutputFormat) throws {
@@ -1498,22 +1583,39 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         case .wav:
             try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
         case .m4a:
-            // Convert WAV to M4A
             let sourceFile = try AVAudioFile(forReading: sourceURL)
             let sourceFormat = sourceFile.processingFormat
-            let sourceFrames = AVAudioFrameCount(sourceFile.length)
-
-            guard let buffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: sourceFrames) else { return }
-            try sourceFile.read(into: buffer)
-
             let outputSettings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatMPEG4AAC,
                 AVSampleRateKey: sourceFormat.sampleRate,
                 AVNumberOfChannelsKey: sourceFormat.channelCount,
                 AVEncoderBitRateKey: 192000,
             ]
-            let outputFile = try AVAudioFile(forWriting: destinationURL, settings: outputSettings)
-            try outputFile.write(from: buffer)
+            let outputFile: AVAudioFile
+            do {
+                outputFile = try AVAudioFile(forWriting: destinationURL, settings: outputSettings)
+            } catch {
+                throw RecorderError.engineStartFailed(
+                    "Cannot create M4A finalization output: \(error.localizedDescription)"
+                )
+            }
+            let reader = try AudioFileChunkReader(
+                url: sourceURL,
+                clientFormat: outputFile.processingFormat,
+                chunkFrameCount: Self.finalizationChunkFrameCount
+            )
+
+            while true {
+                let buffer = try reader.read()
+                guard buffer.frameLength > 0 else { break }
+                do {
+                    try outputFile.write(from: buffer)
+                } catch {
+                    throw RecorderError.engineStartFailed(
+                        "Cannot write M4A finalization output: \(error.localizedDescription)"
+                    )
+                }
+            }
         }
     }
 
@@ -1529,6 +1631,14 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     }
 
     // Aggressively duck the mic while system audio is active to avoid replaying the same content twice.
+    private static func makeMicDuckingProcessor(
+        mode: MicDuckingMode,
+        sampleRate: Double
+    ) -> MicDuckingProcessor? {
+        guard let parameters = micDuckingParameters(for: mode) else { return nil }
+        return MicDuckingProcessor(parameters: parameters, sampleRate: sampleRate)
+    }
+
     private static func buildMicDuckingProfile(
         frameCount: Int,
         sampleRate: Double,
@@ -1536,62 +1646,21 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         referenceSample: (Int) -> Float
     ) -> MicDuckingProfile? {
         guard frameCount > 0,
-              let parameters = micDuckingParameters(for: mode) else {
+              var processor = makeMicDuckingProcessor(mode: mode, sampleRate: sampleRate) else {
             return nil
         }
 
-        let holdSamples = max(1, Int(sampleRate * parameters.holdTime))
-        let envelopeAttack = smoothingCoefficient(timeConstant: parameters.envelopeAttackTime, sampleRate: sampleRate)
-        let envelopeRelease = smoothingCoefficient(timeConstant: parameters.envelopeReleaseTime, sampleRate: sampleRate)
-        let gainAttack = smoothingCoefficient(timeConstant: parameters.gainAttackTime, sampleRate: sampleRate)
-        let gainRelease = smoothingCoefficient(timeConstant: parameters.gainReleaseTime, sampleRate: sampleRate)
-
         var gains = [Float](repeating: 1, count: frameCount)
-        var systemEnvelope: Float = 0
-        var currentMicGain: Float = 1
-        var remainingHold = 0
-        var minimumGain: Float = 1
-        var gainSum: Float = 0
-        var duckingEngaged = false
-
         for index in 0..<frameCount {
-            let sampleMagnitude = abs(referenceSample(index))
-            let envelopeCoefficient = sampleMagnitude > systemEnvelope ? envelopeAttack : envelopeRelease
-            systemEnvelope = sampleMagnitude + envelopeCoefficient * (systemEnvelope - sampleMagnitude)
-
-            let targetMicGain: Float
-            if systemEnvelope >= parameters.highThreshold {
-                targetMicGain = parameters.minimumMicGain
-                remainingHold = holdSamples
-                duckingEngaged = true
-            } else if systemEnvelope <= parameters.lowThreshold {
-                if remainingHold > 0 {
-                    remainingHold -= 1
-                    targetMicGain = parameters.minimumMicGain
-                    duckingEngaged = true
-                } else {
-                    targetMicGain = 1
-                }
-            } else {
-                let progress = (systemEnvelope - parameters.lowThreshold) / (parameters.highThreshold - parameters.lowThreshold)
-                targetMicGain = 1 - progress * (1 - parameters.minimumMicGain)
-                duckingEngaged = true
-            }
-
-            let gainCoefficient = targetMicGain < currentMicGain ? gainAttack : gainRelease
-            currentMicGain = targetMicGain + gainCoefficient * (currentMicGain - targetMicGain)
-
-            gains[index] = currentMicGain
-            minimumGain = min(minimumGain, currentMicGain)
-            gainSum += currentMicGain
+            gains[index] = processor.gain(for: referenceSample(index))
         }
 
-        guard duckingEngaged, minimumGain < 0.99 else { return nil }
+        guard let summary = processor.summary else { return nil }
 
         return MicDuckingProfile(
             gains: gains,
-            minimumGain: minimumGain,
-            averageGain: gainSum / Float(frameCount)
+            minimumGain: summary.minimumGain,
+            averageGain: summary.averageGain
         )
     }
 

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -1188,7 +1188,14 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
     // MARK: - Audio Mixing
 
-    private func mixAudioFiles(micURL: URL, systemURL: URL, outputURL: URL) throws {
+    private func mixAudioFiles(
+        micURL: URL,
+        systemURL: URL,
+        outputURL: URL,
+        trackMode: TrackMode,
+        micDuckingMode: MicDuckingMode,
+        outputFormat: OutputFormat
+    ) throws {
         let micFile = try AVAudioFile(forReading: micURL)
         let sysFile = try AVAudioFile(forReading: systemURL)
 
@@ -1461,18 +1468,32 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     // MARK: - Helpers
 
     private func finalizeOutputFile(finalURL: URL, micURL: URL?, sysURL: URL?) async throws {
+        // Snapshot the current configuration before handing off to the detached task:
+        // these are plain mutable properties on this @unchecked Sendable class, and the
+        // UI can still be running concurrently while this background work is in flight.
+        let trackMode = trackMode
+        let micDuckingMode = micDuckingMode
+        let outputFormat = outputFormat
+
         try await Task.detached(priority: .userInitiated) { [self] in
             if let micURL, let sysURL {
-                try mixAudioFiles(micURL: micURL, systemURL: sysURL, outputURL: finalURL)
+                try mixAudioFiles(
+                    micURL: micURL,
+                    systemURL: sysURL,
+                    outputURL: finalURL,
+                    trackMode: trackMode,
+                    micDuckingMode: micDuckingMode,
+                    outputFormat: outputFormat
+                )
             } else if let micURL {
-                try copyOrConvert(from: micURL, to: finalURL)
+                try copyOrConvert(from: micURL, to: finalURL, outputFormat: outputFormat)
             } else if let sysURL {
-                try copyOrConvert(from: sysURL, to: finalURL)
+                try copyOrConvert(from: sysURL, to: finalURL, outputFormat: outputFormat)
             }
         }.value
     }
 
-    private func copyOrConvert(from sourceURL: URL, to destinationURL: URL) throws {
+    private func copyOrConvert(from sourceURL: URL, to destinationURL: URL, outputFormat: OutputFormat) throws {
         switch outputFormat {
         case .wav:
             try FileManager.default.copyItem(at: sourceURL, to: destinationURL)

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -534,6 +534,11 @@ final class AudioRecorderViewModel: ObservableObject {
     private func stopRecording(apiSessionID: UUID?) {
         let recordingDuration = duration
 
+        // Flip out of `.recording` immediately so the recording timer/widget disappears
+        // the instant Stop is pressed, instead of staying up while audio finalization
+        // and transcription run (which can take a while for long recordings).
+        state = .finalizing
+
         Task {
             let liveSessionResult = await streamingHandler.finish()
             let url = await recorderService.stopRecording()
@@ -555,7 +560,6 @@ final class AudioRecorderViewModel: ObservableObject {
                     dictionaryTermHints: dictionaryTermHints,
                     liveSessionResult: liveSessionResult
                 )
-                state = .finalizing
                 if let apiSessionID {
                     markRecorderAPISessionFinalizing(id: apiSessionID, outputURL: url)
                 }

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -533,6 +533,7 @@ final class AudioRecorderViewModel: ObservableObject {
 
     private func stopRecording(apiSessionID: UUID?) {
         let recordingDuration = duration
+        let shouldTranscribe = transcriptionEnabled
 
         // Flip out of `.recording` immediately so the recording timer/widget disappears
         // the instant Stop is pressed, instead of staying up while audio finalization
@@ -541,7 +542,7 @@ final class AudioRecorderViewModel: ObservableObject {
 
         Task {
             let stoppedRecording = await recorderService.stopCapture(
-                includeTranscriptionSamples: transcriptionEnabled
+                includeTranscriptionSamples: shouldTranscribe
             )
             async let liveSessionResultTask = streamingHandler.finish(
                 finalSamples: stoppedRecording.transcriptionSamples
@@ -550,7 +551,7 @@ final class AudioRecorderViewModel: ObservableObject {
             let (liveSessionResult, url) = await (liveSessionResultTask, finalizedURLTask)
 
             let finalTranscriptionRequest: FinalTranscriptionRequest?
-            if transcriptionEnabled, let url {
+            if shouldTranscribe, let url {
                 reconcileSelectionWithAvailablePlugins()
                 let providerId = effectiveProviderId
                 let dictionaryPrompt = dictionaryService.getTermsForPrompt(providerId: providerId)

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -540,8 +540,14 @@ final class AudioRecorderViewModel: ObservableObject {
         state = .finalizing
 
         Task {
-            let liveSessionResult = await streamingHandler.finish()
-            let url = await recorderService.stopRecording()
+            let stoppedRecording = await recorderService.stopCapture(
+                includeTranscriptionSamples: transcriptionEnabled
+            )
+            async let liveSessionResultTask = streamingHandler.finish(
+                finalSamples: stoppedRecording.transcriptionSamples
+            )
+            async let finalizedURLTask = recorderService.finalizeRecording(stoppedRecording)
+            let (liveSessionResult, url) = await (liveSessionResultTask, finalizedURLTask)
 
             let finalTranscriptionRequest: FinalTranscriptionRequest?
             if transcriptionEnabled, let url {
@@ -551,7 +557,7 @@ final class AudioRecorderViewModel: ObservableObject {
                 let dictionaryTermHints = dictionaryService.getTermHints(providerId: providerId)
                 finalTranscriptionRequest = FinalTranscriptionRequest(
                     outputURL: url,
-                    buffer: recorderService.getCurrentBuffer(),
+                    buffer: stoppedRecording.transcriptionSamples,
                     languageSelection: languageSelection,
                     task: selectedTask,
                     providerId: providerId,

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -1,7 +1,31 @@
 import AudioToolbox
+import AVFoundation
 import XCTest
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
+
+private actor RecorderStopFinalizationGate {
+    private var continuation: CheckedContinuation<URL?, any Error>?
+    private var started = false
+    private var outputURL: URL?
+
+    func wait(outputURL: URL) async throws -> URL? {
+        started = true
+        self.outputURL = outputURL
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func hasStarted() -> Bool {
+        started
+    }
+
+    func resume() {
+        continuation?.resume(returning: outputURL)
+        continuation = nil
+    }
+}
 
 @MainActor
 final class AudioRecorderViewModelTests: XCTestCase {
@@ -621,6 +645,138 @@ final class AudioRecorderViewModelTests: XCTestCase {
         }
     }
 
+    func testRecorderStopEntersFinalizingBeforeAudioFinalizationCompletes() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let recorderService = AudioRecorderService()
+        recorderService.recordingsDirectoryOverride = recordingsDirectory
+        recorderService.startRecordingOverride = { _, _, _, outputURL, _ in
+            try Data("placeholder".utf8).write(to: outputURL)
+            return outputURL
+        }
+        let gate = RecorderStopFinalizationGate()
+        recorderService.stopRecordingOverride = { outputURL in
+            try await gate.wait(outputURL: outputURL)
+        }
+
+        let viewModel = makeViewModel(defaults: defaults, recorderService: recorderService)
+        viewModel.transcriptionEnabled = false
+        _ = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+
+        viewModel.stopRecording()
+
+        XCTAssertEqual(viewModel.state, .finalizing)
+        XCTAssertFalse(viewModel.canToggleRecording)
+        for _ in 0..<100 where !(await gate.hasStarted()) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let finalizationStarted = await gate.hasStarted()
+        XCTAssertTrue(finalizationStarted)
+
+        await gate.resume()
+        for _ in 0..<100 where viewModel.state != .idle {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(viewModel.state, .idle)
+    }
+
+    func testRecorderFinalizationStreamsMixedAudioAcrossChunkBoundaries() async throws {
+        let directory = makeTemporaryDirectory()
+        let micURL = directory.appendingPathComponent("mic.wav")
+        let systemURL = directory.appendingPathComponent("system.wav")
+        let outputURL = directory.appendingPathComponent("mixed.wav")
+        let outputFrameCount = Int(AudioRecorderService.finalizationChunkFrameCount) * 3 + 137
+        let micFrameCount = Int(
+            (Double(outputFrameCount) * 44_100 / 48_000).rounded(.up)
+        )
+
+        try writePCMFile(
+            at: micURL,
+            frameCount: micFrameCount,
+            sampleRate: 44_100,
+            channelCount: 1,
+            sample: 0.1
+        )
+        try writePCMFile(
+            at: systemURL,
+            frameCount: outputFrameCount,
+            sampleRate: 48_000,
+            channelCount: 2,
+            sample: 0.2
+        )
+
+        let recorderService = AudioRecorderService()
+        let resultURL = await recorderService.finalizeRecording(.init(
+            finalOutputURL: outputURL,
+            micTempURL: micURL,
+            systemTempURL: systemURL,
+            outputFormat: .wav,
+            trackMode: .mixed,
+            micDuckingMode: .aggressive,
+            transcriptionSamples: [],
+            usesFinalizationOverride: false
+        ))
+
+        XCTAssertEqual(resultURL, outputURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path))
+
+        let outputFile = try AVAudioFile(forReading: outputURL)
+        XCTAssertLessThanOrEqual(abs(Int(outputFile.length) - outputFrameCount), 1)
+        guard let outputBuffer = AVAudioPCMBuffer(
+            pcmFormat: outputFile.processingFormat,
+            frameCapacity: AVAudioFrameCount(outputFile.length)
+        ) else {
+            return XCTFail("Could not allocate mixed-audio verification buffer")
+        }
+        try outputFile.read(into: outputBuffer)
+        let leftChannel = try XCTUnwrap(outputBuffer.floatChannelData?[0])
+        let rightChannel = try XCTUnwrap(outputBuffer.floatChannelData?[1])
+        XCTAssertEqual(leftChannel[0], 0.3, accuracy: 0.01)
+        XCTAssertEqual(rightChannel[0], 0.3, accuracy: 0.01)
+        for boundary in [8_192, 16_384] {
+            XCTAssertEqual(leftChannel[boundary - 1], leftChannel[boundary], accuracy: 0.002)
+            XCTAssertEqual(rightChannel[boundary - 1], rightChannel[boundary], accuracy: 0.002)
+            XCTAssertLessThan(leftChannel[boundary], 0.23)
+            XCTAssertLessThan(rightChannel[boundary], 0.23)
+        }
+        XCTAssertEqual(leftChannel[outputFrameCount - 1], 0.218, accuracy: 0.002)
+        XCTAssertEqual(rightChannel[outputFrameCount - 1], 0.218, accuracy: 0.002)
+    }
+
+    func testRecorderFinalizationStreamsSingleSourceM4AConversion() async throws {
+        let directory = makeTemporaryDirectory()
+        let sourceURL = directory.appendingPathComponent("mic.wav")
+        let outputURL = directory.appendingPathComponent("recording.m4a")
+        let frameCount = Int(AudioRecorderService.finalizationChunkFrameCount) * 3 + 137
+        try writePCMFile(
+            at: sourceURL,
+            frameCount: frameCount,
+            sampleRate: 48_000,
+            channelCount: 2,
+            sample: 0.1
+        )
+
+        let recorderService = AudioRecorderService()
+        let resultURL = await recorderService.finalizeRecording(.init(
+            finalOutputURL: outputURL,
+            micTempURL: sourceURL,
+            systemTempURL: nil,
+            outputFormat: .m4a,
+            trackMode: .mixed,
+            micDuckingMode: .off,
+            transcriptionSamples: [],
+            usesFinalizationOverride: false
+        ))
+
+        XCTAssertEqual(resultURL, outputURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sourceURL.path))
+        let outputFile = try AVAudioFile(forReading: outputURL)
+        let outputDuration = Double(outputFile.length) / outputFile.processingFormat.sampleRate
+        XCTAssertEqual(outputDuration, Double(frameCount) / 48_000, accuracy: 0.05)
+    }
+
     private func makeViewModel(
         defaults: UserDefaults,
         modelManager: ModelManagerService = ModelManagerService(),
@@ -645,6 +801,41 @@ final class AudioRecorderViewModelTests: XCTestCase {
             audioSamplesLoader: audioSamplesLoader,
             livePreviewStartObserver: livePreviewStartObserver
         )
+    }
+
+    private func writePCMFile(
+        at url: URL,
+        frameCount: Int,
+        sampleRate: Double,
+        channelCount: AVAudioChannelCount,
+        sample: Float
+    ) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: channelCount,
+            interleaved: false
+        ), let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frameCount)
+        ) else {
+            return XCTFail("Could not allocate recorder finalization fixture")
+        }
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        for channel in 0..<Int(channelCount) {
+            buffer.floatChannelData?[channel].update(repeating: sample, count: frameCount)
+        }
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: channelCount,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+        let file = try AVAudioFile(forWriting: url, settings: settings)
+        try file.write(from: buffer)
     }
 
     private func makeFinalTranscriptionViewModel(

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -735,7 +735,8 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let rightChannel = try XCTUnwrap(outputBuffer.floatChannelData?[1])
         XCTAssertEqual(leftChannel[0], 0.3, accuracy: 0.01)
         XCTAssertEqual(rightChannel[0], 0.3, accuracy: 0.01)
-        for boundary in [8_192, 16_384] {
+        let chunkSize = Int(AudioRecorderService.finalizationChunkFrameCount)
+        for boundary in [chunkSize, chunkSize * 2] {
             XCTAssertEqual(leftChannel[boundary - 1], leftChannel[boundary], accuracy: 0.002)
             XCTAssertEqual(rightChannel[boundary - 1], rightChannel[boundary], accuracy: 0.002)
             XCTAssertLessThan(leftChannel[boundary], 0.23)


### PR DESCRIPTION
## Summary
- Stop microphone and system-audio capture before transcription or file finalization begins, then finalize from an immutable stopped-session snapshot.
- Run streaming-session completion and file finalization concurrently while the UI remains in its existing finalizing state.
- Mix, resample, duck, and encode recordings in bounded 8,192-frame chunks instead of loading entire long recordings and a full gain profile into memory.
- Keep the existing single-source WAV fast path and stream single-source M4A conversion through the same bounded reader.
- Add regression coverage for the immediate finalizing transition, chunk-boundary continuity, resampling, ducking, cleanup, and single-source M4A conversion.

Closes #885

## Test plan
- [x] `xcodebuild build -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -parallel-testing-enabled NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests -only-testing:TypeWhisperTests/APIRouterAndHandlersTests CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/f38d/typewhisper-mac`
- [ ] Manual: record 10+ minutes of microphone and system audio, stop it, and confirm capture ends immediately while the recorder shows its finalizing state without freezing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording stop/finalization so microphone, system capture, and processing fully complete before the output is finalized.
  * The recorder UI now switches to **Finalizing** immediately on Stop, then returns to idle after finalization/transcription completes.
  * Output generation is now format-aware and more reliable for mixed, separate, and single-source recordings, including improved chunk-accurate mixing and mic ducking.

* **Tests**
  * Added deterministic stop/finalization tests and new audio verification coverage for chunk-boundary mixing and format conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->