### PR TITLE
Add live preview engine override (preview locally, transcribe finally on the dictation engine)

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A1C3E59B7D1042F9A8C6E2B1 /* PromptActionTemperaturePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */; };
 		FEEDFACE00000000000000A1 /* PromptProcessingModelResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDFACE00000000000000B1 /* PromptProcessingModelResolutionTests.swift */; };
 		24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */; };
+		8E4B0A32C5D96F7B1E203C4D /* LivePreviewEngineResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3A9F21B4C85E6A0D1F2B3C /* LivePreviewEngineResolutionTests.swift */; };
 		24FFE19AC026C48AE32BCD7D /* SpeechPunctuationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C53 /* SpeechPunctuationServiceTests.swift */; };
 		24FFE19AC026C48AE32BCD7E /* DictationPunctuationProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C54 /* DictationPunctuationProfileStoreTests.swift */; };
 		24FFE19AC026C48AE32BCD7F /* PunctuationRulesLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5852D6767C5FA955B84C55 /* PunctuationRulesLoaderTests.swift */; };
@@ -902,6 +903,7 @@
 		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
 		FEEDFACE00000000000000B1 /* PromptProcessingModelResolutionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptProcessingModelResolutionTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppFormatterServiceTests.swift; sourceTree = "<group>"; };
+		7D3A9F21B4C85E6A0D1F2B3C /* LivePreviewEngineResolutionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LivePreviewEngineResolutionTests.swift; sourceTree = "<group>"; };
 		CE5852D6767C5FA955B84C53 /* SpeechPunctuationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpeechPunctuationServiceTests.swift; sourceTree = "<group>"; };
 		50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NumberWordNormalizerTests.swift; sourceTree = "<group>"; };
 		16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionNormalizationServiceTests.swift; sourceTree = "<group>"; };
@@ -2339,6 +2341,7 @@
 				E6D200DCDD6580F443C5CE0A /* TypeWhisperIntegrationTests.swift */,
 				3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */,
 				CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */,
+				7D3A9F21B4C85E6A0D1F2B3C /* LivePreviewEngineResolutionTests.swift */,
 				CE5852D6767C5FA955B84C53 /* SpeechPunctuationServiceTests.swift */,
 				50756E40757C6BC13C52ED74 /* NumberWordNormalizerTests.swift */,
 				16CD1A34084E0761A8659612 /* TranscriptionNormalizationServiceTests.swift */,
@@ -3881,6 +3884,7 @@
 			files = (
 				7EC0EFA7DA6597CAEA640448 /* TypeWhisperIntegrationTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */,
+				8E4B0A32C5D96F7B1E203C4D /* LivePreviewEngineResolutionTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7D /* SpeechPunctuationServiceTests.swift in Sources */,
 				540AE1FA22F41A63C78B89EC /* NumberWordNormalizerTests.swift in Sources */,
 				E8FB3269B522A8923134AD9A /* TranscriptionNormalizationServiceTests.swift in Sources */,

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -14,6 +14,7 @@ enum UserDefaultsKeys {
     static let indicatorVisibleInScreenCaptures = "indicatorVisibleInScreenCaptures"
     static let indicatorTranscriptPreviewEnabled = "indicatorTranscriptPreviewEnabled"
     static let indicatorTranscriptPreviewFontSizeOffset = "indicatorTranscriptPreviewFontSizeOffset"
+    static let livePreviewEngineId = "livePreviewEngineId"
     static let preserveClipboard = "preserveClipboard"
     static let mediaPauseEnabled = "mediaPauseEnabled"
     static let dictationHotkeysPaused = "dictationHotkeysPaused"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9279,7 +9279,20 @@
       }
     },
     "Live preview engine": {
-
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Engine für die Live-Vorschau"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブプレビューのエンジン"
+          }
+        }
+      }
     },
     "Live transcript size": {
       "localizations": {
@@ -9657,7 +9670,20 @@
       }
     },
     "Match dictation engine": {
-
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diktat-Engine verwenden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディクテーションエンジンと同じ"
+          }
+        }
+      }
     },
     "Media Pause": {
       "localizations": {
@@ -17353,7 +17379,20 @@
       }
     },
     "The live preview runs on this engine while the final transcription still uses your dictation engine. A fast local engine avoids extra network requests while you speak.": {
-
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Live-Vorschau läuft auf dieser Engine, während die endgültige Transkription weiterhin deine Diktat-Engine verwendet. Eine schnelle lokale Engine vermeidet zusätzliche Netzwerkanfragen während des Sprechens."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブプレビューはこのエンジンで実行され、最終的な文字起こしには引き続きディクテーションエンジンが使用されます。高速なローカルエンジンを使えば、話している間の余分なネットワークリクエストを回避できます。"
+          }
+        }
+      }
     },
     "The notch indicator extends the MacBook notch area to show recording status.": {
       "localizations": {

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -9278,6 +9278,9 @@
         }
       }
     },
+    "Live preview engine": {
+
+    },
     "Live transcript size": {
       "localizations": {
         "de": {
@@ -9652,6 +9655,9 @@
           }
         }
       }
+    },
+    "Match dictation engine": {
+
     },
     "Media Pause": {
       "localizations": {
@@ -17345,6 +17351,9 @@
           }
         }
       }
