### PR TITLE
Add Improve TypeWhisper contribution plugin

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -98,6 +98,7 @@ jobs:
             smallest-pulse) TARGET="SmallestAIPlugin" ;;
             cartesia) TARGET="CartesiaPlugin" ;;
             obsidian) TARGET="ObsidianPlugin" ;;
+            contributor) TARGET="ContributorPlugin" ;;
             script) TARGET="ScriptPlugin" ;;
             file-job-script) TARGET="FileJobScriptPlugin" ;;
             livetranscript) TARGET="LiveTranscriptPlugin" ;;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -345,6 +345,13 @@
 		AA00000000000000000219 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000209 /* manifest.json */; };
 		AA00000000000000000220 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000210 /* Localizable.xcstrings */; };
 		AA00000000000000000221 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000025 /* TypeWhisperPluginSDK */; };
+		C07A00000000000000000001 /* ContributorModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B00000000000000000001 /* ContributorModels.swift */; };
+		C07A00000000000000000002 /* ContributorQueueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B00000000000000000002 /* ContributorQueueStore.swift */; };
+		C07A00000000000000000003 /* ContributorAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B00000000000000000003 /* ContributorAPIClient.swift */; };
+		C07A00000000000000000004 /* ContributorPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B00000000000000000004 /* ContributorPlugin.swift */; };
+		C07A00000000000000000005 /* ContributorSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B00000000000000000005 /* ContributorSettingsView.swift */; };
+		C07A00000000000000000006 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = C07B00000000000000000006 /* manifest.json */; };
+		C07A00000000000000000007 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C07A00000000000000000008 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000222 /* ScriptPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000212 /* ScriptPlugin.swift */; };
 		AA00000000000000000223 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000213 /* manifest.json */; };
 		AA00000000000000000224 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000214 /* Localizable.xcstrings */; };
@@ -811,6 +818,13 @@
 		BB00000000000000000209 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000210 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000211 /* ObsidianPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObsidianPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		C07B00000000000000000001 /* ContributorModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorModels.swift; sourceTree = "<group>"; };
+		C07B00000000000000000002 /* ContributorQueueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorQueueStore.swift; sourceTree = "<group>"; };
+		C07B00000000000000000003 /* ContributorAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorAPIClient.swift; sourceTree = "<group>"; };
+		C07B00000000000000000004 /* ContributorPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorPlugin.swift; sourceTree = "<group>"; };
+		C07B00000000000000000005 /* ContributorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributorSettingsView.swift; sourceTree = "<group>"; };
+		C07B00000000000000000006 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		C07B00000000000000000007 /* ContributorPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContributorPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000212 /* ScriptPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000213 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000214 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -1188,6 +1202,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C07C00000000000000000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C07A00000000000000000007 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000100 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1423,6 +1445,7 @@
 				5B2200000000000000000020 /* SaluteSpeechPlugin */,
 				CART00000000000000000020 /* CartesiaPlugin */,
 				CC00000000000000000030 /* ObsidianPlugin */,
+				C07D00000000000000000001 /* ContributorPlugin */,
 				CC00000000000000000031 /* ScriptPlugin */,
 				F18A00000000000000000020 /* FillerWordsPlugin */,
 				F48400000000000000000020 /* FileJobScriptPlugin */,
@@ -1986,6 +2009,20 @@
 			path = TypeWhisperPluginSDK/Plugins/ObsidianPlugin;
 			sourceTree = "<group>";
 		};
+		C07D00000000000000000001 /* ContributorPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				C07B00000000000000000001 /* ContributorModels.swift */,
+				C07B00000000000000000002 /* ContributorQueueStore.swift */,
+				C07B00000000000000000003 /* ContributorAPIClient.swift */,
+				C07B00000000000000000004 /* ContributorPlugin.swift */,
+				C07B00000000000000000005 /* ContributorSettingsView.swift */,
+				C07B00000000000000000006 /* manifest.json */,
+			);
+			name = ContributorPlugin;
+			path = TypeWhisperPluginSDK/Plugins/ContributorPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000031 /* ScriptPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2265,6 +2302,7 @@
 				5B2200000000000000000012 /* SaluteSpeechPlugin.bundle */,
 				CART00000000000000000012 /* CartesiaPlugin.bundle */,
 				BB00000000000000000211 /* ObsidianPlugin.bundle */,
+				C07B00000000000000000007 /* ContributorPlugin.bundle */,
 				BB00000000000000000215 /* ScriptPlugin.bundle */,
 				F18A00000000000000000012 /* FillerWordsPlugin.bundle */,
 				F48400000000000000000012 /* FileJobScriptPlugin.bundle */,
@@ -2834,6 +2872,26 @@
 			productReference = BB00000000000000000211 /* ObsidianPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		C07E00000000000000000001 /* ContributorPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C07F00000000000000000003 /* Build configuration list for PBXNativeTarget "ContributorPlugin" */;
