### PR TITLE
Unify complex settings pages

### DIFF
--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -29,38 +29,43 @@ struct LicenseSettingsView: View {
     }
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    Color.clear
-                        .frame(height: 0)
-                        .id(ScrollAnchor.top)
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "License"))
+            Divider()
 
-                    planSelectionSection
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
+                        Color.clear
+                            .frame(height: 0)
+                            .id(ScrollAnchor.top)
 
-                    if shouldShowCommercialSection {
-                        commercialSection
+                        planSelectionSection
+
+                        if shouldShowCommercialSection {
+                            commercialSection
+                        }
+
+                        supporterSection
+                            .id(ScrollAnchor.supporter)
+
+                        sharedActivationSection
+                            .id(ScrollAnchor.activationKey)
                     }
-
-                    supporterSection
-                        .id(ScrollAnchor.supporter)
-
-                    sharedActivationSection
-                        .id(ScrollAnchor.activationKey)
+                    .padding(SettingsLayoutMetrics.pagePadding)
                 }
-                .padding(20)
-            }
-            .frame(minWidth: 560, minHeight: 360)
-            .task(id: "\(license.supporterStatus.rawValue)-\(license.supporterTier?.rawValue ?? "none")") {
-                if license.isSupporter {
-                    await supporterDiscord.refreshStatusIfNeeded()
-                } else {
-                    supporterDiscord.handleSupporterEntitlementRemoved()
+                .frame(minWidth: 560, minHeight: 360)
+                .task(id: "\(license.supporterStatus.rawValue)-\(license.supporterTier?.rawValue ?? "none")") {
+                    if license.isSupporter {
+                        await supporterDiscord.refreshStatusIfNeeded()
+                    } else {
+                        supporterDiscord.handleSupporterEntitlementRemoved()
+                    }
                 }
-            }
-            .onReceive(settingsNavigation.$request.compactMap { $0 }) { request in
-                guard request.tab == .license else { return }
-                handleNavigation(request.licenseTarget ?? .top, proxy: proxy)
+                .onReceive(settingsNavigation.$request.compactMap { $0 }) { request in
+                    guard request.tab == .license else { return }
+                    handleNavigation(request.licenseTarget ?? .top, proxy: proxy)
+                }
             }
         }
     }
