### PR TITLE
Add ElevenLabs REST-only transcription mode

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -241,6 +241,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "ElevenLabsPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/ElevenLabsPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "Reson8Plugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/Reson8Plugin",
@@ -489,6 +499,15 @@ let package = Package(
                 "AssemblyAIPlugin",
             ],
             path: "Plugins/AssemblyAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "ElevenLabsPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "ElevenLabsPlugin",
+            ],
+            path: "Plugins/ElevenLabsPlugin/Tests"
         ),
         .testTarget(
             name: "Reson8PluginTests",

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -67,14 +67,21 @@ private enum ElevenLabsReceivePayload: Sendable {
     case timedOut
 }
 
+enum ElevenLabsTranscriptionMode: String, CaseIterable, Sendable {
+    case automatic
+    case restOnly
+}
+
 @objc(ElevenLabsPlugin)
 final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.elevenlabs"
     static let pluginName = "ElevenLabs"
+    static let transcriptionModeKey = "transcriptionMode"
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedModelId: String?
+    fileprivate var _transcriptionMode = ElevenLabsTranscriptionMode.automatic
 
     private let logger = Logger(subsystem: "com.typewhisper.elevenlabs", category: "Plugin")
 
@@ -87,6 +94,9 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         _apiKey = host.loadSecret(key: "api-key")
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? transcriptionModels.first?.id
+        _transcriptionMode = (host.userDefault(forKey: Self.transcriptionModeKey) as? String)
+            .flatMap(ElevenLabsTranscriptionMode.init(rawValue:))
+            ?? .automatic
     }
 
     func deactivate() {
@@ -114,8 +124,17 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         host?.setUserDefault(modelId, forKey: "selectedModel")
     }
 
+    var transcriptionMode: ElevenLabsTranscriptionMode { _transcriptionMode }
+
+    func setTranscriptionMode(_ mode: ElevenLabsTranscriptionMode) {
+        guard _transcriptionMode != mode else { return }
+        _transcriptionMode = mode
+        host?.setUserDefault(mode.rawValue, forKey: Self.transcriptionModeKey)
+        host?.notifyCapabilitiesChanged()
+    }
+
     var supportsTranslation: Bool { false }
-    var supportsStreaming: Bool { true }
+    var supportsStreaming: Bool { _transcriptionMode == .automatic }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
     var supportedLanguages: [String] { elevenLabsSupportedLanguages }
 
@@ -150,7 +169,7 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             throw PluginTranscriptionError.noModelSelected
         }
 
-        if !PluginDictionaryTerms.terms(fromPrompt: prompt).isEmpty {
+        if _transcriptionMode == .restOnly || !PluginDictionaryTerms.terms(fromPrompt: prompt).isEmpty {
             let result = try await transcribeREST(
                 audio: audio,
                 language: language,
@@ -506,6 +525,7 @@ private struct ElevenLabsSettingsView: View {
     @State private var validationResult: Bool?
     @State private var showApiKey = false
     @State private var selectedModel = ""
+    @State private var transcriptionMode = ElevenLabsTranscriptionMode.automatic
     private let bundle = Bundle(for: ElevenLabsPlugin.self)
     private var trimmedInputKey: String {
         apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -601,6 +621,27 @@ private struct ElevenLabsSettingsView: View {
                         plugin.selectModel(selectedModel)
                     }
                 }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Transcription mode", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Transcription mode", selection: $transcriptionMode) {
+                        Text("Auto (Realtime with REST fallback)", bundle: bundle)
+                            .tag(ElevenLabsTranscriptionMode.automatic)
+                        Text("REST only (Batch Scribe v2)", bundle: bundle)
+                            .tag(ElevenLabsTranscriptionMode.restOnly)
+                    }
+                    .labelsHidden()
+                    .onChange(of: transcriptionMode) {
+                        plugin.setTranscriptionMode(transcriptionMode)
+                    }
+
+                    Text("Auto streams partial results and falls back to batch REST. REST only avoids realtime concurrency limits and uses consistent batch transcription.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -621,6 +662,7 @@ private struct ElevenLabsSettingsView: View {
                 }
             }
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+            transcriptionMode = plugin.transcriptionMode
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings
@@ -17,6 +17,38 @@
         }
       }
     },
+    "Auto (Realtime with REST fallback)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch (Echtzeit mit REST-Fallback)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動（リアルタイム、RESTフォールバック）"
+          }
+        }
+      }
+    },
+    "Auto streams partial results and falls back to batch REST. REST only avoids realtime concurrency limits and uses consistent batch transcription.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch streamt Teilergebnisse und wechselt bei Fehlern zu Batch-REST. Nur REST vermeidet Echtzeit-Parallelitätslimits und verwendet eine konsistente Batch-Transkription."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動モードでは部分結果をストリーミングし、失敗時はバッチRESTに切り替えます。RESTのみではリアルタイムの同時実行制限を回避し、一貫したバッチ文字起こしを使用します。"
+          }
+        }
+      }
+    },
     "API keys are stored securely in the Keychain": {
       "localizations": {
         "de": {
@@ -81,6 +113,22 @@
         }
       }
     },
