### PR TITLE
Fix clamshell system-default microphone fallback

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -526,33 +526,32 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
         for uid in candidateUIDs {
             guard let device = inputDevices.first(where: { $0.uid == uid }) else { continue }
-            guard let deviceID = resolvedAudioDeviceID(for: device) else { continue }
-
-            // When the MacBook lid is closed, the built-in microphone is
-            // physically disconnected by Apple Silicon / T2 hardware security,
-            // but CoreAudio still reports it as available. Skip it so failover
-            // proceeds to the next candidate in the priority list. See #888.
-            if lidClosed,
-               let transport = transportType(for: deviceID),
-               Self.isBuiltInTransportType(transport) {
-                logger.info("Skipping built-in microphone \(device.name, privacy: .public) because lid is closed (clamshell mode)")
-                continue
-            }
-
-            let usesBluetoothTransport = transportType(for: deviceID)
-                .map(Self.isBluetoothTransportType) ?? false
-            return ResolvedRecordingInputSelection(
-                deviceUID: uid,
-                deviceID: deviceID,
-                deviceName: device.name,
-                usesBluetoothTransport: usesBluetoothTransport
-            )
+            guard let selection = resolvedInputSelection(for: device, lidClosed: lidClosed) else { continue }
+            return selection
         }
 
         guard let defaultInputDeviceID = defaultInputDeviceController.defaultInputDeviceID() else {
             return .systemDefault
         }
-        let usesBluetoothTransport = transportType(for: defaultInputDeviceID)
+        let defaultInputTransport = transportType(for: defaultInputDeviceID)
+
+        if lidClosed,
+           let defaultInputTransport,
+           Self.isBuiltInTransportType(defaultInputTransport) {
+            for device in inputDevices {
+                guard let fallbackSelection = resolvedInputSelection(for: device, lidClosed: true),
+                      fallbackSelection.deviceID != defaultInputDeviceID else {
+                    continue
+                }
+                logger.info("Using \(device.name, privacy: .public) instead of the built-in system-default microphone because the lid is closed")
+                return fallbackSelection
+            }
+
+            logger.warning("Built-in system-default microphone is unavailable because the lid is closed, and no alternative input was found")
+            return .systemDefault
+        }
+
+        let usesBluetoothTransport = defaultInputTransport
             .map(Self.isBluetoothTransportType) ?? false
         guard usesBluetoothTransport else {
             return .systemDefault
@@ -562,6 +561,32 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             deviceID: defaultInputDeviceID,
             deviceName: inputDevices.first(where: { $0.deviceID == defaultInputDeviceID })?.name,
             usesBluetoothTransport: usesBluetoothTransport
+        )
+    }
+
+    private func resolvedInputSelection(
+        for device: AudioInputDevice,
+        lidClosed: Bool
+    ) -> ResolvedRecordingInputSelection? {
+        guard let deviceID = resolvedAudioDeviceID(for: device) else { return nil }
+        let transport = transportType(for: deviceID)
+
+        // When the MacBook lid is closed, the built-in microphone is
+        // physically disconnected by Apple Silicon / T2 hardware security,
+        // but CoreAudio still reports it as available. Skip it so failover
+        // proceeds to the next candidate. See #888 and #983.
+        if lidClosed,
+           let transport,
+           Self.isBuiltInTransportType(transport) {
+            logger.info("Skipping built-in microphone \(device.name, privacy: .public) because lid is closed (clamshell mode)")
+            return nil
+        }
+
+        return ResolvedRecordingInputSelection(
+            deviceUID: device.uid,
+            deviceID: deviceID,
+            deviceName: device.name,
+            usesBluetoothTransport: transport.map(Self.isBluetoothTransportType) ?? false
         )
     }
 

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -543,7 +543,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                       fallbackSelection.deviceID != defaultInputDeviceID else {
                     continue
                 }
-                logger.info("Using \(device.name, privacy: .public) instead of the built-in system-default microphone because the lid is closed")
+                logger.info("Using \(device.name, privacy: .private) instead of the built-in system-default microphone because the lid is closed")
                 return fallbackSelection
             }
 
@@ -578,7 +578,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         if lidClosed,
            let transport,
            Self.isBuiltInTransportType(transport) {
-            logger.info("Skipping built-in microphone \(device.name, privacy: .public) because lid is closed (clamshell mode)")
+            logger.info("Skipping built-in microphone \(device.name, privacy: .private) because lid is closed (clamshell mode)")
             return nil
         }
 

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1061,6 +1061,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             transportResolver: FakeAudioDeviceTransportResolver(
                 transports: [bluetoothDeviceID: kAudioDeviceTransportTypeBluetooth]
             ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
             defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
                 defaultInputDeviceID: bluetoothDeviceID
             )
@@ -1075,7 +1076,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(selection.usesBluetoothTransport)
     }
 
