### PR TITLE
Fix Bluetooth system-default recording startup

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -554,6 +554,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
         let usesBluetoothTransport = transportType(for: defaultInputDeviceID)
             .map(Self.isBluetoothTransportType) ?? false
+        guard usesBluetoothTransport else {
+            return .systemDefault
+        }
         return ResolvedRecordingInputSelection(
             deviceUID: nil,
             deviceID: defaultInputDeviceID,

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -274,6 +274,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private let selectionEngineValidator: AudioInputSelectionEngineValidating
     private let inputCaptureFactory: AudioInputCaptureFactory
     private let clamshellStateProvider: ClamshellStateProviding
+    private let defaultInputDeviceController: AudioInputDeviceDefaultControlling
 
     var selectedDeviceID: AudioDeviceID? {
         guard let uid = selectedDeviceUID else { return nil }
@@ -348,7 +349,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     }
 
     func diagnosticsReport() -> AudioInputDiagnosticsReport {
-        let defaultInputDeviceID = CoreAudioInputDeviceDefaultController().defaultInputDeviceID()
+        let defaultInputDeviceID = defaultInputDeviceController.defaultInputDeviceID()
         var listedDevicesByID: [AudioDeviceID: AudioInputDevice] = [:]
         var listedDevicesByUID: [String: AudioInputDevice] = [:]
         for device in inputDevices {
@@ -405,7 +406,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         selectionEngineValidator: AudioInputSelectionEngineValidating = AVAudioInputSelectionEngineValidator(),
         inputCaptureFactory: AudioInputCaptureFactory = CoreAudioHALInputCaptureFactory(),
         inputActivationGuard: AudioInputDeviceActivating = AudioInputDeviceActivationGuard(),
-        clamshellStateProvider: ClamshellStateProviding = IOKitClamshellStateProvider()
+        clamshellStateProvider: ClamshellStateProviding = IOKitClamshellStateProvider(),
+        defaultInputDeviceController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController()
     ) {
         self.outputVolumeGuard = outputVolumeGuard
         self.transportResolver = transportResolver
@@ -414,6 +416,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         self.inputCaptureFactory = inputCaptureFactory
         self.inputActivationGuard = inputActivationGuard
         self.clamshellStateProvider = clamshellStateProvider
+        self.defaultInputDeviceController = defaultInputDeviceController
         previewNotificationQueue.underlyingQueue = previewRecoveryQueue
         isInitializingSelection = true
         selectedDeviceUID = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -546,7 +549,17 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             )
         }
 
-        return .systemDefault
+        guard let defaultInputDeviceID = defaultInputDeviceController.defaultInputDeviceID() else {
+            return .systemDefault
+        }
+        let usesBluetoothTransport = transportType(for: defaultInputDeviceID)
+            .map(Self.isBluetoothTransportType) ?? false
+        return ResolvedRecordingInputSelection(
+            deviceUID: nil,
+            deviceID: defaultInputDeviceID,
+            deviceName: inputDevices.first(where: { $0.deviceID == defaultInputDeviceID })?.name,
+            usesBluetoothTransport: usesBluetoothTransport
+        )
     }
 
     // MARK: - Audio Preview

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -830,7 +830,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     private var requiresInitialInputReadiness: Bool {
         configLock.withLock {
-            _hasExplicitDeviceSelection && _selectedInputDeviceUsesBluetoothTransport
+            _selectedInputDeviceUsesBluetoothTransport
         }
     }
 
