### PR TITLE
feat(ClaudePlugin): fetch model list from /v1/models with 24h cache 

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/ClaudePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/ClaudePlugin.swift
@@ -9,11 +9,22 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     static let pluginId = "com.typewhisper.claude"
     static let pluginName = "Claude"
 
+    private static let modelsEndpoint = "https://api.anthropic.com/v1/models"
+    private static let messagesEndpoint = "https://api.anthropic.com/v1/messages"
+    private static let anthropicVersion = "2023-06-01"
+    private static let selectedLLMModelKey = "selectedLLMModel"
+    private static let cachedModelsKey = "fetchedLLMModels.v1"
+    /// Serve a cached model list without re-fetching for 24 hours.
+    private static let cacheTTL: TimeInterval = 24 * 60 * 60
+    /// Safety bound on pagination so a misbehaving `has_more` never loops forever.
+    private static let maxModelPages = 20
+
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedLLMModelId: String?
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.3
+    fileprivate var _modelCache: ClaudeModelCache?
 
     required override init() {
         super.init()
@@ -22,11 +33,17 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     func activate(host: HostServices) {
         self.host = host
         _apiKey = host.loadSecret(key: "api-key")
-        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+        _selectedLLMModelId = host.userDefault(forKey: Self.selectedLLMModelKey) as? String
+        if let data = host.userDefault(forKey: Self.cachedModelsKey) as? Data,
+           let cache = try? JSONDecoder().decode(ClaudeModelCache.self, from: data) {
+            _modelCache = cache
+        }
         _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
         _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
             ?? 0.3
+        // Refresh the model list on activation when the cache is missing or stale.
+        refreshModelsIfNeeded()
     }
 
     func deactivate() {
@@ -42,12 +59,37 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         return !key.isEmpty
     }
 
+    /// Shown when no cache exists yet (no key configured, or offline). Uses the
+    /// current alias ids with no date suffixes — the API returns the same aliases.
+    fileprivate static let fallbackLLMModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "claude-opus-4-8", displayName: "Claude Opus 4.8"),
+        PluginModelInfo(id: "claude-sonnet-5", displayName: "Claude Sonnet 5"),
+        PluginModelInfo(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
+        PluginModelInfo(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
+        PluginModelInfo(id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5"),
+    ]
+
+    /// The fetched list (newest-first) when a non-empty cache exists, otherwise
+    /// the hardcoded fallback.
+    private var baseModels: [PluginModelInfo] {
+        if let cache = _modelCache, !cache.models.isEmpty {
+            return cache.models.map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
+        }
+        return Self.fallbackLLMModels
+    }
+
     var supportedModels: [PluginModelInfo] {
-        [
-            PluginModelInfo(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-            PluginModelInfo(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
-            PluginModelInfo(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
-        ]
+        var models = baseModels
+        // Selection preservation: if the user's selected model isn't in the
+        // current list (e.g. a previously-selected dated id, or a model the
+        // account no longer exposes), keep it selectable by appending it rather
+        // than silently switching the user to a different model.
+        if let selected = _selectedLLMModelId,
+           !selected.isEmpty,
+           !models.contains(where: { $0.id == selected }) {
+            models.append(PluginModelInfo(id: selected, displayName: selected))
+        }
+        return models
     }
 
     func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
@@ -81,7 +123,7 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
 
     func selectLLMModel(_ modelId: String) {
         _selectedLLMModelId = modelId
-        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+        host?.setUserDefault(modelId, forKey: Self.selectedLLMModelKey)
     }
 
     var selectedLLMModelId: String? { _selectedLLMModelId }
@@ -137,22 +179,145 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         }
     }
 
+    /// Validates the key by hitting the models endpoint. A successful validation
+    /// also seeds/refreshes the model cache from the same response instead of
+    /// discarding it.
     func validateApiKey(_ key: String) async -> Bool {
         guard !key.isEmpty else { return false }
-        guard let url = URL(string: "https://api.anthropic.com/v1/models") else { return false }
-
-        var request = URLRequest(url: url)
-        request.setValue(key, forHTTPHeaderField: "x-api-key")
-        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        request.timeoutInterval = 10
-
-        do {
-            let (_, response) = try await PluginHTTPClient.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return false }
-            return httpResponse.statusCode == 200
-        } catch {
-            return false
+        guard let models = await fetchModels(apiKey: key) else { return false }
+        if !models.isEmpty {
+            await MainActor.run { self.setModelCache(models) }
         }
+        return true
+    }
+
+    // MARK: - Dynamic Model Discovery
+
+    /// True when a cached list exists and is younger than the TTL.
+    var isModelCacheFresh: Bool {
+        guard let cache = _modelCache else { return false }
+        return Date().timeIntervalSince(cache.fetchedAt) < Self.cacheTTL
+    }
+
+    var cacheLastUpdated: Date? { _modelCache?.fetchedAt }
+
+    fileprivate func setModelCache(_ models: [ClaudeFetchedModel]) {
+        let cache = ClaudeModelCache(models: models, fetchedAt: Date())
+        _modelCache = cache
+        if let data = try? JSONEncoder().encode(cache) {
+            host?.setUserDefault(data, forKey: Self.cachedModelsKey)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    /// Fetches the full model list (following pagination), returning nil on any
+    /// network/HTTP failure so callers can keep serving the existing cache.
+    func fetchModels(apiKey: String) async -> [ClaudeFetchedModel]? {
+        guard !apiKey.isEmpty else { return nil }
+
+        var collected: [ClaudeFetchedModel] = []
+        var afterId: String?
+
+        for _ in 0..<Self.maxModelPages {
+            guard var components = URLComponents(string: Self.modelsEndpoint) else { return nil }
+            if let afterId {
+                components.queryItems = [URLQueryItem(name: "after_id", value: afterId)]
+            }
+            guard let url = components.url else { return nil }
+
+            var request = URLRequest(url: url)
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+            request.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+            request.timeoutInterval = 15
+
+            do {
+                let (data, response) = try await PluginHTTPClient.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse,
+                      httpResponse.statusCode == 200 else { return nil }
+                let page = try Self.decodeModelsPage(from: data)
+                collected.append(contentsOf: page.models)
+                if page.hasMore, let last = page.lastId, !last.isEmpty {
+                    afterId = last
+                } else {
+                    break
+                }
+            } catch {
+                return nil
+            }
+        }
+
+        return Self.sortedNewestFirst(collected)
+    }
+
+    /// Explicit refresh used by the settings UI and the "Refresh models" button.
+    /// Returns whether a fresh list was fetched and cached.
+    @discardableResult
+    func refreshModels() async -> Bool {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else { return false }
+        guard let models = await fetchModels(apiKey: apiKey), !models.isEmpty else { return false }
+        await MainActor.run { self.setModelCache(models) }
+        return true
+    }
+
+    /// Background refresh: serve the cache immediately, refresh only when missing
+    /// or stale, and keep the cache on failure.
+    private func refreshModelsIfNeeded() {
+        guard let apiKey = _apiKey, !apiKey.isEmpty, !isModelCacheFresh else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            guard let models = await self.fetchModels(apiKey: apiKey), !models.isEmpty else { return }
+            await MainActor.run { self.setModelCache(models) }
+        }
+    }
+
+    nonisolated static func decodeModelsPage(
+        from data: Data
+    ) throws -> (models: [ClaudeFetchedModel], hasMore: Bool, lastId: String?) {
+        let decoded = try JSONDecoder().decode(ClaudeModelsResponse.self, from: data)
+        let models = decoded.data.map {
+            ClaudeFetchedModel(
+                id: $0.id,
+                displayName: $0.displayName ?? $0.id,
+                createdAt: parseTimestamp($0.createdAt)
+            )
+        }
+        return (models, decoded.hasMore ?? false, decoded.lastId)
+    }
+
+    /// Sort newest-first by `created_at`; ties fall back to id for determinism.
+    nonisolated static func sortedNewestFirst(_ models: [ClaudeFetchedModel]) -> [ClaudeFetchedModel] {
+        models.sorted { lhs, rhs in
+            lhs.createdAt != rhs.createdAt ? lhs.createdAt > rhs.createdAt : lhs.id < rhs.id
+        }
+    }
+
+    nonisolated private static func parseTimestamp(_ raw: String?) -> Double {
+        guard let raw, !raw.isEmpty else { return 0 }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: raw) {
+            return date.timeIntervalSince1970
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: raw)?.timeIntervalSince1970 ?? 0
+    }
+
+    /// Newer Claude models (Opus 4.8, Opus 4.7, Sonnet 5, Fable/Mythos 5, and any
+    /// id in those 4.7+/5 families) reject `temperature`/`top_p`/`top_k` with HTTP
+    /// 400, so those parameters must be omitted for them. Sonnet 4.6, Opus 4.6,
+    /// Haiku 4.5, and older still honor the app's temperature override, so we keep
+    /// sending it there. Conservative id-prefix check against the known families.
+    nonisolated static func modelRejectsSamplingParams(_ modelId: String) -> Bool {
+        let id = modelId.lowercased()
+        let rejectingPrefixes = [
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-mythos-5",
+            "claude-mythos-preview",
+        ]
+        return rejectingPrefixes.contains { id.hasPrefix($0) }
     }
 
     // MARK: - Anthropic Messages API
@@ -164,7 +329,7 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         userText: String,
         temperature: Double?
     ) async throws -> String {
-        guard let url = URL(string: "https://api.anthropic.com/v1/messages") else {
+        guard let url = URL(string: Self.messagesEndpoint) else {
             throw PluginChatError.apiError("Invalid URL")
         }
 
@@ -176,14 +341,16 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
                 ["role": "user", "content": userText]
             ]
         ]
-        if let temperature {
+        // Only send the temperature override to models that accept it; newer
+        // families 400 on any sampling parameter.
+        if let temperature, !Self.modelRejectsSamplingParams(model) {
             requestBody["temperature"] = temperature
         }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 60
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
@@ -222,6 +389,46 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     }
 }
 
+// MARK: - Models API Decoding
+
+private struct ClaudeModelsResponse: Decodable {
+    let data: [ClaudeAPIModel]
+    let hasMore: Bool?
+    let lastId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case data
+        case hasMore = "has_more"
+        case lastId = "last_id"
+    }
+}
+
+private struct ClaudeAPIModel: Decodable {
+    let id: String
+    let displayName: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+        case createdAt = "created_at"
+    }
+}
+
+// MARK: - Cached Model Types
+
+struct ClaudeFetchedModel: Codable, Sendable, Equatable {
+    let id: String
+    let displayName: String
+    /// Epoch seconds parsed from the API `created_at`; used for newest-first sort.
+    let createdAt: Double
+}
+
+struct ClaudeModelCache: Codable, Sendable {
+    let models: [ClaudeFetchedModel]
+    let fetchedAt: Date
+}
+
 // MARK: - Settings View
 
 private struct ClaudeSettingsView: View {
@@ -233,6 +440,8 @@ private struct ClaudeSettingsView: View {
     @State private var selectedModel: String = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
+    @State private var isRefreshing = false
+    @State private var lastUpdated: Date?
     private let bundle = Bundle(for: ClaudePlugin.self)
 
     var body: some View {
@@ -301,8 +510,25 @@ private struct ClaudeSettingsView: View {
 
                 // LLM Model Selection
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("LLM Model", bundle: bundle)
-                        .font(.headline)
+                    HStack {
+                        Text("LLM Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        if isRefreshing {
+                            ProgressView().controlSize(.small)
+                        }
+
+                        Button {
+                            refresh()
+                        } label: {
+                            Label(String(localized: "Refresh models", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(isRefreshing)
+                    }
 
                     Picker("Model", selection: $selectedModel) {
                         ForEach(plugin.supportedModels, id: \.id) { model in
@@ -312,6 +538,16 @@ private struct ClaudeSettingsView: View {
                     .labelsHidden()
                     .onChange(of: selectedModel) {
                         plugin.selectLLMModel(selectedModel)
+                    }
+
+                    if let lastUpdated {
+                        Text("Last updated \(lastUpdated.formatted(date: .abbreviated, time: .shortened))", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Using default models. Refresh to fetch the full list.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
 
@@ -360,6 +596,11 @@ private struct ClaudeSettingsView: View {
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
+            lastUpdated = plugin.cacheLastUpdated
+            // Serve the cache immediately; refresh in the background if stale.
+            if plugin.isAvailable, !plugin.isModelCacheFresh {
+                refresh()
+            }
         }
     }
 
@@ -376,6 +617,29 @@ private struct ClaudeSettingsView: View {
             await MainActor.run {
                 isValidating = false
                 validationResult = isValid
+                if isValid {
+                    lastUpdated = plugin.cacheLastUpdated
+                    selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+                }
+            }
+        }
+    }
+
+    private func refresh() {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        Task {
+            let ok = await plugin.refreshModels()
+            await MainActor.run {
+                isRefreshing = false
+                if ok {
+                    lastUpdated = plugin.cacheLastUpdated
+                    // Keep the current selection working even if the fetched list
+                    // dropped it; supportedModels appends it back.
+                    selectedModel = plugin.selectedLLMModelId
+                        ?? plugin.supportedModels.first?.id
+                        ?? selectedModel
+                }
             }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/ClaudePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/ClaudePlugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import SwiftUI
 import TypeWhisperPluginSDK
 
@@ -19,35 +20,92 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     /// Safety bound on pagination so a misbehaving `has_more` never loops forever.
     private static let maxModelPages = 20
 
-    fileprivate var host: HostServices?
-    fileprivate var _apiKey: String?
-    fileprivate var _selectedLLMModelId: String?
-    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
-    fileprivate var _llmTemperatureValue: Double = 0.3
-    fileprivate var _modelCache: ClaudeModelCache?
+    typealias ModelFetchOperation = @Sendable (String) async -> [ClaudeFetchedModel]?
+
+    private struct InFlightModelRefresh {
+        let id: UUID
+        let apiKey: String
+        let generation: UInt64
+        let task: Task<Bool, Never>
+        var waiterCount: Int
+    }
+
+    private struct State {
+        var isActive = false
+        var host: HostServices?
+        var apiKey: String?
+        var selectedLLMModelId: String?
+        var llmTemperatureModeRaw = PluginLLMTemperatureMode.providerDefault.rawValue
+        var llmTemperatureValue = 0.3
+        var modelCache: ClaudeModelCache?
+        var refreshGeneration: UInt64 = 0
+        var inFlightModelRefresh: InFlightModelRefresh?
+    }
+
+    private struct ProcessingSnapshot {
+        let apiKey: String?
+        let selectedModelId: String?
+        let defaultModelId: String
+        let temperatureDirective: PluginLLMTemperatureDirective
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let modelFetchOverride: ModelFetchOperation?
 
     required override init() {
+        modelFetchOverride = nil
+        super.init()
+    }
+
+    init(modelFetchOverride: @escaping ModelFetchOperation) {
+        self.modelFetchOverride = modelFetchOverride
         super.init()
     }
 
     func activate(host: HostServices) {
-        self.host = host
-        _apiKey = host.loadSecret(key: "api-key")
-        _selectedLLMModelId = host.userDefault(forKey: Self.selectedLLMModelKey) as? String
+        let apiKey = host.loadSecret(key: "api-key")
+        let selectedLLMModelId = host.userDefault(forKey: Self.selectedLLMModelKey) as? String
+        let modelCache: ClaudeModelCache?
         if let data = host.userDefault(forKey: Self.cachedModelsKey) as? Data,
            let cache = try? JSONDecoder().decode(ClaudeModelCache.self, from: data) {
-            _modelCache = cache
+            modelCache = cache
+        } else {
+            modelCache = nil
         }
-        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+        let llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
-        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+        let llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
             ?? 0.3
+
+        let previousTask = state.withLock { state -> Task<Bool, Never>? in
+            let previousTask = state.inFlightModelRefresh?.task
+            state.isActive = true
+            state.host = host
+            state.apiKey = apiKey
+            state.selectedLLMModelId = selectedLLMModelId
+            state.llmTemperatureModeRaw = llmTemperatureModeRaw
+            state.llmTemperatureValue = llmTemperatureValue
+            state.modelCache = modelCache
+            state.refreshGeneration &+= 1
+            state.inFlightModelRefresh = nil
+            return previousTask
+        }
+        previousTask?.cancel()
+
         // Refresh the model list on activation when the cache is missing or stale.
         refreshModelsIfNeeded()
     }
 
     func deactivate() {
-        host = nil
+        let refreshTask = state.withLock { state -> Task<Bool, Never>? in
+            let refreshTask = state.inFlightModelRefresh?.task
+            state.isActive = false
+            state.host = nil
+            state.refreshGeneration &+= 1
+            state.inFlightModelRefresh = nil
+            return refreshTask
+        }
+        refreshTask?.cancel()
     }
 
     // MARK: - LLMProviderPlugin
@@ -55,9 +113,13 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     var providerName: String { "Claude" }
 
     var isAvailable: Bool {
-        guard let key = _apiKey else { return false }
-        return !key.isEmpty
+        state.withLock { state in
+            guard let key = state.apiKey else { return false }
+            return !key.isEmpty
+        }
     }
+
+    fileprivate var apiKey: String? { state.withLock { $0.apiKey } }
 
     /// Shown when no cache exists yet (no key configured, or offline). Uses the
     /// current alias ids with no date suffixes — the API returns the same aliases.
@@ -71,20 +133,21 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
 
     /// The fetched list (newest-first) when a non-empty cache exists, otherwise
     /// the hardcoded fallback.
-    private var baseModels: [PluginModelInfo] {
-        if let cache = _modelCache, !cache.models.isEmpty {
+    private static func baseModels(from cache: ClaudeModelCache?) -> [PluginModelInfo] {
+        if let cache, !cache.models.isEmpty {
             return cache.models.map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
         }
-        return Self.fallbackLLMModels
+        return fallbackLLMModels
     }
 
     var supportedModels: [PluginModelInfo] {
-        var models = baseModels
+        let snapshot = state.withLock { ($0.modelCache, $0.selectedLLMModelId) }
+        var models = Self.baseModels(from: snapshot.0)
         // Selection preservation: if the user's selected model isn't in the
         // current list (e.g. a previously-selected dated id, or a model the
         // account no longer exposes), keep it selectable by appending it rather
         // than silently switching the user to a different model.
-        if let selected = _selectedLLMModelId,
+        if let selected = snapshot.1,
            !selected.isEmpty,
            !models.contains(where: { $0.id == selected }) {
             models.append(PluginModelInfo(id: selected, displayName: selected))
@@ -107,11 +170,23 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         model: String?,
         temperatureDirective: PluginLLMTemperatureDirective
     ) async throws -> String {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        let snapshot = state.withLock { state -> ProcessingSnapshot in
+            let models = Self.baseModels(from: state.modelCache)
+            return ProcessingSnapshot(
+                apiKey: state.apiKey,
+                selectedModelId: state.selectedLLMModelId,
+                defaultModelId: models.first?.id ?? Self.fallbackLLMModels[0].id,
+                temperatureDirective: PluginLLMTemperatureDirective(
+                    mode: PluginLLMTemperatureMode(rawValue: state.llmTemperatureModeRaw) ?? .providerDefault,
+                    value: state.llmTemperatureValue
+                )
+            )
+        }
+        guard let apiKey = snapshot.apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
-        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
-        let resolvedTemperature = providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
+        let modelId = model ?? snapshot.selectedModelId ?? snapshot.defaultModelId
+        let resolvedTemperature = snapshot.temperatureDirective.resolvedTemperature(applying: temperatureDirective)
         return try await callMessagesAPI(
             apiKey: apiKey,
             model: modelId,
@@ -122,28 +197,36 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     }
 
     func selectLLMModel(_ modelId: String) {
-        _selectedLLMModelId = modelId
+        let host = state.withLock { state -> HostServices? in
+            state.selectedLLMModelId = modelId
+            return state.host
+        }
         host?.setUserDefault(modelId, forKey: Self.selectedLLMModelKey)
     }
 
-    var selectedLLMModelId: String? { _selectedLLMModelId }
-    @objc var preferredModelId: String? { _selectedLLMModelId }
+    var selectedLLMModelId: String? { state.withLock { $0.selectedLLMModelId } }
+    @objc var preferredModelId: String? { state.withLock { $0.selectedLLMModelId } }
     var llmTemperatureMode: PluginLLMTemperatureMode {
-        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+        state.withLock {
+            PluginLLMTemperatureMode(rawValue: $0.llmTemperatureModeRaw) ?? .providerDefault
+        }
     }
-    var llmTemperatureValue: Double { _llmTemperatureValue }
-    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
-        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
-    }
+    var llmTemperatureValue: Double { state.withLock { $0.llmTemperatureValue } }
 
     func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
-        _llmTemperatureModeRaw = mode.rawValue
+        let host = state.withLock { state -> HostServices? in
+            state.llmTemperatureModeRaw = mode.rawValue
+            return state.host
+        }
         host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
     }
 
     func setLLMTemperatureValue(_ value: Double) {
         let clamped = min(max(value, 0.0), 2.0)
-        _llmTemperatureValue = clamped
+        let host = state.withLock { state -> HostServices? in
+            state.llmTemperatureValue = clamped
+            return state.host
+        }
         host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
     }
 
@@ -156,8 +239,19 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     // MARK: - API Key Management
 
     func setApiKey(_ key: String) {
-        _apiKey = key
-        if let host {
+        let transition = state.withLock { state -> (host: HostServices?, task: Task<Bool, Never>?) in
+            let keyChanged = state.apiKey != key
+            let task = keyChanged ? state.inFlightModelRefresh?.task : nil
+            state.apiKey = key
+            if keyChanged {
+                state.refreshGeneration &+= 1
+                state.inFlightModelRefresh = nil
+            }
+            return (state.host, task)
+        }
+        transition.task?.cancel()
+
+        if let host = transition.host {
             do {
                 try host.storeSecret(key: "api-key", value: key)
             } catch {
@@ -168,8 +262,16 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
     }
 
     func removeApiKey() {
-        _apiKey = nil
-        if let host {
+        let transition = state.withLock { state -> (host: HostServices?, task: Task<Bool, Never>?) in
+            let task = state.inFlightModelRefresh?.task
+            state.apiKey = nil
+            state.refreshGeneration &+= 1
+            state.inFlightModelRefresh = nil
+            return (state.host, task)
+        }
+        transition.task?.cancel()
+
+        if let host = transition.host {
             do {
                 try host.storeSecret(key: "api-key", value: "")
             } catch {
@@ -179,35 +281,48 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         }
     }
 
-    /// Validates the key by hitting the models endpoint. A successful validation
-    /// also seeds/refreshes the model cache from the same response instead of
-    /// discarding it.
+    /// Validates the current key through the same coordinated model refresh used
+    /// by activation and the settings UI. The settings flow stores the candidate
+    /// key before calling this method, so an obsolete validation can never replace
+    /// the cache after the key changes again.
     func validateApiKey(_ key: String) async -> Bool {
         guard !key.isEmpty else { return false }
-        guard let models = await fetchModels(apiKey: key) else { return false }
-        if !models.isEmpty {
-            await MainActor.run { self.setModelCache(models) }
-        }
-        return true
+        return await coordinatedModelRefresh(apiKey: key)
     }
 
     // MARK: - Dynamic Model Discovery
 
     /// True when a cached list exists and is younger than the TTL.
     var isModelCacheFresh: Bool {
-        guard let cache = _modelCache else { return false }
+        guard let cache = state.withLock({ $0.modelCache }) else { return false }
         return Date().timeIntervalSince(cache.fetchedAt) < Self.cacheTTL
     }
 
-    var cacheLastUpdated: Date? { _modelCache?.fetchedAt }
+    var cacheLastUpdated: Date? { state.withLock { $0.modelCache?.fetchedAt } }
 
-    fileprivate func setModelCache(_ models: [ClaudeFetchedModel]) {
+    /// Commits only a result that still belongs to the active API key and refresh
+    /// generation. Persistence and host callbacks deliberately run outside the
+    /// state lock.
+    private func commitModelCache(
+        _ models: [ClaudeFetchedModel],
+        apiKey: String,
+        generation: UInt64
+    ) -> Bool {
         let cache = ClaudeModelCache(models: models, fetchedAt: Date())
-        _modelCache = cache
-        if let data = try? JSONEncoder().encode(cache) {
-            host?.setUserDefault(data, forKey: Self.cachedModelsKey)
+        let host = state.withLock { state -> HostServices? in
+            guard state.isActive,
+                  state.apiKey == apiKey,
+                  state.refreshGeneration == generation else { return nil }
+            state.modelCache = cache
+            return state.host
         }
-        host?.notifyCapabilitiesChanged()
+        guard let host else { return false }
+
+        if let data = try? JSONEncoder().encode(cache) {
+            host.setUserDefault(data, forKey: Self.cachedModelsKey)
+        }
+        host.notifyCapabilitiesChanged()
+        return true
     }
 
     /// Fetches the full model list (following pagination), returning nil on any
@@ -217,12 +332,15 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
 
         var collected: [ClaudeFetchedModel] = []
         var afterId: String?
+        var seenCursors = Set<String>()
 
         for _ in 0..<Self.maxModelPages {
             guard var components = URLComponents(string: Self.modelsEndpoint) else { return nil }
+            var queryItems = [URLQueryItem(name: "limit", value: "1000")]
             if let afterId {
-                components.queryItems = [URLQueryItem(name: "after_id", value: afterId)]
+                queryItems.append(URLQueryItem(name: "after_id", value: afterId))
             }
+            components.queryItems = queryItems
             guard let url = components.url else { return nil }
 
             var request = URLRequest(url: url)
@@ -236,38 +354,109 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
                       httpResponse.statusCode == 200 else { return nil }
                 let page = try Self.decodeModelsPage(from: data)
                 collected.append(contentsOf: page.models)
-                if page.hasMore, let last = page.lastId, !last.isEmpty {
-                    afterId = last
-                } else {
-                    break
+                guard page.hasMore else {
+                    return Self.sortedNewestFirst(collected)
                 }
+
+                guard let lastId = page.lastId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !lastId.isEmpty,
+                      seenCursors.insert(lastId).inserted else { return nil }
+                afterId = lastId
             } catch {
                 return nil
             }
         }
 
-        return Self.sortedNewestFirst(collected)
+        // Reaching the safety bound with `has_more` still set means the response
+        // is incomplete. Never replace a known-good cache with a partial list.
+        return nil
     }
 
     /// Explicit refresh used by the settings UI and the "Refresh models" button.
     /// Returns whether a fresh list was fetched and cached.
     @discardableResult
     func refreshModels() async -> Bool {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else { return false }
-        guard let models = await fetchModels(apiKey: apiKey), !models.isEmpty else { return false }
-        await MainActor.run { self.setModelCache(models) }
-        return true
+        guard let apiKey = state.withLock({ state -> String? in
+            guard state.isActive else { return nil }
+            return state.apiKey
+        }), !apiKey.isEmpty else { return false }
+        return await coordinatedModelRefresh(apiKey: apiKey)
     }
 
     /// Background refresh: serve the cache immediately, refresh only when missing
     /// or stale, and keep the cache on failure.
     private func refreshModelsIfNeeded() {
-        guard let apiKey = _apiKey, !apiKey.isEmpty, !isModelCacheFresh else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            guard let models = await self.fetchModels(apiKey: apiKey), !models.isEmpty else { return }
-            await MainActor.run { self.setModelCache(models) }
+        let apiKey = state.withLock { state -> String? in
+            guard state.isActive,
+                  let apiKey = state.apiKey,
+                  !apiKey.isEmpty else { return nil }
+            if let cache = state.modelCache,
+               Date().timeIntervalSince(cache.fetchedAt) < Self.cacheTTL {
+                return nil
+            }
+            return apiKey
         }
+        guard let apiKey else { return }
+
+        Task { [weak self] in
+            _ = await self?.coordinatedModelRefresh(apiKey: apiKey)
+        }
+    }
+
+    /// Starts or joins the single refresh for the active key. The task itself
+    /// performs the guarded commit exactly once, so every same-key caller sees the
+    /// same result without duplicate writes or requests.
+    private func coordinatedModelRefresh(apiKey: String) async -> Bool {
+        let refresh = state.withLock { state -> InFlightModelRefresh? in
+            guard state.isActive, state.apiKey == apiKey else { return nil }
+
+            if var inFlight = state.inFlightModelRefresh,
+               inFlight.apiKey == apiKey,
+               inFlight.generation == state.refreshGeneration {
+                inFlight.waiterCount += 1
+                state.inFlightModelRefresh = inFlight
+                return inFlight
+            }
+
+            let id = UUID()
+            let generation = state.refreshGeneration
+            let task = Task { [weak self] in
+                guard let self, !Task.isCancelled,
+                      let models = await self.performModelFetch(apiKey: apiKey),
+                      !Task.isCancelled,
+                      !models.isEmpty else { return false }
+                return self.commitModelCache(models, apiKey: apiKey, generation: generation)
+            }
+            let refresh = InFlightModelRefresh(
+                id: id,
+                apiKey: apiKey,
+                generation: generation,
+                task: task,
+                waiterCount: 1
+            )
+            state.inFlightModelRefresh = refresh
+            return refresh
+        }
+        guard let refresh else { return false }
+
+        let succeeded = await refresh.task.value
+        state.withLock { state in
+            if state.inFlightModelRefresh?.id == refresh.id {
+                state.inFlightModelRefresh = nil
+            }
+        }
+        return succeeded
+    }
+
+    var inFlightModelRefreshWaiterCountForTesting: Int {
+        state.withLock { $0.inFlightModelRefresh?.waiterCount ?? 0 }
+    }
+
+    private func performModelFetch(apiKey: String) async -> [ClaudeFetchedModel]? {
+        if let modelFetchOverride {
+            return await modelFetchOverride(apiKey)
+        }
+        return await fetchModels(apiKey: apiKey)
     }
 
     nonisolated static func decodeModelsPage(
@@ -302,22 +491,18 @@ final class ClaudePlugin: NSObject, LLMProviderPlugin, LLMModelSelectable, @unch
         return formatter.date(from: raw)?.timeIntervalSince1970 ?? 0
     }
 
-    /// Newer Claude models (Opus 4.8, Opus 4.7, Sonnet 5, Fable/Mythos 5, and any
-    /// id in those 4.7+/5 families) reject `temperature`/`top_p`/`top_k` with HTTP
-    /// 400, so those parameters must be omitted for them. Sonnet 4.6, Opus 4.6,
-    /// Haiku 4.5, and older still honor the app's temperature override, so we keep
-    /// sending it there. Conservative id-prefix check against the known families.
+    /// Anthropic models released after Opus 4.6 reject sampling parameters. Keep
+    /// an explicit allowlist for known compatible families and conservatively
+    /// omit `temperature` for every unknown or future model id.
     nonisolated static func modelRejectsSamplingParams(_ modelId: String) -> Bool {
         let id = modelId.lowercased()
-        let rejectingPrefixes = [
-            "claude-opus-4-8",
-            "claude-opus-4-7",
-            "claude-sonnet-5",
-            "claude-fable-5",
-            "claude-mythos-5",
-            "claude-mythos-preview",
+        let compatiblePrefixes = [
+            "claude-3-",
+            "claude-haiku-4-5",
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
         ]
-        return rejectingPrefixes.contains { id.hasPrefix($0) }
+        return !compatiblePrefixes.contains { id.hasPrefix($0) }
     }
 
     // MARK: - Anthropic Messages API
@@ -442,6 +627,7 @@ private struct ClaudeSettingsView: View {
     @State private var llmTemperatureValue: Double = 0.3
     @State private var isRefreshing = false
     @State private var lastUpdated: Date?
+    @State private var refreshErrorMessage: String?
     private let bundle = Bundle(for: ClaudePlugin.self)
 
     var body: some View {
@@ -472,6 +658,7 @@ private struct ClaudeSettingsView: View {
                         Button(String(localized: "Remove", bundle: bundle)) {
                             apiKeyInput = ""
                             validationResult = nil
+                            refreshErrorMessage = nil
                             plugin.removeApiKey()
                         }
                         .buttonStyle(.bordered)
@@ -549,6 +736,12 @@ private struct ClaudeSettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+
+                    if let refreshErrorMessage {
+                        Label(refreshErrorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
                 }
 
                 Divider()
@@ -590,7 +783,7 @@ private struct ClaudeSettingsView: View {
         }
         .padding()
         .onAppear {
-            if let key = plugin._apiKey, !key.isEmpty {
+            if let key = plugin.apiKey, !key.isEmpty {
                 apiKeyInput = key
             }
             selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
@@ -612,6 +805,7 @@ private struct ClaudeSettingsView: View {
 
         isValidating = true
         validationResult = nil
+        refreshErrorMessage = nil
         Task {
             let isValid = await plugin.validateApiKey(trimmedKey)
             await MainActor.run {
@@ -628,6 +822,7 @@ private struct ClaudeSettingsView: View {
     private func refresh() {
         guard !isRefreshing else { return }
         isRefreshing = true
+        refreshErrorMessage = nil
         Task {
             let ok = await plugin.refreshModels()
             await MainActor.run {
@@ -639,6 +834,11 @@ private struct ClaudeSettingsView: View {
                     selectedModel = plugin.selectedLLMModelId
                         ?? plugin.supportedModels.first?.id
                         ?? selectedModel
+                } else {
+                    refreshErrorMessage = String(
+                        localized: "Unable to refresh models. Check your connection and try again.",
+                        bundle: bundle
+                    )
                 }
             }
         }

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Localizable.xcstrings
@@ -49,6 +49,22 @@
         }
       }
     },
+    "Last updated %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt aktualisiert: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終更新: %@"
+          }
+        }
+      }
+    },
     "LLM Model": {
       "localizations": {
         "de": {
@@ -61,6 +77,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "LLMモデル"
+          }
+        }
+      }
+    },
+    "Refresh models": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle aktualisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを更新"
           }
         }
       }
@@ -109,6 +141,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "有効なAPIキー"
+          }
+        }
+      }
+    },
+    "Using default models. Refresh to fetch the full list.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardmodelle werden verwendet. Aktualisieren, um die vollständige Liste zu laden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトのモデルを使用しています。完全なリストを取得するには更新してください。"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Localizable.xcstrings
@@ -129,6 +129,22 @@
         }
       }
     },
+    "Unable to refresh models. Check your connection and try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle konnten nicht aktualisiert werden. Prüfe deine Verbindung und versuche es erneut."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを更新できませんでした。接続を確認して、もう一度お試しください。"
+          }
+        }
+      }
+    },
     "Valid API Key": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Tests/ClaudePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Tests/ClaudePluginTests.swift
@@ -5,6 +5,18 @@ import TypeWhisperPluginSDK
 @testable import ClaudePlugin
 
 final class ClaudePluginTests: XCTestCase {
+    private static let cachedModelsKey = "fetchedLLMModels.v1"
+    private static let selectedLLMModelKey = "selectedLLMModel"
+    private static let modelsURL = "https://api.anthropic.com/v1/models"
+    private static let messagesURL = "https://api.anthropic.com/v1/messages"
+
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Existing selection behavior
+
     func testPreferredModelIdReflectsSelectedLLMModel() throws {
         let host = try PluginTestHostServices()
         let plugin = ClaudePlugin()
@@ -20,5 +32,368 @@ final class ClaudePluginTests: XCTestCase {
 
         let preferred = (plugin as? LLMModelSelectable)?.preferredModelId
         XCTAssertEqual(preferred, target)
+    }
+
+    // MARK: - Fallback list
+
+    func testFallbackModelsWhenNoCacheOrKey() throws {
+        let host = try PluginTestHostServices()
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(
+            plugin.supportedModels.map(\.id),
+            [
+                "claude-opus-4-8",
+                "claude-sonnet-5",
+                "claude-opus-4-7",
+                "claude-sonnet-4-6",
+                "claude-haiku-4-5",
+            ]
+        )
+        XCTAssertFalse(
+            plugin.supportedModels.contains { $0.id == "claude-haiku-4-5-20251001" },
+            "the dated haiku id must be replaced by the alias in the fallback list"
+        )
+        XCTAssertFalse(plugin.isModelCacheFresh)
+    }
+
+    // MARK: - Pagination
+
+    func testPaginationAssemblesAllPagesSortedNewestFirstWithAfterId() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.modelsPage(
+                        models: [("a-old-model", "A Old", "2024-01-01T00:00:00Z")],
+                        hasMore: true,
+                        lastId: "cursor-1"
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+                .success(
+                    Self.modelsPage(
+                        models: [("z-new-model", "Z New", "2026-05-01T00:00:00Z")],
+                        hasMore: false,
+                        lastId: nil
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        let ok = await plugin.refreshModels()
+        XCTAssertTrue(ok)
+
+        // Both pages assembled and sorted newest-first regardless of page order.
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["z-new-model", "a-old-model"])
+        XCTAssertTrue(plugin.isModelCacheFresh)
+
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertNil(
+            URLComponents(url: requests[0].url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "after_id" }),
+            "first page must not carry an after_id"
+        )
+        let secondAfterId = URLComponents(url: requests[1].url!, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "after_id" })?.value
+        XCTAssertEqual(secondAfterId, "cursor-1")
+        // Requests must carry the Anthropic auth headers.
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "x-api-key"), "claude-key")
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+    }
+
+    // MARK: - Cache TTL
+
+    func testFreshCacheServedWithoutRefetch() throws {
+        let cacheData = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-fresh", displayName: "Cached Fresh", createdAt: 1_000)],
+            fetchedAt: Date()
+        )
+        let host = try PluginTestHostServices(
+            defaults: [Self.cachedModelsKey: cacheData],
+            secrets: ["api-key": "claude-key"]
+        )
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertTrue(plugin.isModelCacheFresh)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["cached-fresh"])
+    }
+
+    func testStaleCacheServedImmediatelyThenRefreshes() async throws {
+        let cacheData = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-stale", displayName: "Cached Stale", createdAt: 1_000)],
+            fetchedAt: Date(timeIntervalSinceNow: -100_000) // > 24h old
+        )
+        // Activate without a key so the background refresh does not race the test.
+        let host = try PluginTestHostServices(defaults: [Self.cachedModelsKey: cacheData])
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.isModelCacheFresh)
+        XCTAssertEqual(
+            plugin.supportedModels.map(\.id),
+            ["cached-stale"],
+            "the stale cache is still served immediately"
+        )
+
+        plugin.setApiKey("claude-key")
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.modelsPage(
+                        models: [("refreshed-model", "Refreshed", "2026-01-01T00:00:00Z")],
+                        hasMore: false,
+                        lastId: nil
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        let ok = await plugin.refreshModels()
+        XCTAssertTrue(ok)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["refreshed-model"])
+        XCTAssertTrue(plugin.isModelCacheFresh)
+    }
+
+    func testRefreshFailureKeepsExistingCache() async throws {
+        let cacheData = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-kept", displayName: "Cached Kept", createdAt: 1_000)],
+            fetchedAt: Date()
+        )
+        let host = try PluginTestHostServices(defaults: [Self.cachedModelsKey: cacheData])
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"boom"}}"#.utf8),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 500)
+                ),
+            ])
+        }
+
+        let ok = await plugin.refreshModels()
+        XCTAssertFalse(ok, "a failed fetch must not report success")
+        XCTAssertEqual(
+            plugin.supportedModels.map(\.id),
+            ["cached-kept"],
+            "the existing cache must keep being served after a failed fetch"
+        )
+    }
+
+    // MARK: - Selection preservation
+
+    func testSelectedModelIsPreservedWhenNotInList() throws {
+        let host = try PluginTestHostServices(
+            defaults: [Self.selectedLLMModelKey: "claude-haiku-4-5-20251001"]
+        )
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.preferredModelId, "claude-haiku-4-5-20251001")
+        XCTAssertTrue(
+            plugin.supportedModels.contains { $0.id == "claude-haiku-4-5-20251001" },
+            "a selected model that is not in the list must be appended so it stays selectable"
+        )
+        // Fallback entries still present.
+        XCTAssertTrue(plugin.supportedModels.contains { $0.id == "claude-opus-4-8" })
+    }
+
+    func testSelectionPreservedAgainstFetchedListThatDropsIt() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [Self.selectedLLMModelKey: "claude-legacy-pinned"]
+        )
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.modelsPage(
+                        models: [("claude-opus-4-8", "Claude Opus 4.8", "2026-01-01T00:00:00Z")],
+                        hasMore: false,
+                        lastId: nil
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        _ = await plugin.refreshModels()
+        XCTAssertEqual(plugin.preferredModelId, "claude-legacy-pinned")
+        XCTAssertTrue(
+            plugin.supportedModels.contains { $0.id == "claude-legacy-pinned" },
+            "the still-selected model must survive even when the fetched list omits it"
+        )
+    }
+
+    // MARK: - Unify: validation seeds the cache
+
+    func testValidateApiKeySeedsModelCache() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host) // no key → no background refresh
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.modelsPage(
+                        models: [("validated-model", "Validated", "2026-03-01T00:00:00Z")],
+                        hasMore: false,
+                        lastId: nil
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        let valid = await plugin.validateApiKey("claude-key")
+        XCTAssertTrue(valid)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["validated-model"])
+        XCTAssertTrue(plugin.isModelCacheFresh)
+    }
+
+    func testValidateApiKeyFailureReturnsFalse() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(Data("{}".utf8), Self.httpResponse(url: Self.modelsURL, statusCode: 401)),
+            ])
+        }
+
+        let valid = await plugin.validateApiKey("bad-key")
+        XCTAssertFalse(valid)
+    }
+
+    // MARK: - Sampling parameter correctness
+
+    func testModelRejectsSamplingParamsByFamily() {
+        for id in [
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-mythos-5",
+        ] {
+            XCTAssertTrue(
+                ClaudePlugin.modelRejectsSamplingParams(id),
+                "\(id) rejects sampling params and must have temperature omitted"
+            )
+        }
+
+        for id in [
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+            "claude-haiku-4-5",
+            "claude-haiku-4-5-20251001",
+            "claude-3-5-sonnet-20241022",
+        ] {
+            XCTAssertFalse(
+                ClaudePlugin.modelRejectsSamplingParams(id),
+                "\(id) honors sampling params and must keep the temperature override"
+            )
+        }
+    }
+
+    func testMessagesRequestOmitsTemperatureForNewerModelAndKeepsForOlder() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "llmTemperatureMode": PluginLLMTemperatureMode.custom.rawValue,
+                "llmTemperatureValue": 0.7,
+            ]
+        )
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host) // no key on host → no background model refresh
+        plugin.setApiKey("claude-key")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(Self.messagesResponse(text: "ok"), Self.httpResponse(url: Self.messagesURL, statusCode: 200)),
+                .success(Self.messagesResponse(text: "ok"), Self.httpResponse(url: Self.messagesURL, statusCode: 200)),
+            ])
+        }
+
+        _ = try await plugin.process(systemPrompt: "sys", userText: "hi", model: "claude-opus-4-8")
+        _ = try await plugin.process(systemPrompt: "sys", userText: "hi", model: "claude-sonnet-4-6")
+
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+
+        let opusBody = try Self.jsonBody(from: requests[0])
+        XCTAssertNil(opusBody["temperature"], "temperature must be omitted for claude-opus-4-8")
+
+        let sonnetBody = try Self.jsonBody(from: requests[1])
+        XCTAssertEqual(sonnetBody["temperature"] as? Double, 0.7, "temperature must be sent for claude-sonnet-4-6")
+    }
+
+    // MARK: - Helpers
+
+    private static func modelsPage(
+        models: [(id: String, displayName: String, createdAt: String)],
+        hasMore: Bool,
+        lastId: String?
+    ) -> Data {
+        var body: [String: Any] = [
+            "data": models.map { model in
+                [
+                    "id": model.id,
+                    "display_name": model.displayName,
+                    "created_at": model.createdAt,
+                    "type": "model",
+                ]
+            },
+            "has_more": hasMore,
+        ]
+        if let lastId {
+            body["last_id"] = lastId
+        }
+        return try! JSONSerialization.data(withJSONObject: body)
+    }
+
+    private static func messagesResponse(text: String) -> Data {
+        let body: [String: Any] = [
+            "content": [["type": "text", "text": text]],
+        ]
+        return try! JSONSerialization.data(withJSONObject: body)
+    }
+
+    private static func encodeCache(models: [ClaudeFetchedModel], fetchedAt: Date) throws -> Data {
+        try JSONEncoder().encode(ClaudeModelCache(models: models, fetchedAt: fetchedAt))
+    }
+
+    private static func jsonBody(from request: URLRequest) throws -> [String: Any] {
+        let data = try XCTUnwrap(request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Tests/ClaudePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Tests/ClaudePluginTests.swift
@@ -312,7 +312,7 @@ final class ClaudePluginTests: XCTestCase {
         )
 
         plugin.activate(host: host)
-        await fetcher.waitForRequestCount(1)
+        try await fetcher.waitForRequestCount(1)
 
         let manualRefresh = Task { await plugin.refreshModels() }
         await Self.waitForRefreshWaiterCount(2, plugin: plugin)
@@ -340,11 +340,11 @@ final class ClaudePluginTests: XCTestCase {
         plugin.setApiKey("old-key")
 
         let oldRefresh = Task { await plugin.refreshModels() }
-        await fetcher.waitForRequestCount(1)
+        try await fetcher.waitForRequestCount(1)
 
         plugin.setApiKey("new-key")
         let newRefresh = Task { await plugin.refreshModels() }
-        await fetcher.waitForRequestCount(2)
+        try await fetcher.waitForRequestCount(2)
 
         await fetcher.resolveFirst(
             apiKey: "new-key",
@@ -378,7 +378,7 @@ final class ClaudePluginTests: XCTestCase {
         let notificationsBeforeRefresh = host.capabilitiesChangedCount
 
         let refresh = Task { await plugin.refreshModels() }
-        await fetcher.waitForRequestCount(1)
+        try await fetcher.waitForRequestCount(1)
         plugin.deactivate()
 
         await fetcher.resolveFirst(
@@ -649,23 +649,25 @@ final class ClaudePluginTests: XCTestCase {
 }
 
 private actor ControlledClaudeModelFetcher {
+    private struct RequestCountTimeoutError: Error, CustomStringConvertible {
+        let expectedCount: Int
+        let actualCount: Int
+
+        var description: String {
+            "Timed out after one second waiting for \(expectedCount) Claude model request(s); observed \(actualCount)"
+        }
+    }
+
     private struct PendingRequest {
         let apiKey: String
         let continuation: CheckedContinuation<[ClaudeFetchedModel]?, Never>
     }
 
-    private struct RequestCountWaiter {
-        let expectedCount: Int
-        let continuation: CheckedContinuation<Void, Never>
-    }
-
     private var keys: [String] = []
     private var pendingRequests: [PendingRequest] = []
-    private var requestCountWaiters: [RequestCountWaiter] = []
 
     func fetch(apiKey: String) async -> [ClaudeFetchedModel]? {
         keys.append(apiKey)
-        resumeSatisfiedRequestCountWaiters()
         return await withCheckedContinuation { continuation in
             pendingRequests.append(
                 PendingRequest(apiKey: apiKey, continuation: continuation)
@@ -673,11 +675,16 @@ private actor ControlledClaudeModelFetcher {
         }
     }
 
-    func waitForRequestCount(_ expectedCount: Int) async {
-        guard keys.count < expectedCount else { return }
-        await withCheckedContinuation { continuation in
-            requestCountWaiters.append(
-                RequestCountWaiter(expectedCount: expectedCount, continuation: continuation)
+    func waitForRequestCount(_ expectedCount: Int) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while keys.count < expectedCount, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        guard keys.count >= expectedCount else {
+            throw RequestCountTimeoutError(
+                expectedCount: expectedCount,
+                actualCount: keys.count
             )
         }
     }
@@ -692,17 +699,5 @@ private actor ControlledClaudeModelFetcher {
 
     func recordedKeys() -> [String] {
         keys
-    }
-
-    private func resumeSatisfiedRequestCountWaiters() {
-        var remaining: [RequestCountWaiter] = []
-        for waiter in requestCountWaiters {
-            if keys.count >= waiter.expectedCount {
-                waiter.continuation.resume()
-            } else {
-                remaining.append(waiter)
-            }
-        }
-        requestCountWaiters = remaining
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Tests/ClaudePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/Tests/ClaudePluginTests.swift
@@ -97,6 +97,11 @@ final class ClaudePluginTests: XCTestCase {
 
         let requests = store.sessions[0].requestedRequests
         XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(
+            URLComponents(url: requests[0].url!, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "limit" })?.value,
+            "1000"
+        )
         XCTAssertNil(
             URLComponents(url: requests[0].url!, resolvingAgainstBaseURL: false)?
                 .queryItems?.first(where: { $0.name == "after_id" }),
@@ -108,6 +113,101 @@ final class ClaudePluginTests: XCTestCase {
         // Requests must carry the Anthropic auth headers.
         XCTAssertEqual(requests[0].value(forHTTPHeaderField: "x-api-key"), "claude-key")
         XCTAssertEqual(requests[0].value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+    }
+
+    func testMissingPaginationCursorKeepsExistingCache() async throws {
+        let cacheData = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-kept", displayName: "Cached Kept", createdAt: 1_000)],
+            fetchedAt: Date()
+        )
+        let host = try PluginTestHostServices(defaults: [Self.cachedModelsKey: cacheData])
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.modelsPage(
+                        models: [("partial-model", "Partial", "2026-01-01T00:00:00Z")],
+                        hasMore: true,
+                        lastId: nil
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        let refreshed = await plugin.refreshModels()
+        XCTAssertFalse(refreshed)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["cached-kept"])
+        XCTAssertEqual(store.sessions[0].requestedRequests.count, 1)
+    }
+
+    func testRepeatedPaginationCursorKeepsExistingCache() async throws {
+        let cacheData = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-kept", displayName: "Cached Kept", createdAt: 1_000)],
+            fetchedAt: Date()
+        )
+        let host = try PluginTestHostServices(defaults: [Self.cachedModelsKey: cacheData])
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.modelsPage(models: [], hasMore: true, lastId: "cursor-1"),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+                .success(
+                    Self.modelsPage(
+                        models: [("partial-model", "Partial", "2026-01-01T00:00:00Z")],
+                        hasMore: true,
+                        lastId: "cursor-1"
+                    ),
+                    Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        let refreshed = await plugin.refreshModels()
+        XCTAssertFalse(refreshed)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["cached-kept"])
+        XCTAssertEqual(store.sessions[0].requestedRequests.count, 2)
+    }
+
+    func testPaginationSafetyLimitKeepsExistingCache() async throws {
+        let cacheData = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-kept", displayName: "Cached Kept", createdAt: 1_000)],
+            fetchedAt: Date()
+        )
+        let host = try PluginTestHostServices(defaults: [Self.cachedModelsKey: cacheData])
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+
+        let outcomes: [PluginHTTPClientTestOutcome] = (0..<20).map { index in
+            .success(
+                Self.modelsPage(
+                    models: [("partial-\(index)", "Partial \(index)", "2026-01-01T00:00:00Z")],
+                    hasMore: true,
+                    lastId: "cursor-\(index)"
+                ),
+                Self.httpResponse(url: Self.modelsURL, statusCode: 200)
+            )
+        }
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: outcomes)
+        }
+
+        let refreshed = await plugin.refreshModels()
+        XCTAssertFalse(refreshed)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["cached-kept"])
+        XCTAssertEqual(store.sessions[0].requestedRequests.count, 20)
     }
 
     // MARK: - Cache TTL
@@ -195,6 +295,103 @@ final class ClaudePluginTests: XCTestCase {
         )
     }
 
+    // MARK: - Refresh coordination
+
+    func testActivationAndManualRefreshShareOneInFlightRequest() async throws {
+        let staleCache = try Self.encodeCache(
+            models: [ClaudeFetchedModel(id: "cached-stale", displayName: "Cached Stale", createdAt: 1_000)],
+            fetchedAt: Date(timeIntervalSinceNow: -100_000)
+        )
+        let fetcher = ControlledClaudeModelFetcher()
+        let plugin = ClaudePlugin { apiKey in
+            await fetcher.fetch(apiKey: apiKey)
+        }
+        let host = try PluginTestHostServices(
+            defaults: [Self.cachedModelsKey: staleCache],
+            secrets: ["api-key": "shared-key"]
+        )
+
+        plugin.activate(host: host)
+        await fetcher.waitForRequestCount(1)
+
+        let manualRefresh = Task { await plugin.refreshModels() }
+        await Self.waitForRefreshWaiterCount(2, plugin: plugin)
+        XCTAssertEqual(plugin.inFlightModelRefreshWaiterCountForTesting, 2)
+
+        await fetcher.resolveFirst(
+            apiKey: "shared-key",
+            models: [ClaudeFetchedModel(id: "shared-result", displayName: "Shared", createdAt: 2_000)]
+        )
+
+        let manualRefreshSucceeded = await manualRefresh.value
+        let recordedKeys = await fetcher.recordedKeys()
+        XCTAssertTrue(manualRefreshSucceeded)
+        XCTAssertEqual(recordedKeys, ["shared-key"])
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["shared-result"])
+    }
+
+    func testAPIKeyChangeDiscardsOlderInFlightResult() async throws {
+        let fetcher = ControlledClaudeModelFetcher()
+        let plugin = ClaudePlugin { apiKey in
+            await fetcher.fetch(apiKey: apiKey)
+        }
+        let host = try PluginTestHostServices()
+        plugin.activate(host: host)
+        plugin.setApiKey("old-key")
+
+        let oldRefresh = Task { await plugin.refreshModels() }
+        await fetcher.waitForRequestCount(1)
+
+        plugin.setApiKey("new-key")
+        let newRefresh = Task { await plugin.refreshModels() }
+        await fetcher.waitForRequestCount(2)
+
+        await fetcher.resolveFirst(
+            apiKey: "new-key",
+            models: [ClaudeFetchedModel(id: "new-model", displayName: "New", createdAt: 2_000)]
+        )
+        let newRefreshSucceeded = await newRefresh.value
+        XCTAssertTrue(newRefreshSucceeded)
+
+        await fetcher.resolveFirst(
+            apiKey: "old-key",
+            models: [ClaudeFetchedModel(id: "old-model", displayName: "Old", createdAt: 1_000)]
+        )
+        let oldRefreshSucceeded = await oldRefresh.value
+        let recordedKeys = await fetcher.recordedKeys()
+        XCTAssertFalse(oldRefreshSucceeded)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["new-model"])
+        XCTAssertEqual(recordedKeys, ["old-key", "new-key"])
+        let persistedData = try XCTUnwrap(host.userDefault(forKey: Self.cachedModelsKey) as? Data)
+        let persistedCache = try JSONDecoder().decode(ClaudeModelCache.self, from: persistedData)
+        XCTAssertEqual(persistedCache.models.map(\.id), ["new-model"])
+    }
+
+    func testDeactivateDiscardsInFlightResultWithoutNotification() async throws {
+        let fetcher = ControlledClaudeModelFetcher()
+        let plugin = ClaudePlugin { apiKey in
+            await fetcher.fetch(apiKey: apiKey)
+        }
+        let host = try PluginTestHostServices()
+        plugin.activate(host: host)
+        plugin.setApiKey("claude-key")
+        let notificationsBeforeRefresh = host.capabilitiesChangedCount
+
+        let refresh = Task { await plugin.refreshModels() }
+        await fetcher.waitForRequestCount(1)
+        plugin.deactivate()
+
+        await fetcher.resolveFirst(
+            apiKey: "claude-key",
+            models: [ClaudeFetchedModel(id: "stale-model", displayName: "Stale", createdAt: 1_000)]
+        )
+
+        let refreshSucceeded = await refresh.value
+        XCTAssertFalse(refreshSucceeded)
+        XCTAssertNil(plugin.cacheLastUpdated)
+        XCTAssertEqual(host.capabilitiesChangedCount, notificationsBeforeRefresh)
+    }
+
     // MARK: - Selection preservation
 
     func testSelectedModelIsPreservedWhenNotInList() throws {
@@ -249,6 +446,7 @@ final class ClaudePluginTests: XCTestCase {
         let host = try PluginTestHostServices()
         let plugin = ClaudePlugin()
         plugin.activate(host: host) // no key → no background refresh
+        plugin.setApiKey("claude-key")
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -274,6 +472,7 @@ final class ClaudePluginTests: XCTestCase {
         let host = try PluginTestHostServices()
         let plugin = ClaudePlugin()
         plugin.activate(host: host)
+        plugin.setApiKey("bad-key")
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -288,6 +487,39 @@ final class ClaudePluginTests: XCTestCase {
 
     // MARK: - Sampling parameter correctness
 
+    func testUnselectedProcessingUsesNewestCachedModel() async throws {
+        let cacheData = try Self.encodeCache(
+            models: [
+                ClaudeFetchedModel(id: "newest-model", displayName: "Newest", createdAt: 2_000),
+                ClaudeFetchedModel(id: "older-model", displayName: "Older", createdAt: 1_000),
+            ],
+            fetchedAt: Date()
+        )
+        let host = try PluginTestHostServices(
+            defaults: [Self.cachedModelsKey: cacheData],
+            secrets: ["api-key": "claude-key"]
+        )
+        let plugin = ClaudePlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Self.messagesResponse(text: "ok"),
+                    Self.httpResponse(url: Self.messagesURL, statusCode: 200)
+                ),
+            ])
+        }
+
+        _ = try await plugin.process(systemPrompt: "sys", userText: "hi", model: nil)
+
+        let request = try XCTUnwrap(store.sessions[0].requestedRequests.first)
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "newest-model")
+        XCTAssertNil(plugin.selectedLLMModelId, "using the newest default must not persist a selection")
+    }
+
     func testModelRejectsSamplingParamsByFamily() {
         for id in [
             "claude-opus-4-8",
@@ -295,6 +527,10 @@ final class ClaudePluginTests: XCTestCase {
             "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",
+            "claude-mythos-preview",
+            "claude-opus-4-9",
+            "claude-haiku-5",
+            "claude-future-unknown",
         ] {
             XCTAssertTrue(
                 ClaudePlugin.modelRejectsSamplingParams(id),
@@ -332,23 +568,37 @@ final class ClaudePluginTests: XCTestCase {
             store.makeSession(outcomes: [
                 .success(Self.messagesResponse(text: "ok"), Self.httpResponse(url: Self.messagesURL, statusCode: 200)),
                 .success(Self.messagesResponse(text: "ok"), Self.httpResponse(url: Self.messagesURL, statusCode: 200)),
+                .success(Self.messagesResponse(text: "ok"), Self.httpResponse(url: Self.messagesURL, statusCode: 200)),
             ])
         }
 
         _ = try await plugin.process(systemPrompt: "sys", userText: "hi", model: "claude-opus-4-8")
         _ = try await plugin.process(systemPrompt: "sys", userText: "hi", model: "claude-sonnet-4-6")
+        _ = try await plugin.process(systemPrompt: "sys", userText: "hi", model: "claude-future-unknown")
 
         let requests = store.sessions[0].requestedRequests
-        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests.count, 3)
 
         let opusBody = try Self.jsonBody(from: requests[0])
         XCTAssertNil(opusBody["temperature"], "temperature must be omitted for claude-opus-4-8")
 
         let sonnetBody = try Self.jsonBody(from: requests[1])
         XCTAssertEqual(sonnetBody["temperature"] as? Double, 0.7, "temperature must be sent for claude-sonnet-4-6")
+
+        let futureBody = try Self.jsonBody(from: requests[2])
+        XCTAssertNil(futureBody["temperature"], "temperature must be omitted for unknown future models")
     }
 
     // MARK: - Helpers
+
+    private static func waitForRefreshWaiterCount(_ expectedCount: Int, plugin: ClaudePlugin) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while plugin.inFlightModelRefreshWaiterCountForTesting < expectedCount,
+              clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+    }
 
     private static func modelsPage(
         models: [(id: String, displayName: String, createdAt: String)],
@@ -395,5 +645,64 @@ final class ClaudePluginTests: XCTestCase {
             httpVersion: nil,
             headerFields: nil
         )!
+    }
+}
+
+private actor ControlledClaudeModelFetcher {
+    private struct PendingRequest {
+        let apiKey: String
+        let continuation: CheckedContinuation<[ClaudeFetchedModel]?, Never>
+    }
+
+    private struct RequestCountWaiter {
+        let expectedCount: Int
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private var keys: [String] = []
+    private var pendingRequests: [PendingRequest] = []
+    private var requestCountWaiters: [RequestCountWaiter] = []
+
+    func fetch(apiKey: String) async -> [ClaudeFetchedModel]? {
+        keys.append(apiKey)
+        resumeSatisfiedRequestCountWaiters()
+        return await withCheckedContinuation { continuation in
+            pendingRequests.append(
+                PendingRequest(apiKey: apiKey, continuation: continuation)
+            )
+        }
+    }
+
+    func waitForRequestCount(_ expectedCount: Int) async {
+        guard keys.count < expectedCount else { return }
+        await withCheckedContinuation { continuation in
+            requestCountWaiters.append(
+                RequestCountWaiter(expectedCount: expectedCount, continuation: continuation)
+            )
+        }
+    }
+
+    func resolveFirst(apiKey: String, models: [ClaudeFetchedModel]?) {
+        guard let index = pendingRequests.firstIndex(where: { $0.apiKey == apiKey }) else {
+            preconditionFailure("No pending Claude model request for \(apiKey)")
+        }
+        let request = pendingRequests.remove(at: index)
+        request.continuation.resume(returning: models)
+    }
+
+    func recordedKeys() -> [String] {
+        keys
+    }
+
+    private func resumeSatisfiedRequestCountWaiters() {
+        var remaining: [RequestCountWaiter] = []
+        for waiter in requestCountWaiters {
+            if keys.count >= waiter.expectedCount {
+                waiter.continuation.resume()
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        requestCountWaiters = remaining
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.claude",
     "name": "Claude",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary
Replace the hardcoded three-model list with a paginated fetch from the Anthropic GET /v1/models endpoint, cached for 24 hours in plugin-scoped UserDefaults (fetchedLLMModels.v1). Seed the cache from the same response validateApiKey already makes instead of discarding the body, and preserve a user's selected model even when it is absent from the fetched list.

Add modelRejectsSamplingParams so temperature/top_p/top_k are omitted for model families that reject them (Opus 4.7/4.8, Sonnet 5, Fable/Mythos 5), which otherwise fail with HTTP 400. Refresh the list on activation and via a new "Refresh models" button in settings, falling back to the cached or hardcoded list on any network failure.

Includes unit tests for the fetch/pagination/cache/merge logic and the sampling-param gate. Bumps the plugin manifest to 1.1.0. No host-side changes.

## Test Plan

- [ ] Ran `scripts/pr-preflight.sh`
- [ ] Built and ran locally
- [ ] Tested the changed functionality manually
- [ ] No regressions in existing features


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic Claude model discovery with persisted, time-bounded caching and background refresh.
  * Added “Refresh models” UI with spinner, last-updated timestamp, and refresh errors.
  * Preserved the user’s selected model even if it’s not included in the latest fetched list.
  * Added localized refresh/fallback/error strings (German/Japanese).
* **Bug Fixes**
  * Improved API key validation by safely fetching models with bounded pagination and deterministic sorting.
  * Omitted temperature for incompatible/unknown model families to prevent request failures.
  * Prevented stale refresh results from overwriting valid cache, including during key changes.
* **Tests**
  * Expanded coverage for cache TTL, pagination edge cases, selection preservation, and sampling-parameter request correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->