### PR TITLE
Bump Deepgram plugin to 1.0.13

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.deepgram",
     "name": "Deepgram",
-    "version": "1.0.4",
+    "version": "1.0.13",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

Prepare the Deepgram plugin release containing the custom REST base URL validation fix from #989. The release workflow now requires the requested version to match the manifest on main.

## Changes

- Bump the Deepgram plugin manifest from 1.0.4 to 1.0.13

## Test plan

- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json >/dev/null`
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme DeepgramPlugin -destination "platform=macOS,arch=arm64" CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Deepgram plugin version from 1.0.4 to 1.0.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->