### PR TITLE
Fix Mistral transcribing non-English speech in English

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -194,7 +194,13 @@ public final class MistralAIPlugin: NSObject, LLMProviderPlugin, LLMProviderIden
     
     public var supportsTranslation: Bool { false }
     public var supportsStreaming: Bool { false } // Note: We declare false here because Mistral's basic API doesn't support WebSocket streaming chunk-by-chunk in a public STT endpoint yet. The TypeWhisper app will just use transcribe(audio:...) normally.
-    public var supportedLanguages: [String] { [] }
+    // Languages officially supported by Voxtral (Mini and Small alike). Declaring
+    // them lets the app show a language picker so users can force a language
+    // instead of relying on auto-detection, which otherwise defaults erratically
+    // (e.g. transcribing Italian speech as English).
+    public var supportedLanguages: [String] {
+        ["en", "fr", "de", "es", "it", "pt", "nl", "hi"]
+    }
     
     public func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
         let client = MistralAPIClient(apiKey: apiKey)
@@ -369,7 +375,10 @@ struct MistralAPIClient {
 
         var instruction = "Transcribe this audio verbatim. Output only the transcription text, with no additional commentary, labels, or quotation marks."
         if let language, !language.isEmpty {
-            instruction += " The spoken language is \(language)."
+            // Use the human-readable name (e.g. "it" -> "Italian") so the chat
+            // model reliably transcribes in the requested language.
+            let languageName = Locale(identifier: "en_US").localizedString(forLanguageCode: language) ?? language
+            instruction += " The spoken language is \(languageName)."
         }
 
         let body: [String: Any] = [

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
@@ -247,15 +247,13 @@ final class MistralAIPluginTests: XCTestCase {
         XCTAssertTrue(content.contains { ($0["type"] as? String) == "text" })
     }
 
-    func testSupportedLanguagesIncludeVoxtralOfficialSet() {
+    func testSupportedLanguagesMatchVoxtralOfficialSet() {
         let plugin = MistralAIPlugin()
-        let languages = plugin.supportedLanguages
         // A non-empty list is what makes the app expose a language picker, so the
-        // user can force a language instead of relying on auto-detection.
-        XCTAssertFalse(languages.isEmpty)
-        for code in ["en", "fr", "de", "es", "it", "pt", "nl", "hi"] {
-            XCTAssertTrue(languages.contains(code), "missing language: \(code)")
-        }
+        // user can force a language instead of relying on auto-detection. Assert
+        // the exact set so an unsupported extra language can't silently slip into
+        // the picker.
+        XCTAssertEqual(Set(plugin.supportedLanguages), ["en", "fr", "de", "es", "it", "pt", "nl", "hi"])
     }
 
     func testVoxtralSmallChatInstructionUsesLanguageName() async throws {

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/Tests/MistralAIPluginTests.swift
@@ -247,6 +247,47 @@ final class MistralAIPluginTests: XCTestCase {
         XCTAssertTrue(content.contains { ($0["type"] as? String) == "text" })
     }
 
+    func testSupportedLanguagesIncludeVoxtralOfficialSet() {
+        let plugin = MistralAIPlugin()
+        let languages = plugin.supportedLanguages
+        // A non-empty list is what makes the app expose a language picker, so the
+        // user can force a language instead of relying on auto-detection.
+        XCTAssertFalse(languages.isEmpty)
+        for code in ["en", "fr", "de", "es", "it", "pt", "nl", "hi"] {
+            XCTAssertTrue(languages.contains(code), "missing language: \(code)")
+        }
+    }
+
+    func testVoxtralSmallChatInstructionUsesLanguageName() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "mistral-key"])
+        let plugin = MistralAIPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel("voxtral-small-latest")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"ciao"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://api.mistral.ai/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        _ = try await plugin.transcribe(audio: audio, language: "it", translate: false, prompt: nil)
+
+        let body = try XCTUnwrap(store.sessions[0].requestedRequests.first?.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+        let content = try XCTUnwrap(messages.first?["content"] as? [[String: Any]])
+        let instruction = content.compactMap { ($0["type"] as? String) == "text" ? $0["text"] as? String : nil }.first
+        // The ISO code "it" must be surfaced to the model as "Italian".
+        XCTAssertEqual(instruction?.contains("Italian"), true)
+        XCTAssertEqual(instruction?.contains(" it."), false)
+    }
+
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: URL(string: url)!,

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.minerale.mistralai",
     "name": "Mistral AI",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

Fixes the Mistral engine transcribing non-English speech in English (e.g. Italian dictation coming out as English, seemingly at random).

**Root cause:** `MistralAIPlugin.supportedLanguages` returned an empty array. The app only exposes a language picker for an engine when it reports supported languages (`guard !supportedLanguages.isEmpty` in `AudioRecorderView`, `FileTranscriptionView`, `DictationRecoveryView`). So Mistral users could never force a language and were always left on auto-detection, which Voxtral performs unreliably on short/ambiguous audio and often defaults to English.

**Fix:** declare Voxtral's officially supported languages (`en, fr, de, es, it, pt, nl, hi`, shared by Voxtral Mini and Small). Now the picker appears and the chosen language reaches the API:
- **Voxtral Mini** (`/audio/transcriptions`) already forwards it as the `language` multipart field.
- **Voxtral Small** (chat path) now surfaces the human-readable name in its instruction (`"it"` → `"Italian"`) so the model reliably pins the output language rather than parsing a bare ISO code.

## Test Plan

- [ ] Ran `scripts/pr-preflight.sh`
- [x] `swift test --package-path TypeWhisperPluginSDK --filter MistralAIPluginTests` — 15 tests pass, including new coverage for the supported-language set and that the chat instruction carries the language name (`"it"` → `"Italian"`).
- [x] **Reproduced the bug and verified the fix against the live Mistral API.** Voxtral Mini on a short Italian clip ("No") auto-detected English and returned `"not"`; the same request with `language=it` correctly returned `"No."`. Longer clips auto-detect Italian fine — consistent with the failure being an auto-detection issue on short/ambiguous audio. The chat path (Voxtral Small) also honours the `"...is Italian."` instruction.

## Notes

Only the languages Mistral officially lists for Voxtral are declared, to avoid promising quality on languages the model handles poorly. A broader (Whisper-style) set could be considered later if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Voxtral transcription language selection for English, French, German, Spanish, Italian, Portuguese, Dutch, and Hindi.
  * Chat-based transcription now uses the selected language’s readable name when a language is specified.

* **Tests**
  * Added coverage to confirm the supported language list and validate language-specific transcription request instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->