-    func testResolvedRecordingInputSelectionKeepsBuiltInSystemDefaultOnDefaultRoute() {
+    func testResolvedRecordingInputSelectionKeepsBuiltInSystemDefaultOnDefaultRouteWhenLidIsOpen() {
         let builtInDeviceID = AudioDeviceID(703)
         let service = AudioDeviceService(
             initialInputDevices: [
@@ -1086,8 +1087,181 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             transportResolver: FakeAudioDeviceTransportResolver(
                 transports: [builtInDeviceID: kAudioDeviceTransportTypeBuiltIn]
             ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: false),
             defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
                 defaultInputDeviceID: builtInDeviceID
+            )
+        )
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection, .systemDefault)
+    }
+
+    func testResolvedRecordingInputSelectionUsesUSBWhenBuiltInSystemDefaultIsUnavailableInClamshell() {
+        let builtInDeviceID = AudioDeviceID(704)
+        let usbDeviceID = AudioDeviceID(705)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input"),
+                AudioInputDevice(deviceID: usbDeviceID, name: "Studio Display Microphone", uid: "display-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    builtInDeviceID: kAudioDeviceTransportTypeBuiltIn,
+                    usbDeviceID: kAudioDeviceTransportTypeUSB
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: builtInDeviceID
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "built-in-input": return builtInDeviceID
+            case "display-input": return usbDeviceID
+            default: return nil
+            }
+        }
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "display-input")
+        XCTAssertEqual(selection.deviceID, usbDeviceID)
+        XCTAssertEqual(selection.deviceName, "Studio Display Microphone")
+        XCTAssertTrue(selection.hasExplicitDeviceSelection)
+        XCTAssertFalse(selection.usesBluetoothTransport)
+    }
+
+    func testResolvedRecordingInputSelectionAllowsAnyNonBuiltInTransportAsClamshellFallback() {
+        struct Scenario {
+            let name: String
+            let transport: UInt32?
+            let usesBluetoothTransport: Bool
+        }
+
+        let scenarios = [
+            Scenario(
+                name: "Bluetooth",
+                transport: kAudioDeviceTransportTypeBluetooth,
+                usesBluetoothTransport: true
+            ),
+            Scenario(
+                name: "Virtual",
+                transport: kAudioDeviceTransportTypeVirtual,
+                usesBluetoothTransport: false
+            ),
+            Scenario(
+                name: "Unknown",
+                transport: nil,
+                usesBluetoothTransport: false
+            )
+        ]
+
+        for (index, scenario) in scenarios.enumerated() {
+            let builtInDeviceID = AudioDeviceID(720 + (index * 2))
+            let fallbackDeviceID = AudioDeviceID(721 + (index * 2))
+            var transports: [AudioDeviceID: UInt32] = [
+                builtInDeviceID: kAudioDeviceTransportTypeBuiltIn
+            ]
+            if let transport = scenario.transport {
+                transports[fallbackDeviceID] = transport
+            }
+            let service = AudioDeviceService(
+                initialInputDevices: [
+                    AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-\(index)"),
+                    AudioInputDevice(deviceID: fallbackDeviceID, name: scenario.name, uid: "fallback-\(index)")
+                ],
+                monitorDeviceChanges: false,
+                probeCompatibilities: false,
+                transportResolver: FakeAudioDeviceTransportResolver(transports: transports),
+                clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+                defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                    defaultInputDeviceID: builtInDeviceID
+                )
+            )
+            service.audioDeviceIDResolverOverride = { uid in
+                switch uid {
+                case "built-in-\(index)": return builtInDeviceID
+                case "fallback-\(index)": return fallbackDeviceID
+                default: return nil
+                }
+            }
+
+            let selection = service.resolvedRecordingInputSelection()
+
+            XCTAssertEqual(selection.deviceUID, "fallback-\(index)", scenario.name)
+            XCTAssertEqual(selection.deviceID, fallbackDeviceID, scenario.name)
+            XCTAssertTrue(selection.hasExplicitDeviceSelection, scenario.name)
+            XCTAssertEqual(
+                selection.usesBluetoothTransport,
+                scenario.usesBluetoothTransport,
+                scenario.name
+            )
+        }
+    }
+
+    func testResolvedRecordingInputSelectionUsesFirstListedNonBuiltInClamshellFallback() {
+        let builtInDeviceID = AudioDeviceID(730)
+        let virtualDeviceID = AudioDeviceID(731)
+        let usbDeviceID = AudioDeviceID(732)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input"),
+                AudioInputDevice(deviceID: virtualDeviceID, name: "BlackHole 2ch", uid: "virtual-input"),
+                AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    builtInDeviceID: kAudioDeviceTransportTypeBuiltIn,
+                    virtualDeviceID: kAudioDeviceTransportTypeVirtual,
+                    usbDeviceID: kAudioDeviceTransportTypeUSB
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: builtInDeviceID
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "built-in-input": return builtInDeviceID
+            case "virtual-input": return virtualDeviceID
+            case "usb-input": return usbDeviceID
+            default: return nil
+            }
+        }
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "virtual-input")
+        XCTAssertEqual(selection.deviceID, virtualDeviceID)
+        XCTAssertEqual(selection.deviceName, "BlackHole 2ch")
+    }
+
+    func testResolvedRecordingInputSelectionKeepsExternalSystemDefaultWhenLidIsClosed() {
+        let virtualDeviceID = AudioDeviceID(733)
+        let usbDeviceID = AudioDeviceID(734)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: virtualDeviceID, name: "BlackHole 2ch", uid: "virtual-input"),
+                AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    virtualDeviceID: kAudioDeviceTransportTypeVirtual,
+                    usbDeviceID: kAudioDeviceTransportTypeUSB
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: usbDeviceID
             )
         )
 