@@ -839,7 +839,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         usesBluetoothTransport: Bool
     ) {
         configLock.withLock {
-            let usesBluetoothTransport = _hasExplicitDeviceSelection && _selectedInputDeviceUsesBluetoothTransport
+            let usesBluetoothTransport = _selectedInputDeviceUsesBluetoothTransport
             return (
                 _selectedDeviceID,
                 usesBluetoothTransport
@@ -849,7 +849,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     private var selectedEngineInputRoute: (selectedDeviceID: AudioDeviceID?, engineDeviceID: AudioDeviceID?) {
         configLock.withLock {
-            let usesBluetoothTransport = _hasExplicitDeviceSelection && _selectedInputDeviceUsesBluetoothTransport
+            let usesBluetoothTransport = _selectedInputDeviceUsesBluetoothTransport
             return (
                 _selectedDeviceID,
                 AudioEngineInputRoute.preferredDeviceIDForEngine(
@@ -864,7 +864,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         configLock.withLock {
             AudioInputCaptureRoute.selectedRoute(
                 selectedDeviceID: _hasExplicitDeviceSelection ? _selectedDeviceID : nil,
-                usesBluetoothTransport: _hasExplicitDeviceSelection && _selectedInputDeviceUsesBluetoothTransport
+                usesBluetoothTransport: _selectedInputDeviceUsesBluetoothTransport
             )
         }
     }

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -4919,6 +4919,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let defaultInputDeviceID = AudioDeviceID(79)
         dictationContext = Self.makeDictationContext(
             appSupportDirectory: appSupportDirectory,
+            audioDeviceTransportResolver: FakeAudioDeviceTransportResolver(
+                transports: [defaultInputDeviceID: kAudioDeviceTransportTypeBluetooth]
+            ),
             audioDeviceDefaultInputController: APIFakeAudioInputDeviceDefaultController(
                 defaultInputDeviceID: defaultInputDeviceID
             )

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -20,6 +20,23 @@ private func rtfAttributedStringContainsFontTrait(
     return NSFontManager.shared.traits(of: font).contains(trait)
 }
 
+private final class APIFakeAudioInputDeviceDefaultController: AudioInputDeviceDefaultControlling {
+    private var deviceID: AudioDeviceID?
+
+    init(defaultInputDeviceID: AudioDeviceID?) {
+        deviceID = defaultInputDeviceID
+    }
+
+    func defaultInputDeviceID() -> AudioDeviceID? {
+        deviceID
+    }
+
+    func setDefaultInputDeviceID(_ deviceID: AudioDeviceID) -> Bool {
+        self.deviceID = deviceID
+        return true
+    }
+}
+
 final class SecureInputDiagnosticsProviderTests: XCTestCase {
     func testSnapshotPrefersOnConsoleIORegistryOwner() {
         let consoleUsers: NSArray = [
@@ -4899,16 +4916,22 @@ final class APIRouterAndHandlersTests: XCTestCase {
             Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
         }
 
-        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let defaultInputDeviceID = AudioDeviceID(79)
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDeviceDefaultInputController: APIFakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: defaultInputDeviceID
+            )
+        )
         let context = try XCTUnwrap(dictationContext)
         context.audioDeviceService.inputDevices = []
         context.audioRecordingService.hasMicrophonePermissionOverride = true
         context.audioRecordingService.inputAvailabilityOverride = { selectedDeviceID in
-            XCTAssertNil(selectedDeviceID)
+            XCTAssertEqual(selectedDeviceID, defaultInputDeviceID)
             return true
         }
         context.audioRecordingService.startRecordingOverride = {
-            XCTAssertNil(context.audioRecordingService.selectedDeviceID)
+            XCTAssertEqual(context.audioRecordingService.selectedDeviceID, defaultInputDeviceID)
             XCTAssertFalse(context.audioRecordingService.hasExplicitDeviceSelection)
         }
 
@@ -5934,6 +5957,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         audioDeviceTransportResolver: AudioDeviceTransportResolving = CoreAudioDeviceTransportResolver(),
         audioDeviceBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
         audioDeviceSelectionEngineValidator: AudioInputSelectionEngineValidating = AVAudioInputSelectionEngineValidator(),
+        audioDeviceDefaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController(),
         audioRecordingBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer()
     ) -> DictationContext {
         EventBus.shared = EventBus()
@@ -5990,7 +6014,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let audioDeviceService = AudioDeviceService(
             transportResolver: audioDeviceTransportResolver,
             bluetoothInputRouteStabilizer: audioDeviceBluetoothInputRouteStabilizer,
-            selectionEngineValidator: audioDeviceSelectionEngineValidator
+            selectionEngineValidator: audioDeviceSelectionEngineValidator,
+            defaultInputDeviceController: audioDeviceDefaultInputController
         )
         let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
         let promptProcessingService = PromptProcessingService()

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1075,6 +1075,27 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(selection.usesBluetoothTransport)
     }
 
+    func testResolvedRecordingInputSelectionKeepsBuiltInSystemDefaultOnDefaultRoute() {
+        let builtInDeviceID = AudioDeviceID(703)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [builtInDeviceID: kAudioDeviceTransportTypeBuiltIn]
+            ),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: builtInDeviceID
+            )
+        )
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection, .systemDefault)
+    }
+
     func testResolvedRecordingInputSelectionSkipsBuiltInMicWhenLidIsClosed() throws {
         let builtInDeviceID = AudioDeviceID(1)
         let usbDeviceID = AudioDeviceID(2)
@@ -1321,6 +1342,76 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         service.stopPreview()
 
         XCTAssertEqual(inputActivationGuard.restoreCalls, ["preview-stop"])
+    }
+
+    @MainActor
+    func testStartPreviewActivatesBluetoothSystemDefaultAndUsesAggregateEngineRoute() {
+        let bluetoothDeviceID = AudioDeviceID(712)
+        let inputActivationGuard = FakeAudioInputDeviceActivator()
+        let routeStabilizer = FakeBluetoothInputRouteStabilizer { inputDeviceID, reason in
+            XCTAssertEqual(inputDeviceID, bluetoothDeviceID)
+            XCTAssertEqual(reason, "preview-start")
+            return true
+        }
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: bluetoothDeviceID, name: "System Headset", uid: "system-headset")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [bluetoothDeviceID: kAudioDeviceTransportTypeBluetooth]
+            ),
+            bluetoothInputRouteStabilizer: routeStabilizer,
+            inputActivationGuard: inputActivationGuard,
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: bluetoothDeviceID
+            )
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.startPreviewOverride = { preferredDeviceID in
+            XCTAssertNil(preferredDeviceID)
+        }
+
+        service.startPreview()
+
+        XCTAssertEqual(inputActivationGuard.activateCalls, [
+            .init(deviceID: bluetoothDeviceID, reason: "preview-start")
+        ])
+        XCTAssertTrue(service.isPreviewActive)
+
+        service.stopPreview()
+
+        XCTAssertEqual(inputActivationGuard.restoreCalls, ["preview-stop"])
+    }
+
+    @MainActor
+    func testStartPreviewKeepsBuiltInSystemDefaultOnDefaultRoute() {
+        let builtInDeviceID = AudioDeviceID(713)
+        let inputActivationGuard = FakeAudioInputDeviceActivator()
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [builtInDeviceID: kAudioDeviceTransportTypeBuiltIn]
+            ),
+            inputActivationGuard: inputActivationGuard,
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: builtInDeviceID
+            )
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.startPreviewOverride = { preferredDeviceID in
+            XCTAssertNil(preferredDeviceID)
+        }
+
+        service.startPreview()
+
+        XCTAssertTrue(inputActivationGuard.activateCalls.isEmpty)
+        XCTAssertTrue(service.isPreviewActive)
     }
 
     @MainActor

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1033,7 +1033,8 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let service = AudioDeviceService(
             initialInputDevices: [],
             monitorDeviceChanges: false,
-            probeCompatibilities: false
+            probeCompatibilities: false,
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(defaultInputDeviceID: nil)
         )
 
         let selection = service.resolvedRecordingInputSelection()
