### PR TITLE
Fix Gemma 4 download watchdog and progress

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -903,7 +903,6 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
             while !Task.isCancelled {
                 guard let self,
                       self.isCurrentModelLoad(generation),
-                      self.loadedModelId == nil,
                       let phase = self.modelLoadPhase else {
                     return
                 }
@@ -1064,6 +1063,10 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
 
     func invalidateModelLoadForTesting() {
         invalidateModelLoad()
+    }
+
+    func setLoadedModelIdForTesting(_ modelId: String?) {
+        loadedModelId = modelId
     }
 
     func isCurrentModelLoadForTesting(_ generation: Int) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import SwiftUI
 import MLX
 import MLXLLM
@@ -7,9 +8,153 @@ import HuggingFace
 import Hub
 import Tokenizers
 import TypeWhisperPluginSDK
+import os
+
+private struct Gemma4DownloadProgressReport: Equatable {
+    let completedUnitCount: Int64
+    let totalUnitCount: Int64
+    let isSnapshotComplete: Bool
+}
+
+private struct Gemma4DownloadProgressAccumulator {
+    private var snapshotCompletedUnitCount: Int64 = 0
+    private var snapshotTotalUnitCount: Int64 = 0
+    private var snapshotFraction: Double = 0
+    private var isSnapshotComplete = false
+    private var receivedBytesByTask: [Int: Int64] = [:]
+    private var lastReport: Gemma4DownloadProgressReport?
+
+    mutating func observeSnapshot(
+        completedUnitCount: Int64,
+        totalUnitCount: Int64,
+        fraction: Double
+    ) -> Gemma4DownloadProgressReport? {
+        let normalizedFraction = fraction.isFinite
+            ? max(0.0, min(fraction, 1.0))
+            : 0.0
+        snapshotCompletedUnitCount = max(snapshotCompletedUnitCount, max(completedUnitCount, 0))
+        snapshotTotalUnitCount = max(snapshotTotalUnitCount, max(totalUnitCount, 0))
+        snapshotFraction = max(snapshotFraction, normalizedFraction)
+        if snapshotTotalUnitCount > 0,
+           snapshotCompletedUnitCount >= snapshotTotalUnitCount || snapshotFraction >= 1.0 {
+            isSnapshotComplete = true
+        }
+        return makeReport()
+    }
+
+    mutating func observeNetworkTasks(
+        receivedBytes: [Int: Int64]
+    ) -> Gemma4DownloadProgressReport? {
+        for (taskIdentifier, byteCount) in receivedBytes {
+            receivedBytesByTask[taskIdentifier] = max(
+                receivedBytesByTask[taskIdentifier] ?? 0,
+                max(byteCount, 0)
+            )
+        }
+        return makeReport()
+    }
+
+    private mutating func makeReport() -> Gemma4DownloadProgressReport? {
+        guard snapshotTotalUnitCount > 0 else { return nil }
+
+        let fractionCompletedUnitCount = Int64(
+            (Double(snapshotTotalUnitCount) * snapshotFraction).rounded(.down)
+        )
+        let receivedByteCount = receivedBytesByTask.values.reduce(Int64(0)) { partial, byteCount in
+            partial.addingReportingOverflow(byteCount).overflow
+                ? Int64.max
+                : partial + byteCount
+        }
+        var completedUnitCount = max(
+            snapshotCompletedUnitCount,
+            max(fractionCompletedUnitCount, receivedByteCount)
+        )
+
+        if isSnapshotComplete {
+            completedUnitCount = snapshotTotalUnitCount
+        } else {
+            completedUnitCount = min(completedUnitCount, max(snapshotTotalUnitCount - 1, 0))
+        }
+
+        let report = Gemma4DownloadProgressReport(
+            completedUnitCount: completedUnitCount,
+            totalUnitCount: snapshotTotalUnitCount,
+            isSnapshotComplete: isSnapshotComplete
+        )
+        guard report != lastReport else { return nil }
+        lastReport = report
+        return report
+    }
+}
+
+private final class Gemma4DownloadProgressSampler: @unchecked Sendable {
+    private let session: URLSession
+    private let progressHandler: @Sendable (Progress) -> Void
+    private let state = OSAllocatedUnfairLock(initialState: Gemma4DownloadProgressAccumulator())
+
+    init(
+        session: URLSession,
+        progressHandler: @Sendable @escaping (Progress) -> Void
+    ) {
+        self.session = session
+        self.progressHandler = progressHandler
+    }
+
+    func start() -> Task<Void, Never> {
+        let session = session
+        return Task { [weak self, session] in
+            while !Task.isCancelled {
+                let tasks = await session.allTasks
+                self?.observeNetworkTasks(tasks)
+                do {
+                    try await Task.sleep(for: .milliseconds(250))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    func observeSnapshot(_ progress: Progress) {
+        let report = state.withLock { accumulator in
+            accumulator.observeSnapshot(
+                completedUnitCount: progress.completedUnitCount,
+                totalUnitCount: progress.totalUnitCount,
+                fraction: progress.fractionCompleted
+            )
+        }
+        emit(report)
+    }
+
+    private func observeNetworkTasks(_ tasks: [URLSessionTask]) {
+        let receivedBytes = tasks.reduce(into: [Int: Int64]()) { result, task in
+            guard Self.isModelFileTask(task) else { return }
+            result[task.taskIdentifier] = max(task.countOfBytesReceived, 0)
+        }
+        let report = state.withLock { accumulator in
+            accumulator.observeNetworkTasks(receivedBytes: receivedBytes)
+        }
+        emit(report)
+    }
+
+    private func emit(_ report: Gemma4DownloadProgressReport?) {
+        guard let report else { return }
+        let progress = Progress(totalUnitCount: report.totalUnitCount)
+        progress.completedUnitCount = report.completedUnitCount
+        progressHandler(progress)
+    }
+
+    private static func isModelFileTask(_ task: URLSessionTask) -> Bool {
+        let path = task.originalRequest?.url?.path
+            ?? task.currentRequest?.url?.path
+            ?? ""
+        return path.contains("/resolve/")
+    }
+}
 
 private struct Gemma4HubDownloader: Downloader {
     let client: HubClient
+    let session: URLSession
     let modelsDirectory: URL
 
     func download(
@@ -29,13 +174,20 @@ private struct Gemma4HubDownloader: Downloader {
             withIntermediateDirectories: true
         )
 
+        let progressSampler = Gemma4DownloadProgressSampler(
+            session: session,
+            progressHandler: progressHandler
+        )
+        let samplingTask = progressSampler.start()
+        defer { samplingTask.cancel() }
+
         return try await client.downloadSnapshot(
             of: repoID,
             to: destination,
             revision: revision ?? "main",
             matching: patterns,
             progressHandler: { @MainActor progress in
-                progressHandler(progress)
+                progressSampler.observeSnapshot(progress)
             }
         )
     }
@@ -91,7 +243,7 @@ private struct Gemma4TokenizerLoader: TokenizerLoader {
 // MARK: - Plugin Entry Point
 
 @objc(Gemma4Plugin)
-final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PluginRuntimeMemoryDiagnosticsReporting, @unchecked Sendable {
+final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMProviderSetupStatusProviding, LLMModelSelectable, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PluginRuntimeMemoryDiagnosticsReporting, @unchecked Sendable {
     static let pluginId = "com.typewhisper.gemma4"
     static let pluginName = "Gemma 4"
     static let defaultGenerationTemperature = 0.1
@@ -101,7 +253,12 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     private static let downloadedModelLoadProgress = 0.8
     private static let loadedModelPreparationProgress = 0.9
     private static let minimumVisibleDownloadProgress = 0.01
-    private static let minimumProgressAdvance = 0.001
+    private static let minimumVisibleProgressAdvance = 0.001
+
+    private enum ModelLoadPhase: Equatable {
+        case downloading
+        case preparing
+    }
 
     enum DownloadError: LocalizedError {
         case invalidRepositoryID(String)
@@ -122,11 +279,16 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.custom.rawValue
     fileprivate var _hfToken: String?
     private var modelLoadGeneration = 0
-    private var modelLoadTimeoutDuration: Duration = .seconds(300)
+    private var downloadInactivityTimeoutDuration: Duration = .seconds(300)
+    private var modelPreparationTimeoutDuration: Duration = .seconds(900)
     private let modelLoadClock = ContinuousClock()
-    private var lastModelLoadProgressInstant = ContinuousClock().now
-    private var lastModelLoadProgressFraction = 0.0
+    private var modelLoadPhase: ModelLoadPhase?
+    private var lastModelLoadActivityInstant = ContinuousClock().now
+    private var lastDownloadCompletedUnitCount: Int64 = 0
+    private var lastObservedDownloadFraction = 0.0
+    private var lastVisibleDownloadFraction = 0.0
     private var activeModelLoadTask: (generation: Int, task: Task<ModelContainer, Error>)?
+    private var modelLoadTimeoutTask: Task<Void, Never>?
     private var restoreModelTask: Task<Void, Never>?
 
     private func modelsDirectory() -> URL {
@@ -157,9 +319,9 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
             hubLockDirectory(for: modelDef.repoId),
         ]
     }
-    fileprivate var downloadProgress: Double = 0
+    @Published var downloadProgress: Double = 0
 
-    var modelState: Gemma4ModelState = .notLoaded
+    @Published var modelState: Gemma4ModelState = .notLoaded
 
     required override init() {
         super.init()
@@ -266,6 +428,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         }
 
         try deleteModelFiles(modelDef)
+        objectWillChange.send()
         host?.notifyCapabilitiesChanged()
     }
 
@@ -433,7 +596,10 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     @discardableResult
     func beginModelLoad(for modelDef: Gemma4ModelDef, isAlreadyDownloaded: Bool) -> Int {
-        let generation = beginModelLoad()
+        let generation = beginModelLoad(
+            phase: isAlreadyDownloaded ? .preparing : .downloading,
+            initialDownloadFraction: isAlreadyDownloaded ? 1.0 : 0.0
+        )
         _selectedLLMModelId = modelDef.id
         modelState = isAlreadyDownloaded ? .loading : .downloading
         downloadProgress = isAlreadyDownloaded ? Self.downloadedModelLoadProgress : Self.initialDownloadProgress
@@ -463,12 +629,19 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                 removeIncompleteModelIfNeeded(modelDef)
             }
 
+            let hubSession = URLSession(configuration: .default)
+            defer { hubSession.invalidateAndCancel() }
             let hubClient = HubClient(
+                session: hubSession,
                 host: HubClient.defaultHost,
                 bearerToken: token?.isEmpty == false ? token : nil,
                 cache: HubCache(cacheDirectory: modelsDir)
             )
-            let downloader = Gemma4HubDownloader(client: hubClient, modelsDirectory: modelsDir)
+            let downloader = Gemma4HubDownloader(
+                client: hubClient,
+                session: hubSession,
+                modelsDirectory: modelsDir
+            )
             let configuration = isAlreadyDownloaded
                 ? ModelConfiguration(
                     directory: localModelDirectory(for: modelDef.repoId),
@@ -485,16 +658,19 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                     configuration: configuration
                 ) { progress in
                     guard !Task.isCancelled else { return }
-                    let fraction = max(0.0, min(progress.fractionCompleted, 1.0))
-                    let mapped = Self.initialDownloadProgress + fraction * 0.78
+                    let rawFraction = progress.fractionCompleted
+                    let fraction = rawFraction.isFinite ? max(0.0, min(rawFraction, 1.0)) : 0.0
+                    let completedUnitCount = Self.effectiveCompletedUnitCount(
+                        completedUnitCount: progress.completedUnitCount,
+                        totalUnitCount: progress.totalUnitCount,
+                        fraction: fraction
+                    )
                     Task { @MainActor in
-                        guard self.recordModelLoadProgress(fraction: fraction, generation: loadGeneration) else {
-                            return
-                        }
-                        self.downloadProgress = max(self.downloadProgress, mapped)
-                        if case .downloading = self.modelState {
-                            self.host?.notifyCapabilitiesChanged()
-                        }
+                        self.recordModelLoadProgress(
+                            completedUnitCount: completedUnitCount,
+                            fraction: fraction,
+                            generation: loadGeneration
+                        )
                     }
                 }
             }
@@ -508,6 +684,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
             try Task.checkCancellation()
             guard isCurrentModelLoad(loadGeneration) else { return }
+            stopModelLoadTimeout(generation: loadGeneration)
             modelState = .loading
             downloadProgress = Self.loadedModelPreparationProgress
             modelContainer = container
@@ -526,6 +703,7 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
                 throw error
             }
             guard isCurrentModelLoad(loadGeneration) else { return }
+            stopModelLoadTimeout(generation: loadGeneration)
             modelContainer = nil
             loadedModelId = nil
             downloadProgress = 0
@@ -608,15 +786,26 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
     }
 
     @discardableResult
-    private func beginModelLoad() -> Int {
+    private func beginModelLoad(
+        phase: ModelLoadPhase,
+        initialDownloadFraction: Double
+    ) -> Int {
         modelLoadGeneration += 1
-        lastModelLoadProgressInstant = modelLoadClock.now
-        lastModelLoadProgressFraction = 0
+        modelLoadTimeoutTask?.cancel()
+        modelLoadTimeoutTask = nil
+        modelLoadPhase = phase
+        lastModelLoadActivityInstant = modelLoadClock.now
+        lastDownloadCompletedUnitCount = 0
+        lastObservedDownloadFraction = max(0.0, min(initialDownloadFraction, 1.0))
+        lastVisibleDownloadFraction = 0
         return modelLoadGeneration
     }
 
     private func invalidateModelLoad() {
         modelLoadGeneration += 1
+        modelLoadTimeoutTask?.cancel()
+        modelLoadTimeoutTask = nil
+        modelLoadPhase = nil
         restoreModelTask?.cancel()
         restoreModelTask = nil
         activeModelLoadTask?.task.cancel()
@@ -627,45 +816,127 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         generation == modelLoadGeneration
     }
 
-    private func recordModelLoadProgress(fraction: Double, generation: Int) -> Bool {
-        guard isCurrentModelLoad(generation) else { return false }
-        let normalized = max(0.0, min(fraction, 1.0))
-        guard normalized - lastModelLoadProgressFraction >= Self.minimumProgressAdvance else {
-            return false
+    private static func effectiveCompletedUnitCount(
+        completedUnitCount: Int64,
+        totalUnitCount: Int64,
+        fraction: Double
+    ) -> Int64 {
+        let normalizedCompletedUnitCount = max(completedUnitCount, 0)
+        guard totalUnitCount > 0 else {
+            return normalizedCompletedUnitCount
         }
-        lastModelLoadProgressFraction = normalized
-        lastModelLoadProgressInstant = modelLoadClock.now
-        return true
+
+        // Snapshot Progress reports in-flight child bytes through fractionCompleted,
+        // while its parent completedUnitCount may not advance until the file finishes.
+        let fractionCompletedUnitCount = Int64(
+            (Double(totalUnitCount) * max(0.0, min(fraction, 1.0))).rounded(.down)
+        )
+        return max(normalizedCompletedUnitCount, fractionCompletedUnitCount)
+    }
+
+    private func recordModelLoadProgress(
+        completedUnitCount: Int64,
+        fraction: Double,
+        generation: Int
+    ) {
+        guard isCurrentModelLoad(generation),
+              modelLoadPhase == .downloading else {
+            return
+        }
+
+        let normalized = max(0.0, min(fraction, 1.0))
+        lastObservedDownloadFraction = max(lastObservedDownloadFraction, normalized)
+
+        if completedUnitCount > lastDownloadCompletedUnitCount {
+            lastDownloadCompletedUnitCount = completedUnitCount
+            lastModelLoadActivityInstant = modelLoadClock.now
+        }
+
+        if normalized >= 1.0 {
+            enterModelPreparation(generation: generation)
+            return
+        }
+
+        guard normalized - lastVisibleDownloadFraction >= Self.minimumVisibleProgressAdvance else {
+            return
+        }
+
+        lastVisibleDownloadFraction = normalized
+        let mapped = Self.initialDownloadProgress + normalized * 0.78
+        downloadProgress = max(downloadProgress, mapped)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    private func enterModelPreparation(generation: Int) {
+        guard isCurrentModelLoad(generation),
+              modelLoadPhase == .downloading else {
+            return
+        }
+
+        modelLoadPhase = .preparing
+        lastModelLoadActivityInstant = modelLoadClock.now
+        lastObservedDownloadFraction = 1.0
+        modelState = .loading
+        downloadProgress = max(downloadProgress, Self.loadedModelPreparationProgress)
+        host?.notifyCapabilitiesChanged()
+    }
+
+    private func stopModelLoadTimeout(generation: Int) {
+        guard isCurrentModelLoad(generation) else { return }
+        modelLoadTimeoutTask?.cancel()
+        modelLoadTimeoutTask = nil
+        modelLoadPhase = nil
+    }
+
+    private func timeoutDuration(for phase: ModelLoadPhase) -> Duration {
+        switch phase {
+        case .downloading:
+            downloadInactivityTimeoutDuration
+        case .preparing:
+            modelPreparationTimeoutDuration
+        }
     }
 
     private func startModelLoadTimeout(generation: Int, modelName: String) {
-        let timeout = modelLoadTimeoutDuration
-        Task { [weak self] in
-            while true {
+        modelLoadTimeoutTask?.cancel()
+        modelLoadTimeoutTask = Task { [weak self] in
+            while !Task.isCancelled {
                 guard let self,
                       self.isCurrentModelLoad(generation),
-                      self.loadedModelId == nil else {
+                      self.loadedModelId == nil,
+                      let phase = self.modelLoadPhase else {
                     return
                 }
 
-                switch self.modelState {
-                case .downloading, .loading:
-                    break
-                default:
+                guard (phase == .downloading && self.modelState == .downloading)
+                        || (phase == .preparing && self.modelState == .loading) else {
                     return
                 }
 
-                let elapsed = self.lastModelLoadProgressInstant.duration(to: self.modelLoadClock.now)
+                let timeout = self.timeoutDuration(for: phase)
+                let elapsed = self.lastModelLoadActivityInstant.duration(to: self.modelLoadClock.now)
                 guard elapsed >= timeout else {
-                    try? await Task.sleep(for: timeout - elapsed)
+                    do {
+                        try await Task.sleep(for: timeout - elapsed)
+                    } catch {
+                        return
+                    }
                     continue
                 }
 
+                guard self.modelLoadPhase == phase else { continue }
+                let lastProgress = self.lastObservedDownloadFraction
                 self.invalidateModelLoad()
                 self.modelContainer = nil
                 self.loadedModelId = nil
                 self.downloadProgress = 0
-                self.modelState = .error(Self.stalledDownloadMessage(for: modelName))
+                self.modelState = .error(
+                    Self.modelLoadTimeoutMessage(
+                        for: phase,
+                        modelName: modelName,
+                        lastDownloadFraction: lastProgress
+                    )
+                )
                 self.host?.setUserDefault(nil, forKey: "loadedModel")
                 self.host?.notifyCapabilitiesChanged()
                 return
@@ -716,22 +987,79 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
 
     #if DEBUG
     func setModelLoadTimeoutForTesting(_ timeout: Duration) {
-        modelLoadTimeoutDuration = timeout
+        downloadInactivityTimeoutDuration = timeout
+        modelPreparationTimeoutDuration = timeout
+    }
+
+    func setModelLoadTimeoutsForTesting(
+        downloadInactivity: Duration,
+        preparation: Duration
+    ) {
+        downloadInactivityTimeoutDuration = downloadInactivity
+        modelPreparationTimeoutDuration = preparation
     }
 
     @discardableResult
     func startModelLoadTimeoutForTesting(modelName: String) -> Int {
-        let generation = beginModelLoad()
+        let generation = beginModelLoad(phase: .downloading, initialDownloadFraction: 0)
         modelState = .downloading
         downloadProgress = Self.initialDownloadProgress
         startModelLoadTimeout(generation: generation, modelName: modelName)
         return generation
     }
 
-    func recordModelLoadProgressForTesting(fraction: Double, generation: Int? = nil) {
+    func recordModelLoadProgressForTesting(
+        completedUnitCount: Int64,
+        totalUnitCount: Int64 = 1_000_000,
+        fraction: Double,
+        generation: Int? = nil
+    ) {
         let resolvedGeneration = generation ?? modelLoadGeneration
-        guard recordModelLoadProgress(fraction: fraction, generation: resolvedGeneration) else { return }
-        downloadProgress = Self.initialDownloadProgress + max(0.0, min(fraction, 1.0)) * 0.78
+        let effectiveCompletedUnitCount = Self.effectiveCompletedUnitCount(
+            completedUnitCount: completedUnitCount,
+            totalUnitCount: totalUnitCount,
+            fraction: fraction
+        )
+        recordModelLoadProgress(
+            completedUnitCount: effectiveCompletedUnitCount,
+            fraction: fraction,
+            generation: resolvedGeneration
+        )
+    }
+
+    static func effectiveCompletedUnitCountForTesting(
+        completedUnitCount: Int64,
+        totalUnitCount: Int64,
+        fraction: Double
+    ) -> Int64 {
+        effectiveCompletedUnitCount(
+            completedUnitCount: completedUnitCount,
+            totalUnitCount: totalUnitCount,
+            fraction: fraction
+        )
+    }
+
+    static func sampledDownloadProgressForTesting(
+        snapshotCompletedUnitCount: Int64,
+        snapshotTotalUnitCount: Int64,
+        snapshotFraction: Double,
+        receivedBytesByTask: [Int: Int64]
+    ) -> (completedUnitCount: Int64, totalUnitCount: Int64, isSnapshotComplete: Bool)? {
+        var accumulator = Gemma4DownloadProgressAccumulator()
+        let snapshotReport = accumulator.observeSnapshot(
+            completedUnitCount: snapshotCompletedUnitCount,
+            totalUnitCount: snapshotTotalUnitCount,
+            fraction: snapshotFraction
+        )
+        guard let report = accumulator.observeNetworkTasks(receivedBytes: receivedBytesByTask)
+            ?? snapshotReport else {
+            return nil
+        }
+        return (
+            completedUnitCount: report.completedUnitCount,
+            totalUnitCount: report.totalUnitCount,
+            isSnapshotComplete: report.isSnapshotComplete
+        )
     }
 
     func invalidateModelLoadForTesting() {
@@ -856,13 +1184,31 @@ final class Gemma4Plugin: NSObject, LLMProviderPlugin, LLMTemperatureControllabl
         return error.localizedDescription
     }
 
-    private static func stalledDownloadMessage(for modelName: String) -> String {
-        let bundle = Bundle(for: Gemma4Plugin.self)
-        let format = String(
-            localized: "Downloading or preparing %@ has not made progress for several minutes. Cancel, delete the cached model if one is shown, and try again. Adding an optional HuggingFace token may also help if Hugging Face is throttling downloads.",
-            bundle: bundle
+    private static func modelLoadTimeoutMessage(
+        for phase: ModelLoadPhase,
+        modelName: String,
+        lastDownloadFraction: Double
+    ) -> String {
+        let progress = String(
+            format: "%.2f%%",
+            locale: Locale(identifier: "en_US_POSIX"),
+            max(0.0, min(lastDownloadFraction, 1.0)) * 100
         )
-        return String(format: format, modelName)
+        let bundle = Bundle(for: Gemma4Plugin.self)
+        switch phase {
+        case .downloading:
+            let format = String(
+                localized: "Downloading %1$@ stalled at %2$@ because no additional bytes were received for five minutes. Try again. If the issue persists, delete the cached model and download it again.",
+                bundle: bundle
+            )
+            return String(format: format, modelName, progress)
+        case .preparing:
+            let format = String(
+                localized: "Preparing %1$@ timed out after 15 minutes (last download progress: %2$@). The downloaded model was kept; try loading it again.",
+                bundle: bundle
+            )
+            return String(format: format, modelName, progress)
+        }
     }
 
     private static func isRecoverableCacheError(_ rawMessage: String) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4SettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import TypeWhisperPluginSDK
 
 struct Gemma4SettingsView: View {
-    let plugin: Gemma4Plugin
+    @ObservedObject var plugin: Gemma4Plugin
     private let bundle = Bundle(for: Gemma4Plugin.self)
     @State private var modelState: Gemma4ModelState = .notLoaded
     @State private var selectedModelId: String = ""
@@ -12,10 +12,7 @@ struct Gemma4SettingsView: View {
     @State private var hfTokenInput = ""
     @State private var isValidatingToken = false
     @State private var tokenValidationResult: Bool?
-    @State private var isPolling = false
     @State private var loadTask: Task<Void, Never>?
-
-    private let pollTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
     private var trimmedHfTokenInput: String {
         hfTokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -177,21 +174,16 @@ struct Gemma4SettingsView: View {
         }
         .task {
             if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
-                isPolling = true
                 await plugin.restoreLoadedModel(allowDownloads: false)
-                isPolling = false
                 modelState = plugin.modelState
+                downloadProgress = plugin.currentDownloadProgress
             }
         }
-        .onReceive(pollTimer) { _ in
-            guard isPolling else { return }
-            downloadProgress = plugin.currentDownloadProgress
-            let pluginState = plugin.modelState
-            if pluginState != .notLoaded {
-                modelState = pluginState
-            }
-            if case .ready = pluginState { isPolling = false }
-            else if case .error = pluginState { isPolling = false }
+        .onReceive(plugin.$modelState) { newValue in
+            modelState = newValue
+        }
+        .onReceive(plugin.$downloadProgress) { newValue in
+            downloadProgress = newValue
         }
         .onChange(of: hfTokenInput) { _, newValue in
             let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -330,7 +322,6 @@ struct Gemma4SettingsView: View {
     private func resetCachedModel(_ modelDef: Gemma4ModelDef) {
         loadTask?.cancel()
         loadTask = nil
-        isPolling = false
         plugin.resetCachedModel(modelDef)
         modelState = plugin.modelState
         downloadProgress = plugin.currentDownloadProgress
@@ -339,7 +330,6 @@ struct Gemma4SettingsView: View {
     private func unloadCurrentModel() {
         loadTask?.cancel()
         loadTask = nil
-        isPolling = false
         plugin.unloadModel()
         modelState = plugin.modelState
         downloadProgress = plugin.currentDownloadProgress
@@ -348,7 +338,6 @@ struct Gemma4SettingsView: View {
     private func removeDownloadedModel(_ modelDef: Gemma4ModelDef) {
         loadTask?.cancel()
         loadTask = nil
-        isPolling = false
         Task {
             do {
                 try await plugin.deleteDownloadedModel(modelDef.id)
@@ -374,7 +363,6 @@ struct Gemma4SettingsView: View {
         plugin.beginModelLoad(for: modelDef, isAlreadyDownloaded: alreadyDownloaded)
         modelState = plugin.modelState
         downloadProgress = plugin.currentDownloadProgress
-        isPolling = true
         loadTask?.cancel()
         loadTask = Task {
             do {
@@ -384,7 +372,6 @@ struct Gemma4SettingsView: View {
             }
 
             await MainActor.run {
-                isPolling = false
                 modelState = plugin.modelState
                 downloadProgress = plugin.currentDownloadProgress
                 loadTask = nil
@@ -395,7 +382,6 @@ struct Gemma4SettingsView: View {
     private func cancelCurrentLoad() {
         loadTask?.cancel()
         loadTask = nil
-        isPolling = false
         plugin.cancelModelLoad()
         modelState = plugin.modelState
         downloadProgress = plugin.currentDownloadProgress

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Localizable.xcstrings
@@ -65,18 +65,34 @@
         }
       }
     },
-    "Downloading or preparing %@ has not made progress for several minutes. Cancel, delete the cached model if one is shown, and try again. Adding an optional HuggingFace token may also help if Hugging Face is throttling downloads.": {
+    "Downloading %1$@ stalled at %2$@ because no additional bytes were received for five minutes. Try again. If the issue persists, delete the cached model and download it again.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Beim Laden oder Vorbereiten von %@ gab es mehrere Minuten keinen Fortschritt. Breche ab, lösche das zwischengespeicherte Modell, falls es angezeigt wird, und versuche es erneut. Ein optionaler HuggingFace-Token kann ebenfalls helfen, wenn Hugging Face Downloads drosselt."
+            "value": "Der Download von %1$@ ist bei %2$@ stehen geblieben, da fünf Minuten lang keine weiteren Bytes empfangen wurden. Versuche es erneut. Wenn das Problem bestehen bleibt, lösche das zwischengespeicherte Modell und lade es erneut herunter."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ のダウンロードまたは準備が数分間進んでいません。キャンセルし、表示されている場合はキャッシュされたモデルを削除してから再試行してください。Hugging Face のダウンロードが制限されている場合は、オプションの HuggingFace トークンも役立つことがあります。"
+            "value": "%1$@ のダウンロードは %2$@ で停止し、5 分間新しいバイトを受信しませんでした。もう一度お試しください。問題が続く場合は、キャッシュされたモデルを削除して再度ダウンロードしてください。"
+          }
+        }
+      }
+    },
+    "Preparing %1$@ timed out after 15 minutes (last download progress: %2$@). The downloaded model was kept; try loading it again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Vorbereitung von %1$@ hat nach 15 Minuten das Zeitlimit erreicht (letzter Downloadfortschritt: %2$@). Das heruntergeladene Modell wurde beibehalten; versuche erneut, es zu laden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ の準備は 15 分後にタイムアウトしました（最後のダウンロード進捗: %2$@）。ダウンロード済みモデルは保持されています。もう一度読み込んでください。"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -620,7 +620,11 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         let plugin = Gemma4Plugin()
         let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E2B")
 
-        plugin.recordModelLoadProgressForTesting(fraction: 0.5, generation: generation)
+        plugin.recordModelLoadProgressForTesting(
+            completedUnitCount: 500_000,
+            fraction: 0.5,
+            generation: generation
+        )
 
         let activity = try XCTUnwrap(plugin.currentSettingsActivity)
         XCTAssertEqual(activity.message, "Downloading model")
@@ -684,16 +688,98 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
     }
 
-    func testGemma4ModelLoadTimeoutSetsErrorAndResetsProgress() async throws {
+    func testGemma4ByteProgressBelowVisibleThresholdPreventsFalseTimeout() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
         let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
         let plugin = Gemma4Plugin()
         plugin.activate(host: host)
-        plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
+        plugin.setModelLoadTimeoutForTesting(.milliseconds(500))
+        let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E2B")
 
-        plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
+        for step in 1 ... 6 {
+            try await Task.sleep(for: .milliseconds(100))
+            plugin.recordModelLoadProgressForTesting(
+                completedUnitCount: Int64(step),
+                fraction: Double(step) * 0.0001,
+                generation: generation
+            )
+        }
+
+        XCTAssertEqual(plugin.modelState, .downloading)
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
+        XCTAssertFalse(plugin.hasVisibleDownloadProgress)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+        plugin.cancelModelLoad()
+    }
+
+    func testGemma4SnapshotChildProgressProducesEffectiveCompletedBytes() {
+        let completedUnitCount = Gemma4Plugin.effectiveCompletedUnitCountForTesting(
+            completedUnitCount: 0,
+            totalUnitCount: 3_550_000_000,
+            fraction: 0.0005
+        )
+
+        XCTAssertEqual(completedUnitCount, 1_775_000)
+    }
+
+    func testGemma4NetworkTaskBytesDriveProgressWhenSnapshotParentIsStatic() throws {
+        let report = try XCTUnwrap(Gemma4Plugin.sampledDownloadProgressForTesting(
+            snapshotCompletedUnitCount: 0,
+            snapshotTotalUnitCount: 3_550_000_000,
+            snapshotFraction: 0,
+            receivedBytesByTask: [
+                41: 250_000_000,
+                42: 105_000_000,
+            ]
+        ))
+
+        XCTAssertEqual(report.completedUnitCount, 355_000_000)
+        XCTAssertEqual(report.totalUnitCount, 3_550_000_000)
+        XCTAssertFalse(report.isSnapshotComplete)
+    }
+
+    func testGemma4NetworkTaskBytesCannotFinishBeforeSnapshotCompletes() throws {
+        let inFlightReport = try XCTUnwrap(Gemma4Plugin.sampledDownloadProgressForTesting(
+            snapshotCompletedUnitCount: 0,
+            snapshotTotalUnitCount: 1_000,
+            snapshotFraction: 0,
+            receivedBytesByTask: [7: 1_000]
+        ))
+        let completedReport = try XCTUnwrap(Gemma4Plugin.sampledDownloadProgressForTesting(
+            snapshotCompletedUnitCount: 1_000,
+            snapshotTotalUnitCount: 1_000,
+            snapshotFraction: 1,
+            receivedBytesByTask: [7: 1_000]
+        ))
+
+        XCTAssertEqual(inFlightReport.completedUnitCount, 999)
+        XCTAssertFalse(inFlightReport.isSnapshotComplete)
+        XCTAssertEqual(completedReport.completedUnitCount, 1_000)
+        XCTAssertTrue(completedReport.isSnapshotComplete)
+    }
+
+    func testGemma4UnchangedByteCountTriggersDownloadTimeout() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        plugin.activate(host: host)
+        plugin.setModelLoadTimeoutForTesting(.milliseconds(40))
+
+        let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
+        plugin.recordModelLoadProgressForTesting(
+            completedUnitCount: 250_000,
+            fraction: 0.25,
+            generation: generation
+        )
+        plugin.recordModelLoadProgressForTesting(
+            completedUnitCount: 250_000,
+            fraction: 0.25,
+            generation: generation
+        )
         try await waitUntil("Gemma 4 timeout error") {
             if case .error = plugin.modelState {
                 return true
@@ -704,10 +790,53 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         guard case .error(let message) = plugin.modelState else {
             return XCTFail("Expected Gemma 4 load timeout to set an error state")
         }
+        XCTAssertTrue(message.contains("Downloading"))
         XCTAssertTrue(message.contains("Gemma 4 E4B"))
+        XCTAssertTrue(message.contains("25.00%"))
+        XCTAssertTrue(message.contains("five minutes"))
         XCTAssertEqual(plugin.currentDownloadProgress, 0)
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    func testGemma4CompletedDownloadUsesLongerPreparationTimeout() async throws {
+        let plugin = Gemma4Plugin()
+        plugin.setModelLoadTimeoutsForTesting(
+            downloadInactivity: .milliseconds(40),
+            preparation: .milliseconds(180)
+        )
+        let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E2B")
+
+        plugin.recordModelLoadProgressForTesting(
+            completedUnitCount: 1_000,
+            totalUnitCount: 1_000,
+            fraction: 1.0,
+            generation: generation
+        )
+
+        XCTAssertEqual(plugin.modelState, .loading)
+        XCTAssertEqual(plugin.currentDownloadProgress, 0.9, accuracy: 0.001)
+        XCTAssertEqual(plugin.currentSettingsActivity?.message, "Preparing model")
+
+        try await Task.sleep(for: .milliseconds(80))
+        XCTAssertEqual(plugin.modelState, .loading)
+
+        try await waitUntil("Gemma 4 preparation timeout error") {
+            if case .error = plugin.modelState {
+                return true
+            }
+            return false
+        }
+
+        guard case .error(let message) = plugin.modelState else {
+            return XCTFail("Expected Gemma 4 preparation timeout to set an error state")
+        }
+        XCTAssertTrue(message.contains("Preparing"))
+        XCTAssertTrue(message.contains("Gemma 4 E2B"))
+        XCTAssertTrue(message.contains("100.00%"))
+        XCTAssertTrue(message.contains("15 minutes"))
+        XCTAssertTrue(message.contains("downloaded model was kept"))
+        XCTAssertEqual(plugin.currentDownloadProgress, 0)
     }
 
     func testGemma4LateProgressFromInvalidatedLoadIsIgnored() throws {
@@ -715,7 +844,12 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
 
         plugin.invalidateModelLoadForTesting()
-        plugin.recordModelLoadProgressForTesting(fraction: 1.0, generation: generation)
+        plugin.recordModelLoadProgressForTesting(
+            completedUnitCount: 1_000,
+            totalUnitCount: 1_000,
+            fraction: 1.0,
+            generation: generation
+        )
 
         XCTAssertEqual(plugin.currentDownloadProgress, 0)
         XCTAssertEqual(plugin.modelState, .downloading)
@@ -725,10 +859,16 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         let plugin = Gemma4Plugin()
         let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
 
-        plugin.setModelLoadTimeoutForTesting(.milliseconds(20))
+        plugin.setModelLoadTimeoutForTesting(.milliseconds(40))
         let generation = plugin.startModelLoadTimeoutForTesting(modelName: model.displayName)
         plugin.cancelModelLoad()
-        try await Task.sleep(for: .milliseconds(40))
+        plugin.recordModelLoadProgressForTesting(
+            completedUnitCount: 1_000,
+            totalUnitCount: 1_000,
+            fraction: 1.0,
+            generation: generation
+        )
+        try await Task.sleep(for: .milliseconds(80))
 
         XCTAssertFalse(plugin.isCurrentModelLoadForTesting(generation))
         XCTAssertEqual(plugin.modelState, .notLoaded)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -799,6 +799,31 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
     }
 
+    func testGemma4ReplacementLoadKeepsDownloadWatchdogActive() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let host = MockHostServices(pluginDataDirectory: appSupportDirectory)
+        let plugin = Gemma4Plugin()
+        plugin.activate(host: host)
+        plugin.setLoadedModelIdForTesting("gemma-4-e2b-it-4bit")
+        plugin.setModelLoadTimeoutForTesting(.milliseconds(40))
+
+        plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E4B")
+        try await waitUntil("replacement Gemma 4 timeout error") {
+            if case .error = plugin.modelState {
+                return true
+            }
+            return false
+        }
+
+        guard case .error(let message) = plugin.modelState else {
+            return XCTFail("Expected a stalled replacement load to time out")
+        }
+        XCTAssertTrue(message.contains("Gemma 4 E4B"))
+        XCTAssertFalse(plugin.isAvailable)
+    }
+
     func testGemma4CompletedDownloadUsesLongerPreparationTimeout() async throws {
         let plugin = Gemma4Plugin()
         plugin.setModelLoadTimeoutsForTesting(


### PR DESCRIPTION
## Context

Gemma4Plugin 1.1.2 fixed the earlier MLX loader/shape failure reported in #847, but a later report showed a separate failure: the E2B download timed out after five minutes even though direct Hugging Face range requests succeeded on Wi-Fi, WARP, and hotspot. The plugin also showed only a spinner rather than byte-level download progress.

The Hugging Face snapshot parent progress does not advance its `completedUnitCount` while the large `model.safetensors` child transfer is in flight. That made the existing watchdog treat an active multi-gigabyte download as stalled.

## Changes

- sample the dedicated Hugging Face `URLSession` tasks and combine their received bytes with snapshot progress
- reset download inactivity on every byte increase while retaining the 0.1% threshold only for visible host notifications
- prevent sampled/retried task bytes from completing the snapshot before the upstream snapshot reports completion
- split the five-minute download inactivity timeout from a 15-minute model preparation timeout
- publish model state and progress directly to the plugin settings view so the determinate progress bar updates live
- add phase-specific localized timeout messages with the last observed progress
- bump Gemma4Plugin to 1.1.3

Closes #847

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS' \
  -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests \
  CODE_SIGNING_ALLOWED=NO
```

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh \
  --clean --run Gemma4Plugin \
  /Users/marco/.codex/worktrees/fb74/typewhisper-mac
```

Live verification on the dev app:

- installed Gemma4Plugin 1.1.3
- downloaded E2B from a fully empty/incomplete cache
- observed the determinate progress bar advance during `model.safetensors` transfer
- completed model preparation and reached the loaded state
- reloaded the completed cache and received the exact prompt response `GEMMA4_OK`

E4B was not downloaded or claimed as verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model downloads now surface more accurate, activity-based progress.
  - Loading now differentiates between downloading and preparing phases.
  - Settings updates react automatically as load state and progress change.
- **Bug Fixes**
  - Better handling of stalled downloads and phase-specific inactivity/timeout behavior.
  - Successful loads stop timeout monitoring correctly; cancellations invalidate pending timeout work.
  - If preparation times out, the downloaded model is kept while the user is prompted to try again.
- **Localization**
  - Added separate, phase-specific timeout messages (including last-known download percentage).
- **Tests**
  - Expanded coverage for progress accounting, timeout messaging, and cancellation/late updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->