### PR TITLE
Mistral AI plugin: add Voxtral Small and temperature control

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings
@@ -51,6 +51,16 @@
         }
       }
     },
+    "Temperature Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperaturmodus"
+          }
+        }
+      }
+    },
     "Cloud API integration for Mistral LLMs and Voxtral STT.": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings
@@ -21,6 +21,16 @@
         }
       }
     },
+    "Cloud API integration for Mistral LLMs and Voxtral STT.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-API-Integration für Mistral-LLMs und Voxtral-STT."
+          }
+        }
+      }
+    },
     "Custom": {
       "localizations": {
         "de": {
@@ -31,42 +41,12 @@
         }
       }
     },
-    "Provider Default": {
+    "Default": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Anbieter-Standard"
-          }
-        }
-      }
-    },
-    "Temperature": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temperatur"
-          }
-        }
-      }
-    },
-    "Temperature Mode": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temperaturmodus"
-          }
-        }
-      }
-    },
-    "Cloud API integration for Mistral LLMs and Voxtral STT.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud-API-Integration für Mistral-LLMs und Voxtral-STT."
+            "value": "Standard"
           }
         }
       }
@@ -101,6 +81,16 @@
         }
       }
     },
+    "Provider Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter-Standard"
+          }
+        }
+      }
+    },
     "Remove": {
       "localizations": {
         "de": {
@@ -121,12 +111,22 @@
         }
       }
     },
-    "None": {
+    "Temperature": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keines"
+            "value": "Temperatur"
+          }
+        }
+      }
+    },
+    "Temperature Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperaturmodus"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Localizable.xcstrings
@@ -11,6 +11,46 @@
         }
       }
     },
+    "Applies to workflow (LLM) processing only.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gilt nur für die Workflow-Verarbeitung (LLM)."
+          }
+        }
+      }
+    },
+    "Custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
+          }
+        }
+      }
+    },
+    "Provider Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter-Standard"
+          }
+        }
+      }
+    },
+    "Temperature": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperatur"
+          }
+        }
+      }
+    },
     "Cloud API integration for Mistral LLMs and Voxtral STT.": {
       "localizations": {
         "de": {
@@ -71,12 +111,12 @@
         }
       }
     },