+    },
+    "The live preview runs on this engine while the final transcription still uses your dictation engine. A fast local engine avoids extra network requests while you speak.": {
+
     },
     "The notch indicator extends the MacBook notch area to show recording status.": {
       "localizations": {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2309,10 +2309,17 @@ final class DictationViewModel: ObservableObject {
     /// `prepareEngineForTranscription` → `triggerRestoreModel`), AND actually able
     /// to produce a preview — via a native live session or the batch fallback.
     func canUseEngineForPreview(_ engine: TranscriptionEnginePlugin) -> Bool {
+        // `loadedModel` is persisted by the host under the plugin's MANIFEST id
+        // (`HostServicesImpl.setUserDefault` writes `plugin.<manifest.id>.<key>`),
+        // which is not the engine's `providerId` — e.g. "parakeet" vs
+        // "com.typewhisper.parakeet". Resolve through the plugin so the lookup
+        // reads the key the plugin actually wrote; an unresolvable engine is not
+        // restorable, so it correctly fails the readiness gate.
+        let pluginId = PluginManager.shared?.loadedTranscriptionPlugin(for: engine.providerId)?.manifest.id
         guard Self.engineIsReadyOrRestorableForPreview(
             authAvailable: modelManager.canUseForTranscription(engine),
             isConfigured: engine.isConfigured,
-            hasPersistedRestorableModel: Self.hasPersistedRestorableModel(providerId: engine.providerId),
+            hasPersistedRestorableModel: pluginId.map { Self.hasPersistedRestorableModel(pluginId: $0) } ?? false,
             canPrepare: modelManager.canPrepareForTranscription(engine)
         ) else { return false }
         if engine is any LiveTranscriptionCapablePlugin { return true }
@@ -2326,11 +2333,15 @@ final class DictationViewModel: ObservableObject {
     /// manually unloading a model clears it (restore is a no-op, so the engine
     /// must not be treated as available). Same plugin-scoped convention key the
     /// host special-cases in `HostServicesImpl.userDefault(forKey:)`.
+    ///
+    /// Takes the plugin's MANIFEST id, not an engine `providerId` — the two differ
+    /// (`com.typewhisper.parakeet` vs `parakeet`) and only the former matches what
+    /// `HostServicesImpl` wrote.
     nonisolated static func hasPersistedRestorableModel(
-        providerId: String,
+        pluginId: String,
         defaults: UserDefaults = .standard
     ) -> Bool {
-        defaults.object(forKey: "plugin.\(providerId).loadedModel") != nil
+        defaults.object(forKey: "plugin.\(pluginId).loadedModel") != nil
     }
 
     /// Pure readiness predicate for the preview engine. A persisted restorable

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2312,7 +2312,7 @@ final class DictationViewModel: ObservableObject {
         guard Self.engineIsReadyOrRestorableForPreview(
             authAvailable: modelManager.canUseForTranscription(engine),
             isConfigured: engine.isConfigured,
-            selectedModelId: engine.selectedModelId,
+            hasPersistedRestorableModel: Self.hasPersistedRestorableModel(providerId: engine.providerId),
             canPrepare: modelManager.canPrepareForTranscription(engine)
         ) else { return false }
         if engine is any LiveTranscriptionCapablePlugin { return true }
@@ -2321,19 +2321,31 @@ final class DictationViewModel: ObservableObject {
         return allowsFallback
     }
 
-    /// Pure readiness predicate for the preview engine. A persisted model
-    /// selection counts as available even when the model is not currently
-    /// loaded (`isConfigured == false`) — auto-unloaded local engines restore
-    /// at session start. `canPrepare` additionally keeps Apple Speech's
+    /// Whether the plugin has a persisted `loadedModel` default —  the state
+    /// `triggerRestoreModel` restores from. Auto-unload keeps it (restorable);
+    /// manually unloading a model clears it (restore is a no-op, so the engine
+    /// must not be treated as available). Same plugin-scoped convention key the
+    /// host special-cases in `HostServicesImpl.userDefault(forKey:)`.
+    nonisolated static func hasPersistedRestorableModel(
+        providerId: String,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        defaults.object(forKey: "plugin.\(providerId).loadedModel") != nil
+    }
+
+    /// Pure readiness predicate for the preview engine. A persisted restorable
+    /// model counts as available even when it is not currently loaded
+    /// (`isConfigured == false`) — auto-unloaded local engines restore at
+    /// session start. `canPrepare` additionally keeps Apple Speech's
     /// catalog-based grace from `canPrepareForTranscription`.
     nonisolated static func engineIsReadyOrRestorableForPreview(
         authAvailable: Bool,
         isConfigured: Bool,
-        selectedModelId: String?,
+        hasPersistedRestorableModel: Bool,
         canPrepare: Bool
     ) -> Bool {
         guard authAvailable else { return false }
-        return isConfigured || selectedModelId != nil || canPrepare
+        return isConfigured || hasPersistedRestorableModel || canPrepare
     }
 
     enum PreviewEngineResolution: Equatable {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -354,6 +354,10 @@ final class DictationViewModel: ObservableObject {
         let normalizeNumbers: Bool?
     }
     private var lastStreamingParams: StreamingParamsSnapshot?
+    /// Whether the most recent `streamingHandler.start(...)` ran the preview on the
+    /// dictation engine. When false (a distinct preview engine), the live session's
+    /// text is display-only and must never be promoted to the final transcription.
+    private var lastPreviewFollowsDictationEngine = true
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
     private var pendingHotkeyDictationStart: PendingHotkeyDictationStart?
@@ -1592,6 +1596,8 @@ final class DictationViewModel: ObservableObject {
 
         let streamingParams = lastStreamingParams
         lastStreamingParams = nil
+        let previewFollowedDictationEngine = lastPreviewFollowsDictationEngine
+        lastPreviewFollowsDictationEngine = true
         stopRecordingTimer()
         let previewText = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
         let stopPolicy = AudioRecordingService.StopPolicy.finalizeShortSpeech()
@@ -1603,6 +1609,11 @@ final class DictationViewModel: ObservableObject {
         logger.info("Stop timing: streamingHandler.finish done elapsedMs=\(stopElapsedMs(), privacy: .public), resultTextLength=\(liveSessionResultBeforePreviewFallback?.text.count ?? -1, privacy: .public)")
         var liveSessionResult = liveSessionResultBeforePreviewFallback.map {
             StreamingHandler.resultPreferringStablePreviewIfNeeded($0, stablePreview: previewText)
+        }
+        if !previewFollowedDictationEngine {
+            // The live session ran on a preview-only engine; its text is display-only.
+            // The final transcription must come from the dictation engine below.
+            liveSessionResult = nil
         }
         let hasPreviewText = !previewText.isEmpty
 
@@ -1617,7 +1628,8 @@ final class DictationViewModel: ObservableObject {
 
         let peakLevel = audioRecordingService.peakRawAudioLevel
         let rawDuration = Double(samples.count) / AudioRecordingService.targetSampleRate
-        if !hasConfirmedTranscriptionResultText(liveSessionResult),
+        if previewFollowedDictationEngine,
+           !hasConfirmedTranscriptionResultText(liveSessionResult),
            let previewResult = stableLivePreviewFallbackResult(
             previewText: previewText,
             streamingParams: streamingParams,
@@ -2224,10 +2236,16 @@ final class DictationViewModel: ObservableObject {
             preferredPreviewEngineId: livePreviewEngineId,
             dictationEngineOverrideId: params.engineOverrideId,
             selectedProviderId: params.providerId,
-            isEngineAvailable: { PluginManager.shared?.transcriptionEngine(for: $0) != nil }
+            isEngineAvailable: { [weak self] engineId in
+                guard let self, let engine = PluginManager.shared?.transcriptionEngine(for: engineId) else {
+                    return false
+                }
+                return self.modelManager.canPrepareForTranscription(engine)
+            }
         )
         let previewFollowsDictationEngine =
             (previewEngineOverrideId ?? params.providerId) == (params.engineOverrideId ?? params.providerId)
+        lastPreviewFollowsDictationEngine = previewFollowsDictationEngine
         let dictionaryProviderId = previewEngineOverrideId ?? params.providerId
         streamingHandler.start(
             streamPrompt: dictionaryService.getTermsForPrompt(providerId: dictionaryProviderId) ?? "",
@@ -2241,6 +2259,12 @@ final class DictationViewModel: ObservableObject {
             allowLiveTranscription: allowLiveTranscription,
             stateCheck: { [weak self] in self?.state == .recording }
         )
+    }
+
+    /// Whether an engine is usable as the live preview engine right now
+    /// (installed, configured, and ready — not merely present).
+    func canUseEngineForPreview(_ engine: TranscriptionEnginePlugin) -> Bool {
+        modelManager.canPrepareForTranscription(engine)
     }
 
     /// Resolve the engine override for the live transcript preview session.

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -203,6 +203,12 @@ final class DictationViewModel: ObservableObject {
     @Published var indicatorVisibleInScreenCaptures: Bool {
         didSet { Self.persistIndicatorVisibleInScreenCaptures(indicatorVisibleInScreenCaptures) }
     }
+    /// Engine override for the live transcript preview only. `nil` = follow the
+    /// dictation engine (prior behavior). Lets the preview run a fast local
+    /// streaming engine while the final transcription uses a cloud engine.
+    @Published var livePreviewEngineId: String? {
+        didSet { Self.persistLivePreviewEngineId(livePreviewEngineId) }
+    }
     @Published var indicatorTranscriptPreviewFontSizeOffset: Int {
         didSet {
             let clampedOffset = Self.clampedIndicatorTranscriptPreviewFontSizeOffset(indicatorTranscriptPreviewFontSizeOffset)
@@ -503,6 +509,7 @@ final class DictationViewModel: ObservableObject {
         self.indicatorTranscriptPreviewEnabled = Self.loadIndicatorTranscriptPreviewEnabled()
         self.indicatorVisibleInScreenCaptures = Self.loadIndicatorVisibleInScreenCaptures()
         self.indicatorTranscriptPreviewFontSizeOffset = Self.loadIndicatorTranscriptPreviewFontSizeOffset()
+        self.livePreviewEngineId = Self.loadLivePreviewEngineId()
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
         self.transcribeShortQuietClipsAggressively = Self.loadTranscribeShortQuietClipsAggressively()
@@ -594,6 +601,22 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistIndicatorVisibleInScreenCaptures(_ visible: Bool, defaults: UserDefaults = .standard) {
         defaults.set(visible, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
+    }
+
+    nonisolated static func loadLivePreviewEngineId(defaults: UserDefaults = .standard) -> String? {
+        guard let engineId = defaults.string(forKey: UserDefaultsKeys.livePreviewEngineId),
+              !engineId.isEmpty else {
+            return nil
+        }
+        return engineId
+    }
+
+    nonisolated static func persistLivePreviewEngineId(_ engineId: String?, defaults: UserDefaults = .standard) {
+        if let engineId, !engineId.isEmpty {
+            defaults.set(engineId, forKey: UserDefaultsKeys.livePreviewEngineId)
+        } else {
+            defaults.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+        }
     }
 
     nonisolated static func loadIndicatorTranscriptPreviewFontSizeOffset(defaults: UserDefaults = .standard) -> Int {
@@ -2197,19 +2220,47 @@ final class DictationViewModel: ObservableObject {
             normalizeNumbers: effectiveNumberNormalizationOverride
         )
         lastStreamingParams = allowLiveTranscription ? params : nil
-        let dictionaryProviderId = params.engineOverrideId ?? params.providerId
+        let previewEngineOverrideId = Self.resolvePreviewEngineOverrideId(
+            preferredPreviewEngineId: livePreviewEngineId,
+            dictationEngineOverrideId: params.engineOverrideId,
+            selectedProviderId: params.providerId,
+            isEngineAvailable: { PluginManager.shared?.transcriptionEngine(for: $0) != nil }
+        )
+        let previewFollowsDictationEngine =
+            (previewEngineOverrideId ?? params.providerId) == (params.engineOverrideId ?? params.providerId)
+        let dictionaryProviderId = previewEngineOverrideId ?? params.providerId
         streamingHandler.start(
             streamPrompt: dictionaryService.getTermsForPrompt(providerId: dictionaryProviderId) ?? "",
             dictionaryTermHints: dictionaryService.getTermHints(providerId: dictionaryProviderId),
-            engineOverrideId: params.engineOverrideId,
+            engineOverrideId: previewEngineOverrideId,
             selectedProviderId: params.providerId,
             languageSelection: params.languageSelection,
             task: params.task,
-            cloudModelOverride: params.cloudModelOverride,
+            cloudModelOverride: previewFollowsDictationEngine ? params.cloudModelOverride : nil,
             normalizeNumbers: params.normalizeNumbers,
             allowLiveTranscription: allowLiveTranscription,
             stateCheck: { [weak self] in self?.state == .recording }
         )
+    }
+
+    /// Resolve the engine override for the live transcript preview session.
+    /// The user's preview engine wins when it is installed and differs from the
+    /// effective dictation engine; otherwise the preview follows the dictation
+    /// engine (prior behavior), keeping any cloud model override intact.
+    nonisolated static func resolvePreviewEngineOverrideId(
+        preferredPreviewEngineId: String?,
+        dictationEngineOverrideId: String?,
+        selectedProviderId: String?,
+        isEngineAvailable: (String) -> Bool
+    ) -> String? {
+        guard let preferred = preferredPreviewEngineId, !preferred.isEmpty,
+              isEngineAvailable(preferred) else {
+            return dictationEngineOverrideId
+        }
+        if preferred == (dictationEngineOverrideId ?? selectedProviderId) {
+            return dictationEngineOverrideId
+        }
+        return preferred
     }
 
     /// Restart live streaming if the currently effective params differ from the ones

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2244,8 +2244,7 @@ final class DictationViewModel: ObservableObject {
             cloudModelOverride: effectiveCloudModelOverride,
             normalizeNumbers: effectiveNumberNormalizationOverride
         )
-        lastStreamingParams = allowLiveTranscription ? params : nil
-        let previewEngineOverrideId = Self.resolvePreviewEngineOverrideId(
+        let resolution = Self.resolvePreviewEngine(
             preferredPreviewEngineId: livePreviewEngineId,
             dictationEngineOverrideId: params.engineOverrideId,
             selectedProviderId: params.providerId,
@@ -2256,6 +2255,25 @@ final class DictationViewModel: ObservableObject {
                 return self.canUseEngineForPreview(engine)
             }
         )
+        let previewEngineOverrideId: String?
+        let previewUsable: Bool
+        switch resolution {
+        case .followsDictationEngine:
+            previewEngineOverrideId = params.engineOverrideId
+            previewUsable = true
+        case .overrideEngine(let engineId):
+            previewEngineOverrideId = engineId
+            previewUsable = true
+        case .previewUnavailable:
+            // The user explicitly chose a preview engine that can't run right now.
+            // Fail visibly (no preview) instead of silently resuming preview
+            // traffic on the (possibly metered cloud) dictation engine.
+            previewEngineOverrideId = params.engineOverrideId
+            previewUsable = false
+            logger.warning("Selected live preview engine is unavailable; preview disabled for this recording instead of falling back to the dictation engine")
+        }
+        let effectiveAllowLiveTranscription = allowLiveTranscription && previewUsable
+        lastStreamingParams = effectiveAllowLiveTranscription ? params : nil
         let previewFollowsDictationEngine =
             (previewEngineOverrideId ?? params.providerId) == (params.engineOverrideId ?? params.providerId)
         lastPreviewFollowsDictationEngine = previewFollowsDictationEngine
@@ -2280,40 +2298,73 @@ final class DictationViewModel: ObservableObject {
             task: previewTask,
             cloudModelOverride: previewFollowsDictationEngine ? params.cloudModelOverride : nil,
             normalizeNumbers: params.normalizeNumbers,
-            allowLiveTranscription: allowLiveTranscription,
+            allowLiveTranscription: effectiveAllowLiveTranscription,
             stateCheck: { [weak self] in self?.state == .recording }
         )
     }
 
-    /// Whether an engine is usable as the live preview engine right now:
-    /// installed, configured, and ready (not merely present), AND actually able
+    /// Whether an engine is usable as the live preview engine: auth-available and
+    /// either currently configured or restorable on demand (an installed local
+    /// engine whose model was auto-unloaded restores at session start via
+    /// `prepareEngineForTranscription` → `triggerRestoreModel`), AND actually able
     /// to produce a preview — via a native live session or the batch fallback.
     func canUseEngineForPreview(_ engine: TranscriptionEnginePlugin) -> Bool {
-        guard modelManager.canPrepareForTranscription(engine) else { return false }
+        guard Self.engineIsReadyOrRestorableForPreview(
+            authAvailable: modelManager.canUseForTranscription(engine),
+            isConfigured: engine.isConfigured,
+            selectedModelId: engine.selectedModelId,
+            canPrepare: modelManager.canPrepareForTranscription(engine)
+        ) else { return false }
         if engine is any LiveTranscriptionCapablePlugin { return true }
         let allowsFallback = (engine as? any TranscriptPreviewFallbackPolicyProviding)?
             .allowsTranscriptPreviewFallback ?? true
         return allowsFallback
     }
 
-    /// Resolve the engine override for the live transcript preview session.
-    /// The user's preview engine wins when it is installed and differs from the
-    /// effective dictation engine; otherwise the preview follows the dictation
-    /// engine (prior behavior), keeping any cloud model override intact.
-    nonisolated static func resolvePreviewEngineOverrideId(
+    /// Pure readiness predicate for the preview engine. A persisted model
+    /// selection counts as available even when the model is not currently
+    /// loaded (`isConfigured == false`) — auto-unloaded local engines restore
+    /// at session start. `canPrepare` additionally keeps Apple Speech's
+    /// catalog-based grace from `canPrepareForTranscription`.
+    nonisolated static func engineIsReadyOrRestorableForPreview(
+        authAvailable: Bool,
+        isConfigured: Bool,
+        selectedModelId: String?,
+        canPrepare: Bool
+    ) -> Bool {
+        guard authAvailable else { return false }
+        return isConfigured || selectedModelId != nil || canPrepare
+    }
+
+    enum PreviewEngineResolution: Equatable {
+        /// No usable distinct preference — the preview follows the dictation
+        /// engine (prior behavior), keeping any cloud model override intact.
+        case followsDictationEngine
+        /// A distinct, usable preview engine runs the preview session.
+        case overrideEngine(String)
+        /// A preview engine is explicitly selected but unusable — suppress the
+        /// preview entirely rather than silently falling back to the (possibly
+        /// metered cloud) dictation engine.
+        case previewUnavailable
+    }
+
+    /// Resolve which engine the live transcript preview session should use.
+    nonisolated static func resolvePreviewEngine(
         preferredPreviewEngineId: String?,
         dictationEngineOverrideId: String?,
         selectedProviderId: String?,
         isEngineAvailable: (String) -> Bool
-    ) -> String? {
-        guard let preferred = preferredPreviewEngineId, !preferred.isEmpty,
-              isEngineAvailable(preferred) else {
-            return dictationEngineOverrideId
+    ) -> PreviewEngineResolution {
+        guard let preferred = preferredPreviewEngineId, !preferred.isEmpty else {
+            return .followsDictationEngine
+        }
+        guard isEngineAvailable(preferred) else {
+            return .previewUnavailable
         }
         if preferred == (dictationEngineOverrideId ?? selectedProviderId) {
-            return dictationEngineOverrideId
+            return .followsDictationEngine
         }
-        return preferred
+        return .overrideEngine(preferred)
     }
 
     /// Restart live streaming if the currently effective params differ from the ones

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1604,16 +1604,20 @@ final class DictationViewModel: ObservableObject {
         var samples = await audioRecordingService.stopRecording(policy: stopPolicy)
         guard !Task.isCancelled else { return }
         logger.info("Stop timing: stopRecording done elapsedMs=\(stopElapsedMs(), privacy: .public), previewTextLength=\(previewText.count, privacy: .public)")
-        let liveSessionResultBeforePreviewFallback = await streamingHandler.finish(finalSamples: samples)
+        let liveSessionResultBeforePreviewFallback: TranscriptionResult?
+        if previewFollowedDictationEngine {
+            liveSessionResultBeforePreviewFallback = await streamingHandler.finish(finalSamples: samples)
+        } else {
+            // The live session ran on a preview-only engine; its text is display-only
+            // and the final transcription comes from the dictation engine below. Don't
+            // await the preview's (possibly network-bound) finalization — cancel it.
+            streamingHandler.stop()
+            liveSessionResultBeforePreviewFallback = nil
+        }
         guard !Task.isCancelled else { return }
         logger.info("Stop timing: streamingHandler.finish done elapsedMs=\(stopElapsedMs(), privacy: .public), resultTextLength=\(liveSessionResultBeforePreviewFallback?.text.count ?? -1, privacy: .public)")
         var liveSessionResult = liveSessionResultBeforePreviewFallback.map {
             StreamingHandler.resultPreferringStablePreviewIfNeeded($0, stablePreview: previewText)
-        }
-        if !previewFollowedDictationEngine {
-            // The live session ran on a preview-only engine; its text is display-only.
-            // The final transcription must come from the dictation engine below.
-            liveSessionResult = nil
         }
         let hasPreviewText = !previewText.isEmpty
 
@@ -1637,7 +1641,16 @@ final class DictationViewModel: ObservableObject {
            ) {
             liveSessionResult = previewResult
         }
+        // A distinct preview engine's text never becomes the final result, but its
+        // having recognized speech still counts for the discard-quiet-clip gating —
+        // otherwise valid quiet speech would be discarded before the dictation
+        // engine gets to transcribe it.
+        let previewEngineConfirmedSpeech = !previewFollowedDictationEngine
+            && StreamingHandler.isSubstantiveStablePreview(
+                previewText.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
         let hasConfirmedText = hasConfirmedTranscriptionResultText(liveSessionResult)
+            || previewEngineConfirmedSpeech
         let decision = classifyShortSpeech(
             rawDuration: rawDuration,
             peakLevel: peakLevel,
@@ -2240,20 +2253,31 @@ final class DictationViewModel: ObservableObject {
                 guard let self, let engine = PluginManager.shared?.transcriptionEngine(for: engineId) else {
                     return false
                 }
-                return self.modelManager.canPrepareForTranscription(engine)
+                return self.canUseEngineForPreview(engine)
             }
         )
         let previewFollowsDictationEngine =
             (previewEngineOverrideId ?? params.providerId) == (params.engineOverrideId ?? params.providerId)
         lastPreviewFollowsDictationEngine = previewFollowsDictationEngine
         let dictionaryProviderId = previewEngineOverrideId ?? params.providerId
+        // A distinct preview engine that can't translate still previews the speech —
+        // as a transcription. The final (translating) result comes from the dictation
+        // engine anyway; keeping .translate here would make its sessions fail outright.
+        var previewTask = params.task
+        if !previewFollowsDictationEngine,
+           previewTask == .translate,
+           let previewProviderId = previewEngineOverrideId,
+           let previewPlugin = PluginManager.shared?.transcriptionEngine(for: previewProviderId),
+           !previewPlugin.supportsTranslation {
+            previewTask = .transcribe
+        }
         streamingHandler.start(
             streamPrompt: dictionaryService.getTermsForPrompt(providerId: dictionaryProviderId) ?? "",
             dictionaryTermHints: dictionaryService.getTermHints(providerId: dictionaryProviderId),
             engineOverrideId: previewEngineOverrideId,
             selectedProviderId: params.providerId,
             languageSelection: params.languageSelection,
-            task: params.task,
+            task: previewTask,
             cloudModelOverride: previewFollowsDictationEngine ? params.cloudModelOverride : nil,
             normalizeNumbers: params.normalizeNumbers,
             allowLiveTranscription: allowLiveTranscription,
@@ -2261,10 +2285,15 @@ final class DictationViewModel: ObservableObject {
         )
     }
 
-    /// Whether an engine is usable as the live preview engine right now
-    /// (installed, configured, and ready — not merely present).
+    /// Whether an engine is usable as the live preview engine right now:
+    /// installed, configured, and ready (not merely present), AND actually able
+    /// to produce a preview — via a native live session or the batch fallback.
     func canUseEngineForPreview(_ engine: TranscriptionEnginePlugin) -> Bool {
-        modelManager.canPrepareForTranscription(engine)
+        guard modelManager.canPrepareForTranscription(engine) else { return false }
+        if engine is any LiveTranscriptionCapablePlugin { return true }
+        let allowsFallback = (engine as? any TranscriptPreviewFallbackPolicyProviding)?
+            .allowsTranscriptPreviewFallback ?? true
+        return allowsFallback
     }
 
     /// Resolve the engine override for the live transcript preview session.

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import ServiceManagement
+import TypeWhisperPluginSDK
 
 struct GeneralSettingsView: View {
     private enum AppVisibilityMode: String, CaseIterable {
@@ -32,6 +33,10 @@ struct GeneralSettingsView: View {
 
     private var supportsPositionSelection: Bool {
         dictation.indicatorStyle == .overlay || dictation.indicatorStyle == .minimal
+    }
+
+    private var previewEngineOptions: [TranscriptionEnginePlugin] {
+        pluginManager.transcriptionEngines
     }
 
     private var dockIconBehavior: DockIconBehavior {
@@ -172,6 +177,21 @@ struct GeneralSettingsView: View {
 
                 if supportsTranscriptPreview {
                     Toggle(String(localized: "Show live transcript preview"), isOn: $dictation.indicatorTranscriptPreviewEnabled)
+
+                    Picker(String(localized: "Live preview engine"), selection: $dictation.livePreviewEngineId) {
+                        Text(String(localized: "Match dictation engine")).tag(nil as String?)
+                        Divider()
+                        ForEach(previewEngineOptions, id: \.providerId) { engine in
+                            Text(engine.providerDisplayName).tag(engine.providerId as String?)
+                        }
+                    }
+                    .disabled(!dictation.indicatorTranscriptPreviewEnabled)
+
+                    if dictation.indicatorTranscriptPreviewEnabled, dictation.livePreviewEngineId != nil {
+                        Text(String(localized: "The live preview runs on this engine while the final transcription still uses your dictation engine. A fast local engine avoids extra network requests while you speak."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
 
                     LabeledContent(String(localized: "Live transcript size")) {
                         HStack(spacing: 12) {

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -182,7 +182,15 @@ struct GeneralSettingsView: View {
                         Text(String(localized: "Match dictation engine")).tag(nil as String?)
                         Divider()
                         ForEach(previewEngineOptions, id: \.providerId) { engine in
-                            Text(engine.providerDisplayName).tag(engine.providerId as String?)
+                            HStack {
+                                Text(engine.providerDisplayName)
+                                if !dictation.canUseEngineForPreview(engine) {
+                                    Text("(\(String(localized: "not ready")))")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .tag(engine.providerId as String?)
+                            .disabled(!dictation.canUseEngineForPreview(engine))
                         }
                     }
                     .disabled(!dictation.indicatorTranscriptPreviewEnabled)

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -192,6 +192,9 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         modelManager: ModelManagerService,
         audioRecordingService: AudioRecordingService
     ) -> DictationViewModel {
+        // Unit tests must start from the documented default (nil = match dictation
+        // engine); the test host app's persisted preference would otherwise leak in.
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
         let textInsertionService = TextInsertionService()
         let hotkeyService = HotkeyService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -192,9 +192,11 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         modelManager: ModelManagerService,
         audioRecordingService: AudioRecordingService
     ) -> DictationViewModel {
-        // Unit tests must start from the documented default (nil = match dictation
-        // engine); the test host app's persisted preference would otherwise leak in.
+        // Unit tests must start from the documented defaults (preview enabled,
+        // preview engine = match dictation engine); the test host app's persisted
+        // preferences would otherwise leak in.
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
         let textInsertionService = TextInsertionService()
         let hotkeyService = HotkeyService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -194,9 +194,27 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
     ) -> DictationViewModel {
         // Unit tests must start from the documented defaults (preview enabled,
         // preview engine = match dictation engine); the test host app's persisted
-        // preferences would otherwise leak in.
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+        // preferences would otherwise leak in. `DictationViewModel` reads both keys
+        // synchronously in its initializer, so restoring on exit keeps the isolation
+        // while leaving a developer's real preferences untouched.
+        let livePreviewEngineKey = UserDefaultsKeys.livePreviewEngineId
+        let previewEnabledKey = UserDefaultsKeys.indicatorTranscriptPreviewEnabled
+        let originalLivePreviewEngine = UserDefaults.standard.object(forKey: livePreviewEngineKey)
+        let originalPreviewEnabled = UserDefaults.standard.object(forKey: previewEnabledKey)
+        UserDefaults.standard.removeObject(forKey: livePreviewEngineKey)
+        UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+        defer {
+            if let originalLivePreviewEngine {
+                UserDefaults.standard.set(originalLivePreviewEngine, forKey: livePreviewEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: livePreviewEngineKey)
+            }
+            if let originalPreviewEnabled {
+                UserDefaults.standard.set(originalPreviewEnabled, forKey: previewEnabledKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+            }
+        }
         let textInsertionService = TextInsertionService()
         let hotkeyService = HotkeyService()
         let historyService = HistoryService(appSupportDirectory: appSupportDirectory)

--- a/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
+++ b/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
@@ -3,98 +3,172 @@ import XCTest
 
 final class LivePreviewEngineResolutionTests: XCTestCase {
     func testNoPreferenceFollowsDictationEngine() {
-        XCTAssertNil(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: nil,
                 dictationEngineOverrideId: nil,
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in true }
-            )
+            ),
+            .followsDictationEngine
         )
     }
 
     func testNoPreferenceKeepsProfileEngineOverride() {
         XCTAssertEqual(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: nil,
                 dictationEngineOverrideId: "profile-engine",
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in true }
             ),
-            "profile-engine"
+            .followsDictationEngine
         )
     }
 
     func testEmptyPreferenceFollowsDictationEngine() {
-        XCTAssertNil(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: "",
                 dictationEngineOverrideId: nil,
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in true }
-            )
+            ),
+            .followsDictationEngine
         )
     }
 
-    func testUnavailablePreferenceFollowsDictationEngine() {
-        XCTAssertNil(
-            DictationViewModel.resolvePreviewEngineOverrideId(
-                preferredPreviewEngineId: "speechanalyzer",
+    func testUnavailablePreferenceSuppressesPreviewInsteadOfMeteredFallback() {
+        // Error class: silently falling back to the (possibly metered cloud)
+        // dictation engine when the explicitly selected preview engine cannot
+        // run — the preview must be suppressed instead (review finding on #943).
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngine(
+                preferredPreviewEngineId: "parakeet",
                 dictationEngineOverrideId: nil,
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in false }
-            )
+            ),
+            .previewUnavailable
         )
     }
 
     func testDistinctAvailablePreferenceWins() {
         XCTAssertEqual(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: "speechanalyzer",
                 dictationEngineOverrideId: nil,
                 selectedProviderId: "groq",
                 isEngineAvailable: { $0 == "speechanalyzer" }
             ),
-            "speechanalyzer"
+            .overrideEngine("speechanalyzer")
         )
     }
 
     func testPreferenceMatchingSelectedProviderStaysOnDictationPath() {
-        // Returning the dictation override (nil) rather than the preference keeps
-        // the cloud model override flowing on the unchanged code path.
-        XCTAssertNil(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+        // Following the dictation path (rather than an override) keeps the cloud
+        // model override flowing on the unchanged prior-behavior code path.
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: "groq",
                 dictationEngineOverrideId: nil,
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in true }
-            )
+            ),
+            .followsDictationEngine
         )
     }
 
     func testPreferenceMatchingProfileOverrideStaysOnDictationPath() {
         XCTAssertEqual(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: "profile-engine",
                 dictationEngineOverrideId: "profile-engine",
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in true }
             ),
-            "profile-engine"
+            .followsDictationEngine
         )
     }
 
     func testPreferenceDistinctFromProfileOverrideWins() {
         XCTAssertEqual(
-            DictationViewModel.resolvePreviewEngineOverrideId(
+            DictationViewModel.resolvePreviewEngine(
                 preferredPreviewEngineId: "speechanalyzer",
                 dictationEngineOverrideId: "profile-engine",
                 selectedProviderId: "groq",
                 isEngineAvailable: { _ in true }
             ),
-            "speechanalyzer"
+            .overrideEngine("speechanalyzer")
         )
     }
+
+    // MARK: - Ready-or-restorable predicate
+
+    func testAutoUnloadedLocalEngineWithPersistedSelectionIsRestorable() {
+        // Error class: rejecting an installed local preview engine whose model
+        // was AUTO-UNLOADED (isConfigured == false, canPrepareForTranscription
+        // == false for non-Apple engines) even though its persisted model
+        // selection restores at session start via triggerRestoreModel — which
+        // silently re-routed the preview to the metered dictation engine
+        // (review finding on #943).
+        XCTAssertTrue(
+            DictationViewModel.engineIsReadyOrRestorableForPreview(
+                authAvailable: true,
+                isConfigured: false,
+                selectedModelId: "parakeet-tdt-0.6b-v3",
+                canPrepare: false
+            )
+        )
+    }
+
+    func testConfiguredEngineIsReady() {
+        XCTAssertTrue(
+            DictationViewModel.engineIsReadyOrRestorableForPreview(
+                authAvailable: true,
+                isConfigured: true,
+                selectedModelId: nil,
+                canPrepare: true
+            )
+        )
+    }
+
+    func testAppleCatalogGraceStillApplies() {
+        // Apple Speech may have no selected model yet still be preparable from
+        // its catalog — canPrepareForTranscription's existing grace is preserved.
+        XCTAssertTrue(
+            DictationViewModel.engineIsReadyOrRestorableForPreview(
+                authAvailable: true,
+                isConfigured: false,
+                selectedModelId: nil,
+                canPrepare: true
+            )
+        )
+    }
+
+    func testNeverConfiguredEngineIsUnavailable() {
+        XCTAssertFalse(
+            DictationViewModel.engineIsReadyOrRestorableForPreview(
+                authAvailable: true,
+                isConfigured: false,
+                selectedModelId: nil,
+                canPrepare: false
+            )
+        )
+    }
+
+    func testAuthUnavailableRejectsEvenConfiguredEngines() {
+        XCTAssertFalse(
+            DictationViewModel.engineIsReadyOrRestorableForPreview(
+                authAvailable: false,
+                isConfigured: true,
+                selectedModelId: "some-model",
+                canPrepare: true
+            )
+        )
+    }
+
+    // MARK: - Persistence
 
     func testLoadPersistRoundTrip() {
         let defaults = UserDefaults(suiteName: "LivePreviewEngineResolutionTests")!

--- a/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
+++ b/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
@@ -105,21 +105,57 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
 
     // MARK: - Ready-or-restorable predicate
 
-    func testAutoUnloadedLocalEngineWithPersistedSelectionIsRestorable() {
+    func testAutoUnloadedLocalEngineWithPersistedLoadedModelIsRestorable() {
         // Error class: rejecting an installed local preview engine whose model
         // was AUTO-UNLOADED (isConfigured == false, canPrepareForTranscription
-        // == false for non-Apple engines) even though its persisted model
-        // selection restores at session start via triggerRestoreModel — which
+        // == false for non-Apple engines) even though its persisted loadedModel
+        // state restores at session start via triggerRestoreModel — which
         // silently re-routed the preview to the metered dictation engine
         // (review finding on #943).
         XCTAssertTrue(
             DictationViewModel.engineIsReadyOrRestorableForPreview(
                 authAvailable: true,
                 isConfigured: false,
-                selectedModelId: "parakeet-tdt-0.6b-v3",
+                hasPersistedRestorableModel: true,
                 canPrepare: false
             )
         )
+    }
+
+    func testManuallyUnloadedEngineIsNotRestorable() {
+        // Error class: treating a retained model SELECTION as restorable after a
+        // MANUAL unload — plugins keep selectedModel but clear the persisted
+        // loadedModel default, so triggerRestoreModel is a no-op and a preview
+        // session can never become ready; the engine must resolve as
+        // unavailable (suppressed preview), not as an override that fails
+        // every fallback poll (second-round review finding on #943).
+        XCTAssertFalse(
+            DictationViewModel.engineIsReadyOrRestorableForPreview(
+                authAvailable: true,
+                isConfigured: false,
+                hasPersistedRestorableModel: false,
+                canPrepare: false
+            )
+        )
+    }
+
+    func testHasPersistedRestorableModelReadsPluginScopedKey() {
+        let suite = "LivePreviewEngineResolutionTests-restore"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        XCTAssertFalse(
+            DictationViewModel.hasPersistedRestorableModel(
+                providerId: "com.typewhisper.parakeet", defaults: defaults
+            )
+        )
+        defaults.set("parakeet-tdt-0.6b-v3", forKey: "plugin.com.typewhisper.parakeet.loadedModel")
+        XCTAssertTrue(
+            DictationViewModel.hasPersistedRestorableModel(
+                providerId: "com.typewhisper.parakeet", defaults: defaults
+            )
+        )
+        defaults.removePersistentDomain(forName: suite)
     }
 
     func testConfiguredEngineIsReady() {
@@ -127,7 +163,7 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
             DictationViewModel.engineIsReadyOrRestorableForPreview(
                 authAvailable: true,
                 isConfigured: true,
-                selectedModelId: nil,
+                hasPersistedRestorableModel: false,
                 canPrepare: true
             )
         )
@@ -140,7 +176,7 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
             DictationViewModel.engineIsReadyOrRestorableForPreview(
                 authAvailable: true,
                 isConfigured: false,
-                selectedModelId: nil,
+                hasPersistedRestorableModel: false,
                 canPrepare: true
             )
         )
@@ -151,7 +187,7 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
             DictationViewModel.engineIsReadyOrRestorableForPreview(
                 authAvailable: true,
                 isConfigured: false,
-                selectedModelId: nil,
+                hasPersistedRestorableModel: false,
                 canPrepare: false
             )
         )
@@ -162,7 +198,7 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
             DictationViewModel.engineIsReadyOrRestorableForPreview(
                 authAvailable: false,
                 isConfigured: true,
-                selectedModelId: "some-model",
+                hasPersistedRestorableModel: true,
                 canPrepare: true
             )
         )

--- a/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
+++ b/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import TypeWhisper
+
+final class LivePreviewEngineResolutionTests: XCTestCase {
+    func testNoPreferenceFollowsDictationEngine() {
+        XCTAssertNil(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: nil,
+                dictationEngineOverrideId: nil,
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in true }
+            )
+        )
+    }
+
+    func testNoPreferenceKeepsProfileEngineOverride() {
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: nil,
+                dictationEngineOverrideId: "profile-engine",
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in true }
+            ),
+            "profile-engine"
+        )
+    }
+
+    func testEmptyPreferenceFollowsDictationEngine() {
+        XCTAssertNil(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: "",
+                dictationEngineOverrideId: nil,
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in true }
+            )
+        )
+    }
+
+    func testUnavailablePreferenceFollowsDictationEngine() {
+        XCTAssertNil(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: "speechanalyzer",
+                dictationEngineOverrideId: nil,
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in false }
+            )
+        )
+    }
+
+    func testDistinctAvailablePreferenceWins() {
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: "speechanalyzer",
+                dictationEngineOverrideId: nil,
+                selectedProviderId: "groq",
+                isEngineAvailable: { $0 == "speechanalyzer" }
+            ),
+            "speechanalyzer"
+        )
+    }
+
+    func testPreferenceMatchingSelectedProviderStaysOnDictationPath() {
+        // Returning the dictation override (nil) rather than the preference keeps
+        // the cloud model override flowing on the unchanged code path.
+        XCTAssertNil(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: "groq",
+                dictationEngineOverrideId: nil,
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in true }
+            )
+        )
+    }
+
+    func testPreferenceMatchingProfileOverrideStaysOnDictationPath() {
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: "profile-engine",
+                dictationEngineOverrideId: "profile-engine",
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in true }
+            ),
+            "profile-engine"
+        )
+    }
+
+    func testPreferenceDistinctFromProfileOverrideWins() {
+        XCTAssertEqual(
+            DictationViewModel.resolvePreviewEngineOverrideId(
+                preferredPreviewEngineId: "speechanalyzer",
+                dictationEngineOverrideId: "profile-engine",
+                selectedProviderId: "groq",
+                isEngineAvailable: { _ in true }
+            ),
+            "speechanalyzer"
+        )
+    }
+
+    func testLoadPersistRoundTrip() {
+        let defaults = UserDefaults(suiteName: "LivePreviewEngineResolutionTests")!
+        defaults.removePersistentDomain(forName: "LivePreviewEngineResolutionTests")
+
+        XCTAssertNil(DictationViewModel.loadLivePreviewEngineId(defaults: defaults))
+
+        DictationViewModel.persistLivePreviewEngineId("speechanalyzer", defaults: defaults)
+        XCTAssertEqual(DictationViewModel.loadLivePreviewEngineId(defaults: defaults), "speechanalyzer")
+
+        DictationViewModel.persistLivePreviewEngineId(nil, defaults: defaults)
+        XCTAssertNil(DictationViewModel.loadLivePreviewEngineId(defaults: defaults))
+
+        DictationViewModel.persistLivePreviewEngineId("", defaults: defaults)
+        XCTAssertNil(DictationViewModel.loadLivePreviewEngineId(defaults: defaults))
+
+        defaults.removePersistentDomain(forName: "LivePreviewEngineResolutionTests")
+    }
+}

--- a/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
+++ b/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
@@ -146,14 +146,42 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
 
         XCTAssertFalse(
             DictationViewModel.hasPersistedRestorableModel(
-                providerId: "com.typewhisper.parakeet", defaults: defaults
+                pluginId: "com.typewhisper.parakeet", defaults: defaults
             )
         )
         defaults.set("parakeet-tdt-0.6b-v3", forKey: "plugin.com.typewhisper.parakeet.loadedModel")
         XCTAssertTrue(
             DictationViewModel.hasPersistedRestorableModel(
-                providerId: "com.typewhisper.parakeet", defaults: defaults
+                pluginId: "com.typewhisper.parakeet", defaults: defaults
             )
+        )
+        defaults.removePersistentDomain(forName: suite)
+    }
+
+    /// `HostServicesImpl` writes `plugin.<manifest.id>.loadedModel`, and a plugin's
+    /// manifest id is NOT its engine `providerId` ("com.typewhisper.parakeet" vs
+    /// "parakeet"). Looking the key up under the provider id silently never matches,
+    /// which would make every auto-unloaded local preview engine resolve as
+    /// unavailable. Lock the distinction so the lookup cannot regress to a provider id.
+    func testPersistedRestorableModelDoesNotMatchProviderIdKey() {
+        let suite = "LivePreviewEngineResolutionTests-restore-idform"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        // Exactly what the plugin host persists.
+        defaults.set("parakeet-tdt-0.6b-v3", forKey: "plugin.com.typewhisper.parakeet.loadedModel")
+
+        XCTAssertTrue(
+            DictationViewModel.hasPersistedRestorableModel(
+                pluginId: "com.typewhisper.parakeet", defaults: defaults
+            ),
+            "manifest-id lookup must find the key the host wrote"
+        )
+        XCTAssertFalse(
+            DictationViewModel.hasPersistedRestorableModel(
+                pluginId: "parakeet", defaults: defaults
+            ),
+            "a providerId-shaped lookup must not match — it is the regression this guards"
         )
         defaults.removePersistentDomain(forName: suite)
     }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -5937,9 +5937,19 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         // Unit tests must start from the documented defaults (preview enabled,
         // preview engine = match dictation engine); the test host app's persisted
-        // preferences would otherwise leak in.
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+        // preferences would otherwise leak in. `DictationViewModel` reads both keys
+        // synchronously in its initializer, so restoring on exit keeps the isolation
+        // while leaving a developer's real preferences untouched.
+        let livePreviewEngineKey = UserDefaultsKeys.livePreviewEngineId
+        let previewEnabledKey = UserDefaultsKeys.indicatorTranscriptPreviewEnabled
+        let originalLivePreviewEngine = UserDefaults.standard.object(forKey: livePreviewEngineKey)
+        let originalPreviewEnabled = UserDefaults.standard.object(forKey: previewEnabledKey)
+        UserDefaults.standard.removeObject(forKey: livePreviewEngineKey)
+        UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+        defer {
+            Self.restoreUserDefault(originalLivePreviewEngine, forKey: livePreviewEngineKey)
+            Self.restoreUserDefault(originalPreviewEnabled, forKey: previewEnabledKey)
+        }
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
@@ -6355,9 +6365,19 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         // Unit tests must start from the documented defaults (preview enabled,
         // preview engine = match dictation engine); the test host app's persisted
-        // preferences would otherwise leak in.
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+        // preferences would otherwise leak in. `DictationViewModel` reads both keys
+        // synchronously in its initializer, so restoring on exit keeps the isolation
+        // while leaving a developer's real preferences untouched.
+        let livePreviewEngineKey = UserDefaultsKeys.livePreviewEngineId
+        let previewEnabledKey = UserDefaultsKeys.indicatorTranscriptPreviewEnabled
+        let originalLivePreviewEngine = UserDefaults.standard.object(forKey: livePreviewEngineKey)
+        let originalPreviewEnabled = UserDefaults.standard.object(forKey: previewEnabledKey)
+        UserDefaults.standard.removeObject(forKey: livePreviewEngineKey)
+        UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+        defer {
+            Self.restoreUserDefault(originalLivePreviewEngine, forKey: livePreviewEngineKey)
+            Self.restoreUserDefault(originalPreviewEnabled, forKey: previewEnabledKey)
+        }
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
@@ -6670,9 +6690,19 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         // Unit tests must start from the documented defaults (preview enabled,
         // preview engine = match dictation engine); the test host app's persisted
-        // preferences would otherwise leak in.
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
-        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+        // preferences would otherwise leak in. `DictationViewModel` reads both keys
+        // synchronously in its initializer, so restoring on exit keeps the isolation
+        // while leaving a developer's real preferences untouched.
+        let livePreviewEngineKey = UserDefaultsKeys.livePreviewEngineId
+        let previewEnabledKey = UserDefaultsKeys.indicatorTranscriptPreviewEnabled
+        let originalLivePreviewEngine = UserDefaults.standard.object(forKey: livePreviewEngineKey)
+        let originalPreviewEnabled = UserDefaults.standard.object(forKey: previewEnabledKey)
+        UserDefaults.standard.removeObject(forKey: livePreviewEngineKey)
+        UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+        defer {
+            Self.restoreUserDefault(originalLivePreviewEngine, forKey: livePreviewEngineKey)
+            Self.restoreUserDefault(originalPreviewEnabled, forKey: previewEnabledKey)
+        }
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -5935,6 +5935,10 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
 
+        // Unit tests must start from the documented default (nil = match dictation
+        // engine); the test host app's persisted preference would otherwise leak in.
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
             textInsertionService: textInsertionService,
@@ -6347,6 +6351,10 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
 
+        // Unit tests must start from the documented default (nil = match dictation
+        // engine); the test host app's persisted preference would otherwise leak in.
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
             textInsertionService: textInsertionService,
@@ -6655,6 +6663,10 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
         let mediaPlaybackService = mediaPlaybackService ?? MediaPlaybackService(startListening: false)
+
+        // Unit tests must start from the documented default (nil = match dictation
+        // engine); the test host app's persisted preference would otherwise leak in.
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -5935,9 +5935,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
 
-        // Unit tests must start from the documented default (nil = match dictation
-        // engine); the test host app's persisted preference would otherwise leak in.
+        // Unit tests must start from the documented defaults (preview enabled,
+        // preview engine = match dictation engine); the test host app's persisted
+        // preferences would otherwise leak in.
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
@@ -6351,9 +6353,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
 
-        // Unit tests must start from the documented default (nil = match dictation
-        // engine); the test host app's persisted preference would otherwise leak in.
+        // Unit tests must start from the documented defaults (preview enabled,
+        // preview engine = match dictation engine); the test host app's persisted
+        // preferences would otherwise leak in.
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,
@@ -6664,9 +6668,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let settingsViewModel = SettingsViewModel(modelManager: modelManager)
         let mediaPlaybackService = mediaPlaybackService ?? MediaPlaybackService(startListening: false)
 
-        // Unit tests must start from the documented default (nil = match dictation
-        // engine); the test host app's persisted preference would otherwise leak in.
+        // Unit tests must start from the documented defaults (preview enabled,
+        // preview engine = match dictation engine); the test host app's persisted
+        // preferences would otherwise leak in.
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.livePreviewEngineId)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
 
         let dictationViewModel = DictationViewModel(
             audioRecordingService: audioRecordingService,


### PR DESCRIPTION
## Summary

Adds an optional **"Live preview engine"** setting so the live transcript preview can run on a different (typically local, streaming) engine while the final transcription keeps using the selected dictation engine.

Motivation (details in the linked issue): with a cloud dictation engine that has no live-session support (e.g. Groq), the preview's batch fallback re-sends the rolling last-10 s audio window to the cloud every ~3 s for the entire recording — a 2–3x multiplier on provider audio-seconds plus ~1 request per 3 s of speech, all for throwaway preview text that an on-device streaming engine (Apple SpeechAnalyzer, Parakeet) could render instantly and for free.

Closes #942

### Changes

- `UserDefaultsKeys.livePreviewEngineId` — new optional preference (`nil` = match dictation engine, the prior behavior).
- `DictationViewModel` — persisted `livePreviewEngineId` published property; pure static `resolvePreviewEngineOverrideId(...)` resolver; `startLiveStreaming` passes the resolved preview engine to `StreamingHandler.start` and only forwards `cloudModelOverride` when the preview follows the dictation engine. Dictionary term hints for the streaming session follow the preview engine.
- **Display-only rule:** when the preview runs on a distinct engine, its output is never promoted to the final transcription — `stopDictation` discards the live-session result and skips the stable-preview fallback (`lastPreviewFollowsDictationEngine`), so the final text always comes from the dictation engine via `transcribeFinalAudio`, with correct model attribution.
- **Readiness gating:** preview-engine resolution requires `modelManager.canPrepareForTranscription` (installed + configured, not merely present), falling back to prior behavior otherwise; the settings picker disables not-ready engines with the existing "(not ready)" affordance.
- `GeneralSettingsView` — picker under the "Show live transcript preview" toggle (default *Match dictation engine*), with a caption when a distinct engine is chosen.
- `LivePreviewEngineResolutionTests` — unit tests for the resolver (preference unset/empty/unavailable/equal-to-dictation-engine/distinct, with and without profile engine overrides) and load/persist round-trip.

Behavior is bit-identical to before whenever the preference is unset, the chosen engine is missing/not ready, or it equals the effective dictation engine — the resolver returns the original `engineOverrideId` in all those cases, and `lastPreviewFollowsDictationEngine` stays `true` so the stop path is untouched.

## Test Plan

- [x] Ran `scripts/pr-preflight.sh`
- [x] Built and ran locally (release build clean, zero new warnings)
- [x] Tested the changed functionality manually (Groq dictation engine + Apple Speech preview: unified log shows `Live transcript preview using live session providerId=speechAnalyzer` while history attributes the final transcript to groq/whisper-large-v3; with the picker on *Match dictation engine*, behavior verified identical to stock)
- [x] No regressions in existing features (full app suite 1226/1226 + SDK suite 384/384 green, including 9 new resolver unit tests)

Verification commands run:

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
swift test --package-path TypeWhisperPluginSDK
scripts/pr-preflight.sh
```

Manual verification: with Groq selected as dictation engine and Apple SpeechAnalyzer as the preview engine, the preview streams locally (no Groq requests until stop) and the final transcript still comes from Groq; with the picker on *Match dictation engine*, behavior is unchanged from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose a separate engine for live transcript previews or match the dictation engine.
  * Live previews can use a fast local engine to reduce network requests while speaking.
  * Preview engine preferences are saved and included in settings backups.
  * Added German and Japanese localization for the new settings.

* **Bug Fixes**
  * Improved fallback behavior when a selected preview engine is unavailable.
  * Ensured final transcription continues using the configured dictation engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->