### PR TITLE
Regroup the menu bar menu for quicker access

### DIFF
--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -10,6 +10,7 @@ private final class MenuBarState: ObservableObject {
     @Published var isModelReady: Bool
     @Published var hasRecentTranscriptions: Bool
     @Published var canCopyLastTranscription: Bool
+    @Published var hasLastTranscribedText: Bool
     @Published var hasRecoverableRecording: Bool
     @Published var recorderState: AudioRecorderViewModel.RecorderState
     @Published var canToggleRecorder: Bool
@@ -34,6 +35,7 @@ private final class MenuBarState: ObservableObject {
         let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
         self.hasRecentTranscriptions = hasRecentTranscriptions
         self.canCopyLastTranscription = hasRecentTranscriptions
+        self.hasLastTranscribedText = dictation.lastTranscribedText != nil
         self.hasRecoverableRecording = audioRecordingService.latestRecoveryRecordingURL != nil
         self.recorderState = recorder.state
         self.canToggleRecorder = recorder.canToggleRecording
@@ -86,6 +88,15 @@ private final class MenuBarState: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] url in
                 self?.hasRecoverableRecording = url != nil
+            }
+            .store(in: &cancellables)
+
+        dictation.$lastTranscribedText
+            .map { $0 != nil }
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] hasText in
+                self?.hasLastTranscribedText = hasText
             }
             .store(in: &cancellables)
 
