### PR TITLE
Add subtle motion to About logo and settings sidebar icons

### DIFF
--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -144,7 +144,7 @@ struct AboutSettingsView: View {
 /// At rest the bars reproduce the app icon's static silhouette
 /// (short / mid / tall / mid / short). When `isActive` is true the bars
 /// animate like a voice spectrum, each oscillating on its own phase.
-private struct WaveformLogoView: View {
+struct WaveformLogoView: View {
     /// Drives the live spectrum motion; bars settle into the static logo shape when false.
     var isActive: Bool
 

--- a/TypeWhisper/Views/AboutSettingsView.swift
+++ b/TypeWhisper/Views/AboutSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct AboutSettingsView: View {
     @ObservedObject private var license = LicenseService.shared
     @AppStorage(UserDefaultsKeys.updateChannel) private var selectedUpdateChannelRawValue = AppConstants.defaultReleaseChannel.rawValue
+    @State private var isLogoHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var selectedUpdateChannel: AppConstants.ReleaseChannel {
         AppConstants.ReleaseChannel(rawValue: selectedUpdateChannelRawValue) ?? AppConstants.defaultReleaseChannel
@@ -27,9 +29,13 @@ struct AboutSettingsView: View {
             Form {
                 Section {
                 VStack(spacing: 12) {
-                    Image(nsImage: NSApp.applicationIconImage)
-                        .resizable()
+                    WaveformLogoView(isActive: isLogoHovering && !reduceMotion)
                         .frame(width: 96, height: 96)
+                        .scaleEffect(isLogoHovering && !reduceMotion ? 1.05 : 1.0)
+                        .animation(.spring(response: 0.35, dampingFraction: 0.6), value: isLogoHovering)
+                        .onHover { isLogoHovering = $0 }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(Text("TypeWhisper"))
 
                     Text("TypeWhisper")
                         .font(.title)
@@ -130,5 +136,52 @@ struct AboutSettingsView: View {
         UserDefaults.standard.set(0, forKey: UserDefaultsKeys.setupWizardCurrentStep)
         NotificationCenter.default.post(name: .resetSetupWizardWindow, object: nil)
         ManagedAppWindowOpener.shared.open(id: "setup")
+    }
+}
+
+/// The TypeWhisper waveform logo, drawn as five live capsule bars.
+///
+/// At rest the bars reproduce the app icon's static silhouette
+/// (short / mid / tall / mid / short). When `isActive` is true the bars
+/// animate like a voice spectrum, each oscillating on its own phase.
+private struct WaveformLogoView: View {
+    /// Drives the live spectrum motion; bars settle into the static logo shape when false.
+    var isActive: Bool
+
+    // Geometry sampled from the app icon (512px canvas): bar width 12.1%,
+    // gap 6.6%, and these resting height fractions.
+    private let barColor = Color(red: 0, green: 120.0 / 255.0, blue: 215.0 / 255.0) // #0078D7
+    private let restHeights: [CGFloat] = [0.371, 0.621, 0.871, 0.621, 0.371]
+    private let phases: [Double] = [0.0, 2.1, 4.0, 0.9, 3.1]
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            let height = geo.size.height
+            let barWidth = width * 0.121
+            let spacing = width * 0.066
+
+            TimelineView(.animation(paused: !isActive)) { timeline in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                HStack(spacing: spacing) {
+                    ForEach(restHeights.indices, id: \.self) { index in
+                        Capsule(style: .continuous)
+                            .fill(barColor)
+                            .frame(width: barWidth, height: barHeight(index, time: time, full: height))
+                    }
+                }
+                .frame(width: width, height: height)
+            }
+        }
+    }
+
+    private func barHeight(_ index: Int, time: Double, full: CGFloat) -> CGFloat {
+        let rest = restHeights[index] * full
+        guard isActive else { return rest }
+        // Each bar breathes ±20% around its own base length, so the logo keeps
+        // its shape while the bars pulse like a spectrum.
+        let speed = 3.2
+        let factor = 1.0 + 0.20 * sin(time * speed + phases[index % phases.count])
+        return min(full, rest * CGFloat(factor))
     }
 }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -549,6 +549,10 @@ private struct SettingsSidebarRow: View {
     // Incremented each time this row becomes selected, to fire the icon bounce
     // only when the tab is pressed (not when it is deselected).
     @State private var bounceTrigger = 0
+    // The List applies its restored selection after the rows are created, so a
+    // freshly opened sidebar sees a false->true transition for the selected row.
+    // Gate the bounce on this flag so only genuine in-session selections animate.
+    @State private var hasAppeared = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
@@ -564,7 +568,11 @@ private struct SettingsSidebarRow: View {
         }
         .contentShape(Rectangle())
         .onChange(of: isSelected) { _, selected in
-            if selected && !reduceMotion { bounceTrigger += 1 }
+            guard hasAppeared, selected, !reduceMotion else { return }
+            bounceTrigger += 1
+        }
+        .onAppear {
+            DispatchQueue.main.async { hasAppeared = true }
         }
     }
 }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -367,8 +367,11 @@ private struct SettingsSidebarContent: View {
                 ForEach(filteredSections) { section in
                     Section {
                         ForEach(section.destinations) { destination in
-                            SettingsSidebarRow(destination: destination)
-                                .tag(destination.tab)
+                            SettingsSidebarRow(
+                                destination: destination,
+                                isSelected: destination.tab == selectedTab
+                            )
+                            .tag(destination.tab)
                         }
                     }
                 }
@@ -497,8 +500,11 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
                     ForEach(sections) { section in
                         Section {
                             ForEach(section.destinations) { destination in
-                                SettingsSidebarRow(destination: destination)
-                                    .tag(destination.tab)
+                                SettingsSidebarRow(
+                                    destination: destination,
+                                    isSelected: destination.tab == selectedTab
+                                )
+                                .tag(destination.tab)
                             }
                         }
                     }
@@ -538,10 +544,17 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
 
 private struct SettingsSidebarRow: View {
     let destination: SettingsDestination
+    let isSelected: Bool
+
+    // Incremented each time this row becomes selected, to fire the icon bounce
+    // only when the tab is pressed (not when it is deselected).
+    @State private var bounceTrigger = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: 10) {
             Label(destination.title, systemImage: destination.systemImage)
+                .symbolEffect(.bounce, value: bounceTrigger)
 
             Spacer(minLength: 8)
 
@@ -550,6 +563,9 @@ private struct SettingsSidebarRow: View {
             }
         }
         .contentShape(Rectangle())
+        .onChange(of: isSelected) { _, selected in
+            if selected && !reduceMotion { bounceTrigger += 1 }
+        }
     }
 }
 

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -18,6 +18,8 @@ struct SetupWizardView: View {
     @State private var isPreparingAppleSpeechFallback = false
     @State private var isActivatingParakeet = false
     @State private var manuallySelectedSetupProviderId: String?
+    @State private var isLogoHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var isTrialFieldFocused: Bool
 
     private let accessibilityAnnouncementService = ServiceContainer.shared.accessibilityAnnouncementService
@@ -321,10 +323,14 @@ struct SetupWizardView: View {
 
     private var welcomeStep: some View {
         VStack(spacing: 22) {
-            Image(nsImage: NSApplication.shared.applicationIconImage)
-                .resizable()
+            WaveformLogoView(isActive: isLogoHovering && !reduceMotion)
                 .frame(width: 74, height: 74)
                 .shadow(color: .blue.opacity(0.35), radius: 16)
+                .scaleEffect(isLogoHovering && !reduceMotion ? 1.05 : 1.0)
+                .animation(.spring(response: 0.35, dampingFraction: 0.6), value: isLogoHovering)
+                .onHover { isLogoHovering = $0 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text("TypeWhisper"))
 
             VStack(alignment: .leading, spacing: 14) {
                 setupFeatureRow(


### PR DESCRIPTION
## Summary

Adds two small, tasteful motion touches to the settings UI:

- **About logo** — replaces the static app-icon image with a faithful SwiftUI rendering of the waveform logo (five capsule bars, drawn to the icon's exact color `#0078D7` and sampled proportions). On hover the bars gently pulse like a voice spectrum, each breathing ±20% around its own base length, so the logo keeps its recognizable shape. Driven by a `TimelineView` that only runs while hovered.
- **Settings sidebar** — the SF Symbol icon of a tab bounces (`symbolEffect(.bounce)`) when that tab becomes selected. The bounce fires only on selection (not deselection).

Accessibility:
- Both animations respect **Reduce Motion**: with the system setting enabled, the sidebar icons stay static and the logo does not animate on hover.
- The custom logo is exposed to VoiceOver as a single element labelled "TypeWhisper" (previously the app-icon image's implicit label).

No behavior or layout changes beyond the animations; the logo occupies the same 96×96 frame.

## Test Plan

- [ ] Ran `scripts/pr-preflight.sh`
- [x] Built and ran locally
- [x] Tested the changed functionality manually (hover the About logo; click sidebar tabs; verified Reduce Motion disables both)
- [x] No regressions in existing features


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive waveform animation to the About page logo when hovered.
  * Added accessibility labeling for the logo and support for reduced-motion preferences.

* **Enhancements**
  * Settings navigation rows now animate when selected, while respecting reduced-motion accessibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->