+    "REST only (Batch Scribe v2)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur REST (Batch Scribe v2)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RESTのみ（バッチScribe v2）"
+          }
+        }
+      }
+    },
     "Save": {
       "localizations": {
         "de": {
@@ -93,6 +141,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "保存"
+          }
+        }
+      }
+    },
+    "Transcription mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしモード"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import os
+import TypeWhisperPluginSDK
+import XCTest
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import ElevenLabsPlugin
+
+final class ElevenLabsPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testTranscriptionModeDefaultsToAutomaticForMissingOrUnknownValue() throws {
+        let defaultHost = try PluginTestHostServices()
+        let defaultPlugin = ElevenLabsPlugin()
+        defaultPlugin.activate(host: defaultHost)
+
+        XCTAssertEqual(defaultPlugin.transcriptionMode, .automatic)
+        XCTAssertTrue(defaultPlugin.supportsStreaming)
+
+        let unknownHost = try PluginTestHostServices(
+            defaults: [ElevenLabsPlugin.transcriptionModeKey: "realtimeOnly"]
+        )
+        let unknownPlugin = ElevenLabsPlugin()
+        unknownPlugin.activate(host: unknownHost)
+
+        XCTAssertEqual(unknownPlugin.transcriptionMode, .automatic)
+        XCTAssertTrue(unknownPlugin.supportsStreaming)
+    }
+
+    func testTranscriptionModePersistsAndUpdatesStreamingCapability() throws {
+        let host = try PluginTestHostServices()
+        let plugin = ElevenLabsPlugin()
+        plugin.activate(host: host)
+
+        plugin.setTranscriptionMode(.restOnly)
+
+        XCTAssertEqual(plugin.transcriptionMode, .restOnly)
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertEqual(
+            host.userDefault(forKey: ElevenLabsPlugin.transcriptionModeKey) as? String,
+            ElevenLabsTranscriptionMode.restOnly.rawValue
+        )
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        plugin.setTranscriptionMode(.restOnly)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        let reloadedPlugin = ElevenLabsPlugin()
+        reloadedPlugin.activate(host: host)
+        XCTAssertEqual(reloadedPlugin.transcriptionMode, .restOnly)
+        XCTAssertFalse(reloadedPlugin.supportsStreaming)
+    }
+
+    func testRESTOnlyProgressTranscriptionUsesBatchEndpointAndReportsFinalText() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "selectedModel": "scribe_v2",
+                ElevenLabsPlugin.transcriptionModeKey: ElevenLabsTranscriptionMode.restOnly.rawValue,
+            ],
+            secrets: ["api-key": "elevenlabs-key"]
+        )
+        let plugin = ElevenLabsPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"REST transcript","language_code":"de"}"#.utf8),
+                    Self.httpResponse(url: "https://api.elevenlabs.io/v1/speech-to-text", statusCode: 200)
+                )
+            ])
+        }
+
+        let progressRecorder = StringRecorder()
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let result = try await plugin.transcribe(
+            audio: AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1),
+            language: "de",
+            translate: false,
+            prompt: "TypeWhisper, Scribe",
+            onProgress: { text in
+                progressRecorder.append(text)
+                return true
+            }
+        )
+
+        XCTAssertEqual(result.text, "REST transcript")
+        XCTAssertEqual(result.detectedLanguage, "de")
+        XCTAssertEqual(progressRecorder.values, ["REST transcript"])
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 1)
+        let request = try XCTUnwrap(requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.scheme, "https")
+        XCTAssertEqual(request.url?.host, "api.elevenlabs.io")
+        XCTAssertEqual(request.url?.path, "/v1/speech-to-text")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "xi-api-key"), "elevenlabs-key")
+
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
+        XCTAssertTrue(body.contains("name=\"model_id\"\r\n\r\nscribe_v2\r\n"))
+        XCTAssertTrue(body.contains("name=\"language_code\"\r\n\r\nde\r\n"))
+        XCTAssertTrue(body.contains("name=\"keyterms\"\r\n\r\nTypeWhisper\r\n"))
+        XCTAssertTrue(body.contains("name=\"keyterms\"\r\n\r\nScribe\r\n"))
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}
+
+private final class StringRecorder: @unchecked Sendable {
+    private let valuesLock = OSAllocatedUnfairLock(initialState: [String]())
+
+    var values: [String] {
+        valuesLock.withLock { $0 }
+    }
+
+    func append(_ value: String) {
+        valuesLock.withLock { $0.append(value) }
+    }
+}


### PR DESCRIPTION
## Summary

- add a persistent ElevenLabs transcription mode with the existing realtime-first behavior as the default
- add a REST-only batch option that skips the Scribe realtime WebSocket and reports the final REST transcript through the progress callback
- update streaming capability reporting, localize the settings UI in English, German, and Japanese, and add focused plugin tests

## Issue context

ElevenLabs realtime STT uses a separate concurrency budget and a different model path from batch Scribe v2. Users who still have credits can therefore hit realtime rate limits or see inconsistent accuracy before TypeWhisper falls back to REST. This change gives users an explicit way to use the batch endpoint consistently.

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter ElevenLabsPluginTests`
- `swift test --package-path TypeWhisperPluginSDK`
- `xcodebuild -project TypeWhisper.xcodeproj -target ElevenLabsPlugin -configuration Debug SYMROOT="$(pwd)/build" CODE_SIGNING_ALLOWED=NO build`
- `scripts/pr-preflight.sh origin/main`

Closes #927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable transcription modes for ElevenLabs: automatic realtime transcription with REST fallback, or REST-only batch transcription.
  * Added a settings picker with explanatory guidance and localized German and Japanese text.
  * The selected mode is remembered between sessions.
* **Bug Fixes**
  * REST-only mode now correctly disables streaming and uses batch transcription.
* **Tests**
  * Added coverage for mode defaults, persistence, capability updates, and REST transcription behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->