@@ -137,7 +142,7 @@ struct LicenseSettingsView: View {
     }
 
     private var sharedActivationSection: some View {
-        PanelCard {
+        SettingsCard {
             VStack(alignment: .leading, spacing: 12) {
                 Text(localizedAppText("Already have a key?", de: "Bereits einen Schlüssel?"))
                     .font(.headline)
@@ -192,7 +197,7 @@ struct LicenseSettingsView: View {
 
     private var inactiveCommercialSection: some View {
         VStack(alignment: .leading, spacing: 20) {
-            PanelCard {
+            SettingsCard {
                 VStack(alignment: .leading, spacing: 12) {
                     Text(localizedAppText("Pricing in short", de: "Preise im Überblick"))
                         .font(.headline)
@@ -236,7 +241,7 @@ struct LicenseSettingsView: View {
                 }
             }
 
-            PanelCard {
+            SettingsCard {
                 VStack(alignment: .leading, spacing: 10) {
                     Label(commercialStatusTitle, systemImage: commercialStatusSymbol)
                         .foregroundStyle(commercialStatusColor)
@@ -252,7 +257,7 @@ struct LicenseSettingsView: View {
 
     private var activeCommercialSection: some View {
         VStack(alignment: .leading, spacing: 20) {
-            PanelCard {
+            SettingsCard {
                 VStack(alignment: .leading, spacing: 10) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Label(localizedAppText("Licensed", de: "Lizenziert"), systemImage: "checkmark.seal.fill")
@@ -271,7 +276,7 @@ struct LicenseSettingsView: View {
                 }
             }
 
-            PanelCard {
+            SettingsCard {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(localizedAppText("Manage this Mac and your subscription", de: "Diesen Mac und dein Abo verwalten"))
                         .font(.headline)
@@ -329,7 +334,7 @@ struct LicenseSettingsView: View {
     // MARK: - Supporter
 
     private var supporterSection: some View {
-        PanelCard {
+        SettingsCard {
             VStack(alignment: .leading, spacing: 12) {
                 Text(localizedAppText("Supporter", de: "Supporter"))
                     .font(.headline)
@@ -982,36 +987,6 @@ func commercialPurchaseOptionCopy(for tier: LicenseTier, cadence: CommercialPurc
             billingLabel: localizedAppText("one-time", de: "einmalig"),
             detail: localizedAppText("Pay once, keep this tier", de: "Einmal zahlen, dieses Tier behalten")
         )
-    }
-}
-
-private struct PanelCard<Content: View>: View {
-    let selected: Bool
-    let accent: Color
-    @ViewBuilder let content: Content
-
-    init(
-        selected: Bool = false,
-        accent: Color = .accentColor,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.selected = selected
-        self.accent = accent
-        self.content = content()
-    }
-
-    var body: some View {
-        content
-            .padding(16)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color(nsColor: .controlBackgroundColor))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .stroke(selected ? accent.opacity(0.8) : Color.primary.opacity(0.08), lineWidth: selected ? 1.5 : 1)
-            )
     }
 }
 

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -188,7 +188,7 @@ struct PluginSettingsView: View {
             Divider()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
                     integrationTabHeader
 
                     switch selectedTab {
@@ -198,7 +198,7 @@ struct PluginSettingsView: View {
                         availableTab
                     }
                 }
-                .padding(16)
+                .padding(SettingsLayoutMetrics.pagePadding)
             }
         }
         .frame(minWidth: 560, minHeight: 420)
@@ -307,43 +307,26 @@ struct PluginSettingsView: View {
     // MARK: - Header
 
     private var integrationsHeader: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.title2)
-                .foregroundStyle(.blue)
-                .frame(width: 38, height: 38)
-                .background(RoundedRectangle(cornerRadius: 8).fill(.blue.opacity(0.12)))
+        SettingsPageHeader(
+            String(localized: "Integrations"),
+            summary: integrationSummaryText
+        ) {
+            HStack(spacing: 12) {
+                Button {
+                    pluginManager.openPluginsFolder()
+                } label: {
+                    Label(String(localized: "Open Plugins Folder"), systemImage: "folder")
+                }
+                .help(String(localized: "Open Plugins Folder"))
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "Integrations"))
-                    .font(.title3.weight(.semibold))
-                Text(integrationSummaryText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Button {
+                    installFromFile()
+                } label: {
+                    Label(localizedAppText("Install Plugin", de: "Plugin installieren"), systemImage: "plus")
+                }
+                .help(String(localized: "Install from File..."))
             }
-
-            Spacer()
-
-            Button {
-                pluginManager.openPluginsFolder()
-            } label: {
-                Label(String(localized: "Open Plugins Folder"), systemImage: "folder")
-            }
-            .controlSize(.small)
-            .help(String(localized: "Open Plugins Folder"))
-
-            Button {
-                installFromFile()
-            } label: {
-                Label(localizedAppText("Install Plugin", de: "Plugin installieren"), systemImage: "plus")
-            }
-            .controlSize(.small)
-            .help(String(localized: "Install from File..."))
         }
-        .padding(.horizontal)
-        .padding(.top, 14)
-        .padding(.bottom, 14)
-        .background(.bar)
     }
 
     private var integrationSummaryText: String {

--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -29,13 +29,18 @@ struct PremiumSettingsView: View {
     }
 
     var body: some View {
-        ScrollView {
-            premiumAccountCard
+        VStack(spacing: 0) {
+            SettingsPageHeader(String(localized: "Premium"))
+            Divider()
 
-            if license.hasCommercialLicense || premiumAccount.hasPremiumEntitlement {
-                premiumControlCenter
-            } else {
-                lockedPremiumLanding
+            ScrollView {
+                premiumAccountCard
+
+                if license.hasCommercialLicense || premiumAccount.hasPremiumEntitlement {
+                    premiumControlCenter
+                } else {
+                    lockedPremiumLanding
+                }
             }
         }
         .frame(minWidth: 560, minHeight: 360, alignment: .topLeading)
@@ -50,77 +55,77 @@ struct PremiumSettingsView: View {
     }
 
     private var premiumAccountCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Label(String(localized: "Cross-device Premium Account"), systemImage: "person.crop.circle")
-                    .font(.headline)
-                Spacer()
-                if premiumAccount.hasPremiumEntitlement {
-                    Label(String(localized: "Premium active"), systemImage: "checkmark.seal.fill")
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.green)
-                }
-            }
-
-            if premiumAccount.isSignedIn {
-                Text(String(localized: "Your Apple account keeps Polar and App Store entitlements available on Mac and iPhone."))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 10) {
                 HStack {
-                    Button(String(localized: "Sign Out")) { premiumAccount.signOut() }
-                    Button(String(localized: "Delete Account"), role: .destructive) { confirmingAccountDeletion = true }
-                }
-            } else {
-                SignInWithAppleButton(.signIn) { request in
-                    request.requestedScopes = [.fullName, .email]
-                    let nonceHash = SHA256.hash(data: Data(UUID().uuidString.utf8))
-                        .map { String(format: "%02x", $0) }
-                        .joined()
-                    appleNonceHash = nonceHash
-                    request.nonce = nonceHash
-                } onCompletion: { result in
-                    switch result {
-                    case .success(let authorization):
-                        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                              let tokenData = credential.identityToken,
-                              let identityToken = String(data: tokenData, encoding: .utf8),
-                              let nonceHash = appleNonceHash else { return }
-                        appleNonceHash = nil
-                        let authorizationCode = credential.authorizationCode.flatMap { String(data: $0, encoding: .utf8) }
-                        Task {
-                            await premiumAccount.signIn(
-                                identityToken: identityToken,
-                                authorizationCode: authorizationCode,
-                                nonceHash: nonceHash,
-                                polarLicenseKey: license.commercialLicenseKeyForAccountLink
-                            )
-                        }
-                    case .failure(let error):
-                        appleNonceHash = nil
-                        if (error as? ASAuthorizationError)?.code != .canceled {
-                            premiumAccount.errorMessage = error.localizedDescription
-                        }
+                    Label(String(localized: "Cross-device Premium Account"), systemImage: "person.crop.circle")
+                        .font(.headline)
+                    Spacer()
+                    if premiumAccount.hasPremiumEntitlement {
+                        Label(String(localized: "Premium active"), systemImage: "checkmark.seal.fill")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.green)
                     }
                 }
-                .signInWithAppleButtonStyle(.whiteOutline)
-                .frame(width: 240, height: 38)
 
-                Text(String(localized: "Sync data stays in your selected cloud location and never passes through the TypeWhisper account service."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                if premiumAccount.isSignedIn {
+                    Text(String(localized: "Your Apple account keeps Polar and App Store entitlements available on Mac and iPhone."))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    HStack {
+                        Button(String(localized: "Sign Out")) { premiumAccount.signOut() }
+                        Button(String(localized: "Delete Account"), role: .destructive) { confirmingAccountDeletion = true }
+                    }
+                } else {
+                    SignInWithAppleButton(.signIn) { request in
+                        request.requestedScopes = [.fullName, .email]
+                        let nonceHash = SHA256.hash(data: Data(UUID().uuidString.utf8))
+                            .map { String(format: "%02x", $0) }
+                            .joined()
+                        appleNonceHash = nonceHash
+                        request.nonce = nonceHash
+                    } onCompletion: { result in
+                        switch result {
+                        case .success(let authorization):
+                            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                                  let tokenData = credential.identityToken,
+                                  let identityToken = String(data: tokenData, encoding: .utf8),
+                                  let nonceHash = appleNonceHash else { return }
+                            appleNonceHash = nil
+                            let authorizationCode = credential.authorizationCode.flatMap { String(data: $0, encoding: .utf8) }
+                            Task {
+                                await premiumAccount.signIn(
+                                    identityToken: identityToken,
+                                    authorizationCode: authorizationCode,
+                                    nonceHash: nonceHash,
+                                    polarLicenseKey: license.commercialLicenseKeyForAccountLink
+                                )
+                            }
+                        case .failure(let error):
+                            appleNonceHash = nil
+                            if (error as? ASAuthorizationError)?.code != .canceled {
+                                premiumAccount.errorMessage = error.localizedDescription
+                            }
+                        }
+                    }
+                    .signInWithAppleButtonStyle(.whiteOutline)
+                    .frame(width: 240, height: 38)
 
-            if let errorMessage = premiumAccount.errorMessage {
-                Label(errorMessage, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
+                    Text(String(localized: "Sync data stays in your selected cloud location and never passes through the TypeWhisper account service."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let errorMessage = premiumAccount.errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
             }
         }
-        .padding(16)
         .frame(maxWidth: 760, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.055)))
-        .padding(.horizontal, 22)
-        .padding(.top, 22)
+        .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
+        .padding(.top, SettingsLayoutMetrics.pagePadding)
     }
 
     private var featureColumns: [GridItem] {
@@ -136,7 +141,7 @@ struct PremiumSettingsView: View {
     }
 
     private var lockedPremiumLanding: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
             lockedPremiumHero
 
             LazyVGrid(columns: featureColumns, alignment: .leading, spacing: 14) {
@@ -174,51 +179,47 @@ struct PremiumSettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(22)
+        .padding(SettingsLayoutMetrics.pagePadding)
         .frame(maxWidth: 760, alignment: .topLeading)
     }
 
     private var lockedPremiumHero: some View {
-        HStack(alignment: .top, spacing: 16) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 34, weight: .semibold))
-                .foregroundStyle(.yellow)
-                .frame(width: 58, height: 58)
-                .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(.yellow.opacity(0.13)))
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text(String(localized: "TypeWhisper gets better with every workflow"))
-                    .font(.system(size: 24, weight: .semibold))
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text(String(localized: "Teach TypeWhisper your corrections and keep dictionaries and snippets in sync across Macs."))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(3)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Label(String(localized: "Commercial license required"), systemImage: "lock.fill")
-                    .font(.caption.weight(.medium))
+        SettingsCard {
+            HStack(alignment: .top, spacing: SettingsLayoutMetrics.cardSpacing) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 34, weight: .semibold))
                     .foregroundStyle(.yellow)
-                    .padding(.horizontal, 9)
-                    .padding(.vertical, 5)
-                    .background(Capsule().fill(.yellow.opacity(0.13)))
-            }
+                    .frame(width: 58, height: 58)
+                    .background(
+                        RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)
+                            .fill(.yellow.opacity(0.13))
+                    )
+                    .accessibilityHidden(true)
 
-            Spacer(minLength: 12)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(String(localized: "TypeWhisper gets better with every workflow"))
+                        .font(.system(size: 24, weight: .semibold))
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(String(localized: "Teach TypeWhisper your corrections and keep dictionaries and snippets in sync across Macs."))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Label(String(localized: "Commercial license required"), systemImage: "lock.fill")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.yellow)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(Capsule().fill(.yellow.opacity(0.13)))
+                }
+
+                Spacer(minLength: 12)
+            }
         }
-        .padding(18)
         .frame(maxWidth: 640, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.07))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
-        )
     }
 
     private func premiumLandingFeatureCard(
@@ -229,80 +230,73 @@ struct PremiumSettingsView: View {
         examples: [PremiumCorrectionExample] = [],
         badges: [String] = []
     ) -> some View {
-        VStack(alignment: .leading, spacing: 13) {
-            HStack(alignment: .center, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.title2)
-                    .foregroundStyle(iconColor)
-                    .frame(width: 42, height: 42)
-                    .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(iconColor.opacity(0.12)))
-                    .accessibilityHidden(true)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 13) {
+                HStack(alignment: .center, spacing: 12) {
+                    Image(systemName: icon)
+                        .font(.title2)
+                        .foregroundStyle(iconColor)
+                        .frame(width: 42, height: 42)
+                        .background(
+                            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)
+                                .fill(iconColor.opacity(0.12))
+                        )
+                        .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(title)
-                        .font(.headline)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(title)
+                            .font(.headline)
 
-                    lockedPremiumBadge
-                }
-            }
-
-            Text(description)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            if !examples.isEmpty {
-                VStack(alignment: .leading, spacing: 7) {
-                    Text(String(localized: "Correction examples"))
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-
-                    ForEach(examples) { example in
-                        correctionExampleRow(example)
+                        lockedPremiumBadge
                     }
                 }
-            }
 
-            if !badges.isEmpty {
-                VStack(alignment: .leading, spacing: 7) {
-                    Text(String(localized: "Works with"))
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                Text(description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                    FlexibleTagRow(items: badges)
+                if !examples.isEmpty {
+                    VStack(alignment: .leading, spacing: 7) {
+                        Text(String(localized: "Correction examples"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        ForEach(examples) { example in
+                            correctionExampleRow(example)
+                        }
+                    }
                 }
-            }
 
-            Spacer(minLength: 0)
+                if !badges.isEmpty {
+                    VStack(alignment: .leading, spacing: 7) {
+                        Text(String(localized: "Works with"))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        FlexibleTagRow(items: badges)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
         }
-        .padding(16)
         .frame(maxWidth: .infinity, minHeight: 210, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.055))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
-        )
     }
 
     private var premiumLicenseCallout: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Label(String(localized: "A Commercial license unlocks both premium features."), systemImage: "lock.open")
-                .font(.callout.weight(.medium))
-                .foregroundStyle(.secondary)
+        SettingsCard {
+            HStack(alignment: .center, spacing: 12) {
+                Label(String(localized: "A Commercial license unlocks both premium features."), systemImage: "lock.open")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.secondary)
 
-            Spacer(minLength: 12)
+                Spacer(minLength: 12)
 
-            premiumLockedActionButton
+                premiumLockedActionButton
+            }
         }
-        .padding(14)
         .frame(maxWidth: 640, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.black.opacity(0.18))
-        )
     }
 
     private var premiumLockedActionButton: some View {
@@ -319,7 +313,7 @@ struct PremiumSettingsView: View {
             .font(.caption.weight(.medium))
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(Color.white.opacity(0.08))
+            .background(Color.secondary.opacity(0.10))
             .foregroundStyle(.secondary)
             .clipShape(Capsule())
             .lineLimit(1)
@@ -351,7 +345,7 @@ struct PremiumSettingsView: View {
 
             CloudFolderSyncSettingsView(controller: syncController)
         }
-        .padding(22)
+        .padding(SettingsLayoutMetrics.pagePadding)
         .frame(maxWidth: 760, alignment: .topLeading)
     }
 
@@ -394,39 +388,35 @@ struct PremiumSettingsView: View {
         value: String,
         description: String
     ) -> some View {
-        HStack(alignment: .top, spacing: 11) {
-            Image(systemName: icon)
-                .font(.headline)
-                .foregroundStyle(iconColor)
-                .frame(width: 30, height: 30)
-                .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(iconColor.opacity(0.12)))
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                Text(value)
+        SettingsCard {
+            HStack(alignment: .top, spacing: 11) {
+                Image(systemName: icon)
                     .font(.headline)
-                    .lineLimit(1)
+                    .foregroundStyle(iconColor)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)
+                            .fill(iconColor.opacity(0.12))
+                    )
+                    .accessibilityHidden(true)
 
-                Text(description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    Text(value)
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
             }
         }
-        .padding(13)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.055))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
-        )
     }
 
     private var targetAppCorrectionLearningSection: some View {
@@ -594,7 +584,7 @@ struct PremiumSettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(Color.black.opacity(0.16))
+                .fill(Color(nsColor: .controlBackgroundColor))
         )
     }
 
@@ -655,50 +645,46 @@ private struct PremiumControlSection<Content: View>: View {
     @ViewBuilder let content: Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.title2)
-                    .foregroundStyle(iconColor)
-                    .frame(width: 38, height: 38)
-                    .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(iconColor.opacity(0.12)))
-                    .accessibilityHidden(true)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: icon)
+                        .font(.title2)
+                        .foregroundStyle(iconColor)
+                        .frame(width: 38, height: 38)
+                        .background(
+                            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)
+                                .fill(iconColor.opacity(0.12))
+                        )
+                        .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(.headline)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(title)
+                            .font(.headline)
 
-                    Text(description)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                        Text(description)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Text(statusText)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(statusColor)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(Capsule().fill(statusColor.opacity(0.13)))
                 }
 
-                Spacer(minLength: 12)
-
-                Text(statusText)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(statusColor)
-                    .padding(.horizontal, 9)
-                    .padding(.vertical, 5)
-                    .background(Capsule().fill(statusColor.opacity(0.13)))
+                VStack(alignment: .leading, spacing: 10) {
+                    content
+                }
+                .padding(.leading, 50)
             }
