### PR TITLE
Notarize plugin releases

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -285,11 +285,27 @@ jobs:
           printf '%s' "$APPLE_API_KEY_P8" > "$NOTARY_KEY_PATH"
           chmod 600 "$NOTARY_KEY_PATH"
 
-          xcrun notarytool submit "$NOTARIZATION_ZIP" \
+          NOTARIZATION_EXIT=0
+          NOTARIZATION_RESULT=$(xcrun notarytool submit "$NOTARIZATION_ZIP" \
             --key "$NOTARY_KEY_PATH" \
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER_ID" \
-            --wait
+            --wait \
+            --output-format json) || NOTARIZATION_EXIT=$?
+          printf '%s\n' "$NOTARIZATION_RESULT"
+
+          SUBMISSION_ID=$(printf '%s' "$NOTARIZATION_RESULT" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("id", ""))')
+          NOTARIZATION_STATUS=$(printf '%s' "$NOTARIZATION_RESULT" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("status", ""))')
+          if [ "$NOTARIZATION_EXIT" -ne 0 ] || [ "$NOTARIZATION_STATUS" != "Accepted" ]; then
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --key "$NOTARY_KEY_PATH" \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER_ID" || true
+            fi
+            echo "Notarization failed: exit=$NOTARIZATION_EXIT status=${NOTARIZATION_STATUS:-unknown}"
+            exit 1
+          fi
 
           xcrun stapler staple "$BUNDLE_PATH"
           xcrun stapler validate "$BUNDLE_PATH"

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -267,12 +267,57 @@ jobs:
             "$BUNDLE_PATH"
           codesign --verify --deep --strict --verbose=2 "$BUNDLE_PATH"
 
-      - name: Create ZIP
+      - name: Create Notarization ZIP
         run: |
           cd build/Release
+          ditto -c -k --keepParent "${TARGET}.bundle" "${TARGET}-notarize.zip"
+
+      - name: Notarize Plugin
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APPLE_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+        run: |
+          NOTARY_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          BUNDLE_PATH="build/Release/${TARGET}.bundle"
+          NOTARIZATION_ZIP="build/Release/${TARGET}-notarize.zip"
+
+          printf '%s' "$APPLE_API_KEY_P8" > "$NOTARY_KEY_PATH"
+          chmod 600 "$NOTARY_KEY_PATH"
+
+          xcrun notarytool submit "$NOTARIZATION_ZIP" \
+            --key "$NOTARY_KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+
+          xcrun stapler staple "$BUNDLE_PATH"
+          xcrun stapler validate "$BUNDLE_PATH"
+
+      - name: Create and Verify Distribution ZIP
+        run: |
+          cd build/Release
+          rm -f "${TARGET}.zip"
           ditto -c -k --keepParent "${TARGET}.bundle" "${TARGET}.zip"
+
+          VERIFY_DIR="$(mktemp -d "$RUNNER_TEMP/plugin-release-verify.XXXXXX")"
+          trap 'rm -rf "$VERIFY_DIR"' EXIT
+          ditto -x -k "${TARGET}.zip" "$VERIFY_DIR"
+          VERIFIED_BUNDLE="$VERIFY_DIR/${TARGET}.bundle"
+
+          codesign --verify --deep --strict --verbose=2 "$VERIFIED_BUNDLE"
+          xcrun stapler validate "$VERIFIED_BUNDLE"
+          spctl --assess --type execute --verbose=4 "$VERIFIED_BUNDLE"
+
+          INFO_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$VERIFIED_BUNDLE/Contents/Info.plist")
+          MANIFEST_VERSION=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["version"])' "$VERIFIED_BUNDLE/Contents/Resources/manifest.json")
+          if [ "$INFO_VERSION" != "$PLUGIN_VERSION" ] || [ "$MANIFEST_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "Version mismatch: Info.plist=$INFO_VERSION manifest=$MANIFEST_VERSION expected=$PLUGIN_VERSION"
+            exit 1
+          fi
+
           ZIP_SIZE=$(stat -f%z "${TARGET}.zip")
-          echo "ZIP_SIZE=$ZIP_SIZE" >> $GITHUB_ENV
+          echo "ZIP_SIZE=$ZIP_SIZE" >> "$GITHUB_ENV"
           echo "ZIP size: $ZIP_SIZE bytes"
 
       - name: Cleanup Signing Assets
@@ -282,6 +327,8 @@ jobs:
             security delete-keychain "$KEYCHAIN_PATH" || true
           fi
           rm -f /tmp/cert.p12
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
+          rm -f "build/Release/${TARGET}-notarize.zip"
 
       - name: Create GitHub Release
         env:

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
-    "version": "1.1.0",
+    "version": "1.1.5",
     "minHostVersion": "1.4.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Issue context

Issue #965 reports that the separately downloaded Qwen3 ASR 1.1.4 bundle is blocked by Gatekeeper. The bundle is Developer ID signed, but the published artifact is not notarized (`source=Unnotarized Developer ID`).

## Changes

- notarize every official and community plugin after Developer ID signing
- staple the ticket to the plugin bundle before creating the final distribution ZIP
- re-extract and verify the exact final ZIP with `codesign`, `stapler validate`, and `spctl --type execute` before publishing or updating registry feeds
- remove the temporary App Store Connect API key in the existing unconditional cleanup step
- bump the Qwen3 ASR manifest to 1.1.5 without changing host, SDK, or inference behavior

## Test plan

- `actionlint -ignore 'SC2086' -ignore 'SC2129' .github/workflows/plugin-release.yml`
- `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests`
- `bash scripts/pr-preflight.sh origin/main`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run Qwen3Plugin /Users/marco/.codex/worktrees/6c92/typewhisper-mac`

After merge, dispatch `plugin-release.yml` for `qwen3` 1.1.5 from `main` and verify the published ZIP and both registry feeds.

Closes #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Qwen3 plugin version to **1.1.5**.

* **Bug Fixes**
  * Strengthened macOS release packaging by creating a dedicated notarization distribution ZIP.
  * Added verification steps for code signing, notarization stapling/validation, and Gatekeeper (spctl) checks, including enforced version consistency between the bundle and manifest.

* **Chores**
  * Improved cleanup by removing temporary notarization artifacts after packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->