@@ -1041,6 +1042,37 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertNil(selection.deviceUID)
         XCTAssertNil(selection.deviceID)
         XCTAssertFalse(selection.hasExplicitDeviceSelection)
+    }
+
+    func testResolvedRecordingInputSelectionDetectsBluetoothSystemDefault() throws {
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "missing-primary", name: "Desk Mic")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let bluetoothDeviceID = AudioDeviceID(702)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: bluetoothDeviceID, name: "Sony WH-1000XM4", uid: "sony-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [bluetoothDeviceID: kAudioDeviceTransportTypeBluetooth]
+            ),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: bluetoothDeviceID
+            )
+        )
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertNil(selection.deviceUID)
+        XCTAssertEqual(selection.deviceID, bluetoothDeviceID)
+        XCTAssertEqual(selection.deviceName, "Sony WH-1000XM4")
+        XCTAssertFalse(selection.hasExplicitDeviceSelection)
+        XCTAssertTrue(selection.usesBluetoothTransport)
     }
 
     func testResolvedRecordingInputSelectionSkipsBuiltInMicWhenLidIsClosed() throws {
@@ -1145,7 +1177,8 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             transportResolver: FakeAudioDeviceTransportResolver(
                 transports: [builtInDeviceID: kAudioDeviceTransportTypeBuiltIn]
             ),
-            clamshellStateProvider: clamshellProvider
+            clamshellStateProvider: clamshellProvider,
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(defaultInputDeviceID: nil)
         )
         service.audioDeviceIDResolverOverride = { uid in
             uid == "built-in" ? builtInDeviceID : nil
@@ -1526,6 +1559,45 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertEqual(inputActivationGuard.restoreCalls, ["recording-stop-override"])
     }
 
