### PR TITLE
Unify dashboard and collection settings pages

### DIFF
--- a/TypeWhisper/Views/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/DictionarySettingsView.swift
@@ -20,6 +20,9 @@ struct DictionarySettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "Dictionary"))
+            Divider()
+
             dictionaryHeader
 
             if viewModel.filterTab == .termPacks {
@@ -32,8 +35,6 @@ struct DictionarySettingsView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .padding(.vertical, 8)
-        .padding(.horizontal, 8)
         .sheet(isPresented: $viewModel.isEditing) {
             DictionaryEditorSheet(viewModel: viewModel)
         }
@@ -144,8 +145,12 @@ struct DictionarySettingsView: View {
             .menuStyle(.borderlessButton)
             .frame(width: 28)
         }
-        .padding(.horizontal, 4)
-        .padding(.bottom, 4)
+        .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+        .padding(.vertical, SettingsLayoutMetrics.sectionSpacing)
+        .background(.bar)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
     }
 
     @ViewBuilder
@@ -249,8 +254,8 @@ struct DictionarySettingsView: View {
         )
         .frame(maxWidth: .infinity)
         .frame(height: 32)
-        .padding(.horizontal, 2)
-        .padding(.vertical, 6)
+        .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+        .padding(.vertical, 8)
     }
 
     private var dictionaryEntriesView: some View {
@@ -268,7 +273,8 @@ struct DictionarySettingsView: View {
                     }
                 }
             }
-            .padding(.horizontal, 2)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
     }
 
@@ -348,20 +354,12 @@ struct DictionarySettingsView: View {
     }
 
     private var emptyState: some View {
-        VStack {
-            Spacer()
+        SettingsEmptyState(
+            systemImage: "character.book.closed",
+            title: String(localized: "No dictionary entries"),
+            message: String(localized: "Terms help only on engines that support transcription-time biasing. Corrections always run after transcription and apply across engines.")
+        ) {
             VStack(spacing: 12) {
-                Image(systemName: "character.book.closed")
-                    .font(.system(size: 40))
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "No dictionary entries"))
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "Terms help only on engines that support transcription-time biasing. Corrections always run after transcription and apply across engines."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
                 HStack(spacing: 12) {
                     Button(String(localized: "Add Term")) {
                         viewModel.startCreating(type: .term)
@@ -394,7 +392,6 @@ struct DictionarySettingsView: View {
                 }
                 .buttonStyle(.bordered)
             }
-            Spacer()
         }
     }
 
@@ -409,7 +406,8 @@ struct DictionarySettingsView: View {
                 // Community Packs
                 communityPacksSection
             }
-            .padding(.horizontal, 2)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
     }
 
@@ -1119,11 +1117,11 @@ private struct TermPackCardView: View {
             }
         }
         .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .fill(Color(NSColor.controlBackgroundColor))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .strokeBorder(isHovering ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.06), lineWidth: 1)
         )
         .onHover { hovering in
@@ -1215,11 +1213,11 @@ private struct DictionaryCardView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .fill(Color(NSColor.controlBackgroundColor))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
         )
         .contentShape(Rectangle())
@@ -1312,11 +1310,11 @@ private struct DictionaryCorrectionGroupCardView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .fill(Color(NSColor.controlBackgroundColor))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
         )
         .contextMenu {

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -14,26 +14,17 @@ struct HomeSettingsView: View {
 
     private var dashboardView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Row 0: Permissions banner (outside scroll)
+            SettingsPageHeader(String(localized: "Dashboard"))
+            Divider()
+
             if dictation.needsMicPermission || dictation.needsAccessibilityPermission {
                 permissionsBanner
-                    .padding(.horizontal)
-                    .padding(.top)
+                    .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+                    .padding(.top, SettingsLayoutMetrics.sectionSpacing)
             }
-
-            // Header (outside scroll, always visible)
-            HStack {
-                Text(String(localized: "Dashboard"))
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                Spacer()
-            }
-            .padding(.horizontal)
-            .padding(.top)
-            .padding(.bottom, 8)
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
                     if license.shouldShowWorkUsagePrompt && !workUsagePromptDismissed {
                         workUsageCard
                     }
@@ -70,8 +61,8 @@ struct HomeSettingsView: View {
                     }
                     #endif
                 }
-                .padding(.horizontal)
-                .padding(.bottom)
+                .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+                .padding(.vertical, SettingsLayoutMetrics.sectionSpacing)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -130,10 +121,14 @@ struct HomeSettingsView: View {
                 )
             }
         }
