### PR TITLE
Bump temperature-aware plugin release versions

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CerebrasPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CerebrasPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.cerebras",
     "name": "Cerebras",
-    "version": "1.0.1",
+    "version": "1.0.5",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.claude",
     "name": "Claude",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/FireworksPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FireworksPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.fireworks",
     "name": "Fireworks AI",
-    "version": "1.0.1",
+    "version": "1.0.6",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemini",
     "name": "Gemini",
-    "version": "1.0.12",
+    "version": "1.0.21",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.groq",
     "name": "Groq",
-    "version": "1.0.16",
+    "version": "1.0.24",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
-    "version": "1.1.1",
+    "version": "1.1.4",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -144,7 +144,7 @@ final class PluginManifestValidationTests: XCTestCase {
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
-        XCTAssertEqual(manifest.version, "1.0.16")
+        XCTAssertEqual(manifest.version, "1.0.24")
         XCTAssertEqual(manifest.minHostVersion, "1.5.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
     }


### PR DESCRIPTION
## Summary

Prepare the six provider plugins updated by #987 for marketplace publication:

- CerebrasPlugin `1.0.5`
- ClaudePlugin `1.1.1`
- FireworksPlugin `1.0.6`
- GeminiPlugin `1.0.21`
- GroqPlugin `1.0.24`
- OpenRouterPlugin `1.1.4`

The versions advance from the latest releases already present in the public registries. Publishing new bundles is required because the temperature-control conformance from #987 is compiled into each plugin bundle.

## Test Plan

```bash
git diff --check
scripts/pr-preflight.sh origin/main
```

The preflight completed successfully with 416 Plugin SDK tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Bumped the plugin versions for Cerebras, Claude, Fireworks, Gemini, Groq, and OpenRouter to the latest available releases, ensuring the platform reflects current plugin build numbers.
* **Tests**
  * Adjusted plugin manifest validation to match the updated Groq plugin version expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->