### PR TITLE
Fix Apple Speech regional model selection

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -1382,6 +1382,8 @@ final class ModelManagerService: ObservableObject {
                 from: plugin.modelCatalog,
                 localeIdentifier: $0,
                 languageCode: $0,
+                preferredModelId: plugin.selectedModelId,
+                fallbackLocaleIdentifier: Locale.current.identifier,
                 fallbackToFirst: false
             )
         }

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -382,6 +382,8 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
             fromModelIds: cachedModels.map(\.id),
             localeIdentifier: languageCode,
             languageCode: languageCode,
+            preferredModelId: selectedModelId,
+            fallbackLocaleIdentifier: Locale.current.identifier,
             fallbackToFirst: false
         ) else {
             return nil

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/Tests/AppleSpeechModelSelectionTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/Tests/AppleSpeechModelSelectionTests.swift
@@ -55,6 +55,71 @@ final class AppleSpeechModelSelectionTests: XCTestCase {
         XCTAssertEqual(modelId, "speechanalyzer-de_CH")
     }
 
+    func testGenericLanguagePrefersMatchingSelectedRegionalModel() {
+        let modelId = AppleSpeechModelSelection.preferredModelId(
+            fromModelIds: [
+                "speechanalyzer-en_AU",
+                "speechanalyzer-en_US"
+            ],
+            localeIdentifier: "en",
+            languageCode: "en",
+            preferredModelId: "speechanalyzer-en_US",
+            fallbackLocaleIdentifier: "en_AU",
+            fallbackToFirst: false
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-en_US")
+    }
+
+    func testGenericLanguageUsesMatchingFallbackLocaleBeforeFirstLanguageModel() {
+        let modelId = AppleSpeechModelSelection.preferredModelId(
+            fromModelIds: [
+                "speechanalyzer-en_AU",
+                "speechanalyzer-en_US"
+            ],
+            localeIdentifier: "en",
+            languageCode: "en",
+            fallbackLocaleIdentifier: "en_US",
+            fallbackToFirst: false
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-en_US")
+    }
+
+    func testExactRegionalLanguageTakesPrecedenceOverPreferredAndFallbackModels() {
+        let modelId = AppleSpeechModelSelection.preferredModelId(
+            fromModelIds: [
+                "speechanalyzer-en_AU",
+                "speechanalyzer-en_GB",
+                "speechanalyzer-en_US"
+            ],
+            localeIdentifier: "en-GB",
+            languageCode: "en-GB",
+            preferredModelId: "speechanalyzer-en_US",
+            fallbackLocaleIdentifier: "en_AU",
+            fallbackToFirst: false
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-en_GB")
+    }
+
+    func testGenericLanguageIgnoresPreferredModelFromAnotherLanguage() {
+        let modelId = AppleSpeechModelSelection.preferredModelId(
+            fromModelIds: [
+                "speechanalyzer-en_AU",
+                "speechanalyzer-en_US",
+                "speechanalyzer-de_DE"
+            ],
+            localeIdentifier: "en",
+            languageCode: "en",
+            preferredModelId: "speechanalyzer-de_DE",
+            fallbackLocaleIdentifier: "en_US",
+            fallbackToFirst: false
+        )
+
+        XCTAssertEqual(modelId, "speechanalyzer-en_US")
+    }
+
     func testReturnsNilForEmptyModelCatalog() {
         let modelId = AppleSpeechModelSelection.preferredModelId(
             fromModelIds: [],

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/AppleSpeechModelSelection.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/AppleSpeechModelSelection.swift
@@ -9,12 +9,16 @@ public enum AppleSpeechModelSelection {
         from models: [PluginModelInfo],
         localeIdentifier: String = Locale.current.identifier,
         languageCode: String? = Locale.current.language.languageCode?.identifier,
+        preferredModelId: String? = nil,
+        fallbackLocaleIdentifier: String? = nil,
         fallbackToFirst: Bool = true
     ) -> String? {
-        preferredModelId(
+        Self.preferredModelId(
             fromModelIds: models.map(\.id),
             localeIdentifier: localeIdentifier,
             languageCode: languageCode,
+            preferredModelId: preferredModelId,
+            fallbackLocaleIdentifier: fallbackLocaleIdentifier,
             fallbackToFirst: fallbackToFirst
         )
     }
@@ -23,6 +27,8 @@ public enum AppleSpeechModelSelection {
         fromModelIds modelIds: [String],
         localeIdentifier: String = Locale.current.identifier,
         languageCode: String? = Locale.current.language.languageCode?.identifier,
+        preferredModelId: String? = nil,
+        fallbackLocaleIdentifier: String? = nil,
         fallbackToFirst: Bool = true
     ) -> String? {
         guard !modelIds.isEmpty else { return nil }
@@ -44,6 +50,21 @@ public enum AppleSpeechModelSelection {
             let languageModelId = "\(modelIdPrefix)\(normalizedLanguageCode)"
             if modelIds.contains(languageModelId) {
                 return languageModelId
+            }
+
+            if let preferredModelId,
+               modelIds.contains(preferredModelId),
+               modelLanguageCode(for: preferredModelId) == normalizedLanguageCode {
+                return preferredModelId
+            }
+
+            if let fallbackLocaleIdentifier,
+               Self.normalizedLanguageCode(for: fallbackLocaleIdentifier) == normalizedLanguageCode {
+                for modelId in localeModelIds(for: fallbackLocaleIdentifier) {
+                    if modelIds.contains(modelId) {
+                        return modelId
+                    }
+                }
             }
 
             if let match = modelIds.first(where: { modelLanguageCode(for: $0) == normalizedLanguageCode }) {

--- a/TypeWhisperTests/ModelManagerAppleSpeechModelSelectionTests.swift
+++ b/TypeWhisperTests/ModelManagerAppleSpeechModelSelectionTests.swift
@@ -69,6 +69,37 @@ final class ModelManagerAppleSpeechModelSelectionTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelId, "speechanalyzer-de_DE")
     }
 
+    func testGenericLanguageKeepsMatchingConfiguredRegionalAppleSpeechModelAcrossDictations() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockAppleSpeechTranscriptionPlugin(
+            availableModels: [
+                PluginModelInfo(id: "speechanalyzer-en_AU", displayName: "English (Australia)"),
+                PluginModelInfo(id: "speechanalyzer-en_US", displayName: "English (United States)")
+            ]
+        )
+        plugin.selectModel("speechanalyzer-en_US")
+        let modelManager = installAppleSpeechPlugin(plugin, appSupportDirectory: appSupportDirectory)
+
+        let firstResult = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            languageSelection: .exact("en"),
+            task: .transcribe
+        )
+        let secondResult = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            languageSelection: .exact("en"),
+            task: .transcribe
+        )
+
+        XCTAssertEqual(firstResult.text, "transcribed with speechanalyzer-en_US")
+        XCTAssertEqual(secondResult.text, "transcribed with speechanalyzer-en_US")
+        XCTAssertEqual(plugin.requestedLanguagePreparations, ["en", "en"])
+        XCTAssertEqual(plugin.transcribedModelIds, ["speechanalyzer-en_US", "speechanalyzer-en_US"])
+        XCTAssertEqual(plugin.selectedModelId, "speechanalyzer-en_US")
+    }
+
     func testExactUnsupportedLanguageDoesNotUseConfiguredAppleSpeechModel() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -254,6 +285,8 @@ private final class MockAppleSpeechTranscriptionPlugin: NSObject, TranscriptionM
                 from: availableModels,
                 localeIdentifier: language,
                 languageCode: language,
+                preferredModelId: selectedModelId,
+                fallbackLocaleIdentifier: Locale.current.identifier,
                 fallbackToFirst: false
             )
         } else if let currentModelId {


### PR DESCRIPTION
## Summary

- preserve a manually selected Apple Speech regional model when a generic language such as `en` is configured
- prefer a matching system locale before falling back to the first same-language catalog model
- keep plugin preparation and host-side expected-model validation on the same resolver inputs

## Issue context

With the global spoken language restricted to generic English (`en`), Apple Speech resolved every dictation to the first English catalog entry (for example `en_AU`). That overrode a manually selected `en_US` model. This change keeps a compatible manual regional selection stable and otherwise prefers the matching system locale.

Closes #919

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter AppleSpeechModelSelectionTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/ModelManagerAppleSpeechModelSelectionTests CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/6f87/typewhisper-mac`
- Manual dev-app smoke: selected global English, enabled Apple Speech with English (United States), dictated twice, and verified both History details and the active model remained English (United States).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Apple Speech now better preserves the selected regional model when using a generic language such as English.
  * Model selection can use the device’s current locale to choose the most appropriate regional model.
  * Exact regional language matches continue to take priority over fallback options.
* **Bug Fixes**
  * Prevented incompatible preferred models from being selected for a different language.
  * Improved model restoration and consistency across multiple dictations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->