### PR TITLE
Add missing description to Filler Words plugin manifest

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json
@@ -1,11 +1,15 @@
 {
   "id": "com.typewhisper.filler-words",
   "name": "Filler Words",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minHostVersion": "1.0.0",
   "sdkCompatibilityVersion": "v1",
   "minOSVersion": "14.0",
   "author": "TypeWhisper",
+  "description": "Removes filler words like \"um\" and \"uh\" from transcribed text.",
+  "descriptions": {
+    "de": "Entfernt Füllwörter wie „ähm“ und „äh“ aus transkribiertem Text."
+  },
   "principalClass": "FillerWordsPlugin",
   "requiresAPIKey": false,
   "iconSystemName": "text.badge.minus",


### PR DESCRIPTION
Filler Words was the only bundled plugin without a marketplace description; bump version to 1.0.1 alongside the metadata fix.

## Summary

- Added a `description` (and German `descriptions.de`) field to `FillerWordsPlugin/manifest.json`, matching every other bundled plugin
- Bumped the plugin version from 1.0.0 to 1.0.1

## Test Plan

- [x] Ran `scripts/pr-preflight.sh`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features