+    func testStartRecordingActivatesBluetoothSystemDefaultWithoutExplicitSelection() async {
+        var routeEvents: [String] = []
+        let inputActivationGuard = FakeAudioInputDeviceActivator { call in
+            routeEvents.append("input:\(call.reason)")
+        }
+        let routeStabilizer = FakeBluetoothInputRouteStabilizer { inputDeviceID, reason in
+            XCTAssertEqual(inputDeviceID, AudioDeviceID(42))
+            XCTAssertEqual(reason, "recording-start")
+            routeEvents.append("stabilize:\(reason)")
+            return true
+        }
+        let service = AudioRecordingService(
+            inputActivationGuard: inputActivationGuard,
+            bluetoothInputRouteStabilizer: routeStabilizer
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = false
+        service.selectedDeviceID = AudioDeviceID(42)
+        service.selectedInputDeviceUsesBluetoothTransport = true
+        service.inputAvailabilityOverride = { selectedDeviceID in
+            XCTAssertEqual(selectedDeviceID, AudioDeviceID(42))
+            return true
+        }
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in [] }
+
+        XCTAssertNoThrow(try service.startRecording())
+        _ = await service.stopRecording(policy: .immediate)
+
+        XCTAssertEqual(routeEvents, [
+            "input:recording-start",
+            "stabilize:recording-start"
+        ])
+        XCTAssertEqual(inputActivationGuard.activateCalls, [
+            .init(deviceID: AudioDeviceID(42), reason: "recording-start")
+        ])
+        XCTAssertEqual(inputActivationGuard.restoreCalls, ["recording-stop-override"])
+    }
+
     func testSelectedDeviceUsesBluetoothTransport_resolvesTransportFromSelectedUID() {
         let bluetoothDeviceID = AudioDeviceID(700)
         let transportResolver = FakeAudioDeviceTransportResolver(
@@ -1683,6 +1755,16 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         try service.testingMarkInitialInputTapSeen(makeMonoBuffer(samples: [0, 0.002, 0, -0.001]))
 
         XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded())
+    }
+
+    func testBluetoothInputReadinessRunsForSystemDefaultWithoutExplicitSelection() {
+        let readinessChecker = FakeAudioInputReadinessChecker()
+        let service = AudioRecordingService(inputReadinessChecker: readinessChecker)
+        service.hasExplicitDeviceSelection = false
+        service.selectedInputDeviceUsesBluetoothTransport = true
+
+        XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded())
+        XCTAssertEqual(readinessChecker.waitCalls, [.init(label: "test")])
     }
 
     func testBluetoothInputReadinessProbeIsSkippedForNonBluetoothInput() {


### PR DESCRIPTION
## Summary

- resolve the concrete CoreAudio default input device when microphone selection falls back to System Default
- preserve System Default semantics while applying Bluetooth route activation, stabilization, and readiness checks to the resolved device
- add unit and API regression coverage for the system-default Bluetooth path

## Issue context

When the configured priority microphones are unavailable, TypeWhisper falls back to System Default. If macOS currently points System Default at a Bluetooth microphone, the fallback previously discarded the concrete device ID and marked the route as non-Bluetooth. The recording service also gated its Bluetooth safeguards on an explicit TypeWhisper device selection, so route activation, stabilization, and readiness checks were skipped.

This is related to the Bluetooth startup failures discussed in #938, but covers the distinct System Default path described in #963.

Closes #963

## Test Plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `swift test --package-path TypeWhisperPluginSDK`
- [x] `scripts/pr-preflight.sh origin/main`
- [x] Manually reproduced the microphone pickup failure with TypeWhisper 1.5.1 and verified that the PR build records correctly with the same System Default Bluetooth microphone setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone selection fallback behavior when priority devices are unavailable, including correct handling of Bluetooth system defaults.
  * Refined Bluetooth routing/readiness so Bluetooth-specific stabilization can apply even without an explicit device selection.
* **Tests**
  * Added a controllable default-device test double and expanded coverage for system-default vs Bluetooth scenarios, including preview and recording start/stop restoration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->