@@ -364,7 +375,7 @@ struct MenuBarView: View {
             .disabled(
                 !status.hasRecentTranscriptions
                     && !status.canCopyLastTranscription
-                    && DictationViewModel.shared.lastTranscribedText == nil
+                    && !status.hasLastTranscribedText
             )
 
         case .recentTranscriptions:
@@ -416,7 +427,7 @@ struct MenuBarView: View {
             Label(String(localized: "Read Back Last Transcription"), systemImage: "speaker.wave.2")
         }
         .keyboardShortcut("r", modifiers: [.command, .shift])
-        .disabled(DictationViewModel.shared.lastTranscribedText == nil)
+        .disabled(!status.hasLastTranscribedText)
     }
 
     private var recorderToggleTitle: String {

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -206,6 +206,7 @@ enum MenuBarMenuItem: Hashable {
     case toggleDictationHotkeysPause
     case transcribeFile
     case recoverLastRecording
+    case lastTranscription
     case recentTranscriptions
     case copyLastTranscription
     case readBackLastTranscription
@@ -214,9 +215,7 @@ enum MenuBarMenuItem: Hashable {
 
 enum MenuBarMenuSection: String, CaseIterable, Hashable {
     case general = "General"
-    case recorder = "Recorder"
     case transcription = "Transcription"
-    case updates = "Updates"
 
     var titleLocalizationKey: String {
         rawValue
@@ -226,12 +225,8 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
         switch self {
         case .general:
             "General"
-        case .recorder:
-            "settings.tab.recorder"
         case .transcription:
             "Transcription"
-        case .updates:
-            "Updates"
         }
     }
 
@@ -243,14 +238,10 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
         switch self {
         case .general:
             [.settings, .history, .errorLog]
-        case .recorder:
-            [.toggleRecorder]
         case .transcription:
             hasRecoverableRecording
-                ? [.toggleDictationHotkeysPause, .transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
-                : [.toggleDictationHotkeysPause, .transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
-        case .updates:
-            [.checkForUpdates]
+                ? [.toggleDictationHotkeysPause, .transcribeFile, .recoverLastRecording, .lastTranscription]
+                : [.toggleDictationHotkeysPause, .transcribeFile, .lastTranscription]
         }
     }
 }
@@ -267,6 +258,12 @@ struct MenuBarView: View {
 
             Divider()
 
+            // Primary action, promoted above the grouped sections so it is
+            // always the first actionable item under the status line.
+            menuItem(for: .toggleRecorder)
+
+            Divider()
+
             ForEach(MenuBarMenuSection.allCases, id: \.self) { section in
                 Section(String(localized: section.titleResource)) {
                     ForEach(section.items(hasRecoverableRecording: status.hasRecoverableRecording), id: \.self) { item in
@@ -276,6 +273,8 @@ struct MenuBarView: View {
             }
 
             Divider()
+
+            menuItem(for: .checkForUpdates)
 
             Button(String(localized: "Quit")) {
                 NSApplication.shared.terminate(nil)
@@ -351,32 +350,31 @@ struct MenuBarView: View {
                 Label(String(localized: "Recover Last Recording"), systemImage: "waveform")
             }
 
-        case .recentTranscriptions:
-            Button {
-                DictationViewModel.shared.triggerRecentTranscriptionsPalette()
+        case .lastTranscription:
+            Menu {
+                recentTranscriptionsButton
+                copyLastTranscriptionButton
+                readBackLastTranscriptionButton
             } label: {
-                Label(String(localized: "Recent Transcriptions"), systemImage: "clock.arrow.circlepath")
+                Label(
+                    localizedAppText("Last Transcription", de: "Letzte Transkription"),
+                    systemImage: "clock.arrow.circlepath"
+                )
             }
-            .keyboardShortcut(keyboardShortcut(from: status.recentTranscriptionsMenuShortcut))
-            .disabled(!status.hasRecentTranscriptions)
+            .disabled(
+                !status.hasRecentTranscriptions
+                    && !status.canCopyLastTranscription
+                    && DictationViewModel.shared.lastTranscribedText == nil
+            )
+
+        case .recentTranscriptions:
+            recentTranscriptionsButton
 
         case .copyLastTranscription:
-            Button {
-                DictationViewModel.shared.copyLastTranscriptionToClipboard()
-            } label: {
-                Label(String(localized: "Copy Last Transcription"), systemImage: "doc.on.doc")
-            }
-            .keyboardShortcut(keyboardShortcut(from: status.copyLastTranscriptionMenuShortcut))
-            .disabled(!status.canCopyLastTranscription)
+            copyLastTranscriptionButton
 
         case .readBackLastTranscription:
-            Button {
-                DictationViewModel.shared.readBackLastTranscription()
-            } label: {
-                Label(String(localized: "Read Back Last Transcription"), systemImage: "speaker.wave.2")
-            }
-            .keyboardShortcut("r", modifiers: [.command, .shift])
-            .disabled(DictationViewModel.shared.lastTranscribedText == nil)
+            readBackLastTranscriptionButton
 
         case .checkForUpdates:
             Button(String(localized: "Check for Updates...")) {
@@ -384,6 +382,41 @@ struct MenuBarView: View {
             }
             .disabled(UpdateChecker.shared?.canCheckForUpdates() != true)
         }
+    }
+
+    // These are factored out so the "Last Transcription" submenu can reuse them
+    // without menuItem(for:) recursively referencing its own opaque return type.
+    @ViewBuilder
+    private var recentTranscriptionsButton: some View {
+        Button {
+            DictationViewModel.shared.triggerRecentTranscriptionsPalette()
+        } label: {
+            Label(String(localized: "Recent Transcriptions"), systemImage: "clock.arrow.circlepath")
+        }
+        .keyboardShortcut(keyboardShortcut(from: status.recentTranscriptionsMenuShortcut))
+        .disabled(!status.hasRecentTranscriptions)
+    }
+
+    @ViewBuilder
+    private var copyLastTranscriptionButton: some View {
+        Button {
+            DictationViewModel.shared.copyLastTranscriptionToClipboard()
+        } label: {
+            Label(String(localized: "Copy Last Transcription"), systemImage: "doc.on.doc")
+        }
+        .keyboardShortcut(keyboardShortcut(from: status.copyLastTranscriptionMenuShortcut))
+        .disabled(!status.canCopyLastTranscription)
+    }
+
+    @ViewBuilder
+    private var readBackLastTranscriptionButton: some View {
+        Button {
+            DictationViewModel.shared.readBackLastTranscription()
+        } label: {
+            Label(String(localized: "Read Back Last Transcription"), systemImage: "speaker.wave.2")
+        }
+        .keyboardShortcut("r", modifiers: [.command, .shift])
+        .disabled(DictationViewModel.shared.lastTranscribedText == nil)
     }
 
     private var recorderToggleTitle: String {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -878,7 +878,7 @@ final class MenuBarGroupingTests: XCTestCase {
     func testMenuBarSectionsUseExpectedOrderAndLocalizedKeys() {
         XCTAssertEqual(
             MenuBarMenuSection.allCases.map(\.titleLocalizationKey),
-            ["General", "Recorder", "Transcription", "Updates"]
+            ["General", "Transcription"]
         )
     }
 
@@ -888,20 +888,12 @@ final class MenuBarGroupingTests: XCTestCase {
             [.settings, .history, .errorLog]
         )
         XCTAssertEqual(
-            MenuBarMenuSection.recorder.items,
-            [.toggleRecorder]
-        )
-        XCTAssertEqual(
             MenuBarMenuSection.transcription.items(hasRecoverableRecording: true),
-            [.toggleDictationHotkeysPause, .transcribeFile, .recoverLastRecording, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
+            [.toggleDictationHotkeysPause, .transcribeFile, .recoverLastRecording, .lastTranscription]
         )
         XCTAssertEqual(
             MenuBarMenuSection.transcription.items(hasRecoverableRecording: false),
-            [.toggleDictationHotkeysPause, .transcribeFile, .recentTranscriptions, .copyLastTranscription, .readBackLastTranscription]
-        )
-        XCTAssertEqual(
-            MenuBarMenuSection.updates.items,
-            [.checkForUpdates]
+            [.toggleDictationHotkeysPause, .transcribeFile, .lastTranscription]
         )
     }
 }


### PR DESCRIPTION
## What & why

The menu bar dropdown had grown awkward: two sections held a single item each (Recorder, Updates), and the Transcription section crowded six items together, mixing controls (pause hotkeys, transcribe file) with actions on the last result (recent, copy, read back). This reorganizes it without changing any behavior.

- Promote **Start/Stop Recording** to the top, directly under the status line, so the primary action is always the first actionable item.
- Move **Check for Updates** down next to Quit and drop the standalone **Updates** and **Recorder** section headers.
- Collapse **Recent Transcriptions**, **Copy Last Transcription**, and **Read Back Last Transcription** into a **Last Transcription** submenu, disabled as a whole when none of them are available.

Before / after top-level structure:

```
Before                          After
------                          -----
<status>                        <status>
General                         Start / Stop Recording
  Settings / History / Errors   General
Recorder                          Settings / History / Errors
  Start Recording               Transcription
Transcription                     Pause Dictation Hotkeys
  Pause Dictation Hotkeys         Transcribe File...
  Transcribe File...              Recover Last Recording (conditional)
  Recover Last Recording          Last Transcription >
  Recent Transcriptions             Recent Transcriptions
  Copy Last Transcription           Copy Last Transcription
  Read Back Last Transcription      Read Back Last Transcription
Updates                         Check for Updates...
  Check for Updates...          Quit
Quit
```

The three result actions are factored into shared `@ViewBuilder` properties so the submenu can reuse them without `menuItem(for:)` recursively referencing its own opaque return type. The new submenu label is localized (English/German). No icons or status styling are added: the `.menu` MenuBarExtra style renders a native `NSMenu`, which does not show `Label` symbols — a richer visual layer would require switching to the `.window` style and is out of scope here.

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -only-testing:TypeWhisperTests/MenuBarGroupingTests \
  CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Manual verification in a dev build:
1. Open the menu bar dropdown -> Start/Stop Recording is the first item under the status line; there are no single-item Recorder/Updates headers.
2. Open the Last Transcription submenu -> Recent Transcriptions, Copy Last, and Read Back Last appear there; the submenu is disabled when there is nothing to act on.
3. Check for Updates sits directly above Quit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Last Transcription** submenu with actions to view recent transcriptions, copy the latest transcription, and read it back.
  * Reorganized the menu layout to highlight recording controls and move update checking alongside core menu actions.
* **Improvements**
  * Updated transcription menu grouping to show only **General** and **Transcription** sections.
  * Improved action availability: items now enable/disable based on whether recent transcriptions, clipboard copy, and the last transcribed text are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->