### PR TITLE
Harden CI: pin setup-xcode, scope token permissions, drop unused imports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ env:
   SCHEME: TypeWhisper
   PROJECT: TypeWhisper.xcodeproj
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     runs-on: macos-15

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -158,7 +158,7 @@ jobs:
           python3 scripts/assemble_community_plugin_registry.py
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 

--- a/.github/workflows/redeploy-website.yml
+++ b/.github/workflows/redeploy-website.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [edited]
 
+permissions: {}
+
 jobs:
   trigger-website:
     runs-on: ubuntu-latest

--- a/scripts/assemble_termpacks.py
+++ b/scripts/assemble_termpacks.py
@@ -2,7 +2,6 @@
 """Assemble individual term pack JSON files into a single termpacks.json registry."""
 
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/scripts/update_appcast.py
+++ b/scripts/update_appcast.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

CI hardening that clears the outstanding CodeQL code-scanning alerts:

- **Pin `maxim-lobanov/setup-xcode` to its commit SHA** in `plugin-release.yml` (was the only `@v1` mutable-tag usage; every other workflow — `build.yml`, `release.yml`, `codeql.yml` — already pins the same action to `ed7a3b1…`). This is the release workflow that handles signing/notarization secrets, so pinning matters most here.
- **Scope `GITHUB_TOKEN` to least privilege**:
  - `build.yml` → top-level `permissions: contents: read` (the three jobs only checkout/build/test/upload-artifact).
  - `redeploy-website.yml` → `permissions: {}` (it authenticates with a dedicated `WEBSITE_DEPLOY_TOKEN` PAT, so the default token needs nothing).
- **Remove unused `import os`** from `scripts/assemble_termpacks.py` and `scripts/update_appcast.py`.

No behavior change — only CI permissions/pinning and dead-import cleanup.

## Test Plan

- [x] `python3 -m py_compile` passes on both edited scripts; confirmed no residual `os.` usage
- [x] Reviewed workflow diffs; permission scopes cover exactly what each job does
- [ ] CI (build/tests) green on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted workflow permissions to the minimum required access.
  * Prevented default token permissions in the website redeployment workflow.
  * Pinned the Xcode setup action to a specific version for more predictable builds.

* **Maintenance**
  * Removed unused imports without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->