### PR TITLE
Allow temporary Developer ID releases without iCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,11 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           REQUESTED_TAG: ${{ inputs.release_tag }}
           REQUESTED_WITHOUT_ICLOUD: ${{ inputs.without_icloud }}
+          SCHEDULED_WITHOUT_ICLOUD: ${{ vars.MACOS_SCHEDULED_WITHOUT_ICLOUD }}
         run: |
           WITHOUT_ICLOUD="false"
-          if [ "$EVENT_NAME" = "schedule" ] || [ "$REQUESTED_WITHOUT_ICLOUD" = "true" ]; then
+          if [ "$REQUESTED_WITHOUT_ICLOUD" = "true" ] ||
+            { [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULED_WITHOUT_ICLOUD" = "true" ]; }; then
             WITHOUT_ICLOUD="true"
           fi
           echo "without_icloud=$WITHOUT_ICLOUD" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         description: Optional exact release tag (for example v1.6.0-daily.20260719.1)
         required: false
         type: string
+      without_icloud:
+        description: Build without iCloud entitlements while the production App ID is unavailable
+        required: false
+        default: false
+        type: boolean
 
 env:
   SCHEME: TypeWhisper
@@ -28,6 +33,7 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       should_run: ${{ steps.resolve.outputs.should_run }}
+      without_icloud: ${{ steps.resolve.outputs.without_icloud }}
     steps:
       - name: Checkout
         if: github.event_name != 'push'
@@ -41,7 +47,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           REQUESTED_TAG: ${{ inputs.release_tag }}
+          REQUESTED_WITHOUT_ICLOUD: ${{ inputs.without_icloud }}
         run: |
+          WITHOUT_ICLOUD="false"
+          if [ "$EVENT_NAME" = "schedule" ] || [ "$REQUESTED_WITHOUT_ICLOUD" = "true" ]; then
+            WITHOUT_ICLOUD="true"
+          fi
+          echo "without_icloud=$WITHOUT_ICLOUD" >> "$GITHUB_OUTPUT"
+
           if [ "$EVENT_NAME" = "push" ]; then
             printf 'tag=%s\n' "$REF_NAME" >> "$GITHUB_OUTPUT"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -158,6 +171,7 @@ jobs:
     runs-on: macos-15
     env:
       RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      WITHOUT_ICLOUD: ${{ needs.prepare.outputs.without_icloud }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -202,6 +216,7 @@ jobs:
           bash scripts/check_release_signing.sh --self-test
 
       - name: Decode Developer ID Provisioning Profile
+        if: needs.prepare.outputs.without_icloud != 'true'
         env:
           MACOS_DEVELOPER_ID_PROVISIONING_PROFILE: ${{ secrets.MACOS_DEVELOPER_ID_PROVISIONING_PROFILE }}
         run: |
@@ -233,15 +248,22 @@ jobs:
           echo "RELEASE_CHANNEL=$RELEASE_CHANNEL" >> $GITHUB_ENV
           echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
 
+          ARCHIVE_ARGS=(
+            --archive-path build/TypeWhisper.xcarchive
+            --export-path build/export
+            --release-tag "$RELEASE_TAG"
+            --release-channel "$RELEASE_CHANNEL"
+            --build-number "$BUILD_NUMBER"
+            --signing-identity "$MACOS_SIGNING_IDENTITY"
+          )
+          if [ "$WITHOUT_ICLOUD" = "true" ]; then
+            ARCHIVE_ARGS+=(--without-icloud)
+          else
+            ARCHIVE_ARGS+=(--profile "$MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH")
+          fi
+
           set -o pipefail
-          bash scripts/archive_release.sh \
-            --archive-path build/TypeWhisper.xcarchive \
-            --export-path build/export \
-            --profile "$MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH" \
-            --release-tag "$RELEASE_TAG" \
-            --release-channel "$RELEASE_CHANNEL" \
-            --build-number "$BUILD_NUMBER" \
-            --signing-identity "$MACOS_SIGNING_IDENTITY" | tee build.log
+          bash scripts/archive_release.sh "${ARCHIVE_ARGS[@]}" | tee build.log
 
       - name: Check First-Party Warnings
         run: bash scripts/check_first_party_warnings.sh build.log
@@ -250,7 +272,12 @@ jobs:
         run: bash scripts/check_release_binary_instrumentation.sh build/export/TypeWhisper.app/Contents/MacOS/typewhisper-cli
 
       - name: Check Developer ID Signing
-        run: bash scripts/check_release_signing.sh build/export/TypeWhisper.app
+        run: |
+          CHECK_ARGS=()
+          if [ "$WITHOUT_ICLOUD" = "true" ]; then
+            CHECK_ARGS+=(--without-icloud)
+          fi
+          bash scripts/check_release_signing.sh "${CHECK_ARGS[@]}" build/export/TypeWhisper.app
 
       - name: Notarize App
         env:
@@ -275,7 +302,12 @@ jobs:
 
       - name: Verify Notarized App and Spawn
         run: |
+          CHECK_ARGS=()
+          if [ "$WITHOUT_ICLOUD" = "true" ]; then
+            CHECK_ARGS+=(--without-icloud)
+          fi
           bash scripts/check_release_signing.sh \
+            "${CHECK_ARGS[@]}" \
             --require-notarization \
             --spawn \
             build/export/TypeWhisper.app

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -4636,7 +4636,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = TypeWhisper/Resources/TypeWhisper.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "$(TYPEWHISPER_MAIN_ENTITLEMENTS)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
@@ -4660,6 +4660,8 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 6.0;
+				TYPEWHISPER_ICLOUD_ENABLED = YES;
+				TYPEWHISPER_MAIN_ENTITLEMENTS = TypeWhisper/Resources/TypeWhisper.entitlements;
 			};
 			name = Debug;
 		};
@@ -4667,7 +4669,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = TypeWhisper/Resources/TypeWhisper.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "$(TYPEWHISPER_MAIN_ENTITLEMENTS)";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
@@ -4691,6 +4693,8 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 6.0;
+				TYPEWHISPER_ICLOUD_ENABLED = YES;
+				TYPEWHISPER_MAIN_ENTITLEMENTS = TypeWhisper/Resources/TypeWhisper.entitlements;
 			};
 			name = Release;
 		};