-
-            VStack(alignment: .leading, spacing: 10) {
-                content
-            }
-            .padding(.leading, 50)
         }
-        .padding(16)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.065))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.11), lineWidth: 1)
-        )
     }
 }
 
@@ -715,7 +701,7 @@ private struct FlexibleTagRow: View {
                     .padding(.vertical, 5)
                     .background(
                         RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(Color.white.opacity(0.08))
+                            .fill(Color.secondary.opacity(0.10))
                     )
             }
         }

--- a/TypeWhisper/Views/WorkflowsSettingsView.swift
+++ b/TypeWhisper/Views/WorkflowsSettingsView.swift
@@ -142,7 +142,7 @@ private struct MyWorkflowsPage: View {
             Divider()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
                     fallbackPriorityCard
 
                     if workflowService.workflows.isEmpty {
@@ -161,7 +161,7 @@ private struct MyWorkflowsPage: View {
                         }
                     }
                 }
-                .padding(16)
+                .padding(SettingsLayoutMetrics.pagePadding)
                 .frame(maxWidth: .infinity, alignment: .topLeading)
             }
         }
@@ -204,23 +204,13 @@ private struct MyWorkflowsPage: View {
     }
 
     private var header: some View {
-        HStack(alignment: .top, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(localizedAppText("Workflows", de: "Workflows"))
-                    .font(.headline)
-                Text(
-                    localizedAppText(
-                        "Create and manage the workflows TypeWhisper should actively run.",
-                        de: "Erstelle und verwalte die Workflows, die TypeWhisper aktiv ausführen soll."
-                    )
-                )
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .layoutPriority(1)
-
+        SettingsPageHeader(
+            localizedAppText("Workflows", de: "Workflows"),
+            summary: localizedAppText(
+                "Create and manage the workflows TypeWhisper should actively run.",
+                de: "Erstelle und verwalte die Workflows, die TypeWhisper aktiv ausführen soll."
+            )
+        ) {
             Button {
                 navigation.createWorkflow()
             } label: {
@@ -234,8 +224,6 @@ private struct MyWorkflowsPage: View {
             .fixedSize()
             .help(localizedAppText("New Workflow", de: "Neuer Workflow"))
         }
-        .padding(16)
-        .background(.bar)
     }
 
     private var fallbackPriorityCard: some View {
@@ -1050,7 +1038,7 @@ private struct WorkflowEditorPage: View {
             Divider()
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
                     if let validationMessage {
                         ValidationBanner(message: validationMessage)
                     }
@@ -1060,7 +1048,7 @@ private struct WorkflowEditorPage: View {
                     behaviorSection
                     reviewSection
                 }
-                .padding(16)
+                .padding(SettingsLayoutMetrics.pagePadding)
             }
         }
         .sheet(isPresented: $showingAppPicker) {
@@ -1072,8 +1060,15 @@ private struct WorkflowEditorPage: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center) {
+        SettingsPageHeader(
+            isEditing
+                ? localizedAppText("Edit Workflow", de: "Workflow bearbeiten")
+                : localizedAppText("New Workflow", de: "Neuer Workflow"),
+            summary: isEditing
+                ? localizedAppText("Adjust the current workflow without changing its template.", de: "Passe den aktuellen Workflow an, ohne seine Vorlage zu ändern.")
+                : localizedAppText("Pick a concrete outcome first, then add behavior and one or more triggers.", de: "Wähle zuerst ein konkretes Ergebnis und ergänze dann Verhalten und einen oder mehrere Trigger.")
+        ) {
+            HStack(spacing: 12) {
                 Button {
                     navigation.goBackToList()
                 } label: {
@@ -1081,33 +1076,12 @@ private struct WorkflowEditorPage: View {
                 }
                 .buttonStyle(.borderless)
 
-                Spacer()
-
                 Button(localizedAppText("Save Workflow", de: "Workflow speichern")) {
                     save()
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(isEditing
-                    ? localizedAppText("Edit Workflow", de: "Workflow bearbeiten")
-                    : localizedAppText("New Workflow", de: "Neuer Workflow")
-                )
-                .font(.headline)
-
-                Text(
-                    isEditing
-                        ? localizedAppText("Adjust the current workflow without changing its template.", de: "Passe den aktuellen Workflow an, ohne seine Vorlage zu ändern.")
-                        : localizedAppText("Pick a concrete outcome first, then add behavior and one or more triggers.", de: "Wähle zuerst ein konkretes Ergebnis und ergänze dann Verhalten und einen oder mehrere Trigger.")
-                )
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
             }
         }
-        .padding(16)
-        .background(.bar)
     }
 
     private var templateSection: some View {


### PR DESCRIPTION
## Issue context

Issue #940 defines a shared native macOS hybrid visual language for all 17 settings destinations while preserving navigation, behavior, and specialized product layouts. This fourth phase aligns Workflows, Integrations, Premium, and License without changing workflow construction, plugin management, entitlement behavior, or pricing hierarchy.

## Changes

- replace custom Workflows and Integrations headers with the shared fixed settings header while preserving all actions
- migrate Premium's general surfaces to shared cards and semantic system colors while retaining product and status tints
- replace License's private `PanelCard` foundation with the shared `SettingsCard`
- apply shared page spacing without changing builder, registry, activation, or purchase flows

## Test plan

```bash
git diff --check origin/main...HEAD
./scripts/pr-preflight.sh origin/main
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Closes #947
