### PR TITLE
Unify tool and workspace settings pages

### DIFF
--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -33,7 +33,11 @@ struct AudioRecorderView: View {
     }
 
     var body: some View {
-        Form {
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "settings.tab.recorder"))
+            Divider()
+
+            Form {
             // Recording Controls
             Section {
                 VStack(spacing: 16) {
@@ -309,9 +313,11 @@ struct AudioRecorderView: View {
                     }
                 }
             }
+            }
+            .formStyle(.grouped)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+            .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
-        .formStyle(.grouped)
-        .padding()
         .frame(minWidth: 500, minHeight: 400)
     }
 

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -11,23 +11,27 @@ struct FileTranscriptionView: View {
     @State private var expandedFileId: UUID?
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 16) {
-                if viewModel.files.isEmpty {
-                    dropZone
-                } else {
-                    fileList
-                    controls
-                }
-            }
-            .padding()
-
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "File Transcription"))
             Divider()
-                .padding(.horizontal)
 
-            // MARK: - Watch Folder
+            ScrollView {
+                VStack(spacing: SettingsLayoutMetrics.sectionSpacing) {
+                    if viewModel.files.isEmpty {
+                        dropZone
+                    } else {
+                        fileList
+                        controls
+                    }
+                }
+                .padding(SettingsLayoutMetrics.pagePadding)
 
-            Form {
+                Divider()
+                    .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+
+                // MARK: - Watch Folder
+
+                Form {
                 Section(String(localized: "watchFolder.folders")) {
                     HStack {
                         VStack(alignment: .leading, spacing: 2) {
@@ -193,8 +197,11 @@ struct FileTranscriptionView: View {
                         }
                     }
                 }
+                }
+                .formStyle(.grouped)
+                .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+                .padding(.bottom, SettingsLayoutMetrics.pagePadding)
             }
-            .formStyle(.grouped)
         }
         .frame(minWidth: 500, minHeight: 400)
         .onDrop(of: [.fileURL], isTargeted: $isDragTargeted) { providers in
@@ -247,10 +254,14 @@ struct FileTranscriptionView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(isDragTargeted ? Color.blue.opacity(0.1) : Color.clear)
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
+                .fill(
+                    isDragTargeted
+                        ? Color.blue.opacity(0.1)
+                        : Color(nsColor: .controlBackgroundColor)
+                )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12)
+                    RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
                         .strokeBorder(
                             isDragTargeted ? Color.blue : Color.secondary.opacity(0.3),
                             style: StrokeStyle(lineWidth: 2, dash: [8])
@@ -263,7 +274,7 @@ struct FileTranscriptionView: View {
 
     @ViewBuilder
     private var fileList: some View {
-        LazyVStack(spacing: 8) {
+        LazyVStack(spacing: SettingsLayoutMetrics.cardSpacing) {
             ForEach(viewModel.files) { item in
                 fileRow(item)
             }

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -8,21 +8,26 @@ struct HistoryView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            listPanel
-                .frame(minWidth: 280)
-
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "History"))
             Divider()
-                .opacity(hasSelection ? 1 : 0)
-                .frame(width: hasSelection ? 1 : 0)
 
-            detailPanelContainer
-                .frame(
-                    minWidth: hasSelection ? 300 : 0,
-                    idealWidth: hasSelection ? 340 : 0,
-                    maxWidth: hasSelection ? .infinity : 0
-                )
-                .clipped()
+            HStack(spacing: 0) {
+                listPanel
+                    .frame(minWidth: 280)
+
+                Divider()
+                    .opacity(hasSelection ? 1 : 0)
+                    .frame(width: hasSelection ? 1 : 0)
+
+                detailPanelContainer
+                    .frame(
+                        minWidth: hasSelection ? 300 : 0,
+                        idealWidth: hasSelection ? 340 : 0,
+                        maxWidth: hasSelection ? .infinity : 0
+                    )
+                    .clipped()
+            }
         }
         .frame(minHeight: 400)
     }
@@ -38,7 +43,7 @@ struct HistoryView: View {
             )
             .frame(maxWidth: .infinity)
             .frame(height: 32)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
             .padding(.vertical, 6)
             .background(.bar)
 
@@ -71,7 +76,7 @@ struct HistoryView: View {
 
                 Spacer()
             }
-            .padding(.horizontal, 8)
+            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
             .padding(.vertical, 6)
             .background(.bar)
 


### PR DESCRIPTION
## Issue context

Issue #940 defines a shared native macOS hybrid visual language for all 17 settings destinations while preserving navigation, behavior, and specialized workspace layouts. This third phase aligns History, File Transcription, and Recorder without changing their split view, progress, watch-folder, or recording flows.

## Changes

- add fixed shared settings headers above each workspace
- apply shared spacing and semantic surfaces to History and File Transcription
- preserve the History split layout, file-processing flow, watch-folder form, and Recorder controls

## Test plan

```bash
git diff --check origin/main...HEAD
./scripts/pr-preflight.sh origin/main
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Closes #946
