### PR TITLE
Support explicit workflow dictation in the local API

### DIFF
--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -623,6 +623,8 @@ final class APIHandlers: @unchecked Sendable {
             let status: String
             let engine: String?
             let model: String?
+            let api_version: String
+            let supports_workflow_dictation: Bool
             let supports_streaming: Bool
             let supports_translation: Bool
         }
@@ -631,6 +633,8 @@ final class APIHandlers: @unchecked Sendable {
             status: isReady ? "ready" : "no_model",
             engine: providerId,
             model: modelId,
+            api_version: "1.1",
+            supports_workflow_dictation: true,
             supports_streaming: supportsStreaming,
             supports_translation: supportsTranslation
         )
@@ -1098,14 +1102,48 @@ final class APIHandlers: @unchecked Sendable {
 
     // MARK: - POST /v1/dictation/start
 
+    private struct DictationStartRequest: Decodable {
+        let workflowId: String?
+
+        enum CodingKeys: String, CodingKey {
+            case workflowId = "workflow_id"
+        }
+    }
+
     private func handleStartDictation(_ request: HTTPRequest) async -> HTTPResponse {
+        let payload: DictationStartRequest?
+        if request.body.isEmpty {
+            payload = nil
+        } else {
+            guard let decoded = try? JSONDecoder().decode(DictationStartRequest.self, from: request.body) else {
+                return .error(status: 400, message: "Invalid JSON body")
+            }
+            payload = decoded
+        }
+
         let dictationViewModel = self.dictationViewModel
+        let workflowService = self.workflowService
         return await MainActor.run {
             guard !dictationViewModel.isRecording else {
                 return .error(status: 409, message: "Already recording")
             }
 
-            let id = dictationViewModel.apiStartRecording()
+            var workflow: Workflow?
+            if let workflowId = payload?.workflowId {
+                guard !workflowId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                      let uuid = UUID(uuidString: workflowId) else {
+                    return .error(status: 400, message: "Missing or invalid 'workflow_id'")
+                }
+                guard let requestedWorkflow = workflowService.workflow(id: uuid) else {
+                    return .error(status: 404, message: "Workflow not found")
+                }
+                guard requestedWorkflow.isEnabled else {
+                    return .error(status: 409, message: "Workflow is disabled")
+                }
+                workflow = requestedWorkflow
+            }
+
+            let id = dictationViewModel.apiStartRecording(forcedWorkflowId: workflow?.id)
             if let session = dictationViewModel.apiDictationSession(id: id), session.status == .failed {
                 return .error(status: 409, message: session.error ?? "Failed to start dictation")
             }
@@ -1113,8 +1151,15 @@ final class APIHandlers: @unchecked Sendable {
             struct StartResponse: Encodable {
                 let id: String
                 let status: String
+                let workflow_id: String?
+                let workflow_name: String?
             }
-            return .json(StartResponse(id: id.uuidString, status: "recording"))
+            return .json(StartResponse(
+                id: id.uuidString,
+                status: "recording",
+                workflow_id: workflow?.id.uuidString,
+                workflow_name: workflow?.name
+            ))
         }
     }
 
@@ -1142,9 +1187,22 @@ final class APIHandlers: @unchecked Sendable {
 
     private func handleDictationStatus(_ request: HTTPRequest) async -> HTTPResponse {
         let dictationViewModel = self.dictationViewModel
+        let activeModel = await modelManager.selectedModelId
         return await MainActor.run {
-            struct DictationStatusResponse: Encodable { let is_recording: Bool }
-            return .json(DictationStatusResponse(is_recording: dictationViewModel.isRecording))
+            struct DictationStatusResponse: Encodable {
+                let state: String
+                let is_recording: Bool
+                let active_model: String?
+                let active_workflow: String?
+                let active_workflow_id: String?
+            }
+            return .json(DictationStatusResponse(
+                state: dictationViewModel.apiStateName,
+                is_recording: dictationViewModel.isRecording,
+                active_model: activeModel,
+                active_workflow: dictationViewModel.activeRuleName,
+                active_workflow_id: dictationViewModel.activeWorkflowId?.uuidString
+            ))
         }
     }
 

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -1124,8 +1124,8 @@ final class APIHandlers: @unchecked Sendable {
         let dictationViewModel = self.dictationViewModel
         let workflowService = self.workflowService
         return await MainActor.run {
-            guard !dictationViewModel.isRecording else {
-                return .error(status: 409, message: "Already recording")
+            guard dictationViewModel.canStartAPIRecording else {
+                return .error(status: 409, message: "Dictation is not idle")
             }
 
             var workflow: Workflow?
@@ -1187,7 +1187,6 @@ final class APIHandlers: @unchecked Sendable {
 
     private func handleDictationStatus(_ request: HTTPRequest) async -> HTTPResponse {
         let dictationViewModel = self.dictationViewModel
-        let activeModel = await modelManager.selectedModelId
         return await MainActor.run {
             struct DictationStatusResponse: Encodable {
                 let state: String
@@ -1199,7 +1198,7 @@ final class APIHandlers: @unchecked Sendable {
             return .json(DictationStatusResponse(
                 state: dictationViewModel.apiStateName,
                 is_recording: dictationViewModel.isRecording,
-                active_model: activeModel,
+                active_model: dictationViewModel.apiActiveModelId,
                 active_workflow: dictationViewModel.activeRuleName,
                 active_workflow_id: dictationViewModel.activeWorkflowId?.uuidString
             ))

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -670,9 +670,26 @@ final class DictationViewModel: ObservableObject {
         state == .recording
     }
 
-    func apiStartRecording() -> UUID {
+    var activeWorkflowId: UUID? {
+        matchedWorkflow?.id
+    }
+
+    var apiStateName: String {
+        switch state {
+        case .idle: "idle"
+        case .recording: "recording"
+        case .processing: "processing"
+        case .inserting: "inserting"
+        case .promptSelection: "prompt_selection"
+        case .promptProcessing: "prompt_processing"
+        case .error: "error"
+        }
+    }
+
+    func apiStartRecording(forcedWorkflowId: UUID? = nil) -> UUID {
         let sessionID = UUID()
         startRecording(
+            forcedWorkflowId: forcedWorkflowId,
             sessionID: sessionID,
             requestUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds
         )

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -670,6 +670,10 @@ final class DictationViewModel: ObservableObject {
         state == .recording
     }
 
+    var canStartAPIRecording: Bool {
+        state == .idle
+    }
+
     var activeWorkflowId: UUID? {
         matchedWorkflow?.id
     }
@@ -684,6 +688,13 @@ final class DictationViewModel: ObservableObject {
         case .promptProcessing: "prompt_processing"
         case .error: "error"
         }
+    }
+
+    var apiActiveModelId: String? {
+        modelManager.resolvedModelId(
+            engineOverrideId: effectiveEngineOverrideId,
+            cloudModelOverride: effectiveCloudModelOverride
+        )
     }
 
     func apiStartRecording(forcedWorkflowId: UUID? = nil) -> UUID {

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -1342,6 +1342,8 @@ final class APIRouterAndHandlersTests: XCTestCase {
         )
 
         XCTAssertEqual(status["status"] as? String, "no_model")
+        XCTAssertEqual(status["api_version"] as? String, "1.1")
+        XCTAssertEqual(status["supports_workflow_dictation"] as? Bool, true)
         XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 1)
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["language_mode"] as? String, "multiple")
@@ -2567,6 +2569,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let statusJSON = try Self.jsonObject(statusResponse)
         XCTAssertEqual(statusResponse.status, 200)
         XCTAssertEqual(statusJSON["is_recording"] as? Bool, false)
+        XCTAssertEqual(statusJSON["state"] as? String, "idle")
+        XCTAssertNil(statusJSON["active_workflow"] as? String)
+        XCTAssertNil(statusJSON["active_workflow_id"] as? String)
 
         let stopResponse = await router.route(
             HTTPRequest(method: "POST", path: "/v1/dictation/stop", queryParams: [:], headers: [:], body: Data())
@@ -2953,6 +2958,64 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, TranscriptionEngineError.modelNotLoaded.localizedDescription)
     }
 
+    func testWorkflowDictationStartRejectsMalformedUnknownAndDisabledWorkflow() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run {
+            let context = Self.makeAPIContext(appSupportDirectory: appSupportDirectory)
+            _ = context.workflowService.addWorkflow(
+                name: "Disabled",
+                template: .custom,
+                trigger: .manual(),
+                isEnabled: false
+            )
+            return context
+        }
+        let apiContext = try XCTUnwrap(context)
+        let disabledID = try await MainActor.run {
+            try XCTUnwrap(apiContext.workflowService.workflows.first?.id.uuidString)
+        }
+
+        let malformed = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: ["content-type": "application/json"],
+            body: Data("{".utf8)
+        ))
+        let invalidID = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: ["content-type": "application/json"],
+            body: try JSONSerialization.data(withJSONObject: ["workflow_id": "not-a-uuid"])
+        ))
+        let unknown = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: ["content-type": "application/json"],
+            body: try JSONSerialization.data(withJSONObject: ["workflow_id": UUID().uuidString])
+        ))
+        let disabled = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: ["content-type": "application/json"],
+            body: try JSONSerialization.data(withJSONObject: ["workflow_id": disabledID])
+        ))
+
+        XCTAssertEqual(malformed.status, 400)
+        XCTAssertEqual(invalidID.status, 400)
+        XCTAssertEqual(unknown.status, 404)
+        XCTAssertEqual(disabled.status, 409)
+    }
+
     func testDictationEndpointsReturnSessionIDAndCompletedTranscription() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let historyEnabledKey = UserDefaultsKeys.historyEnabled
@@ -2976,7 +3039,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let apiContext = try XCTUnwrap(context)
         let router = apiContext.router
 
-        await MainActor.run {
+        let workflowID = try await MainActor.run {
             apiContext.audioRecordingService.hasMicrophonePermissionOverride = true
             apiContext.audioRecordingService.inputAvailabilityOverride = { _ in true }
             apiContext.audioRecordingService.startRecordingOverride = {}
@@ -2989,14 +3052,34 @@ final class APIRouterAndHandlersTests: XCTestCase {
             }
             apiContext.textInsertionService.selectedTextOverride = { nil }
             apiContext.textInsertionService.pasteSimulatorOverride = {}
+            return try XCTUnwrap(apiContext.workflowService.addWorkflow(
+                name: "Meeting notes",
+                template: .custom,
+                trigger: .manual()
+            )?.id.uuidString)
         }
 
         let start = try Self.jsonObject(
-            await router.route(HTTPRequest(method: "POST", path: "/v1/dictation/start", queryParams: [:], headers: [:], body: Data()))
+            await router.route(HTTPRequest(
+                method: "POST",
+                path: "/v1/dictation/start",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: try JSONSerialization.data(withJSONObject: ["workflow_id": workflowID])
+            ))
         )
         let startID = try XCTUnwrap(start["id"] as? String)
         XCTAssertEqual(start["status"] as? String, "recording")
+        XCTAssertEqual(start["workflow_id"] as? String, workflowID)
+        XCTAssertEqual(start["workflow_name"] as? String, "Meeting notes")
         XCTAssertNotNil(UUID(uuidString: startID))
+
+        let activeStatus = try Self.jsonObject(
+            await router.route(HTTPRequest(method: "GET", path: "/v1/dictation/status", queryParams: [:], headers: [:], body: Data()))
+        )
+        XCTAssertEqual(activeStatus["state"] as? String, "recording")
+        XCTAssertEqual(activeStatus["active_workflow_id"] as? String, workflowID)
+        XCTAssertEqual(activeStatus["active_workflow"] as? String, "Meeting notes")
 
         await MainActor.run {
             apiContext.dictationViewModel.partialText = "transcribed"

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3009,11 +3009,33 @@ final class APIRouterAndHandlersTests: XCTestCase {
             headers: ["content-type": "application/json"],
             body: try JSONSerialization.data(withJSONObject: ["workflow_id": disabledID])
         ))
+        await MainActor.run {
+            apiContext.dictationViewModel.state = .processing
+        }
+        let processing = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: [:],
+            body: Data()
+        ))
+        await MainActor.run {
+            apiContext.dictationViewModel.state = .inserting
+        }
+        let inserting = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: [:],
+            body: Data()
+        ))
 
         XCTAssertEqual(malformed.status, 400)
         XCTAssertEqual(invalidID.status, 400)
         XCTAssertEqual(unknown.status, 404)
         XCTAssertEqual(disabled.status, 409)
