### PR TITLE
Show canonical release tags in About

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,10 +249,11 @@ jobs:
       - name: Check Release Binary Instrumentation
         run: bash scripts/check_release_binary_instrumentation.sh build/Build/Products/Release/TypeWhisper.app/Contents/MacOS/typewhisper-cli
 
-      - name: Configure Release Channel
+      - name: Configure Release Metadata
         run: |
           APP_INFO_PLIST="build/Build/Products/Release/TypeWhisper.app/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Set :TypeWhisperReleaseChannel ${RELEASE_CHANNEL}" "$APP_INFO_PLIST"
+          /usr/libexec/PlistBuddy -c "Set :TypeWhisperReleaseTag ${RELEASE_TAG}" "$APP_INFO_PLIST"
 
       - name: Sign App (Developer ID)
         env:

--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -51,6 +51,11 @@ enum AppConstants {
         }
     }
 
+    struct PreviewRelease: Equatable {
+        let tag: String
+        let url: URL
+    }
+
     nonisolated(unsafe) static var testAppSupportDirectoryOverride: URL?
 
     static let appSupportDirectoryName: String = {
@@ -85,6 +90,9 @@ enum AppConstants {
 
     static let appVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
     static let buildVersion: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+    private static let githubReleaseTagsURL = URL(
+        string: "https://github.com/TypeWhisper/typewhisper-mac/releases/tag"
+    )!
     static let currentReleaseFingerprint: String = {
         let channel = bundledReleaseChannel()
         return "\(appVersion)+\(buildVersion)@\(channel.rawValue)"
@@ -95,6 +103,28 @@ enum AppConstants {
             return .stable
         }
         return channel
+    }
+
+    static func bundledPreviewRelease(
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> PreviewRelease? {
+        let channel = bundledReleaseChannel(infoDictionary: infoDictionary)
+        guard channel == .daily || channel == .releaseCandidate,
+              let rawTag = infoDictionary?["TypeWhisperReleaseTag"] as? String else {
+            return nil
+        }
+
+        let tag = rawTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tag.isEmpty else { return nil }
+
+        return PreviewRelease(
+            tag: tag,
+            url: githubReleaseTagsURL.appendingPathComponent(tag)
+        )
+    }
+
+    static var previewRelease: PreviewRelease? {
+        bundledPreviewRelease()
     }
 
     static func selectedUpdateChannel(

--- a/TypeWhisper/Resources/Info.plist
+++ b/TypeWhisper/Resources/Info.plist
@@ -54,6 +54,8 @@
 	<string>OdAMiN136Ckglxnq4FeLagPjcrZiASYGaeUWBkK6tuc=</string>
 	<key>TypeWhisperReleaseChannel</key>
 	<string>stable</string>
+	<key>TypeWhisperReleaseTag</key>
+	<string></string>
 	<key>TypeWhisperDiscordClaimBaseURL</key>
 	<string>https://community.typewhisper.com</string>
 	<key>AppGroupIdentifier</key>

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -10854,6 +10854,22 @@
         }
       }
     },
+    "Release %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release %1$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リリース %@"
+          }
+        }
+      }
+    },
     "Release Candidate": {
       "localizations": {
         "de": {

--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -41,6 +41,13 @@ struct AboutSettingsView: View {
                     Text("Version \(version) (\(build))\(channelSuffix)")
                         .foregroundStyle(.secondary)
 
+                    if let previewRelease = AppConstants.previewRelease {
+                        Link(destination: previewRelease.url) {
+                            Text("Release \(previewRelease.tag)")
+                        }
+                        .font(.caption)
+                    }
+
                     Text(String(localized: "Fast, private speech-to-text for your Mac. Transcribe with local or cloud engines, process text with AI prompts, and insert directly into any app."))
                         .multilineTextAlignment(.center)
                         .foregroundStyle(.secondary)

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -10,6 +10,61 @@ final class AppFormatterServiceTests: XCTestCase {
         XCTAssertEqual(channel, .releaseCandidate)
     }
 
+    func testBundledPreviewReleaseUsesDailyTagAndURL() throws {
+        let release = try XCTUnwrap(AppConstants.bundledPreviewRelease(
+            infoDictionary: [
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.daily.rawValue,
+                "TypeWhisperReleaseTag": "v1.6.0-daily.20260716",
+            ]
+        ))
+
+        XCTAssertEqual(release.tag, "v1.6.0-daily.20260716")
+        XCTAssertEqual(
+            release.url.absoluteString,
+            "https://github.com/TypeWhisper/typewhisper-mac/releases/tag/v1.6.0-daily.20260716"
+        )
+    }
+
+    func testBundledPreviewReleaseUsesReleaseCandidateTagAndURL() throws {
+        let release = try XCTUnwrap(AppConstants.bundledPreviewRelease(
+            infoDictionary: [
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.releaseCandidate.rawValue,
+                "TypeWhisperReleaseTag": "v1.6.0-rc1",
+            ]
+        ))
+
+        XCTAssertEqual(release.tag, "v1.6.0-rc1")
+        XCTAssertEqual(
+            release.url.absoluteString,
+            "https://github.com/TypeWhisper/typewhisper-mac/releases/tag/v1.6.0-rc1"
+        )
+    }
+
+    func testBundledPreviewReleaseIsHiddenForStableBuild() {
+        let release = AppConstants.bundledPreviewRelease(
+            infoDictionary: [
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.stable.rawValue,
+                "TypeWhisperReleaseTag": "v1.6.0",
+            ]
+        )
+
+        XCTAssertNil(release)
+    }
+
+    func testBundledPreviewReleaseIgnoresMissingOrBlankTag() {
+        XCTAssertNil(AppConstants.bundledPreviewRelease(
+            infoDictionary: [
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.daily.rawValue,
+            ]
+        ))
+        XCTAssertNil(AppConstants.bundledPreviewRelease(
+            infoDictionary: [
+                "TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.daily.rawValue,
+                "TypeWhisperReleaseTag": " \n ",
+            ]
+        ))
+    }
+
     func testSelectedUpdateChannelUsesStoredOverride() {
         let defaults = UserDefaults(suiteName: #function)!
         defaults.removePersistentDomain(forName: #function)


### PR DESCRIPTION
## Summary

- embed the canonical GitHub release tag in signed app bundles
- show Daily and release-candidate tags as clickable links in About
- preserve `CFBundleVersion`, Sparkle version ordering, and release fingerprints

## Issue context

Daily and release-candidate builds currently show only the monotonic bundle version plus a channel label, so users cannot map an installed build to its exact GitHub release. The release workflow already has the canonical tag; this stores it in `TypeWhisperReleaseTag` before code signing and surfaces it only for preview channels.

Closes #916

## Test plan

- `git diff --check`
- `actionlint -shellcheck "" .github/workflows/release.yml`
- `plutil -lint TypeWhisper/Resources/Info.plist`
- `python3 -m json.tool TypeWhisper/Resources/Localizable.xcstrings >/dev/null`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AppFormatterServiceTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$PWD"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview and release-candidate builds now display a link to their corresponding release notes in the About settings.
  * Release tags are shown alongside the release link.
  * Added German and Japanese translations for the release label.

* **Bug Fixes**
  * Release metadata now includes the correct release tag for preview builds.

* **Tests**
  * Added coverage for preview release links, supported release channels, and missing or blank tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->