@@ -1180,7 +1354,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(selection.hasExplicitDeviceSelection)
     }
 
-    func testResolvedRecordingInputSelectionFallsBackToSystemDefaultWhenAllSkippedInClamshell() throws {
+    func testResolvedRecordingInputSelectionKeepsSystemDefaultWhenNoNonBuiltInClamshellFallbackExists() throws {
         let builtInDeviceID = AudioDeviceID(1)
         UserDefaults.standard.set(
             try JSONEncoder().encode([
@@ -1199,7 +1373,9 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
                 transports: [builtInDeviceID: kAudioDeviceTransportTypeBuiltIn]
             ),
             clamshellStateProvider: clamshellProvider,
-            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(defaultInputDeviceID: nil)
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: builtInDeviceID
+            )
         )
         service.audioDeviceIDResolverOverride = { uid in
             uid == "built-in" ? builtInDeviceID : nil
@@ -1399,6 +1575,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
                 transports: [builtInDeviceID: kAudioDeviceTransportTypeBuiltIn]
             ),
             inputActivationGuard: inputActivationGuard,
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: false),
             defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
                 defaultInputDeviceID: builtInDeviceID
             )
@@ -1412,6 +1589,54 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
 
         XCTAssertTrue(inputActivationGuard.activateCalls.isEmpty)
         XCTAssertTrue(service.isPreviewActive)
+    }
+
+    @MainActor
+    func testStartPreviewUsesInputOnlyCaptureForBuiltInSystemDefaultClamshellFallback() {
+        let builtInDeviceID = AudioDeviceID(715)
+        let usbDeviceID = AudioDeviceID(716)
+        let inputActivationGuard = FakeAudioInputDeviceActivator()
+        let inputCaptureFactory = FakeAudioInputCaptureFactory()
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input"),
+                AudioInputDevice(deviceID: usbDeviceID, name: "Studio Display Microphone", uid: "display-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    builtInDeviceID: kAudioDeviceTransportTypeBuiltIn,
+                    usbDeviceID: kAudioDeviceTransportTypeUSB
+                ]
+            ),
+            inputCaptureFactory: inputCaptureFactory,
+            inputActivationGuard: inputActivationGuard,
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: builtInDeviceID
+            )
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "built-in-input": builtInDeviceID
+            case "display-input": usbDeviceID
+            default: nil
+            }
+        }
+
+        service.startPreview()
+
+        XCTAssertTrue(inputActivationGuard.activateCalls.isEmpty)
+        XCTAssertEqual(inputCaptureFactory.startCalls, [
+            .init(deviceID: usbDeviceID, label: "preview", bufferSize: 1024)
+        ])
+        XCTAssertTrue(service.isPreviewActive)
+
+        service.stopPreview()
+
+        XCTAssertEqual(inputCaptureFactory.createdSessions.first?.stopCalls, 1)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- resolve a closed-lid built-in system-default microphone to the first listed, resolvable non-built-in input
- preserve explicit priority-list ordering, healthy non-Bluetooth system-default routing, and the Bluetooth behavior introduced in #964
- carry the fallback UID, device ID, name, and Bluetooth metadata into the existing recording and preview routes
- add deterministic resolver and preview regression coverage for USB, Bluetooth, virtual, unknown, and no-fallback cases

## Issue context

When **System Default** resolves to the MacBook's built-in microphone while the lid is closed, CoreAudio still exposes that device even though the hardware input is unavailable. The existing clamshell filtering from #888 only covered explicit candidates, so the later system-default fallback could still bind the audio engine to the disconnected built-in microphone and record silence.

This change applies the same closed-lid rule to the concrete system-default device. It selects the first listed non-built-in fallback without changing the saved TypeWhisper selection or the macOS system default.

Closes #983

## Test plan

- [x] `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` (1,270 tests, 0 failures)
- [ ] Physical clamshell smoke test was not run because the current Mac has no suitable external hardware microphone attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone input selection for clamshell (lid-closed) scenarios when the built-in default microphone isn’t available.
  * Added smarter fallback behavior to use alternate external microphones (e.g., USB/non-built-in) when the lid is closed.
  * Preserved external system-default behavior during clamshell use.
  * Improved audio preview routing to use the selected fallback microphone when needed.
* **Tests**
  * Expanded and refined audio engine and microphone selection tests to cover lid-closed edge cases and preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->