### PR TITLE
Bump ElevenLabs plugin to 1.0.9

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.elevenlabs",
     "name": "ElevenLabs",
-    "version": "1.0.0",
+    "version": "1.0.9",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary
- bump the ElevenLabs plugin manifest to 1.0.9
- prepare the REST-only transcription mode from #928 for plugin distribution

## Context
This is the release-version follow-up for #927 after the implementation landed in #928. The plugin release workflow requires the target manifest version to exist on `main` before dispatch.

## Test plan
- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json`
- `xcodebuild -project TypeWhisper.xcodeproj -target ElevenLabsPlugin -configuration Release SYMROOT="$(pwd)/build" CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.0.9 build`
- verify the built bundle manifest and `CFBundleShortVersionString` both report `1.0.9`