+        XCTAssertEqual(processing.status, 409)
+        XCTAssertEqual(inserting.status, 409)
     }
 
     func testDictationEndpointsReturnSessionIDAndCompletedTranscription() async throws {
@@ -3054,8 +3076,12 @@ final class APIRouterAndHandlersTests: XCTestCase {
             apiContext.textInsertionService.pasteSimulatorOverride = {}
             return try XCTUnwrap(apiContext.workflowService.addWorkflow(
                 name: "Meeting notes",
-                template: .custom,
-                trigger: .manual()
+                template: .dictation,
+                trigger: .manual(),
+                behavior: WorkflowBehavior(
+                    transcriptionEngineId: "mock",
+                    transcriptionModelId: "workflow-model"
+                )
             )?.id.uuidString)
         }
 
@@ -3080,6 +3106,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(activeStatus["state"] as? String, "recording")
         XCTAssertEqual(activeStatus["active_workflow_id"] as? String, workflowID)
         XCTAssertEqual(activeStatus["active_workflow"] as? String, "Meeting notes")
+        XCTAssertEqual(activeStatus["active_model"] as? String, "workflow-model")
 
         await MainActor.run {
             apiContext.dictationViewModel.partialText = "transcribed"

--- a/TypeWhisperTests/APIRouterAndHandlersTests.swift
+++ b/TypeWhisperTests/APIRouterAndHandlersTests.swift
@@ -3062,6 +3062,25 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let router = apiContext.router
 
         let workflowID = try await MainActor.run {
+            let globalPlugin = NamedTranscriptionPlugin(
+                providerId: "global-mock",
+                providerDisplayName: "Global Mock",
+                modelId: "global-model"
+            )
+            PluginManager.shared.loadedPlugins.append(LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.global-transcription",
+                    name: "Global Mock Transcription",
+                    version: "1.0.0",
+                    principalClass: "APIRouterNamedTranscriptionPlugin"
+                ),
+                instance: globalPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ))
+            apiContext.modelManager.selectProvider(globalPlugin.providerId)
+
             apiContext.audioRecordingService.hasMicrophonePermissionOverride = true
             apiContext.audioRecordingService.inputAvailabilityOverride = { _ in true }
             apiContext.audioRecordingService.startRecordingOverride = {}
@@ -3080,7 +3099,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
                 trigger: .manual(),
                 behavior: WorkflowBehavior(
                     transcriptionEngineId: "mock",
-                    transcriptionModelId: "workflow-model"
+                    transcriptionModelId: "tiny"
                 )
             )?.id.uuidString)
         }
