### PR TITLE
Fix duplicate text insertion in Firefox and Zen

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -126,6 +126,12 @@ final class TextInsertionService {
         if normalized.contains("wavebox") {
             return .chromiumBased
         }
+        if normalized == "org.mozilla.firefox"
+            || normalized == "org.mozilla.firefoxdeveloperedition"
+            || normalized == "org.mozilla.nightly"
+            || normalized == "app.zen-browser.zen" {
+            return .firefox
+        }
 
         switch bundleId {
         case "com.apple.Safari":
@@ -140,8 +146,6 @@ final class TextInsertionService {
              "com.vivaldi.Vivaldi",
              "org.chromium.Chromium":
             return .chromiumBased
-        case "org.mozilla.firefox":
-            return .firefox
         default:
             return .notABrowser
         }
@@ -553,12 +557,14 @@ final class TextInsertionService {
         let appName = activeApp.name
         let bundleId = activeApp.bundleId
         let isTerminalApp = bundleId.map { syntheticPastePreferredBundleIdentifiers.contains($0) } ?? false
+        let isFirefoxBasedBrowser = bundleId.map { Self.identifyBrowser($0) == .firefox } ?? false
+        let prefersSyntheticPaste = isTerminalApp || isFirefoxBasedBrowser
 
         logger.info(
-            "insertText requested: app=\(appName ?? "nil", privacy: .public), bundle=\(bundleId ?? "nil", privacy: .public), preserveClipboard=\(preserveClipboard, privacy: .public), outputFormat=\(outputFormat ?? "plain", privacy: .public), terminalPreferredSyntheticPaste=\(isTerminalApp, privacy: .public)"
+            "insertText requested: app=\(appName ?? "nil", privacy: .public), bundle=\(bundleId ?? "nil", privacy: .public), preserveClipboard=\(preserveClipboard, privacy: .public), outputFormat=\(outputFormat ?? "plain", privacy: .public), prefersSyntheticPaste=\(prefersSyntheticPaste, privacy: .public)"
         )
 
-        if preserveClipboard, !requiresPasteboardInsertion, !isTerminalApp,
+        if preserveClipboard, !requiresPasteboardInsertion, !prefersSyntheticPaste,
            let focusedElement = getFocusedTextElement(),
            insertTextAtAndVerifyChange(element: focusedElement, text: text) {
             if hadFocusedTextField {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3353,6 +3353,57 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
+    func testFirefoxFamilyForcesSingleSyntheticPasteInsteadOfDirectAccessibilityInsertion() async throws {
+        let browsers = [
+            (name: "Firefox", bundleIdentifier: "org.mozilla.firefox"),
+            (name: "Firefox Developer Edition", bundleIdentifier: "org.mozilla.firefoxdeveloperedition"),
+            (name: "Firefox Nightly", bundleIdentifier: "org.mozilla.nightly"),
+            (name: "Zen", bundleIdentifier: "app.zen-browser.zen")
+        ]
+
+        for browser in browsers {
+            let service = TextInsertionService()
+            let pasteboard = NSPasteboard.withUniqueName()
+            let element = AXUIElementCreateSystemWide()
+            service.accessibilityGrantedOverride = true
+            service.pasteboardProvider = { pasteboard }
+            service.focusedTextElementOverride = { element }
+            service.captureActiveAppOverride = { (browser.name, browser.bundleIdentifier, nil) }
+            service.verifiedRestoreGraceDelay = .milliseconds(1)
+
+            var pasteCount = 0
+            service.pasteSimulatorOverride = {
+                pasteCount += 1
+            }
+            service.focusedTextStateOverride = { _ in
+                if pasteCount == 0 {
+                    return (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+                }
+                return (value: "Hello", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+            }
+
+            var didAttemptDirectAXInsertion = false
+            service.insertTextAtOverride = { _, _ in
+                didAttemptDirectAXInsertion = true
+                return true
+            }
+
+            pasteboard.clearContents()
+            pasteboard.setString("Existing", forType: .string)
+
+            let result = try await service.insertText("Hello", preserveClipboard: true)
+
+            XCTAssertFalse(
+                didAttemptDirectAXInsertion,
+                "\(browser.name) should bypass direct AX insertion"
+            )
+            XCTAssertEqual(pasteCount, 1, "\(browser.name) should paste exactly once")
+            XCTAssertEqual(result, .pasted(verification: .verified))
+            XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
+        }
+    }
+
+    @MainActor
     func testVerifiedTerminalPasteKeepsGeneratedTextUntilTerminalRestoreDelay() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()


### PR DESCRIPTION
## Summary

- route preserve-clipboard insertion in Firefox-family browsers through one synthetic paste
- recognize Firefox, Firefox Developer Edition, Firefox Nightly, and Zen in the existing browser classification
- preserve the separate terminal clipboard timing policy and add regression coverage

## Issue context

Firefox-family browsers can apply an accessibility selected-text write asynchronously. TypeWhisper's immediate verification can therefore still observe the previous value and fall back to Cmd+V after the accessibility write takes effect, inserting the transcription twice when **Preserve clipboard content** is enabled.

Closes #972

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testFirefoxFamilyForcesSingleSyntheticPasteInsteadOfDirectAccessibilityInsertion -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testTerminalBundleForcesSyntheticPasteInsteadOfDirectAccessibilityInsertion -only-testing:TypeWhisperTests/APIRouterAndHandlersTests/testPreserveClipboardAvoidsPasteboardWhenVerifiedAccessibilityInsertionSucceeds CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/79f8/typewhisper-mac`
- Manual preserve-clipboard smoke test with the signed dev app in Firefox 152.0.6 and Zen 1.21.8b: both inserted a 29-character transcription exactly once after a 4-character prefix (33 characters total), verified the paste, and restored the clipboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text insertion reliability in Firefox and other Firefox-based browsers.
  * Preserves existing clipboard contents while inserting text through the appropriate paste method.
  * Supports Firefox, Developer Edition, Nightly, and Zen Browser variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->