-        .padding()
+        .padding(SettingsLayoutMetrics.cardPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     private func statisticsSummaryCard(title: String, value: String, systemImage: String) -> some View {
@@ -187,14 +182,14 @@ struct HomeSettingsView: View {
                 .buttonStyle(.bordered)
             }
         }
-        .padding(16)
+        .padding(SettingsLayoutMetrics.cardPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .fill(Color(nsColor: .controlBackgroundColor))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .stroke(Color.accentColor.opacity(0.2), lineWidth: 1)
         )
     }
@@ -274,9 +269,13 @@ struct HomeSettingsView: View {
                 }
             }
         }
-        .padding()
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(SettingsLayoutMetrics.cardPadding)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     // MARK: - Getting Started Card
@@ -311,7 +310,10 @@ struct HomeSettingsView: View {
                     .font(.body.weight(.medium))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.accentColor.opacity(0.1)))
+                    .background(
+                        RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius)
+                            .fill(Color.accentColor.opacity(0.1))
+                    )
                 Text(String(localized: "in any app to begin."))
                     .foregroundStyle(.secondary)
             }
@@ -319,8 +321,12 @@ struct HomeSettingsView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 24)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     // MARK: - Permissions Banner
@@ -357,8 +363,12 @@ struct HomeSettingsView: View {
             }
         }
         .foregroundStyle(.red)
-        .padding()
+        .padding(SettingsLayoutMetrics.cardPadding)
         .background(.red.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.red.opacity(0.25), lineWidth: 1)
+        )
     }
 }

--- a/TypeWhisper/Views/SnippetsSettingsView.swift
+++ b/TypeWhisper/Views/SnippetsSettingsView.swift
@@ -5,41 +5,42 @@ struct SnippetsSettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "Snippets")) {
+                Button {
+                    viewModel.startCreating()
+                } label: {
+                    Label(String(localized: "Add Snippet"), systemImage: "plus")
+                }
+                .help(String(localized: "Add new snippet"))
+                .accessibilityLabel(String(localized: "Add new snippet"))
+            }
+            Divider()
+
             if viewModel.snippets.isEmpty {
                 emptyState
             } else {
-                // Header with add button
                 HStack {
                     Text(String(format: String(localized: "%d Snippets"), viewModel.snippets.count))
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
                     Spacer()
-
-                    Button {
-                        viewModel.startCreating()
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .help(String(localized: "Add new snippet"))
-                    .accessibilityLabel(String(localized: "Add new snippet"))
                 }
-                .padding(.horizontal, 4)
-                .padding(.bottom, 8)
+                .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+                .padding(.vertical, 10)
 
                 ScrollView {
-                    LazyVStack(spacing: 10) {
+                    LazyVStack(spacing: SettingsLayoutMetrics.cardSpacing) {
                         ForEach(viewModel.snippets) { snippet in
                             SnippetCardView(snippet: snippet, viewModel: viewModel)
                         }
                     }
-                    .padding(.horizontal, 2)
+                    .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+                    .padding(.bottom, SettingsLayoutMetrics.pagePadding)
                 }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.vertical, 8)
-        .padding(.horizontal, 8)
         .sheet(isPresented: $viewModel.isEditing) {
             SnippetEditorSheet(viewModel: viewModel)
         }
@@ -54,26 +55,15 @@ struct SnippetsSettingsView: View {
     }
 
     private var emptyState: some View {
-        VStack {
-            Spacer()
-            VStack(spacing: 12) {
-                Image(systemName: "text.badge.plus")
-                    .font(.system(size: 40))
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "No snippets yet"))
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "Create snippets to automatically expand short triggers into longer text"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 320)
-                Button(String(localized: "Add Snippet")) {
-                    viewModel.startCreating()
-                }
-                .buttonStyle(.borderedProminent)
+        SettingsEmptyState(
+            systemImage: "text.badge.plus",
+            title: String(localized: "No snippets yet"),
+            message: String(localized: "Create snippets to automatically expand short triggers into longer text")
+        ) {
+            Button(String(localized: "Add Snippet")) {
+                viewModel.startCreating()
             }
-            Spacer()
+            .buttonStyle(.borderedProminent)
         }
     }
 }
