### PR TITLE
Finish settings visual language audit

### DIFF
--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -40,7 +40,7 @@ struct AudioRecorderView: View {
             Form {
             // Recording Controls
             Section {
-                VStack(spacing: 16) {
+                VStack(spacing: SettingsLayoutMetrics.sectionSpacing) {
                     // Duration display
                     Text(viewModel.formattedDuration(viewModel.duration))
                         .font(.system(size: 48, weight: .light, design: .monospaced))

--- a/TypeWhisper/Views/FileTranscriptionView.swift
+++ b/TypeWhisper/Views/FileTranscriptionView.swift
@@ -347,7 +347,10 @@ struct FileTranscriptionView: View {
                 activeFileDetails(item)
             }
         }
-        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
+        .background(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius)
+                .fill(.quaternary)
+        )
     }
 
     @ViewBuilder

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -16,10 +16,6 @@ struct HistoryView: View {
                 listPanel
                     .frame(minWidth: 280)
 
-                Divider()
-                    .opacity(hasSelection ? 1 : 0)
-                    .frame(width: hasSelection ? 1 : 0)
-
                 detailPanelContainer
                     .frame(
                         minWidth: hasSelection ? 300 : 0,
@@ -35,137 +31,147 @@ struct HistoryView: View {
     // MARK: - List Panel
 
     private var listPanel: some View {
-        VStack(spacing: 0) {
-            // Search
-            NativeSearchField(
-                text: $viewModel.searchQuery,
-                placeholder: String(localized: "Search...")
-            )
-            .frame(maxWidth: .infinity)
-            .frame(height: 32)
-            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
-            .padding(.vertical, 6)
-            .background(.bar)
+        VStack(spacing: SettingsLayoutMetrics.cardSpacing) {
+            SettingsCard {
+                VStack(spacing: 12) {
+                    NativeSearchField(
+                        text: $viewModel.searchQuery,
+                        placeholder: String(localized: "Search...")
+                    )
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 28)
 
-            // Filter pickers
-            HStack(spacing: 6) {
-                Picker(selection: Binding(
-                    get: { viewModel.selectedAppFilter ?? "" },
-                    set: { viewModel.selectedAppFilter = $0.isEmpty ? nil : $0 }
-                )) {
-                    Text(String(localized: "All Apps")).tag("")
-                    if !viewModel.availableApps.isEmpty {
-                        Divider()
-                        ForEach(viewModel.availableApps) { app in
-                            Text(app.name).tag(app.bundleId)
-                        }
-                    }
-                } label: {
-                    EmptyView()
-                }
-                .fixedSize()
-
-                Picker(selection: $viewModel.selectedTimeRange) {
-                    ForEach(HistoryTimeRange.allCases) { range in
-                        Text(range.displayName).tag(range)
-                    }
-                } label: {
-                    EmptyView()
-                }
-                .fixedSize()
-
-                Spacer()
-            }
-            .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
-            .padding(.vertical, 6)
-            .background(.bar)
-
-            Divider()
-
-            // List
-            if viewModel.filteredRecords.isEmpty {
-                ContentUnavailableView {
-                    Label(String(localized: "No Entries"), systemImage: "clock")
-                } description: {
-                    if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
-                        Text(String(localized: "No results for the active filters."))
-                    } else {
-                        Text(String(localized: "Dictated text will appear here."))
-                    }
-                } actions: {
-                    if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
-                        Button(String(localized: "Clear Filters")) {
-                            viewModel.clearAllFilters()
-                        }
-                    }
-                }
-                .frame(maxHeight: .infinity)
-            } else {
-                List(selection: $viewModel.selectedRecordIDs) {
-                    ForEach(viewModel.groupedSections) { section in
-                        Section {
-                            if !viewModel.collapsedGroups.contains(section.group) {
-                                ForEach(section.records, id: \.id) { record in
-                                    RecordRow(record: record)
-                                        .tag(record.id)
-                                        .contextMenu {
-                                            recordContextMenu(for: record)
-                                        }
+                    HStack(spacing: 8) {
+                        Picker(selection: Binding(
+                            get: { viewModel.selectedAppFilter ?? "" },
+                            set: { viewModel.selectedAppFilter = $0.isEmpty ? nil : $0 }
+                        )) {
+                            Text(String(localized: "All Apps")).tag("")
+                            if !viewModel.availableApps.isEmpty {
+                                Divider()
+                                ForEach(viewModel.availableApps) { app in
+                                    Text(app.name).tag(app.bundleId)
                                 }
                             }
-                        } header: {
-                            SectionHeader(
-                                group: section.group,
-                                count: section.records.count,
-                                isCollapsed: viewModel.collapsedGroups.contains(section.group)
-                            ) {
-                                viewModel.toggleSection(section.group)
+                        } label: {
+                            EmptyView()
+                        }
+                        .fixedSize()
+
+                        Picker(selection: $viewModel.selectedTimeRange) {
+                            ForEach(HistoryTimeRange.allCases) { range in
+                                Text(range.displayName).tag(range)
                             }
+                        } label: {
+                            EmptyView()
+                        }
+                        .fixedSize()
+
+                        Spacer()
+                    }
+                    .controlSize(.small)
+                }
+            }
+
+            SettingsCard {
+                if viewModel.filteredRecords.isEmpty {
+                    historyEmptyState
+                } else {
+                    VStack(spacing: 0) {
+                        historyList
+                        Divider()
+                        historyFooter
+                    }
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .padding(SettingsLayoutMetrics.pagePadding)
+    }
+
+    private var historyList: some View {
+        List(selection: $viewModel.selectedRecordIDs) {
+            ForEach(viewModel.groupedSections) { section in
+                Section {
+                    if !viewModel.collapsedGroups.contains(section.group) {
+                        ForEach(section.records, id: \.id) { record in
+                            RecordRow(record: record)
+                                .tag(record.id)
+                                .contextMenu {
+                                    recordContextMenu(for: record)
+                                }
                         }
                     }
-                }
-                .listStyle(.plain)
-            }
-
-            Divider()
-
-            // Footer stats
-            HStack {
-                if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
-                    Text("\(viewModel.visibleRecordCount) \(String(localized: "entries")) (\(viewModel.totalRecords) \(String(localized: "total")))")
-                } else {
-                    Text("\(viewModel.totalRecords) \(String(localized: "entries"))")
-                }
-                Spacer()
-                if !viewModel.filteredRecords.isEmpty {
-                    Button(String(localized: "Delete All Visible"), role: .destructive) {
-                        viewModel.showDeleteAllVisibleConfirmation = true
+                } header: {
+                    SectionHeader(
+                        group: section.group,
+                        count: section.records.count,
+                        isCollapsed: viewModel.collapsedGroups.contains(section.group)
+                    ) {
+                        viewModel.toggleSection(section.group)
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.red)
-                    .font(.caption)
                 }
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(.bar)
-            .confirmationDialog(
-                String(localized: "Delete Entries"),
-                isPresented: $viewModel.showDeleteAllVisibleConfirmation,
-                titleVisibility: .visible
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var historyEmptyState: some View {
+        if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
+            SettingsEmptyState(
+                systemImage: "clock",
+                title: String(localized: "No Entries"),
+                message: String(localized: "No results for the active filters.")
             ) {
-                Button(String(localized: "Delete"), role: .destructive) {
-                    viewModel.deleteAllVisible()
+                Button(String(localized: "Clear Filters")) {
+                    viewModel.clearAllFilters()
                 }
-                Button(String(localized: "Cancel"), role: .cancel) {}
-            } message: {
-                if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
-                    Text("Delete \(viewModel.visibleRecordCount) entries matching current filters?")
-                } else {
-                    Text("Delete all \(viewModel.visibleRecordCount) entries? This cannot be undone.")
-                }
+            }
+        } else {
+            SettingsEmptyState(
+                systemImage: "clock",
+                title: String(localized: "No Entries"),
+                message: String(localized: "Dictated text will appear here.")
+            )
+        }
+    }
+
+    private var historyFooter: some View {
+        HStack {
+            if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
+                Text("\(viewModel.visibleRecordCount) \(String(localized: "entries")) (\(viewModel.totalRecords) \(String(localized: "total")))")
+            } else {
+                Text("\(viewModel.totalRecords) \(String(localized: "entries"))")
+            }
+
+            Spacer()
+
+            Button(String(localized: "Delete All Visible"), role: .destructive) {
+                viewModel.showDeleteAllVisibleConfirmation = true
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.red)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.top, 10)
+        .confirmationDialog(
+            String(localized: "Delete Entries"),
+            isPresented: $viewModel.showDeleteAllVisibleConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Delete"), role: .destructive) {
+                viewModel.deleteAllVisible()
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: {
+            if viewModel.hasActiveFilters || !viewModel.searchQuery.isEmpty {
+                Text("Delete \(viewModel.visibleRecordCount) entries matching current filters?")
+            } else {
+                Text("Delete all \(viewModel.visibleRecordCount) entries? This cannot be undone.")
             }
         }
     }
@@ -175,7 +181,11 @@ struct HistoryView: View {
     @ViewBuilder
     private var detailPanelContainer: some View {
         if hasSelection {
-            detailPanel
+            SettingsCard {
+                detailPanel
+            }
+            .padding(.vertical, SettingsLayoutMetrics.pagePadding)
+            .padding(.trailing, SettingsLayoutMetrics.pagePadding)
         } else {
             Color.clear
         }
@@ -184,11 +194,11 @@ struct HistoryView: View {
     @ViewBuilder
     private var detailPanel: some View {
         if viewModel.selectedRecordIDs.count > 1 {
-            ContentUnavailableView {
-                Label(String(localized: "\(viewModel.selectedRecordIDs.count) items selected"), systemImage: "checkmark.circle")
-            } description: {
-                Text(String(localized: "Right-click to export or delete selected entries."))
-            } actions: {
+            SettingsEmptyState(
+                systemImage: "checkmark.circle",
+                title: String(localized: "\(viewModel.selectedRecordIDs.count) items selected"),
+                message: String(localized: "Right-click to export or delete selected entries.")
+            ) {
                 Button {
                     viewModel.selectRecord(nil)
                 } label: {

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -72,63 +72,57 @@ struct HomeSettingsView: View {
     // MARK: - Statistics summary
 
     private var statisticsSummarySection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Button {
-                viewModel.navigateToStatistics = true
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "chart.bar.xaxis")
-                        .font(.subheadline)
-                        .foregroundStyle(Color.accentColor)
-                    Text(String(localized: "Your Activity"))
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                    Spacer()
-                    Text(String(localized: "View all statistics"))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Image(systemName: "chevron.right")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Button {
+                    viewModel.navigateToStatistics = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chart.bar.xaxis")
+                            .font(.subheadline)
+                            .foregroundStyle(Color.accentColor)
+                        Text(String(localized: "Your Activity"))
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(String(localized: "View all statistics"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .contentShape(Rectangle())
                 }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(String(localized: "View your statistics"))
-            .accessibilityAddTraits(.isButton)
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(String(localized: "View your statistics"))
+                .accessibilityAddTraits(.isButton)
 
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 4), spacing: 12) {
-                statisticsSummaryCard(
-                    title: String(localized: "Words"),
-                    value: "\(statistics.wordsCount)",
-                    systemImage: "text.word.spacing"
-                )
-                statisticsSummaryCard(
-                    title: String(localized: "Avg. WPM"),
-                    value: statistics.averageWPM,
-                    systemImage: "speedometer"
-                )
-                statisticsSummaryCard(
-                    title: String(localized: "Apps Used"),
-                    value: "\(statistics.appsUsed)",
-                    systemImage: "app.badge"
-                )
-                statisticsSummaryCard(
-                    title: String(localized: "Time Saved"),
-                    value: statistics.timeSaved,
-                    systemImage: "clock.badge.checkmark"
-                )
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 4), spacing: 12) {
+                    statisticsSummaryCard(
+                        title: String(localized: "Words"),
+                        value: "\(statistics.wordsCount)",
+                        systemImage: "text.word.spacing"
+                    )
+                    statisticsSummaryCard(
+                        title: String(localized: "Avg. WPM"),
+                        value: statistics.averageWPM,
+                        systemImage: "speedometer"
+                    )
+                    statisticsSummaryCard(
+                        title: String(localized: "Apps Used"),
+                        value: "\(statistics.appsUsed)",
+                        systemImage: "app.badge"
+                    )
+                    statisticsSummaryCard(
+                        title: String(localized: "Time Saved"),
+                        value: statistics.timeSaved,
+                        systemImage: "clock.badge.checkmark"
+                    )
+                }
             }
         }
-        .padding(SettingsLayoutMetrics.cardPadding)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     private func statisticsSummaryCard(title: String, value: String, systemImage: String) -> some View {
@@ -197,85 +191,80 @@ struct HomeSettingsView: View {
     // MARK: - Recent Transcriptions
 
     private var recentTranscriptionsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Button {
-                viewModel.navigateToHistory = true
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "clock.arrow.circlepath")
-                        .font(.subheadline)
-                        .foregroundStyle(Color.accentColor)
-                    Text(String(localized: "Recent Transcriptions"))
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-                    Spacer()
-                    Text(String(localized: "View all history"))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Image(systemName: "chevron.right")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Button {
+                    viewModel.navigateToHistory = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .font(.subheadline)
+                            .foregroundStyle(Color.accentColor)
+                        Text(String(localized: "Recent Transcriptions"))
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(String(localized: "View all history"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .contentShape(Rectangle())
                 }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(String(localized: "View all history"))
-            .accessibilityAddTraits(.isButton)
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(String(localized: "View all history"))
+                .accessibilityAddTraits(.isButton)
 
-            if viewModel.recentTranscriptions.isEmpty {
-                Text(String(localized: "Press \(primaryHotkeyLabel) in any app to get started."))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, minHeight: 60)
-            } else {
-                VStack(spacing: 0) {
-                    ForEach(viewModel.recentTranscriptions, id: \.id) { record in
-                        Button {
-                            viewModel.navigateToHistory = true
-                        } label: {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(record.finalText)
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                        .font(.body)
-                                        .foregroundStyle(.primary)
-                                    HStack(spacing: 4) {
-                                        Text(record.timestamp, format: .relative(presentation: .named))
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        if let appName = record.appName {
-                                            Text("- \(appName)")
+                if viewModel.recentTranscriptions.isEmpty {
+                    Text(String(localized: "Press \(primaryHotkeyLabel) in any app to get started."))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 60)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(viewModel.recentTranscriptions, id: \.id) { record in
+                            Button {
+                                viewModel.navigateToHistory = true
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(record.finalText)
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
+                                            .font(.body)
+                                            .foregroundStyle(.primary)
+                                        HStack(spacing: 4) {
+                                            Text(record.timestamp, format: .relative(presentation: .named))
                                                 .font(.caption)
-                                                .foregroundStyle(.tertiary)
+                                                .foregroundStyle(.secondary)
+                                            if let appName = record.appName {
+                                                Text("- \(appName)")
+                                                    .font(.caption)
+                                                    .foregroundStyle(.tertiary)
+                                            }
                                         }
                                     }
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption)
+                                        .foregroundStyle(.tertiary)
                                 }
-                                Spacer()
-                                Image(systemName: "chevron.right")
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
+                                .padding(.vertical, 8)
+                                .padding(.horizontal, 4)
+                                .contentShape(Rectangle())
                             }
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 4)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
+                            .buttonStyle(.plain)
 
-                        if record.id != viewModel.recentTranscriptions.last?.id {
-                            Divider()
+                            if record.id != viewModel.recentTranscriptions.last?.id {
+                                Divider()
+                            }
                         }
                     }
                 }
             }
         }
-        .padding(SettingsLayoutMetrics.cardPadding)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     // MARK: - Getting Started Card
@@ -294,39 +283,35 @@ struct HomeSettingsView: View {
     }
 
     private var gettingStartedCard: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "mic.badge.plus")
-                .font(.system(size: 36))
-                .foregroundStyle(Color.accentColor)
-                .accessibilityHidden(true)
+        SettingsCard {
+            VStack(spacing: 12) {
+                Image(systemName: "mic.badge.plus")
+                    .font(.system(size: 36))
+                    .foregroundStyle(Color.accentColor)
+                    .accessibilityHidden(true)
 
-            Text(String(localized: "Ready to start dictating?"))
-                .font(.headline)
+                Text(String(localized: "Ready to start dictating?"))
+                    .font(.headline)
 
-            HStack(spacing: 6) {
-                Text(String(localized: "Press"))
-                    .foregroundStyle(.secondary)
-                Text(primaryHotkeyLabel)
-                    .font(.body.weight(.medium))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius)
-                            .fill(Color.accentColor.opacity(0.1))
-                    )
-                Text(String(localized: "in any app to begin."))
-                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    Text(String(localized: "Press"))
+                        .foregroundStyle(.secondary)
+                    Text(primaryHotkeyLabel)
+                        .font(.body.weight(.medium))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius)
+                                .fill(Color.accentColor.opacity(0.1))
+                        )
+                    Text(String(localized: "in any app to begin."))
+                        .foregroundStyle(.secondary)
+                }
+                .font(.callout)
             }
-            .font(.callout)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 24)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     // MARK: - Permissions Banner

--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -355,7 +355,10 @@ struct PremiumSettingsView: View {
                 .font(.title2)
                 .foregroundStyle(.yellow)
                 .frame(width: 44, height: 44)
-                .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(.yellow.opacity(0.13)))
+                .background(
+                    RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)
+                        .fill(.yellow.opacity(0.13))
+                )
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 5) {

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -406,7 +406,10 @@ private struct SettingsSidebarSearchField: View {
             }
         }
         .padding(6)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color(nsColor: .controlBackgroundColor)))
+        .background(
+            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
         .padding(EdgeInsets(top: 8, leading: 8, bottom: 4, trailing: 8))
     }
 }

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -21,7 +21,7 @@ struct StatisticsView: View {
                         overviewGrid
                         metricsGrid
                         chartSection
-                        HStack(alignment: .top, spacing: 16) {
+                        HStack(alignment: .top, spacing: SettingsLayoutMetrics.cardSpacing) {
                             appsSection
                             modelsSection
                         }
@@ -134,16 +134,17 @@ struct StatisticsView: View {
     // MARK: - Activity chart
 
     private var chartSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "Activity"))
-                .font(.headline)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(localized: "Activity"))
+                    .font(.headline)
 
-            if viewModel.chartData.isEmpty || viewModel.chartData.allSatisfy({ $0.wordCount == 0 }) {
-                Text(String(localized: "No activity in this period."))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, minHeight: 200)
-            } else {
-                ZStack(alignment: .top) {
+                if viewModel.chartData.isEmpty || viewModel.chartData.allSatisfy({ $0.wordCount == 0 }) {
+                    Text(String(localized: "No activity in this period."))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 200)
+                } else {
+                    ZStack(alignment: .top) {
                     Chart(viewModel.chartData) { point in
                         BarMark(
                             x: .value(String(localized: "Date"), point.date, unit: .day),
@@ -198,20 +199,14 @@ struct StatisticsView: View {
                             .allowsHitTesting(false)
                         }
                     }
+                    }
+                    .frame(height: 200)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityAddTraits(.isStaticText)
+                    .accessibilityLabel(chartAccessibilitySummary)
                 }
-                .frame(height: 200)
-                .accessibilityElement(children: .ignore)
-                .accessibilityAddTraits(.isStaticText)
-                .accessibilityLabel(chartAccessibilitySummary)
             }
         }
-        .padding(SettingsLayoutMetrics.cardPadding)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     private var chartAccessibilitySummary: Text {
@@ -236,7 +231,8 @@ struct StatisticsView: View {
     // MARK: - Apps
 
     private var appsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 8) {
             Text(String(localized: "Top Apps"))
                 .font(.headline)
 
@@ -275,15 +271,8 @@ struct StatisticsView: View {
                     }
                 }
             }
+            }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(SettingsLayoutMetrics.cardPadding)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     // MARK: - Heatmap
@@ -301,25 +290,20 @@ struct StatisticsView: View {
     }
 
     private var heatmapSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "Usage by Time of Day"))
-                .font(.headline)
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(localized: "Usage by Time of Day"))
+                    .font(.headline)
 
-            if viewModel.maxHourlyCount == 0 {
-                Text(String(localized: "No activity for this period."))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, minHeight: 60)
-            } else {
-                heatmapGrid
+                if viewModel.maxHourlyCount == 0 {
+                    Text(String(localized: "No activity for this period."))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 60)
+                } else {
+                    heatmapGrid
+                }
             }
         }
-        .padding(SettingsLayoutMetrics.cardPadding)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     private let heatmapLabelWidth: CGFloat = 28
@@ -389,7 +373,8 @@ struct StatisticsView: View {
     // MARK: - Models
 
     private var modelsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 8) {
             Text(String(localized: "Models Used"))
                 .font(.headline)
 
@@ -428,39 +413,28 @@ struct StatisticsView: View {
                     }
                 }
             }
+            }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(SettingsLayoutMetrics.cardPadding)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 
     // MARK: - Empty state
 
     private var emptyStateCard: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "chart.bar.xaxis")
-                .font(.system(size: 36))
-                .foregroundStyle(Color.accentColor)
-                .accessibilityHidden(true)
+        SettingsCard {
+            VStack(spacing: 12) {
+                Image(systemName: "chart.bar.xaxis")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
 
-            Text(String(localized: "Your statistics will appear here after your first transcription."))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+                Text(String(localized: "Your statistics will appear here after your first transcription."))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 24)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
     }
 }
 
@@ -472,27 +446,22 @@ private struct StatisticsStatCard: View {
     var accessibilityValue: String?
 
     var body: some View {
-        VStack(spacing: 6) {
-            Image(systemName: systemImage)
-                .font(.title2)
-                .foregroundStyle(Color.accentColor)
-                .accessibilityHidden(true)
-            Text(value)
-                .font(.title)
-                .fontWeight(.bold)
-                .monospacedDigit()
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+        SettingsCard {
+            VStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+                    .accessibilityHidden(true)
+                Text(value)
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .monospacedDigit()
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text("\(title), \(accessibilityValue ?? value)"))
     }
@@ -505,30 +474,25 @@ struct StatisticsMetricCard: View {
     var trend: Double?
 
     var body: some View {
-        VStack(spacing: 6) {
-            Image(systemName: systemImage)
-                .font(.title2)
-                .foregroundStyle(Color.accentColor)
-                .accessibilityHidden(true)
-            Text(value)
-                .font(.title)
-                .fontWeight(.bold)
-                .monospacedDigit()
-            if let trend {
-                trendLabel(trend)
+        SettingsCard {
+            VStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+                    .accessibilityHidden(true)
+                Text(value)
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .monospacedDigit()
+                if let trend {
+                    trendLabel(trend)
+                }
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: SettingsLayoutMetrics.cardCornerRadius)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(trendAwareAccessibilityLabel)
     }


### PR DESCRIPTION
## Issue context

This final audit completes the native macOS hybrid settings migration tracked in #940 after the foundation, collections, workspaces, and complex settings phases.

It removes the remaining duplicated generic card surfaces from Dashboard and Statistics, applies the shared compact-control radius and spacing tokens to the remaining settings controls, and keeps specialized product, workflow, split-view, and recorder behavior unchanged.

Closes #940

## Changes

- replace remaining Dashboard and Statistics generic card foundations with `SettingsCard`
- use shared card spacing for the Statistics workspace
- use `SettingsLayoutMetrics` for remaining compact control radii and recorder section spacing
- preserve all existing navigation, actions, data models, persistence, and premium entitlement behavior

## Test plan

```bash
git diff --check origin/main...HEAD
./scripts/pr-preflight.sh origin/main
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/a220/typewhisper-mac
```

- `./scripts/pr-preflight.sh origin/main` passed
- macOS test suite passed: 1,228 tests, 0 failures
- signed TypeWhisper Dev build and launch passed with the development App Group, iCloud, and Sign in with Apple entitlements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Standardized dashboard, statistics, and history layouts using consistent card styling for backgrounds, borders, padding, and corner treatment.
  * Updated spacing in the recording view and refined card spacing in getting-started content.
  * Applied compact corner radii across recording, transcription, premium, and settings search surfaces.
  * Refreshed history list/empty states, filters header, and selection detail presentation while preserving existing behavior and accessibility semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->