### PR TITLE
Fix scroll lag elsewhere in the app while a Recorder session is active

### DIFF
--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -1105,10 +1105,8 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
                 let samples = UnsafeBufferPointer(start: channelData, count: Int(writeBuffer.frameLength))
                 let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(samples.count))
                 let level = min(1.0, rms * 5)
-                if self.micLevelThrottle.shouldPublish() {
-                    DispatchQueue.main.async {
-                        self.micLevel = level
-                    }
+                self.micLevelThrottle.publish(level) { [weak self] level in
+                    self?.micLevel = level
                 }
             }
 
@@ -1198,10 +1196,8 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
                 let samples = UnsafeBufferPointer(start: channelData, count: Int(writeBuffer.frameLength))
                 let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
                 let level = min(1.0, rms * 5)
-                if self.micLevelThrottle.shouldPublish() {
-                    DispatchQueue.main.async {
-                        self.micLevel = level
-                    }
+                self.micLevelThrottle.publish(level) { [weak self] level in
+                    self?.micLevel = level
                 }
             }
 
@@ -1812,8 +1808,7 @@ private final class SystemLevelSetter: @unchecked Sendable {
     }
 
     func setLevel(_ level: Float) {
-        guard throttle.shouldPublish() else { return }
-        DispatchQueue.main.async { [weak service] in
+        throttle.publish(level) { [weak service] level in
             service?.updateSystemLevel(level)
         }
     }
@@ -1821,28 +1816,81 @@ private final class SystemLevelSetter: @unchecked Sendable {
 
 // MARK: - Level Publish Throttle
 
-/// Caps a value stream to at most one publish per `minInterval`, dropping
-/// (not queueing) intermediate values — appropriate for a UI level meter
-/// where only the latest reading matters. Thread-safe so it can be checked
-/// from the background audio/capture callback queues that produce levels.
+/// Caps a value stream to at most one publish per `minInterval` — appropriate
+/// for a UI level meter, where only the latest reading matters. Unlike a
+/// naive throttle, a value that arrives inside the window is never silently
+/// lost: it's held as `pending` and flushed once the window closes, so the
+/// meter can't get stuck showing a stale reading if buffers happen to stop
+/// arriving right after a drop. Thread-safe so it can be called from the
+/// background audio/capture callback queues that produce levels.
+///
+/// Mirrors the equivalent `publishAudioLevel`/`flushPendingAudioLevelUpdate`
+/// pattern already used at the same ~30 Hz cadence for the dictation audio
+/// pipeline in `AudioRecordingService.swift`. Not shared into one type since
+/// the two host services have unrelated lifecycles and this fix intentionally
+/// stays scoped to the Recorder path that was reported laggy — worth
+/// extracting if a third caller shows up.
 private final class LevelPublishThrottle: @unchecked Sendable {
-    private let minInterval: TimeInterval
+    private let minIntervalNanoseconds: UInt64
     private let lock = NSLock()
-    private var lastPublish: TimeInterval = 0
+    private var lastPublishUptimeNanoseconds: UInt64 = 0
+    private var pendingValue: Float?
 
     /// Defaults to ~30 Hz — smooth enough for a level meter while staying
     /// well clear of the main-run-loop contention that unthrottled
     /// buffer-rate publishing causes (see `micLevelThrottle` for details).
     init(minInterval: TimeInterval = 1.0 / 30.0) {
-        self.minInterval = minInterval
+        self.minIntervalNanoseconds = UInt64(minInterval * 1_000_000_000)
     }
 
-    func shouldPublish(now: TimeInterval = CFAbsoluteTimeGetCurrent()) -> Bool {
+    /// Publishes `value` on the main queue via `deliver`, immediately if
+    /// outside the throttle window, or after the remainder of the window
+    /// elapses otherwise. Uses `DispatchTime.uptimeNanoseconds` (monotonic)
+    /// rather than wall-clock time, since a wall-clock adjustment (NTP sync,
+    /// manual clock change, DST) moving backward mid-recording would
+    /// otherwise make the elapsed-time check permanently fail and freeze the
+    /// meter until wall-clock time caught back up.
+    func publish(_ value: Float, deliver: @escaping @Sendable (Float) -> Void) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        var publishImmediately = false
+        var flushDelayNanoseconds: UInt64?
+
         lock.lock()
-        defer { lock.unlock() }
-        guard now - lastPublish >= minInterval else { return false }
-        lastPublish = now
-        return true
+        let elapsed = now &- lastPublishUptimeNanoseconds
+        if lastPublishUptimeNanoseconds == 0 || elapsed >= minIntervalNanoseconds {
+            lastPublishUptimeNanoseconds = now
+            pendingValue = nil
+            publishImmediately = true
+        } else {
+            let alreadyScheduled = pendingValue != nil
+            pendingValue = value
+            if !alreadyScheduled {
+                flushDelayNanoseconds = minIntervalNanoseconds - elapsed
+            }
+        }
+        lock.unlock()
+
+        if publishImmediately {
+            DispatchQueue.main.async { deliver(value) }
+        }
+        if let flushDelayNanoseconds {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .nanoseconds(Int(flushDelayNanoseconds))) { [weak self] in
+                self?.flushPending(deliver: deliver)
+            }
+        }
+    }
+
+    private func flushPending(deliver: @Sendable (Float) -> Void) {
+        lock.lock()
+        let value = pendingValue
+        pendingValue = nil
+        if value != nil {
+            lastPublishUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+        }
+        lock.unlock()
+
+        guard let value else { return }
+        deliver(value)
     }
 }
 

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -646,6 +646,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     private let micFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
     private var scStream: SCStream?
     private var streamOutput: SystemAudioStreamOutput?
+    private var systemLevelSetter: SystemLevelSetter?
     private let sysFileLock = OSAllocatedUnfairLock<AVAudioFile?>(initialState: nil)
     private var durationTimer: Timer?
     private var startTime: Date?
@@ -931,6 +932,13 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         systemTempURL = nil
         finalOutputURL = nil
         startTime = nil
+
+        // Must happen before the reset below: an already-scheduled flush
+        // from a value received just before this stop would otherwise still
+        // land afterward and restore a stale nonzero reading.
+        micLevelThrottle.reset()
+        systemLevelSetter?.reset()
+        systemLevelSetter = nil
 
         DispatchQueue.main.async {
             self.isRecording = false
@@ -1344,6 +1352,7 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         let output = SystemAudioStreamOutput()
         output.fileLock = sysFileLock
         let levelSetter = SystemLevelSetter(service: self)
+        systemLevelSetter = levelSetter
         output.levelCallback = { level in
             levelSetter.setLevel(level)
         }
@@ -1788,6 +1797,11 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
         finalOutputURL = nil
         transcriptionBufferLock.withLock { $0.reset() }
 
+        // See the matching comment in stopCapture().
+        micLevelThrottle.reset()
+        systemLevelSetter?.reset()
+        systemLevelSetter = nil
+
         DispatchQueue.main.async {
             self.isRecording = false
             self.duration = 0
@@ -1811,6 +1825,11 @@ private final class SystemLevelSetter: @unchecked Sendable {
         throttle.publish(level) { [weak service] level in
             service?.updateSystemLevel(level)
         }
+    }
+
+    /// See `LevelPublishThrottle.reset()`.
+    func reset() {
+        throttle.reset()
     }
 }
 
@@ -1851,11 +1870,17 @@ private final class LevelPublishThrottle: @unchecked Sendable {
     /// otherwise make the elapsed-time check permanently fail and freeze the
     /// meter until wall-clock time caught back up.
     func publish(_ value: Float, deliver: @escaping @Sendable (Float) -> Void) {
-        let now = DispatchTime.now().uptimeNanoseconds
         var publishImmediately = false
         var flushDelayNanoseconds: UInt64?
 
         lock.lock()
+        // Sampled under the lock, not before it: if `now` were captured
+        // first, a concurrent `flushPending` could advance
+        // `lastPublishUptimeNanoseconds` past this (now-stale) `now` while
+        // this call was waiting on the lock, making the unsigned subtraction
+        // below underflow/wrap to a huge value and slip an extra publish
+        // through inside the throttle window.
+        let now = DispatchTime.now().uptimeNanoseconds
         let elapsed = now &- lastPublishUptimeNanoseconds
         if lastPublishUptimeNanoseconds == 0 || elapsed >= minIntervalNanoseconds {
             lastPublishUptimeNanoseconds = now
@@ -1891,6 +1916,18 @@ private final class LevelPublishThrottle: @unchecked Sendable {
 
         guard let value else { return }
         deliver(value)
+    }
+
+    /// Clears any pending value and rearms the throttle to publish
+    /// immediately next time. Call this when a recording session ends and
+    /// its level is explicitly reset to 0 — without it, a flush already
+    /// scheduled from a value received just before the stop would otherwise
+    /// still fire afterward and restore a stale nonzero reading.
+    func reset() {
+        lock.lock()
+        pendingValue = nil
+        lastPublishUptimeNanoseconds = 0
+        lock.unlock()
     }
 }
 

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -1854,6 +1854,7 @@ private final class LevelPublishThrottle: @unchecked Sendable {
     private let lock = NSLock()
     private var lastPublishUptimeNanoseconds: UInt64 = 0
     private var pendingValue: Float?
+    private var scheduledWork: DispatchWorkItem?
 
     /// Defaults to ~30 Hz — smooth enough for a level meter while staying
     /// well clear of the main-run-loop contention that unthrottled
@@ -1862,70 +1863,82 @@ private final class LevelPublishThrottle: @unchecked Sendable {
         self.minIntervalNanoseconds = UInt64(minInterval * 1_000_000_000)
     }
 
-    /// Publishes `value` on the main queue via `deliver`, immediately if
-    /// outside the throttle window, or after the remainder of the window
-    /// elapses otherwise. Uses `DispatchTime.uptimeNanoseconds` (monotonic)
-    /// rather than wall-clock time, since a wall-clock adjustment (NTP sync,
-    /// manual clock change, DST) moving backward mid-recording would
-    /// otherwise make the elapsed-time check permanently fail and freeze the
-    /// meter until wall-clock time caught back up.
+    /// Publishes `value` on the main queue via `deliver`. At most one
+    /// delivery is ever scheduled on the main queue at a time: if one is
+    /// already pending (immediate or delayed), this call just replaces the
+    /// value it will eventually carry instead of scheduling a second one.
+    ///
+    /// A prior version scheduled an "immediate" `.async` block and a delayed
+    /// `.asyncAfter` flush as two independent main-queue submissions, and
+    /// stamped `lastPublishUptimeNanoseconds` at decision time rather than
+    /// actual delivery time. Under main-queue congestion past a throttle
+    /// window, later `publish()` calls could see enough elapsed time to take
+    /// the "immediate" path again — enqueuing their own block — while an
+    /// older delayed flush was still sitting in the queue; GCD gives no
+    /// ordering guarantee between two independently-submitted blocks once
+    /// both are eligible to run, so they could execute in either order and
+    /// deliver values out of sequence (e.g. inputs 1,2,3,4 arriving as
+    /// 1,4,3). Coalescing to a single scheduled work item removes the
+    /// second submission entirely, so there's nothing left to reorder.
     func publish(_ value: Float, deliver: @escaping @Sendable (Float) -> Void) {
-        var publishImmediately = false
-        var flushDelayNanoseconds: UInt64?
-
         lock.lock()
+        pendingValue = value
+        guard scheduledWork == nil else {
+            lock.unlock()
+            return
+        }
+
         // Sampled under the lock, not before it: if `now` were captured
-        // first, a concurrent `flushPending` could advance
+        // first, a concurrent delivery could advance
         // `lastPublishUptimeNanoseconds` past this (now-stale) `now` while
         // this call was waiting on the lock, making the unsigned subtraction
         // below underflow/wrap to a huge value and slip an extra publish
         // through inside the throttle window.
         let now = DispatchTime.now().uptimeNanoseconds
         let elapsed = now &- lastPublishUptimeNanoseconds
-        if lastPublishUptimeNanoseconds == 0 || elapsed >= minIntervalNanoseconds {
-            lastPublishUptimeNanoseconds = now
-            pendingValue = nil
-            publishImmediately = true
-        } else {
-            let alreadyScheduled = pendingValue != nil
-            pendingValue = value
-            if !alreadyScheduled {
-                flushDelayNanoseconds = minIntervalNanoseconds - elapsed
-            }
+        let delayNanoseconds = (lastPublishUptimeNanoseconds == 0 || elapsed >= minIntervalNanoseconds)
+            ? 0
+            : minIntervalNanoseconds - elapsed
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.deliverPending(deliver: deliver)
         }
+        scheduledWork = work
         lock.unlock()
 
-        if publishImmediately {
-            DispatchQueue.main.async { deliver(value) }
-        }
-        if let flushDelayNanoseconds {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .nanoseconds(Int(flushDelayNanoseconds))) { [weak self] in
-                self?.flushPending(deliver: deliver)
-            }
+        if delayNanoseconds == 0 {
+            DispatchQueue.main.async(execute: work)
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .nanoseconds(Int(delayNanoseconds)), execute: work)
         }
     }
 
-    private func flushPending(deliver: @Sendable (Float) -> Void) {
+    private func deliverPending(deliver: @Sendable (Float) -> Void) {
         lock.lock()
         let value = pendingValue
         pendingValue = nil
-        if value != nil {
-            lastPublishUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
-        }
+        scheduledWork = nil
+        // Stamped at actual delivery time, not when the work item was
+        // scheduled — the whole point of coalescing is that those two
+        // moments can now be far apart under main-queue congestion.
+        lastPublishUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
         lock.unlock()
 
         guard let value else { return }
         deliver(value)
     }
 
-    /// Clears any pending value and rearms the throttle to publish
-    /// immediately next time. Call this when a recording session ends and
-    /// its level is explicitly reset to 0 — without it, a flush already
-    /// scheduled from a value received just before the stop would otherwise
-    /// still fire afterward and restore a stale nonzero reading.
+    /// Clears any pending value, cancels an already-scheduled delivery so it
+    /// can't fire, and rearms the throttle to publish immediately next time.
+    /// Call this when a recording session ends and its level is explicitly
+    /// reset to 0 — without it, a delivery already scheduled from a value
+    /// received just before the stop would otherwise still fire afterward
+    /// and restore a stale nonzero reading.
     func reset() {
         lock.lock()
         pendingValue = nil
+        scheduledWork?.cancel()
+        scheduledWork = nil
         lastPublishUptimeNanoseconds = 0
         lock.unlock()
     }

--- a/TypeWhisper/Services/AudioRecorderService.swift
+++ b/TypeWhisper/Services/AudioRecorderService.swift
@@ -612,6 +612,19 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
     @Published private(set) var micLevel: Float = 0
     @Published private(set) var systemLevel: Float = 0
     @Published private(set) var systemAudioWarningMessage: String?
+
+    /// Caps how often `micLevel`/`systemLevel` are actually published while
+    /// recording. Audio buffers can arrive tens of times per second (mic
+    /// taps) or even faster (system audio via ScreenCaptureKit, OS-paced),
+    /// and each unthrottled `@Published` write triggers a SwiftUI re-render
+    /// plus a Core Animation commit in every indicator view observing this
+    /// service. Left unthrottled, that flood of main-run-loop work starves
+    /// the queue used to deliver discrete `NSEvent.scrollWheel` ticks,
+    /// making menus/lists feel laggy under mouse-wheel scrolling while
+    /// recording (scrollbar-thumb dragging is unaffected, since AppKit just
+    /// re-samples the mouse position on each pass of its own tracking loop
+    /// instead of draining a backlog of discrete events).
+    private let micLevelThrottle = LevelPublishThrottle()
     var recordingsDirectoryOverride: URL?
     var startRecordingOverride: ((
         _ micEnabled: Bool,
@@ -1092,8 +1105,10 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
                 let samples = UnsafeBufferPointer(start: channelData, count: Int(writeBuffer.frameLength))
                 let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(samples.count))
                 let level = min(1.0, rms * 5)
-                DispatchQueue.main.async {
-                    self.micLevel = level
+                if self.micLevelThrottle.shouldPublish() {
+                    DispatchQueue.main.async {
+                        self.micLevel = level
+                    }
                 }
             }
 
@@ -1183,8 +1198,10 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
                 let samples = UnsafeBufferPointer(start: channelData, count: Int(writeBuffer.frameLength))
                 let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
                 let level = min(1.0, rms * 5)
-                DispatchQueue.main.async {
-                    self.micLevel = level
+                if self.micLevelThrottle.shouldPublish() {
+                    DispatchQueue.main.async {
+                        self.micLevel = level
+                    }
                 }
             }
 
@@ -1788,15 +1805,44 @@ final class AudioRecorderService: ObservableObject, @unchecked Sendable {
 
 private final class SystemLevelSetter: @unchecked Sendable {
     private weak var service: AudioRecorderService?
+    private let throttle = LevelPublishThrottle()
 
     init(service: AudioRecorderService) {
         self.service = service
     }
 
     func setLevel(_ level: Float) {
+        guard throttle.shouldPublish() else { return }
         DispatchQueue.main.async { [weak service] in
             service?.updateSystemLevel(level)
         }
+    }
+}
+
+// MARK: - Level Publish Throttle
+
+/// Caps a value stream to at most one publish per `minInterval`, dropping
+/// (not queueing) intermediate values — appropriate for a UI level meter
+/// where only the latest reading matters. Thread-safe so it can be checked
+/// from the background audio/capture callback queues that produce levels.
+private final class LevelPublishThrottle: @unchecked Sendable {
+    private let minInterval: TimeInterval
+    private let lock = NSLock()
+    private var lastPublish: TimeInterval = 0
+
+    /// Defaults to ~30 Hz — smooth enough for a level meter while staying
+    /// well clear of the main-run-loop contention that unthrottled
+    /// buffer-rate publishing causes (see `micLevelThrottle` for details).
+    init(minInterval: TimeInterval = 1.0 / 30.0) {
+        self.minInterval = minInterval
+    }
+
+    func shouldPublish(now: TimeInterval = CFAbsoluteTimeGetCurrent()) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard now - lastPublish >= minInterval else { return false }
+        lastPublish = now
+        return true
     }
 }
 

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -151,7 +151,12 @@ struct NotchIndicatorView: View {
         .animation(.easeOut(duration: 0.24), value: currentWidth)
         .animation(.easeOut(duration: 0.24), value: expandedBodyHeight)
         .animation(.easeInOut(duration: 0.18), value: presentation.state)
-        .animation(.linear(duration: 0.025), value: presentation.audioLevel)
+        // Matches the ~30 Hz (33ms) level-publish throttle shared by both
+        // audio level sources (AudioRecordingService's dictation pipeline and
+        // AudioRecorderService's Recorder tab) — a shorter duration here
+        // finishes each segment before the next value lands, producing a
+        // tiny stutter instead of a continuous glide.
+        .animation(.linear(duration: 0.033), value: presentation.audioLevel)
         .onChange(of: presentation.partialText) {
             if showTranscriptPreview, !presentation.partialText.isEmpty, !textExpanded {
                 withAnimation(.easeOut(duration: 0.24)) {

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -120,7 +120,12 @@ struct OverlayIndicatorView: View {
         .preferredColorScheme(.dark)
         .animation(.easeInOut(duration: 0.3), value: textExpanded)
         .animation(.easeInOut(duration: 0.2), value: presentation.state)
-        .animation(.linear(duration: 0.025), value: presentation.audioLevel)
+        // Matches the ~30 Hz (33ms) level-publish throttle shared by both
+        // audio level sources (AudioRecordingService's dictation pipeline and
+        // AudioRecorderService's Recorder tab) — a shorter duration here
+        // finishes each segment before the next value lands, producing a
+        // tiny stutter instead of a continuous glide.
+        .animation(.linear(duration: 0.033), value: presentation.audioLevel)
         .onChange(of: presentation.partialText) {
             expandTranscriptPreviewIfNeeded()
         }


### PR DESCRIPTION
## Summary

While a Recorder session is running, `micLevel`/`systemLevel` were published from the audio callback threads completely unthrottled (~11-12 Hz for the mic tap, faster and OS-paced for system audio via ScreenCaptureKit). Each publish re-renders every indicator view observing `AudioRecorderService` (Notch/Overlay/Minimal indicators, all always alive, plus the Settings-panel meter) and commits a Core Animation transaction, flooding the main run loop. That starves the discrete `NSEvent.scrollWheel` processing used by mouse-wheel scrolling elsewhere in the app — scrollbar-thumb dragging is unaffected since AppKit just re-samples the mouse position on each pass of its own tracking loop instead of draining a backlog of discrete events.

Fix: cap the level-meter publish rate to ~30 Hz via a small thread-safe throttle, mirroring the existing flush-based `publishAudioLevel`/`flushPendingAudioLevelUpdate` pattern already used at the same cadence in `AudioRecordingService.swift`'s dictation pipeline (a dropped value is held as pending and flushed once the throttle window closes, rather than silently discarded). Also:
- Uses a monotonic clock (`DispatchTime.uptimeNanoseconds`) so a wall-clock adjustment mid-recording can't freeze the throttle.
- Matches the Notch/Overlay indicator level-bar animation duration (25ms → 33ms) to the new ~30 Hz cadence, removing a stutter where each animation segment finished before the next value landed.

Closes an issue reported by the maintainer: scrolling any list/menu with the mouse wheel while a Recorder session is active feels laggy/unresponsive.

## Test Plan

- [x] Ran `scripts/pr-preflight.sh` (passes; one pre-existing, unrelated failure in `verify_appcast_publication.py` due to local Python 3.9.6 vs the script's Python 3.10+ syntax — reproduces identically on `main`, not touched by this change)
- [x] Built and ran locally
- [x] Tested the changed functionality manually — reproduced the original scroll lag with a screen recording while a Recorder session was active, confirmed it's gone after the fix
- [x] No regressions in existing features — full `xcodebuild test` suite (1217 tests) passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Smoothed microphone and system audio level updates by coalescing high-frequency level changes to reduce unnecessary UI refreshes.
  * Adjusted audio-level indicator animation timing to better align with the ~30Hz throttled updates for smoother motion.

* **Bug Fixes**
  * Prevented stale or queued audio level updates from briefly reappearing after recording stops or when a recording start is rolled back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->