### PR TITLE
Use bundle-aware notarization verification

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -323,7 +323,7 @@ jobs:
 
           codesign --verify --deep --strict --verbose=2 "$VERIFIED_BUNDLE"
           xcrun stapler validate "$VERIFIED_BUNDLE"
-          spctl --assess --type execute --verbose=4 "$VERIFIED_BUNDLE"
+          codesign -vvvv -R='notarized' --check-notarization "$VERIFIED_BUNDLE"
 
           INFO_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$VERIFIED_BUNDLE/Contents/Info.plist")
           MANIFEST_VERSION=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["version"])' "$VERIFIED_BUNDLE/Contents/Resources/manifest.json")


### PR DESCRIPTION
## Issue context

The first Qwen3 ASR 1.1.5 release attempt for #965 successfully completed Apple notarization and stapling, but the exact extracted `.bundle` was then rejected by `spctl --type execute` with `the code is valid but does not seem to be an app`. This is an app-only assessment limitation, not a notarization failure, and it correctly prevented publication in [run 29735686294](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/29735686294).

## Change

Replace the app-oriented `spctl` gate with `codesign -R='notarized' --check-notarization`, which evaluates the notarization requirement for loadable bundles. The existing strict signature verification, stapled-ticket validation, explicit `notarytool` `Accepted` status check, version checks, and exact-ZIP re-extraction remain unchanged.

## Test plan

- `actionlint -ignore 'SC2086' -ignore 'SC2129' .github/workflows/plugin-release.yml`
- `bash scripts/pr-preflight.sh origin/main`
- `codesign --verify --deep --strict --verbose=2 /Applications/TypeWhisper.app/Contents/PlugIns/SpeechAnalyzerPlugin.bundle`
- `codesign -vvvv -R='notarized' --check-notarization /Applications/TypeWhisper.app/Contents/PlugIns/SpeechAnalyzerPlugin.bundle`
- confirm `spctl --assess --type execute --verbose=4` rejects that same notarized bundle as `the code is valid but does not seem to be an app`

After merge, rerun the official Qwen3 ASR 1.1.5 plugin release from `main`.

Closes #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation for macOS plugin distributions by using a dedicated notarization check before packaging and manifest verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->