-    "Select a Model": {
+    "None": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Modell auswählen"
+            "value": "Keines"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -416,6 +416,7 @@ struct MistralAPIClient {
         guard let url = URL(string: "https://api.mistral.ai/v1/models") else { return false }
         var request = URLRequest(url: url)
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 120
 
         do {
             let (_, response) = try await PluginHTTPClient.data(for: request)
@@ -526,11 +527,13 @@ struct MistralSettingsView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
                     
-                    Picker("Transcription Model", selection: $selectedSTTModel) {
+                    Picker(selection: $selectedSTTModel) {
                         Text("None", bundle: bundle).tag("")
                         ForEach(plugin.transcriptionModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
+                    } label: {
+                        Text("Transcription Model", bundle: bundle)
                     }
                     .pickerStyle(.menu)
                     .labelsHidden()
@@ -544,11 +547,13 @@ struct MistralSettingsView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    Picker("LLM Model", selection: $selectedLLMModel) {
+                    Picker(selection: $selectedLLMModel) {
                         Text("None", bundle: bundle).tag("")
                         ForEach(plugin.supportedModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
+                    } label: {
+                        Text("LLM Model", bundle: bundle)
                     }
                     .pickerStyle(.menu)
                     .labelsHidden()
@@ -562,9 +567,11 @@ struct MistralSettingsView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
 
-                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                    Picker(selection: $llmTemperatureMode) {
                         Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
                         Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    } label: {
+                        Text("Temperature Mode", bundle: bundle)
                     }
                     .pickerStyle(.menu)
                     .labelsHidden()

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -528,7 +528,7 @@ struct MistralSettingsView: View {
                         .fontWeight(.medium)
                     
                     Picker(selection: $selectedSTTModel) {
-                        Text("None", bundle: bundle).tag("")
+                        Text("Default", bundle: bundle).tag("")
                         ForEach(plugin.transcriptionModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
@@ -548,7 +548,7 @@ struct MistralSettingsView: View {
                         .fontWeight(.medium)
 
                     Picker(selection: $selectedLLMModel) {
-                        Text("None", bundle: bundle).tag("")
+                        Text("Default", bundle: bundle).tag("")
                         ForEach(plugin.supportedModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -3,7 +3,7 @@ import TypeWhisperPluginSDK
 import SwiftUI
 
 @objc(MistralAIPlugin)
-public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIdentityProviding, LLMModelSelectable, TranscriptionEnginePlugin, @unchecked Sendable {
+public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIdentityProviding, LLMModelSelectable, LLMTemperatureControllableProvider, TranscriptionEnginePlugin, @unchecked Sendable {
     
     public static var pluginId: String { "com.minerale.mistralai" }
     public static var pluginName: String { "Mistral AI" }
@@ -29,6 +29,9 @@ public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIden
             self._host = host
             self._selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
             self._selectedModelId = host.userDefault(forKey: "selectedModel") as? String
+            self._llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+                ?? PluginLLMTemperatureMode.providerDefault.rawValue
+            self._llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double ?? 0.3
         }
         print("Mistral AI Plugin activated")
     }
@@ -85,10 +88,56 @@ public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIden
     }
     
     public func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    public func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
         let llmModelId = lock.withLock { _selectedLLMModelId }
         let selectedModel = model ?? ((llmModelId?.isEmpty == false) ? llmModelId! : "mistral-small-latest")
+        let temperature = providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective)
         let client = MistralAPIClient(apiKey: apiKey)
-        return try await client.processChat(systemPrompt: systemPrompt, userText: userText, model: selectedModel)
+        return try await client.processChat(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: selectedModel,
+            temperature: temperature
+        )
+    }
+
+    // MARK: - LLMTemperatureControllableProvider
+
+    private var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    private var _llmTemperatureValue: Double = 0.3
+
+    public var llmTemperatureMode: PluginLLMTemperatureMode {
+        lock.withLock { PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault }
+    }
+
+    public var llmTemperatureValue: Double { lock.withLock { _llmTemperatureValue } }
+
+    private var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        lock.withLock { PluginLLMTemperatureDirective(mode: PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault, value: _llmTemperatureValue) }
+    }
+
+    public func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        lock.withLock { _llmTemperatureModeRaw = mode.rawValue }
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    public func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        lock.withLock { _llmTemperatureValue = clamped }
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
     }
     
     // MARK: - LLMModelSelectable
@@ -120,9 +169,15 @@ public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIden
     public var transcriptionModels: [PluginModelInfo] {
         guard !apiKey.isEmpty else { return [] }
         return [
-            PluginModelInfo(id: "voxtral-mini-latest", displayName: "Voxtral Mini Latest")
+            PluginModelInfo(id: "voxtral-mini-latest", displayName: "Voxtral Mini Latest"),
+            PluginModelInfo(id: "voxtral-small-latest", displayName: "Voxtral Small (24B)")
         ]
     }
+
+    /// Models that transcribe through the chat/completions endpoint (audio input)
+    /// rather than the dedicated /audio/transcriptions endpoint, which only serves
+    /// `voxtral-mini-latest`.
+    static let chatTranscriptionModelIds: Set<String> = ["voxtral-small-latest"]
     
     private var _selectedModelId: String?
     public var selectedModelId: String? { lock.withLock { _selectedModelId } }
@@ -145,6 +200,9 @@ public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIden
         let client = MistralAPIClient(apiKey: apiKey)
         let sttModelId = lock.withLock { _selectedModelId }
         let sttModel = (sttModelId?.isEmpty == false) ? sttModelId! : "voxtral-mini-latest"
+        if Self.chatTranscriptionModelIds.contains(sttModel) {
+            return try await client.transcribeViaChat(audio: audio, language: language, model: sttModel)
+        }
         return try await client.transcribe(audio: audio, language: language, model: sttModel)
     }
 }
@@ -172,31 +230,35 @@ struct MistralAPIClient {
     
     // MARK: - Chat Completions (LLM)
     
-    func processChat(systemPrompt: String, userText: String, model: String) async throws -> String {
+    func processChat(systemPrompt: String, userText: String, model: String, temperature: Double? = nil) async throws -> String {
         guard let url = URL(string: "https://api.mistral.ai/v1/chat/completions") else {
             throw MistralAPIError.invalidURL
         }
-        
-        let body: [String: Any] = [
+
+        var body: [String: Any] = [
             "model": model,
             "messages": [
                 ["role": "system", "content": systemPrompt],
                 ["role": "user", "content": userText]
             ]
         ]
-        
+        if let temperature {
+            body["temperature"] = temperature
+        }
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
+
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MistralAPIError.invalidResponse
         }
-        
+
         if httpResponse.statusCode == 200 {
             return try parseChatResponse(data)
         } else {
@@ -279,21 +341,84 @@ struct MistralAPIClient {
                   let text = json["text"] as? String else {
                 throw MistralAPIError.apiError("Failed to parse transcription response")
             }
-            return PluginTranscriptionResult(text: text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines), detectedLanguage: language ?? "en")
+            // The endpoint doubles as a language-detection service, so prefer the
+            // language reported in the response over the (optional) requested one.
+            let detectedLanguage = (json["language"] as? String)
+                .flatMap { $0.isEmpty ? nil : $0 }
+                ?? language
+                ?? "en"
+            return PluginTranscriptionResult(text: text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines), detectedLanguage: detectedLanguage)
         } else {
             throw MistralAPIError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
         }
     }
-    
+
+    // MARK: - Transcription via Chat (audio-input LLM, e.g. Voxtral Small)
+
+    /// Transcribes by sending base64 audio to /v1/chat/completions. Used for
+    /// audio-capable chat models like Voxtral Small that the dedicated
+    /// transcription endpoint does not serve. The endpoint only accepts mp3/wav
+    /// audio, so we always upload WAV.
+    func transcribeViaChat(audio: AudioData, language: String?, model: String) async throws -> PluginTranscriptionResult {
+        guard let url = URL(string: "https://api.mistral.ai/v1/chat/completions") else {
+            throw MistralAPIError.invalidURL
+        }
+
+        let wav = PluginAudioUploadEncoder.wavUpload(from: PluginAudioUploadEncoder.normalizedAudioForUpload(audio))
+        let audioBase64 = wav.data.base64EncodedString()
+
+        var instruction = "Transcribe this audio verbatim. Output only the transcription text, with no additional commentary, labels, or quotation marks."
+        if let language, !language.isEmpty {
+            instruction += " The spoken language is \(language)."
+        }
+
+        let body: [String: Any] = [
+            "model": model,
+            // Transcription must be deterministic, independent of the LLM
+            // workflow temperature setting.
+            "temperature": 0.0,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": [
+                        ["type": "input_audio", "input_audio": audioBase64],
+                        ["type": "text", "text": instruction]
+                    ]
+                ]
+            ]
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await PluginHTTPClient.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MistralAPIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 200 {
+            let text = try parseChatResponse(data)
+            // Chat completions returns no structured detected-language field, so
+            // fall back to the requested language (or English).
+            return PluginTranscriptionResult(text: text, detectedLanguage: language ?? "en")
+        } else {
+            throw MistralAPIError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+        }
+    }
+
     // MARK: - Validation
     
     func validate() async throws -> Bool {
         guard let url = URL(string: "https://api.mistral.ai/v1/models") else { return false }
         var request = URLRequest(url: url)
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        
+
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await PluginHTTPClient.data(for: request)
             if let http = response as? HTTPURLResponse, http.statusCode == 200 {
                 return true
             }
@@ -323,6 +448,8 @@ struct MistralSettingsView: View {
     @State private var validationResult: Bool?
     @State private var selectedSTTModel: String = ""
     @State private var selectedLLMModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
     private let bundle = Bundle(for: MistralAIPlugin.self)
     
     var body: some View {
@@ -399,8 +526,8 @@ struct MistralSettingsView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
                     
-                    Picker("", selection: $selectedSTTModel) {
-                        Text("Select a Model", bundle: bundle).tag("")
+                    Picker("Transcription Model", selection: $selectedSTTModel) {
+                        Text("None", bundle: bundle).tag("")
                         ForEach(plugin.transcriptionModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
@@ -411,14 +538,14 @@ struct MistralSettingsView: View {
                         plugin.selectModel(newValue)
                     }
                 }
-                
+
                 VStack(alignment: .leading, spacing: 4) {
                     Text("LLM Model", bundle: bundle)
                         .font(.subheadline)
                         .fontWeight(.medium)
-                    
-                    Picker("", selection: $selectedLLMModel) {
-                        Text("Select a Model", bundle: bundle).tag("")
+
+                    Picker("LLM Model", selection: $selectedLLMModel) {
+                        Text("None", bundle: bundle).tag("")
                         ForEach(plugin.supportedModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
@@ -429,6 +556,39 @@ struct MistralSettingsView: View {
                         plugin.selectLLMModel(newValue)
                     }
                 }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .onChange(of: llmTemperatureMode) { _, newValue in
+                        plugin.setLLMTemperatureMode(newValue)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Applies to workflow (LLM) processing only.", bundle: bundle)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundColor(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) { _, newValue in
+                                plugin.setLLMTemperatureValue(newValue)
+                            }
+                    }
+                }
             }
         }
         .padding()
@@ -436,6 +596,8 @@ struct MistralSettingsView: View {
             apiKeyInput = plugin.apiKey
             selectedSTTModel = plugin.selectedModelId ?? ""
             selectedLLMModel = plugin.selectedLLMModelId ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
         }
     }
     

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
@@ -38,10 +38,11 @@ final class MistralAIPluginTests: XCTestCase {
         let host = try PluginTestHostServices(secrets: ["api-key": "test-key"])
         let plugin = MistralAIPlugin()
         plugin.activate(host: host)
-        
+
         let models = plugin.transcriptionModels
         XCTAssertFalse(models.isEmpty)
         XCTAssertTrue(models.contains { $0.id == "voxtral-mini-latest" })
+        XCTAssertTrue(models.contains { $0.id == "voxtral-small-latest" })
     }
 
     func testMistralAILLMModelsIncludeMistralSmall() throws {
@@ -121,6 +122,108 @@ final class MistralAIPluginTests: XCTestCase {
         XCTAssertTrue(retryBody.contains("Content-Type: audio/wav"))
         XCTAssertTrue(retryBody.contains("name=\"model\"\r\n\r\nvoxtral-mini-latest"))
         XCTAssertTrue(retryBody.contains("name=\"language\"\r\n\r\nfr"))
+    }
+
+    func testTranscriptionUsesDetectedLanguageFromResponse() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
+        let plugin = MistralAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"hello there","language":"en"}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        // Request a different language than the response detects: the detected
+        // language from the response must win over the requested one.
+        let result = try await plugin.transcribe(audio: audio, language: "fr", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "hello there")
+        XCTAssertEqual(result.detectedLanguage, "en")
+    }
+
+    func testMistralAIConformsToTemperatureControllableProvider() {
+        let plugin = MistralAIPlugin()
+        XCTAssertTrue(plugin is any LLMTemperatureControllableProvider)
+    }
+
+    func testCustomTemperatureIsSentInLLMRequest() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
+        let plugin = MistralAIPlugin()
+        plugin.activate(host: host)
+        plugin.selectLLMModel("mistral-small-latest")
+        plugin.setLLMTemperatureMode(.custom)
+        plugin.setLLMTemperatureValue(0.7)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        // Route through PluginHTTPClient by using the same client the plugin uses.
+        let client = MistralAPIClient(apiKey: "mistral-key")
+        _ = try? await client.processChat(systemPrompt: "s", userText: "u", model: "mistral-small-latest", temperature: 0.7)
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 1)
+        let body = try XCTUnwrap(requests[0].httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["temperature"] as? Double, 0.7)
+    }
+
+    func testProviderDefaultTemperatureOmitsField() throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
+        let plugin = MistralAIPlugin()
+        plugin.activate(host: host)
+        plugin.setLLMTemperatureMode(.providerDefault)
+
+        XCTAssertEqual(plugin.llmTemperatureMode, .providerDefault)
+    }
+
+    func testVoxtralSmallTranscribesViaChatCompletions() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
+        let plugin = MistralAIPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel("voxtral-small-latest")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"hello there"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(audio: audio, language: "en", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "hello there")
+
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 1)
+        let request = requests[0]
+        XCTAssertEqual(request.url?.absoluteString, "https://api.mistral.ai/v1/chat/completions")
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["model"] as? String, "voxtral-small-latest")
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let content = try XCTUnwrap(messages.first?["content"] as? [[String: Any]])
+        XCTAssertTrue(content.contains { ($0["type"] as? String) == "input_audio" && ($0["input_audio"] as? String)?.isEmpty == false })
+        XCTAssertTrue(content.contains { ($0["type"] as? String) == "text" })
     }
 
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
@@ -158,7 +158,6 @@ final class MistralAIPluginTests: XCTestCase {
         let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
         let plugin = MistralAIPlugin()
         plugin.activate(host: host)
-        plugin.selectLLMModel("mistral-small-latest")
         plugin.setLLMTemperatureMode(.custom)
         plugin.setLLMTemperatureValue(0.7)
 
@@ -172,23 +171,45 @@ final class MistralAIPluginTests: XCTestCase {
             ])
         }
 
