### PR TITLE
Add notarization log diagnostics

### DIFF
--- a/.github/workflows/notarization-log.yml
+++ b/.github/workflows/notarization-log.yml
@@ -1,0 +1,33 @@
+name: Fetch Notarization Log
+
+on:
+  workflow_dispatch:
+    inputs:
+      submission_id:
+        description: Apple notarization submission ID
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  fetch:
+    runs-on: macos-latest
+    steps:
+      - name: Fetch Notarization Log
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APPLE_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+          SUBMISSION_ID: ${{ inputs.submission_id }}
+        run: |
+          key_path="${RUNNER_TEMP}/AuthKey.p8"
+          trap 'rm -f "$key_path"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          chmod 600 "$key_path"
+
+          xcrun notarytool log "$SUBMISSION_ID" \
+            --key "$key_path" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID"


### PR DESCRIPTION
## Context

The no-iCloud repair release for #956 reached Apple's notary service, but the submission was marked `Invalid` before stapling. The existing release workflow only showed the final status and therefore hid Apple's actionable validation issues.

This adds a manual, read-only diagnostic workflow that fetches the official notarization log for a supplied submission ID using the existing protected App Store Connect credentials. The temporary key is removed from the runner after every invocation.

## Test plan

- `actionlint -shellcheck= .github/workflows/notarization-log.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for retrieving macOS notarization logs using a submission ID.
  * Credentials are handled securely and temporary authentication files are removed automatically after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->