@@ -4702,6 +4706,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				MARKETING_VERSION = 1.6.0;
 				PRODUCT_NAME = "typewhisper-cli";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
@@ -4714,6 +4719,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				MARKETING_VERSION = 1.6.0;
 				PRODUCT_NAME = "typewhisper-cli";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Release;

--- a/TypeWhisper/Resources/Info.plist
+++ b/TypeWhisper/Resources/Info.plist
@@ -62,6 +62,8 @@
 	<string>$(APP_GROUP_ID)</string>
 	<key>TypeWhisperICloudContainer</key>
 	<string>$(ICLOUD_CONTAINER_ID)</string>
+	<key>TypeWhisperICloudEnabled</key>
+	<string>$(TYPEWHISPER_ICLOUD_ENABLED)</string>
 	<key>TypeWhisperAccountBaseURL</key>
 	<string>https://app.typewhisper.com</string>
 </dict>

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -21,6 +21,15 @@ enum PremiumSyncMode: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
+private enum TypeWhisperBuildCapabilities {
+    static var iCloudSyncEnabled: Bool {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: "TypeWhisperICloudEnabled") as? String else {
+            return true
+        }
+        return !["no", "false", "0"].contains(value.lowercased())
+    }
+}
+
 struct CrossDevicePremiumEntitlement: Codable, Equatable, Sendable {
     struct SignedClaims: Codable, Equatable, Sendable {
         let status: String
@@ -569,6 +578,7 @@ final class CloudFolderSyncController: ObservableObject {
     private let premiumAccountService: PremiumAccountService
     private let syncStore: any UserDataSyncStore
     private let defaults: UserDefaults
+    private let automaticICloudAvailable: Bool
     private var customState: CloudFolderSyncState
     private var automaticState: CloudFolderSyncState
     private var localChangeObserverId: UUID?
@@ -592,6 +602,10 @@ final class CloudFolderSyncController: ObservableObject {
         premiumAccountService.isSignedIn && premiumAccountService.hasPremiumEntitlement
     }
 
+    var availableModes: [PremiumSyncMode] {
+        automaticICloudAvailable ? PremiumSyncMode.allCases : [.off, .cloudFolder]
+    }
+
     var selectedFolderDisplayName: String {
         switch mode {
         case .automaticICloud: String(localized: "TypeWhisper private iCloud container")
@@ -605,15 +619,18 @@ final class CloudFolderSyncController: ObservableObject {
     init(
         premiumAccountService: PremiumAccountService,
         syncStore: any UserDataSyncStore,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        automaticICloudAvailable: Bool = TypeWhisperBuildCapabilities.iCloudSyncEnabled
     ) {
         self.premiumAccountService = premiumAccountService
         self.syncStore = syncStore
         self.defaults = defaults
+        self.automaticICloudAvailable = automaticICloudAvailable
         self.customState = Self.loadState(from: defaults, key: Keys.syncState, legacyKey: Keys.legacySyncState)
         self.automaticState = Self.loadState(from: defaults, key: Keys.automaticSyncState)
         let storedMode = defaults.string(forKey: Keys.mode).flatMap(PremiumSyncMode.init(rawValue:))
-        self.mode = storedMode ?? (defaults.data(forKey: Keys.folderBookmark) != nil ? .cloudFolder : .off)
+        let requestedMode = storedMode ?? (defaults.data(forKey: Keys.folderBookmark) != nil ? .cloudFolder : .off)
+        self.mode = requestedMode == .automaticICloud && !automaticICloudAvailable ? .off : requestedMode
         self.lastSyncDate = mode == .automaticICloud ? automaticState.lastSyncAt : customState.lastSyncAt
 
         restoreSelectedFolder()
@@ -657,6 +674,7 @@ final class CloudFolderSyncController: ObservableObject {
     }
 
     func setMode(_ newMode: PremiumSyncMode) async {
+        guard automaticICloudAvailable || newMode != .automaticICloud else { return }
         guard newMode != mode, !isSyncing else { return }
         if isConfigured, canUseSync { await syncNow() }
         guard !isSyncing else { return }
@@ -1008,7 +1026,7 @@ struct CloudFolderSyncSettingsView: View {
                     get: { controller.mode },
                     set: { mode in Task { await controller.setMode(mode) } }
                 )) {
-                    ForEach(PremiumSyncMode.allCases) { mode in
+                    ForEach(controller.availableModes) { mode in
                         Text(mode.displayName).tag(mode)
                     }
                 }

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -466,6 +466,37 @@ final class CloudFolderSyncTests: XCTestCase {
     }
 
     @MainActor
+    func testNoICloudBuildHidesAutomaticModeWithoutOverwritingStoredChoice() async throws {
+        let suiteName = "PremiumSyncNoICloud-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(PremiumSyncMode.automaticICloud.rawValue, forKey: "premiumSync.mode")
+
+        let account = PremiumAccountService(
+            defaults: defaults,
+            keychainService: suiteName,
+            isSignedInOverride: false,
+            automaticallyRefresh: false
+        )
+        let controller = CloudFolderSyncController(
+            premiumAccountService: account,
+            syncStore: InMemoryUserDataSyncStore(),
+            defaults: defaults,
+            automaticICloudAvailable: false
+        )
+        defer { controller.deactivate() }
+
+        XCTAssertEqual(controller.availableModes, [.off, .cloudFolder])
+        XCTAssertEqual(controller.mode, .off)
+        XCTAssertEqual(defaults.string(forKey: "premiumSync.mode"), PremiumSyncMode.automaticICloud.rawValue)
+
+        await controller.setMode(.automaticICloud)
+
+        XCTAssertEqual(controller.mode, .off)
+        XCTAssertEqual(defaults.string(forKey: "premiumSync.mode"), PremiumSyncMode.automaticICloud.rawValue)
+    }
+
+    @MainActor
     func testDeletingPrivateFolderStopsSyncBeforeRemovingPackage() async throws {
         let suiteName = "PremiumSyncDelete-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/docs/release-notes/1.6.0-daily.20260719.1.md
+++ b/docs/release-notes/1.6.0-daily.20260719.1.md
@@ -1,0 +1,5 @@
+## Bug Fixes
+
+- Replaces the unavailable native Sign in with Apple entitlement with browser-based Apple authentication.
+- Uses target-specific Developer ID signing so the widget no longer inherits the main app's entitlements.
+- Temporarily disables automatic iCloud sync while Apple restores the production App ID. Cloud Folder sync remains available, and existing iCloud data is not deleted.

--- a/scripts/archive_release.sh
+++ b/scripts/archive_release.sh
@@ -14,15 +14,16 @@ release_tag=""
 release_channel=""
 build_number=""
 signing_identity="${MACOS_SIGNING_IDENTITY:-}"
+without_icloud=false
 
 usage() {
   cat >&2 <<'USAGE'
 Usage: scripts/archive_release.sh \
   --archive-path PATH \
   --export-path PATH \
-  --profile PATH \
   --release-tag TAG \
   --build-number NUMBER \
+  (--profile PATH | --without-icloud) \
   [--release-channel CHANNEL] \
   [--signing-identity IDENTITY]
 USAGE
@@ -55,12 +56,13 @@ while [[ $# -gt 0 ]]; do
     --release-channel) release_channel="${2:-}"; shift 2 ;;
     --build-number) build_number="${2:-}"; shift 2 ;;
     --signing-identity) signing_identity="${2:-}"; shift 2 ;;
+    --without-icloud) without_icloud=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown option: $1" >&2; usage; exit 2 ;;
   esac
 done
 
-for required_value in archive_path export_path profile_path release_tag build_number; do
+for required_value in archive_path export_path release_tag build_number; do
   if [[ -z "${!required_value}" ]]; then
     echo "error: --${required_value//_/-} is required" >&2
     usage
@@ -68,7 +70,15 @@ for required_value in archive_path export_path profile_path release_tag build_nu
   fi
 done
 
-if [[ ! -f "$profile_path" ]]; then
+if [[ "$without_icloud" == true && -n "$profile_path" ]]; then
+  echo "error: --profile and --without-icloud cannot be combined" >&2
+  exit 2
+fi
+if [[ "$without_icloud" == false && -z "$profile_path" ]]; then
+  echo "error: --profile or MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is required" >&2
+  exit 2
+fi
+if [[ "$without_icloud" == false && ! -f "$profile_path" ]]; then
   echo "error: provisioning profile not found: $profile_path" >&2
   exit 2
 fi
@@ -123,55 +133,71 @@ cleanup() {
 trap cleanup EXIT
 
 decoded_profile="$temporary_dir/profile.plist"
-security cms -D -i "$profile_path" > "$decoded_profile"
+profile_name=""
+main_entitlements="$repo_root/TypeWhisper/Resources/TypeWhisper.entitlements"
+icloud_enabled="YES"
 
-profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$decoded_profile")"
-profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$decoded_profile")"
-profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
-profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
-profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
-profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
+if [[ "$without_icloud" == true ]]; then
+  main_entitlements="$temporary_dir/TypeWhisper-NoICloud.entitlements"
+  cp "$repo_root/TypeWhisper/Resources/TypeWhisper.entitlements" "$main_entitlements"
+  /usr/libexec/PlistBuddy -c 'Delete :com.apple.developer.icloud-container-identifiers' "$main_entitlements"
+  /usr/libexec/PlistBuddy -c 'Delete :com.apple.developer.icloud-services' "$main_entitlements"
+  /usr/libexec/PlistBuddy -c 'Delete :com.apple.developer.ubiquity-container-identifiers' "$main_entitlements"
+  icloud_enabled="NO"
+  echo "Building without iCloud entitlements or a provisioning profile"
+else
+  security cms -D -i "$profile_path" > "$decoded_profile"
 
-if [[ "$profile_team" != "$team_id" ]]; then
-  echo "error: profile team is '$profile_team', expected '$team_id'" >&2
-  exit 1
-fi
-if [[ "$profile_app_id" != "$team_id.$bundle_id" ]]; then
-  echo "error: profile application identifier is '$profile_app_id', expected '$team_id.$bundle_id'" >&2
-  exit 1
-fi
-if [[ "$profile_all_devices" != "true" ]]; then
-  echo "error: profile is not a Developer ID provisioning profile" >&2
-  exit 1
-fi
-if ! plist_array_contains \
-  "$decoded_profile" \
-  "Entitlements:com.apple.developer.icloud-container-identifiers" \
-  "$icloud_container"; then
-  echo "error: profile does not contain iCloud container '$icloud_container'" >&2
-  exit 1
-fi
-expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
-if (( expiration_epoch <= $(date '+%s') )); then
-  echo "error: provisioning profile expired at $profile_expiration" >&2
-  exit 1
+  profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$decoded_profile")"
+  profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$decoded_profile")"
+  profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
+  profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
+  profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
+  profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
+
+  if [[ "$profile_team" != "$team_id" ]]; then
+    echo "error: profile team is '$profile_team', expected '$team_id'" >&2
+    exit 1
+  fi
+  if [[ "$profile_app_id" != "$team_id.$bundle_id" ]]; then
+    echo "error: profile application identifier is '$profile_app_id', expected '$team_id.$bundle_id'" >&2
+    exit 1
+  fi
+  if [[ "$profile_all_devices" != "true" ]]; then
+    echo "error: profile is not a Developer ID provisioning profile" >&2
+    exit 1
+  fi
+  if ! plist_array_contains \
+    "$decoded_profile" \
+    "Entitlements:com.apple.developer.icloud-container-identifiers" \
+    "$icloud_container"; then
+    echo "error: profile does not contain iCloud container '$icloud_container'" >&2
+    exit 1
+  fi
+  expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
+  if (( expiration_epoch <= $(date '+%s') )); then
+    echo "error: provisioning profile expired at $profile_expiration" >&2
+    exit 1
+  fi
+
+  profile_directory="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
+  mkdir -p "$profile_directory"
+  installed_profile="$profile_directory/$profile_uuid.provisionprofile"
+  if [[ -f "$installed_profile" ]]; then
+    installed_profile_backup="$temporary_dir/existing-profile.provisionprofile"
+    cp "$installed_profile" "$installed_profile_backup"
+  fi
+  cp "$profile_path" "$installed_profile"
+
+  echo "Using profile: $profile_name ($profile_uuid, expires $profile_expiration)"
 fi
 
-profile_directory="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
-mkdir -p "$profile_directory"
-installed_profile="$profile_directory/$profile_uuid.provisionprofile"
-if [[ -f "$installed_profile" ]]; then
-  installed_profile_backup="$temporary_dir/existing-profile.provisionprofile"
-  cp "$installed_profile" "$installed_profile_backup"
-fi
-cp "$profile_path" "$installed_profile"
-
-echo "Using profile: $profile_name ($profile_uuid, expires $profile_expiration)"
 echo "Using signing identity: $signing_identity"
 echo "Archiving $release_tag (build $build_number, channel $release_channel)"
 
 set -o pipefail
-xcodebuild archive \
+archive_arguments=(
+  archive
   -project "$project" \
   -scheme "$scheme" \
   -configuration Release \
@@ -181,13 +207,16 @@ xcodebuild archive \
   DEVELOPMENT_TEAM="$team_id" \
   CODE_SIGN_STYLE=Manual \
   CODE_SIGN_IDENTITY="$signing_identity" \
-  TYPEWHISPER_DEVELOPER_ID_PROFILE_SPECIFIER="$profile_name" \
+  TYPEWHISPER_DEVELOPER_ID_PROFILE_SPECIFIER="$profile_name"
+  TYPEWHISPER_MAIN_ENTITLEMENTS="$main_entitlements"
+  TYPEWHISPER_ICLOUD_ENABLED="$icloud_enabled"
   TYPEWHISPER_RELEASE_CHANNEL="$release_channel" \
   TYPEWHISPER_RELEASE_TAG="$release_tag" \
   MARKETING_VERSION="$marketing_version" \
   CURRENT_PROJECT_VERSION="$build_number" \
-  OTHER_CODE_SIGN_FLAGS="--timestamp" \
-  archive
+  OTHER_CODE_SIGN_FLAGS="--timestamp"
+)
+xcodebuild "${archive_arguments[@]}"
 
 export_options="$temporary_dir/ExportOptions.plist"
 plutil -create xml1 "$export_options"
@@ -196,10 +225,12 @@ plutil -create xml1 "$export_options"
 /usr/libexec/PlistBuddy -c "Add :teamID string $team_id" "$export_options"
 /usr/libexec/PlistBuddy -c 'Add :signingStyle string manual' "$export_options"
 /usr/libexec/PlistBuddy -c 'Add :signingCertificate string Developer ID Application' "$export_options"
-/usr/libexec/PlistBuddy -c 'Add :provisioningProfiles dict' "$export_options"
-/usr/libexec/PlistBuddy \
-  -c "Add :provisioningProfiles:$bundle_id string $profile_name" \
-  "$export_options"
+if [[ "$without_icloud" == false ]]; then
+  /usr/libexec/PlistBuddy -c 'Add :provisioningProfiles dict' "$export_options"
+  /usr/libexec/PlistBuddy \
+    -c "Add :provisioningProfiles:$bundle_id string $profile_name" \
+    "$export_options"
+fi
 
 xcodebuild -exportArchive \
   -archivePath "$archive_path" \

--- a/scripts/build-release-local.sh
+++ b/scripts/build-release-local.sh
@@ -8,11 +8,12 @@ profile_path="${MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH:-}"
 release_tag=""
 build_number=""
 skip_dmg=false
+without_icloud=false
 
 usage() {
   cat >&2 <<'USAGE'
 Usage: scripts/build-release-local.sh \
-  --profile PATH \
+  [--profile PATH | --without-icloud] \
   [--release-tag TAG] \
   [--build-number NUMBER] \
   [--skip-dmg]
@@ -25,12 +26,17 @@ while [[ $# -gt 0 ]]; do
     --release-tag) release_tag="${2:-}"; shift 2 ;;
     --build-number) build_number="${2:-}"; shift 2 ;;
     --skip-dmg) skip_dmg=true; shift ;;
+    --without-icloud) without_icloud=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown option: $1" >&2; usage; exit 2 ;;
   esac
 done
 
-if [[ -z "$profile_path" ]]; then
+if [[ "$without_icloud" == true && -n "$profile_path" ]]; then
+  echo "error: --profile and --without-icloud cannot be combined" >&2
+  exit 2
+fi
+if [[ "$without_icloud" == false && -z "$profile_path" ]]; then
   echo "error: --profile or MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is required" >&2
   exit 2
 fi
@@ -58,25 +64,34 @@ mkdir -p "$build_dir"
 echo "=== TypeWhisper Local Developer ID Release ==="
 echo "Tag: $release_tag"
 echo "Build: $build_number"
+echo "iCloud: $([[ "$without_icloud" == true ]] && echo disabled || echo enabled)"
 
 xcodebuild -resolvePackageDependencies \
   -project "$project_dir/TypeWhisper.xcodeproj" \
   -scheme TypeWhisper
 
 set -o pipefail
-bash "$script_dir/archive_release.sh" \
+archive_arguments=(
   --archive-path "$archive_path" \
   --export-path "$export_path" \
-  --profile "$profile_path" \
   --release-tag "$release_tag" \
   --release-channel local \
-  --build-number "$build_number" |
+  --build-number "$build_number"
+)
+check_arguments=()
+if [[ "$without_icloud" == true ]]; then
+  archive_arguments+=(--without-icloud)
+  check_arguments+=(--without-icloud)
+else
+  archive_arguments+=(--profile "$profile_path")
+fi
+bash "$script_dir/archive_release.sh" "${archive_arguments[@]}" |
   tee "$build_dir/build.log"
 
 bash "$script_dir/check_first_party_warnings.sh" "$build_dir/build.log"
 bash "$script_dir/check_release_binary_instrumentation.sh" \
   "$app_path/Contents/MacOS/typewhisper-cli"
-bash "$script_dir/check_release_signing.sh" "$app_path"
+bash "$script_dir/check_release_signing.sh" "${check_arguments[@]}" "$app_path"
 
 if [[ "$skip_dmg" == false ]]; then
   if ! command -v dmgbuild >/dev/null 2>&1; then

--- a/scripts/check_release_signing.sh
+++ b/scripts/check_release_signing.sh
@@ -8,10 +8,11 @@ app_group="$team_id.com.typewhisper.mac"
 icloud_container="iCloud.com.typewhisper.sync"
 require_notarization=false
 spawn_test=false
+without_icloud=false
 app_path=""
 
 usage() {
-  echo "Usage: $0 [--require-notarization] [--spawn] <TypeWhisper.app> | --self-test" >&2
+  echo "Usage: $0 [--without-icloud] [--require-notarization] [--spawn] <TypeWhisper.app> | --self-test" >&2
 }
 
 contains_unresolved_variable() {
@@ -56,6 +57,10 @@ widget_has_forbidden_entitlement() {
     >/dev/null
 }
 
+main_has_icloud_entitlement() {
+  grep -Eq 'com\.apple\.developer\.(icloud|ubiquity)' >/dev/null
+}
+
 self_test() {
   # shellcheck disable=SC2016 # Exercise the literal unresolved marker.
   if printf '%s\n' '<string>$(ICLOUD_CONTAINER_ID)</string>' | contains_unresolved_variable; then
@@ -76,6 +81,14 @@ self_test() {
     echo "self-test failed: allowed widget entitlement was rejected" >&2
     return 1
   fi
+  if ! printf '%s\n' '<key>com.apple.developer.icloud-services</key>' | main_has_icloud_entitlement; then
+    echo "self-test failed: main-app iCloud entitlement was not detected" >&2
+    return 1
+  fi
+  if printf '%s\n' '<key>com.apple.security.application-groups</key>' | main_has_icloud_entitlement; then
+    echo "self-test failed: non-iCloud main entitlement was rejected" >&2
+    return 1
+  fi
   echo "release signing self-test passed"
 }
 
@@ -88,6 +101,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --require-notarization) require_notarization=true; shift ;;
     --spawn) spawn_test=true; shift ;;
+    --without-icloud) without_icloud=true; shift ;;
     -h|--help) usage; exit 0 ;;
     -*) echo "error: unknown option: $1" >&2; usage; exit 2 ;;
     *)
@@ -114,10 +128,6 @@ if [[ ! -d "$widget_path" ]]; then
   echo "error: widget extension is missing" >&2
   exit 1
 fi
-if [[ ! -f "$profile_path" ]]; then
-  echo "error: Developer ID provisioning profile is missing from the main app" >&2
-  exit 1
-fi
 
 temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/typewhisper-signing-check.XXXXXX")"
 cleanup() {
@@ -128,56 +138,82 @@ trap cleanup EXIT
 decoded_profile="$temporary_dir/profile.plist"
 main_entitlements="$temporary_dir/main-entitlements.plist"
 widget_entitlements="$temporary_dir/widget-entitlements.plist"
-security cms -D -i "$profile_path" > "$decoded_profile"
 codesign -d --entitlements :- "$app_path" > "$main_entitlements" 2>/dev/null
 codesign -d --entitlements :- "$widget_path" > "$widget_entitlements" 2>/dev/null
 
 actual_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")"
-profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
-profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
-profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
-profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
+icloud_enabled="$(/usr/libexec/PlistBuddy -c 'Print :TypeWhisperICloudEnabled' "$info_plist")"
 
 [[ "$actual_bundle_id" == "$bundle_id" ]] || {
   echo "error: main bundle identifier is '$actual_bundle_id'" >&2
   exit 1
 }
-[[ "$profile_team" == "$team_id" ]] || {
-  echo "error: profile team is '$profile_team'" >&2
-  exit 1
-}
-[[ "$profile_app_id" == "$team_id.$bundle_id" ]] || {
-  echo "error: profile application identifier is '$profile_app_id'" >&2
-  exit 1
-}
-[[ "$profile_all_devices" == "true" ]] || {
-  echo "error: embedded profile is not a Developer ID profile" >&2
-  exit 1
-}
-plist_array_contains \
-  "$decoded_profile" \
-  "Entitlements:com.apple.developer.icloud-container-identifiers" \
-  "$icloud_container" || {
-  echo "error: profile is missing iCloud container '$icloud_container'" >&2
-  exit 1
-}
-expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
-(( expiration_epoch > $(date '+%s') )) || {
-  echo "error: profile expired at $profile_expiration" >&2
-  exit 1
-}
+if [[ "$without_icloud" == true ]]; then
+  [[ ! -f "$profile_path" ]] || {
+    echo "error: no-iCloud release unexpectedly contains a provisioning profile" >&2
+    exit 1
+  }
+  [[ "$icloud_enabled" == "NO" ]] || {
+    echo "error: no-iCloud release does not declare iCloud disabled" >&2
+    exit 1
+  }
+  if plutil -convert xml1 -o - "$main_entitlements" | main_has_icloud_entitlement; then
+    echo "error: no-iCloud release contains iCloud entitlements" >&2
+    exit 1
+  fi
+else
+  [[ -f "$profile_path" ]] || {
+    echo "error: Developer ID provisioning profile is missing from the main app" >&2
+    exit 1
+  }
+  security cms -D -i "$profile_path" > "$decoded_profile"
+  profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
+  profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
+  profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
+  profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
 
-main_application_id="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.application-identifier' "$main_entitlements")"
-main_team="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.team-identifier' "$main_entitlements")"
+  [[ "$icloud_enabled" == "YES" ]] || {
+    echo "error: iCloud release does not declare iCloud enabled" >&2
+    exit 1
+  }
+  [[ "$profile_team" == "$team_id" ]] || {
+    echo "error: profile team is '$profile_team'" >&2
+    exit 1
+  }
+  [[ "$profile_app_id" == "$team_id.$bundle_id" ]] || {
+    echo "error: profile application identifier is '$profile_app_id'" >&2
+    exit 1
+  }
+  [[ "$profile_all_devices" == "true" ]] || {
+    echo "error: embedded profile is not a Developer ID profile" >&2
+    exit 1
+  }
+  plist_array_contains \
+    "$decoded_profile" \
+    "Entitlements:com.apple.developer.icloud-container-identifiers" \
+    "$icloud_container" || {
+    echo "error: profile is missing iCloud container '$icloud_container'" >&2
+    exit 1
+  }
+  expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
+  (( expiration_epoch > $(date '+%s') )) || {
+    echo "error: profile expired at $profile_expiration" >&2
+    exit 1
+  }
 
-[[ "$main_application_id" == "$team_id.$bundle_id" ]] || {
-  echo "error: signed application identifier is '$main_application_id'" >&2
-  exit 1
-}
-[[ "$main_team" == "$team_id" ]] || {
-  echo "error: signed team identifier is '$main_team'" >&2
-  exit 1
-}
+  main_application_id="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.application-identifier' "$main_entitlements")"
+  main_team="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.team-identifier' "$main_entitlements")"
+
+  [[ "$main_application_id" == "$team_id.$bundle_id" ]] || {
+    echo "error: signed application identifier is '$main_application_id'" >&2
+    exit 1
+  }
+  [[ "$main_team" == "$team_id" ]] || {
+    echo "error: signed team identifier is '$main_team'" >&2
+    exit 1
+  }
+fi
+
 plist_array_equals_single_value \
   "$main_entitlements" \
   "com.apple.security.application-groups" \
@@ -185,16 +221,18 @@ plist_array_equals_single_value \
   echo "error: signed app group is incorrect" >&2
   exit 1
 }
-if ! plist_array_equals_single_value \
-    "$main_entitlements" \
-    "com.apple.developer.icloud-container-identifiers" \
-    "$icloud_container" ||
-  ! plist_array_equals_single_value \
-    "$main_entitlements" \
-    "com.apple.developer.ubiquity-container-identifiers" \
-    "$icloud_container"; then
-  echo "error: signed iCloud containers are incorrect" >&2
-  exit 1
+if [[ "$without_icloud" == false ]]; then
+  if ! plist_array_equals_single_value \
+      "$main_entitlements" \
+      "com.apple.developer.icloud-container-identifiers" \
+      "$icloud_container" ||
+    ! plist_array_equals_single_value \
+      "$main_entitlements" \
+      "com.apple.developer.ubiquity-container-identifiers" \
+      "$icloud_container"; then
+    echo "error: signed iCloud containers are incorrect" >&2
+    exit 1
+  fi
 fi
 if /usr/libexec/PlistBuddy -c 'Print :com.apple.developer.applesignin' "$main_entitlements" >/dev/null 2>&1; then
   echo "error: native Sign in with Apple entitlement must not be signed into the Developer ID app" >&2
@@ -220,7 +258,11 @@ if plutil -convert xml1 -o - "$widget_entitlements" | widget_has_forbidden_entit
   exit 1
 fi
 
-for plist in "$info_plist" "$main_entitlements" "$widget_entitlements" "$decoded_profile"; do
+plists_to_check=("$info_plist" "$main_entitlements" "$widget_entitlements")
+if [[ -f "$decoded_profile" ]]; then
+  plists_to_check+=("$decoded_profile")
+fi
+for plist in "${plists_to_check[@]}"; do
   if plutil -convert xml1 -o - "$plist" | contains_unresolved_variable; then
     echo "error: unresolved build setting found in $(basename "$plist")" >&2
     exit 1


### PR DESCRIPTION
## Context

The production Developer ID App ID `com.typewhisper.mac` is currently unavailable in the Apple Developer portal, so Apple cannot issue the required iCloud provisioning profile. This follow-up keeps the repaired Developer ID archive/export and browser-based Apple login from #956 releasable while Apple Support restores the App ID.

The release workflow now supports an explicit no-iCloud mode. It removes only the main app iCloud entitlements, embeds no provisioning profile, hides automatic iCloud sync without overwriting the stored preference, and leaves Cloud Folder sync available. The CLI is marked `SKIP_INSTALL` so Xcode produces a distributable app archive while still embedding the universal CLI in the app bundle.

Closes #956

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -parallel-testing-enabled NO -only-testing:TypeWhisperTests/CloudFolderSyncTests CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `bash scripts/check_release_signing.sh --self-test`
- `bash scripts/archive_release.sh --archive-path "$TMPDIR/TypeWhisper.xcarchive" --export-path "$TMPDIR/export" --without-icloud --release-tag v1.6.0-daily.20260719.1 --release-channel daily --build-number 1004 --signing-identity "Developer ID Application: Marco Hillger (2D8ALY3LCL)"`
- `bash scripts/check_release_signing.sh --without-icloud --spawn "$TMPDIR/export/TypeWhisper.app"`
- `bash scripts/pr-preflight.sh origin/main`
- `actionlint -shellcheck= .github/workflows/release.yml`
- `shellcheck scripts/archive_release.sh scripts/check_release_signing.sh scripts/build-release-local.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to build and release the app without iCloud entitlements.
  * Local and automated release builds now support choosing iCloud-enabled vs iCloud-disabled packaging.
* **Bug Fixes**
  * iCloud Automatic Sync is hidden and forced off when iCloud isn’t available; Cloud Folder sync remains available.
  * Prevented unavailable iCloud sync settings from being activated or incorrectly restored.
  * Improved authentication and widget signing behavior in the daily release notes.
* **Documentation**
  * Updated release notes to document authentication, widget signing, and temporary iCloud sync changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->