### PR TITLE
Show transcription provider alongside model in menu bar

### DIFF
--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -150,11 +150,24 @@ private final class MenuBarState: ObservableObject {
             return (String(localized: "No model loaded"), "exclamationmark.triangle.fill")
         }
 
+        let label = activeModelLabel(engine: modelManager.activeEngineName, model: name)
+
         if modelManager.isModelReady {
-            return (String(localized: "\(name) ready"), "checkmark.circle.fill")
+            return (String(localized: "\(label) ready"), "checkmark.circle.fill")
         }
 
-        return (String(localized: "\(name) selected"), "clock.fill")
+        return (String(localized: "\(label) selected"), "clock.fill")
+    }
+
+    /// Prefixes the model name with its provider/engine (e.g. "Groq • whisper-large-v3") so the
+    /// menu bar shows which provider handles transcription. Skips the prefix when it would be
+    /// redundant — e.g. local engines whose model name already contains the provider ("Parakeet").
+    static func activeModelLabel(engine: String?, model: String) -> String {
+        guard let engine, !engine.isEmpty, engine != model,
+              !model.localizedCaseInsensitiveContains(engine) else {
+            return model
+        }
+        return "\(engine) • \(model)"
     }
 
     private func refreshCopyAvailability() {


### PR DESCRIPTION
## What & why

The menu bar status item shows the active transcription model (e.g. `Parakeet TDT v3 selected` / `… ready`) but not the **provider** handling it. For cloud engines the model name alone is ambiguous — you can't tell whether a given model runs through Groq, OpenAI, WhisperKit, etc.

This prefixes the model with its provider display name in the idle status label:

- `Groq • whisper-large-v3 selected`
- `WhisperKit • Whisper Large v3 ready`

It reuses the existing `ModelManagerService.activeEngineName` (the plugin's `providerDisplayName`) and the `•` separator already used for engine/model summaries in `SpokenPunctuationSettingsSection`. Redundant prefixes are skipped when the model name already contains the provider, so local engines like Parakeet stay exactly as before (`Parakeet TDT v3 selected`).

No new localizable strings: the interpolated keys (`%@ selected` / `%@ ready`) are unchanged — only the composed value passed in differs.

## Test plan

```bash
xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Manual verification in a dev build:
1. Select a cloud provider (e.g. Groq) with a model → menu bar shows `Groq • <model> selected` / `… ready`.
2. Select a local Parakeet model → menu bar still shows `Parakeet TDT v3 selected` (no redundant prefix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Menu bar status messages now identify the active AI engine alongside the model name when helpful.
  * Redundant or unavailable engine names are omitted for clearer, more concise status labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->