+			buildPhases = (
+				C07C00000000000000000001 /* Sources */,
+				C07C00000000000000000002 /* Frameworks */,
+				C07C00000000000000000003 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ContributorPlugin;
+			packageProductDependencies = (
+				C07A00000000000000000008 /* TypeWhisperPluginSDK */,
+			);
+			productName = ContributorPlugin;
+			productReference = C07B00000000000000000007 /* ContributorPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000019 /* ScriptPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000102 /* Build configuration list for PBXNativeTarget "ScriptPlugin" */;
@@ -3370,6 +3428,7 @@
 				5B2200000000000000000040 /* SaluteSpeechPlugin */,
 				CART00000000000000000040 /* CartesiaPlugin */,
 				DD00000000000000000018 /* ObsidianPlugin */,
+				C07E00000000000000000001 /* ContributorPlugin */,
 				DD00000000000000000019 /* ScriptPlugin */,
 				F18A00000000000000000030 /* FillerWordsPlugin */,
 				F48400000000000000000030 /* FileJobScriptPlugin */,
@@ -3601,6 +3660,14 @@
 			files = (
 				AA00000000000000000219 /* manifest.json in Resources */,
 				AA00000000000000000220 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C07C00000000000000000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C07A00000000000000000006 /* manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4256,6 +4323,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000218 /* ObsidianPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C07C00000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C07A00000000000000000001 /* ContributorModels.swift in Sources */,
+				C07A00000000000000000002 /* ContributorQueueStore.swift in Sources */,
+				C07A00000000000000000003 /* ContributorAPIClient.swift in Sources */,
+				C07A00000000000000000004 /* ContributorPlugin.swift in Sources */,
+				C07A00000000000000000005 /* ContributorSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5756,6 +5835,52 @@
 			};
 			name = Release;
 		};
+		C07F00000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Improve TypeWhisper";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = ContributorPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.improve;
+				PRODUCT_NAME = ContributorPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		C07F00000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Improve TypeWhisper";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = ContributorPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.improve;
+				PRODUCT_NAME = ContributorPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		XX00000000000000000077 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -7052,6 +7177,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C07F00000000000000000003 /* Build configuration list for PBXNativeTarget "ContributorPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C07F00000000000000000001 /* Debug */,
+				C07F00000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000102 /* Build configuration list for PBXNativeTarget "ScriptPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7441,6 +7575,10 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000025 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		C07A00000000000000000008 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -4,6 +4,7 @@ import Foundation
 /// Prevents typo-induced bugs and makes keys discoverable via autocomplete.
 enum UserDefaultsKeys {
     // MARK: - Dictation
+    static let devTrainingCaptureEnabled = "devTrainingCaptureEnabled"
     static let audioDuckingEnabled = "audioDuckingEnabled"
     static let audioDuckingLevel = "audioDuckingLevel"
     static let soundFeedbackEnabled = "soundFeedbackEnabled"
@@ -110,6 +111,7 @@ enum UserDefaultsKeys {
     // MARK: - Plugin Registry
     static let pluginRegistryLastFetch = "pluginRegistryLastFetch"
     static let selectedIntegrationTab = "selectedIntegrationTab"
+    static let improveTypeWhisperCaptureEnabled = "plugin.com.typewhisper.improve.collectCorrections"
 
     // MARK: - Recorder
     static let recorderMicEnabled = "recorderMicEnabled"

--- a/TypeWhisper/Services/HistoryService.swift
+++ b/TypeWhisper/Services/HistoryService.swift
@@ -4,6 +4,7 @@ import Combine
 import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "HistoryService")
+private let trainingCaptureLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "TrainingCaptureStore")
 
 @MainActor
 final class HistoryService: ObservableObject {
@@ -316,4 +317,250 @@ final class HistoryService: ObservableObject {
         fetchRecords()
     }
     #endif
+}
+
+struct TrainingCaptureRecord: Codable, Equatable, Sendable {
+    struct TargetApp: Codable, Equatable, Sendable {
+        let name: String?
+        let bundleIdentifier: String?
+    }
+
+    let schemaVersion: Int
+    let id: UUID
+    let recordType: String
+    let parentId: UUID?
+    let createdAt: Date
+    let source: String
+    let locale: String?
+    let configuredLanguage: String?
+    let detectedLanguage: String?
+    let engineUsed: String
+    let modelId: String?
+    let modelDisplayName: String?
+    let workflowId: UUID?
+    let workflowName: String?
+    let outputFormat: String?
+    let pipelineSteps: [String]
+    let rawText: String
+    let finalText: String
+    let insertedText: String
+    let correctedText: String?
+    let commitSignal: String?
+    let accepted: Bool
+    let reviewed: Bool
+    let targetApp: TargetApp?
+
+    init(
+        id: UUID = UUID(),
+        recordType: String = "accepted-candidate",
+        parentId: UUID? = nil,
+        createdAt: Date = Date(),
+        locale: String?,
+        configuredLanguage: String?,
+        detectedLanguage: String?,
+        engineUsed: String,
+        modelId: String?,
+        modelDisplayName: String?,
+        workflowId: UUID?,
+        workflowName: String?,
+        outputFormat: String?,
+        pipelineSteps: [String],
+        rawText: String,
+        finalText: String,
+        insertedText: String,
+        correctedText: String? = nil,
+        commitSignal: String? = nil,
+        accepted: Bool = true,
+        reviewed: Bool = false,
+        targetApp: TargetApp?
+    ) {
+        self.schemaVersion = 1
+        self.id = id
+        self.recordType = recordType
+        self.parentId = parentId
+        self.createdAt = createdAt
+        self.source = "typewhisper-mac-dev-dictation"
+        self.locale = locale
+        self.configuredLanguage = configuredLanguage
+        self.detectedLanguage = detectedLanguage
+        self.engineUsed = engineUsed
+        self.modelId = modelId
+        self.modelDisplayName = modelDisplayName
+        self.workflowId = workflowId
+        self.workflowName = workflowName
+        self.outputFormat = outputFormat
+        self.pipelineSteps = pipelineSteps
+        self.rawText = rawText
+        self.finalText = finalText
+        self.insertedText = insertedText
+        self.correctedText = correctedText
+        self.commitSignal = commitSignal
+        self.accepted = accepted
+        self.reviewed = reviewed
+        self.targetApp = targetApp
+    }
+
+    func manualCorrection(
+        correctionId: UUID = UUID(),
+        correctedText: String,
+        commitSignal: TargetAppCorrectionCommitSignal?
+    ) -> TrainingCaptureRecord {
+        TrainingCaptureRecord(
+            id: correctionId,
+            recordType: "manual-correction",
+            parentId: id,
+            locale: locale,
+            configuredLanguage: configuredLanguage,
+            detectedLanguage: detectedLanguage,
+            engineUsed: engineUsed,
+            modelId: modelId,
+            modelDisplayName: modelDisplayName,
+            workflowId: workflowId,
+            workflowName: workflowName,
+            outputFormat: outputFormat,
+            pipelineSteps: pipelineSteps,
+            rawText: rawText,
+            finalText: finalText,
+            insertedText: insertedText,
+            correctedText: correctedText,
+            commitSignal: commitSignal?.trainingCaptureValue,
+            accepted: false,
+            reviewed: true,
+            targetApp: targetApp
+        )
+    }
+}
+
+final class TrainingCaptureStore {
+    private let fileManager: FileManager
+    private let enabledProvider: () -> Bool
+    private let lock = NSLock()
+    private let encoder: JSONEncoder
+
+    let captureFileURL: URL
+
+    var isEnabled: Bool {
+        enabledProvider()
+    }
+
+    init(
+        captureDirectory: URL = AppConstants.appSupportDirectory.appendingPathComponent("TrainingCapture", isDirectory: true),
+        fileManager: FileManager = .default,
+        enabledProvider: @escaping () -> Bool = { TrainingCaptureStore.defaultEnabled() }
+    ) {
+        self.captureFileURL = captureDirectory.appendingPathComponent("dictation-cleanup-captures.jsonl")
+        self.fileManager = fileManager
+        self.enabledProvider = enabledProvider
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+    }
+
+    func record(_ record: TrainingCaptureRecord) {
+        guard isEnabled else { return }
+
+        let sanitizedRecord = sanitized(record)
+        guard !sanitizedRecord.rawText.isEmpty,
+              !sanitizedRecord.finalText.isEmpty,
+              !sanitizedRecord.insertedText.isEmpty else {
+            trainingCaptureLogger.warning("Skipping training capture record: empty text after sanitization")
+            return
+        }
+
+        lock.withLock {
+            do {
+                try fileManager.createDirectory(
+                    at: captureFileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                var data = try encoder.encode(sanitizedRecord)
+                data.append(0x0A)
+
+                if fileManager.fileExists(atPath: captureFileURL.path) {
+                    let handle = try FileHandle(forWritingTo: captureFileURL)
+                    defer { try? handle.close() }
+                    try handle.seekToEnd()
+                    try handle.write(contentsOf: data)
+                } else {
+                    try data.write(to: captureFileURL, options: .atomic)
+                }
+            } catch {
+                trainingCaptureLogger.error("Failed to write training capture record: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private static func defaultEnabled() -> Bool {
+        let environment = ProcessInfo.processInfo.environment
+        let disabledValues: Set<String> = ["1", "true", "yes"]
+        if let disabled = environment["TYPEWHISPER_DEV_TRAINING_CAPTURE_DISABLED"]?.lowercased(),
+           disabledValues.contains(disabled) {
+            return false
+        }
+
+        guard AppConstants.isDevelopment, !AppConstants.isRunningTests else {
+            return false
+        }
+
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
+        let isDevBundle = bundleIdentifier == "com.typewhisper.mac.dev"
+            || bundleIdentifier.hasSuffix(".dev")
+            || AppConstants.appSupportDirectoryName == "TypeWhisper-Dev"
+        guard isDevBundle else { return false }
+
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: UserDefaultsKeys.devTrainingCaptureEnabled) != nil else {
+            return true
+        }
+        return defaults.bool(forKey: UserDefaultsKeys.devTrainingCaptureEnabled)
+    }
+
+    private func sanitized(_ record: TrainingCaptureRecord) -> TrainingCaptureRecord {
+        TrainingCaptureRecord(
+            id: record.id,
+            recordType: Self.sanitize(record.recordType) ?? "accepted-candidate",
+            parentId: record.parentId,
+            createdAt: record.createdAt,
+            locale: Self.sanitize(record.locale),
+            configuredLanguage: Self.sanitize(record.configuredLanguage),
+            detectedLanguage: Self.sanitize(record.detectedLanguage),
+            engineUsed: Self.sanitize(record.engineUsed) ?? "unknown",
+            modelId: Self.sanitize(record.modelId),
+            modelDisplayName: Self.sanitize(record.modelDisplayName),
+            workflowId: record.workflowId,
+            workflowName: Self.sanitize(record.workflowName),
+            outputFormat: Self.sanitize(record.outputFormat),
+            pipelineSteps: record.pipelineSteps.compactMap(Self.sanitize),
+            rawText: Self.sanitize(record.rawText) ?? "",
+            finalText: Self.sanitize(record.finalText) ?? "",
+            insertedText: Self.sanitize(record.insertedText) ?? "",
+            correctedText: Self.sanitize(record.correctedText),
+            commitSignal: Self.sanitize(record.commitSignal),
+            accepted: record.accepted,
+            reviewed: record.reviewed,
+            targetApp: sanitized(record.targetApp)
+        )
+    }
+
+    private func sanitized(_ targetApp: TrainingCaptureRecord.TargetApp?) -> TrainingCaptureRecord.TargetApp? {
+        guard let targetApp else { return nil }
+        let sanitizedName = Self.sanitize(targetApp.name)
+        let sanitizedBundleIdentifier = Self.sanitize(targetApp.bundleIdentifier)
+        guard sanitizedName != nil || sanitizedBundleIdentifier != nil else { return nil }
+        return TrainingCaptureRecord.TargetApp(
+            name: sanitizedName,
+            bundleIdentifier: sanitizedBundleIdentifier
+        )
+    }
+
+    private static func sanitize(_ string: String?) -> String? {
+        let sanitized = string?
+            .unicodeScalars
+            .filter { $0 != "\0" }
+            .map(String.init)
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return sanitized?.isEmpty == false ? sanitized : nil
+    }
 }

--- a/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
+++ b/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
@@ -490,7 +490,7 @@ final class TargetAppCorrectionLearningService: ObservableObject {
         let beforeCorrection = baselineText[baselineInsertedRange.lowerBound..<changedRanges.baseline.lowerBound]
         let correction = editedText[changedRanges.edited]
         let afterCorrection = baselineText[changedRanges.baseline.upperBound..<baselineInsertedRange.upperBound]
-        let corrected = String(beforeCorrection) + String(correction) + String(afterCorrection)
+        let corrected = (String(beforeCorrection) + String(correction) + String(afterCorrection))
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return corrected.isEmpty || corrected == insertedText ? nil : corrected
     }

--- a/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
+++ b/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
@@ -8,6 +8,26 @@ enum TargetAppCorrectionCommitSignal: String, Codable, Equatable, Sendable {
     case tabKey
     case focusChanged
     case activeApplicationChanged
+
+    var trainingCaptureValue: String {
+        switch self {
+        case .returnKey:
+            "return-key"
+        case .keypadEnterKey:
+            "keypad-enter-key"
+        case .tabKey:
+            "tab-key"
+        case .focusChanged:
+            "focus-changed"
+        case .activeApplicationChanged:
+            "active-application-changed"
+        }
+    }
+}
+
+struct TargetAppCorrectionObservation: Equatable, Sendable {
+    let correctedInsertedText: String
+    let commitSignal: TargetAppCorrectionCommitSignal?
 }
 
 enum TargetAppCorrectionLearningOutcome: String, Codable, Equatable, Sendable {
@@ -31,6 +51,7 @@ struct TargetAppCorrectionLearningAttemptSnapshot: Codable, Equatable, Sendable 
 struct TargetAppCorrectionLearningResult: Equatable, Sendable {
     let snapshot: TargetAppCorrectionLearningAttemptSnapshot
     let learnedCorrections: [LearnedDictionaryCorrection]
+    let correctionObservation: TargetAppCorrectionObservation?
 }
 
 private func targetAppCorrectionCommitSignal(forKeyCode keyCode: UInt16) -> TargetAppCorrectionCommitSignal? {
@@ -270,6 +291,7 @@ final class TargetAppCorrectionLearningService: ObservableObject {
 
         var latestSuggestions: [CorrectionSuggestion] = []
         var latestNonConfidentOutcome: TargetAppCorrectionLearningOutcome = .unsupportedTextObservation
+        var latestObservation: TargetAppCorrectionObservation?
         var elapsed: Duration = .seconds(0)
         for pollOffset in pollSchedule {
             let waitDuration: Duration
@@ -302,19 +324,35 @@ final class TargetAppCorrectionLearningService: ObservableObject {
                             id: attemptID,
                             suggestions: latestSuggestions,
                             fallbackOutcome: latestNonConfidentOutcome,
-                            commitSignal: commitSignal
+                            commitSignal: commitSignal,
+                            correctionObservation: committedObservation(
+                                latestObservation,
+                                commitSignal: commitSignal
+                            )
                         )
                     }
                     continue
                 case .different:
+                    let resolvedCommitSignal = commitSignal ?? .focusChanged
                     return completeCommittedAttempt(
                         id: attemptID,
                         suggestions: latestSuggestions,
                         fallbackOutcome: latestNonConfidentOutcome,
-                        commitSignal: commitSignal ?? .focusChanged
+                        commitSignal: resolvedCommitSignal,
+                        correctionObservation: committedObservation(
+                            latestObservation,
+                            commitSignal: resolvedCommitSignal
+                        )
                     )
                 }
             }
+
+            latestObservation = correctionObservation(
+                insertedText: insertedText,
+                baselineText: baseline.value,
+                editedText: observation.value,
+                commitSignal: commitSignal
+            )
 
             let suggestions = highConfidenceCorrectionSuggestions(
                 insertedText: insertedText,
@@ -333,7 +371,8 @@ final class TargetAppCorrectionLearningService: ObservableObject {
                     id: attemptID,
                     suggestions: latestSuggestions,
                     fallbackOutcome: latestNonConfidentOutcome,
-                    commitSignal: commitSignal
+                    commitSignal: commitSignal,
+                    correctionObservation: latestObservation
                 )
             }
         }
@@ -352,17 +391,26 @@ final class TargetAppCorrectionLearningService: ObservableObject {
         )
     }
 
+    func trackInsertionResult(
+        insertedText: String,
+        baseline: TextInsertionService.FocusedTextObservation
+    ) async -> TargetAppCorrectionLearningResult {
+        await trackInsertion(insertedText: insertedText, baseline: baseline)
+    }
+
     private func completeCommittedAttempt(
         id: UUID,
         suggestions: [CorrectionSuggestion],
         fallbackOutcome: TargetAppCorrectionLearningOutcome,
-        commitSignal: TargetAppCorrectionCommitSignal
+        commitSignal: TargetAppCorrectionCommitSignal,
+        correctionObservation: TargetAppCorrectionObservation?
     ) -> TargetAppCorrectionLearningResult {
         guard !suggestions.isEmpty else {
             return completeAttempt(
                 id: id,
                 outcome: fallbackOutcome,
-                commitSignal: commitSignal
+                commitSignal: commitSignal,
+                correctionObservation: correctionObservation
             )
         }
 
@@ -381,7 +429,8 @@ final class TargetAppCorrectionLearningService: ObservableObject {
             id: id,
             outcome: outcome,
             commitSignal: commitSignal,
-            learnedCorrections: dictionaryResult.learnedCorrections
+            learnedCorrections: dictionaryResult.learnedCorrections,
+            correctionObservation: correctionObservation
         )
     }
 
@@ -389,7 +438,8 @@ final class TargetAppCorrectionLearningService: ObservableObject {
         id: UUID,
         outcome: TargetAppCorrectionLearningOutcome,
         commitSignal: TargetAppCorrectionCommitSignal?,
-        learnedCorrections: [LearnedDictionaryCorrection] = []
+        learnedCorrections: [LearnedDictionaryCorrection] = [],
+        correctionObservation: TargetAppCorrectionObservation? = nil
     ) -> TargetAppCorrectionLearningResult {
         let snapshot = TargetAppCorrectionLearningAttemptSnapshot(
             outcome: outcome,
@@ -404,7 +454,8 @@ final class TargetAppCorrectionLearningService: ObservableObject {
         }
         return TargetAppCorrectionLearningResult(
             snapshot: snapshot,
-            learnedCorrections: learnedCorrections
+            learnedCorrections: learnedCorrections,
+            correctionObservation: correctionObservation
         )
     }
 
@@ -419,6 +470,59 @@ final class TargetAppCorrectionLearningService: ObservableObject {
             return nil
         }
         return try? JSONDecoder().decode(TargetAppCorrectionLearningAttemptSnapshot.self, from: data)
+    }
+
+    func correctedInsertedText(
+        insertedText: String,
+        baselineText: String,
+        editedText: String
+    ) -> String? {
+        guard let changedRanges = Self.changedRanges(from: baselineText, to: editedText),
+              let baselineInsertedRange = Self.insertedRange(
+                containing: changedRanges.baseline,
+                insertedText: insertedText,
+                in: baselineText
+              ),
+              Self.range(changedRanges.baseline, isContainedIn: baselineInsertedRange) else {
+            return nil
+        }
+
+        let beforeCorrection = baselineText[baselineInsertedRange.lowerBound..<changedRanges.baseline.lowerBound]
+        let correction = editedText[changedRanges.edited]
+        let afterCorrection = baselineText[changedRanges.baseline.upperBound..<baselineInsertedRange.upperBound]
+        let corrected = String(beforeCorrection) + String(correction) + String(afterCorrection)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return corrected.isEmpty || corrected == insertedText ? nil : corrected
+    }
+
+    private func correctionObservation(
+        insertedText: String,
+        baselineText: String,
+        editedText: String,
+        commitSignal: TargetAppCorrectionCommitSignal?
+    ) -> TargetAppCorrectionObservation? {
+        correctedInsertedText(
+            insertedText: insertedText,
+            baselineText: baselineText,
+            editedText: editedText
+        ).map {
+            TargetAppCorrectionObservation(
+                correctedInsertedText: $0,
+                commitSignal: commitSignal
+            )
+        }
+    }
+
+    private func committedObservation(
+        _ observation: TargetAppCorrectionObservation?,
+        commitSignal: TargetAppCorrectionCommitSignal
+    ) -> TargetAppCorrectionObservation? {
+        observation.map {
+            TargetAppCorrectionObservation(
+                correctedInsertedText: $0.correctedInsertedText,
+                commitSignal: commitSignal
+            )
+        }
     }
 
     func highConfidenceCorrectionSuggestions(

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -292,6 +292,7 @@ final class DictationViewModel: ObservableObject {
     private let accessibilityAnnouncementService: AccessibilityAnnouncementService
     private let errorLogService: ErrorLogService
     private let mediaPlaybackService: MediaPlaybackService
+    private let trainingCaptureStore: TrainingCaptureStore
     private let postProcessingPipeline: PostProcessingPipeline
     private let recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider
     private let recoveryFallbackRunner: RecoveryFallbackRunner
@@ -384,6 +385,7 @@ final class DictationViewModel: ObservableObject {
         accessibilityAnnouncementService: AccessibilityAnnouncementService,
         errorLogService: ErrorLogService,
         mediaPlaybackService: MediaPlaybackService,
+        trainingCaptureStore: TrainingCaptureStore = TrainingCaptureStore(),
         usageStatisticsRecorder: UsageStatisticsRecording? = nil,
         recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider? = nil,
         recoveryFallbackRunner: RecoveryFallbackRunner? = nil
@@ -423,6 +425,7 @@ final class DictationViewModel: ObservableObject {
         self.accessibilityAnnouncementService = accessibilityAnnouncementService
         self.errorLogService = errorLogService
         self.mediaPlaybackService = mediaPlaybackService
+        self.trainingCaptureStore = trainingCaptureStore
         self.recoveryFallbackConfigurationProvider = recoveryFallbackConfigurationProvider ?? { _, _ in nil }
         self.recoveryFallbackRunner = recoveryFallbackRunner ?? { [modelManager] samples, languageSelection, task, configuration, prompt, dictionaryTermHints, normalizeNumbers in
             try await modelManager.transcribe(
@@ -1565,6 +1568,8 @@ final class DictationViewModel: ObservableObject {
                 )
 
                 partialText = ""
+                var insertedTextForTrainingCapture: String?
+                var targetAppCorrectionBaseline: TextInsertionService.FocusedTextObservation?
 
                 // Route to action plugin or insert text
                 if let actionPluginId = self.effectiveActionPluginId,
@@ -1583,7 +1588,12 @@ final class DictationViewModel: ObservableObject {
                         insertionContext: insertionContext,
                         contextualInsertionEnabled: contextualInsertionEnabled
                     )
-                    let learningPreInsertionObservation = shouldTrackTargetAppCorrectionLearning && resolvedOutputFormat == nil
+                    let shouldObservePostInsertionEdits = (
+                        shouldTrackTargetAppCorrectionLearning
+                            || trainingCaptureStore.isEnabled
+                            || improveTypeWhisperCaptureEnabled
+                    ) && resolvedOutputFormat == nil
+                    let learningPreInsertionObservation = shouldObservePostInsertionEdits
                         ? textInsertionService.captureFocusedTextObservation()
                         : nil
                     let insertionResult = try await textInsertionService.insertText(
@@ -1601,10 +1611,8 @@ final class DictationViewModel: ObservableObject {
                     let learningBaselineObservation = learningPreInsertionObservation.flatMap {
                         textInsertionService.recaptureFocusedTextObservation(matching: $0)
                     }
-                    startTargetAppCorrectionLearningIfNeeded(
-                        insertedText: insertionText,
-                        baseline: learningBaselineObservation
-                    )
+                    targetAppCorrectionBaseline = learningBaselineObservation
+                    insertedTextForTrainingCapture = insertionText
                     EventBus.shared.emit(.textInserted(TextInsertedPayload(
                         text: insertionText,
                         appName: activeApp.name,
@@ -1616,6 +1624,41 @@ final class DictationViewModel: ObservableObject {
                 var pipelineSteps = ppResult.appliedSteps
                 if transcription.usedRecoveryFallback {
                     pipelineSteps.append(localizedAppText("Recovery fallback", de: "Recovery-Fallback"))
+                }
+
+                var trainingCaptureRecord: TrainingCaptureRecord?
+                if let insertedTextForTrainingCapture {
+                    let record = TrainingCaptureRecord(
+                        id: transcriptionID,
+                        createdAt: completionTimestamp,
+                        locale: Locale.current.identifier,
+                        configuredLanguage: language,
+                        detectedLanguage: result.detectedLanguage,
+                        engineUsed: result.engineUsed,
+                        modelId: transcription.modelId,
+                        modelDisplayName: modelDisplayName,
+                        workflowId: matchedWorkflow?.id,
+                        workflowName: matchedWorkflow?.name,
+                        outputFormat: resolvedOutputFormat,
+                        pipelineSteps: pipelineSteps,
+                        rawText: result.text,
+                        finalText: text,
+                        insertedText: insertedTextForTrainingCapture,
+                        targetApp: TrainingCaptureRecord.TargetApp(
+                            name: activeApp.name,
+                            bundleIdentifier: activeApp.bundleId
+                        )
+                    )
+                    trainingCaptureRecord = record
+                    trainingCaptureStore.record(record)
+                }
+
+                if let insertedTextForTrainingCapture {
+                    startTargetAppCorrectionLearningIfNeeded(
+                        insertedText: insertedTextForTrainingCapture,
+                        baseline: targetAppCorrectionBaseline,
+                        trainingCaptureRecord: trainingCaptureRecord
+                    )
                 }
 
                 if UserDefaults.standard.object(forKey: UserDefaultsKeys.historyEnabled) as? Bool ?? true {
@@ -2249,17 +2292,22 @@ final class DictationViewModel: ObservableObject {
 
     private func startTargetAppCorrectionLearningIfNeeded(
         insertedText: String,
-        baseline: TextInsertionService.FocusedTextObservation?
+        baseline: TextInsertionService.FocusedTextObservation?,
+        trainingCaptureRecord: TrainingCaptureRecord?
     ) {
         targetAppCorrectionLearningTask?.cancel()
         targetAppCorrectionLearningTask = nil
 
-        guard shouldTrackTargetAppCorrectionLearning,
+        let shouldLearn = shouldTrackTargetAppCorrectionLearning
+        let shouldCaptureTrainingCorrection = trainingCaptureRecord != nil && trainingCaptureStore.isEnabled
+        let shouldCaptureContributorCorrection = trainingCaptureRecord != nil && improveTypeWhisperCaptureEnabled
+        guard (shouldLearn || shouldCaptureTrainingCorrection || shouldCaptureContributorCorrection),
               let baseline else {
             return
         }
 
-        targetAppCorrectionLearningTask = Task { @MainActor [weak self, baseline, insertedText] in
+        targetAppCorrectionLearningTask = Task {
+            @MainActor [weak self, baseline, insertedText, trainingCaptureRecord, shouldLearn, shouldCaptureContributorCorrection] in
             guard let self else { return }
             let result = await self.targetAppCorrectionLearningService.trackInsertion(
                 insertedText: insertedText,
@@ -2267,9 +2315,39 @@ final class DictationViewModel: ObservableObject {
             )
             guard !Task.isCancelled else { return }
             self.targetAppCorrectionLearningTask = nil
-            guard !result.learnedCorrections.isEmpty else { return }
+            if let trainingCaptureRecord,
+               let correctionObservation = result.correctionObservation {
+                let correctionId = UUID()
+                let manualCorrectionRecord = trainingCaptureRecord.manualCorrection(
+                    correctionId: correctionId,
+                    correctedText: correctionObservation.correctedInsertedText,
+                    commitSignal: correctionObservation.commitSignal
+                )
+                self.trainingCaptureStore.record(manualCorrectionRecord)
+                if shouldCaptureContributorCorrection {
+                    EventBus.shared.emit(.textCorrectionCommitted(TextCorrectionCommittedPayload(
+                        id: correctionId,
+                        capturedAt: manualCorrectionRecord.createdAt,
+                        originalText: insertedText,
+                        correctedText: correctionObservation.correctedInsertedText,
+                        language: trainingCaptureRecord.detectedLanguage ?? trainingCaptureRecord.configuredLanguage,
+                        engineId: trainingCaptureRecord.engineUsed,
+                        modelId: trainingCaptureRecord.modelId,
+                        appVersion: AppConstants.appVersion,
+                        appBuild: AppConstants.buildVersion,
+                        platformVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                        commitSignal: correctionObservation.commitSignal?.trainingCaptureValue,
+                        sourceChannel: AppConstants.isDevelopment ? .development : .production
+                    )))
+                }
+            }
+            guard shouldLearn, !result.learnedCorrections.isEmpty else { return }
             self.showLearnedCorrectionsFeedback(result.learnedCorrections)
         }
+    }
+
+    private var improveTypeWhisperCaptureEnabled: Bool {
+        UserDefaults.standard.bool(forKey: UserDefaultsKeys.improveTypeWhisperCaptureEnabled)
     }
 
     private func cancelTargetAppCorrectionLearning() {

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -11,6 +11,10 @@ final class PluginSettingsWindowManager {
 
     func present(_ plugin: LoadedPlugin) {
         guard let settingsView = plugin.instance.settingsView else { return }
+        let layout = plugin.instance as? any PluginSettingsWindowLayoutProviding
+        let preferredSize = layout?.preferredSettingsWindowSize ?? CGSize(width: 560, height: 440)
+        let minimumSize = layout?.minimumSettingsWindowSize ?? CGSize(width: 500, height: 400)
+        let settingsViewManagesScrolling = layout?.settingsViewManagesScrolling ?? false
 
         if let window = windows[plugin.id] {
             window.makeKeyAndOrderFront(nil)
@@ -19,13 +23,16 @@ final class PluginSettingsWindowManager {
         }
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 440),
+            contentRect: NSRect(origin: .zero, size: preferredSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         let hostingView = NSHostingView(
-            rootView: PluginSettingsWindowContent(settingsView: settingsView)
+            rootView: PluginSettingsWindowContent(
+                settingsView: settingsView,
+                settingsViewManagesScrolling: settingsViewManagesScrolling
+            )
                 .environment(\.pluginSettingsClose, { [weak window] in
                     window?.close()
                 })
@@ -33,7 +40,7 @@ final class PluginSettingsWindowManager {
         )
         hostingView.sizingOptions = []
         window.title = plugin.manifest.name
-        window.contentMinSize = NSSize(width: 500, height: 400)
+        window.contentMinSize = minimumSize
         window.isReleasedWhenClosed = false
         window.contentView = hostingView
 
@@ -57,13 +64,23 @@ final class PluginSettingsWindowManager {
 
 private struct PluginSettingsWindowContent: View {
     let settingsView: AnyView
+    let settingsViewManagesScrolling: Bool
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: true) {
+        if settingsViewManagesScrolling {
             settingsView
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: .topLeading
+                )
+        } else {
+            ScrollView(.vertical, showsIndicators: true) {
+                settingsView
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }
 

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -172,6 +172,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "ContributorPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/ContributorPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "SystemTTSPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/SystemTTSPlugin",
@@ -445,6 +454,15 @@ let package = Package(
                 "ObsidianPlugin",
             ],
             path: "Plugins/ObsidianPlugin/Tests"
+        ),
+        .testTarget(
+            name: "ContributorPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "ContributorPlugin",
+            ],
+            path: "Plugins/ContributorPlugin/Tests"
         ),
         .testTarget(
             name: "SystemTTSPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorAPIClient.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorAPIClient.swift
@@ -1,0 +1,136 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+struct ContributorAPIClient: Sendable {
+    let baseURL: URL
+    let token: String?
+
+    func createSession() async throws -> ContributionSession {
+        try await request(
+            path: "/v1/contributors/session",
+            method: "POST",
+            body: EmptyBody(),
+            authorization: nil
+        )
+    }
+
+    func submit(
+        batchId: UUID,
+        records: [ContributionRecord],
+        consentVersion: String,
+        pluginVersion: String
+    ) async throws -> ContributionBatchResponse {
+        guard let token else { throw ContributorAPIError.missingToken }
+        return try await request(
+            path: "/v1/contributions/batches",
+            method: "POST",
+            body: ContributionBatchRequest(
+                batchId: batchId,
+                consentVersion: consentVersion,
+                pluginVersion: pluginVersion,
+                records: records
+            ),
+            authorization: "Contributor \(token)"
+        )
+    }
+
+    func statuses(for ids: [UUID]) async throws -> [ContributionRemoteStatus] {
+        guard let token else { throw ContributorAPIError.missingToken }
+        guard !ids.isEmpty else { return [] }
+        var components = URLComponents(
+            url: endpoint(path: "/v1/contributions/status"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [
+            URLQueryItem(name: "ids", value: ids.map(\.uuidString).joined(separator: ","))
+        ]
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        request.setValue("Contributor \(token)", forHTTPHeaderField: "Authorization")
+        let response = try await PluginHTTPClient.data(for: request)
+        return try decodeResponse(ContributionStatusResponse.self, from: response).records
+    }
+
+    func delete(_ id: UUID) async throws {
+        guard let token else { throw ContributorAPIError.missingToken }
+        var request = URLRequest(url: endpoint(path: "/v1/contributions/\(id.uuidString.lowercased())"))
+        request.httpMethod = "DELETE"
+        request.setValue("Contributor \(token)", forHTTPHeaderField: "Authorization")
+        let response = try await PluginHTTPClient.data(for: request)
+        _ = try decodeResponse(EmptyResponse.self, from: response)
+    }
+
+    private func request<Body: Encodable, Response: Decodable>(
+        path: String,
+        method: String,
+        body: Body,
+        authorization: String?
+    ) async throws -> Response {
+        var request = URLRequest(url: endpoint(path: path))
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let authorization {
+            request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        request.httpBody = try encoder.encode(body)
+        let response = try await PluginHTTPClient.data(for: request)
+        return try decodeResponse(Response.self, from: response)
+    }
+
+    private func endpoint(path: String) -> URL {
+        var url = baseURL
+        for component in path.split(separator: "/") {
+            url.appendPathComponent(String(component))
+        }
+        return url
+    }
+
+    private func decodeResponse<Response: Decodable>(
+        _ type: Response.Type,
+        from result: (Data, URLResponse)
+    ) throws -> Response {
+        let (data, response) = result
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ContributorAPIError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let apiError = try? JSONDecoder().decode(APIErrorResponse.self, from: data)
+            throw ContributorAPIError.server(
+                status: httpResponse.statusCode,
+                message: apiError?.error ?? HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode)
+            )
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(type, from: data)
+    }
+}
+
+private struct EmptyBody: Encodable {}
+
+private struct EmptyResponse: Decodable {
+    let ok: Bool
+}
+
+private struct APIErrorResponse: Decodable {
+    let error: String
+}
+
+enum ContributorAPIError: LocalizedError {
+    case missingToken
+    case invalidResponse
+    case server(status: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingToken:
+            "No contributor session is available."
+        case .invalidResponse:
+            "The contributor service returned an invalid response."
+        case .server(let status, let message):
+            "Contributor service error \(status): \(message)"
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorAPIClient.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorAPIClient.swift
@@ -123,6 +123,11 @@ enum ContributorAPIError: LocalizedError {
     case invalidResponse
     case server(status: Int, message: String)
 
+    var isAuthenticationFailure: Bool {
+        guard case .server(let status, _) = self else { return false }
+        return status == 401 || status == 403
+    }
+
     var errorDescription: String? {
         switch self {
         case .missingToken:

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorModels.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorModels.swift
@@ -1,0 +1,156 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+enum ContributionLocalStatus: String, Codable, Sendable {
+    case local
+    case pending
+    case accepted
+    case rejected
+    case quarantined
+
+    var isRemote: Bool {
+        self != .local
+    }
+
+    var isTerminal: Bool {
+        self == .accepted || self == .rejected
+    }
+}
+
+struct ContributionRecord: Codable, Identifiable, Equatable, Sendable {
+    let schemaVersion: Int
+    let id: UUID
+    let capturedAt: Date
+    let originalText: String
+    let correctedText: String
+    let language: String?
+    let engineId: String
+    let modelId: String?
+    let appVersion: String
+    let appBuild: String
+    let platformVersion: String
+    let commitSignal: String?
+    let sourceChannel: TextCorrectionCommittedPayload.SourceChannel
+    var status: ContributionLocalStatus
+    var reasonCode: String?
+    var qualityCredit: Int
+
+    init(
+        payload: TextCorrectionCommittedPayload,
+        status: ContributionLocalStatus = .local,
+        reasonCode: String? = nil,
+        qualityCredit: Int = 0
+    ) {
+        self.schemaVersion = payload.schemaVersion
+        self.id = payload.id
+        self.capturedAt = payload.capturedAt
+        self.originalText = payload.originalText
+        self.correctedText = payload.correctedText
+        self.language = payload.language
+        self.engineId = payload.engineId
+        self.modelId = payload.modelId
+        self.appVersion = payload.appVersion
+        self.appBuild = payload.appBuild
+        self.platformVersion = payload.platformVersion
+        self.commitSignal = payload.commitSignal
+        self.sourceChannel = payload.sourceChannel
+        self.status = status
+        self.reasonCode = reasonCode
+        self.qualityCredit = qualityCredit
+    }
+
+    var isValidCorrection: Bool {
+        schemaVersion == 1
+            && !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !correctedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && originalText != correctedText
+            && !engineId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+struct ContributionReceipt: Codable, Identifiable, Equatable, Sendable {
+    let id: UUID
+    let status: ContributionLocalStatus
+    let reasonCode: String?
+    let qualityCredit: Int
+    let completedAt: Date
+}
+
+struct ContributionRemoteStatus: Codable, Sendable {
+    let id: UUID
+    let status: ContributionLocalStatus
+    let reasonCode: String?
+    let qualityCredit: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case status
+        case reasonCode = "reason_code"
+        case qualityCredit = "quality_credit"
+    }
+}
+
+struct ContributionSession: Codable, Sendable {
+    let contributorId: UUID
+    let token: String
+}
+
+struct ContributionBatchResponse: Codable, Sendable {
+    let batchId: UUID
+    let records: [ContributionRemoteStatus]
+}
+
+struct ContributionStatusResponse: Codable, Sendable {
+    let records: [ContributionRemoteStatus]
+}
+
+private struct ContributionUploadRecord: Encodable {
+    let schemaVersion: Int
+    let id: UUID
+    let capturedAt: Date
+    let originalText: String
+    let correctedText: String
+    let language: String?
+    let engineId: String
+    let modelId: String?
+    let appVersion: String
+    let appBuild: String
+    let platformVersion: String
+    let commitSignal: String?
+    let sourceChannel: TextCorrectionCommittedPayload.SourceChannel
+
+    init(_ record: ContributionRecord) {
+        schemaVersion = record.schemaVersion
+        id = record.id
+        capturedAt = record.capturedAt
+        originalText = record.originalText
+        correctedText = record.correctedText
+        language = record.language
+        engineId = record.engineId
+        modelId = record.modelId
+        appVersion = record.appVersion
+        appBuild = record.appBuild
+        platformVersion = record.platformVersion
+        commitSignal = record.commitSignal
+        sourceChannel = record.sourceChannel
+    }
+}
+
+struct ContributionBatchRequest: Encodable {
+    let batchId: UUID
+    let consentVersion: String
+    let pluginVersion: String
+    private let contributions: [ContributionUploadRecord]
+
+    init(
+        batchId: UUID,
+        consentVersion: String,
+        pluginVersion: String,
+        records: [ContributionRecord]
+    ) {
+        self.batchId = batchId
+        self.consentVersion = consentVersion
+        self.pluginVersion = pluginVersion
+        self.contributions = records.map(ContributionUploadRecord.init)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorPlugin.swift
@@ -1,0 +1,305 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+@objc(ContributorPlugin)
+final class ContributorPlugin: NSObject, TypeWhisperPlugin, PluginSettingsWindowLayoutProviding,
+    ObservableObject, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.improve"
+    static let pluginName = "Improve TypeWhisper"
+
+    static let pluginVersion = "0.1.0"
+    static let consentVersion = "contribution-text-v1"
+    static let defaultServiceURL = URL(string: "https://app.typewhisper.com")!
+    static let contributionPolicyURL = URL(
+        string: "https://www.typewhisper.com/addons/improve-typewhisper/"
+    )!
+
+    @Published private(set) var records: [ContributionRecord] = []
+    @Published private(set) var activityMessage: String?
+    @Published private(set) var activityIsError = false
+    @Published private(set) var isWorking = false
+    @Published var selectedIds: Set<UUID> = []
+    @Published var selectedPreviewId: UUID?
+    @Published var sendConfirmed = false
+
+    fileprivate var host: HostServices?
+    private var queueStore: ContributorQueueStore?
+    private var subscriptionId: UUID?
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        self.queueStore = ContributorQueueStore(rootDirectory: host.pluginDataDirectory)
+        if captureEnabled {
+            subscribe()
+        }
+        Task { @MainActor [weak self] in
+            self?.reloadQueue()
+        }
+    }
+
+    func deactivate() {
+        unsubscribe()
+        host = nil
+        queueStore = nil
+    }
+
+    @MainActor
+    var settingsView: AnyView? {
+        AnyView(ContributorSettingsView(plugin: self))
+    }
+
+    var settingsViewManagesScrolling: Bool { true }
+    var preferredSettingsWindowSize: CGSize? { CGSize(width: 860, height: 620) }
+    var minimumSettingsWindowSize: CGSize? { CGSize(width: 700, height: 500) }
+
+    var captureEnabled: Bool {
+        host?.userDefault(forKey: "collectCorrections") as? Bool ?? false
+    }
+
+    @MainActor
+    func updateCaptureEnabled(_ enabled: Bool) {
+        host?.setUserDefault(enabled, forKey: "collectCorrections")
+        if enabled {
+            subscribe()
+        } else {
+            unsubscribe()
+        }
+        objectWillChange.send()
+    }
+
+    @MainActor
+    func reloadQueue() {
+        do {
+            let loaded = try queueStore?.loadRecords() ?? []
+            records = loaded
+            let currentIds = Set(loaded.map(\.id))
+            selectedIds.formIntersection(currentIds)
+            if selectedPreviewId.flatMap({ currentIds.contains($0) }) != true {
+                selectedPreviewId = loaded.first?.id
+            }
+            sendConfirmed = false
+        } catch {
+            showActivity(error.localizedDescription, isError: true)
+        }
+    }
+
+    @MainActor
+    func sendSelected() {
+        let selected = records.filter {
+            selectedIds.contains($0.id) && $0.status == .local
+        }
+        guard sendConfirmed, !selected.isEmpty, !isWorking else { return }
+        guard let host, let queueStore else { return }
+        isWorking = true
+        clearActivity()
+
+        Task { [weak self] in
+            do {
+                let client = try await Self.authenticatedClient(host: host, baseURL: self?.serviceURL)
+                for chunk in selected.chunked(maximumCount: 50) {
+                    let response = try await client.submit(
+                        batchId: UUID(),
+                        records: chunk,
+                        consentVersion: Self.consentVersion,
+                        pluginVersion: Self.pluginVersion
+                    )
+                    try Self.apply(response.records, to: chunk, store: queueStore)
+                }
+                await MainActor.run {
+                    guard let self else { return }
+                    self.isWorking = false
+                    self.reloadQueue()
+                    self.showActivity(contributorText(
+                        "\(selected.count) changes were sent for review.",
+                        de: "\(selected.count) Änderungen wurden zur Prüfung gesendet.",
+                        ja: "\(selected.count)件の変更をレビュー用に送信しました。"
+                    ))
+                }
+            } catch {
+                await MainActor.run {
+                    self?.isWorking = false
+                    self?.showActivity(error.localizedDescription, isError: true)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    func refreshStatuses() {
+        let submitted = records.filter(\.status.isRemote)
+        guard !submitted.isEmpty, !isWorking, let host, let queueStore else { return }
+        isWorking = true
+        clearActivity()
+
+        Task { [weak self] in
+            do {
+                let client = try await Self.authenticatedClient(host: host, baseURL: self?.serviceURL)
+                for chunk in submitted.chunked(maximumCount: 100) {
+                    let statuses = try await client.statuses(for: chunk.map(\.id))
+                    try Self.apply(statuses, to: chunk, store: queueStore)
+                }
+                await MainActor.run {
+                    guard let self else { return }
+                    self.isWorking = false
+                    self.reloadQueue()
+                    self.showActivity(contributorText(
+                        "Review status updated.",
+                        de: "Prüfstatus aktualisiert.",
+                        ja: "レビュー状況を更新しました。"
+                    ))
+                }
+            } catch {
+                await MainActor.run {
+                    self?.isWorking = false
+                    self?.showActivity(error.localizedDescription, isError: true)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    func delete(_ record: ContributionRecord) {
+        guard !isWorking, let queueStore else { return }
+        if !record.status.isRemote {
+            do {
+                try queueStore.remove(record.id)
+                reloadQueue()
+            } catch {
+                showActivity(error.localizedDescription, isError: true)
+            }
+            return
+        }
+        guard let host else { return }
+        isWorking = true
+        clearActivity()
+        Task { [weak self] in
+            do {
+                let client = try await Self.authenticatedClient(host: host, baseURL: self?.serviceURL)
+                try await client.delete(record.id)
+                try queueStore.remove(record.id)
+                await MainActor.run {
+                    self?.isWorking = false
+                    self?.reloadQueue()
+                }
+            } catch {
+                await MainActor.run {
+                    self?.isWorking = false
+                    self?.showActivity(error.localizedDescription, isError: true)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    func toggleSelection(_ id: UUID) {
+        if selectedIds.contains(id) {
+            selectedIds.remove(id)
+        } else {
+            selectedIds.insert(id)
+        }
+        selectedPreviewId = id
+        sendConfirmed = false
+    }
+
+    @MainActor
+    private func showActivity(_ message: String, isError: Bool = false) {
+        activityMessage = message
+        activityIsError = isError
+    }
+
+    @MainActor
+    private func clearActivity() {
+        activityMessage = nil
+        activityIsError = false
+    }
+
+    private var serviceURL: URL? {
+        guard let override = host?.userDefault(forKey: "serviceURL") as? String,
+              let url = URL(string: override) else {
+            return Self.defaultServiceURL
+        }
+        return url
+    }
+
+    private func subscribe() {
+        guard subscriptionId == nil, let eventBus = host?.eventBus else { return }
+        subscriptionId = eventBus.subscribe { [weak self] event in
+            guard case .textCorrectionCommitted(let payload) = event else { return }
+            await self?.capture(payload)
+        }
+    }
+
+    private func unsubscribe() {
+        if let subscriptionId {
+            host?.eventBus.unsubscribe(id: subscriptionId)
+            self.subscriptionId = nil
+        }
+    }
+
+    private func capture(_ payload: TextCorrectionCommittedPayload) async {
+        guard captureEnabled, let queueStore else { return }
+        do {
+            _ = try queueStore.insert(ContributionRecord(payload: payload))
+            await MainActor.run {
+                self.reloadQueue()
+            }
+        } catch {
+            await MainActor.run {
+                self.showActivity(error.localizedDescription, isError: true)
+            }
+        }
+    }
+
+    private static func authenticatedClient(
+        host: HostServices,
+        baseURL: URL?
+    ) async throws -> ContributorAPIClient {
+        guard let baseURL else { throw ContributorAPIError.invalidResponse }
+        if let token = host.loadSecret(key: "contributor-token") {
+            return ContributorAPIClient(baseURL: baseURL, token: token)
+        }
+        let session = try await ContributorAPIClient(baseURL: baseURL, token: nil).createSession()
+        try host.storeSecret(key: "contributor-token", value: session.token)
+        return ContributorAPIClient(baseURL: baseURL, token: session.token)
+    }
+
+    private static func apply(
+        _ statuses: [ContributionRemoteStatus],
+        to records: [ContributionRecord],
+        store: ContributorQueueStore
+    ) throws {
+        let statusById = Dictionary(uniqueKeysWithValues: statuses.map { ($0.id, $0) })
+        for var record in records {
+            guard let remote = statusById[record.id] else { continue }
+            record.status = remote.status
+            record.reasonCode = remote.reasonCode
+            record.qualityCredit = remote.qualityCredit
+            if record.status.isTerminal {
+                try store.complete(record)
+            } else {
+                try store.upsert(record)
+            }
+        }
+    }
+}
+
+extension Array {
+    func chunked(maximumCount: Int) -> [[Element]] {
+        guard maximumCount > 0 else { return [] }
+        return stride(from: 0, to: count, by: maximumCount).map {
+            Array(self[$0..<Swift.min($0 + maximumCount, count)])
+        }
+    }
+}
+
+func contributorText(_ english: String, de german: String, ja japanese: String) -> String {
+    let language = Locale.preferredLanguages.first?.lowercased() ?? "en"
+    if language.hasPrefix("de") { return german }
+    if language.hasPrefix("ja") { return japanese }
+    return english
+}

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorPlugin.swift
@@ -100,14 +100,19 @@ final class ContributorPlugin: NSObject, TypeWhisperPlugin, PluginSettingsWindow
 
         Task { [weak self] in
             do {
-                let client = try await Self.authenticatedClient(host: host, baseURL: self?.serviceURL)
                 for chunk in selected.chunked(maximumCount: 50) {
-                    let response = try await client.submit(
-                        batchId: UUID(),
-                        records: chunk,
-                        consentVersion: Self.consentVersion,
-                        pluginVersion: Self.pluginVersion
-                    )
+                    let batchId = UUID()
+                    let response = try await Self.withAuthenticatedClient(
+                        host: host,
+                        baseURL: self?.serviceURL
+                    ) { client in
+                        try await client.submit(
+                            batchId: batchId,
+                            records: chunk,
+                            consentVersion: Self.consentVersion,
+                            pluginVersion: Self.pluginVersion
+                        )
+                    }
                     try Self.apply(response.records, to: chunk, store: queueStore)
                 }
                 await MainActor.run {
@@ -138,9 +143,13 @@ final class ContributorPlugin: NSObject, TypeWhisperPlugin, PluginSettingsWindow
 
         Task { [weak self] in
             do {
-                let client = try await Self.authenticatedClient(host: host, baseURL: self?.serviceURL)
                 for chunk in submitted.chunked(maximumCount: 100) {
-                    let statuses = try await client.statuses(for: chunk.map(\.id))
+                    let statuses = try await Self.withAuthenticatedClient(
+                        host: host,
+                        baseURL: self?.serviceURL
+                    ) { client in
+                        try await client.statuses(for: chunk.map(\.id))
+                    }
                     try Self.apply(statuses, to: chunk, store: queueStore)
                 }
                 await MainActor.run {
@@ -179,8 +188,12 @@ final class ContributorPlugin: NSObject, TypeWhisperPlugin, PluginSettingsWindow
         clearActivity()
         Task { [weak self] in
             do {
-                let client = try await Self.authenticatedClient(host: host, baseURL: self?.serviceURL)
-                try await client.delete(record.id)
+                try await Self.withAuthenticatedClient(
+                    host: host,
+                    baseURL: self?.serviceURL
+                ) { client in
+                    try await client.delete(record.id)
+                }
                 try queueStore.remove(record.id)
                 await MainActor.run {
                     self?.isWorking = false
@@ -260,12 +273,27 @@ final class ContributorPlugin: NSObject, TypeWhisperPlugin, PluginSettingsWindow
         baseURL: URL?
     ) async throws -> ContributorAPIClient {
         guard let baseURL else { throw ContributorAPIError.invalidResponse }
-        if let token = host.loadSecret(key: "contributor-token") {
+        if let token = host.loadSecret(key: "contributor-token"), !token.isEmpty {
             return ContributorAPIClient(baseURL: baseURL, token: token)
         }
         let session = try await ContributorAPIClient(baseURL: baseURL, token: nil).createSession()
         try host.storeSecret(key: "contributor-token", value: session.token)
         return ContributorAPIClient(baseURL: baseURL, token: session.token)
+    }
+
+    private static func withAuthenticatedClient<Result: Sendable>(
+        host: HostServices,
+        baseURL: URL?,
+        operation: @Sendable (ContributorAPIClient) async throws -> Result
+    ) async throws -> Result {
+        let client = try await authenticatedClient(host: host, baseURL: baseURL)
+        do {
+            return try await operation(client)
+        } catch let error as ContributorAPIError where error.isAuthenticationFailure {
+            try host.storeSecret(key: "contributor-token", value: "")
+            let renewedClient = try await authenticatedClient(host: host, baseURL: baseURL)
+            return try await operation(renewedClient)
+        }
     }
 
     private static func apply(

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorQueueStore.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorQueueStore.swift
@@ -1,0 +1,154 @@
+import Foundation
+import TypeWhisperPluginSDK
+
+final class ContributorQueueStore: @unchecked Sendable {
+    private static let privateDirectoryPermissions = 0o700
+    private static let privateFilePermissions = 0o600
+
+    private let rootDirectory: URL
+    private let pendingDirectory: URL
+    private let receiptsDirectory: URL
+    private let fileManager: FileManager
+    private let lock = NSLock()
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(rootDirectory: URL, fileManager: FileManager = .default) {
+        self.rootDirectory = rootDirectory
+        self.pendingDirectory = rootDirectory.appendingPathComponent("pending", isDirectory: true)
+        self.receiptsDirectory = rootDirectory.appendingPathComponent("receipts", isDirectory: true)
+        self.fileManager = fileManager
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    func loadRecords() throws -> [ContributionRecord] {
+        try lock.withLock {
+            try ensureDirectories()
+            let urls = try fileManager.contentsOfDirectory(
+                at: pendingDirectory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+            return try urls
+                .filter { $0.pathExtension == "json" }
+                .map { try decoder.decode(ContributionRecord.self, from: Data(contentsOf: $0)) }
+                .sorted { $0.capturedAt > $1.capturedAt }
+        }
+    }
+
+    @discardableResult
+    func insert(_ record: ContributionRecord) throws -> Bool {
+        guard record.isValidCorrection else {
+            throw ContributorQueueError.invalidCorrection
+        }
+        return try lock.withLock {
+            try ensureDirectories()
+            let destination = recordURL(record.id)
+            guard !fileManager.fileExists(atPath: destination.path) else { return false }
+            try writeSecurely(encoder.encode(record), to: destination)
+            return true
+        }
+    }
+
+    func upsert(_ record: ContributionRecord) throws {
+        guard record.isValidCorrection else {
+            throw ContributorQueueError.invalidCorrection
+        }
+        try lock.withLock {
+            try ensureDirectories()
+            try writeSecurely(encoder.encode(record), to: recordURL(record.id))
+        }
+    }
+
+    func remove(_ id: UUID) throws {
+        try lock.withLock {
+            let url = recordURL(id)
+            guard fileManager.fileExists(atPath: url.path) else { return }
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    func complete(_ record: ContributionRecord) throws {
+        guard record.status.isTerminal else { return }
+        try lock.withLock {
+            try ensureDirectories()
+            let receipt = ContributionReceipt(
+                id: record.id,
+                status: record.status,
+                reasonCode: record.reasonCode,
+                qualityCredit: record.qualityCredit,
+                completedAt: Date()
+            )
+            try writeSecurely(
+                encoder.encode(receipt),
+                to: receiptsDirectory.appendingPathComponent("\(record.id.uuidString.lowercased()).json")
+            )
+            let pendingURL = recordURL(record.id)
+            if fileManager.fileExists(atPath: pendingURL.path) {
+                try fileManager.removeItem(at: pendingURL)
+            }
+        }
+    }
+
+    private func ensureDirectories() throws {
+        try secureDirectory(rootDirectory)
+        try secureDirectory(pendingDirectory)
+        try secureDirectory(receiptsDirectory)
+        try secureExistingFiles(in: pendingDirectory)
+        try secureExistingFiles(in: receiptsDirectory)
+    }
+
+    private func secureDirectory(_ directory: URL) throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try fileManager.setAttributes(
+            [.posixPermissions: Self.privateDirectoryPermissions],
+            ofItemAtPath: directory.path
+        )
+    }
+
+    private func writeSecurely(_ data: Data, to destination: URL) throws {
+        try data.write(to: destination, options: .atomic)
+        try secureFile(destination)
+    }
+
+    private func secureExistingFiles(in directory: URL) throws {
+        let urls = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+        for url in urls where try url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true {
+            try secureFile(url)
+        }
+    }
+
+    private func secureFile(_ file: URL) throws {
+        try fileManager.setAttributes(
+            [.posixPermissions: Self.privateFilePermissions],
+            ofItemAtPath: file.path
+        )
+    }
+
+    private func recordURL(_ id: UUID) -> URL {
+        pendingDirectory.appendingPathComponent("\(id.uuidString.lowercased()).json")
+    }
+}
+
+enum ContributorQueueError: LocalizedError {
+    case invalidCorrection
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCorrection:
+            "The correction is incomplete or unchanged."
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorQueueStore.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorQueueStore.swift
@@ -37,9 +37,12 @@ final class ContributorQueueStore: @unchecked Sendable {
                 includingPropertiesForKeys: nil,
                 options: [.skipsHiddenFiles]
             )
-            return try urls
+            return urls
                 .filter { $0.pathExtension == "json" }
-                .map { try decoder.decode(ContributionRecord.self, from: Data(contentsOf: $0)) }
+                .compactMap { url in
+                    guard let data = try? Data(contentsOf: url) else { return nil }
+                    return try? decoder.decode(ContributionRecord.self, from: data)
+                }
                 .sorted { $0.capturedAt > $1.capturedAt }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorSettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/ContributorSettingsView.swift
@@ -1,0 +1,454 @@
+import SwiftUI
+
+struct ContributorSettingsView: View {
+    @ObservedObject var plugin: ContributorPlugin
+    @State private var captureEnabled = false
+    @State private var showingSendConfirmation = false
+
+    private var selectedRecord: ContributionRecord? {
+        plugin.records.first { $0.id == plugin.selectedPreviewId }
+    }
+
+    private var locallySelectedCount: Int {
+        plugin.records.filter {
+            plugin.selectedIds.contains($0.id) && $0.status == .local
+        }.count
+    }
+
+    private var hasRemoteRecords: Bool {
+        plugin.records.contains(where: \.status.isRemote)
+    }
+
+    private var sentRecordCount: Int {
+        plugin.records.filter(\.status.isRemote).count
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            captureSection
+            Divider()
+            queueHeader
+            Divider()
+            queueContent
+            Divider()
+            submissionFooter
+        }
+        .frame(minWidth: 760, minHeight: 520)
+        .onAppear {
+            captureEnabled = plugin.captureEnabled
+            plugin.reloadQueue()
+        }
+        .onChange(of: plugin.selectedIds) { _, _ in
+            plugin.sendConfirmed = false
+        }
+        .alert(
+            contributorText(
+                "Send selected changes?",
+                de: "Ausgewählte Änderungen senden?",
+                ja: "選択した変更を送信しますか？"
+            ),
+            isPresented: $showingSendConfirmation
+        ) {
+            Button(contributorText("Cancel", de: "Abbrechen", ja: "キャンセル"), role: .cancel) {}
+            Button(contributorText("Send", de: "Senden", ja: "送信")) {
+                plugin.sendConfirmed = true
+                plugin.sendSelected()
+            }
+        } message: {
+            Text(contributorText(
+                "Both complete text versions of \(locallySelectedCount) changes will be sent for review. You can delete a submission until it is included in a validated training dataset.",
+                de: "Von \(locallySelectedCount) Änderungen werden jeweils beide vollständigen Textversionen zur Prüfung gesendet. Du kannst eine Einsendung löschen, bis sie in einen validierten Trainingsdatensatz übernommen wurde.",
+                ja: "\(locallySelectedCount)件の変更について、修正前後の全文をレビュー用に送信します。検証済みの学習データセットに追加されるまでは削除できます。"
+            ))
+        }
+    }
+
+    private var captureSection: some View {
+        HStack(alignment: .center, spacing: 14) {
+            Image(systemName: "lock.shield")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(contributorText(
+                    "Collect corrections",
+                    de: "Korrekturen sammeln",
+                    ja: "修正を収集"
+                ))
+                .font(.headline)
+
+                Text(contributorText(
+                    "Only manually changed before/after text is kept locally. Audio, target app, URL, and unchanged dictations are excluded.",
+                    de: "Nur manuell geänderte Vorher-/Nachher-Texte bleiben lokal. Audio, Ziel-App, URL und unveränderte Diktate sind ausgeschlossen.",
+                    ja: "手動で変更した修正前後のテキストのみローカルに保存します。音声、対象アプリ、URL、未変更の音声入力は除外されます。"
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                Link(destination: ContributorPlugin.contributionPolicyURL) {
+                    Label(
+                        contributorText(
+                            "Contribution and privacy policy",
+                            de: "Beitrags- und Datenschutzregeln",
+                            ja: "提供とプライバシーに関する方針"
+                        ),
+                        systemImage: "arrow.up.right.square"
+                    )
+                }
+                .font(.caption)
+            }
+
+            Spacer(minLength: 16)
+
+            Toggle("", isOn: $captureEnabled)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .onChange(of: captureEnabled) { _, enabled in
+                    plugin.updateCaptureEnabled(enabled)
+                }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    private var queueHeader: some View {
+        HStack(spacing: 8) {
+            Text(contributorText("Changes", de: "Änderungen", ja: "変更"))
+                .font(.headline)
+
+            Text("\(plugin.records.count)")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+
+            if sentRecordCount > 0 {
+                Label(
+                    contributorText(
+                        "\(sentRecordCount) sent",
+                        de: "\(sentRecordCount) gesendet",
+                        ja: "\(sentRecordCount)件送信済み"
+                    ),
+                    systemImage: "paperplane.fill"
+                )
+                .font(.caption)
+                .foregroundStyle(.blue)
+            }
+
+            if locallySelectedCount > 0 {
+                Text(contributorText(
+                    "\(locallySelectedCount) selected",
+                    de: "\(locallySelectedCount) ausgewählt",
+                    ja: "\(locallySelectedCount)件選択"
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if hasRemoteRecords {
+                Button {
+                    plugin.refreshStatuses()
+                } label: {
+                    Label(
+                        contributorText(
+                            "Refresh status",
+                            de: "Status aktualisieren",
+                            ja: "状況を更新"
+                        ),
+                        systemImage: "arrow.clockwise"
+                    )
+                }
+                .labelStyle(.iconOnly)
+                .help(contributorText(
+                    "Refresh review status",
+                    de: "Prüfstatus aktualisieren",
+                    ja: "レビュー状況を更新"
+                ))
+                .disabled(plugin.isWorking)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var queueContent: some View {
+        if plugin.records.isEmpty {
+            ContentUnavailableView(
+                contributorText(
+                    "No corrections",
+                    de: "Keine Korrekturen",
+                    ja: "修正はありません"
+                ),
+                systemImage: "checkmark.bubble"
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            HSplitView {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(plugin.records) { record in
+                            ContributionRow(
+                                record: record,
+                                isSelected: plugin.selectedIds.contains(record.id),
+                                isPreviewed: plugin.selectedPreviewId == record.id,
+                                onToggle: { plugin.toggleSelection(record.id) },
+                                onPreview: { plugin.selectedPreviewId = record.id },
+                                onDelete: { plugin.delete(record) }
+                            )
+                            Divider()
+                        }
+                    }
+                }
+                .frame(minWidth: 280, idealWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+
+                if let selectedRecord {
+                    ContributionPreview(record: selectedRecord)
+                        .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ContentUnavailableView(
+                        contributorText(
+                            "Select a change",
+                            de: "Änderung auswählen",
+                            ja: "変更を選択"
+                        ),
+                        systemImage: "text.magnifyingglass"
+                    )
+                    .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var submissionFooter: some View {
+        HStack(spacing: 12) {
+            if plugin.isWorking {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            if let message = plugin.activityMessage {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(plugin.activityIsError ? Color.red : Color.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Button {
+                showingSendConfirmation = true
+            } label: {
+                Label(
+                    contributorText(
+                        "Send \(locallySelectedCount)",
+                        de: "\(locallySelectedCount) senden",
+                        ja: "\(locallySelectedCount)件を送信"
+                    ),
+                    systemImage: "paperplane"
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(locallySelectedCount == 0 || plugin.isWorking)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}
+
+private struct ContributionRow: View {
+    let record: ContributionRecord
+    let isSelected: Bool
+    let isPreviewed: Bool
+    let onToggle: () -> Void
+    let onPreview: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if record.status == .local {
+                Button(action: onToggle) {
+                    Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                }
+                .buttonStyle(.plain)
+                .help(contributorText(
+                    "Select for sending",
+                    de: "Zum Versand auswählen",
+                    ja: "送信用に選択"
+                ))
+                .frame(width: 18, height: 18)
+            } else {
+                Image(systemName: contributionStatusSymbol(record.status))
+                    .foregroundStyle(contributionStatusColor(record.status))
+                    .frame(width: 18, height: 18)
+                    .help(contributionStatusTitle(record.status))
+            }
+
+            Button(action: onPreview) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(record.correctedText)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    HStack(spacing: 6) {
+                        Label(
+                            contributionStatusTitle(record.status),
+                            systemImage: contributionStatusSymbol(record.status)
+                        )
+                        .foregroundStyle(contributionStatusColor(record.status))
+                        if let language = record.language {
+                            Text(language)
+                        }
+                        Text(record.capturedAt, style: .date)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity)
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.plain)
+            .help(contributorText(
+                "Delete correction",
+                de: "Korrektur löschen",
+                ja: "修正を削除"
+            ))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(isPreviewed ? Color.accentColor.opacity(0.12) : Color.clear)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onPreview)
+    }
+}
+
+private struct ContributionPreview: View {
+    let record: ContributionRecord
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(contributorText("Preview", de: "Vorschau", ja: "プレビュー"))
+                    .font(.headline)
+                Spacer()
+                Label(
+                    contributionStatusTitle(record.status),
+                    systemImage: contributionStatusSymbol(record.status)
+                )
+                .font(.caption.weight(.medium))
+                .foregroundStyle(contributionStatusColor(record.status))
+                Text(record.capturedAt, style: .date)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    previewSection(
+                        title: contributorText("Before", de: "Vorher", ja: "修正前"),
+                        text: record.originalText,
+                        color: .red
+                    )
+
+                    Divider()
+
+                    previewSection(
+                        title: contributorText("After", de: "Nachher", ja: "修正後"),
+                        text: record.correctedText,
+                        color: .green
+                    )
+
+                    Divider()
+
+                    HStack(spacing: 12) {
+                        Label(record.engineId, systemImage: "waveform")
+                        if let language = record.language {
+                            Label(language, systemImage: "character.bubble")
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+            .textSelection(.enabled)
+        }
+    }
+
+    private func previewSection(title: String, text: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(color)
+            Text(text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+private func contributionStatusTitle(_ status: ContributionLocalStatus) -> String {
+    switch status {
+    case .local:
+        contributorText("Ready to send", de: "Bereit zum Senden", ja: "送信準備完了")
+    case .pending:
+        contributorText(
+            "Sent · Pending review",
+            de: "Gesendet · Prüfung ausstehend",
+            ja: "送信済み・レビュー待ち"
+        )
+    case .accepted:
+        contributorText("Accepted", de: "Angenommen", ja: "承認済み")
+    case .rejected:
+        contributorText("Rejected", de: "Abgelehnt", ja: "却下")
+    case .quarantined:
+        contributorText(
+            "Sent · Manual review",
+            de: "Gesendet · Manuelle Prüfung",
+            ja: "送信済み・要確認"
+        )
+    }
+}
+
+private func contributionStatusSymbol(_ status: ContributionLocalStatus) -> String {
+    switch status {
+    case .local:
+        "tray"
+    case .pending:
+        "paperplane.circle.fill"
+    case .accepted:
+        "checkmark.seal.fill"
+    case .rejected:
+        "xmark.octagon.fill"
+    case .quarantined:
+        "exclamationmark.triangle.fill"
+    }
+}
+
+private func contributionStatusColor(_ status: ContributionLocalStatus) -> Color {
+    switch status {
+    case .local:
+        .secondary
+    case .pending:
+        .blue
+    case .accepted:
+        .green
+    case .rejected:
+        .red
+    case .quarantined:
+        .orange
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/Tests/ContributorPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/Tests/ContributorPluginTests.swift
@@ -1,10 +1,15 @@
 import Foundation
 import XCTest
 import TypeWhisperPluginSDK
-import TypeWhisperPluginSDKTesting
+@_spi(Testing) import TypeWhisperPluginSDKTesting
 @testable import ContributorPlugin
 
 final class ContributorPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
     func testPluginIdentity() {
         XCTAssertEqual(ContributorPlugin.pluginId, "com.typewhisper.improve")
         XCTAssertEqual(ContributorPlugin.pluginName, "Improve TypeWhisper")
@@ -75,6 +80,22 @@ final class ContributorPluginTests: XCTestCase {
         XCTAssertEqual(try permissions(at: receiptFile), 0o600)
     }
 
+    func testQueueSkipsCorruptPendingFiles() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContributorPluginCorruptQueue-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContributorQueueStore(rootDirectory: directory)
+        let record = makeRecord()
+
+        XCTAssertTrue(try store.insert(record))
+        let corruptFile = directory
+            .appendingPathComponent("pending", isDirectory: true)
+            .appendingPathComponent("corrupt.json")
+        try Data("not-json".utf8).write(to: corruptFile)
+
+        XCTAssertEqual(try store.loadRecords(), [record])
+    }
+
     @MainActor
     func testPluginCapturesEventOnlyWhenEnabled() async throws {
         let eventBus = PluginTestEventBus()
@@ -90,6 +111,96 @@ final class ContributorPluginTests: XCTestCase {
         XCTAssertEqual(plugin.records.count, 1)
         XCTAssertEqual(plugin.records.first?.correctedText, "Ich kaufe kein Auto.")
         XCTAssertTrue(plugin.selectedIds.isEmpty)
+        plugin.deactivate()
+    }
+
+    @MainActor
+    func testPluginDoesNotCaptureEventWhenDisabled() async throws {
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(eventBus: eventBus)
+        let plugin = ContributorPlugin()
+        plugin.activate(host: host)
+
+        await eventBus.emit(.textCorrectionCommitted(makePayload()))
+
+        XCTAssertTrue(plugin.records.isEmpty)
+        plugin.deactivate()
+    }
+
+    @MainActor
+    func testPluginRenewsStaleContributorTokenAfterAuthenticationFailure() async throws {
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(
+            defaults: ["collectCorrections": true],
+            secrets: ["contributor-token": "stale-token"],
+            eventBus: eventBus
+        )
+        let plugin = ContributorPlugin()
+        plugin.activate(host: host)
+        await eventBus.emit(.textCorrectionCommitted(makePayload()))
+        plugin.selectedIds = [makePayload().id]
+        plugin.sendConfirmed = true
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":"Not authenticated."}"#.utf8),
+                    Self.httpResponse(path: "/v1/contributions/batches", statusCode: 401)
+                ),
+                .success(
+                    Data(
+                        #"""
+                        {
+                          "contributorId": "66666666-6666-4666-8666-666666666666",
+                          "token": "fresh-token"
+                        }
+                        """#.utf8
+                    ),
+                    Self.httpResponse(path: "/v1/contributors/session", statusCode: 201)
+                ),
+                .success(
+                    Data(
+                        #"""
+                        {
+                          "batchId": "77777777-7777-4777-8777-777777777777",
+                          "records": [{
+                            "id": "55555555-5555-4555-8555-555555555555",
+                            "status": "pending",
+                            "reason_code": null,
+                            "quality_credit": 0
+                          }]
+                        }
+                        """#.utf8
+                    ),
+                    Self.httpResponse(path: "/v1/contributions/batches", statusCode: 201)
+                ),
+            ])
+        }
+
+        plugin.sendSelected()
+        for _ in 0..<1_000 where plugin.isWorking {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+
+        XCTAssertFalse(plugin.isWorking)
+        XCTAssertEqual(host.loadSecret(key: "contributor-token"), "fresh-token")
+        XCTAssertEqual(plugin.records.first?.status, .pending)
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map(\.url?.path), [
+            "/v1/contributions/batches",
+            "/v1/contributors/session",
+            "/v1/contributions/batches",
+        ])
+        XCTAssertEqual(
+            requests[0].value(forHTTPHeaderField: "Authorization"),
+            "Contributor stale-token"
+        )
+        XCTAssertNil(requests[1].value(forHTTPHeaderField: "Authorization"))
+        XCTAssertEqual(
+            requests[2].value(forHTTPHeaderField: "Authorization"),
+            "Contributor fresh-token"
+        )
         plugin.deactivate()
     }
 
@@ -137,5 +248,14 @@ final class ContributorPluginTests: XCTestCase {
             commitSignal: "return-key",
             sourceChannel: .development
         )
+    }
+
+    private static func httpResponse(path: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://app.typewhisper.com\(path)")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/Tests/ContributorPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/Tests/ContributorPluginTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import XCTest
+import TypeWhisperPluginSDK
+import TypeWhisperPluginSDKTesting
+@testable import ContributorPlugin
+
+final class ContributorPluginTests: XCTestCase {
+    func testPluginIdentity() {
+        XCTAssertEqual(ContributorPlugin.pluginId, "com.typewhisper.improve")
+        XCTAssertEqual(ContributorPlugin.pluginName, "Improve TypeWhisper")
+        XCTAssertEqual(
+            ContributorPlugin.contributionPolicyURL.absoluteString,
+            "https://www.typewhisper.com/addons/improve-typewhisper/"
+        )
+    }
+
+    func testQueuePersistsOnlyCorrectionPayload() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContributorPluginTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContributorQueueStore(rootDirectory: directory)
+        let record = makeRecord()
+
+        XCTAssertTrue(try store.insert(record))
+        var submittedRecord = record
+        submittedRecord.status = .pending
+        try store.upsert(submittedRecord)
+        XCTAssertFalse(try store.insert(record))
+        XCTAssertEqual(try store.loadRecords(), [submittedRecord])
+
+        let fileURL = directory
+            .appendingPathComponent("pending")
+            .appendingPathComponent("\(record.id.uuidString.lowercased()).json")
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        )
+        XCTAssertNil(object["targetApp"])
+        XCTAssertNil(object["bundleIdentifier"])
+        XCTAssertNil(object["url"])
+        XCTAssertNil(object["audio"])
+    }
+
+    func testQueueUsesPrivateFilePermissions() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("ContributorPluginPermissions-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let pendingDirectory = directory.appendingPathComponent("pending", isDirectory: true)
+        let receiptsDirectory = directory.appendingPathComponent("receipts", isDirectory: true)
+        let store = ContributorQueueStore(rootDirectory: directory)
+        let record = makeRecord()
+        let pendingFile = pendingDirectory
+            .appendingPathComponent("\(record.id.uuidString.lowercased()).json")
+
+        XCTAssertTrue(try store.insert(record))
+        XCTAssertEqual(try permissions(at: directory), 0o700)
+        XCTAssertEqual(try permissions(at: pendingDirectory), 0o700)
+        XCTAssertEqual(try permissions(at: receiptsDirectory), 0o700)
+        XCTAssertEqual(try permissions(at: pendingFile), 0o600)
+
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pendingDirectory.path)
+        try fileManager.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pendingFile.path)
+        _ = try store.loadRecords()
+
+        XCTAssertEqual(try permissions(at: directory), 0o700)
+        XCTAssertEqual(try permissions(at: pendingDirectory), 0o700)
+        XCTAssertEqual(try permissions(at: pendingFile), 0o600)
+
+        var acceptedRecord = record
+        acceptedRecord.status = .accepted
+        try store.complete(acceptedRecord)
+        let receiptFile = receiptsDirectory
+            .appendingPathComponent("\(record.id.uuidString.lowercased()).json")
+        XCTAssertEqual(try permissions(at: receiptFile), 0o600)
+    }
+
+    @MainActor
+    func testPluginCapturesEventOnlyWhenEnabled() async throws {
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(
+            defaults: ["collectCorrections": true],
+            eventBus: eventBus
+        )
+        let plugin = ContributorPlugin()
+        plugin.activate(host: host)
+
+        await eventBus.emit(.textCorrectionCommitted(makePayload()))
+
+        XCTAssertEqual(plugin.records.count, 1)
+        XCTAssertEqual(plugin.records.first?.correctedText, "Ich kaufe kein Auto.")
+        XCTAssertTrue(plugin.selectedIds.isEmpty)
+        plugin.deactivate()
+    }
+
+    func testUploadShapeExcludesContext() throws {
+        let request = ContributionBatchRequest(
+            batchId: UUID(),
+            consentVersion: "contribution-text-v1",
+            pluginVersion: "0.1.0",
+            records: [makeRecord()]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any]
+        )
+        let contributions = try XCTUnwrap(object["contributions"] as? [[String: Any]])
+        let contribution = try XCTUnwrap(contributions.first)
+        XCTAssertNil(contribution["targetApp"])
+        XCTAssertNil(contribution["bundleIdentifier"])
+        XCTAssertNil(contribution["url"])
+        XCTAssertNil(contribution["audio"])
+    }
+
+    private func makeRecord() -> ContributionRecord {
+        ContributionRecord(payload: makePayload())
+    }
+
+    private func permissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+    }
+
+    private func makePayload() -> TextCorrectionCommittedPayload {
+        TextCorrectionCommittedPayload(
+            id: UUID(uuidString: "55555555-5555-4555-8555-555555555555")!,
+            capturedAt: Date(timeIntervalSince1970: 1_721_476_800),
+            originalText: "Ich kaufe ein Auto.",
+            correctedText: "Ich kaufe kein Auto.",
+            language: "de",
+            engineId: "reson8",
+            modelId: "typewhisper",
+            appVersion: "1.6.0",
+            appBuild: "160",
+            platformVersion: "macOS 26.0",
+            commitSignal: "return-key",
+            sourceChannel: .development
+        )
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/manifest.json
@@ -1,0 +1,20 @@
+{
+    "id": "com.typewhisper.improve",
+    "name": "Improve TypeWhisper",
+    "version": "0.1.0",
+    "minHostVersion": "1.6.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Review and manually contribute corrected dictation text to improve TypeWhisper.",
+    "descriptions": {
+        "de": "Korrigierte Diktattexte prüfen und manuell zur Verbesserung von TypeWhisper beitragen.",
+        "ja": "修正済みの音声入力テキストを確認し、TypeWhisperの改善に手動で提供します。"
+    },
+    "category": "utility",
+    "hosting": "cloud",
+    "requiresAPIKey": false,
+    "iconSystemName": "checkmark.bubble",
+    "principalClass": "ContributorPlugin",
+    "detailsURL": "https://www.typewhisper.com/addons/improve-typewhisper/"
+}

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperEvent.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperEvent.swift
@@ -16,6 +16,7 @@ public enum TypeWhisperEvent: Sendable {
     case transcriptionCompleted(TranscriptionCompletedPayload)
     case transcriptionFailed(TranscriptionFailedPayload)
     case textInserted(TextInsertedPayload)
+    case textCorrectionCommitted(TextCorrectionCommittedPayload)
     case actionCompleted(ActionCompletedPayload)
     case partialTranscriptionUpdate(PartialTranscriptionPayload)
 }
@@ -188,6 +189,57 @@ public struct TextInsertedPayload: Sendable, Codable {
         self.text = text
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
+    }
+}
+
+public struct TextCorrectionCommittedPayload: Sendable, Codable, Equatable {
+    public enum SourceChannel: String, Sendable, Codable {
+        case production
+        case development
+    }
+
+    public let schemaVersion: Int
+    public let id: UUID
+    public let capturedAt: Date
+    public let originalText: String
+    public let correctedText: String
+    public let language: String?
+    public let engineId: String
+    public let modelId: String?
+    public let appVersion: String
+    public let appBuild: String
+    public let platformVersion: String
+    public let commitSignal: String?
+    public let sourceChannel: SourceChannel
+
+    public init(
+        schemaVersion: Int = 1,
+        id: UUID = UUID(),
+        capturedAt: Date = Date(),
+        originalText: String,
+        correctedText: String,
+        language: String? = nil,
+        engineId: String,
+        modelId: String? = nil,
+        appVersion: String,
+        appBuild: String,
+        platformVersion: String,
+        commitSignal: String? = nil,
+        sourceChannel: SourceChannel
+    ) {
+        self.schemaVersion = schemaVersion
+        self.id = id
+        self.capturedAt = capturedAt
+        self.originalText = originalText
+        self.correctedText = correctedText
+        self.language = language
+        self.engineId = engineId
+        self.modelId = modelId
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.platformVersion = platformVersion
+        self.commitSignal = commitSignal
+        self.sourceChannel = sourceChannel
     }
 }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -18,6 +18,18 @@ public extension TypeWhisperPlugin {
     var settingsView: AnyView? { nil }
 }
 
+public protocol PluginSettingsWindowLayoutProviding: TypeWhisperPlugin {
+    var settingsViewManagesScrolling: Bool { get }
+    var preferredSettingsWindowSize: CGSize? { get }
+    var minimumSettingsWindowSize: CGSize? { get }
+}
+
+public extension PluginSettingsWindowLayoutProviding {
+    var settingsViewManagesScrolling: Bool { false }
+    var preferredSettingsWindowSize: CGSize? { nil }
+    var minimumSettingsWindowSize: CGSize? { nil }
+}
+
 public protocol HostModelLifecyclePolicyAwarePlugin: TypeWhisperPlugin {}
 
 // MARK: - Shared Settings Activity

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/TypeWhisperEventTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/TypeWhisperEventTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class TypeWhisperEventTests: XCTestCase {
+    func testTextCorrectionCommittedPayloadRoundTripsWithoutAppContext() throws {
+        let id = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+        let capturedAt = Date(timeIntervalSince1970: 1_721_476_800)
+        let payload = TextCorrectionCommittedPayload(
+            id: id,
+            capturedAt: capturedAt,
+            originalText: "Ich kaufe ein Auto.",
+            correctedText: "Ich kaufe kein Auto.",
+            language: "de",
+            engineId: "reson8",
+            modelId: "typewhisper-dictation",
+            appVersion: "1.6.0",
+            appBuild: "160",
+            platformVersion: "macOS 26.0",
+            commitSignal: "return-key",
+            sourceChannel: .development
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let encoded = try encoder.encode(payload)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertNil(object["appName"])
+        XCTAssertNil(object["bundleIdentifier"])
+        XCTAssertNil(object["url"])
+        XCTAssertNil(object["audio"])
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        XCTAssertEqual(try decoder.decode(TextCorrectionCommittedPayload.self, from: encoded), payload)
+    }
+}

--- a/TypeWhisperTests/HistoryServiceTests.swift
+++ b/TypeWhisperTests/HistoryServiceTests.swift
@@ -53,4 +53,148 @@ final class HistoryServiceTests: XCTestCase {
         XCTAssertEqual(allTimeUsage.words, 5)
         XCTAssertEqual(allTimeUsage.appCount, 2)
     }
+
+    func testTrainingCaptureStoreWritesJSONLWhenEnabled() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let store = TrainingCaptureStore(
+            captureDirectory: appSupportDirectory.appendingPathComponent("TrainingCapture", isDirectory: true),
+            enabledProvider: { true }
+        )
+        let id = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+        store.record(TrainingCaptureRecord(
+            id: id,
+            createdAt: createdAt,
+            locale: "de_DE",
+            configuredLanguage: "de",
+            detectedLanguage: "de",
+            engineUsed: "qwen3",
+            modelId: "qwen3-asr",
+            modelDisplayName: "Qwen3",
+            workflowId: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            workflowName: "Cleaned Text",
+            outputFormat: nil,
+            pipelineSteps: ["Workflow"],
+            rawText: "ähm morgen um neun",
+            finalText: "Morgen um 9 Uhr.",
+            insertedText: "Morgen um 9 Uhr.",
+            targetApp: TrainingCaptureRecord.TargetApp(
+                name: "Notes",
+                bundleIdentifier: "com.apple.Notes"
+            )
+        ))
+
+        let contents = try String(contentsOf: store.captureFileURL, encoding: .utf8)
+        let lines = contents.split(separator: "\n")
+        XCTAssertEqual(lines.count, 1)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(TrainingCaptureRecord.self, from: Data(lines[0].utf8))
+
+        XCTAssertEqual(decoded.id, id)
+        XCTAssertEqual(decoded.schemaVersion, 1)
+        XCTAssertEqual(decoded.recordType, "accepted-candidate")
+        XCTAssertNil(decoded.parentId)
+        XCTAssertEqual(decoded.source, "typewhisper-mac-dev-dictation")
+        XCTAssertEqual(decoded.locale, "de_DE")
+        XCTAssertEqual(decoded.configuredLanguage, "de")
+        XCTAssertEqual(decoded.detectedLanguage, "de")
+        XCTAssertEqual(decoded.engineUsed, "qwen3")
+        XCTAssertEqual(decoded.modelId, "qwen3-asr")
+        XCTAssertEqual(decoded.modelDisplayName, "Qwen3")
+        XCTAssertEqual(decoded.workflowName, "Cleaned Text")
+        XCTAssertEqual(decoded.pipelineSteps, ["Workflow"])
+        XCTAssertEqual(decoded.rawText, "ähm morgen um neun")
+        XCTAssertEqual(decoded.finalText, "Morgen um 9 Uhr.")
+        XCTAssertEqual(decoded.insertedText, "Morgen um 9 Uhr.")
+        XCTAssertNil(decoded.correctedText)
+        XCTAssertNil(decoded.commitSignal)
+        XCTAssertEqual(decoded.accepted, true)
+        XCTAssertEqual(decoded.reviewed, false)
+        XCTAssertEqual(decoded.targetApp?.bundleIdentifier, "com.apple.Notes")
+    }
+
+    func testTrainingCaptureStoreWritesManualCorrectionJSONLWhenEnabled() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let store = TrainingCaptureStore(
+            captureDirectory: appSupportDirectory.appendingPathComponent("TrainingCapture", isDirectory: true),
+            enabledProvider: { true }
+        )
+        let parentID = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let parent = TrainingCaptureRecord(
+            id: parentID,
+            locale: "de_DE",
+            configuredLanguage: "de",
+            detectedLanguage: "de",
+            engineUsed: "reson8",
+            modelId: "dictation-model",
+            modelDisplayName: "TypeWhisper Dictation Model",
+            workflowId: nil,
+            workflowName: nil,
+            outputFormat: nil,
+            pipelineSteps: [],
+            rawText: "Ich kaufe ein Auto.",
+            finalText: "Ich kaufe ein Auto.",
+            insertedText: "Ich kaufe ein Auto.",
+            targetApp: nil
+        )
+
+        let correctionID = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+        store.record(parent.manualCorrection(
+            correctionId: correctionID,
+            correctedText: "Ich kaufe kein Auto.",
+            commitSignal: .returnKey
+        ))
+
+        let contents = try String(contentsOf: store.captureFileURL, encoding: .utf8)
+        let line = try XCTUnwrap(contents.split(separator: "\n").first)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(TrainingCaptureRecord.self, from: Data(line.utf8))
+
+        XCTAssertEqual(decoded.id, correctionID)
+        XCTAssertEqual(decoded.recordType, "manual-correction")
+        XCTAssertEqual(decoded.parentId, parentID)
+        XCTAssertEqual(decoded.rawText, "Ich kaufe ein Auto.")
+        XCTAssertEqual(decoded.insertedText, "Ich kaufe ein Auto.")
+        XCTAssertEqual(decoded.correctedText, "Ich kaufe kein Auto.")
+        XCTAssertEqual(decoded.commitSignal, "return-key")
+        XCTAssertEqual(decoded.accepted, false)
+        XCTAssertEqual(decoded.reviewed, true)
+    }
+
+    func testTrainingCaptureStoreSkipsWhenDisabled() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let store = TrainingCaptureStore(
+            captureDirectory: appSupportDirectory.appendingPathComponent("TrainingCapture", isDirectory: true),
+            enabledProvider: { false }
+        )
+
+        store.record(TrainingCaptureRecord(
+            locale: "de_DE",
+            configuredLanguage: "de",
+            detectedLanguage: "de",
+            engineUsed: "qwen3",
+            modelId: nil,
+            modelDisplayName: nil,
+            workflowId: nil,
+            workflowName: nil,
+            outputFormat: nil,
+            pipelineSteps: [],
+            rawText: "test",
+            finalText: "Test.",
+            insertedText: "Test.",
+            targetApp: nil
+        ))
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.captureFileURL.path))
+    }
 }

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -190,6 +190,26 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
+    func testCorrectedInsertedTextTrimsTheCompleteReconstructedCorrection() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: TextInsertionService(),
+            textDiffService: TextDiffService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory),
+            pollSchedule: []
+        )
+
+        XCTAssertEqual(
+            service.correctedInsertedText(
+                insertedText: "  wrong value  ",
+                baselineText: "Before  wrong value  After",
+                editedText: "Before  right value  After"
+            ),
+            "right value"
+        )
+    }
+
     func testSkipsInsertedTextRemovalAfterCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -101,6 +101,95 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertEqual(dictionaryService.correctionsCount, 0)
     }
 
+    func testTrackInsertionResultCapturesManualCorrectionAfterCommitSignal() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+
+        var observations = [
+            "Bitte schreibe Korrekturen."
+        ]
+        textInsertionService.focusedTextStateOverride = { _ in
+            let value = observations.removeFirst()
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.seconds(5)],
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Bitte schreibe Korrektur.",
+            selectedText: nil,
+            selectedRange: NSRange(location: 25, length: 0)
+        )
+
+        let task = Task { @MainActor in
+            await service.trackInsertionResult(insertedText: "Korrektur.", baseline: baseline)
+        }
+        for _ in 0..<1000 where !commitEmitter.isReady {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(commitEmitter.isReady)
+        commitEmitter.emit(.returnKey)
+        let result = await task.value
+
+        XCTAssertEqual(result.correctionObservation?.correctedInsertedText, "Korrekturen.")
+        XCTAssertEqual(result.correctionObservation?.commitSignal, .returnKey)
+    }
+
+    func testTrackInsertionResultCapturesRewriteWithoutDictionaryLearning() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+        textInsertionService.focusedTextStateOverride = { _ in
+            let value = "Neue bessere Version."
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.seconds(5)],
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Alte Version.",
+            selectedText: nil,
+            selectedRange: NSRange(location: 13, length: 0)
+        )
+
+        let task = Task { @MainActor in
+            await service.trackInsertionResult(insertedText: "Alte Version.", baseline: baseline)
+        }
+        for _ in 0..<1000 where !commitEmitter.isReady {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        XCTAssertTrue(commitEmitter.isReady)
+        commitEmitter.emit(.returnKey)
+        let result = await task.value
+
+        XCTAssertEqual(result.correctionObservation?.correctedInsertedText, "Neue bessere Version.")
+        XCTAssertTrue(result.learnedCorrections.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
     func testSkipsInsertedTextRemovalAfterCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/docs/specs/2026-07-20-contributor-plugin-design.md
+++ b/docs/specs/2026-07-20-contributor-plugin-design.md
@@ -1,0 +1,418 @@
+# Improve TypeWhisper Plugin
+
+## Context
+
+TypeWhisper can improve dictation cleanup models when users voluntarily contribute real
+before-and-after correction pairs. The existing development-only training capture is useful for
+local experimentation, but it is not an appropriate production contribution flow: it is tied to
+the development app, records accepted candidates before a correction exists, has no user-facing
+review step, and has no consent or reward model.
+
+The product should offer an official first-party plugin that works the same way in TypeWhisper
+Production and TypeWhisper Dev. Users must not need to know which app variant captured a
+correction. The host continues to isolate each app's local plugin data.
+
+The existing `TypeWhisper/app.typewhisper.com` Cloudflare Worker is the backend. Its `APP_DB` D1
+database already owns Sign in with Apple accounts, bearer sessions, devices, and cross-platform
+Premium entitlements. Contributor APIs extend this service instead of introducing a second
+account system or domain.
+
+## Goals
+
+- Capture only text that a user actually changes after TypeWhisper inserts it.
+- Show the complete original and corrected text before any contribution leaves the Mac.
+- Require explicit selection and a manual send action.
+- Allow anonymous contributions without requiring a TypeWhisper account.
+- Support optional contributor rewards without rewarding raw submission volume.
+- Keep Production and Dev behavior identical while preserving separate local storage.
+- Provide a corpus format suitable for cleanup-model evaluation and training.
+
+## Non-Goals
+
+- Capturing or uploading audio.
+- Collecting unchanged or merely accepted dictations.
+- Uploading target application names, bundle identifiers, URLs, selected text, or document
+  contents outside the corrected pair.
+- Automatically exporting contributions to Obsidian or another synced folder.
+- Importing existing training captures or arbitrary correction files.
+- Automatically sending data in the background.
+- Publishing a contributor leaderboard in the first release.
+- Running an MCP server or scheduled validation automation in the first release.
+- Promising that every submitted correction will be accepted or used for training.
+
+## Product Decisions
+
+- The feature ships as an official TypeWhisper marketplace plugin named **Improve TypeWhisper**.
+- The plugin is inactive until the user explicitly enables contribution capture.
+- A contribution exists only after TypeWhisper detects a committed manual correction.
+- The full original and corrected texts are shown and submitted as a pair.
+- Sending remains a separate manual action after review and selection.
+- Anonymous contribution is the default.
+- Reward participation is optional and does not change the text payload.
+- Rewards are based on accepted quality, not total submitted records.
+- `app.typewhisper.com` owns contribution submission, review status, account linking, and rewards.
+- The existing Apple account bearer token is never exposed directly to the plugin.
+- V1 validation is an operator-triggered Codex review, not an MCP workflow.
+
+## User Experience
+
+### Activation
+
+The Improve TypeWhisper plugin appears in Integrations as a first-party utility plugin. Its settings view
+starts with a concise consent screen describing:
+
+- what is captured,
+- what is never captured,
+- where pending corrections are stored,
+- that nothing is sent automatically,
+- that both complete text versions are transmitted after confirmation, and
+- how accepted contributions may be used for evaluation and model training.
+
+The user must enable **Collect corrections for review** before the plugin subscribes to correction
+events. Disabling the setting stops future capture but does not silently delete pending entries.
+
+### Review Queue
+
+The primary plugin view is a compact review queue. It contains only actual corrections and never
+shows unchanged dictations.
+
+Each row shows:
+
+- capture date,
+- detected language,
+- a short preview,
+- review state, and
+- a selection checkbox.
+
+Opening an entry shows:
+
+- **Before**: the complete text inserted by TypeWhisper,
+- **After**: the complete text after the user's committed correction,
+- detected language,
+- transcription engine, and
+- capture date.
+
+The user can exclude an entry or delete it permanently. A sensitive-data warning may flag common
+email addresses, phone numbers, access tokens, or payment-card-like values locally, but it must
+not claim to detect every private value. The complete visible pair remains the source of truth for
+what will be sent.
+
+### Sending
+
+The queue provides **Send selected corrections** as its only submission action. No entry is
+selected by default. Before the network request, a confirmation dialog states the number of
+selected pairs and repeats that both
+complete text versions will be transmitted.
+
+The plugin never schedules background submission. A retry after a network error requires no new
+consent for the unchanged selected batch, but it remains a user-visible action and uses idempotent
+record identifiers.
+
+After a successful server response:
+
+- rejected entries remain local with a short reason and can be deleted,
+- pending-review entries retain their local text until the server reaches a terminal decision,
+- accepted entries delete their local text and retain only a receipt, timestamp, status, and
+  quality-credit summary.
+
+## Host and Plugin Architecture
+
+### New Correction Event
+
+The plugin SDK adds an event for a committed manual correction. The host emits it only when the
+inserted text and committed text differ.
+
+The payload contains:
+
+- stable correction UUID,
+- correction timestamp,
+- original inserted text,
+- corrected committed text,
+- detected language,
+- transcription engine identifier,
+- model identifier when available,
+- TypeWhisper version and build,
+- platform version,
+- commit signal, and
+- source channel (`production` or `development`).
+
+The payload deliberately excludes active application identity, bundle identifier, URL, selected
+text, and audio references.
+
+The event is additive to the existing event bus. The SDK compatibility and minimum host version
+must be updated if the public enum change requires a compatibility boundary. Existing plugins
+must continue to handle unknown events through a default switch branch.
+
+### Detection Lifetime
+
+The host keeps only the transient state required to associate inserted text with a subsequent
+committed edit. If no correction is detected, no contribution record is created. Enabling the
+plugin must not turn accepted-candidate capture on in Production.
+
+The host remains responsible for correction detection because a plugin cannot reliably observe
+the target application's edited text by itself. The plugin is responsible for consent, local
+queue storage, preview, submission, and receipts.
+
+### Local Storage
+
+The plugin stores pending records below `HostServices.pluginDataDirectory`. The host already
+provides distinct plugin data directories for Production and Dev, so both apps can run at the
+same time without writing to a shared file.
+
+Pending corrections use one atomic JSON file per UUID. This permits a single entry to be deleted
+without leaving its text in an append-only log. Submission receipts are stored separately and do
+not retain original or corrected text after terminal acceptance.
+
+The existing development capture JSONL file remains a separate developer-only training artifact.
+The Improve TypeWhisper plugin never reads it and exposes no import command. Its review queue contains only
+corrections captured by the enabled plugin after installation.
+
+## Contribution Schema
+
+Each submitted correction contains:
+
+- `schemaVersion`
+- `id`
+- `capturedAt`
+- `originalText`
+- `correctedText`
+- `language`
+- `engineId`
+- `modelId`
+- `appVersion`
+- `appBuild`
+- `platformVersion`
+- `commitSignal`
+- `sourceChannel`
+
+Each batch additionally contains:
+
+- consent-text version,
+- plugin version,
+- an anonymous contributor identifier or optional reward identity assertion, and
+- batch UUID for idempotency.
+
+The API rejects records where the two text fields are equal, required fields are absent, the
+schema is unsupported, or the same UUID was already processed. Server-side quality checks may
+reject obvious placeholders, unrelated replacements, duplicates, and abuse, but unusual grammar
+or genuine ASR mistakes are not rejected merely for looking imperfect.
+
+## Backend Flow
+
+The Contributor API is added to the existing Cloudflare Worker in
+`TypeWhisper/app.typewhisper.com`. It uses the existing `APP_DB` D1 binding for the initial beta
+and adds migrations for:
+
+- anonymous contributor identities and hashed contributor tokens,
+- optional links from a contributor identity to an existing Apple account,
+- encrypted contribution payloads and non-content indexing metadata,
+- per-record review decisions and quality credit,
+- idempotent batch receipts, and
+- reward grants.
+
+Account, contributor, contribution, and reward data remain in separate tables. Contribution rows
+reference the opaque contributor UUID, not an Apple subject, email address, license key, or account
+session token.
+
+The first backend routes provide:
+
+- authenticated transport for an anonymous contributor token,
+- idempotent batch submission,
+- per-record validation results,
+- status polling for pending review,
+- receipt retrieval, and
+- deletion of contributions that have not yet been incorporated into a training dataset.
+
+Anonymous bootstrap and submission use a dedicated contributor token. Linking rewards requires
+an existing `account_sessions` bearer session and mints a short-lived, contributor-scoped
+assertion. The TypeWhisper host obtains that assertion through `PremiumAccountService`; the plugin
+receives only the scoped assertion.
+
+All transport uses TLS. Original and corrected text are encrypted at the application layer before
+being stored in D1, using a dedicated Worker secret with explicit key-version metadata. Access is
+restricted to the model-evaluation and corpus-maintenance workflow. D1 remains the operational
+source for the beta. Versioned accepted-corpus snapshots may later be exported to a private R2
+bucket without changing client APIs.
+
+The current portal documentation states that the service does not store transcripts. That
+statement and the public privacy material must be updated before Improve TypeWhisper reaches external
+users. The release is blocked until the contribution consent, retention policy, deletion
+behavior, and post-training withdrawal limitations have received privacy and legal review and are
+presented accurately in the plugin.
+
+The backend stores contribution identity separately from text content. Account linking updates
+reward ownership but does not add account details to an existing correction payload.
+
+## V1 Codex Validation Gate
+
+V1 assumes a small contribution volume. Validation runs on demand, approximately weekly when new
+pending records exist, and does not require an MCP server or scheduled automation.
+
+The operator workflow is:
+
+1. Run deterministic server checks for schema validity, equal texts, empty fields, duplicate UUIDs,
+   known placeholders, and exact corpus duplicates.
+2. Export the remaining pending records through an operator-only review command.
+3. Ask Codex to evaluate each pair against a versioned review rubric.
+4. Apply high-confidence accept decisions and route every ambiguous, sensitive, or low-confidence
+   pair to a short manual queue.
+5. Review a small random sample of Codex-accepted pairs.
+6. Create an immutable validated dataset snapshot only after the manual queue and sample are
+   complete.
+
+The operator command uses narrowly scoped review credentials and creates only a temporary local
+review artifact. It must not expose account, Apple, license, reward, target-app, or session data.
+Temporary plaintext review files are removed after decisions are recorded.
+
+Codex receives each original and corrected text as untrusted data, never as instructions. The
+review prompt and tool wrapper must prevent text inside a contribution from changing the rubric,
+requesting additional data, or triggering commands.
+
+Each recorded decision contains:
+
+- contribution UUID,
+- `accepted`, `rejected`, or `quarantined`,
+- concise reason code,
+- confidence class,
+- validator name and model,
+- rubric version,
+- validation timestamp, and
+- `automatic` or `human` decision source.
+
+Codex may automatically accept only pairs that satisfy every rubric criterion unambiguously with
+high confidence. All other pairs require manual review. If a run contains more than 100 pending
+records, produces an unusual rejection rate, or fails the random sample, snapshot creation stops
+and reports the anomaly instead of increasing automatic throughput.
+
+Use of Codex as a validation processor must be disclosed in the contribution consent and privacy
+material before external users participate. No submitted pair may enter a training corpus without
+a terminal validation decision.
+
+An MCP review server and scheduled weekly automation are deferred until actual volume shows that
+the manual operator workflow is insufficient.
+
+## Identity and Rewards
+
+### Anonymous Default
+
+On activation, the plugin creates a random contributor identifier and secret in plugin-scoped
+Keychain storage. Anonymous contributors can submit and receive local acceptance receipts without
+an account.
+
+### Optional Reward Link
+
+Users may voluntarily link the contributor identity to their TypeWhisper account for rewards.
+The link reuses the existing Sign in with Apple account and `PremiumAccountService`. A new
+host-service method exchanges the account bearer token for a short-lived scoped assertion rather
+than exposing the bearer token to the plugin or adding identity fields to each text record.
+
+Anonymous contribution remains available when the user does not link an account. Unlinking an
+account stops future reward attribution but is separate from contribution deletion.
+
+### Quality Credit
+
+Credit is awarded only for accepted, non-duplicate corrections. The scoring service may consider:
+
+- whether the correction is a real edit,
+- whether the pair is structurally usable,
+- whether it adds language or error-pattern diversity,
+- whether it duplicates existing corpus material, and
+- whether the contributor shows repeated low-quality or abusive behavior.
+
+The client displays accepted contribution counts and broad progress levels. Exact scoring weights
+remain server-controlled to reduce gaming. Initial rewards may include a Contributor badge,
+Premium time, and opt-in public recognition. Thresholds are configured only after the beta
+provides enough quality and cost data; they are not hard-coded into the plugin.
+
+Premium-time rewards are issued through the existing signed entitlement response. The backend
+records a unique contributor reward grant and exposes it to the entitlement resolver alongside
+Polar and StoreKit entitlements. Reward grants must be idempotent and must never shorten or
+replace a stronger paid entitlement.
+
+There is no public leaderboard in the first release.
+
+## Failure Handling
+
+- Network failure leaves selected entries pending locally and reports no successful send.
+- A partial batch response updates each record independently.
+- Duplicate submissions return the existing receipt and do not grant credit twice.
+- Corrupt local records are quarantined and shown as a local problem; they are never uploaded.
+- Unsupported schema versions remain local until the plugin can migrate them.
+- Disabling or uninstalling the plugin never causes a final background upload.
+- Deleting a pending entry removes its content from plugin storage.
+
+## Verification
+
+### Host Tests
+
+1. No event is emitted for unchanged text.
+2. A committed edit emits exactly one correction event.
+3. The event preserves the complete before-and-after texts.
+4. The event excludes target app, URL, selected text, and audio metadata.
+5. Production and Dev resolve different plugin data directories.
+6. Correction capture remains inactive when the plugin setting is disabled.
+
+### Plugin Tests
+
+1. Enabling capture persists explicit consent state.
+2. A correction event creates one atomic pending record.
+3. The review view renders the complete pair.
+4. Selection and deletion operate per entry.
+5. No submission occurs without the manual send action.
+6. The serialized payload matches the visible pair and excludes forbidden context.
+7. Retries are idempotent.
+8. Partial success updates only the corresponding records.
+9. Accepted content is removed locally while its receipt remains.
+10. Account linking changes reward attribution without changing correction payloads.
+11. Newly loaded queue entries are not selected automatically.
+
+### Backend Tests
+
+1. Anonymous contributor tokens are stored only as hashes.
+2. Batch UUIDs and correction UUIDs are idempotent.
+3. Stored text fields contain versioned ciphertext rather than plaintext.
+4. Contribution responses never expose account, Apple, license, or session identifiers.
+5. Account linking requires a valid existing account session and produces only a scoped assertion.
+6. Deleting an unincorporated contribution removes its encrypted payload.
+7. Quality credit is granted only once for an accepted correction.
+8. Contributor Premium rewards do not override a stronger Polar or StoreKit entitlement.
+9. Account deletion unlinks reward attribution without silently changing contribution consent.
+10. Only terminally accepted records can enter a dataset snapshot.
+11. Review exports exclude all account, reward, target-app, and session data.
+12. Duplicate validation decisions do not grant quality credit twice.
+
+### Validation Tests
+
+1. Deterministic invalid records never reach Codex review.
+2. Contribution text is treated as untrusted data and cannot alter the review rubric.
+3. High-confidence valid pairs can be accepted automatically.
+4. Ambiguous, sensitive, and low-confidence pairs are quarantined for manual review.
+5. A failed random sample blocks snapshot creation.
+6. A run above the V1 volume threshold blocks snapshot creation and reports the anomaly.
+7. Temporary plaintext review artifacts are removed after decisions are recorded.
+
+### End-to-End Smoke
+
+Run the signed TypeWhisper-Dev app with the development plugin build and verify:
+
+1. A normal unchanged dictation creates no review item.
+2. Editing an inserted dictation and committing the change creates one review item.
+3. The full pair and highlighted diff match the target application.
+4. The outbound request is absent until manual confirmation.
+5. A successful test-server response updates the queue and removes accepted local text.
+6. Production and Dev can run at the same time without sharing pending queues.
+
+## Rollout
+
+1. Add and test the correction event in the host and SDK.
+2. Build the local Improve TypeWhisper plugin queue and preview without any upload endpoint.
+3. Add the Contributor D1 migration and development-only routes to `app.typewhisper.com`.
+4. Exercise consent, encryption, retries, deletion, and receipts against the test API.
+5. Add the operator-only Codex review export, decision import, and snapshot commands.
+6. Invite a small contributor beta with rewards disabled but acceptance counts visible.
+7. Complete privacy and legal review and publish the contribution policy.
+8. Enable optional Apple-account reward linking and manually configured Premium rewards.
+9. Publish the signed plugin through the official marketplace feed.
+
+The plugin remains opt-in at every rollout stage. Existing development captures remain separate
+and local.


### PR DESCRIPTION
## Summary
- add the optional Improve TypeWhisper plugin for reviewing and manually submitting correction pairs
- capture only manually changed before/after text and exclude audio, target app, URLs, and unchanged dictations
- show local, sent, and pending-review states clearly and link the contribution privacy policy
- wire the plugin into SwiftPM, Xcode, SDK events, and the release workflow

## Verification
- `PATH=/opt/homebrew/bin:$PATH scripts/pr-preflight.sh origin/main`
- full Xcode test suite: 1,259 tests, 0 failures
- plugin dev build, signing validation, installation, launch, and live UI smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Improve TypeWhisper plugin for reviewing, selecting, and manually sending text corrections via a local queue.
  * Added an opt-in “Collect corrections” setting with queue previews, status tracking, and record deletion.
  * Added committed-correction events in the plugin SDK, including support for richer edit context.
  * Added optional training-capture recording of correction-related workflow data.
* **Improvements**
  * Plugin settings windows can now determine preferred sizing and whether the view manages its own scrolling.
* **Documentation**
  * Added design documentation for the Improve TypeWhisper opt-in workflow, privacy model, and rollout plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->