### PR TITLE
Unify form-based settings pages

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA9400000000000000000001 /* SettingsVisualComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9400000000000000000001 /* SettingsVisualComponents.swift */; };
 		1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */; };
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
 		1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */; };
@@ -547,6 +548,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BB9400000000000000000001 /* SettingsVisualComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsVisualComponents.swift; sourceTree = "<group>"; };
 		05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDiffServiceTests.swift; sourceTree = "<group>"; };
 			3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioEngineRecoverySupportTests.swift; sourceTree = "<group>"; };
 			533A00000000000000000001 /* DictationRecoveryAudioStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationRecoveryAudioStoreTests.swift; sourceTree = "<group>"; };
@@ -1637,6 +1639,7 @@
 				BB00000000000000000016 /* FileTranscriptionView.swift */,
 				533C00000000000000000003 /* DictationRecoveryView.swift */,
 				BB00000000000000000017 /* SettingsView.swift */,
+				BB9400000000000000000001 /* SettingsVisualComponents.swift */,
 				C1F000000000000000000008 /* PremiumSettingsView.swift */,
 				BB00000000000000000359 /* WorkflowsSettingsView.swift */,
 				BB00000000000000000046 /* AdvancedSettingsView.swift */,
@@ -3909,6 +3912,7 @@
 				AA00000000000000000016 /* FileTranscriptionView.swift in Sources */,
 				533C00000000000000000004 /* DictationRecoveryView.swift in Sources */,
 				AA00000000000000000017 /* SettingsView.swift in Sources */,
+				AA9400000000000000000001 /* SettingsVisualComponents.swift in Sources */,
 				AA00000000000000000030 /* AudioRecordingService.swift in Sources */,
 				533A00000000000000000004 /* DictationRecoveryAudioStore.swift in Sources */,
 				AA00000000000000000350 /* ObjCExceptionCatcher.m in Sources */,

