### PR TITLE
Fix AssemblyAI file-transcription diarization routing

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -90,7 +90,8 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
     }
 
     var supportsTranslation: Bool { false }
-    var supportsStreaming: Bool { true }
+    // AssemblyAI's streaming API does not return the speaker metadata preserved by the structured REST path.
+    var supportsStreaming: Bool { !_speakerDiarizationEnabled }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
     var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryTermsBudget(for: _selectedModelId) }
     var isSpeakerDiarizationEnabled: Bool { _speakerDiarizationEnabled }

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
@@ -16,12 +16,22 @@ final class AssemblyAIPluginTests: XCTestCase {
         plugin.activate(host: host)
 
         XCTAssertFalse(plugin.isSpeakerDiarizationEnabled)
+        XCTAssertTrue(plugin.supportsStreaming)
 
         plugin.setSpeakerDiarizationEnabled(true)
 
         XCTAssertTrue(plugin.isSpeakerDiarizationEnabled)
+        XCTAssertFalse(plugin.supportsStreaming)
         XCTAssertEqual(host.userDefault(forKey: AssemblyAIPlugin.speakerDiarizationEnabledKey) as? Bool, true)
         XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        plugin.setSpeakerDiarizationEnabled(true)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        let reloadedPlugin = AssemblyAIPlugin()
+        reloadedPlugin.activate(host: host)
+        XCTAssertTrue(reloadedPlugin.isSpeakerDiarizationEnabled)
+        XCTAssertFalse(reloadedPlugin.supportsStreaming)
     }
 
     func testSubmitBodyIncludesSpeakerLabelsOnlyWhenEnabled() {

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
@@ -106,6 +106,66 @@ final class AssemblyAIPluginTests: XCTestCase {
         XCTAssertTrue(result.segments.isEmpty)
     }
 
+    func testDiarizationRESTTranscriptionPreservesMultipleSpeakers() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "assembly-key"])
+        let plugin = AssemblyAIPlugin()
+        plugin.activate(host: host)
+        plugin.setSpeakerDiarizationEnabled(true)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"upload_url":"https://cdn.example.test/audio.m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/upload", statusCode: 200)
+                ),
+                .success(
+                    Data(#"{"id":"transcript_diarized"}"#.utf8),
+                    Self.httpResponse(url: "https://api.assemblyai.com/v2/transcript", statusCode: 200)
+                ),
+                .success(
+                    Data(
+                        #"""
+                        {
+                          "status": "completed",
+                          "text": "fallback text",
+                          "language_code": "en",
+                          "utterances": [
+                            {"speaker":"A","text":"Hello","start":0,"end":900,"confidence":0.97},
+                            {"speaker":"B","text":"Hi","start":900,"end":1500,"confidence":0.91}
+                          ]
+                        }
+                        """#.utf8
+                    ),
+                    Self.httpResponse(
+                        url: "https://api.assemblyai.com/v2/transcript/transcript_diarized",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribeStructured(
+            audio: audio,
+            language: "en",
+            translate: false,
+            prompt: "TypeWhisper"
+        )
+
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertEqual(result.text, "Speaker A: Hello\nSpeaker B: Hi")
+        XCTAssertEqual(result.segments.map(\.speakerLabel), ["Speaker A", "Speaker B"])
+        XCTAssertEqual(result.segments.map(\.speakerConfidence), [0.97, 0.91])
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        let submitBody = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try XCTUnwrap(requests[1].httpBody)) as? [String: Any]
+        )
+        XCTAssertEqual(submitBody["speaker_labels"] as? Bool, true)
+    }
+
     func testRESTTranscriptionUploadsCompressedM4A() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "assembly-key"])
         let plugin = AssemblyAIPlugin()


### PR DESCRIPTION
## Summary

Closes #912.

AssemblyAI's WebSocket streaming path returns plain transcription segments and
cannot carry speaker labels. When speaker diarization is enabled, the plugin
now reports `supportsStreaming == false`, which makes the existing
`ModelManagerService` choose the structured REST path for file transcription
and preserve `speakerLabel` and `speakerConfidence`.

The capability remains dynamic and the existing settings notification refreshes
it immediately. Regression coverage now verifies:

- default, enabled, idempotent, and persisted capability state
- the real REST submission includes `speaker_labels: true`
- a completed two-speaker response produces `Speaker A` / `Speaker B` text
- structured segments preserve both labels and confidence values

## Test Plan

- [ ] Ran `scripts/pr-preflight.sh`
- [x] Built the changed target: `swift build --package-path TypeWhisperPluginSDK --target AssemblyAIPlugin`
- [x] Parsed changed sources: `swiftc -parse TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift`
- [x] Added an end-to-end mocked REST regression for diarized multi-speaker output
- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [x] No regressions in existing features by source-path review

Full `swift test --package-path TypeWhisperPluginSDK --filter
AssemblyAIPluginTests` reaches test compilation, then fails because this
machine only has Command Line Tools and its Swift toolchain cannot import
`XCTest` without `Xcode.app`. The production AssemblyAI target builds
successfully; GitHub Actions runs the full plugin SDK suite with Xcode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming transcription is now disabled when speaker diarization is enabled, ensuring speaker metadata is preserved via the appropriate transcription path.
  * Speaker diarization settings now persist correctly across plugin reactivation and correctly update available streaming capability.

* **Tests**
  * Expanded diarization configuration tests to verify streaming capability toggles and remains stable on repeated enable calls.
  * Added an async transcription test covering diarization with multiple speakers, including validation of the structured transcription output and request payload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->