### PR TITLE
Fix Deepgram crash on malformed custom base URL

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -463,7 +463,9 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        var components = URLComponents(string: "\(effectiveBaseURL)/v1/listen")!
+        guard var components = URLComponents(string: "\(effectiveBaseURL)/v1/listen") else {
+            throw PluginTranscriptionError.apiError("Invalid base URL: \(effectiveBaseURL)")
+        }
         var queryItems = [
             URLQueryItem(name: "model", value: modelId),
             URLQueryItem(name: "smart_format", value: "true"),
@@ -475,8 +477,12 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
         components.queryItems = queryItems
 
+        guard let requestURL = components.url else {
+            throw PluginTranscriptionError.apiError("Invalid base URL: \(effectiveBaseURL)")
+        }
+
         return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
-            var request = URLRequest(url: components.url!)
+            var request = URLRequest(url: requestURL)
             request.httpMethod = "POST"
             request.setValue(authHeaderValue(apiKey: apiKey), forHTTPHeaderField: effectiveAuthHeader)
             request.setValue(uploadFile.contentType, forHTTPHeaderField: "Content-Type")

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -401,6 +401,37 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         return apiKey
     }
 
+    static func restRequestURL(
+        baseURL: String,
+        modelId: String,
+        language: String?,
+        prompt: String?
+    ) throws -> URL {
+        guard var components = URLComponents(string: "\(baseURL)/v1/listen"),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            throw PluginTranscriptionError.apiError("Invalid base URL: \(baseURL)")
+        }
+
+        var queryItems = [
+            URLQueryItem(name: "model", value: modelId),
+            URLQueryItem(name: "smart_format", value: "true"),
+            URLQueryItem(name: "punctuate", value: "true"),
+        ]
+        if let language, !language.isEmpty {
+            queryItems.append(URLQueryItem(name: "language", value: language))
+        }
+        queryItems.append(contentsOf: dictionaryQueryItems(prompt: prompt, modelId: modelId))
+        components.queryItems = queryItems
+
+        guard let requestURL = components.url else {
+            throw PluginTranscriptionError.apiError("Invalid base URL: \(baseURL)")
+        }
+        return requestURL
+    }
+
     // MARK: - Transcription (REST Fallback)
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
@@ -463,23 +494,12 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        guard var components = URLComponents(string: "\(effectiveBaseURL)/v1/listen") else {
-            throw PluginTranscriptionError.apiError("Invalid base URL: \(effectiveBaseURL)")
-        }
-        var queryItems = [
-            URLQueryItem(name: "model", value: modelId),
-            URLQueryItem(name: "smart_format", value: "true"),
-            URLQueryItem(name: "punctuate", value: "true"),
-        ]
-        if let lang = language, !lang.isEmpty {
-            queryItems.append(URLQueryItem(name: "language", value: lang))
-        }
-        queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
-        components.queryItems = queryItems
-
-        guard let requestURL = components.url else {
-            throw PluginTranscriptionError.apiError("Invalid base URL: \(effectiveBaseURL)")
-        }
+        let requestURL = try Self.restRequestURL(
+            baseURL: effectiveBaseURL,
+            modelId: modelId,
+            language: language,
+            prompt: prompt
+        )
 
         return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
             var request = URLRequest(url: requestURL)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1448,7 +1448,7 @@ final class PluginDictionaryGuardTests: XCTestCase {
     }
 
     func testDeepgramRESTRequestURLPreservesEndpointAndQueryParameters() throws {
-        let prompt = PluginDictionaryTerms.prompt(from: ["TypeWhisper"], maxLength: 10_000)
+        let prompt = PluginDictionaryTerms.prompt(from: ["TypeWhisper", "Deepgram"], maxLength: 10_000)
         let url = try DeepgramPlugin.restRequestURL(
             baseURL: "http://localhost:8080/deepgram",
             modelId: "nova-3",
@@ -1456,19 +1456,23 @@ final class PluginDictionaryGuardTests: XCTestCase {
             prompt: prompt
         )
         let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let queryItems = Dictionary(
-            uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") }
-        )
+        let queryItems = components.queryItems ?? []
+        let firstValue = { (name: String) in
+            queryItems.first(where: { $0.name == name })?.value
+        }
 
         XCTAssertEqual(components.scheme, "http")
         XCTAssertEqual(components.host, "localhost")
         XCTAssertEqual(components.port, 8080)
         XCTAssertEqual(components.path, "/deepgram/v1/listen")
-        XCTAssertEqual(queryItems["model"], "nova-3")
-        XCTAssertEqual(queryItems["smart_format"], "true")
-        XCTAssertEqual(queryItems["punctuate"], "true")
-        XCTAssertEqual(queryItems["language"], "de")
-        XCTAssertEqual(queryItems["keyterm"], "TypeWhisper")
+        XCTAssertEqual(firstValue("model"), "nova-3")
+        XCTAssertEqual(firstValue("smart_format"), "true")
+        XCTAssertEqual(firstValue("punctuate"), "true")
+        XCTAssertEqual(firstValue("language"), "de")
+        XCTAssertEqual(
+            queryItems.filter { $0.name == "keyterm" }.compactMap(\.value),
+            ["TypeWhisper", "Deepgram"]
+        )
     }
 
     @available(macOS 26, *)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1413,6 +1413,64 @@ final class PluginDictionaryGuardTests: XCTestCase {
         XCTAssertEqual(queryItems.last?.value, "Term100-xx")
     }
 
+    func testDeepgramRESTRequestURLRejectsMalformedBaseURL() {
+        XCTAssertThrowsError(
+            try DeepgramPlugin.restRequestURL(
+                baseURL: "https://api deepgram.com",
+                modelId: "nova-3",
+                language: nil,
+                prompt: nil
+            )
+        ) { error in
+            guard case PluginTranscriptionError.apiError(let message) = error else {
+                return XCTFail("Expected apiError, got \(error)")
+            }
+            XCTAssertEqual(message, "Invalid base URL: https://api deepgram.com")
+        }
+    }
+
+    func testDeepgramRESTRequestURLRejectsHostlessAndUnsupportedURLs() {
+        for baseURL in ["not a URL", "file:///tmp/deepgram", "ftp://example.com"] {
+            XCTAssertThrowsError(
+                try DeepgramPlugin.restRequestURL(
+                    baseURL: baseURL,
+                    modelId: "nova-3",
+                    language: nil,
+                    prompt: nil
+                ),
+                baseURL
+            ) { error in
+                guard case PluginTranscriptionError.apiError = error else {
+                    return XCTFail("Expected apiError for \(baseURL), got \(error)")
+                }
+            }
+        }
+    }
+
+    func testDeepgramRESTRequestURLPreservesEndpointAndQueryParameters() throws {
+        let prompt = PluginDictionaryTerms.prompt(from: ["TypeWhisper"], maxLength: 10_000)
+        let url = try DeepgramPlugin.restRequestURL(
+            baseURL: "http://localhost:8080/deepgram",
+            modelId: "nova-3",
+            language: "de",
+            prompt: prompt
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let queryItems = Dictionary(
+            uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") }
+        )
+
+        XCTAssertEqual(components.scheme, "http")
+        XCTAssertEqual(components.host, "localhost")
+        XCTAssertEqual(components.port, 8080)
+        XCTAssertEqual(components.path, "/deepgram/v1/listen")
+        XCTAssertEqual(queryItems["model"], "nova-3")
+        XCTAssertEqual(queryItems["smart_format"], "true")
+        XCTAssertEqual(queryItems["punctuate"], "true")
+        XCTAssertEqual(queryItems["language"], "de")
+        XCTAssertEqual(queryItems["keyterm"], "TypeWhisper")
+    }
+
     @available(macOS 26, *)
     func testSpeechAnalyzerAnalysisContextLimitsDictionaryTermsTo100() {
         let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 150, length: 10), maxLength: 10_000)


### PR DESCRIPTION
## Summary

Fixes a crash in the Deepgram plugin's REST transcription path when a user configures a malformed custom base URL.

`transcribeREST` force-unwrapped `URLComponents` built from the user-supplied base URL:

```swift
var components = URLComponents(string: "\(effectiveBaseURL)/v1/listen")!
...
var request = URLRequest(url: components.url!)
```

`effectiveBaseURL` comes straight from the "Custom Base URL" text field (stored under `customBaseURL`), trimmed of whitespace/trailing slashes but otherwise unvalidated. A value with an internal space or other invalid character (e.g. `https://api deepgram.com`) makes `URLComponents(string:)` return `nil`, so the force-unwrap **crashes the app mid-transcription**.

This path was the only unsafe one:
- Deepgram's own streaming path (`guard let urlComponents = URLComponents(string: baseURL)`) and `validate()` (`guard let url = URL(string:...) else { return false }`) already handle `nil` safely.
- The sibling plugins that also expose a custom base URL — Reson8 (`guard var components = URLComponents(...)`), OpenAICompatible, and CloudflareASR — all use `guard let`.

This brings the REST path in line: guard both the `URLComponents` and its resolved `url`, throwing a clean `PluginTranscriptionError.apiError` instead of crashing.

## Test Plan

- [x] `xcodebuild build -scheme DeepgramPlugin` succeeds
- [ ] Set an invalid custom base URL (e.g. one containing a space) and run a transcription: surfaces a transcription error instead of crashing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved REST transcription reliability by defensively validating the service URL before issuing requests.
  * Prevents failures caused by malformed base URLs by returning a clear, user-facing error instead of an unexpected crash.
* **Tests**
  * Added unit test coverage for REST transcription request URL validation, including malformed inputs, unsupported schemes/empty hosts, and correct construction of the endpoint path and required query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->