### PR TITLE
Manage stale external plugin bundles

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -22033,6 +22033,12 @@
     },
     "Remove": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -22947,6 +22953,86 @@
           "stringUnit": {
             "state": "translated",
             "value": "最初の文字起こしの後、ここに統計が表示されます。"
+          }
+        }
+      }
+    },
+    "Could Not Remove Plugin Bundle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plugin-Bundle konnte nicht entfernt werden"
+          }
+        }
+      }
+    },
+    "Remove %@? This will delete the incompatible plugin bundle, its stored data, and its credentials.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ entfernen? Dadurch werden das inkompatible Plugin-Bundle, seine gespeicherten Daten und seine Zugangsdaten gelöscht."
+          }
+        }
+      }
+    },
+    "Remove Incompatible Plugin Bundle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inkompatibles Plugin-Bundle entfernen"
+          }
+        }
+      }
+    },
+    "Remove incompatible bundle for %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inkompatibles Bundle für %@ entfernen"
+          }
+        }
+      }
+    },
+    "Replace %@ with the Marketplace version": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ durch die Marketplace-Version ersetzen"
+          }
+        }
+      }
+    },
+    "Replace with Marketplace Version": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durch Marketplace-Version ersetzen"
+          }
+        }
+      }
+    },
+    "The incompatible plugin bundle is outside the managed Plugins folder and cannot be removed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das inkompatible Plugin-Bundle liegt außerhalb des verwalteten Plugins-Ordners und kann nicht entfernt werden."
+          }
+        }
+      }
+    },
+    "This incompatible plugin bundle is no longer registered.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses inkompatible Plugin-Bundle ist nicht mehr registriert."
           }
         }
       }

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -487,6 +487,7 @@ final class PluginRegistryService: ObservableObject {
     private let userDefaults: UserDefaults
     private let infoDictionary: [String: Any]?
     private let fetchData: (URLRequest) async throws -> (Data, URLResponse)
+    private let deleteCredentials: (String) throws -> Void
     private let cacheDirectory: URL
     private static let lastUpdateCheckKey = "pluginRegistryLastUpdateCheck"
     private static let lastHostFingerprintCheckKey = "pluginRegistryLastHostFingerprintCheck"
@@ -561,6 +562,9 @@ final class PluginRegistryService: ObservableObject {
         cacheDuration: TimeInterval = 300,
         userDefaults: UserDefaults = .standard,
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
+        deleteCredentials: @escaping (String) throws -> Void = { prefix in
+            try KeychainService.deleteAll(withServicePrefix: prefix)
+        },
         fetchData: @escaping (URLRequest) async throws -> (Data, URLResponse) = { request in
             try await URLSession.shared.data(for: request)
         }
@@ -570,6 +574,7 @@ final class PluginRegistryService: ObservableObject {
         self.cacheDuration = cacheDuration
         self.userDefaults = userDefaults
         self.infoDictionary = infoDictionary
+        self.deleteCredentials = deleteCredentials
         self.fetchData = fetchData
 
         try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
@@ -857,7 +862,7 @@ final class PluginRegistryService: ObservableObject {
                 .appendingPathComponent(pluginId, isDirectory: true)
             try? FileManager.default.removeItem(at: dataDir)
             do {
-                try KeychainService.deleteAll(withServicePrefix: "\(pluginId).")
+                try deleteCredentials("\(pluginId).")
             } catch {
                 logger.error("Keychain cleanup failed for \(pluginId): \(error.localizedDescription)")
                 keychainError = error

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -21,6 +21,20 @@ enum PluginDownloadError: LocalizedError {
     }
 }
 
+enum IncompatiblePluginBundleRemovalError: LocalizedError {
+    case bundleNoLongerRegistered
+    case invalidBundleLocation
+
+    var errorDescription: String? {
+        switch self {
+        case .bundleNoLongerRegistered:
+            return String(localized: "This incompatible plugin bundle is no longer registered.")
+        case .invalidBundleLocation:
+            return String(localized: "The incompatible plugin bundle is outside the managed Plugins folder and cannot be removed.")
+        }
+    }
+}
+
 // MARK: - Plugin Category
 
 enum PluginCategory: String, CaseIterable {
@@ -639,23 +653,24 @@ final class PluginRegistryService: ObservableObject {
         return true
     }
 
-    static func canRepairInstalledPlugin(
-        isBundled: Bool,
+    static func canReplaceIncompatibleExternalBundle(
         registryPlugin: RegistryPlugin?,
         installInfo: PluginInstallInfo,
         installState: InstallState?,
         externalNotice: ExternalBundleNotice?
     ) -> Bool {
-        guard !isBundled,
-              registryPlugin != nil,
+        guard registryPlugin != nil,
               installState == nil,
               externalNotice?.requiresConfirmation == true else {
             return false
         }
-        if case .installed = installInfo {
+
+        switch installInfo {
+        case .installed, .bundled:
             return true
+        case .notInstalled, .updateAvailable:
+            return false
         }
-        return false
     }
 
     func updateAvailableUpdatesCount() {
@@ -789,9 +804,55 @@ final class PluginRegistryService: ObservableObject {
         logger.info("Removing installed plugin bundle at \(bundleURL.path, privacy: .public)")
         try? FileManager.default.removeItem(at: bundleURL)
 
+        let keychainError = clearPluginPersistence(
+            pluginId,
+            appSupportDirectory: AppConstants.appSupportDirectory,
+            deleteData: deleteData
+        )
+        logger.info("Uninstalled plugin: \(pluginId)")
+
+        if let error = keychainError {
+            throw error
+        }
+    }
+
+    func removeIncompatibleExternalBundle(_ bundle: IncompatibleExternalBundle) throws {
+        let pluginManager = PluginManager.shared!
+        guard pluginManager.incompatibleExternalBundle(for: bundle.pluginId) == bundle else {
+            throw IncompatiblePluginBundleRemovalError.bundleNoLongerRegistered
+        }
+
+        let pluginsDirectory = pluginManager.pluginsDirectory.standardizedFileURL
+        let bundleURL = bundle.bundleURL.standardizedFileURL
+        guard bundleURL.pathExtension == "bundle",
+              bundleURL.deletingLastPathComponent() == pluginsDirectory else {
+            throw IncompatiblePluginBundleRemovalError.invalidBundleLocation
+        }
+
+        logger.info("Removing incompatible external plugin bundle at \(bundleURL.path, privacy: .public)")
+        try FileManager.default.removeItem(at: bundleURL)
+        pluginManager.clearIncompatibleExternalBundle(bundle.pluginId)
+
+        let keychainError = clearPluginPersistence(
+            bundle.pluginId,
+            appSupportDirectory: pluginsDirectory.deletingLastPathComponent(),
+            deleteData: true
+        )
+        logger.info("Removed incompatible external plugin bundle: \(bundle.pluginId)")
+
+        if let error = keychainError {
+            throw error
+        }
+    }
+
+    private func clearPluginPersistence(
+        _ pluginId: String,
+        appSupportDirectory: URL,
+        deleteData: Bool
+    ) -> Error? {
         var keychainError: Error?
         if deleteData {
-            let dataDir = AppConstants.appSupportDirectory
+            let dataDir = appSupportDirectory
                 .appendingPathComponent("PluginData", isDirectory: true)
                 .appendingPathComponent(pluginId, isDirectory: true)
             try? FileManager.default.removeItem(at: dataDir)
@@ -803,12 +864,8 @@ final class PluginRegistryService: ObservableObject {
             }
         }
 
-        UserDefaults.standard.removeObject(forKey: "plugin.\(pluginId).enabled")
-        logger.info("Uninstalled plugin: \(pluginId)")
-
-        if let error = keychainError {
-            throw error
-        }
+        userDefaults.removeObject(forKey: "plugin.\(pluginId).enabled")
+        return keychainError
     }
 
     // MARK: - Install from File
@@ -933,6 +990,7 @@ final class PluginRegistryService: ObservableObject {
                 try PluginManager.shared.loadPlugin(at: destinationURL)
             }
             try removeDuplicateBundles(for: manifest.id, keeping: destinationURL)
+            PluginManager.shared.clearIncompatibleExternalBundle(manifest.id)
 
             if hadExistingBundle, fm.fileExists(atPath: backupURL.path) {
                 logger.info("Removing plugin backup after successful install: \(backupURL.path, privacy: .public)")

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -172,8 +172,10 @@ struct PluginSettingsView: View {
     @State private var pluginToUninstall: LoadedPlugin?
     @State private var pendingBoundaryUpgradePlugin: RegistryPlugin?
     @State private var pendingBoundaryUpgradeNotice: ExternalBundleNotice?
+    @State private var incompatibleBundleToRemove: IncompatibleExternalBundle?
     @State private var installFromFileError: String?
     @State private var uninstallError: String?
+    @State private var incompatibleBundleRemovalError: String?
     @State private var includeCommunityPlugins = true
     @State private var selectedCapabilityFilters: Set<PluginCategory> = []
     @State private var searchText = ""
@@ -248,6 +250,28 @@ struct PluginSettingsView: View {
         } message: { plugin in
             Text(boundaryUpgradeMessage(for: plugin, notice: pendingBoundaryUpgradeNotice))
         }
+        .alert(
+            String(localized: "Remove Incompatible Plugin Bundle"),
+            isPresented: .init(
+                get: { incompatibleBundleToRemove != nil },
+                set: { if !$0 { incompatibleBundleToRemove = nil } }
+            ),
+            presenting: incompatibleBundleToRemove
+        ) { bundle in
+            Button(String(localized: "Remove"), role: .destructive) {
+                incompatibleBundleToRemove = nil
+                do {
+                    try registryService.removeIncompatibleExternalBundle(bundle)
+                } catch {
+                    incompatibleBundleRemovalError = error.localizedDescription
+                }
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                incompatibleBundleToRemove = nil
+            }
+        } message: { bundle in
+            Text(String(localized: "Remove \(bundle.pluginName)? This will delete the incompatible plugin bundle, its stored data, and its credentials."))
+        }
         .alert(String(localized: "Install Failed"), isPresented: .init(
             get: { installFromFileError != nil },
             set: { if !$0 { installFromFileError = nil } }
@@ -265,6 +289,16 @@ struct PluginSettingsView: View {
             Button(String(localized: "OK")) { uninstallError = nil }
         } message: {
             if let error = uninstallError {
+                Text(error)
+            }
+        }
+        .alert(String(localized: "Could Not Remove Plugin Bundle"), isPresented: .init(
+            get: { incompatibleBundleRemovalError != nil },
+            set: { if !$0 { incompatibleBundleRemovalError = nil } }
+        )) {
+            Button(String(localized: "OK")) { incompatibleBundleRemovalError = nil }
+        } message: {
+            if let error = incompatibleBundleRemovalError {
                 Text(error)
             }
         }
@@ -562,7 +596,7 @@ struct PluginSettingsView: View {
                                 startInstall(registryPlugin)
                             }
                         },
-                        onRepair: {
+                        onReplace: {
                             if let registryPlugin = registryService.registry.first(where: { $0.id == plugin.id }) {
                                 startInstall(registryPlugin)
                             }
@@ -579,8 +613,13 @@ struct PluginSettingsView: View {
             }
 
             if !pluginManager.incompatibleExternalBundles.isEmpty {
-                ForEach(pluginManager.incompatibleExternalBundles.values.sorted { $0.pluginName < $1.pluginName }, id: \.pluginId) { bundle in
-                    IncompatibleBundleRow(bundle: bundle)
+                ForEach(pluginManager.incompatibleExternalBundles.values.sorted { $0.pluginName < $1.pluginName }, id: \.bundleURL) { bundle in
+                    IncompatibleBundleRow(
+                        bundle: bundle,
+                        onRemove: {
+                            incompatibleBundleToRemove = bundle
+                        }
+                    )
                         .background {
                             integrationGroupedSurface(cornerRadius: 14)
                         }
@@ -1505,7 +1544,7 @@ private struct InstalledPluginRow: View {
     let hosting: PluginHosting
     let registryPlugin: RegistryPlugin?
     let onUpdate: () -> Void
-    let onRepair: () -> Void
+    let onReplace: () -> Void
     let onUninstall: () -> Void
     @State private var pluginActivity: PluginSettingsActivity?
     @State private var modelsExpanded = false
@@ -1621,23 +1660,11 @@ private struct InstalledPluginRow: View {
                                 }
                             }
 
-                            if detailsURL != nil || homepageURL != nil {
+                            if (detailsURL != nil || homepageURL != nil) && !plugin.isBundled {
                                 Divider()
                             }
 
-                            if canRepairInstallation {
-                                Button {
-                                    onRepair()
-                                } label: {
-                                    Label(localizedAppText("Repair Installation", de: "Installation reparieren"), systemImage: "arrow.down.app")
-                                }
-                            }
-
                             if !plugin.isBundled {
-                                if canRepairInstallation {
-                                    Divider()
-                                }
-
                                 Button(role: .destructive) {
                                     onUninstall()
                                 } label: {
@@ -1731,6 +1758,15 @@ private struct InstalledPluginRow: View {
     private var pluginActions: some View {
         if let state = installState {
             PluginInstallStateView(state: state, name: plugin.manifest.name)
+        } else if canReplaceIncompatibleExternalBundle {
+            Button {
+                onReplace()
+            } label: {
+                Label(String(localized: "Replace with Marketplace Version"), systemImage: "arrow.down.app")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel(String(localized: "Replace \(plugin.manifest.name) with the Marketplace version"))
         } else if case .updateAvailable = installInfo {
             Button {
                 onUpdate()
@@ -1745,9 +1781,8 @@ private struct InstalledPluginRow: View {
         }
     }
 
-    private var canRepairInstallation: Bool {
-        PluginRegistryService.canRepairInstalledPlugin(
-            isBundled: plugin.isBundled,
+    private var canReplaceIncompatibleExternalBundle: Bool {
+        PluginRegistryService.canReplaceIncompatibleExternalBundle(
             registryPlugin: registryPlugin,
             installInfo: installInfo,
             installState: installState,
@@ -1779,7 +1814,7 @@ private struct InstalledPluginRow: View {
     }
 
     private var hasOverflowActions: Bool {
-        detailsURL != nil || homepageURL != nil || canRepairInstallation || !plugin.isBundled
+        detailsURL != nil || homepageURL != nil || !plugin.isBundled
     }
 
     private var restartRequired: Bool {
@@ -1980,6 +2015,7 @@ private struct AvailablePluginRow: View {
 
 private struct IncompatibleBundleRow: View {
     let bundle: IncompatibleExternalBundle
+    let onRemove: () -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -2004,6 +2040,17 @@ private struct IncompatibleBundleRow: View {
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
             }
+
+            Spacer(minLength: 12)
+
+            Button(role: .destructive) {
+                onRemove()
+            } label: {
+                Label(String(localized: "Remove"), systemImage: "trash")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel(String(localized: "Remove incompatible bundle for \(bundle.pluginName)"))
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -2109,7 +2109,7 @@ final class PluginRegistryDestinationTests: XCTestCase {
         XCTAssertEqual(destination, pluginsDirectory.appendingPathComponent("ParakeetPlugin.bundle"))
     }
 
-    func testRepairEligibilityRequiresActionableExternalBundleNotice() {
+    func testReplacementEligibilitySupportsBundledAndInstalledPluginsWithActionableNotice() {
         let registryPlugin = makeRegistryPlugin(id: "com.typewhisper.qwen3")
         let boundaryNotice = ExternalBundleNotice.boundaryUpgradeRequired(
             installedVersion: "1.1.0",
@@ -2117,17 +2117,23 @@ final class PluginRegistryDestinationTests: XCTestCase {
         )
 
         XCTAssertTrue(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: false,
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
                 installState: nil,
                 externalNotice: boundaryNotice
             )
         )
+        XCTAssertTrue(
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
+                registryPlugin: registryPlugin,
+                installInfo: .bundled,
+                installState: nil,
+                externalNotice: boundaryNotice
+            )
+        )
         XCTAssertFalse(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: false,
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
                 installState: nil,
@@ -2135,8 +2141,7 @@ final class PluginRegistryDestinationTests: XCTestCase {
             )
         )
         XCTAssertFalse(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: false,
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
                 installState: nil,
@@ -2144,17 +2149,7 @@ final class PluginRegistryDestinationTests: XCTestCase {
             )
         )
         XCTAssertFalse(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: true,
-                registryPlugin: registryPlugin,
-                installInfo: .installed(version: "1.1.1"),
-                installState: nil,
-                externalNotice: boundaryNotice
-            )
-        )
-        XCTAssertFalse(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: false,
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
                 registryPlugin: nil,
                 installInfo: .installed(version: "1.1.1"),
                 installState: nil,
@@ -2162,8 +2157,7 @@ final class PluginRegistryDestinationTests: XCTestCase {
             )
         )
         XCTAssertFalse(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: false,
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
                 registryPlugin: registryPlugin,
                 installInfo: .updateAvailable(installed: "1.1.0", available: "1.1.1"),
                 installState: nil,
@@ -2171,8 +2165,7 @@ final class PluginRegistryDestinationTests: XCTestCase {
             )
         )
         XCTAssertFalse(
-            PluginRegistryService.canRepairInstalledPlugin(
-                isBundled: false,
+            PluginRegistryService.canReplaceIncompatibleExternalBundle(
                 registryPlugin: registryPlugin,
                 installInfo: .installed(version: "1.1.1"),
                 installState: .extracting,

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -594,6 +594,246 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertFalse(registeredPlugin.isRuntimeLoaded)
     }
 
+    @MainActor
+    func testReplacingBundledFallbackRemovesStaleBundleAndKeepsPluginData() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBoundaryReplacement")
+        let incomingDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBoundaryReplacementIncoming")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBoundaryReplacementCache")
+        let pluginId = "com.typewhisper.boundary-replacement"
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(incomingDirectory)
+            TestSupport.remove(cacheDirectory)
+            UserDefaults.standard.removeObject(forKey: "plugin.\(pluginId).enabled")
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let staleBundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("LegacyBoundaryPlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: staleBundleURL,
+            pluginId: pluginId,
+            pluginName: "Boundary Plugin",
+            version: "1.0.0"
+        )
+        try pluginManager.loadPlugin(at: staleBundleURL)
+        XCTAssertNotNil(pluginManager.incompatibleExternalBundle(for: pluginId))
+
+        let builtInURL = (Bundle.main.builtInPlugInsURL
+            ?? URL(fileURLWithPath: "/Applications/TypeWhisper.app/Contents/PlugIns", isDirectory: true))
+            .appendingPathComponent("BoundaryPlugin.bundle", isDirectory: true)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: pluginId,
+                    name: "Boundary Plugin",
+                    version: "1.0.1",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "RuntimeUpdatePlugin"
+                ),
+                instance: MockRuntimeUpdatePlugin(),
+                bundle: Bundle.main,
+                sourceURL: builtInURL,
+                isEnabled: true
+            ),
+        ]
+
+        let pluginDataDirectory = appSupportDirectory
+            .appendingPathComponent("PluginData", isDirectory: true)
+            .appendingPathComponent(pluginId, isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginDataDirectory, withIntermediateDirectories: true)
+        let sentinelURL = pluginDataDirectory.appendingPathComponent("settings-sentinel")
+        try Data("keep plugin data".utf8).write(to: sentinelURL)
+
+        let incomingBundleURL = incomingDirectory
+            .appendingPathComponent("BoundaryPlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: incomingBundleURL,
+            pluginId: pluginId,
+            pluginName: "Boundary Plugin",
+            version: "1.0.2",
+            sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion
+        )
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+
+        let manifest = try await service.installFromFile(incomingBundleURL)
+
+        let installedBundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("BoundaryPlugin.bundle", isDirectory: true)
+        XCTAssertEqual(manifest.version, "1.0.2")
+        XCTAssertEqual(service.installStates[pluginId], .restartRequired)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installedBundleURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: staleBundleURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinelURL.path))
+        XCTAssertNil(pluginManager.incompatibleExternalBundle(for: pluginId))
+
+        let registeredPlugin = try XCTUnwrap(pluginManager.loadedPlugins.first { $0.id == pluginId })
+        XCTAssertEqual(
+            URL(fileURLWithPath: registeredPlugin.sourceURL.path).standardizedFileURL,
+            URL(fileURLWithPath: installedBundleURL.path).standardizedFileURL
+        )
+        XCTAssertFalse(registeredPlugin.isRuntimeLoaded)
+    }
+
+    @MainActor
+    func testRemovingIncompatibleBundleDeletesDataAndKeepsBundledFallbackLoaded() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatibleRemoval")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatibleRemovalCache")
+        let pluginId = "com.typewhisper.incompatible-removal"
+        let enabledKey = "plugin.\(pluginId).enabled"
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(cacheDirectory)
+            UserDefaults.standard.removeObject(forKey: enabledKey)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let incompatibleBundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("IncompatiblePlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: incompatibleBundleURL,
+            pluginId: pluginId,
+            pluginName: "Incompatible Plugin",
+            version: "1.0.0"
+        )
+        try pluginManager.loadPlugin(at: incompatibleBundleURL)
+        let incompatibleBundle = try XCTUnwrap(pluginManager.incompatibleExternalBundle(for: pluginId))
+
+        let fallback = LoadedPlugin(
+            manifest: PluginManifest(
+                id: pluginId,
+                name: "Incompatible Plugin",
+                version: "1.0.1",
+                sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                principalClass: "RuntimeUpdatePlugin"
+            ),
+            instance: MockRuntimeUpdatePlugin(),
+            bundle: Bundle.main,
+            sourceURL: (Bundle.main.builtInPlugInsURL
+                ?? URL(fileURLWithPath: "/Applications/TypeWhisper.app/Contents/PlugIns", isDirectory: true))
+                .appendingPathComponent("IncompatiblePlugin.bundle", isDirectory: true),
+            isEnabled: true
+        )
+        pluginManager.loadedPlugins = [fallback]
+
+        let pluginDataDirectory = appSupportDirectory
+            .appendingPathComponent("PluginData", isDirectory: true)
+            .appendingPathComponent(pluginId, isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginDataDirectory, withIntermediateDirectories: true)
+        try Data("delete plugin data".utf8)
+            .write(to: pluginDataDirectory.appendingPathComponent("data-sentinel"))
+        UserDefaults.standard.set(true, forKey: enabledKey)
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+        try service.removeIncompatibleExternalBundle(incompatibleBundle)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: incompatibleBundleURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pluginDataDirectory.path))
+        XCTAssertNil(UserDefaults.standard.object(forKey: enabledKey))
+        XCTAssertNil(pluginManager.incompatibleExternalBundle(for: pluginId))
+        XCTAssertEqual(pluginManager.loadedPlugins.count, 1)
+        XCTAssertEqual(pluginManager.loadedPlugins.first?.sourceURL, fallback.sourceURL)
+        XCTAssertTrue(pluginManager.loadedPlugins.first?.isRuntimeLoaded == true)
+    }
+
+    @MainActor
+    func testRemovingIncompatibleBundleRejectsLocationsOutsideManagedPluginsFolder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatiblePathGuard")
+        let externalDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatiblePathGuardExternal")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatiblePathGuardCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(externalDirectory)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let externalBundleURL = externalDirectory
+            .appendingPathComponent("ExternalIncompatiblePlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: externalBundleURL,
+            pluginId: "com.typewhisper.external-incompatible",
+            pluginName: "External Incompatible Plugin",
+            version: "1.0.0"
+        )
+        try pluginManager.loadPlugin(at: externalBundleURL)
+        let incompatibleBundle = try XCTUnwrap(
+            pluginManager.incompatibleExternalBundle(for: "com.typewhisper.external-incompatible")
+        )
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+
+        XCTAssertThrowsError(try service.removeIncompatibleExternalBundle(incompatibleBundle)) { error in
+            guard case IncompatiblePluginBundleRemovalError.invalidBundleLocation = error else {
+                return XCTFail("Expected invalid bundle location error, got \(error)")
+            }
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalBundleURL.path))
+        XCTAssertEqual(pluginManager.incompatibleExternalBundle(for: incompatibleBundle.pluginId), incompatibleBundle)
+    }
+
+    @MainActor
+    func testRemovingIncompatibleBundleKeepsDiagnosticWhenBundleDeletionFails() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatibleDeletionFailure")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginIncompatibleDeletionFailureCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let incompatibleBundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("DeletionFailurePlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: incompatibleBundleURL,
+            pluginId: "com.typewhisper.deletion-failure",
+            pluginName: "Deletion Failure Plugin",
+            version: "1.0.0"
+        )
+        try pluginManager.loadPlugin(at: incompatibleBundleURL)
+        let incompatibleBundle = try XCTUnwrap(
+            pluginManager.incompatibleExternalBundle(for: "com.typewhisper.deletion-failure")
+        )
+        try FileManager.default.removeItem(at: incompatibleBundleURL)
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+
+        XCTAssertThrowsError(try service.removeIncompatibleExternalBundle(incompatibleBundle))
+        XCTAssertEqual(pluginManager.incompatibleExternalBundle(for: incompatibleBundle.pluginId), incompatibleBundle)
+    }
+
     func testMalformedPluginEntryIsSkippedInsteadOfFailingEntireRegistry() throws {
         // A single bad entry (wrong type on a required field) must not empty
         // the marketplace: the decoder reports the error and keeps the rest.
@@ -1129,7 +1369,8 @@ final class PluginRegistryServiceTests: XCTestCase {
         at bundleURL: URL,
         pluginId: String,
         pluginName: String,
-        version: String
+        version: String,
+        sdkCompatibilityVersion: String? = nil
     ) throws {
         let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
         let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
@@ -1153,6 +1394,7 @@ final class PluginRegistryServiceTests: XCTestCase {
             id: pluginId,
             name: pluginName,
             version: version,
+            sdkCompatibilityVersion: sdkCompatibilityVersion,
             principalClass: "RuntimeUpdatePlugin"
         )
         try JSONEncoder()

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -618,10 +618,25 @@ final class PluginRegistryServiceTests: XCTestCase {
             at: staleBundleURL,
             pluginId: pluginId,
             pluginName: "Boundary Plugin",
-            version: "1.0.0"
+            version: "1.0.0",
+            sdkCompatibilityVersion: nil
         )
         try pluginManager.loadPlugin(at: staleBundleURL)
-        XCTAssertNotNil(pluginManager.incompatibleExternalBundle(for: pluginId))
+
+        let additionalStaleBundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("OlderBoundaryPlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: additionalStaleBundleURL,
+            pluginId: pluginId,
+            pluginName: "Boundary Plugin",
+            version: "0.9.0",
+            sdkCompatibilityVersion: nil
+        )
+        try pluginManager.loadPlugin(at: additionalStaleBundleURL)
+        XCTAssertEqual(
+            pluginManager.incompatibleExternalBundle(for: pluginId)?.bundleURL,
+            additionalStaleBundleURL
+        )
 
         let builtInURL = (Bundle.main.builtInPlugInsURL
             ?? URL(fileURLWithPath: "/Applications/TypeWhisper.app/Contents/PlugIns", isDirectory: true))
@@ -648,6 +663,8 @@ final class PluginRegistryServiceTests: XCTestCase {
         try FileManager.default.createDirectory(at: pluginDataDirectory, withIntermediateDirectories: true)
         let sentinelURL = pluginDataDirectory.appendingPathComponent("settings-sentinel")
         try Data("keep plugin data".utf8).write(to: sentinelURL)
+        let credentialService = "\(pluginId).api-key"
+        var credentials = [credentialService: "keep credential"]
 
         let incomingBundleURL = incomingDirectory
             .appendingPathComponent("BoundaryPlugin.bundle", isDirectory: true)
@@ -661,6 +678,11 @@ final class PluginRegistryServiceTests: XCTestCase {
         let service = PluginRegistryService(
             registryBaseURL: URL(string: "https://example.com")!,
             cacheDirectory: cacheDirectory,
+            deleteCredentials: { prefix in
+                for service in credentials.keys.filter({ $0.hasPrefix(prefix) }) {
+                    credentials.removeValue(forKey: service)
+                }
+            },
             fetchData: { _ in throw URLError(.badServerResponse) }
         )
 
@@ -672,7 +694,9 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(service.installStates[pluginId], .restartRequired)
         XCTAssertTrue(FileManager.default.fileExists(atPath: installedBundleURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: staleBundleURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: additionalStaleBundleURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sentinelURL.path))
+        XCTAssertEqual(credentials[credentialService], "keep credential")
         XCTAssertNil(pluginManager.incompatibleExternalBundle(for: pluginId))
 
         let registeredPlugin = try XCTUnwrap(pluginManager.loadedPlugins.first { $0.id == pluginId })
@@ -706,7 +730,8 @@ final class PluginRegistryServiceTests: XCTestCase {
             at: incompatibleBundleURL,
             pluginId: pluginId,
             pluginName: "Incompatible Plugin",
-            version: "1.0.0"
+            version: "1.0.0",
+            sdkCompatibilityVersion: nil
         )
         try pluginManager.loadPlugin(at: incompatibleBundleURL)
         let incompatibleBundle = try XCTUnwrap(pluginManager.incompatibleExternalBundle(for: pluginId))
@@ -735,10 +760,21 @@ final class PluginRegistryServiceTests: XCTestCase {
         try Data("delete plugin data".utf8)
             .write(to: pluginDataDirectory.appendingPathComponent("data-sentinel"))
         UserDefaults.standard.set(true, forKey: enabledKey)
+        let credentialService = "\(pluginId).api-key"
+        let unrelatedCredentialService = "com.typewhisper.other-plugin.api-key"
+        var credentials = [
+            credentialService: "delete credential",
+            unrelatedCredentialService: "keep unrelated credential",
+        ]
 
         let service = PluginRegistryService(
             registryBaseURL: URL(string: "https://example.com")!,
             cacheDirectory: cacheDirectory,
+            deleteCredentials: { prefix in
+                for service in credentials.keys.filter({ $0.hasPrefix(prefix) }) {
+                    credentials.removeValue(forKey: service)
+                }
+            },
             fetchData: { _ in throw URLError(.badServerResponse) }
         )
         try service.removeIncompatibleExternalBundle(incompatibleBundle)
@@ -746,6 +782,8 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: incompatibleBundleURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: pluginDataDirectory.path))
         XCTAssertNil(UserDefaults.standard.object(forKey: enabledKey))
+        XCTAssertNil(credentials[credentialService])
+        XCTAssertEqual(credentials[unrelatedCredentialService], "keep unrelated credential")
         XCTAssertNil(pluginManager.incompatibleExternalBundle(for: pluginId))
         XCTAssertEqual(pluginManager.loadedPlugins.count, 1)
         XCTAssertEqual(pluginManager.loadedPlugins.first?.sourceURL, fallback.sourceURL)
@@ -774,7 +812,8 @@ final class PluginRegistryServiceTests: XCTestCase {
             at: externalBundleURL,
             pluginId: "com.typewhisper.external-incompatible",
             pluginName: "External Incompatible Plugin",
-            version: "1.0.0"
+            version: "1.0.0",
+            sdkCompatibilityVersion: nil
         )
         try pluginManager.loadPlugin(at: externalBundleURL)
         let incompatibleBundle = try XCTUnwrap(
@@ -816,7 +855,8 @@ final class PluginRegistryServiceTests: XCTestCase {
             at: incompatibleBundleURL,
             pluginId: "com.typewhisper.deletion-failure",
             pluginName: "Deletion Failure Plugin",
-            version: "1.0.0"
+            version: "1.0.0",
+            sdkCompatibilityVersion: nil
         )
         try pluginManager.loadPlugin(at: incompatibleBundleURL)
         let incompatibleBundle = try XCTUnwrap(
@@ -1370,7 +1410,7 @@ final class PluginRegistryServiceTests: XCTestCase {
         pluginId: String,
         pluginName: String,
         version: String,
-        sdkCompatibilityVersion: String? = nil
+        sdkCompatibilityVersion: String? = PluginSDKCompatibility.currentVersion
     ) throws {
         let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
         let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)


### PR DESCRIPTION
## Summary

- add direct Marketplace replacement for built-in and installed plugins with incompatible external copies
- add safe destructive removal for incompatible or orphaned bundles
- preserve plugin data and credentials during replacement while clearing diagnostics and stale duplicates
- clean plugin data, activation state, and credentials during explicit removal without touching built-in fallbacks

## Context

TypeWhisper could detect stale or incompatible external plugin bundles, but built-in fallback plugins had no actionable confirmation path and orphaned bundles had no removal control. This left users with permanent diagnostics and required manual filesystem cleanup.

Closes #920

## Implementation

- show a direct **Replace with Marketplace Version** action when a Marketplace boundary replacement is available
- reuse the existing confirmation and installation flow
- remove stale external duplicates and clear incompatible-bundle diagnostics after a successful replacement
- add a localized destructive **Remove** confirmation and failure alert
- validate that removal targets the exact registered bundle directly inside the managed Plugins directory
- clear plugin data, activation state, and keychain entries after removal
- keep diagnostics intact when bundle deletion fails
- give incompatible diagnostic rows a distinct SwiftUI identity so they remain visible beside the built-in fallback row

## Test Plan

- [x] Ran the full project test command
- [x] Built and ran the signed development app locally
- [x] Tested replacement and diagnostic cleanup manually with Computer Use
- [x] Verified the direct replacement and Remove actions in the integrations UI
- [x] Verified no repair action remains in the overflow menu
- [x] Verified the replacement installs Marketplace Apple Speech 1.0.14, removes the stale diagnostic, and shows restart-required state
- [x] No regressions observed in 1,216 tests

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to replace incompatible external plugins with Marketplace versions.
  * Added confirmation and error alerts for removing incompatible plugin bundles.
  * Added a Remove action for incompatible bundles.
  * German translations now cover plugin replacement and removal workflows.

* **Bug Fixes**
  * Improved cleanup of plugin data, settings, and credentials during removal.
  * Incompatible bundle state is now cleared after successful installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->