### PR TITLE
Stabilize Gemma preparation timeout test

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -924,23 +924,43 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
                 }
 
                 guard self.modelLoadPhase == phase else { continue }
-                let lastProgress = self.lastObservedDownloadFraction
-                self.invalidateModelLoad()
-                self.modelContainer = nil
-                self.loadedModelId = nil
-                self.downloadProgress = 0
-                self.modelState = .error(
-                    Self.modelLoadTimeoutMessage(
-                        for: phase,
-                        modelName: modelName,
-                        lastDownloadFraction: lastProgress
-                    )
-                )
-                self.host?.setUserDefault(nil, forKey: "loadedModel")
-                self.host?.notifyCapabilitiesChanged()
-                return
+                if self.applyModelLoadTimeout(
+                    generation: generation,
+                    modelName: modelName,
+                    phase: phase
+                ) {
+                    return
+                }
             }
         }
+    }
+
+    @discardableResult
+    private func applyModelLoadTimeout(
+        generation: Int,
+        modelName: String,
+        phase: ModelLoadPhase
+    ) -> Bool {
+        guard isCurrentModelLoad(generation),
+              modelLoadPhase == phase else {
+            return false
+        }
+
+        let lastProgress = lastObservedDownloadFraction
+        invalidateModelLoad()
+        modelContainer = nil
+        loadedModelId = nil
+        downloadProgress = 0
+        modelState = .error(
+            Self.modelLoadTimeoutMessage(
+                for: phase,
+                modelName: modelName,
+                lastDownloadFraction: lastProgress
+            )
+        )
+        host?.setUserDefault(nil, forKey: "loadedModel")
+        host?.notifyCapabilitiesChanged()
+        return true
     }
 
     private func isUsableDownloadedModel(_ modelDef: Gemma4ModelDef) -> Bool {
@@ -999,11 +1019,16 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
     }
 
     @discardableResult
-    func startModelLoadTimeoutForTesting(modelName: String) -> Int {
+    func startModelLoadTimeoutForTesting(
+        modelName: String,
+        scheduleWatchdog: Bool = true
+    ) -> Int {
         let generation = beginModelLoad(phase: .downloading, initialDownloadFraction: 0)
         modelState = .downloading
         downloadProgress = Self.initialDownloadProgress
-        startModelLoadTimeout(generation: generation, modelName: modelName)
+        if scheduleWatchdog {
+            startModelLoadTimeout(generation: generation, modelName: modelName)
+        }
         return generation
     }
 
@@ -1063,6 +1088,21 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
 
     func invalidateModelLoadForTesting() {
         invalidateModelLoad()
+    }
+
+    func currentModelLoadTimeoutForTesting() -> Duration? {
+        guard let phase = modelLoadPhase else { return nil }
+        return timeoutDuration(for: phase)
+    }
+
+    @discardableResult
+    func applyModelLoadTimeoutForTesting(generation: Int, modelName: String) -> Bool {
+        guard let phase = modelLoadPhase else { return false }
+        return applyModelLoadTimeout(
+            generation: generation,
+            modelName: modelName,
+            phase: phase
+        )
     }
 
     func setLoadedModelIdForTesting(_ modelId: String?) {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -824,13 +824,17 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertFalse(plugin.isAvailable)
     }
 
-    func testGemma4CompletedDownloadUsesLongerPreparationTimeout() async throws {
+    func testGemma4CompletedDownloadUsesLongerPreparationTimeout() {
         let plugin = Gemma4Plugin()
         plugin.setModelLoadTimeoutsForTesting(
             downloadInactivity: .milliseconds(40),
             preparation: .milliseconds(180)
         )
-        let generation = plugin.startModelLoadTimeoutForTesting(modelName: "Gemma 4 E2B")
+        let generation = plugin.startModelLoadTimeoutForTesting(
+            modelName: "Gemma 4 E2B",
+            scheduleWatchdog: false
+        )
+        XCTAssertEqual(plugin.currentModelLoadTimeoutForTesting(), .milliseconds(40))
 
         plugin.recordModelLoadProgressForTesting(
             completedUnitCount: 1_000,
@@ -842,16 +846,12 @@ final class Gemma4PluginModelPolicyTests: XCTestCase {
         XCTAssertEqual(plugin.modelState, .loading)
         XCTAssertEqual(plugin.currentDownloadProgress, 0.9, accuracy: 0.001)
         XCTAssertEqual(plugin.currentSettingsActivity?.message, "Preparing model")
+        XCTAssertEqual(plugin.currentModelLoadTimeoutForTesting(), .milliseconds(180))
 
-        try await Task.sleep(for: .milliseconds(80))
-        XCTAssertEqual(plugin.modelState, .loading)
-
-        try await waitUntil("Gemma 4 preparation timeout error") {
-            if case .error = plugin.modelState {
-                return true
-            }
-            return false
-        }
+        XCTAssertTrue(plugin.applyModelLoadTimeoutForTesting(
+            generation: generation,
+            modelName: "Gemma 4 E2B"
+        ))
 
         guard case .error(let message) = plugin.modelState else {
             return XCTFail("Expected Gemma 4 preparation timeout to set an error state")


### PR DESCRIPTION
## Context

Today's scheduled [Build and Release run](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/29896873648/job/88848825592) failed in `testGemma4CompletedDownloadUsesLongerPreparationTimeout`. The test used 40 ms and 180 ms real-time watchdog delays plus a one-second polling deadline. On a cold test process, the watchdog task and polling task could resume in the wrong order after scheduler starvation, producing a false timeout failure.

## What changed

- Extract the existing Gemma model-load timeout transition into one shared production path.
- Add DEBUG-only hooks so the test can inspect the active timeout for each load phase and invoke that same transition deterministically.
- Replace the test's real sleeps and polling with direct assertions for the 40 ms download timeout, the 180 ms preparation timeout, and the resulting preparation-timeout error.

There is no user-facing runtime behavior change; the asynchronous production watchdog still uses the same timeout logic and side effects.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests/testGemma4CompletedDownloadUsesLongerPreparationTimeout -test-iterations 50 CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 50/50 passed.
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/Gemma4PluginModelPolicyTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 43/43 passed.
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 1,265/1,265 passed.
- `bash scripts/check_first_party_warnings.sh <test-log>` — no first-party warnings.
- `swift test --package-path TypeWhisperPluginSDK` — 411/411 passed.
- `git diff --check` — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading timeout handling to reliably invalidate stalled loads, clear loading state, and display a timeout error.
  * Preserved the appropriate extended timeout during model preparation.

* **Tests**
  * Added coverage for timeout behavior across model-loading phases.
  * Improved test controls for validating timeout handling without waiting for real-time watchdog execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->