@@ -129,11 +119,11 @@ private struct SnippetCardView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .fill(Color(NSColor.controlBackgroundColor))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius, style: .continuous)
                 .strokeBorder(isHovering ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.06), lineWidth: 1)
         )
         .contentShape(Rectangle())

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -10,19 +10,13 @@ struct StatisticsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(String(localized: "Statistics"))
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                Spacer()
+            SettingsPageHeader(String(localized: "Statistics")) {
                 timePeriodPicker
             }
-            .padding(.horizontal)
-            .padding(.top)
-            .padding(.bottom, 8)
+            Divider()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
                     if viewModel.hasAnyData {
                         overviewGrid
                         metricsGrid
@@ -36,8 +30,7 @@ struct StatisticsView: View {
                         emptyStateCard
                     }
                 }
-                .padding(.horizontal)
-                .padding(.bottom)
+                .padding(SettingsLayoutMetrics.pagePadding)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -54,7 +47,7 @@ struct StatisticsView: View {
         }
         .padding(2)
         .background(.quaternary.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius))
     }
 
     private func periodButton(_ period: TimePeriod) -> some View {
@@ -69,7 +62,7 @@ struct StatisticsView: View {
                 .padding(.vertical, 4)
                 .background(isSelected ? Color.accentColor : Color.clear)
                 .foregroundStyle(isSelected ? .white : .secondary)
-                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius))
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
@@ -212,9 +205,13 @@ struct StatisticsView: View {
                 .accessibilityLabel(chartAccessibilitySummary)
             }
         }
-        .padding()
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(SettingsLayoutMetrics.cardPadding)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     private var chartAccessibilitySummary: Text {
@@ -280,9 +277,13 @@ struct StatisticsView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding()
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(SettingsLayoutMetrics.cardPadding)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     // MARK: - Heatmap
@@ -312,9 +313,13 @@ struct StatisticsView: View {
                 heatmapGrid
             }
         }
-        .padding()
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(SettingsLayoutMetrics.cardPadding)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     private let heatmapLabelWidth: CGFloat = 28
@@ -425,9 +430,13 @@ struct StatisticsView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding()
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(SettingsLayoutMetrics.cardPadding)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 
     // MARK: - Empty state
@@ -446,8 +455,12 @@ struct StatisticsView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 24)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
     }
 }
 
@@ -474,8 +487,12 @@ private struct StatisticsStatCard: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text("\(title), \(accessibilityValue ?? value)"))
     }
@@ -506,8 +523,12 @@ struct StatisticsMetricCard: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(trendAwareAccessibilityLabel)
     }


### PR DESCRIPTION
## Issue context

Issue #940 defines a five-phase migration toward a consistent native macOS hybrid visual language across all settings destinations. This collection phase aligns Dashboard, Statistics, Dictionary, and Snippets while preserving their search, filtering, editing, navigation, and data behavior.

## What changed

- Replace destination-specific title rows with the shared fixed settings header.
- Apply shared page, section, card, and compact-control metrics.
- Use semantic macOS surfaces and shared card contours for dashboard and collection content.
- Adopt the shared empty-state presentation for existing Dictionary and Snippets copy.

## Test plan

```bash
git diff --check origin/main...HEAD
./scripts/pr-preflight.sh origin/main
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO\n```\n\nThe complete test scheme passed with 1,217 tests and 0 failures.\n\nCloses #945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized headers, spacing, padding, dividers, and empty states across settings, dictionary, snippets, home, and statistics views.
  * Updated cards, buttons, and selectors with consistent corner radii, backgrounds, borders, and visual styling.
  * Improved snippets empty state with clearer messaging and an accessible “Add Snippet” action.
  * Refined dashboard, statistics, dictionary, and term pack layouts for a more cohesive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->