@@ -3106,7 +3125,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual(activeStatus["state"] as? String, "recording")
         XCTAssertEqual(activeStatus["active_workflow_id"] as? String, workflowID)
         XCTAssertEqual(activeStatus["active_workflow"] as? String, "Meeting notes")
-        XCTAssertEqual(activeStatus["active_model"] as? String, "workflow-model")
+        XCTAssertEqual(activeStatus["active_model"] as? String, "tiny")
 
         await MainActor.run {
             apiContext.dictationViewModel.partialText = "transcribed"


### PR DESCRIPTION
## Summary
- accept an optional `workflow_id` when starting dictation through the local API
- reject malformed, unknown, and disabled workflow requests
- expose workflow capability, normalized dictation state, model, and active workflow identity
- preserve existing bodyless dictation starts

## User impact
Local integrations such as the Stream Deck plugin can safely start a selected enabled workflow with the same contract on macOS and Windows.

## Validation
- added API handler tests for bodyless compatibility, explicit workflows, rejection cases, and status fields
- `git diff origin/main --check`
- macOS tests are delegated to CI because this checkout is running on Windows

## Test plan
- `xcodebuild test -scheme TypeWhisper -destination 'platform=macOS'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended `GET /v1/status` with API version (`1.1`) and workflow dictation support flags.
  * Enhanced `POST /v1/dictation/start` to accept an optional `workflow_id`, start against it when valid/enabled, and return workflow metadata.
  * Expanded `GET /v1/dictation/status` to include richer state details, including active workflow and active model context.
* **Bug Fixes**
  * Improved dictation start eligibility checks to only allow starts when dictation is idle.
* **Tests**
  * Broadened API contract coverage for dictation workflow start/status, including validation, disabled workflows, and non-startable UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->