-        // Route through PluginHTTPClient by using the same client the plugin uses.
-        let client = MistralAPIClient(apiKey: "mistral-key")
-        _ = try? await client.processChat(systemPrompt: "s", userText: "u", model: "mistral-small-latest", temperature: 0.7)
+        // End-to-end through the provider: the custom mode/value must be
+        // resolved and sent as the request's temperature field.
+        let output = try await plugin.process(systemPrompt: "s", userText: "u", model: nil)
+        XCTAssertEqual(output, "ok")
+
         let requests = store.sessions[0].requestedRequests
         XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].url?.absoluteString, "https://api.mistral.ai/v1/chat/completions")
         let body = try XCTUnwrap(requests[0].httpBody)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["model"] as? String, "mistral-small-latest")
         XCTAssertEqual(json["temperature"] as? Double, 0.7)
     }
 
-    func testProviderDefaultTemperatureOmitsField() throws {
+    func testProviderDefaultTemperatureOmitsField() async throws {
         let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
         let plugin = MistralAIPlugin()
         plugin.activate(host: host)
         plugin.setLLMTemperatureMode(.providerDefault)
 
-        XCTAssertEqual(plugin.llmTemperatureMode, .providerDefault)
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        // End-to-end through the provider: provider-default mode must omit the
+        // temperature field entirely from the request.
+        _ = try await plugin.process(systemPrompt: "s", userText: "u", model: nil)
+
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 1)
+        let body = try XCTUnwrap(requests[0].httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertNil(json["temperature"])
     }
 
     func testVoxtralSmallTranscribesViaChatCompletions() async throws {

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.minerale.mistralai",
     "name": "Mistral AI",
-    "version": "1.0.1",
+    "version": "1.0.4",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

Extends the Mistral AI plugin with a new transcription model, LLM temperature control, and a few correctness/consistency fixes. All changes are contained within the Mistral plugin.

- **Voxtral Small (24B) transcription.** Added as a Transcription Model option. Since Mistral's `/audio/transcriptions` endpoint only serves `voxtral-mini-latest`, Voxtral Small is transcribed through `/chat/completions` audio input (base64 WAV), routed automatically based on the selected model. Transcription uses a fixed `temperature: 0` for determinism.
- **LLM temperature control.** New "Temperature" section (Provider Default / Custom + slider), matching the other provider plugins. The plugin now conforms to `LLMTemperatureControllableProvider`, so per-workflow temperature overrides are actually applied (not just the provider-level setting).
- **Detected language fix.** Transcription now reads the `language` field from the API response (the endpoint doubles as a language detector) instead of always reporting English.
- **HTTP client unification.** Chat and validation requests now go through `PluginHTTPClient` (120s timeout) like the transcription path, so all call paths share one client and are testable.
- **UI consistency.** Empty picker option renamed from "Select a Model" to "None"; added accessibility labels to the pickers.
- Manifest bumped to `1.0.4`.

## Test Plan

- [x] Ran `scripts/pr-preflight.sh` — whitespace/conflict-marker, shell-parse and Python script checks pass. (The `verify_appcast_publication` test errors on `str | None` under the local Python 3.9.6; that is a pre-existing Python 3.10+ requirement unrelated to this PR.)
- [x] Built and ran locally — dev build with the plugin bundle installed; Voxtral Small transcribes, "None" option and Temperature section render.
- [x] Tested the changed functionality manually — verified end-to-end against the live Mistral API.
- [x] No regressions in existing features — full plugin SDK suite passes (398 tests); Mistral plugin suite 13 tests including new coverage for Voxtral Small chat routing, detected-language, temperature conformance, and custom temperature in the request body.

```bash
swift test --package-path TypeWhisperPluginSDK --filter MistralAIPluginTests
swift test --package-path TypeWhisperPluginSDK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workflow-only LLM temperature controls (Provider Default and Custom), including new temperature mode/value UI.
  - Expanded supported Voxtral transcription models and enabled chat-based transcription for compatible models.
  - Updated the settings interface with clearer model options and labels, plus added German translations.

- **Bug Fixes**
  - Improved transcription language handling by preferring the detected language returned by the service.
  - Enhanced LLM request behavior with optional temperature support and a stricter request timeout.

- **Tests**
  - Added coverage for temperature directives, language detection precedence, and Voxtral chat transcription routing.

- **Chores**
  - Bumped plugin version to **1.0.4**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->