### PR TITLE
Release AssemblyAIPlugin v1.0.14

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.assemblyai",
     "name": "AssemblyAI",
-    "version": "1.0.4",
+    "version": "1.0.14",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

Prepare AssemblyAIPlugin v1.0.14 for release after the diarization routing fix from #939. The manifest now matches the next public plugin version required by the release workflow.

Refs #912.

## Test plan

- `jq -e '.id == "com.typewhisper.assemblyai" and .version == "1.0.14" and .minHostVersion == "1.5.0" and .sdkCompatibilityVersion == "v1"' TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json`
- `git diff --check`
- `python3 scripts/test_plugin_registry_metadata.py`
- `swift test --package-path TypeWhisperPluginSDK --filter AssemblyAIPluginTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AssemblyAI plugin to version 1.0.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->