--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -20,8 +20,12 @@ struct AboutSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            Section {
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "About"))
+            Divider()
+
+            Form {
+                Section {
                 VStack(spacing: 12) {
                     Image(nsImage: NSApp.applicationIconImage)
                         .resizable()
@@ -57,7 +61,7 @@ struct AboutSettingsView: View {
                 .padding(.vertical, 12)
             }
 
-            Section {
+                Section {
                 Picker(String(localized: "Update Channel"), selection: updateChannelBinding) {
                     ForEach(AppConstants.ReleaseChannel.allCases, id: \.self) { channel in
                         Text(channel.selectionDisplayName)
@@ -80,7 +84,7 @@ struct AboutSettingsView: View {
                 }
             }
 
-            Section {
+                Section {
                 HStack {
                     Spacer()
                     Button {
@@ -102,7 +106,7 @@ struct AboutSettingsView: View {
                 .foregroundStyle(.secondary)
             }
 
-            Section {
+                Section {
                 VStack(spacing: 4) {
                     Text(String(localized: "\u{00A9} 2024-2026 TypeWhisper Contributors"))
                         .font(.caption)
@@ -113,10 +117,12 @@ struct AboutSettingsView: View {
                         .foregroundStyle(.tertiary)
                 }
                 .frame(maxWidth: .infinity)
+                }
             }
+            .formStyle(.grouped)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
-        .formStyle(.grouped)
-        .padding()
         .frame(minWidth: 500, minHeight: 300)
     }
 

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -24,9 +24,13 @@ struct AdvancedSettingsView: View {
     @AppStorage(UserDefaultsKeys.saveAudioWithHistory) private var saveAudioWithHistory: Bool = false
 
     var body: some View {
-        Form {
-            // MARK: - Support Diagnostics
-            Section(localizedAppText("Support Diagnostics", de: "Support-Diagnose")) {
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "Advanced"))
+            Divider()
+
+            Form {
+                // MARK: - Support Diagnostics
+                Section(localizedAppText("Support Diagnostics", de: "Support-Diagnose")) {
                 HStack {
                     Button {
                         exportDiagnostics()
@@ -44,8 +48,8 @@ struct AdvancedSettingsView: View {
                 }
             }
 
-            // MARK: - Memory
-            Section(String(localized: "Memory")) {
+                // MARK: - Memory
+                Section(String(localized: "Memory")) {
                 Toggle(isOn: $memoryService.isEnabled) {
                     SettingsInfoLabel(
                         title: String(localized: "Enable Memory"),
@@ -147,8 +151,8 @@ struct AdvancedSettingsView: View {
                 }
             }
 
-            // MARK: - Recording
-            Section(String(localized: "Recording")) {
+                // MARK: - Recording
+                Section(String(localized: "Recording")) {
                 Picker(selection: Binding(
                     get: { modelManager.autoUnloadSeconds },
                     set: { modelManager.autoUnloadSeconds = $0 }
@@ -269,10 +273,10 @@ struct AdvancedSettingsView: View {
                 }
             }
 
-            SpokenPunctuationSettingsSection()
+                SpokenPunctuationSettingsSection()
 
-            // MARK: - History
-            Section(String(localized: "History")) {
+                // MARK: - History
+                Section(String(localized: "History")) {
                 Toggle(isOn: $historyEnabled) {
                     SettingsInfoLabel(
                         title: String(localized: "Save history"),
@@ -319,8 +323,8 @@ struct AdvancedSettingsView: View {
                 }
             }
 
-            // MARK: - API Server
-            Section(String(localized: "API Server")) {
+                // MARK: - API Server
+                Section(String(localized: "API Server")) {
                 Toggle(isOn: $viewModel.isEnabled) {
                     SettingsInfoLabel(
                         title: String(localized: "Enable API Server"),
@@ -363,8 +367,8 @@ struct AdvancedSettingsView: View {
                 }
             }
 
-            // MARK: - Command Line Tool
-            Section(String(localized: "Command Line Tool")) {
+                // MARK: - Command Line Tool
+                Section(String(localized: "Command Line Tool")) {
                 HStack {
                     Image(systemName: "circle.fill")
                         .foregroundStyle(cliInstalled ? .green : .orange)
@@ -396,19 +400,19 @@ struct AdvancedSettingsView: View {
                 }
             }
 
-            // MARK: - Usage Examples
-            if viewModel.isEnabled {
-                Section(String(localized: "Usage Examples")) {
+                // MARK: - Usage Examples
+                if viewModel.isEnabled {
+                    Section(String(localized: "Usage Examples")) {
                     if cliInstalled {
                         cliExamples
                     } else {
                         curlExamples
                     }
+                    }
                 }
-            }
 
-            // MARK: - Integrations
-            Section(String(localized: "Integrations")) {
+                // MARK: - Integrations
+                Section(String(localized: "Integrations")) {
                 HStack(alignment: .top, spacing: 12) {
                     Image(systemName: "command.square")
                         .font(.title2)
@@ -438,10 +442,12 @@ struct AdvancedSettingsView: View {
                         }
                     }
                 }
+                }
             }
+            .formStyle(.grouped)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
-        .formStyle(.grouped)
-        .padding()
         .frame(minWidth: 500, minHeight: 300)
         .onAppear {
             raycastInstalled = NSWorkspace.shared.urlForApplication(

--- a/TypeWhisper/Views/DictationRecoveryView.swift
+++ b/TypeWhisper/Views/DictationRecoveryView.swift
@@ -6,7 +6,14 @@ struct DictationRecoveryView: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        recoveryForm
+        VStack(spacing: 0) {
+            SettingsPageHeader(localizedAppText("Recovery", de: "Wiederherstellung"))
+            Divider()
+
+            recoveryForm
+                .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+                .padding(.bottom, SettingsLayoutMetrics.pagePadding)
+        }
         .frame(minWidth: 500, minHeight: 400)
     }
 

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -85,8 +85,12 @@ struct GeneralSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            Section(String(localized: "Spoken Language")) {
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "General"))
+            Divider()
+
+            Form {
+                Section(String(localized: "Spoken Language")) {
                 LanguageSelectionEditor(
                     selection: $settings.languageSelection,
                     availableLanguages: settings.availableLanguages,
@@ -98,9 +102,9 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            #if canImport(Translation)
-            if #available(macOS 15, *) {
-                Section(String(localized: "Translation")) {
+                #if canImport(Translation)
+                if #available(macOS 15, *) {
+                    Section(String(localized: "Translation")) {
                     Toggle(String(localized: "Enable translation"), isOn: $settings.translationEnabled)
 
                     if settings.translationEnabled {
@@ -114,11 +118,11 @@ struct GeneralSettingsView: View {
                     Text(String(localized: "Uses Apple Translate (on-device)"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    }
                 }
-            }
-            #endif
+                #endif
 
-            Section(String(localized: "Language")) {
+                Section(String(localized: "Language")) {
                 Picker(String(localized: "App Language"), selection: $appLanguage) {
                     Text("English").tag("en")
                     Text("Deutsch").tag("de")
@@ -131,7 +135,7 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            Section(String(localized: "Startup")) {
+                Section(String(localized: "Startup")) {
                 Toggle(String(localized: "Launch at Login"), isOn: $launchAtLogin)
                     .onChange(of: launchAtLogin) { _, newValue in
                         toggleLaunchAtLogin(newValue)
@@ -142,7 +146,7 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section(String(localized: "Appearance")) {
+                Section(String(localized: "Appearance")) {
                 Picker(String(localized: "App visibility"), selection: Binding(
                     get: { appVisibilityMode },
                     set: { appVisibilityMode = $0 }
@@ -157,7 +161,7 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section(String(localized: "Indicator")) {
+                Section(String(localized: "Indicator")) {
                 IndicatorPreviewView()
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Color.clear)
@@ -231,11 +235,12 @@ struct GeneralSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                }
             }
-
+            .formStyle(.grouped)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
-        .formStyle(.grouped)
-        .padding()
         .frame(minWidth: 500, minHeight: 300)
         .alert(String(localized: "Restart Required"), isPresented: $showRestartAlert) {
             Button(String(localized: "Restart Now")) {

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -7,9 +7,13 @@ struct HotkeySettingsView: View {
     private let secureInputRefresh = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        Form {
-            if secureInputDiagnostics.isActive {
-                Section {
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "Hotkeys"))
+            Divider()
+
+            Form {
+                if secureInputDiagnostics.isActive {
+                    Section {
                     Label {
                         Text(String(localized: "Secure Input is active in \(secureInputDiagnostics.userFacingOwner). Standard key+modifier shortcuts should keep working. Fallback-only shortcut types may not work until that app leaves password or sensitive input."))
                             .font(.callout)
@@ -18,10 +22,10 @@ struct HotkeySettingsView: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                     }
+                    }
                 }
-            }
 
-            Section(String(localized: "Hotkeys")) {
+                Section(String(localized: "Hotkeys")) {
                 MultiHotkeySlotRecorder(
                     slot: .hybrid,
                     title: String(localized: "Hybrid"),
@@ -41,7 +45,7 @@ struct HotkeySettingsView: View {
                 )
             }
 
-            Section(localizedAppText("Workflow Palette", de: "Workflow-Palette")) {
+                Section(localizedAppText("Workflow Palette", de: "Workflow-Palette")) {
                 MultiHotkeySlotRecorder(
                     slot: .promptPalette,
                     title: localizedAppText("Palette shortcut", de: "Palette-Shortcut"),
@@ -56,7 +60,7 @@ struct HotkeySettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section(String(localized: "settings.tab.recorder")) {
+                Section(String(localized: "settings.tab.recorder")) {
                 MultiHotkeySlotRecorder(
                     slot: .recorderToggle,
                     title: String(localized: "recorder.shortcut.title"),
@@ -64,7 +68,7 @@ struct HotkeySettingsView: View {
                 )
             }
 
-            Section(String(localized: "Recent Transcriptions")) {
+                Section(String(localized: "Recent Transcriptions")) {
                 MultiHotkeySlotRecorder(
                     slot: .recentTranscriptions,
                     title: String(localized: "Recent transcription shortcut"),
@@ -76,10 +80,12 @@ struct HotkeySettingsView: View {
                     title: String(localized: "Copy last transcription shortcut"),
                     subtitle: String(localized: "Copy your latest transcription to the clipboard.")
                 )
+                }
             }
+            .formStyle(.grouped)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
-        .formStyle(.grouped)
-        .padding()
         .frame(minWidth: 500, minHeight: 300)
         .onReceive(secureInputRefresh) { _ in
             secureInputDiagnostics = SecureInputDiagnosticsProvider.snapshot()

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -773,12 +773,16 @@ struct RecordingSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            if needsPermissions {
-                PermissionsBanner(dictation: dictation)
-            }
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "Dictation"))
+            Divider()
 
-            Section(String(localized: "Spoken Language")) {
+            Form {
+                if needsPermissions {
+                    PermissionsBanner(dictation: dictation)
+                }
+
+                Section(String(localized: "Spoken Language")) {
                 LanguageSelectionEditor(
                     selection: $settings.languageSelection,
                     availableLanguages: settings.availableLanguages,
@@ -790,7 +794,7 @@ struct RecordingSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section(String(localized: "Engine")) {
+                Section(String(localized: "Engine")) {
                 let engines = pluginManager.transcriptionEngines
                 if engines.isEmpty {
                     Text(String(localized: "No transcription engines installed. Install engines via Integrations."))
@@ -836,7 +840,7 @@ struct RecordingSettingsView: View {
                 }
             }
 
-            Section(String(localized: "Microphone")) {
+                Section(String(localized: "Microphone")) {
                 Picker(String(localized: "Input Device"), selection: inputDeviceSelectionBinding) {
                     Text(String(localized: "System Default")).tag(nil as String?)
                     Divider()
@@ -904,7 +908,7 @@ struct RecordingSettingsView: View {
                 }
             }
 
-            Section(String(localized: "Sound")) {
+                Section(String(localized: "Sound")) {
                 Toggle(String(localized: "Play sound feedback"), isOn: $dictation.soundFeedbackEnabled)
 
                 if dictation.soundFeedbackEnabled {
@@ -919,7 +923,7 @@ struct RecordingSettingsView: View {
 
             }
 
-            Section(String(localized: "Clipboard")) {
+                Section(String(localized: "Clipboard")) {
                 Toggle(String(localized: "Preserve clipboard content"), isOn: $dictation.preserveClipboard)
 
                 Text(String(localized: "Restores your clipboard after text insertion. Without this, your clipboard contains the transcribed text after dictation."))
@@ -927,7 +931,7 @@ struct RecordingSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section(String(localized: "Output Formatting")) {
+                Section(String(localized: "Output Formatting")) {
                 Toggle(String(localized: "App-aware formatting"), isOn: Binding(
                     get: { UserDefaults.standard.bool(forKey: UserDefaultsKeys.appFormattingEnabled) },
                     set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.appFormattingEnabled) }
@@ -947,7 +951,7 @@ struct RecordingSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section(String(localized: "Audio Ducking")) {
+                Section(String(localized: "Audio Ducking")) {
                 Toggle(String(localized: "Reduce system volume during recording"), isOn: $dictation.audioDuckingEnabled)
 
                 if dictation.audioDuckingEnabled {
@@ -965,7 +969,7 @@ struct RecordingSettingsView: View {
                 }
             }
 
-            Section(String(localized: "Media Pause")) {
+                Section(String(localized: "Media Pause")) {
                 Toggle(String(localized: "Pause media playback during recording"), isOn: $dictation.mediaPauseEnabled)
 
                 Text(String(localized: "Automatically pauses music and videos while recording and resumes when done. Uses macOS system media controls - may not work with all apps."))
@@ -973,8 +977,8 @@ struct RecordingSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            if needsPermissions {
-                Section(String(localized: "Permissions")) {
+                if needsPermissions {
+                    Section(String(localized: "Permissions")) {
                     if dictation.needsMicPermission {
                         HStack {
                             Label(
@@ -1010,11 +1014,13 @@ struct RecordingSettingsView: View {
                             .controlSize(.small)
                         }
                     }
+                    }
                 }
             }
+            .formStyle(.grouped)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
-        .formStyle(.grouped)
-        .padding()
         .frame(minWidth: 500, minHeight: 300)
         .onAppear {
             modelManager.restoreProviderSelection()

--- a/TypeWhisper/Views/SettingsVisualComponents.swift
+++ b/TypeWhisper/Views/SettingsVisualComponents.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+enum SettingsLayoutMetrics {
+    static let pagePadding: CGFloat = 20
+    static let sectionSpacing: CGFloat = 16
+    static let cardSpacing: CGFloat = 16
+    static let cardPadding: CGFloat = 16
+    static let cardCornerRadius: CGFloat = 12
+    static let compactCornerRadius: CGFloat = 8
+}
+
+struct SettingsPageHeader<Actions: View>: View {
+    let title: String
+    let summary: String?
+    @ViewBuilder let actions: Actions
+
+    init(
+        _ title: String,
+        summary: String? = nil,
+        @ViewBuilder actions: () -> Actions
+    ) {
+        self.title = title
+        self.summary = summary
+        self.actions = actions()
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.title2.weight(.semibold))
+
+                if let summary {
+                    Text(summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 16)
+
+            actions
+                .controlSize(.small)
+        }
+        .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.bar)
+    }
+}
+
+extension SettingsPageHeader where Actions == EmptyView {
+    init(_ title: String, summary: String? = nil) {
+        self.init(title, summary: summary) {
+            EmptyView()
+        }
+    }
+}
+
+struct SettingsCard<Content: View>: View {
+    let selected: Bool
+    let accent: Color
+    @ViewBuilder let content: Content
+
+    init(
+        selected: Bool = false,
+        accent: Color = .accentColor,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.selected = selected
+        self.accent = accent
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(SettingsLayoutMetrics.cardPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
+                    .stroke(
+                        selected ? accent.opacity(0.8) : Color.primary.opacity(0.08),
+                        lineWidth: selected ? 1.5 : 1
+                    )
+            )
+    }
+}
+
+struct SettingsEmptyState<Action: View>: View {
+    let systemImage: String
+    let title: String
+    let message: String
+    @ViewBuilder let action: Action
+
+    init(
+        systemImage: String,
+        title: String,
+        message: String,
+        @ViewBuilder action: () -> Action
+    ) {
+        self.systemImage = systemImage
+        self.title = title
+        self.message = message
+        self.action = action()
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            Text(title)
+                .font(.headline)
+
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+
+            action
+        }
+        .padding(SettingsLayoutMetrics.pagePadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+extension SettingsEmptyState where Action == EmptyView {
+    init(systemImage: String, title: String, message: String) {
+        self.init(systemImage: systemImage, title: title, message: message) {
+            EmptyView()
+        }
+    }
+}

--- a/docs/specs/2026-07-18-settings-visual-language-design.md
+++ b/docs/specs/2026-07-18-settings-visual-language-design.md
@@ -1,0 +1,81 @@
+# Settings Visual Language
+
+## Context
+
+TypeWhisper's settings destinations currently use several unrelated presentation styles:
+native grouped forms, custom lists and toolbars, data dashboards, and branded card layouts.
+The settings sidebar already provides a stable macOS navigation shell, so this work focuses on
+making the destination views feel like one product without replacing their specialized behavior.
+
+## Direction
+
+Use a native macOS hybrid visual language:
+
+- Keep native `Form`, `List`, picker, toolbar, and split-view behavior where it fits the task.
+- Give every destination the same fixed page-header rhythm.
+- Reuse semantic system surfaces, spacing, corner radii, borders, and empty-state presentation.
+- Preserve specialized layouts for workflows, history, integrations, premium, and licensing.
+- Keep the existing macOS 15+ `NSSplitViewController` shell and macOS 14 sidebar fallback.
+
+## Shared Components
+
+The shared vocabulary is deliberately small:
+
+- `SettingsPageHeader` presents a title, an optional existing summary, and optional trailing actions.
+- `SettingsCard` provides the standard semantic card surface and optional selected-state accent.
+- `SettingsEmptyState` provides a consistent symbol, title, message, and optional action.
+- `SettingsLayoutMetrics` defines the common 20-point page edge, 16-point section/card spacing,
+  16-point card inset, 12-point card radius, and 8-point compact-control radius.
+
+These components are internal to the app. They do not change the plugin SDK, persistence,
+view-model interfaces, or user data.
+
+## Page Families
+
+### Form pages
+
+General, Dictation, Hotkeys, Recovery, Advanced, and About keep grouped native forms. Their page
+header sits above the form, separated by a divider, and their content uses the shared page edge.
+
+### Dashboard and collection pages
+
+Home, Statistics, Dictionary, and Snippets keep their existing dashboards, filters, editing flows,
+and list structures. They adopt the shared page header, cards, empty states, and layout metrics.
+
+### Tool and workspace pages
+
+History, File Transcription, and Recorder keep their specialized split, progress, and tool layouts.
+Only their top-level chrome and general surfaces are standardized.
+
+### Complex and commercial pages
+
+Workflows, Integrations, Premium, and License keep their builder, marketplace, entitlement, pricing,
+and purchasing hierarchy. General page chrome and base card surfaces use the shared vocabulary,
+while meaningful product/status tints remain local.
+
+## Color and Accessibility
+
+- Use semantic macOS colors for general surfaces and text.
+- Use accent or status colors only where they communicate selection, state, or product meaning.
+- Avoid white-opacity fills as general-purpose backgrounds because they do not adapt reliably
+  between light, dark, and increased-contrast appearances.
+- Keep keyboard behavior, accessibility labels, and VoiceOver grouping intact.
+- New user-facing strings must include English, German, and Japanese localizations.
+
+## Rollout
+
+Deliver the migration in five sequential pull requests:
+
+1. Shared foundation and form pages.
+2. Dashboard and collection pages.
+3. Tool and workspace pages.
+4. Complex and commercial pages.
+5. Full visual, localization, resize, and accessibility audit.
+
+No phase may intentionally change navigation, persisted state, view-model behavior, or plugin APIs.
+
+## Verification
+
+Each phase runs whitespace checks, repository preflight, and the complete `TypeWhisper` test scheme.
+The final audit uses the signed TypeWhisper-Dev app and covers all destinations at minimum, ideal,
+and wide window sizes in light and dark appearance, with English, German, and Japanese content.


### PR DESCRIPTION
## Issue context

Issue #940 defines a five-phase migration toward a consistent native macOS hybrid visual language across all settings destinations. This foundation phase documents the approved direction, introduces shared internal settings primitives, and migrates General, Dictation, Hotkeys, Recovery, Advanced, and About without changing navigation, view models, persistence, or behavior.

## What changed

- Document the shared settings visual language and rollout constraints.
- Add `SettingsPageHeader`, `SettingsCard`, `SettingsEmptyState`, and `SettingsLayoutMetrics` to the Xcode project.
- Move the six form destinations to fixed semantic headers while preserving grouped forms and existing actions.

## Test plan

```bash
git diff --check origin/main...HEAD
./scripts/pr-preflight.sh origin/main
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO\n```\n\nThe complete test scheme passed with 1,217 tests and 0 failures.\n\nCloses #944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent page headers, dividers, grouped forms, and spacing across settings screens.
  * Introduced reusable settings cards, empty states, and layout styling components.
  * Improved visual consistency for General, Advanced, Dictation, Hotkey, Recovery, and About settings.

* **Documentation**
  * Added design guidance for the settings visual language, accessibility, localization, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->