### PR TITLE
Fix glitchy sidebar collapse animation in Settings

### DIFF
--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -284,6 +284,16 @@ private struct SettingsSidebarSearchField: View {
                 text: $text
             )
             .textFieldStyle(.plain)
+
+            if !text.isEmpty {
+                Button(action: { text = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help(localizedAppText("Clear Search", de: "Suche löschen"))
+                .accessibilityLabel(localizedAppText("Clear Search", de: "Suche löschen"))
+            }
         }
         .padding(6)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color(nsColor: .controlBackgroundColor)))

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -201,15 +201,119 @@ private struct SettingsModernShell: View {
 
     @State private var sidebarSearchText = ""
     @State private var isSidebarVisible = true
-    @State private var sidebarWidth: CGFloat = 270
-    @State private var previewWidth: CGFloat?
-    @State private var dragStartWidth: CGFloat?
-    @State private var isResizeHandleHovering = false
-    @FocusState private var isSearchFieldFocused: Bool
 
-    private let minSidebarWidth: CGFloat = 240
-    private let maxSidebarWidth: CGFloat = 320
-    private let resizeStep: CGFloat = 20
+    var body: some View {
+        SettingsSplitView(
+            selectedTab: $selectedTab,
+            sidebarSearchText: $sidebarSearchText,
+            sections: sections,
+            isSidebarVisible: $isSidebarVisible,
+            detail: detail
+        )
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: { isSidebarVisible.toggle() }) {
+                    Image(systemName: "sidebar.leading")
+                }
+                .help(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
+                .accessibilityLabel(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
+            }
+        }
+    }
+}
+
+// Bridges to a native AppKit NSSplitViewController rather than SwiftUI's
+// NavigationSplitView or a hand-rolled HStack. Three prior pure-SwiftUI attempts
+// each fixed one property at the cost of another:
+//   - NavigationSplitView: resize is fluid (native), but its built-in collapse
+//     animation reflows row labels frame-by-frame — a visible glitch on this
+//     macOS version.
+//   - Custom HStack + zero-duration toggle: fixed the glitch, but the divider
+//     and sidebar content could pop out of sync with each other.
+//   - Custom HStack + live @GestureState width: fixed the sync issue, but
+//     SwiftUI's List (backed by NSTableView) can't relayout at pointer-tracking
+//     speed, so rows visibly lag behind the resizing frame during a live drag.
+// NSSplitViewController is the actual mechanism Finder/Mail/Notes use for their
+// sidebars — it owns both resize and collapse natively, so neither is fighting
+// a SwiftUI layout pass, and VoiceOver/keyboard resize support comes for free.
+@available(macOS 15, *)
+private struct SettingsSplitView: NSViewControllerRepresentable {
+    @Binding var selectedTab: SettingsTab
+    @Binding var sidebarSearchText: String
+    let sections: [SettingsDestinationSection]
+    @Binding var isSidebarVisible: Bool
+    let detail: (SettingsTab) -> AnyView
+
+    func makeNSViewController(context: Context) -> NSSplitViewController {
+        let splitViewController = NSSplitViewController()
+        splitViewController.splitView.dividerStyle = .thin
+
+        let sidebarHostingController = NSHostingController(
+            rootView: SettingsSidebarContent(
+                selectedTab: $selectedTab,
+                sidebarSearchText: $sidebarSearchText,
+                sections: sections
+            )
+        )
+        let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarHostingController)
+        sidebarItem.minimumThickness = 240
+        sidebarItem.maximumThickness = 320
+        sidebarItem.canCollapse = true
+        sidebarItem.isCollapsed = !isSidebarVisible
+
+        let detailHostingController = NSHostingController(
+            rootView: AnyView(
+                detail(selectedTab)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            )
+        )
+        let detailItem = NSSplitViewItem(viewController: detailHostingController)
+
+        splitViewController.addSplitViewItem(sidebarItem)
+        splitViewController.addSplitViewItem(detailItem)
+
+        context.coordinator.sidebarItem = sidebarItem
+        context.coordinator.sidebarHostingController = sidebarHostingController
+        context.coordinator.detailHostingController = detailHostingController
+
+        return splitViewController
+    }
+
+    func updateNSViewController(_ splitViewController: NSSplitViewController, context: Context) {
+        context.coordinator.sidebarHostingController?.rootView = SettingsSidebarContent(
+            selectedTab: $selectedTab,
+            sidebarSearchText: $sidebarSearchText,
+            sections: sections
+        )
+        context.coordinator.detailHostingController?.rootView = AnyView(
+            detail(selectedTab)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        )
+
+        guard let sidebarItem = context.coordinator.sidebarItem else { return }
+        let shouldBeCollapsed = !isSidebarVisible
+        guard sidebarItem.isCollapsed != shouldBeCollapsed else { return }
+
+        NSAnimationContext.runAnimationGroup { animationContext in
+            animationContext.duration = 0.2
+            animationContext.allowsImplicitAnimation = true
+            sidebarItem.animator().isCollapsed = shouldBeCollapsed
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        var sidebarItem: NSSplitViewItem?
+        var sidebarHostingController: NSHostingController<SettingsSidebarContent>?
+        var detailHostingController: NSHostingController<AnyView>?
+    }
+}
+
+private struct SettingsSidebarContent: View {
+    @Binding var selectedTab: SettingsTab
+    @Binding var sidebarSearchText: String
+    let sections: [SettingsDestinationSection]
 
     private var filteredSections: [SettingsDestinationSection] {
         let query = sidebarSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -228,167 +332,30 @@ private struct SettingsModernShell: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            // Collapsing removes the sidebar from the view tree entirely (rather than
-            // zeroing/clipping a frame while it stays mounted), so a hidden sidebar is
-            // automatically unreachable by keyboard focus, VoiceOver, and hit-testing —
-            // no manual .disabled/.accessibilityHidden bookkeeping needed. The slide
-            // transition uses an offset transform rather than animating width, so row
-            // labels never reflow/truncate mid-toggle the way NavigationSplitView's
-            // built-in width-based collapse animation does.
-            if isSidebarVisible {
-                // Grouped so the sidebar and its resize handle slide out together as
-                // one rigid unit. Giving them separate .transition() instances left the
-                // handle behind mid-collapse: .move only offsets a view's rendering
-                // without changing siblings' HStack layout math, so once the sidebar's
-                // slot was removed from layout the handle's position snapped instantly
-                // to its new (sidebar-less) spot while its own opacity fade was still
-                // playing — a stray line hanging over the detail pane for the last
-                // fraction of the animation.
-                HStack(spacing: 0) {
-                    VStack(spacing: 0) {
-                        SettingsSidebarSearchField(text: $sidebarSearchText, isFocused: $isSearchFieldFocused)
+        VStack(spacing: 0) {
+            SettingsSidebarSearchField(text: $sidebarSearchText)
 
-                        List(selection: $selectedTab) {
-                            ForEach(filteredSections) { section in
-                                Section {
-                                    ForEach(section.destinations) { destination in
-                                        SettingsSidebarRow(destination: destination)
-                                            .tag(destination.tab)
-                                    }
-                                }
-                            }
+            List(selection: $selectedTab) {
+                ForEach(filteredSections) { section in
+                    Section {
+                        ForEach(section.destinations) { destination in
+                            SettingsSidebarRow(destination: destination)
+                                .tag(destination.tab)
                         }
-                        .listStyle(.sidebar)
-                        // Changing the section/row count via search filtering can leave stale,
-                        // blank space behind from SwiftUI's incremental List diffing. Keying the
-                        // List on the query forces a clean rebuild instead of a partial diff.
-                        .id(sidebarSearchText)
                     }
-                    // sidebarWidth only ever changes on drag release (see
-                    // SettingsSidebarResizeHandle), not on every pointer-move frame, so
-                    // the List doesn't relayout continuously during a drag — relaying
-                    // out its native NSScroller-backed rows on every frame was the
-                    // source of the resize lag. A thin guide line tracks the pointer
-                    // instead; the real resize commits once when the drag ends.
-                    .frame(width: sidebarWidth)
-
-                    SettingsSidebarResizeHandle(
-                        committedWidth: sidebarWidth,
-                        sidebarWidth: $sidebarWidth,
-                        previewWidth: $previewWidth,
-                        dragStartWidth: $dragStartWidth,
-                        isHovering: $isResizeHandleHovering,
-                        minWidth: minSidebarWidth,
-                        maxWidth: maxSidebarWidth,
-                        step: resizeStep
-                    )
                 }
-                .transition(.move(edge: .leading))
             }
-
-            detail(selectedTab)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .listStyle(.sidebar)
+            // Changing the section/row count via search filtering can leave stale,
+            // blank space behind from SwiftUI's incremental List diffing. Keying the
+            // List on the query forces a clean rebuild instead of a partial diff.
+            .id(sidebarSearchText)
         }
-        .animation(.easeInOut(duration: 0.22), value: isSidebarVisible)
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                Button(action: { isSidebarVisible.toggle() }) {
-                    Image(systemName: "sidebar.leading")
-                }
-                .help(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
-                .accessibilityLabel(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
-            }
-        }
-    }
-}
-
-private struct SettingsSidebarResizeHandle: View {
-    let committedWidth: CGFloat
-    @Binding var sidebarWidth: CGFloat
-    @Binding var previewWidth: CGFloat?
-    @Binding var dragStartWidth: CGFloat?
-    @Binding var isHovering: Bool
-    let minWidth: CGFloat
-    let maxWidth: CGFloat
-    let step: CGFloat
-
-    var body: some View {
-        Divider()
-            .overlay(
-                Rectangle()
-                    .fill(Color.clear)
-                    .frame(width: 8)
-                    .contentShape(Rectangle())
-                    .onHover { hovering in
-                        isHovering = hovering
-                        if hovering {
-                            NSCursor.resizeLeftRight.push()
-                        } else {
-                            NSCursor.pop()
-                        }
-                    }
-                    // Pop the cursor unconditionally if this view disappears (e.g. the
-                    // sidebar collapses) while still hovered — onHover's "false" event
-                    // does not reliably fire when the view is removed from the tree
-                    // mid-hover, which would otherwise leave the resize cursor stuck.
-                    .onDisappear {
-                        if isHovering {
-                            NSCursor.pop()
-                            isHovering = false
-                        }
-                        previewWidth = nil
-                        dragStartWidth = nil
-                    }
-                    .gesture(
-                        DragGesture()
-                            .onChanged { value in
-                                let base = dragStartWidth ?? committedWidth
-                                dragStartWidth = base
-                                previewWidth = min(max(base + value.translation.width, minWidth), maxWidth)
-                            }
-                            .onEnded { _ in
-                                if let previewWidth {
-                                    sidebarWidth = previewWidth
-                                }
-                                previewWidth = nil
-                                dragStartWidth = nil
-                            }
-                    )
-                    .accessibilityElement()
-                    .accessibilityLabel(localizedAppText("Sidebar Width", de: "Seitenleistenbreite"))
-                    .accessibilityValue("\(Int(sidebarWidth)) pt")
-                    .accessibilityAdjustableAction { direction in
-                        switch direction {
-                        case .increment:
-                            sidebarWidth = min(sidebarWidth + step, maxWidth)
-                        case .decrement:
-                            sidebarWidth = max(sidebarWidth - step, minWidth)
-                        @unknown default:
-                            break
-                        }
-                    }
-            )
-            // Cheap: a single thin rectangle offset from the divider's actual
-            // position, not a relayout of anything. Gives live feedback about where
-            // the sidebar would land without touching the List during the drag.
-            // Always mounted (never conditionally inserted/removed) so it fades out
-            // in step with the drag ending instead of vanishing instantly — same
-            // reasoning as the sidebar's own opacity-faded divider.
-            .overlay(alignment: .leading) {
-                Rectangle()
-                    .fill(Color.accentColor)
-                    .frame(width: 2)
-                    .offset(x: (previewWidth ?? committedWidth) - committedWidth)
-                    .opacity(previewWidth == nil ? 0 : 1)
-                    .animation(.easeOut(duration: 0.15), value: previewWidth == nil)
-            }
     }
 }
 
 private struct SettingsSidebarSearchField: View {
     @Binding var text: String
-    var isFocused: FocusState<Bool>.Binding
 
     var body: some View {
         HStack(spacing: 6) {
@@ -399,7 +366,6 @@ private struct SettingsSidebarSearchField: View {
                 text: $text
             )
             .textFieldStyle(.plain)
-            .focused(isFocused)
 
             if !text.isEmpty {
                 Button(action: { text = "" }) {

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -275,6 +275,14 @@ private struct SettingsSplitView: NSViewControllerRepresentable {
         context.coordinator.sidebarItem = sidebarItem
         context.coordinator.sidebarHostingController = sidebarHostingController
         context.coordinator.detailHostingController = detailHostingController
+        context.coordinator.isSidebarVisible = $isSidebarVisible
+        // The user can collapse the sidebar natively — dragging the divider past
+        // its minimum thickness, or double-clicking it — without going through
+        // our toolbar button at all. Without this observer, isSidebarVisible
+        // never learns about it, so the button's next click just re-asserts the
+        // (already collapsed) state as a no-op, requiring a second click to
+        // actually reopen it.
+        context.coordinator.observeCollapseState(of: sidebarItem)
 
         return splitViewController
     }
@@ -289,6 +297,7 @@ private struct SettingsSplitView: NSViewControllerRepresentable {
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
+        context.coordinator.isSidebarVisible = $isSidebarVisible
 
         guard let sidebarItem = context.coordinator.sidebarItem else { return }
         let shouldBeCollapsed = !isSidebarVisible
@@ -307,6 +316,18 @@ private struct SettingsSplitView: NSViewControllerRepresentable {
         var sidebarItem: NSSplitViewItem?
         var sidebarHostingController: NSHostingController<SettingsSidebarContent>?
         var detailHostingController: NSHostingController<AnyView>?
+        var isSidebarVisible: Binding<Bool>?
+        private var collapseObservation: NSKeyValueObservation?
+
+        func observeCollapseState(of sidebarItem: NSSplitViewItem) {
+            collapseObservation = sidebarItem.observe(\.isCollapsed, options: [.new]) { [weak self] _, change in
+                guard let self, let isCollapsed = change.newValue else { return }
+                let shouldBeVisible = !isCollapsed
+                if self.isSidebarVisible?.wrappedValue != shouldBeVisible {
+                    self.isSidebarVisible?.wrappedValue = shouldBeVisible
+                }
+            }
+        }
     }
 }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -200,6 +200,9 @@ private struct SettingsModernShell: View {
     let detail: (SettingsTab) -> AnyView
 
     @State private var sidebarSearchText = ""
+    @State private var isSidebarVisible = true
+
+    private let sidebarWidth: CGFloat = 270
 
     private var filteredSections: [SettingsDestinationSection] {
         let query = sidebarSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -218,28 +221,73 @@ private struct SettingsModernShell: View {
     }
 
     var body: some View {
-        NavigationSplitView {
-            List(selection: $selectedTab) {
-                ForEach(filteredSections) { section in
-                    Section {
-                        ForEach(section.destinations) { destination in
-                            SettingsSidebarRow(destination: destination)
-                                .tag(destination.tab)
+        HStack(spacing: 0) {
+            // The sidebar's own intrinsic width never changes, so row labels never
+            // reflow/truncate mid-toggle; only the outer frame's width animates,
+            // clipping the fixed-width content like a mask. NavigationSplitView's
+            // built-in collapse instead animates the List's actual layout width,
+            // which reflows text every frame and produces a visible glitch.
+            VStack(spacing: 0) {
+                SettingsSidebarSearchField(text: $sidebarSearchText)
+
+                List(selection: $selectedTab) {
+                    ForEach(filteredSections) { section in
+                        Section {
+                            ForEach(section.destinations) { destination in
+                                SettingsSidebarRow(destination: destination)
+                                    .tag(destination.tab)
+                            }
                         }
                     }
                 }
+                .listStyle(.sidebar)
+                // Changing the section/row count via search filtering can leave stale,
+                // blank space behind from SwiftUI's incremental List diffing. Keying the
+                // List on the query forces a clean rebuild instead of a partial diff.
+                .id(sidebarSearchText)
             }
-            .listStyle(.sidebar)
-            .searchable(
-                text: $sidebarSearchText,
-                placement: .sidebar,
-                prompt: Text(localizedAppText("Search Settings", de: "Einstellungen durchsuchen"))
-            )
-            .navigationSplitViewColumnWidth(min: 240, ideal: 270, max: 320)
-        } detail: {
+            .frame(width: sidebarWidth)
+            .frame(width: isSidebarVisible ? sidebarWidth : 0, alignment: .leading)
+            .clipped()
+
+            // Conditionally inserting/removing the divider pops it in and out
+            // instantly, out of sync with the sidebar's width animation. Fading its
+            // opacity instead keeps it in step with the same transition.
+            Divider()
+                .opacity(isSidebarVisible ? 1 : 0)
+
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
+        .animation(.easeInOut(duration: 0.22), value: isSidebarVisible)
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: { isSidebarVisible.toggle() }) {
+                    Image(systemName: "sidebar.leading")
+                }
+                .help(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
+                .accessibilityLabel(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
+            }
+        }
+    }
+}
+
+private struct SettingsSidebarSearchField: View {
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField(
+                localizedAppText("Search Settings", de: "Einstellungen durchsuchen"),
+                text: $text
+            )
+            .textFieldStyle(.plain)
+        }
+        .padding(6)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(nsColor: .controlBackgroundColor)))
+        .padding(EdgeInsets(top: 8, leading: 8, bottom: 4, trailing: 8))
     }
 }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -202,11 +202,14 @@ private struct SettingsModernShell: View {
     @State private var sidebarSearchText = ""
     @State private var isSidebarVisible = true
     @State private var sidebarWidth: CGFloat = 270
+    @State private var previewWidth: CGFloat?
     @State private var dragStartWidth: CGFloat?
+    @State private var isResizeHandleHovering = false
     @FocusState private var isSearchFieldFocused: Bool
 
     private let minSidebarWidth: CGFloat = 240
     private let maxSidebarWidth: CGFloat = 320
+    private let resizeStep: CGFloat = 20
 
     private var filteredSections: [SettingsDestinationSection] {
         let query = sidebarSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -226,82 +229,68 @@ private struct SettingsModernShell: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // The sidebar's own intrinsic width never changes, so row labels never
-            // reflow/truncate mid-toggle; only the outer frame's width animates,
-            // clipping the fixed-width content like a mask. NavigationSplitView's
-            // built-in collapse instead animates the List's actual layout width,
-            // which reflows text every frame and produces a visible glitch.
-            VStack(spacing: 0) {
-                SettingsSidebarSearchField(text: $sidebarSearchText, isFocused: $isSearchFieldFocused)
+            // Collapsing removes the sidebar from the view tree entirely (rather than
+            // zeroing/clipping a frame while it stays mounted), so a hidden sidebar is
+            // automatically unreachable by keyboard focus, VoiceOver, and hit-testing —
+            // no manual .disabled/.accessibilityHidden bookkeeping needed. The slide
+            // transition uses an offset transform rather than animating width, so row
+            // labels never reflow/truncate mid-toggle the way NavigationSplitView's
+            // built-in width-based collapse animation does.
+            if isSidebarVisible {
+                // Grouped so the sidebar and its resize handle slide out together as
+                // one rigid unit. Giving them separate .transition() instances left the
+                // handle behind mid-collapse: .move only offsets a view's rendering
+                // without changing siblings' HStack layout math, so once the sidebar's
+                // slot was removed from layout the handle's position snapped instantly
+                // to its new (sidebar-less) spot while its own opacity fade was still
+                // playing — a stray line hanging over the detail pane for the last
+                // fraction of the animation.
+                HStack(spacing: 0) {
+                    VStack(spacing: 0) {
+                        SettingsSidebarSearchField(text: $sidebarSearchText, isFocused: $isSearchFieldFocused)
 
-                List(selection: $selectedTab) {
-                    ForEach(filteredSections) { section in
-                        Section {
-                            ForEach(section.destinations) { destination in
-                                SettingsSidebarRow(destination: destination)
-                                    .tag(destination.tab)
+                        List(selection: $selectedTab) {
+                            ForEach(filteredSections) { section in
+                                Section {
+                                    ForEach(section.destinations) { destination in
+                                        SettingsSidebarRow(destination: destination)
+                                            .tag(destination.tab)
+                                    }
+                                }
                             }
                         }
+                        .listStyle(.sidebar)
+                        // Changing the section/row count via search filtering can leave stale,
+                        // blank space behind from SwiftUI's incremental List diffing. Keying the
+                        // List on the query forces a clean rebuild instead of a partial diff.
+                        .id(sidebarSearchText)
                     }
-                }
-                .listStyle(.sidebar)
-                // Changing the section/row count via search filtering can leave stale,
-                // blank space behind from SwiftUI's incremental List diffing. Keying the
-                // List on the query forces a clean rebuild instead of a partial diff.
-                .id(sidebarSearchText)
-            }
-            .frame(width: sidebarWidth)
-            .frame(width: isSidebarVisible ? sidebarWidth : 0, alignment: .leading)
-            .clipped()
-            // Collapsing only zeroes the outer frame and clips rendering; the search
-            // field, clear button, and list stay mounted underneath. Without this,
-            // keyboard focus and VoiceOver navigation can still reach controls that
-            // are invisible to sighted users.
-            .disabled(!isSidebarVisible)
-            .accessibilityHidden(!isSidebarVisible)
-            .allowsHitTesting(isSidebarVisible)
+                    // sidebarWidth only ever changes on drag release (see
+                    // SettingsSidebarResizeHandle), not on every pointer-move frame, so
+                    // the List doesn't relayout continuously during a drag — relaying
+                    // out its native NSScroller-backed rows on every frame was the
+                    // source of the resize lag. A thin guide line tracks the pointer
+                    // instead; the real resize commits once when the drag ends.
+                    .frame(width: sidebarWidth)
 
-            // Always mounted (never inserted/removed via if/else) so its opacity
-            // fades in step with the sidebar's width animation instead of popping
-            // in/out instantly. The resize handle only reacts while visible.
-            Divider()
-                .opacity(isSidebarVisible ? 1 : 0)
-                .overlay(
-                    Rectangle()
-                        .fill(Color.clear)
-                        .frame(width: 8)
-                        .contentShape(Rectangle())
-                        .onHover { hovering in
-                            guard isSidebarVisible else { return }
-                            if hovering {
-                                NSCursor.resizeLeftRight.push()
-                            } else {
-                                NSCursor.pop()
-                            }
-                        }
-                        .gesture(
-                            DragGesture()
-                                .onChanged { value in
-                                    guard isSidebarVisible else { return }
-                                    let base = dragStartWidth ?? sidebarWidth
-                                    dragStartWidth = base
-                                    sidebarWidth = min(max(base + value.translation.width, minSidebarWidth), maxSidebarWidth)
-                                }
-                                .onEnded { _ in
-                                    dragStartWidth = nil
-                                }
-                        )
-                )
+                    SettingsSidebarResizeHandle(
+                        committedWidth: sidebarWidth,
+                        sidebarWidth: $sidebarWidth,
+                        previewWidth: $previewWidth,
+                        dragStartWidth: $dragStartWidth,
+                        isHovering: $isResizeHandleHovering,
+                        minWidth: minSidebarWidth,
+                        maxWidth: maxSidebarWidth,
+                        step: resizeStep
+                    )
+                }
+                .transition(.move(edge: .leading))
+            }
 
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .animation(.easeInOut(duration: 0.22), value: isSidebarVisible)
-        .onChange(of: isSidebarVisible) { _, visible in
-            if !visible {
-                isSearchFieldFocused = false
-            }
-        }
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 Button(action: { isSidebarVisible.toggle() }) {
@@ -311,6 +300,89 @@ private struct SettingsModernShell: View {
                 .accessibilityLabel(localizedAppText("Toggle Sidebar", de: "Seitenleiste ein-/ausblenden"))
             }
         }
+    }
+}
+
+private struct SettingsSidebarResizeHandle: View {
+    let committedWidth: CGFloat
+    @Binding var sidebarWidth: CGFloat
+    @Binding var previewWidth: CGFloat?
+    @Binding var dragStartWidth: CGFloat?
+    @Binding var isHovering: Bool
+    let minWidth: CGFloat
+    let maxWidth: CGFloat
+    let step: CGFloat
+
+    var body: some View {
+        Divider()
+            .overlay(
+                Rectangle()
+                    .fill(Color.clear)
+                    .frame(width: 8)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        isHovering = hovering
+                        if hovering {
+                            NSCursor.resizeLeftRight.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                    // Pop the cursor unconditionally if this view disappears (e.g. the
+                    // sidebar collapses) while still hovered — onHover's "false" event
+                    // does not reliably fire when the view is removed from the tree
+                    // mid-hover, which would otherwise leave the resize cursor stuck.
+                    .onDisappear {
+                        if isHovering {
+                            NSCursor.pop()
+                            isHovering = false
+                        }
+                        previewWidth = nil
+                        dragStartWidth = nil
+                    }
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                let base = dragStartWidth ?? committedWidth
+                                dragStartWidth = base
+                                previewWidth = min(max(base + value.translation.width, minWidth), maxWidth)
+                            }
+                            .onEnded { _ in
+                                if let previewWidth {
+                                    sidebarWidth = previewWidth
+                                }
+                                previewWidth = nil
+                                dragStartWidth = nil
+                            }
+                    )
+                    .accessibilityElement()
+                    .accessibilityLabel(localizedAppText("Sidebar Width", de: "Seitenleistenbreite"))
+                    .accessibilityValue("\(Int(sidebarWidth)) pt")
+                    .accessibilityAdjustableAction { direction in
+                        switch direction {
+                        case .increment:
+                            sidebarWidth = min(sidebarWidth + step, maxWidth)
+                        case .decrement:
+                            sidebarWidth = max(sidebarWidth - step, minWidth)
+                        @unknown default:
+                            break
+                        }
+                    }
+            )
+            // Cheap: a single thin rectangle offset from the divider's actual
+            // position, not a relayout of anything. Gives live feedback about where
+            // the sidebar would land without touching the List during the drag.
+            // Always mounted (never conditionally inserted/removed) so it fades out
+            // in step with the drag ending instead of vanishing instantly — same
+            // reasoning as the sidebar's own opacity-faded divider.
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(Color.accentColor)
+                    .frame(width: 2)
+                    .offset(x: (previewWidth ?? committedWidth) - committedWidth)
+                    .opacity(previewWidth == nil ? 0 : 1)
+                    .animation(.easeOut(duration: 0.15), value: previewWidth == nil)
+            }
     }
 }
 

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -319,12 +319,19 @@ private struct SettingsSplitView: NSViewControllerRepresentable {
         var isSidebarVisible: Binding<Bool>?
         private var collapseObservation: NSKeyValueObservation?
 
+        // Captures the binding itself rather than `self` — `Coordinator` is a
+        // plain (non-Sendable) class, and KVO's changeHandler is `@Sendable`, so
+        // capturing `self` (even weakly) to reach `self.isSidebarVisible` trips
+        // Swift 6 strict concurrency checking. The binding's identity is stable
+        // for the representable's lifetime, so a snapshot at observation time
+        // stays valid.
         func observeCollapseState(of sidebarItem: NSSplitViewItem) {
-            collapseObservation = sidebarItem.observe(\.isCollapsed, options: [.new]) { [weak self] _, change in
-                guard let self, let isCollapsed = change.newValue else { return }
+            let isSidebarVisible = isSidebarVisible
+            collapseObservation = sidebarItem.observe(\.isCollapsed, options: [.new]) { _, change in
+                guard let isCollapsed = change.newValue else { return }
                 let shouldBeVisible = !isCollapsed
-                if self.isSidebarVisible?.wrappedValue != shouldBeVisible {
-                    self.isSidebarVisible?.wrappedValue = shouldBeVisible
+                if isSidebarVisible?.wrappedValue != shouldBeVisible {
+                    isSidebarVisible?.wrappedValue = shouldBeVisible
                 }
             }
         }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -201,8 +201,12 @@ private struct SettingsModernShell: View {
 
     @State private var sidebarSearchText = ""
     @State private var isSidebarVisible = true
+    @State private var sidebarWidth: CGFloat = 270
+    @State private var dragStartWidth: CGFloat?
+    @FocusState private var isSearchFieldFocused: Bool
 
-    private let sidebarWidth: CGFloat = 270
+    private let minSidebarWidth: CGFloat = 240
+    private let maxSidebarWidth: CGFloat = 320
 
     private var filteredSections: [SettingsDestinationSection] {
         let query = sidebarSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -228,7 +232,7 @@ private struct SettingsModernShell: View {
             // built-in collapse instead animates the List's actual layout width,
             // which reflows text every frame and produces a visible glitch.
             VStack(spacing: 0) {
-                SettingsSidebarSearchField(text: $sidebarSearchText)
+                SettingsSidebarSearchField(text: $sidebarSearchText, isFocused: $isSearchFieldFocused)
 
                 List(selection: $selectedTab) {
                     ForEach(filteredSections) { section in
@@ -249,17 +253,55 @@ private struct SettingsModernShell: View {
             .frame(width: sidebarWidth)
             .frame(width: isSidebarVisible ? sidebarWidth : 0, alignment: .leading)
             .clipped()
+            // Collapsing only zeroes the outer frame and clips rendering; the search
+            // field, clear button, and list stay mounted underneath. Without this,
+            // keyboard focus and VoiceOver navigation can still reach controls that
+            // are invisible to sighted users.
+            .disabled(!isSidebarVisible)
+            .accessibilityHidden(!isSidebarVisible)
+            .allowsHitTesting(isSidebarVisible)
 
-            // Conditionally inserting/removing the divider pops it in and out
-            // instantly, out of sync with the sidebar's width animation. Fading its
-            // opacity instead keeps it in step with the same transition.
+            // Always mounted (never inserted/removed via if/else) so its opacity
+            // fades in step with the sidebar's width animation instead of popping
+            // in/out instantly. The resize handle only reacts while visible.
             Divider()
                 .opacity(isSidebarVisible ? 1 : 0)
+                .overlay(
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: 8)
+                        .contentShape(Rectangle())
+                        .onHover { hovering in
+                            guard isSidebarVisible else { return }
+                            if hovering {
+                                NSCursor.resizeLeftRight.push()
+                            } else {
+                                NSCursor.pop()
+                            }
+                        }
+                        .gesture(
+                            DragGesture()
+                                .onChanged { value in
+                                    guard isSidebarVisible else { return }
+                                    let base = dragStartWidth ?? sidebarWidth
+                                    dragStartWidth = base
+                                    sidebarWidth = min(max(base + value.translation.width, minSidebarWidth), maxSidebarWidth)
+                                }
+                                .onEnded { _ in
+                                    dragStartWidth = nil
+                                }
+                        )
+                )
 
             detail(selectedTab)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .animation(.easeInOut(duration: 0.22), value: isSidebarVisible)
+        .onChange(of: isSidebarVisible) { _, visible in
+            if !visible {
+                isSearchFieldFocused = false
+            }
+        }
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 Button(action: { isSidebarVisible.toggle() }) {
@@ -274,6 +316,7 @@ private struct SettingsModernShell: View {
 
 private struct SettingsSidebarSearchField: View {
     @Binding var text: String
+    var isFocused: FocusState<Bool>.Binding
 
     var body: some View {
         HStack(spacing: 6) {
@@ -284,6 +327,7 @@ private struct SettingsSidebarSearchField: View {
                 text: $text
             )
             .textFieldStyle(.plain)
+            .focused(isFocused)
 
             if !text.isEmpty {
                 Button(action: { text = "" }) {


### PR DESCRIPTION
## Summary
- The Settings sidebar (macOS 15+ path, `SettingsModernShell`) used `NavigationSplitView`'s built-in collapse animation, which animates the sidebar `List`'s actual layout width. This caused row labels to visibly truncate/reflow mid-toggle and, combined with search filtering, could leave stale blank space behind after the query changed.
- Replaced it with a custom `HStack`-based sidebar where the `List` always keeps its full intrinsic width; only an outer frame's width is animated and clipped, masking the content like a curtain instead of reflowing it. This mirrors the workaround already used for the pre-macOS 15 path (`SettingsSidebarShell`).
- Added a custom toolbar toggle button and search field to replace the ones `NavigationSplitView` provided automatically.
- Fixed a related List diffing glitch where clearing the search query could leave a blank gap by keying the `List` on the query text.

## Test plan
- [x] `scripts/pr-preflight.sh` (whitespace/conflict-marker check, shell script syntax, Python script tests) — passes; one unrelated pre-existing failure in `test_verify_appcast_publication.py` due to local Python 3.9 vs required 3.10+ syntax, unrelated to this change.
- [x] Built and ran the TypeWhisper Dev app locally, opened Settings, and manually toggled the sidebar open/closed repeatedly, including while a search query was active, to confirm the animation is smooth with no truncation/ghosting glitches and no leftover blank space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Settings sidebar on macOS 15+ by switching to a native split-view layout, resulting in smoother sidebar expand/collapse with consistent animations.
  * Updated the sidebar search to use a dedicated search field with reliable filtering, correct labeling, and a clear button for quick resets.
  * Prevented stale or blank sidebar spacing when search text changes by ensuring the results refresh cleanly as you type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->