### PR TITLE
Fix AirPods dictation microphone readiness

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -123,7 +123,7 @@
 		AA7080000000000000000002 /* TargetAppCorrectionLearningServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7080000000000000000002 /* TargetAppCorrectionLearningServiceTests.swift */; };
 		7DADCC6E1AEA99CA48F83F50 /* CLISupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD34FDF9D999D85DA1C35375 /* CLISupportTests.swift */; };
 		A40500000000000000000101 /* CLIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000104 /* CLIClient.swift */; };
-		7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */; };
+		7EC0EFA7DA6597CAEA640448 /* TypeWhisperIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D200DCDD6580F443C5CE0A /* TypeWhisperIntegrationTests.swift */; };
 		7B8C9D0E1F22334455667790 /* FloatingPanelSpacePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B8C9D0E1F223344556679 /* FloatingPanelSpacePolicyTests.swift */; };
 		86F4253D3CDE30E859D0F219 /* ProfileServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BD305007A3A158038C75C /* ProfileServiceTests.swift */; };
 		C50700000000000000000001 /* MemoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50700000000000000000002 /* MemoryServiceTests.swift */; };
@@ -913,7 +913,7 @@
 		D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		DD00000000000000000098 /* typewhisper-cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "typewhisper-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD00000000000000000099 /* TypeWhisper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TypeWhisper.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIRouterAndHandlersTests.swift; sourceTree = "<group>"; };
+		E6D200DCDD6580F443C5CE0A /* TypeWhisperIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TypeWhisperIntegrationTests.swift; sourceTree = "<group>"; };
 		E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TypeWhisperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4D6A8B0C1E3F5A7B9D2C4F /* DictationViewModelIndicatorSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DictationViewModelIndicatorSettingsTests.swift; sourceTree = "<group>"; };
 		2F4D6A8B0C1E3F5A7B9D2C51 /* IndicatorTranscriptPreviewSizingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IndicatorTranscriptPreviewSizingTests.swift; sourceTree = "<group>"; };
@@ -2336,7 +2336,7 @@
 		D310CE5CC61C8F01487BBDF4 /* TypeWhisperTests */ = {
 			isa = PBXGroup;
 			children = (
-				E6D200DCDD6580F443C5CE0A /* APIRouterAndHandlersTests.swift */,
+				E6D200DCDD6580F443C5CE0A /* TypeWhisperIntegrationTests.swift */,
 				3A4B5C6D7E8F901234567891 /* AudioEngineRecoverySupportTests.swift */,
 				CE5852D6767C5FA955B84C52 /* AppFormatterServiceTests.swift */,
 				CE5852D6767C5FA955B84C53 /* SpeechPunctuationServiceTests.swift */,
@@ -3879,7 +3879,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7EC0EFA7DA6597CAEA640448 /* APIRouterAndHandlersTests.swift in Sources */,
+				7EC0EFA7DA6597CAEA640448 /* TypeWhisperIntegrationTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7C /* AppFormatterServiceTests.swift in Sources */,
 				24FFE19AC026C48AE32BCD7D /* SpeechPunctuationServiceTests.swift in Sources */,
 				540AE1FA22F41A63C78B89EC /* NumberWordNormalizerTests.swift in Sources */,

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -12761,6 +12761,12 @@
     },
     "Preparing microphone": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon wird vorbereitet …"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -2810,12 +2810,17 @@ enum BluetoothAudioRouteStabilizer {
         pollInterval: TimeInterval = defaultPollInterval,
         now: () -> TimeInterval = { CFAbsoluteTimeGetCurrent() },
         sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) },
-        readDefaultInput: () -> AudioDeviceID? = { CoreAudioInputDeviceDefaultController().defaultInputDeviceID() }
+        readDefaultInput: () -> AudioDeviceID? = { CoreAudioInputDeviceDefaultController().defaultInputDeviceID() },
+        shouldCancel: () -> Bool = { false }
     ) -> Bool {
         let deadline = now() + timeout
         var stableSince: TimeInterval?
 
         while true {
+            guard !shouldCancel() else {
+                deviceHelperLogger.info("Bluetooth default route stabilization cancelled for \(reason, privacy: .public)")
+                return false
+            }
             let currentTime = now()
             let inputMatches = inputDeviceID.map { readDefaultInput() == $0 } ?? true
 
@@ -2941,6 +2946,24 @@ enum AudioInputFormatStabilizer {
 
 protocol BluetoothInputRouteStabilizing: AnyObject {
     func waitForActivatedDefaultInput(deviceID: AudioDeviceID?, reason: String) -> Bool
+    func waitForActivatedDefaultInput(
+        deviceID: AudioDeviceID?,
+        reason: String,
+        timeout: TimeInterval,
+        shouldCancel: () -> Bool
+    ) -> Bool
+}
+
+extension BluetoothInputRouteStabilizing {
+    func waitForActivatedDefaultInput(
+        deviceID: AudioDeviceID?,
+        reason: String,
+        timeout: TimeInterval,
+        shouldCancel: () -> Bool
+    ) -> Bool {
+        guard !shouldCancel() else { return false }
+        return waitForActivatedDefaultInput(deviceID: deviceID, reason: reason)
+    }
 }
 
 final class CoreAudioBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing {
@@ -2948,6 +2971,20 @@ final class CoreAudioBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizi
         BluetoothAudioRouteStabilizer.waitForActivatedDefaultRoute(
             inputDeviceID: deviceID,
             reason: reason
+        )
+    }
+
+    func waitForActivatedDefaultInput(
+        deviceID: AudioDeviceID?,
+        reason: String,
+        timeout: TimeInterval,
+        shouldCancel: () -> Bool
+    ) -> Bool {
+        BluetoothAudioRouteStabilizer.waitForActivatedDefaultRoute(
+            inputDeviceID: deviceID,
+            reason: reason,
+            timeout: timeout,
+            shouldCancel: shouldCancel
         )
     }
 }

--- a/TypeWhisper/Services/AudioEngineRecoverySupport.swift
+++ b/TypeWhisper/Services/AudioEngineRecoverySupport.swift
@@ -187,6 +187,16 @@ final class AudioEngineRecoveryCoordinator: @unchecked Sendable {
         }
     }
 
+    var hasPendingConfigurationChange: Bool {
+        state.withLock { $0.pendingConfigurationChange }
+    }
+
+    func consumePendingConfigurationChangeForEngineReplacement() {
+        state.withLock { state in
+            state.pendingConfigurationChange = false
+        }
+    }
+
     func beginScheduledRecovery(generation: UInt64) -> Bool {
         state.withLock { state in
             guard state.lifecycle == .running,

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -188,6 +188,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let stopStateLock = NSLock()
     private let engineLock = NSLock()
     private let audioLevelPublishLock = NSLock()
+    private let recordingActivityLock = OSAllocatedUnfairLock(initialState: false)
+    private struct AsyncRecordingStartState {
+        var nextRequestID: UInt64 = 0
+        var activeRequestID: UInt64?
+        var isCancelled = false
+        var isCommitted = false
+    }
+    private let asyncRecordingStartState = OSAllocatedUnfairLock(initialState: AsyncRecordingStartState())
+    private let recordingStartQueue = DispatchQueue(label: "com.typewhisper.audio-recording-start", qos: .userInitiated)
     private let processingQueue = DispatchQueue(label: "com.typewhisper.audio-processing", qos: .userInteractive)
     private let recoveryQueue = DispatchQueue(label: "com.typewhisper.audio-recovery", qos: .userInitiated)
     private let engineTeardownRetainer = DelayedReleaseRetainer<AVAudioEngine>(label: "com.typewhisper.audio-engine-teardown")
@@ -200,7 +209,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private let inputCaptureFactory: AudioInputCaptureFactory
     private let defaultInputController: AudioInputDeviceDefaultControlling
     private let inputTransportResolver: AudioDeviceTransportResolving
-    private let initialInputTapSeenLock = OSAllocatedUnfairLock(initialState: false)
+    private let bluetoothInputStartupTracker = BluetoothInputStartupTracker()
     private var _lastStopGraceCaptureApplied = false
     private var recordingRequestUptimeNanoseconds: UInt64?
     private var hasLoggedFirstConvertedSample = false
@@ -209,6 +218,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private var isAudioLevelPublishScheduled = false
 
     static let targetSampleRate: Double = 16000
+    private static let bluetoothInputReadinessTimeout: TimeInterval = 5.0
     private static let captureTapFrames: AVAudioFrameCount = 256
     private static let audioLevelPublishIntervalNanoseconds: UInt64 = 33_333_333
     private static let engineTeardownRetentionInterval: TimeInterval = 0.3
@@ -241,6 +251,31 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         bufferLock.lock()
         defer { bufferLock.unlock() }
         return _peakRawAudioLevel
+    }
+
+    private var isRecordingActive: Bool {
+        recordingActivityLock.withLock { $0 }
+    }
+
+    private func setRecordingActive(_ active: Bool) {
+        recordingActivityLock.withLock { $0 = active }
+        if Thread.isMainThread {
+            isRecording = active
+        } else {
+            DispatchQueue.main.sync { [self] in
+                isRecording = active
+            }
+        }
+    }
+
+    private func publishRecoveryError(_ error: AudioRecordingError?) {
+        if Thread.isMainThread {
+            recoveryError = error
+        } else {
+            DispatchQueue.main.sync { [self] in
+                recoveryError = error
+            }
+        }
     }
 
     var lastStopGraceCaptureApplied: Bool {
@@ -330,15 +365,138 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     func startRecording(requestUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds) throws {
+        try performStartRecording(
+            requestUptimeNanoseconds: requestUptimeNanoseconds,
+            shouldCancel: { false },
+            commitStart: { true }
+        )
+    }
+
+    func startRecordingAsync(
+        requestUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) async throws {
+        let requestID = asyncRecordingStartState.withLock { state -> UInt64 in
+            state.nextRequestID &+= 1
+            state.activeRequestID = state.nextRequestID
+            state.isCancelled = false
+            state.isCommitted = false
+            return state.nextRequestID
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                recordingStartQueue.async { [weak self] in
+                    guard let self else {
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
+
+                    defer {
+                        self.asyncRecordingStartState.withLock { state in
+                            if state.activeRequestID == requestID {
+                                state.activeRequestID = nil
+                                state.isCancelled = false
+                                state.isCommitted = false
+                            }
+                        }
+                    }
+
+                    do {
+                        try self.performStartRecording(
+                            requestUptimeNanoseconds: requestUptimeNanoseconds,
+                            shouldCancel: { [weak self] in
+                                self?.isRecordingStartCancelled(requestID: requestID) ?? true
+                            },
+                            commitStart: { [weak self] in
+                                self?.commitRecordingStart(requestID: requestID) ?? false
+                            }
+                        )
+                        continuation.resume()
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        } onCancel: {
+            asyncRecordingStartState.withLock { state in
+                guard state.activeRequestID == requestID, !state.isCommitted else { return }
+                state.isCancelled = true
+            }
+        }
+    }
+
+    func cancelPendingRecordingStart() {
+        asyncRecordingStartState.withLock { state in
+            guard state.activeRequestID != nil, !state.isCommitted else { return }
+            state.isCancelled = true
+        }
+    }
+
+    private func isRecordingStartCancelled(requestID: UInt64) -> Bool {
+        asyncRecordingStartState.withLock { state in
+            state.activeRequestID != requestID || state.isCancelled
+        }
+    }
+
+    private func commitRecordingStart(requestID: UInt64) -> Bool {
+        asyncRecordingStartState.withLock { state in
+            guard state.activeRequestID == requestID,
+                  !state.isCancelled,
+                  !state.isCommitted else {
+                return false
+            }
+            state.isCommitted = true
+            return true
+        }
+    }
+
+    private func throwIfRecordingStartCancelled(_ shouldCancel: () -> Bool) throws {
+        if shouldCancel() {
+            throw CancellationError()
+        }
+    }
+
+    private func throwIfRecordingStartExpired(_ deadline: TimeInterval?) throws {
+        guard let deadline, CFAbsoluteTimeGetCurrent() >= deadline else { return }
+        throw AudioRecordingError.noAudioData
+    }
+
+    private func waitBeforeRecordingStartRetry(
+        _ delay: TimeInterval,
+        readinessDeadline: TimeInterval?,
+        shouldCancel: () -> Bool
+    ) throws {
+        let requestedEnd = CFAbsoluteTimeGetCurrent() + delay
+        let end = min(requestedEnd, readinessDeadline ?? requestedEnd)
+        while CFAbsoluteTimeGetCurrent() < end {
+            try throwIfRecordingStartCancelled(shouldCancel)
+            let remaining = end - CFAbsoluteTimeGetCurrent()
+            Thread.sleep(forTimeInterval: min(0.01, max(0, remaining)))
+        }
+        try throwIfRecordingStartCancelled(shouldCancel)
+        try throwIfRecordingStartExpired(readinessDeadline)
+    }
+
+    private func performStartRecording(
+        requestUptimeNanoseconds: UInt64,
+        shouldCancel: @escaping () -> Bool,
+        commitStart: @escaping () -> Bool
+    ) throws {
+        try throwIfRecordingStartCancelled(shouldCancel)
         guard hasMicrophonePermission else {
             throw AudioRecordingError.microphonePermissionDenied
         }
+        let readinessDeadline = requiresInitialInputReadiness
+            ? CFAbsoluteTimeGetCurrent() + Self.bluetoothInputReadinessTimeout
+            : nil
 
         // Clear any terminal-recovery error from a previous session so the
         // view model doesn't see a stale failure on the first buffer update.
-        recoveryError = nil
+        publishRecoveryError(nil)
 
         try validateRecordingInputAvailability()
+        try throwIfRecordingStartCancelled(shouldCancel)
+        try throwIfRecordingStartExpired(readinessDeadline)
         clearRecordingBuffer(requestUptimeNanoseconds: requestUptimeNanoseconds)
         recoveryAudioStore.startNewRecording()
         publishRecoverableRecordingURLs(recoveryAudioStore.recoveryURLs)
@@ -361,12 +519,24 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             try waitForBluetoothRouteStabilizationIfNeeded(
                 inputDeviceID: routeActivationRequest.inputDeviceID,
                 usesBluetoothTransport: routeActivationRequest.usesBluetoothTransport,
-                reason: "recording-start"
+                reason: "recording-start",
+                readinessDeadline: readinessDeadline,
+                shouldCancel: shouldCancel
             )
         } catch {
             outputVolumeGuard.restoreIfRaised(reason: "recording-start-route-stabilization-failed")
             outputVolumeGuard.clear()
             inputActivationGuard.restore(reason: "recording-start-route-stabilization-failed")
+            discardActiveRecoveryRecording(keepingLatest: true)
+            throw error
+        }
+        do {
+            try throwIfRecordingStartCancelled(shouldCancel)
+            try throwIfRecordingStartExpired(readinessDeadline)
+        } catch {
+            outputVolumeGuard.restoreIfRaised(reason: "recording-start-cancelled")
+            outputVolumeGuard.clear()
+            inputActivationGuard.restore(reason: "recording-start-cancelled")
             discardActiveRecoveryRecording(keepingLatest: true)
             throw error
         }
@@ -378,9 +548,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             bufferLock.unlock()
             do {
                 try startRecordingOverride()
+                try throwIfRecordingStartCancelled(shouldCancel)
+                guard commitStart() else { throw CancellationError() }
                 outputVolumeGuard.restoreIfRaised(reason: "recording-start-override")
                 outputVolumeGuard.clear()
-                isRecording = true
+                setRecordingActive(true)
             } catch {
                 outputVolumeGuard.restoreIfRaised(reason: "recording-start-override-failed")
                 outputVolumeGuard.clear()
@@ -394,9 +566,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         if case .inputOnlyDevice(let inputOnlyDeviceID) = selectedCaptureRoute {
             do {
                 try startInputOnlyRecording(deviceID: inputOnlyDeviceID, label: "recording")
+                try throwIfRecordingStartCancelled(shouldCancel)
+                guard commitStart() else { throw CancellationError() }
                 outputVolumeGuard.restoreIfRaised(reason: "recording-start")
                 outputVolumeGuard.clear()
-                isRecording = true
+                setRecordingActive(true)
             } catch {
                 cleanupAfterFailedInputOnlyStart()
                 discardActiveRecoveryRecording(keepingLatest: true)
@@ -415,7 +589,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         installConfigurationObserver(for: engine)
 
         do {
-            try startEngineWithRecovery(engine, label: "recording")
+            try startEngineWithRecovery(
+                engine,
+                label: "recording",
+                readinessDeadline: readinessDeadline,
+                shouldCancel: shouldCancel
+            )
 
             if recoveryCoordinator.finishStartingSuccessfully() == .performImmediateRecovery {
                 guard let currentEngine = engineLock.withLock({ audioEngine }) else {
@@ -425,14 +604,22 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                     logger.info("Ignoring benign post-start audio engine configuration change after tap renegotiation")
                 } else {
                     logger.warning("Audio engine configuration changed while recording was starting, restarting with fresh input format")
-                    try restartEngineWithRecovery(currentEngine, label: "recording-startup")
+                    try restartEngineWithRecovery(
+                        currentEngine,
+                        label: "recording-startup",
+                        readinessDeadline: readinessDeadline,
+                        shouldCancel: shouldCancel
+                    )
                 }
                 scheduleRecoveryIfNeeded(recoveryCoordinator.finishRecovery())
             }
 
+            try throwIfRecordingStartCancelled(shouldCancel)
+            guard commitStart() else { throw CancellationError() }
+            finishBluetoothInputStartupIfNeeded()
             outputVolumeGuard.restoreIfRaised(reason: "recording-start")
             outputVolumeGuard.clear()
-            isRecording = true
+            setRecordingActive(true)
         } catch {
             let failedEngine = engineLock.withLock { audioEngine } ?? engine
             cleanupAfterFailedStart(failedEngine)
@@ -461,9 +648,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             }
 
             setLastStopGraceCaptureApplied(false)
+            setRecordingActive(false)
             resetAudioLevelPublishing()
             DispatchQueue.main.async { [weak self] in
-                self?.isRecording = false
                 self?.audioLevel = normalizedLevel
                 self?.rawAudioLevel = rms
             }
@@ -478,6 +665,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             startupConfigurationChangeGuard = nil
             return capture
         }
+        setRecordingActive(false)
         if let inputCaptureSession = capture.inputCaptureSession {
             let bufferedDuration = totalBufferDuration
             var graceApplied = false
@@ -506,7 +694,6 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
             resetAudioLevelPublishing()
             DispatchQueue.main.async { [weak self] in
-                self?.isRecording = false
                 self?.audioLevel = 0
                 self?.rawAudioLevel = 0
             }
@@ -552,7 +739,6 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         resetAudioLevelPublishing()
         DispatchQueue.main.async { [weak self] in
-            self?.isRecording = false
             self?.audioLevel = 0
             self?.rawAudioLevel = 0
         }
@@ -586,7 +772,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         let engine: AVAudioEngine? = engineLock.withLock { audioEngine }
-        guard isRecording, let engine else { return }
+        guard isRecordingActive, let engine else { return }
 
         if consumeStartupConfigurationChangeGuardIfNeeded(for: engine) {
             logger.info("Ignoring benign post-start audio engine configuration change after tap renegotiation")
@@ -618,6 +804,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func failActiveRecordingDueToRecovery(_ error: AudioRecordingError) {
+        setRecordingActive(false)
         recoveryCoordinator.transitionToIdle()
         removeConfigurationObserver()
         outputVolumeGuard.captureBaselineIfNeeded()
@@ -641,7 +828,6 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.recoveryError = error
-            self.isRecording = false
             self.audioLevel = 0
             self.rawAudioLevel = 0
             self.recoverableRecordingURLs = recoveryURLs
@@ -667,20 +853,40 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private func startEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+    private func startEngineWithRecovery(
+        _ engine: AVAudioEngine,
+        label: String,
+        readinessDeadline: TimeInterval? = nil,
+        shouldCancel: @escaping () -> Bool = { false }
+    ) throws {
         let explicitDeviceSelected = hasExplicitDeviceSelection
         let selectedBluetoothDevice = requiresInitialInputReadiness
+        let effectiveReadinessDeadline = readinessDeadline ?? (
+            selectedBluetoothDevice
+                ? CFAbsoluteTimeGetCurrent() + Self.bluetoothInputReadinessTimeout
+                : nil
+        )
         var currentEngine = engine
         // Main-thread callers (e.g. startRecording from hotkey) get a bounded
         // backoff to keep UI responsive; the observer-based recovery queue
         // uses the full schedule. See AudioEngineRecoveryPolicy.
         let backoff = AudioEngineRecoveryPolicy.retryBackoffForCurrentThread()
-        for (attempt, delay) in backoff.enumerated() {
+        var retryCount = 0
+        while true {
             do {
-                try configureAndStartEngine(currentEngine, label: label)
+                try throwIfRecordingStartCancelled(shouldCancel)
+                try throwIfRecordingStartExpired(effectiveReadinessDeadline)
+                try configureAndStartEngine(
+                    currentEngine,
+                    label: label,
+                    readinessDeadline: effectiveReadinessDeadline,
+                    shouldCancel: shouldCancel
+                )
                 return
             } catch let error as SelectedInputDeviceError {
                 throw mapSelectedInputDeviceError(error)
+            } catch is CancellationError {
+                throw CancellationError()
             } catch let error as AudioRecordingError {
                 throw error
             } catch {
@@ -691,32 +897,42 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                     throw AudioRecordingError.engineStartFailed(error.localizedDescription)
                 }
 
-                logger.warning("\(label, privacy: .public) audio engine start failed with retryable error, retry \(attempt + 1) in \(delay, privacy: .public)s: \(error.localizedDescription, privacy: .public)")
+                if !selectedBluetoothDevice, retryCount >= backoff.count {
+                    if explicitDeviceSelected {
+                        throw AudioRecordingError.selectedInputDeviceIncompatible(.engineStartFailed)
+                    }
+                    throw AudioRecordingError.engineStartFailed(error.localizedDescription)
+                }
+
+                try throwIfRecordingStartExpired(effectiveReadinessDeadline)
+                let delay = backoff.isEmpty
+                    ? 0.05
+                    : backoff[min(retryCount, backoff.count - 1)]
+                retryCount += 1
+                logger.warning("\(label, privacy: .public) audio engine start failed with retryable error, retry \(retryCount, privacy: .public) in \(delay, privacy: .public)s: \(error.localizedDescription, privacy: .public)")
+                recoveryCoordinator.consumePendingConfigurationChangeForEngineReplacement()
                 if let replacementEngine = replaceAudioEngineForRecoveryIfNeeded(currentEngine) {
                     installConfigurationObserver(for: replacementEngine)
                     teardownEngine(currentEngine)
                     engineTeardownRetainer.retain(currentEngine, for: Self.engineTeardownRetentionInterval)
                     currentEngine = replacementEngine
                 }
-                Thread.sleep(forTimeInterval: delay)
+                try throwIfRecordingStartCancelled(shouldCancel)
+                try waitBeforeRecordingStartRetry(
+                    delay,
+                    readinessDeadline: effectiveReadinessDeadline,
+                    shouldCancel: shouldCancel
+                )
             }
-        }
-
-        do {
-            try configureAndStartEngine(currentEngine, label: label)
-        } catch let error as SelectedInputDeviceError {
-            throw mapSelectedInputDeviceError(error)
-        } catch let error as AudioRecordingError {
-            throw error
-        } catch {
-            if explicitDeviceSelected && !selectedBluetoothDevice {
-                throw AudioRecordingError.selectedInputDeviceIncompatible(.engineStartFailed)
-            }
-            throw AudioRecordingError.engineStartFailed(error.localizedDescription)
         }
     }
 
-    private func restartEngineWithRecovery(_ engine: AVAudioEngine, label: String) throws {
+    private func restartEngineWithRecovery(
+        _ engine: AVAudioEngine,
+        label: String,
+        readinessDeadline: TimeInterval? = nil,
+        shouldCancel: @escaping () -> Bool = { false }
+    ) throws {
         outputVolumeGuard.captureBaselineIfNeeded()
         guard let replacementEngine = replaceAudioEngineForRecoveryIfNeeded(engine) else { return }
         defer {
@@ -729,14 +945,28 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
 
         do {
-            try startEngineWithRecovery(replacementEngine, label: label)
+            try startEngineWithRecovery(
+                replacementEngine,
+                label: label,
+                readinessDeadline: readinessDeadline,
+                shouldCancel: shouldCancel
+            )
+            if isRecordingActive {
+                finishBluetoothInputStartupIfNeeded()
+            }
         } catch {
             cleanupAfterFailedStart(replacementEngine)
             throw error
         }
     }
 
-    private func configureAndStartEngine(_ engine: AVAudioEngine, label: String) throws {
+    private func configureAndStartEngine(
+        _ engine: AVAudioEngine,
+        label: String,
+        readinessDeadline: TimeInterval?,
+        shouldCancel: @escaping () -> Bool
+    ) throws {
+        try throwIfRecordingStartCancelled(shouldCancel)
         let inputRoute = selectedEngineInputRoute
         // Set non-Bluetooth explicit inputs before reading the format so each retry sees fresh hardware state.
         // Bluetooth inputs are first activated as the system default input and then left to AVAudioEngine's
@@ -786,6 +1016,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.engineStartFailed("Cannot create audio converter")
         }
 
+        let bluetoothInputGeneration = requiresInitialInputReadiness
+            ? bluetoothInputStartupTracker.beginGeneration()
+            : nil
         inputNode.removeTap(onBus: 0)
 
         do {
@@ -794,8 +1027,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                     guard let normalizedBuffer = Self.normalizedInputBuffer(buffer) else {
                         return
                     }
-                    self?.markInitialInputTapSeenIfNeeded(normalizedBuffer)
-                    self?.processAudioBuffer(normalizedBuffer, converter: converter, targetFormat: targetFormat)
+                    self?.processAudioBuffer(
+                        normalizedBuffer,
+                        converter: converter,
+                        targetFormat: targetFormat,
+                        bluetoothInputGeneration: bluetoothInputGeneration
+                    )
                 }
             }
         } catch {
@@ -818,7 +1055,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             // sequence (Bluetooth A2DP↔HFP renegotiation) are deferred
             // instead of driving an infinite restart loop. See issue #332.
             recoveryCoordinator.noteEngineStarted()
-            try waitForInitialInputReadinessIfNeeded(label: label, isEngineRunning: { engine.isRunning })
+            try waitForInitialInputReadinessIfNeeded(
+                label: label,
+                generation: bluetoothInputGeneration,
+                deadline: readinessDeadline,
+                isEngineRunning: { [recoveryCoordinator] in
+                    engine.isRunning && !recoveryCoordinator.hasPendingConfigurationChange
+                },
+                shouldCancel: shouldCancel
+            )
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - engineStartTime) * 1000
             logger.info("\(label, privacy: .public) audio engine started in \(String(format: "%.1f", elapsedMs), privacy: .public)ms")
         } catch {
@@ -869,38 +1114,75 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private var hasCapturedInitialInput: Bool {
-        initialInputTapSeenLock.withLock { $0 }
-    }
-
     private func waitForBluetoothRouteStabilizationIfNeeded(
         inputDeviceID: AudioDeviceID?,
         usesBluetoothTransport: Bool,
-        reason: String
+        reason: String,
+        readinessDeadline: TimeInterval?,
+        shouldCancel: @escaping () -> Bool
     ) throws {
         guard usesBluetoothTransport else { return }
+        try throwIfRecordingStartCancelled(shouldCancel)
+        try throwIfRecordingStartExpired(readinessDeadline)
+        let timeout = readinessDeadline.map {
+            max(0, $0 - CFAbsoluteTimeGetCurrent())
+        } ?? BluetoothAudioRouteStabilizer.defaultTimeout
 
         guard bluetoothInputRouteStabilizer.waitForActivatedDefaultInput(
             deviceID: inputDeviceID,
-            reason: reason
+            reason: reason,
+            timeout: timeout,
+            shouldCancel: shouldCancel
         ) else {
+            try throwIfRecordingStartCancelled(shouldCancel)
+            try throwIfRecordingStartExpired(readinessDeadline)
             throw AudioRecordingError.audioRoutingConflict
         }
     }
 
     private func waitForInitialInputReadinessIfNeeded(
         label: String,
-        isEngineRunning: (() -> Bool)? = nil
+        generation: UInt64?,
+        deadline: TimeInterval? = nil,
+        isEngineRunning: (() -> Bool)? = nil,
+        shouldCancel: @escaping () -> Bool = { false }
     ) throws {
-        guard requiresInitialInputReadiness else { return }
+        guard requiresInitialInputReadiness, let generation else { return }
 
         try inputReadinessChecker.waitForInitialInput(
             label: label,
-            hasCapturedInitialInput: { [weak self] in
-                self?.hasCapturedInitialInput ?? false
+            deadline: deadline,
+            readinessSnapshot: { [weak self] in
+                self?.bluetoothInputStartupTracker.snapshot(for: generation)
             },
-            isEngineRunning: isEngineRunning
+            isEngineRunning: isEngineRunning,
+            shouldCancel: shouldCancel
         )
+    }
+
+    private func finishBluetoothInputStartupIfNeeded() {
+        guard requiresInitialInputReadiness else { return }
+
+        var promotion: BluetoothInputStartupTracker.Promotion?
+        processingQueue.sync {
+            promotion = bluetoothInputStartupTracker.promoteCurrentGeneration()
+            guard let promotion else { return }
+            bufferLock.withLock {
+                sampleBuffer.append(contentsOf: promotion.samples)
+                if promotion.peakInputRMS > _peakRawAudioLevel {
+                    _peakRawAudioLevel = promotion.peakInputRMS
+                }
+            }
+            recoveryAudioStore.append(promotion.samples)
+        }
+        guard let promotion else { return }
+
+        logger.info(
+            "Bluetooth recording input ready: generation=\(promotion.generation, privacy: .public), bufferedSamples=\(promotion.samples.count, privacy: .public), readinessMs=\(String(format: "%.1f", promotion.readinessDuration * 1000), privacy: .public)"
+        )
+        DispatchQueue.main.async { [weak self] in
+            self?.onFirstRecordingAudioBuffer?()
+        }
     }
 
     private func teardownEngine(_ engine: AVAudioEngine) {
@@ -922,6 +1204,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func cleanupAfterFailedStart(_ engine: AVAudioEngine) {
+        setRecordingActive(false)
+        bluetoothInputStartupTracker.reset()
         recoveryCoordinator.transitionToIdle()
         removeConfigurationObserver()
         engineLock.withLock {
@@ -940,7 +1224,6 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         inputActivationGuard.restore(reason: "recording-start-failed")
         resetAudioLevelPublishing()
         DispatchQueue.main.async { [weak self] in
-            self?.isRecording = false
             self?.audioLevel = 0
             self?.rawAudioLevel = 0
         }
@@ -971,13 +1254,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         recordingRequestUptimeNanoseconds = requestUptimeNanoseconds
         hasLoggedFirstConvertedSample = false
         bufferLock.unlock()
-        initialInputTapSeenLock.withLock { $0 = false }
+        bluetoothInputStartupTracker.reset()
         resetAudioLevelPublishing()
-    }
-
-    private func markInitialInputTapSeenIfNeeded(_ buffer: AVAudioPCMBuffer) {
-        guard AudioInputSignal.containsSignal(buffer) else { return }
-        initialInputTapSeenLock.withLock { $0 = true }
     }
 
     private func enableVoiceProcessingIfNeeded(
@@ -1024,7 +1302,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     private func processAudioBuffer(
         _ buffer: AVAudioPCMBuffer,
         converter: AVAudioConverter,
-        targetFormat: AVAudioFormat
+        targetFormat: AVAudioFormat,
+        bluetoothInputGeneration: UInt64? = nil
     ) {
         // Convert sample rate on the render thread (AVAudioConverter requires thread consistency)
         let frameCount = AVAudioFrameCount(
@@ -1061,7 +1340,10 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let samples = Array(UnsafeBufferPointer(start: channelData, count: Int(convertedBuffer.frameLength)))
 
         processingQueue.async { [weak self] in
-            self?.processConvertedSamples(samples)
+            self?.processConvertedSamples(
+                samples,
+                bluetoothInputGeneration: bluetoothInputGeneration
+            )
         }
     }
 
@@ -1088,7 +1370,6 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
                       let monoBuffer = AudioInputBufferNormalizer.monoFloatBuffer(from: buffer) else {
                     return
                 }
-                self.markInitialInputTapSeenIfNeeded(monoBuffer)
                 self.processAudioBuffer(monoBuffer, converter: converter, targetFormat: targetFormat)
             }
 
@@ -1109,6 +1390,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func cleanupAfterFailedInputOnlyStart() {
+        setRecordingActive(false)
         recoveryCoordinator.transitionToIdle()
         removeConfigurationObserver()
         let session: AudioInputCaptureSession? = engineLock.withLock {
@@ -1124,19 +1406,42 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         inputActivationGuard.restore(reason: "recording-start-failed")
         resetAudioLevelPublishing()
         DispatchQueue.main.async { [weak self] in
-            self?.isRecording = false
             self?.audioLevel = 0
             self?.rawAudioLevel = 0
         }
     }
 
-    private func processConvertedSamples(_ samples: [Float]) {
+    private func processConvertedSamples(
+        _ samples: [Float],
+        bluetoothInputGeneration: UInt64? = nil
+    ) {
         let boostResult = MicrophoneBoostProcessor.process(samples, enabled: microphoneBoostEnabled)
         let processedSamples = boostResult.samples
         let rms = boostResult.outputRMS
         let normalizedLevel = AudioLevelMeter.normalizedLevel(rms: rms)
         var requestToFirstBufferMs: Double?
         var didReceiveFirstBuffer = false
+
+        if let bluetoothInputGeneration {
+            let disposition = bluetoothInputStartupTracker.consume(
+                samples: processedSamples,
+                inputRMS: boostResult.inputRMS,
+                generation: bluetoothInputGeneration
+            )
+            switch disposition {
+            case .ignored:
+                return
+            case .staged:
+                logFirstConvertedBufferIfNeeded(
+                    sampleCount: processedSamples.count,
+                    requestToFirstBufferMs: &requestToFirstBufferMs
+                )
+                publishAudioLevel(normalizedLevel, rms: rms, force: requestToFirstBufferMs != nil)
+                return
+            case .appendDirectly:
+                break
+            }
+        }
 
         bufferLock.lock()
         sampleBuffer.append(contentsOf: processedSamples)
@@ -1163,6 +1468,26 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             DispatchQueue.main.async { [weak self] in
                 self?.onFirstRecordingAudioBuffer?()
             }
+        }
+    }
+
+    private func logFirstConvertedBufferIfNeeded(
+        sampleCount: Int,
+        requestToFirstBufferMs: inout Double?
+    ) {
+        bufferLock.withLock {
+            guard !hasLoggedFirstConvertedSample else { return }
+            hasLoggedFirstConvertedSample = true
+            requestToFirstBufferMs = Self.elapsedMilliseconds(
+                from: recordingRequestUptimeNanoseconds,
+                to: DispatchTime.now().uptimeNanoseconds
+            )
+        }
+
+        if let requestToFirstBufferMs {
+            logger.info(
+                "First recording audio buffer received: requestToFirstBufferMs=\(Self.formatMilliseconds(requestToFirstBufferMs), privacy: .public), sampleCount=\(sampleCount, privacy: .public)"
+            )
         }
     }
 
@@ -1269,7 +1594,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     /// handled it. Called from `DictationViewModel` once the session is
     /// unwound so the @Published value doesn't linger for later bindings.
     func clearRecoveryError() {
-        recoveryError = nil
+        publishRecoveryError(nil)
     }
 
     var latestRecoveryRecordingURL: URL? {
@@ -1379,27 +1704,191 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 }
 
+struct AudioInputReadinessSnapshot: Equatable, Sendable {
+    let generation: UInt64
+    let consecutiveBufferCount: Int
+    let buffersSinceSignal: Int
+    let continuousDuration: TimeInterval
+    let lastBufferTimestamp: TimeInterval
+}
+
+final class BluetoothInputStartupTracker: @unchecked Sendable {
+    enum ConsumeDisposition: Equatable {
+        case ignored
+        case staged
+        case appendDirectly
+    }
+
+    struct Promotion {
+        let generation: UInt64
+        let samples: [Float]
+        let peakInputRMS: Float
+        let readinessDuration: TimeInterval
+    }
+
+    private struct State {
+        var generation: UInt64 = 0
+        var isActive = false
+        var isReady = false
+        var generationStartedAt: TimeInterval = 0
+        var streakStartedAt: TimeInterval?
+        var lastBufferTimestamp: TimeInterval?
+        var consecutiveBufferCount = 0
+        var buffersSinceSignal = 0
+        var stagedSamples: [Float] = []
+        var peakInputRMS: Float = 0
+    }
+
+    private static let maximumBufferGap: TimeInterval = 0.25
+    private static let signalPeakThreshold: Float = 0.000_01
+    private let now: @Sendable () -> TimeInterval
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(now: @escaping @Sendable () -> TimeInterval = { CFAbsoluteTimeGetCurrent() }) {
+        self.now = now
+    }
+
+    func beginGeneration() -> UInt64 {
+        let timestamp = now()
+        return state.withLock { state in
+            state.generation &+= 1
+            state.isActive = true
+            state.isReady = false
+            state.generationStartedAt = timestamp
+            state.streakStartedAt = nil
+            state.lastBufferTimestamp = nil
+            state.consecutiveBufferCount = 0
+            state.buffersSinceSignal = 0
+            state.stagedSamples.removeAll(keepingCapacity: true)
+            state.peakInputRMS = 0
+            return state.generation
+        }
+    }
+
+    func consume(
+        samples: [Float],
+        inputRMS: Float,
+        generation: UInt64
+    ) -> ConsumeDisposition {
+        let timestamp = now()
+        let containsSignal = samples.contains { abs($0) > Self.signalPeakThreshold }
+
+        return state.withLock { state in
+            guard state.isActive, state.generation == generation else {
+                return .ignored
+            }
+            guard !state.isReady else {
+                return .appendDirectly
+            }
+
+            if let lastBufferTimestamp = state.lastBufferTimestamp,
+               timestamp - lastBufferTimestamp <= Self.maximumBufferGap {
+                state.consecutiveBufferCount += 1
+                if state.buffersSinceSignal > 0 {
+                    state.buffersSinceSignal += 1
+                }
+            } else {
+                state.streakStartedAt = timestamp
+                state.consecutiveBufferCount = 1
+                state.buffersSinceSignal = 0
+            }
+
+            if containsSignal, state.buffersSinceSignal == 0 {
+                state.buffersSinceSignal = 1
+            }
+            state.lastBufferTimestamp = timestamp
+            state.stagedSamples.append(contentsOf: samples)
+            if inputRMS > state.peakInputRMS {
+                state.peakInputRMS = inputRMS
+            }
+            return .staged
+        }
+    }
+
+    func snapshot(for generation: UInt64) -> AudioInputReadinessSnapshot? {
+        state.withLock { state in
+            guard state.isActive,
+                  !state.isReady,
+                  state.generation == generation,
+                  let streakStartedAt = state.streakStartedAt,
+                  let lastBufferTimestamp = state.lastBufferTimestamp else {
+                return nil
+            }
+            return AudioInputReadinessSnapshot(
+                generation: generation,
+                consecutiveBufferCount: state.consecutiveBufferCount,
+                buffersSinceSignal: state.buffersSinceSignal,
+                continuousDuration: max(0, lastBufferTimestamp - streakStartedAt),
+                lastBufferTimestamp: lastBufferTimestamp
+            )
+        }
+    }
+
+    func promoteCurrentGeneration() -> Promotion? {
+        let timestamp = now()
+        return state.withLock { state in
+            guard state.isActive, !state.isReady else { return nil }
+            state.isReady = true
+            let promotion = Promotion(
+                generation: state.generation,
+                samples: state.stagedSamples,
+                peakInputRMS: state.peakInputRMS,
+                readinessDuration: max(0, timestamp - state.generationStartedAt)
+            )
+            state.stagedSamples.removeAll(keepingCapacity: false)
+            return promotion
+        }
+    }
+
+    func reset() {
+        state.withLock { state in
+            state.isActive = false
+            state.isReady = false
+            state.streakStartedAt = nil
+            state.lastBufferTimestamp = nil
+            state.consecutiveBufferCount = 0
+            state.buffersSinceSignal = 0
+            state.stagedSamples.removeAll(keepingCapacity: false)
+            state.peakInputRMS = 0
+        }
+    }
+}
+
 protocol AudioInputReadinessChecking: AnyObject {
     func waitForInitialInput(
         label: String,
-        hasCapturedInitialInput: () -> Bool,
-        isEngineRunning: (() -> Bool)?
+        deadline: TimeInterval?,
+        readinessSnapshot: () -> AudioInputReadinessSnapshot?,
+        isEngineRunning: (() -> Bool)?,
+        shouldCancel: () -> Bool
     ) throws
 }
 
 final class BluetoothInputReadinessChecker: AudioInputReadinessChecking {
     private let timeout: TimeInterval
+    private let silentFallback: TimeInterval
+    private let missingBufferRecoveryInterval: TimeInterval
+    private let maximumBufferGap: TimeInterval
+    private let requiredSignalBufferCount: Int
     private let pollInterval: TimeInterval
     private let now: () -> TimeInterval
     private let sleep: (TimeInterval) -> Void
 
     init(
-        timeout: TimeInterval = 1.0,
+        timeout: TimeInterval = 5.0,
+        silentFallback: TimeInterval = 3.0,
+        missingBufferRecoveryInterval: TimeInterval = 3.0,
+        maximumBufferGap: TimeInterval = 0.25,
+        requiredSignalBufferCount: Int = 3,
         pollInterval: TimeInterval = 0.01,
         now: @escaping () -> TimeInterval = { CFAbsoluteTimeGetCurrent() },
         sleep: @escaping (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) }
     ) {
         self.timeout = timeout
+        self.silentFallback = silentFallback
+        self.missingBufferRecoveryInterval = missingBufferRecoveryInterval
+        self.maximumBufferGap = maximumBufferGap
+        self.requiredSignalBufferCount = requiredSignalBufferCount
         self.pollInterval = pollInterval
         self.now = now
         self.sleep = sleep
@@ -1407,35 +1896,73 @@ final class BluetoothInputReadinessChecker: AudioInputReadinessChecking {
 
     func waitForInitialInput(
         label: String,
-        hasCapturedInitialInput: () -> Bool,
-        isEngineRunning: (() -> Bool)?
+        deadline: TimeInterval?,
+        readinessSnapshot: () -> AudioInputReadinessSnapshot?,
+        isEngineRunning: (() -> Bool)?,
+        shouldCancel: () -> Bool
     ) throws {
-        let deadline = now() + timeout
-        while now() < deadline {
-            if hasCapturedInitialInput() {
-                logger.info("\(label, privacy: .public) Bluetooth input delivered initial non-silent audio")
-                return
+        let startedAt = now()
+        let localDeadline = startedAt + timeout
+        let effectiveDeadline = min(localDeadline, deadline ?? localDeadline)
+        while now() < effectiveDeadline {
+            if shouldCancel() {
+                throw CancellationError()
             }
             if let isEngineRunning, !isEngineRunning() {
-                throw makeStartupRouteChangeError(label: label)
+                throw makeStartupRouteChangeError(
+                    label: label,
+                    detail: "Bluetooth input route changed before readiness"
+                )
             }
-            sleep(min(pollInterval, max(0, deadline - now())))
+            if let snapshot = readinessSnapshot() {
+                if snapshot.buffersSinceSignal >= requiredSignalBufferCount {
+                    logger.info(
+                        "\(label, privacy: .public) Bluetooth input delivered stable non-silent audio in generation \(snapshot.generation, privacy: .public)"
+                    )
+                    return
+                }
+                if snapshot.consecutiveBufferCount >= requiredSignalBufferCount,
+                   snapshot.continuousDuration >= silentFallback {
+                    logger.info(
+                        "\(label, privacy: .public) Bluetooth input delivered a stable silent stream for \(self.silentFallback, privacy: .public)s in generation \(snapshot.generation, privacy: .public)"
+                    )
+                    return
+                }
+                if now() - snapshot.lastBufferTimestamp > maximumBufferGap {
+                    throw makeStartupRouteChangeError(
+                        label: label,
+                        detail: "Bluetooth input stalled before readiness"
+                    )
+                }
+            } else if now() - startedAt >= missingBufferRecoveryInterval {
+                throw makeStartupRouteChangeError(
+                    label: label,
+                    detail: "Bluetooth input did not deliver buffers before readiness"
+                )
+            }
+            sleep(min(pollInterval, max(0, effectiveDeadline - now())))
         }
 
+        if shouldCancel() {
+            throw CancellationError()
+        }
         if let isEngineRunning, !isEngineRunning() {
-            throw makeStartupRouteChangeError(label: label)
+            throw makeStartupRouteChangeError(
+                label: label,
+                detail: "Bluetooth input route changed before readiness"
+            )
         }
 
         logger.error("\(label, privacy: .public) Bluetooth input did not deliver audio within \(self.timeout, privacy: .public)s after engine start")
         throw AudioRecordingService.AudioRecordingError.noAudioData
     }
 
-    private func makeStartupRouteChangeError(label: String) -> NSError {
+    private func makeStartupRouteChangeError(label: String, detail: String) -> NSError {
         NSError(
             domain: AudioEngineRecoveryErrorDomains.transientFormatMismatch,
             code: 0,
             userInfo: [
-                NSLocalizedDescriptionKey: "\(label) Bluetooth input route changed before initial audio"
+                NSLocalizedDescriptionKey: "\(label) \(detail)"
             ]
         )
     }
@@ -1471,16 +1998,34 @@ extension AudioRecordingService {
         consumeStartupConfigurationChangeGuardIfMatching(for: engine, liveFormat: liveFormat)
     }
 
-    func testingWaitForInitialInputReadinessIfNeeded(isEngineRunning: (() -> Bool)? = nil) throws {
-        try waitForInitialInputReadinessIfNeeded(label: "test", isEngineRunning: isEngineRunning)
+    func testingWaitForInitialInputReadinessIfNeeded(
+        generation: UInt64,
+        isEngineRunning: (() -> Bool)? = nil,
+        shouldCancel: @escaping () -> Bool = { false }
+    ) throws {
+        try waitForInitialInputReadinessIfNeeded(
+            label: "test",
+            generation: generation,
+            isEngineRunning: isEngineRunning,
+            shouldCancel: shouldCancel
+        )
     }
 
-    func testingMarkInitialInputTapSeen() {
-        initialInputTapSeenLock.withLock { $0 = true }
+    func testingBeginBluetoothInputGeneration() -> UInt64 {
+        bluetoothInputStartupTracker.beginGeneration()
     }
 
-    func testingMarkInitialInputTapSeen(_ buffer: AVAudioPCMBuffer) {
-        markInitialInputTapSeenIfNeeded(buffer)
+    @discardableResult
+    func testingConsumeBluetoothInputSamples(
+        _ samples: [Float],
+        inputRMS: Float,
+        generation: UInt64
+    ) -> BluetoothInputStartupTracker.ConsumeDisposition {
+        bluetoothInputStartupTracker.consume(
+            samples: samples,
+            inputRMS: inputRMS,
+            generation: generation
+        )
     }
 
     func testingProcessConvertedSamples(_ samples: [Float]) {

--- a/TypeWhisper/Services/DictionaryTrainingService.swift
+++ b/TypeWhisper/Services/DictionaryTrainingService.swift
@@ -285,7 +285,10 @@ final class DictionaryTrainingService: ObservableObject {
         do {
             guard requestedSessionID == sessionID else { return }
             try await dependencies.startRecording()
-            guard requestedSessionID == sessionID, !isCancelled else {
+            guard requestedSessionID == sessionID,
+                  !isCancelled,
+                  samples.indices.contains(index),
+                  samples[index].id == sampleID else {
                 _ = await dependencies.stopRecording()
                 dependencies.discardActiveRecording()
                 return

--- a/TypeWhisper/Services/DictionaryTrainingService.swift
+++ b/TypeWhisper/Services/DictionaryTrainingService.swift
@@ -73,7 +73,8 @@ struct DictionaryTrainingDependencies {
     var engineSnapshot: () -> DictionaryTrainingEngineSnapshot?
     var canTranscribe: () -> Bool
     var requestMicrophonePermission: () async -> Bool
-    var startRecording: () throws -> Void
+    var startRecording: () async throws -> Void
+    var cancelRecordingStart: () -> Void = {}
     var stopRecording: () async -> [Float]
     var discardActiveRecording: () -> Void
     var transcribe: (DictionaryTrainingTranscriptionRequest) async throws -> String
@@ -105,7 +106,10 @@ struct DictionaryTrainingDependencies {
                 await audioRecordingService.requestMicrophonePermission()
             },
             startRecording: {
-                try audioRecordingService.startRecording()
+                try await audioRecordingService.startRecordingAsync()
+            },
+            cancelRecordingStart: {
+                audioRecordingService.cancelPendingRecordingStart()
             },
             stopRecording: {
                 await audioRecordingService.stopRecording(policy: .immediate)
@@ -280,7 +284,7 @@ final class DictionaryTrainingService: ObservableObject {
 
         do {
             guard requestedSessionID == sessionID else { return }
-            try dependencies.startRecording()
+            try await dependencies.startRecording()
             guard requestedSessionID == sessionID, !isCancelled else {
                 _ = await dependencies.stopRecording()
                 dependencies.discardActiveRecording()
@@ -291,6 +295,11 @@ final class DictionaryTrainingService: ObservableObject {
             samples[index].state = .recording
         } catch {
             dependencies.discardActiveRecording()
+            guard requestedSessionID == sessionID,
+                  samples.indices.contains(index),
+                  samples[index].id == sampleID else {
+                return
+            }
             samples[index].state = .failed(error.localizedDescription)
         }
     }
@@ -410,6 +419,11 @@ final class DictionaryTrainingService: ObservableObject {
 
     func cancel() async {
         isCancelled = true
+        if let activeSampleID,
+           let index = samples.firstIndex(where: { $0.id == activeSampleID }),
+           samples[index].state == .preparing {
+            dependencies.cancelRecordingStart()
+        }
         if let activeSampleID,
            let index = samples.firstIndex(where: { $0.id == activeSampleID }),
            samples[index].state == .recording {

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -1110,6 +1110,34 @@ final class APIHandlers: @unchecked Sendable {
         }
     }
 
+    private struct DictationStartPreparation: Sendable {
+        let id: UUID?
+        let workflowID: UUID?
+        let workflowName: String?
+        let errorStatus: Int?
+        let errorMessage: String?
+
+        static func start(id: UUID, workflowID: UUID?, workflowName: String?) -> Self {
+            Self(
+                id: id,
+                workflowID: workflowID,
+                workflowName: workflowName,
+                errorStatus: nil,
+                errorMessage: nil
+            )
+        }
+
+        static func failure(status: Int, message: String) -> Self {
+            Self(
+                id: nil,
+                workflowID: nil,
+                workflowName: nil,
+                errorStatus: status,
+                errorMessage: message
+            )
+        }
+    }
+
     private func handleStartDictation(_ request: HTTPRequest) async -> HTTPResponse {
         let payload: DictationStartRequest?
         if request.body.isEmpty {
@@ -1123,44 +1151,87 @@ final class APIHandlers: @unchecked Sendable {
 
         let dictationViewModel = self.dictationViewModel
         let workflowService = self.workflowService
-        return await MainActor.run {
+        let preparation = await MainActor.run {
             guard dictationViewModel.canStartAPIRecording else {
-                return .error(status: 409, message: "Dictation is not idle")
+                return DictationStartPreparation.failure(
+                    status: 409,
+                    message: "Dictation is not idle"
+                )
             }
 
-            var workflow: Workflow?
+            let workflowID: UUID?
+            let workflowName: String?
             if let workflowId = payload?.workflowId {
                 guard !workflowId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                       let uuid = UUID(uuidString: workflowId) else {
-                    return .error(status: 400, message: "Missing or invalid 'workflow_id'")
+                    return DictationStartPreparation.failure(
+                        status: 400,
+                        message: "Missing or invalid 'workflow_id'"
+                    )
                 }
                 guard let requestedWorkflow = workflowService.workflow(id: uuid) else {
-                    return .error(status: 404, message: "Workflow not found")
+                    return DictationStartPreparation.failure(
+                        status: 404,
+                        message: "Workflow not found"
+                    )
                 }
                 guard requestedWorkflow.isEnabled else {
-                    return .error(status: 409, message: "Workflow is disabled")
+                    return DictationStartPreparation.failure(
+                        status: 409,
+                        message: "Workflow is disabled"
+                    )
                 }
-                workflow = requestedWorkflow
+                workflowID = requestedWorkflow.id
+                workflowName = requestedWorkflow.name
+            } else {
+                workflowID = nil
+                workflowName = nil
             }
 
-            let id = dictationViewModel.apiStartRecording(forcedWorkflowId: workflow?.id)
+            let id = dictationViewModel.apiStartRecording(forcedWorkflowId: workflowID)
             if let session = dictationViewModel.apiDictationSession(id: id), session.status == .failed {
-                return .error(status: 409, message: session.error ?? "Failed to start dictation")
+                return DictationStartPreparation.failure(
+                    status: 409,
+                    message: session.error ?? "Failed to start dictation"
+                )
             }
-
-            struct StartResponse: Encodable {
-                let id: String
-                let status: String
-                let workflow_id: String?
-                let workflow_name: String?
-            }
-            return .json(StartResponse(
-                id: id.uuidString,
-                status: "recording",
-                workflow_id: workflow?.id.uuidString,
-                workflow_name: workflow?.name
-            ))
+            return DictationStartPreparation.start(
+                id: id,
+                workflowID: workflowID,
+                workflowName: workflowName
+            )
         }
+        if let errorStatus = preparation.errorStatus,
+           let errorMessage = preparation.errorMessage {
+            return .error(status: errorStatus, message: errorMessage)
+        }
+
+        guard let id = preparation.id else {
+            return .error(status: 500, message: "Failed to reserve dictation session")
+        }
+        await dictationViewModel.apiWaitForRecordingReadiness()
+        let failedMessage: String? = await MainActor.run {
+            if let session = dictationViewModel.apiDictationSession(id: id), session.status == .failed {
+                return session.error ?? "Failed to start dictation"
+            }
+            return nil
+        }
+        if let failedMessage {
+            return .error(status: 409, message: failedMessage)
+        }
+
+        struct StartResponse: Encodable {
+            let id: String
+            let status: String
+            let workflow_id: String?
+            let workflow_name: String?
+        }
+        return .json(StartResponse(
+            id: id.uuidString,
+            status: "recording",
+            workflow_id: preparation.workflowID?.uuidString,
+            workflow_name: preparation.workflowName
+        ))
     }
 
     // MARK: - POST /v1/dictation/stop

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -72,6 +72,16 @@ struct IndicatorPresentationData {
         source == .recorder
     }
 
+    var isPreparingMicrophone: Bool {
+        state == .recording && !isRecordingInputReady
+    }
+
+    var recordingStatusLabel: String {
+        isPreparingMicrophone
+            ? String(localized: "Preparing microphone")
+            : String(localized: "Recording")
+    }
+
     @MainActor
     static func make(
         dictation: DictationViewModel,

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1004,6 +1004,9 @@ final class DictationViewModel: ObservableObject {
     }
 
     func handleCancelHotkey() {
+        logger.info(
+            "Cancel hotkey received: state=\(String(describing: self.state), privacy: .public), inputReady=\(self.isRecordingInputReady, privacy: .public), startPending=\(self.recordingStartTask != nil, privacy: .public)"
+        )
         guard let target = cancelWarningTargetForCurrentState() else { return }
 
         if target == .recording, !requireSecondEscapeToCancelRecording {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -315,6 +315,7 @@ final class DictationViewModel: ObservableObject {
     private let recentTranscriptionPaletteHandler: RecentTranscriptionPaletteHandler
     private let settingsHandler: DictationSettingsHandler
     private var transcriptionTask: Task<Void, Never>?
+    private var recordingStartTask: Task<Void, Never>?
     private var stopFinalizationTask: Task<Void, Never>?
     private var targetAppCorrectionLearningTask: Task<Void, Never>?
     private var pendingLearnedCorrections: [LearnedDictionaryCorrection] = []
@@ -707,6 +708,24 @@ final class DictationViewModel: ObservableObject {
         return sessionID
     }
 
+    func apiStartRecordingAwaitingReadiness(forcedWorkflowId: UUID? = nil) async -> UUID {
+        let sessionID = apiStartRecording(forcedWorkflowId: forcedWorkflowId)
+        await apiWaitForRecordingReadiness()
+        return sessionID
+    }
+
+    func apiWaitForRecordingReadiness() async {
+        let startTask = recordingStartTask
+        await startTask?.value
+    }
+
+#if DEBUG
+    func testingWaitForRecordingStart() async {
+        let startTask = recordingStartTask
+        await startTask?.value
+    }
+#endif
+
     func apiStopRecording() -> UUID? {
         let sessionID = activeDictationSessionID
         stopDictation()
@@ -859,12 +878,18 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func abortActiveRecordingImmediately(sessionMessage: String, preserveRecoveryAudio: Bool = false) {
+        let pendingStartTask = recordingStartTask
+        if pendingStartTask != nil {
+            pendingStartTask?.cancel()
+            audioRecordingService.cancelPendingRecordingStart()
+        }
         clearRecordingStartCueState()
         clearDeferredRecordingContext()
         restoreRecordingSideEffects()
         streamingHandler.stop()
         stopRecordingTimer()
         Task {
+            await pendingStartTask?.value
             _ = await audioRecordingService.stopRecording(policy: .immediate)
             if preserveRecoveryAudio {
                 audioRecordingService.preserveActiveRecoveryRecording()
@@ -937,8 +962,8 @@ final class DictationViewModel: ObservableObject {
         // it to the UI and unwind the dictation session cleanly — restore
         // ducking, resume media, stop streaming, cancel the session.
         audioRecordingService.$recoveryError
-            .compactMap { $0 }
             .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
             .sink { [weak self] error in
                 guard let self else { return }
                 // Always drain the publisher so `recoveryError` never lingers
@@ -1099,100 +1124,193 @@ final class DictationViewModel: ObservableObject {
         }
 
         let resolvedInputSelection = audioDeviceService.resolvedRecordingInputSelection()
+        let initialForcedWorkflow = forcedWorkflow(for: forcedWorkflowId)
+        audioRecordingService.microphoneBoostEnabled = microphoneBoostEnabled(for: initialForcedWorkflow)
+        audioRecordingService.selectedDeviceID = resolvedInputSelection.deviceID
+        audioRecordingService.hasExplicitDeviceSelection = resolvedInputSelection.hasExplicitDeviceSelection
+        let selectedInputUsesBluetooth = resolvedInputSelection.usesBluetoothTransport
+        audioRecordingService.selectedInputDeviceUsesBluetoothTransport = selectedInputUsesBluetooth
+        prepareRecordingStartCue(playsSound: !selectedInputUsesBluetooth)
+        let audioStartTimestamp = DispatchTime.now().uptimeNanoseconds
+
+        if selectedInputUsesBluetooth {
+            beginRecordingPreparation()
+            logger.info("Preparing Bluetooth recording input without blocking the main actor")
+            recordingStartTask?.cancel()
+            recordingStartTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer {
+                    if self.activeDictationSessionID == sessionID || self.activeDictationSessionID == nil {
+                        self.recordingStartTask = nil
+                    }
+                }
+
+                do {
+                    try await self.audioRecordingService.startRecordingAsync(
+                        requestUptimeNanoseconds: requestUptimeNanoseconds
+                    )
+                    guard !Task.isCancelled,
+                          self.activeDictationSessionID == sessionID,
+                          self.state == .recording else {
+                        return
+                    }
+                    self.completeRecordingStart(
+                        forcedWorkflowId: forcedWorkflowId,
+                        sessionID: sessionID,
+                        requestUptimeNanoseconds: requestUptimeNanoseconds,
+                        startTimestamp: startTimestamp,
+                        audioStartTimestamp: audioStartTimestamp,
+                        selectedInputUsesBluetooth: true,
+                        initialForcedWorkflow: initialForcedWorkflow
+                    )
+                } catch is CancellationError {
+                    logger.info("Bluetooth recording preparation cancelled")
+                } catch {
+                    guard self.activeDictationSessionID == sessionID else { return }
+                    self.handleRecordingStartFailure(
+                        error,
+                        sessionID: sessionID,
+                        resolvedInputSelection: resolvedInputSelection
+                    )
+                }
+            }
+            return
+        }
 
         do {
-            let initialForcedWorkflow = forcedWorkflow(for: forcedWorkflowId)
-            audioRecordingService.microphoneBoostEnabled = microphoneBoostEnabled(for: initialForcedWorkflow)
-            audioRecordingService.selectedDeviceID = resolvedInputSelection.deviceID
-            audioRecordingService.hasExplicitDeviceSelection = resolvedInputSelection.hasExplicitDeviceSelection
-            let selectedInputUsesBluetooth = resolvedInputSelection.usesBluetoothTransport
-            audioRecordingService.selectedInputDeviceUsesBluetoothTransport = selectedInputUsesBluetooth
-            prepareRecordingStartCue(playsSound: !selectedInputUsesBluetooth)
-            let audioStartTimestamp = DispatchTime.now().uptimeNanoseconds
             try audioRecordingService.startRecording(requestUptimeNanoseconds: requestUptimeNanoseconds)
-            let audioStartCompletedTimestamp = DispatchTime.now().uptimeNanoseconds
-            let audioStartMs = Self.elapsedMilliseconds(
-                from: audioStartTimestamp,
-                to: audioStartCompletedTimestamp
-            )
-            let requestToAudioStartMs = Self.elapsedMilliseconds(
-                from: requestUptimeNanoseconds,
-                to: audioStartCompletedTimestamp
-            )
-            promptPaletteHandler.hide()
-            recentTranscriptionPaletteHandler.hide()
-            modelManager.cancelAutoUnloadTimer()
-            if selectedInputUsesBluetooth {
-                logger.info("Skipping recording start sound for Bluetooth input device")
-            }
-            if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
-            if audioDuckingEnabled {
-                pendingRecordingAudioDuckingLevel = max(0, min(1, Float(audioDuckingLevel)))
-            } else {
-                pendingRecordingAudioDuckingLevel = nil
-            }
-            state = .recording
-            // Reset hotkey timer so hybrid threshold counts from recording start,
-            // not from key press. Slow device init (e.g. iPhone Continuity ~2-3s)
-            // would otherwise make the hold appear as "long press" → PTT stop.
-            hotkeyService.resetKeyDownTime()
-            partialText = ""
-            isStopInFlight = false
-            recordingStartTime = Date()
-            startRecordingTimer()
-
-            let contextStartTimestamp = CFAbsoluteTimeGetCurrent()
-            // Match rule after the audio engine is live so app/context lookup does
-            // not delay capture of the user's first spoken words.
-            let activeApp = textInsertionService.captureActiveApp()
-            capturedActiveApp = activeApp
-            capturedSelectedText = nil
-            activeAppIcon = nil
-
-            if let forcedWorkflow = initialForcedWorkflow {
-                applyWorkflowMatch(workflowService.forcedWorkflowMatch(for: forcedWorkflow), activeApp: activeApp)
-            } else if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: activeApp.bundleId, url: nil) {
-                applyWorkflowMatch(workflowMatch, activeApp: activeApp)
-            } else {
-                clearActiveRuleState()
-            }
-            applyEffectiveMicrophoneBoostToAudioService()
-            updateRecordingStartCuePayload(activeApp: activeApp)
-            let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
-
-            startLiveStreaming(allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0)
-            scheduleDeferredRecordingMetadataCapture(
-                activeApp: activeApp,
-                forcedWorkflowId: forcedWorkflowId
-            )
-
-            let totalStartMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
-            logger.info(
-                "Recording started: requestToAudioStartMs=\(Self.formatMilliseconds(requestToAudioStartMs), privacy: .public), audioStartMs=\(Self.formatMilliseconds(audioStartMs), privacy: .public), contextMs=\(String(format: "%.1f", contextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
+            completeRecordingStart(
+                forcedWorkflowId: forcedWorkflowId,
+                sessionID: sessionID,
+                requestUptimeNanoseconds: requestUptimeNanoseconds,
+                startTimestamp: startTimestamp,
+                audioStartTimestamp: audioStartTimestamp,
+                selectedInputUsesBluetooth: false,
+                initialForcedWorkflow: initialForcedWorkflow
             )
         } catch {
-            clearRecordingStartCueState()
-            clearDeferredRecordingContext()
-            restoreRecordingSideEffects()
-            let errorMessage: String
-            if let recordingError = error as? AudioRecordingService.AudioRecordingError,
-               case .noMicrophoneDetected = recordingError {
-                errorMessage = String(localized: "No mic detected.")
-            } else if let recordingError = error as? AudioRecordingService.AudioRecordingError,
-                      case .selectedInputDeviceIncompatible(let issue) = recordingError {
-                audioDeviceService.markRecordingInputSelectionCompatibility(
-                    .incompatible(issue),
-                    selection: resolvedInputSelection
-                )
-                errorMessage = recordingError.localizedDescription
-            } else {
-                errorMessage = error.localizedDescription
-            }
-            accessibilityAnnouncementService.announceError(errorMessage)
-            failDictationSession(id: sessionID, error: errorMessage)
-            showError(errorMessage, category: "recording")
-            hotkeyService.cancelDictation()
+            handleRecordingStartFailure(
+                error,
+                sessionID: sessionID,
+                resolvedInputSelection: resolvedInputSelection
+            )
         }
+    }
+
+    private func beginRecordingPreparation() {
+        promptPaletteHandler.hide()
+        recentTranscriptionPaletteHandler.hide()
+        modelManager.cancelAutoUnloadTimer()
+        state = .recording
+        partialText = ""
+        isStopInFlight = false
+        recordingStartTime = nil
+        stopRecordingTimer()
+    }
+
+    private func completeRecordingStart(
+        forcedWorkflowId: UUID?,
+        sessionID: UUID,
+        requestUptimeNanoseconds: UInt64,
+        startTimestamp: TimeInterval,
+        audioStartTimestamp: UInt64,
+        selectedInputUsesBluetooth: Bool,
+        initialForcedWorkflow: Workflow?
+    ) {
+        guard activeDictationSessionID == sessionID else { return }
+
+        let audioStartCompletedTimestamp = DispatchTime.now().uptimeNanoseconds
+        let audioStartMs = Self.elapsedMilliseconds(
+            from: audioStartTimestamp,
+            to: audioStartCompletedTimestamp
+        )
+        let requestToAudioStartMs = Self.elapsedMilliseconds(
+            from: requestUptimeNanoseconds,
+            to: audioStartCompletedTimestamp
+        )
+        promptPaletteHandler.hide()
+        recentTranscriptionPaletteHandler.hide()
+        modelManager.cancelAutoUnloadTimer()
+        if selectedInputUsesBluetooth {
+            logger.info("Skipping recording start sound for Bluetooth input device")
+        }
+        if mediaPauseEnabled { mediaPlaybackService.pauseIfPlaying() }
+        if audioDuckingEnabled {
+            pendingRecordingAudioDuckingLevel = max(0, min(1, Float(audioDuckingLevel)))
+        } else {
+            pendingRecordingAudioDuckingLevel = nil
+        }
+        state = .recording
+        // Reset hotkey timer so hybrid threshold counts from recording readiness,
+        // not from the key press or Bluetooth route preparation.
+        hotkeyService.resetKeyDownTime()
+        partialText = ""
+        isStopInFlight = false
+        recordingStartTime = Date()
+        startRecordingTimer()
+
+        let contextStartTimestamp = CFAbsoluteTimeGetCurrent()
+        // Match rule after the audio engine is live so app/context lookup does
+        // not delay capture of the user's first spoken words.
+        let activeApp = textInsertionService.captureActiveApp()
+        capturedActiveApp = activeApp
+        capturedSelectedText = nil
+        activeAppIcon = nil
+
+        if let forcedWorkflow = initialForcedWorkflow {
+            applyWorkflowMatch(workflowService.forcedWorkflowMatch(for: forcedWorkflow), activeApp: activeApp)
+        } else if let workflowMatch = workflowService.matchWorkflow(bundleIdentifier: activeApp.bundleId, url: nil) {
+            applyWorkflowMatch(workflowMatch, activeApp: activeApp)
+        } else {
+            clearActiveRuleState()
+        }
+        applyEffectiveMicrophoneBoostToAudioService()
+        if selectedInputUsesBluetooth {
+            // The asynchronous Bluetooth start only returns after the current
+            // engine generation has produced a confirmed ready stream.
+            firstRecordingAudioBufferSeen = true
+        }
+        updateRecordingStartCuePayload(activeApp: activeApp)
+        let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
+
+        startLiveStreaming(allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0)
+        scheduleDeferredRecordingMetadataCapture(
+            activeApp: activeApp,
+            forcedWorkflowId: forcedWorkflowId
+        )
+
+        let totalStartMs = (CFAbsoluteTimeGetCurrent() - startTimestamp) * 1000
+        logger.info(
+            "Recording started: requestToAudioStartMs=\(Self.formatMilliseconds(requestToAudioStartMs), privacy: .public), audioStartMs=\(Self.formatMilliseconds(audioStartMs), privacy: .public), contextMs=\(String(format: "%.1f", contextMs), privacy: .public), totalStartMs=\(String(format: "%.1f", totalStartMs), privacy: .public)"
+        )
+    }
+
+    private func handleRecordingStartFailure(
+        _ error: Error,
+        sessionID: UUID,
+        resolvedInputSelection: ResolvedRecordingInputSelection
+    ) {
+        clearRecordingStartCueState()
+        clearDeferredRecordingContext()
+        restoreRecordingSideEffects()
+        let errorMessage: String
+        if let recordingError = error as? AudioRecordingService.AudioRecordingError,
+           case .noMicrophoneDetected = recordingError {
+            errorMessage = String(localized: "No mic detected.")
+        } else if let recordingError = error as? AudioRecordingService.AudioRecordingError,
+                  case .selectedInputDeviceIncompatible(let issue) = recordingError {
+            audioDeviceService.markRecordingInputSelectionCompatibility(
+                .incompatible(issue),
+                selection: resolvedInputSelection
+            )
+            errorMessage = recordingError.localizedDescription
+        } else {
+            errorMessage = error.localizedDescription
+        }
+        accessibilityAnnouncementService.announceError(errorMessage)
+        failDictationSession(id: sessionID, error: errorMessage)
+        showError(errorMessage, category: "recording")
+        hotkeyService.cancelDictation()
     }
 
     private func scheduleDeferredRecordingMetadataCapture(
@@ -1340,6 +1458,12 @@ final class DictationViewModel: ObservableObject {
     private func stopDictation() {
         guard state == .recording, !isStopInFlight else { return }
         clearCancelWarning()
+        if recordingStartTask != nil, !isRecordingInputReady {
+            let cancelledMessage = String(localized: "Cancelled")
+            abortActiveRecordingImmediately(sessionMessage: cancelledMessage)
+            showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
+            return
+        }
         isStopInFlight = true
         state = .processing
         processingPhase = String(localized: "Processing...")
@@ -1928,6 +2052,9 @@ final class DictationViewModel: ObservableObject {
         stopFinalizationTask = nil
         transcriptionTask?.cancel()
         transcriptionTask = nil
+        recordingStartTask?.cancel()
+        recordingStartTask = nil
+        audioRecordingService.cancelPendingRecordingStart()
         urlResolutionTask?.cancel()
         urlResolutionTask = nil
         metadataCaptureTask?.cancel()

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -17,6 +17,9 @@ struct MinimalIndicatorView: View {
     }
 
     private var recordingWidth: CGFloat {
+        if presentation.isPreparingMicrophone {
+            return 220
+        }
         switch viewModel.notchIndicatorRightContent {
         case .none:
             return idleWidth
@@ -118,10 +121,7 @@ struct MinimalIndicatorView: View {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
-            if !presentation.isRecordingInputReady {
-                return String(localized: "Preparing microphone")
-            }
-            return String(localized: "Recording")
+            return presentation.recordingStatusLabel
         case .processing:
             return String(localized: "Processing transcription")
         case .inserting:
@@ -173,7 +173,7 @@ struct MinimalIndicatorView: View {
     private var compactStatus: some View {
         switch presentation.state {
         case .recording:
-            HStack(spacing: viewModel.notchIndicatorRightContent == .none ? 0 : 8) {
+            HStack(spacing: presentation.isPreparingMicrophone || viewModel.notchIndicatorRightContent != .none ? 8 : 0) {
                 IndicatorLeftStatus(
                     presentation: presentation,
                     sizing: sizing,
@@ -181,7 +181,9 @@ struct MinimalIndicatorView: View {
                     hasActionFeedback: false
                 )
 
-                if viewModel.notchIndicatorRightContent != .none {
+                if presentation.isPreparingMicrophone {
+                    IndicatorPreparingLabel(presentation: presentation, sizing: sizing)
+                } else if viewModel.notchIndicatorRightContent != .none {
                     IndicatorRecordingContent(
                         presentation: presentation,
                         content: viewModel.notchIndicatorRightContent,

--- a/TypeWhisper/Views/NotchIndicatorLayout.swift
+++ b/TypeWhisper/Views/NotchIndicatorLayout.swift
@@ -66,6 +66,31 @@ enum NotchIndicatorLayout {
         return max(baseWidth, candidateWidth)
     }
 
+    static func preparingClosedWidth(
+        hasNotch: Bool,
+        notchWidth: CGFloat,
+        label: String
+    ) -> CGFloat {
+        let baseWidth = closedWidth(hasNotch: hasNotch, notchWidth: notchWidth)
+        let labelWidth = measureTextWidth(
+            label,
+            font: NSFont.systemFont(
+                ofSize: IndicatorSizing.notch.profileFontSize,
+                weight: .medium
+            )
+        )
+        let requiredContentWidth = leadingInset
+            + IndicatorSizing.notch.iconSize
+            + leftContentSpacing
+            + labelWidth
+            + trailingInset
+            + widthSafetyBuffer
+        let candidateWidth = hasNotch
+            ? notchWidth + requiredContentWidth
+            : requiredContentWidth
+        return max(baseWidth, candidateWidth)
+    }
+
     static func reservedTimerText(for seconds: TimeInterval) -> String {
         let totalSeconds = max(0, Int(seconds))
         let minuteDigits = max(2, String(totalSeconds / 60).count)

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -23,6 +23,13 @@ struct NotchIndicatorView: View {
 
     private var closedWidth: CGFloat {
         if case .recording = presentation.state {
+            if presentation.isPreparingMicrophone {
+                return NotchIndicatorLayout.preparingClosedWidth(
+                    hasNotch: geometry.hasNotch,
+                    notchWidth: geometry.notchWidth,
+                    label: presentation.recordingStatusLabel
+                )
+            }
             return NotchIndicatorLayout.recordingClosedWidth(
                 hasNotch: geometry.hasNotch,
                 notchWidth: geometry.notchWidth,
@@ -39,6 +46,9 @@ struct NotchIndicatorView: View {
     private var leftStatusSpacing: CGFloat {
         guard case .recording = presentation.state else {
             return 0
+        }
+        if presentation.isPreparingMicrophone {
+            return NotchIndicatorLayout.leftContentSpacing
         }
 
         let leftContentWidth = NotchIndicatorLayout.recordingContentWidth(
@@ -205,10 +215,7 @@ struct NotchIndicatorView: View {
             if let warning = presentation.cancelWarningMessage {
                 return warning
             }
-            if !presentation.isRecordingInputReady {
-                return String(localized: "Preparing microphone")
-            }
-            return String(localized: "Recording")
+            return presentation.recordingStatusLabel
         case .processing:
             if let warning = presentation.cancelWarningMessage {
                 return warning
@@ -314,24 +321,30 @@ struct NotchIndicatorView: View {
     @ViewBuilder
     private var leftContent: some View {
         if case .recording = presentation.state {
-            IndicatorRecordingContent(
-                presentation: presentation,
-                content: viewModel.notchIndicatorLeftContent,
-                sizing: sizing,
-                dotPulse: dotPulse
-            )
+            if presentation.isPreparingMicrophone {
+                IndicatorPreparingLabel(presentation: presentation, sizing: sizing)
+            } else {
+                IndicatorRecordingContent(
+                    presentation: presentation,
+                    content: viewModel.notchIndicatorLeftContent,
+                    sizing: sizing,
+                    dotPulse: dotPulse
+                )
+            }
         }
     }
 
     @ViewBuilder
     private var rightContent: some View {
         if case .recording = presentation.state {
-            IndicatorRecordingContent(
-                presentation: presentation,
-                content: viewModel.notchIndicatorRightContent,
-                sizing: sizing,
-                dotPulse: dotPulse
-            )
+            if !presentation.isPreparingMicrophone {
+                IndicatorRecordingContent(
+                    presentation: presentation,
+                    content: viewModel.notchIndicatorRightContent,
+                    sizing: sizing,
+                    dotPulse: dotPulse
+                )
+            }
         } else if case .processing = presentation.state {
             ProgressView()
                 .controlSize(.mini)

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -183,10 +183,7 @@ struct OverlayIndicatorView: View {
         case .idle, .promptSelection, .promptProcessing:
             return String(localized: "Idle")
         case .recording:
-            if !presentation.isRecordingInputReady {
-                return String(localized: "Preparing microphone")
-            }
-            return String(localized: "Recording")
+            return presentation.recordingStatusLabel
         case .processing:
             return String(localized: "Processing transcription")
         case .inserting:
@@ -276,23 +273,29 @@ struct OverlayIndicatorView: View {
             )
 
             if case .recording = presentation.state {
-                IndicatorRecordingContent(
-                    presentation: presentation,
-                    content: viewModel.notchIndicatorLeftContent,
-                    sizing: sizing,
-                    dotPulse: dotPulse
-                )
+                if presentation.isPreparingMicrophone {
+                    IndicatorPreparingLabel(presentation: presentation, sizing: sizing)
+                } else {
+                    IndicatorRecordingContent(
+                        presentation: presentation,
+                        content: viewModel.notchIndicatorLeftContent,
+                        sizing: sizing,
+                        dotPulse: dotPulse
+                    )
+                }
             }
 
             Spacer()
 
             if case .recording = presentation.state {
-                IndicatorRecordingContent(
-                    presentation: presentation,
-                    content: viewModel.notchIndicatorRightContent,
-                    sizing: sizing,
-                    dotPulse: dotPulse
-                )
+                if !presentation.isPreparingMicrophone {
+                    IndicatorRecordingContent(
+                        presentation: presentation,
+                        content: viewModel.notchIndicatorRightContent,
+                        sizing: sizing,
+                        dotPulse: dotPulse
+                    )
+                }
             } else if case .processing = presentation.state {
                 if let phase = presentation.processingPhase {
                     Text(phase)

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -97,7 +97,7 @@ struct IndicatorLeftStatus: View {
         case .idle, .promptSelection, .promptProcessing:
             Color.clear.frame(width: 0, height: 0)
         case .recording:
-            if !presentation.isRecordingInputReady {
+            if presentation.isPreparingMicrophone {
                 IndicatorPreparingView(sizing: sizing)
             } else if let icon = presentation.activeAppIcon {
                 IndicatorAppIconView(icon: icon, sizing: sizing)
@@ -148,6 +148,20 @@ struct IndicatorPreparingView: View {
     }
 }
 
+struct IndicatorPreparingLabel: View {
+    let presentation: IndicatorPresentationData
+    let sizing: IndicatorSizing
+
+    var body: some View {
+        Text(presentation.recordingStatusLabel)
+            .font(.system(size: sizing.profileFontSize, weight: .medium))
+            .foregroundStyle(.white.opacity(sizing.timerOpacity))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityLabel(presentation.recordingStatusLabel)
+    }
+}
+
 // MARK: - Recording Dot
 
 struct IndicatorDot: View {
@@ -176,23 +190,27 @@ struct IndicatorRecordingContent: View {
     var body: some View {
         switch content {
         case .indicator:
-            if presentation.isRecordingInputReady {
-                IndicatorDot(audioLevel: presentation.audioLevel, dotPulse: dotPulse, sizing: sizing)
-            } else {
+            if presentation.isPreparingMicrophone {
                 IndicatorPreparingView(sizing: sizing)
+            } else {
+                IndicatorDot(audioLevel: presentation.audioLevel, dotPulse: dotPulse, sizing: sizing)
             }
         case .timer:
-            Text(formatDuration(presentation.recordingDuration))
-                .font(.system(size: sizing.timerFontSize, weight: .medium).monospacedDigit())
-                .foregroundStyle(.white.opacity(sizing.timerOpacity))
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                .accessibilityLabel(String(localized: "Recording timer"))
-                .accessibilityValue(formatDuration(presentation.recordingDuration))
+            if presentation.isPreparingMicrophone {
+                IndicatorPreparingLabel(presentation: presentation, sizing: sizing)
+            } else {
+                Text(formatDuration(presentation.recordingDuration))
+                    .font(.system(size: sizing.timerFontSize, weight: .medium).monospacedDigit())
+                    .foregroundStyle(.white.opacity(sizing.timerOpacity))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .accessibilityLabel(String(localized: "Recording timer"))
+                    .accessibilityValue(formatDuration(presentation.recordingDuration))
+            }
         case .waveform:
             AudioWaveformView(
                 audioLevel: presentation.audioLevel,
-                isSetup: !presentation.isRecordingInputReady || (presentation.recordingDuration < 0.5 && presentation.audioLevel < 0.05),
+                isSetup: presentation.isPreparingMicrophone || (presentation.recordingDuration < 0.5 && presentation.audioLevel < 0.05),
                 compact: true
             )
         case .profile:

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -337,6 +337,19 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertEqual(coordinator.finishRecovery(), .none)
     }
 
+    func testConfigurationChangeDuringReadinessCanBeConsumedByEngineReplacement() {
+        let coordinator = AudioEngineRecoveryCoordinator()
+
+        coordinator.beginStarting()
+        XCTAssertEqual(coordinator.noteConfigurationChange(), .none)
+        XCTAssertTrue(coordinator.hasPendingConfigurationChange)
+
+        coordinator.consumePendingConfigurationChangeForEngineReplacement()
+
+        XCTAssertFalse(coordinator.hasPendingConfigurationChange)
+        XCTAssertEqual(coordinator.finishStartingSuccessfully(), .none)
+    }
+
     func testConfigurationChangeWithinQuiescenceWindow_preservesStartupRecoveryPath() {
         let clock = TestClock()
         let coordinator = AudioEngineRecoveryCoordinator(now: { clock.now })
@@ -1966,7 +1979,7 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertFalse(service.selectedDeviceUsesBluetoothTransport)
     }
 
-    func testBluetoothInputReadinessProbeTimesOutWithNoInitialInput() {
+    func testBluetoothInputReadinessTimesOutWhenNoBuffersArrive() {
         let clock = FakeReadinessClock()
         let checker = BluetoothInputReadinessChecker(
             timeout: 0.002,
@@ -1977,8 +1990,10 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
 
         XCTAssertThrowsError(try checker.waitForInitialInput(
             label: "test",
-            hasCapturedInitialInput: { false },
-            isEngineRunning: nil
+            deadline: nil,
+            readinessSnapshot: { nil },
+            isEngineRunning: nil,
+            shouldCancel: { false }
         )) { error in
             guard case AudioRecordingService.AudioRecordingError.noAudioData = error else {
                 return XCTFail("Expected noAudioData, got \(error)")
@@ -1986,7 +2001,58 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         }
     }
 
-    func testBluetoothInputReadinessThrowsRetryableErrorWhenEngineStopsBeforeInitialInput() {
+    func testBluetoothInputReadinessHonorsSharedFiveSecondDeadline() {
+        let clock = FakeReadinessClock()
+        let checker = BluetoothInputReadinessChecker(
+            timeout: 30,
+            missingBufferRecoveryInterval: .infinity,
+            pollInterval: 0.1,
+            now: { clock.now },
+            sleep: { clock.now += $0 }
+        )
+
+        XCTAssertThrowsError(try checker.waitForInitialInput(
+            label: "test",
+            deadline: 5,
+            readinessSnapshot: { nil },
+            isEngineRunning: nil,
+            shouldCancel: { false }
+        )) { error in
+            guard case AudioRecordingService.AudioRecordingError.noAudioData = error else {
+                return XCTFail("Expected noAudioData, got \(error)")
+            }
+        }
+        XCTAssertEqual(clock.now, 5, accuracy: 0.001)
+    }
+
+    func testBluetoothInputReadinessTreatsMissingBuffersAsRetryable() {
+        let clock = FakeReadinessClock()
+        let checker = BluetoothInputReadinessChecker(
+            timeout: 5,
+            missingBufferRecoveryInterval: 0.2,
+            pollInterval: 0.05,
+            now: { clock.now },
+            sleep: { clock.now += $0 }
+        )
+
+        XCTAssertThrowsError(try checker.waitForInitialInput(
+            label: "test",
+            deadline: nil,
+            readinessSnapshot: { nil },
+            isEngineRunning: nil,
+            shouldCancel: { false }
+        )) { error in
+            XCTAssertEqual(
+                (error as NSError).domain,
+                AudioEngineRecoveryErrorDomains.transientFormatMismatch
+            )
+            XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: error))
+        }
+        XCTAssertGreaterThanOrEqual(clock.now, 0.2)
+        XCTAssertLessThan(clock.now, 1)
+    }
+
+    func testBluetoothInputReadinessThrowsRetryableErrorWhenEngineStopsBeforeReadiness() {
         let clock = FakeReadinessClock()
         let checker = BluetoothInputReadinessChecker(
             timeout: 0.05,
@@ -1998,11 +2064,13 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
 
         XCTAssertThrowsError(try checker.waitForInitialInput(
             label: "test",
-            hasCapturedInitialInput: { false },
+            deadline: nil,
+            readinessSnapshot: { nil },
             isEngineRunning: {
                 engineRunningProbeCalls += 1
                 return engineRunningProbeCalls == 1
-            }
+            },
+            shouldCancel: { false }
         )) { error in
             let nsError = error as NSError
             XCTAssertEqual(nsError.domain, AudioEngineRecoveryErrorDomains.transientFormatMismatch)
@@ -2011,66 +2079,337 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(engineRunningProbeCalls, 2)
     }
 
-    func testBluetoothInputReadinessProbeSucceedsWhenInitialInputArrives() {
+    func testBluetoothInputReadinessRejectsReadyCandidateAfterRouteChange() {
+        let checker = BluetoothInputReadinessChecker()
+
+        XCTAssertThrowsError(try checker.waitForInitialInput(
+            label: "test",
+            deadline: nil,
+            readinessSnapshot: {
+                AudioInputReadinessSnapshot(
+                    generation: 1,
+                    consecutiveBufferCount: 3,
+                    buffersSinceSignal: 3,
+                    continuousDuration: 0.02,
+                    lastBufferTimestamp: 0
+                )
+            },
+            isEngineRunning: { false },
+            shouldCancel: { false }
+        )) { error in
+            XCTAssertEqual(
+                (error as NSError).domain,
+                AudioEngineRecoveryErrorDomains.transientFormatMismatch
+            )
+            XCTAssertTrue(AudioEngineRecoveryPolicy.isRetryable(error: error))
+        }
+    }
+
+    func testBluetoothInputReadinessAcceptsSignalBeginningAfterOneAndAHalfSeconds() {
         let clock = FakeReadinessClock()
         let checker = BluetoothInputReadinessChecker(
-            timeout: 0.05,
-            pollInterval: 0.001,
+            timeout: 5,
+            pollInterval: 0.05,
             now: { clock.now },
             sleep: { clock.now += $0 }
         )
-        var probeCalls = 0
-        let probe = {
-            probeCalls += 1
-            return probeCalls >= 2
-        }
 
         XCTAssertNoThrow(try checker.waitForInitialInput(
             label: "test",
-            hasCapturedInitialInput: probe,
-            isEngineRunning: nil
+            deadline: nil,
+            readinessSnapshot: {
+                guard clock.now >= 1.5 else { return nil }
+                let buffersSinceSignal = min(3, 1 + Int((clock.now - 1.5) / 0.1))
+                return AudioInputReadinessSnapshot(
+                    generation: 1,
+                    consecutiveBufferCount: buffersSinceSignal,
+                    buffersSinceSignal: buffersSinceSignal,
+                    continuousDuration: clock.now - 1.5,
+                    lastBufferTimestamp: clock.now
+                )
+            },
+            isEngineRunning: nil,
+            shouldCancel: { false }
         ))
-        XCTAssertGreaterThanOrEqual(probeCalls, 2)
+        XCTAssertGreaterThanOrEqual(clock.now, 1.7)
+        XCTAssertLessThan(clock.now, 2)
     }
 
-    func testBluetoothInputReadinessDoesNotAcceptZeroFilledTapCallback() throws {
+    func testBluetoothInputReadinessAcceptsImmediateStableSignal() {
         let clock = FakeReadinessClock()
-        let service = AudioRecordingService(
-            inputReadinessChecker: BluetoothInputReadinessChecker(
-                timeout: 0.002,
-                pollInterval: 0.001,
-                now: { clock.now },
-                sleep: { clock.now += $0 }
-            )
+        let checker = BluetoothInputReadinessChecker(
+            timeout: 5,
+            now: { clock.now },
+            sleep: { clock.now += $0 }
         )
-        service.hasExplicitDeviceSelection = true
-        service.selectedInputDeviceUsesBluetoothTransport = true
 
-        try service.testingMarkInitialInputTapSeen(makeMonoBuffer(samples: [0, 0, 0, 0]))
+        XCTAssertNoThrow(try checker.waitForInitialInput(
+            label: "test",
+            deadline: nil,
+            readinessSnapshot: {
+                AudioInputReadinessSnapshot(
+                    generation: 1,
+                    consecutiveBufferCount: 3,
+                    buffersSinceSignal: 3,
+                    continuousDuration: 0.02,
+                    lastBufferTimestamp: clock.now
+                )
+            },
+            isEngineRunning: nil,
+            shouldCancel: { false }
+        ))
+        XCTAssertEqual(clock.now, 0)
+    }
 
-        XCTAssertThrowsError(try service.testingWaitForInitialInputReadinessIfNeeded()) { error in
-            guard case AudioRecordingService.AudioRecordingError.noAudioData = error else {
-                return XCTFail("Expected noAudioData, got \(error)")
-            }
+    func testBluetoothInputReadinessUsesThreeSecondSilentStreamFallback() {
+        let clock = FakeReadinessClock()
+        let checker = BluetoothInputReadinessChecker(
+            timeout: 5,
+            silentFallback: 3,
+            pollInterval: 0.1,
+            now: { clock.now },
+            sleep: { clock.now += $0 }
+        )
+
+        XCTAssertNoThrow(try checker.waitForInitialInput(
+            label: "test",
+            deadline: nil,
+            readinessSnapshot: {
+                AudioInputReadinessSnapshot(
+                    generation: 1,
+                    consecutiveBufferCount: max(3, Int(clock.now / 0.1)),
+                    buffersSinceSignal: 0,
+                    continuousDuration: clock.now,
+                    lastBufferTimestamp: clock.now
+                )
+            },
+            isEngineRunning: nil,
+            shouldCancel: { false }
+        ))
+        XCTAssertGreaterThanOrEqual(clock.now, 3)
+        XCTAssertLessThan(clock.now, 3.2)
+    }
+
+    func testBluetoothInputReadinessTreatsStagnatingBuffersAsRetryable() {
+        let clock = FakeReadinessClock()
+        let checker = BluetoothInputReadinessChecker(
+            timeout: 5,
+            maximumBufferGap: 0.25,
+            pollInterval: 0.1,
+            now: { clock.now },
+            sleep: { clock.now += $0 }
+        )
+
+        XCTAssertThrowsError(try checker.waitForInitialInput(
+            label: "test",
+            deadline: nil,
+            readinessSnapshot: {
+                AudioInputReadinessSnapshot(
+                    generation: 1,
+                    consecutiveBufferCount: 1,
+                    buffersSinceSignal: 0,
+                    continuousDuration: 0,
+                    lastBufferTimestamp: 0
+                )
+            },
+            isEngineRunning: nil,
+            shouldCancel: { false }
+        )) { error in
+            XCTAssertEqual(
+                (error as NSError).domain,
+                AudioEngineRecoveryErrorDomains.transientFormatMismatch
+            )
         }
     }
 
-    func testBluetoothInputReadinessSucceedsWhenTapCallbackContainsSignalBeforeConvertedSamples() throws {
+    func testBluetoothInputReadinessCanBeCancelledBeforeReady() {
         let clock = FakeReadinessClock()
-        let service = AudioRecordingService(
-            inputReadinessChecker: BluetoothInputReadinessChecker(
-                timeout: 0.01,
-                pollInterval: 0.001,
-                now: { clock.now },
-                sleep: { clock.now += $0 }
-            )
+        let checker = BluetoothInputReadinessChecker(
+            timeout: 5,
+            pollInterval: 0.1,
+            now: { clock.now },
+            sleep: { clock.now += $0 }
         )
-        service.hasExplicitDeviceSelection = true
+
+        XCTAssertThrowsError(try checker.waitForInitialInput(
+            label: "test",
+            deadline: nil,
+            readinessSnapshot: { nil },
+            isEngineRunning: nil,
+            shouldCancel: { clock.now >= 0.2 }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertLessThan(clock.now, 1)
+    }
+
+    func testBluetoothRouteStabilizationCanBeCancelledBeforeTimeout() {
+        let clock = FakeReadinessClock()
+
+        XCTAssertFalse(BluetoothAudioRouteStabilizer.waitForActivatedDefaultRoute(
+            inputDeviceID: AudioDeviceID(938),
+            reason: "test",
+            timeout: 5,
+            stableDuration: 0.25,
+            pollInterval: 0.1,
+            now: { clock.now },
+            sleep: { clock.now += $0 },
+            readDefaultInput: { AudioDeviceID(1) },
+            shouldCancel: { clock.now >= 0.2 }
+        ))
+        XCTAssertEqual(clock.now, 0.2, accuracy: 0.001)
+    }
+
+    func testBluetoothInputStartupTrackerRejectsOldGenerationsAndPromotesOnlyCurrentSamples() throws {
+        let clock = FakeReadinessClock()
+        let tracker = BluetoothInputStartupTracker(now: { clock.now })
+        let firstGeneration = tracker.beginGeneration()
+
+        XCTAssertEqual(
+            tracker.consume(samples: [0.2, 0.1], inputRMS: 0.15, generation: firstGeneration),
+            .staged
+        )
+
+        clock.now = 0.1
+        let secondGeneration = tracker.beginGeneration()
+        XCTAssertEqual(
+            tracker.consume(samples: [0.9], inputRMS: 0.9, generation: firstGeneration),
+            .ignored
+        )
+        XCTAssertNil(tracker.snapshot(for: firstGeneration))
+
+        XCTAssertEqual(
+            tracker.consume(samples: [0, 0.3], inputRMS: 0.2, generation: secondGeneration),
+            .staged
+        )
+        clock.now = 0.15
+        XCTAssertEqual(
+            tracker.consume(samples: [0.4], inputRMS: 0.4, generation: secondGeneration),
+            .staged
+        )
+        clock.now = 0.2
+        XCTAssertEqual(
+            tracker.consume(samples: [0.5], inputRMS: 0.5, generation: secondGeneration),
+            .staged
+        )
+
+        let snapshot = try XCTUnwrap(tracker.snapshot(for: secondGeneration))
+        XCTAssertEqual(snapshot.buffersSinceSignal, 3)
+        XCTAssertEqual(snapshot.consecutiveBufferCount, 3)
+
+        let promotion = try XCTUnwrap(tracker.promoteCurrentGeneration())
+        XCTAssertEqual(promotion.generation, secondGeneration)
+        XCTAssertEqual(promotion.samples, [0, 0.3, 0.4, 0.5])
+        XCTAssertEqual(promotion.peakInputRMS, 0.5)
+        XCTAssertEqual(
+            tracker.consume(samples: [0.6], inputRMS: 0.6, generation: secondGeneration),
+            .appendDirectly
+        )
+        XCTAssertNil(tracker.promoteCurrentGeneration())
+    }
+
+    func testAsyncRecordingStartCancellationDuringPreparationDoesNotBecomeRecording() async throws {
+        let recoveryDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(recoveryDirectory) }
+        let enteredStart = expectation(description: "async Bluetooth start entered")
+        let releaseStart = DispatchSemaphore(value: 0)
+        defer { releaseStart.signal() }
+        let inputActivationGuard = FakeAudioInputDeviceActivator()
+        let routeStabilizer = FakeBluetoothInputRouteStabilizer { _, _ in true }
+        let service = AudioRecordingService(
+            inputActivationGuard: inputActivationGuard,
+            bluetoothInputRouteStabilizer: routeStabilizer,
+            recoveryAudioStore: DictationRecoveryAudioStore(directory: recoveryDirectory)
+        )
+        service.hasMicrophonePermissionOverride = true
+        service.hasExplicitDeviceSelection = false
+        service.selectedDeviceID = AudioDeviceID(938)
         service.selectedInputDeviceUsesBluetoothTransport = true
+        service.startRecordingOverride = {
+            enteredStart.fulfill()
+            releaseStart.wait()
+        }
 
-        try service.testingMarkInitialInputTapSeen(makeMonoBuffer(samples: [0, 0.002, 0, -0.001]))
+        let startTask = Task {
+            try await service.startRecordingAsync()
+        }
 
-        XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded())
+        await fulfillment(of: [enteredStart], timeout: 1)
+        service.cancelPendingRecordingStart()
+        releaseStart.signal()
+
+        do {
+            try await startTask.value
+            XCTFail("Expected Bluetooth preparation to be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        XCTAssertFalse(service.isRecording)
+        XCTAssertTrue(service.getCurrentBuffer().isEmpty)
+        XCTAssertTrue(service.recoveryRecordingURLs.isEmpty)
+        XCTAssertEqual(inputActivationGuard.restoreCalls, ["recording-start-override-failed"])
+    }
+
+    func testAsyncRecordingStartCancelReadyRaceLeavesAConsistentState() async throws {
+        let raceQueue = DispatchQueue(
+            label: "com.typewhisper.tests.audio-start-race",
+            attributes: .concurrent
+        )
+
+        for iteration in 0..<12 {
+            let recoveryDirectory = try TestSupport.makeTemporaryDirectory()
+            defer { TestSupport.remove(recoveryDirectory) }
+            let enteredStart = expectation(description: "race start entered \(iteration)")
+            let releaseStart = DispatchSemaphore(value: 0)
+            let service = AudioRecordingService(
+                inputActivationGuard: FakeAudioInputDeviceActivator(),
+                bluetoothInputRouteStabilizer: FakeBluetoothInputRouteStabilizer { _, _ in true },
+                recoveryAudioStore: DictationRecoveryAudioStore(directory: recoveryDirectory)
+            )
+            service.hasMicrophonePermissionOverride = true
+            service.hasExplicitDeviceSelection = false
+            service.selectedDeviceID = AudioDeviceID(938)
+            service.selectedInputDeviceUsesBluetoothTransport = true
+            service.startRecordingOverride = {
+                enteredStart.fulfill()
+                releaseStart.wait()
+            }
+            service.stopRecordingOverride = { _ in [] }
+
+            let startTask = Task {
+                try await service.startRecordingAsync()
+            }
+            await fulfillment(of: [enteredStart], timeout: 1)
+
+            let raceFinished = expectation(description: "cancel/ready race finished \(iteration)")
+            raceFinished.expectedFulfillmentCount = 2
+            raceQueue.async {
+                service.cancelPendingRecordingStart()
+                raceFinished.fulfill()
+            }
+            raceQueue.async {
+                releaseStart.signal()
+                raceFinished.fulfill()
+            }
+            await fulfillment(of: [raceFinished], timeout: 1)
+
+            do {
+                try await startTask.value
+                XCTAssertTrue(service.isRecording)
+                _ = await service.stopRecording(policy: .immediate)
+                service.discardActiveRecoveryRecording()
+            } catch is CancellationError {
+                XCTAssertFalse(service.isRecording)
+            } catch {
+                XCTFail("Expected a committed start or CancellationError, got \(error)")
+            }
+
+            XCTAssertFalse(service.isRecording)
+            XCTAssertTrue(service.recoveryRecordingURLs.isEmpty)
+        }
     }
 
     func testBluetoothInputReadinessRunsForSystemDefaultWithoutExplicitSelection() {
@@ -2078,8 +2417,9 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         let service = AudioRecordingService(inputReadinessChecker: readinessChecker)
         service.hasExplicitDeviceSelection = false
         service.selectedInputDeviceUsesBluetoothTransport = true
+        let generation = service.testingBeginBluetoothInputGeneration()
 
-        XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded())
+        XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded(generation: generation))
         XCTAssertEqual(readinessChecker.waitCalls, [.init(label: "test")])
     }
 
@@ -2089,7 +2429,7 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         service.hasExplicitDeviceSelection = true
         service.selectedInputDeviceUsesBluetoothTransport = false
 
-        XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded())
+        XCTAssertNoThrow(try service.testingWaitForInitialInputReadinessIfNeeded(generation: 1))
         XCTAssertTrue(readinessChecker.waitCalls.isEmpty)
     }
 
@@ -3143,7 +3483,7 @@ private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating,
     }
 }
 
-private final class FakeReadinessClock {
+private final class FakeReadinessClock: @unchecked Sendable {
     var now: TimeInterval = 0
 }
 
@@ -3156,8 +3496,10 @@ private final class FakeAudioInputReadinessChecker: AudioInputReadinessChecking 
 
     func waitForInitialInput(
         label: String,
-        hasCapturedInitialInput: () -> Bool,
-        isEngineRunning: (() -> Bool)?
+        deadline: TimeInterval?,
+        readinessSnapshot: () -> AudioInputReadinessSnapshot?,
+        isEngineRunning: (() -> Bool)?,
+        shouldCancel: () -> Bool
     ) throws {
         waitCalls.append(.init(label: label))
     }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -937,6 +937,26 @@ final class MenuBarIconStateTests: XCTestCase {
 }
 
 final class IndicatorPresentationStateTests: XCTestCase {
+    private func makeRecordingPresentation(isInputReady: Bool) -> IndicatorPresentationData {
+        IndicatorPresentationData(
+            source: .dictation,
+            state: .recording,
+            recordingDuration: 0,
+            audioLevel: 0,
+            partialText: "",
+            activeRuleName: nil,
+            activeAppIcon: nil,
+            isRecordingInputReady: isInputReady,
+            cancelWarningMessage: nil,
+            processingPhase: nil,
+            actionFeedbackMessage: nil,
+            actionFeedbackIcon: nil,
+            actionFeedbackIsError: false,
+            actionFeedbackUndoTitle: nil,
+            externalStreamingDisplayCount: 0
+        )
+    }
+
     func testRecorderRecordingShowsRecordingPresentationWhenDictationIsIdle() {
         let presentation = IndicatorPresentationState.resolve(
             dictationState: .idle,
@@ -1004,6 +1024,28 @@ final class IndicatorPresentationStateTests: XCTestCase {
         XCTAssertFalse(IndicatorPresentationState.shouldShow(
             visibility: .never,
             presentation: recorderPresentation
+        ))
+    }
+
+    func testBluetoothPreparationUsesSharedPreparingMicrophonePresentation() {
+        let preparing = makeRecordingPresentation(isInputReady: false)
+        let ready = makeRecordingPresentation(isInputReady: true)
+
+        XCTAssertTrue(preparing.isPreparingMicrophone)
+        XCTAssertEqual(preparing.recordingStatusLabel, String(localized: "Preparing microphone"))
+        XCTAssertFalse(ready.isPreparingMicrophone)
+        XCTAssertEqual(ready.recordingStatusLabel, String(localized: "Recording"))
+    }
+
+    func testNeverVisibilityStillSuppressesMicrophonePreparation() {
+        let preparing = IndicatorPresentationState.resolve(
+            dictationState: .recording,
+            recorderState: .idle
+        )
+
+        XCTAssertFalse(IndicatorPresentationState.shouldShow(
+            visibility: .never,
+            presentation: preparing
         ))
     }
 }
@@ -1167,6 +1209,16 @@ final class LanguageLocalizationTests: XCTestCase {
 
         XCTAssertEqual(options.map(\.code), ["de", "en"])
         XCTAssertEqual(options.map(\.name), ["German", "English"])
+    }
+
+    func testPreparingMicrophoneHasGermanLocalization() throws {
+        XCTAssertEqual(
+            try TestSupport.localizedCatalogValue(
+                for: "Preparing microphone",
+                language: "de"
+            ),
+            "Mikrofon wird vorbereitet …"
+        )
     }
 
     func testLanguageSearchTermsIncludeEnglishAliasForEnglish() {

--- a/TypeWhisperTests/DictionaryTrainingServiceTests.swift
+++ b/TypeWhisperTests/DictionaryTrainingServiceTests.swift
@@ -317,6 +317,7 @@ final class DictionaryTrainingServiceTests: XCTestCase {
     func testCancelDuringMicrophonePreparationCancelsPendingAudioStart() async {
         let snapshot = makeSnapshot()
         var startContinuation: CheckedContinuation<Void, Error>?
+        let recordingStartEntered = expectation(description: "recording start entered")
         var cancelStartCount = 0
         var stopCount = 0
         var discardCount = 0
@@ -327,6 +328,7 @@ final class DictionaryTrainingServiceTests: XCTestCase {
             startRecording: {
                 try await withCheckedThrowingContinuation { continuation in
                     startContinuation = continuation
+                    recordingStartEntered.fulfill()
                 }
             },
             cancelRecordingStart: {
@@ -351,9 +353,8 @@ final class DictionaryTrainingServiceTests: XCTestCase {
             await service.startRecording(sampleID: sampleID)
         }
 
-        for _ in 0..<20 where startContinuation == nil {
-            await Task.yield()
-        }
+        await fulfillment(of: [recordingStartEntered], timeout: 1)
+        XCTAssertNotNil(startContinuation)
         XCTAssertEqual(service.samples[0].state, .preparing)
 
         await service.cancel()
@@ -364,6 +365,55 @@ final class DictionaryTrainingServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(discardCount, 1)
         XCTAssertEqual(service.stage, .word)
         XCTAssertTrue(service.samples.isEmpty)
+    }
+
+    @MainActor
+    func testReplacedTrainingSamplesCannotBeMutatedByLateRecordingStart() async {
+        let snapshot = makeSnapshot()
+        var startContinuation: CheckedContinuation<Void, Never>?
+        let recordingStartEntered = expectation(description: "recording start entered")
+        var stopCount = 0
+        var discardCount = 0
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {
+                await withCheckedContinuation { continuation in
+                    startContinuation = continuation
+                    recordingStartEntered.fulfill()
+                }
+            },
+            stopRecording: {
+                stopCount += 1
+                return []
+            },
+            discardActiveRecording: { discardCount += 1 },
+            transcribe: { _ in "unused" },
+            dictionaryEntries: { [] },
+            commit: { [self] _, _ in self.emptyCommitResult() }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        let originalSampleID = service.samples[0].id
+        let startTask = Task { @MainActor in
+            await service.startRecording(sampleID: originalSampleID)
+        }
+
+        await fulfillment(of: [recordingStartEntered], timeout: 1)
+        service.canonicalWord = "WhisperFlow"
+        service.beginTraining(localeIdentifier: "en_US")
+        let replacementSampleIDs = service.samples.map(\.id)
+
+        startContinuation?.resume()
+        startContinuation = nil
+        await startTask.value
+
+        XCTAssertEqual(service.samples.map(\.id), replacementSampleIDs)
+        XCTAssertTrue(service.samples.allSatisfy { $0.state == .pending })
+        XCTAssertEqual(stopCount, 1)
+        XCTAssertGreaterThanOrEqual(discardCount, 1)
     }
 
     @MainActor

--- a/TypeWhisperTests/DictionaryTrainingServiceTests.swift
+++ b/TypeWhisperTests/DictionaryTrainingServiceTests.swift
@@ -314,6 +314,59 @@ final class DictionaryTrainingServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testCancelDuringMicrophonePreparationCancelsPendingAudioStart() async {
+        let snapshot = makeSnapshot()
+        var startContinuation: CheckedContinuation<Void, Error>?
+        var cancelStartCount = 0
+        var stopCount = 0
+        var discardCount = 0
+        let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(
+            engineSnapshot: { snapshot },
+            canTranscribe: { true },
+            requestMicrophonePermission: { true },
+            startRecording: {
+                try await withCheckedThrowingContinuation { continuation in
+                    startContinuation = continuation
+                }
+            },
+            cancelRecordingStart: {
+                cancelStartCount += 1
+                startContinuation?.resume(throwing: CancellationError())
+                startContinuation = nil
+            },
+            stopRecording: {
+                stopCount += 1
+                return []
+            },
+            discardActiveRecording: { discardCount += 1 },
+            transcribe: { _ in "unused" },
+            dictionaryEntries: { [] },
+            commit: { [self] _, _ in self.emptyCommitResult() }
+        ))
+
+        service.canonicalWord = "TypeWhisper"
+        service.beginTraining(localeIdentifier: "en_US")
+        let sampleID = service.samples[0].id
+        let startTask = Task { @MainActor in
+            await service.startRecording(sampleID: sampleID)
+        }
+
+        for _ in 0..<20 where startContinuation == nil {
+            await Task.yield()
+        }
+        XCTAssertEqual(service.samples[0].state, .preparing)
+
+        await service.cancel()
+        await startTask.value
+
+        XCTAssertEqual(cancelStartCount, 1)
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertGreaterThanOrEqual(discardCount, 1)
+        XCTAssertEqual(service.stage, .word)
+        XCTAssertTrue(service.samples.isEmpty)
+    }
+
+    @MainActor
     func testLateTranscriptionResultCannotMutateCancelledSession() async {
         let snapshot = makeSnapshot()
         let service = DictionaryTrainingService(dependencies: DictionaryTrainingDependencies(

--- a/TypeWhisperTests/NotchIndicatorLayoutTests.swift
+++ b/TypeWhisperTests/NotchIndicatorLayoutTests.swift
@@ -50,6 +50,21 @@ final class NotchIndicatorLayoutTests: XCTestCase {
         XCTAssertGreaterThan(recordingWidth, baseline)
     }
 
+    func testPreparingWidthReservesSpaceForStatusLabel() {
+        let shortLabelWidth = NotchIndicatorLayout.preparingClosedWidth(
+            hasNotch: false,
+            notchWidth: 0,
+            label: ""
+        )
+        let longLabelWidth = NotchIndicatorLayout.preparingClosedWidth(
+            hasNotch: false,
+            notchWidth: 0,
+            label: "Mikrofon wird vorbereitet …"
+        )
+
+        XCTAssertGreaterThan(longLabelWidth, shortLabelWidth)
+    }
+
     func testReservedTimerTextUsesTwoMinuteDigitsBelowOneHundredMinutes() {
         XCTAssertEqual(NotchIndicatorLayout.reservedTimerText(for: 3), "00:00")
     }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -5201,6 +5201,74 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testBluetoothPreparationCanBeCancelledByEscapeBeforeReadiness() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        let defaultInputDeviceID = AudioDeviceID(940)
+        let audioStartEntered = expectation(description: "Bluetooth preparation entered")
+        let audioStartGate = DispatchSemaphore(value: 0)
+        defer { audioStartGate.signal() }
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDeviceTransportResolver: FakeAudioDeviceTransportResolver(
+                transports: [defaultInputDeviceID: kAudioDeviceTransportTypeBluetooth]
+            ),
+            audioDeviceDefaultInputController: APIFakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: defaultInputDeviceID
+            ),
+            audioRecordingBluetoothInputRouteStabilizer: FakeBluetoothInputRouteStabilizer { _, _ in true },
+            audioRecordingRecoveryAudioStore: DictationRecoveryAudioStore(
+                directory: appSupportDirectory.appendingPathComponent("dictation-recovery", isDirectory: true)
+            )
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = false
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.startRecordingOverride = {
+            audioStartEntered.fulfill()
+            audioStartGate.wait()
+        }
+        context.audioRecordingService.stopRecordingOverride = { _ in [] }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await fulfillment(of: [audioStartEntered], timeout: 1)
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+
+        let escapeCGEvent = try XCTUnwrap(
+            CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(0x35), keyDown: true)
+        )
+        let escapeEvent = try XCTUnwrap(NSEvent(cgEvent: escapeCGEvent))
+        XCTAssertFalse(context.hotkeyService.processEventForTesting(escapeEvent, source: .monitor))
+
+        XCTAssertEqual(context.dictationViewModel.recordingDuration, 0)
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+
+        audioStartGate.signal()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        try await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertFalse(context.audioRecordingService.isRecording)
+        XCTAssertTrue(context.audioRecordingService.recoveryRecordingURLs.isEmpty)
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
+        XCTAssertEqual(
+            context.dictationViewModel.apiDictationSession(id: sessionID)?.error,
+            String(localized: "Cancelled")
+        )
+    }
+
+    @MainActor
     func testApiStartRecording_keepsStartSoundForUSBInputAfterInputIsReady() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
@@ -6407,7 +6475,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         audioDeviceBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
         audioDeviceSelectionEngineValidator: AudioInputSelectionEngineValidating = AVAudioInputSelectionEngineValidator(),
         audioDeviceDefaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController(),
-        audioRecordingBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer()
+        audioRecordingBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
+        audioRecordingRecoveryAudioStore: DictationRecoveryAudioStore = DictationRecoveryAudioStore()
     ) -> DictationContext {
         EventBus.shared = EventBus()
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
@@ -6448,7 +6517,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         modelManager.selectProvider(mockPlugin.providerId)
 
         let audioRecordingService = AudioRecordingService(
-            bluetoothInputRouteStabilizer: audioRecordingBluetoothInputRouteStabilizer
+            bluetoothInputRouteStabilizer: audioRecordingBluetoothInputRouteStabilizer,
+            recoveryAudioStore: audioRecordingRecoveryAudioStore
         )
         let hotkeyService = HotkeyService()
         let textInsertionService = TextInsertionService()

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -147,7 +147,20 @@ final class SecureInputDiagnosticsProviderTests: XCTestCase {
     }
 }
 
-final class APIRouterAndHandlersTests: XCTestCase {
+final class TypeWhisperIntegrationTests: XCTestCase {
+    private final class LockedFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedValue = false
+
+        var value: Bool {
+            lock.withLock { storedValue }
+        }
+
+        func set() {
+            lock.withLock { storedValue = true }
+        }
+    }
+
     private actor RecorderStartGate {
         private var entries = 0
         private var firstEntryContinuation: CheckedContinuation<Void, Never>?
@@ -979,6 +992,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let dictionaryService: DictionaryService
         let dictationViewModel: DictationViewModel
         let audioRecordingService: AudioRecordingService
+        let audioDeviceService: AudioDeviceService
         let audioRecorderViewModel: AudioRecorderViewModel
         let audioRecorderService: AudioRecorderService
         let textInsertionService: TextInsertionService
@@ -994,6 +1008,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictionaryService: DictionaryService,
             dictationViewModel: DictationViewModel,
             audioRecordingService: AudioRecordingService,
+            audioDeviceService: AudioDeviceService,
             audioRecorderViewModel: AudioRecorderViewModel,
             audioRecorderService: AudioRecorderService,
             textInsertionService: TextInsertionService,
@@ -1008,6 +1023,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             self.dictionaryService = dictionaryService
             self.dictationViewModel = dictationViewModel
             self.audioRecordingService = audioRecordingService
+            self.audioDeviceService = audioDeviceService
             self.audioRecorderViewModel = audioRecorderViewModel
             self.audioRecorderService = audioRecorderService
             self.textInsertionService = textInsertionService
@@ -2958,6 +2974,150 @@ final class APIRouterAndHandlersTests: XCTestCase {
         XCTAssertEqual((json["error"] as? [String: Any])?["message"] as? String, TranscriptionEngineError.modelNotLoaded.localizedDescription)
     }
 
+    func testDictationStartEndpointWaitsForBluetoothReadinessAndKeepsResponseSchema() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(
+            forKey: UserDefaultsKeys.selectedInputDeviceUID
+        )
+        let originalPriorityList = UserDefaults.standard.object(
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let bluetoothDeviceID = AudioDeviceID(938)
+        let audioStartEntered = expectation(description: "Bluetooth audio start entered")
+        let audioStartGate = DispatchSemaphore(value: 0)
+        let responseReturned = LockedFlag()
+        var context: APIContext?
+        defer {
+            audioStartGate.signal()
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(
+                originalPriorityList,
+                forKey: UserDefaultsKeys.inputDevicePriorityList
+            )
+        }
+
+        let transportResolver = FakeAudioDeviceTransportResolver(
+            transports: [bluetoothDeviceID: kAudioDeviceTransportTypeBluetooth]
+        )
+        let selectionRouteStabilizer = FakeBluetoothInputRouteStabilizer { inputDeviceID, reason in
+            XCTAssertEqual(inputDeviceID, bluetoothDeviceID)
+            XCTAssertEqual(reason, "selection-validation")
+            return true
+        }
+        let recordingRouteStabilizer = FakeBluetoothInputRouteStabilizer { inputDeviceID, reason in
+            XCTAssertEqual(inputDeviceID, bluetoothDeviceID)
+            XCTAssertEqual(reason, "recording-start")
+            return true
+        }
+        let selectionEngineValidator = FakeAudioInputSelectionEngineValidator { preferredDeviceID in
+            XCTAssertNil(preferredDeviceID)
+        }
+
+        context = await MainActor.run {
+            Self.makeAPIContext(
+                appSupportDirectory: appSupportDirectory,
+                withMockTranscriptionPlugin: true,
+                audioDeviceTransportResolver: transportResolver,
+                audioDeviceBluetoothInputRouteStabilizer: selectionRouteStabilizer,
+                audioDeviceSelectionEngineValidator: selectionEngineValidator,
+                audioRecordingBluetoothInputRouteStabilizer: recordingRouteStabilizer
+            )
+        }
+        let apiContext = try XCTUnwrap(context)
+        let workflowID = try await MainActor.run {
+            apiContext.audioDeviceService.inputDevices = [
+                AudioInputDevice(
+                    deviceID: bluetoothDeviceID,
+                    name: "AirPods Pro",
+                    uid: "issue-938-airpods"
+                )
+            ]
+            apiContext.audioDeviceService.audioDeviceIDResolverOverride = { uid in
+                uid == "issue-938-airpods" ? bluetoothDeviceID : nil
+            }
+            apiContext.audioDeviceService.selectedDeviceUID = "issue-938-airpods"
+            apiContext.audioRecordingService.hasMicrophonePermissionOverride = true
+            apiContext.audioRecordingService.inputAvailabilityOverride = { selectedDeviceID in
+                selectedDeviceID == bluetoothDeviceID
+            }
+            apiContext.audioRecordingService.startRecordingOverride = {
+                audioStartEntered.fulfill()
+                audioStartGate.wait()
+            }
+            apiContext.audioRecordingService.stopRecordingOverride = { _ in [] }
+            return try XCTUnwrap(apiContext.workflowService.addWorkflow(
+                name: "AirPods readiness",
+                template: .dictation,
+                trigger: .manual()
+            )?.id.uuidString)
+        }
+        let requestBody = try JSONSerialization.data(
+            withJSONObject: ["workflow_id": workflowID]
+        )
+
+        let responseTask = Task {
+            let response = await apiContext.router.route(HTTPRequest(
+                method: "POST",
+                path: "/v1/dictation/start",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: requestBody
+            ))
+            responseReturned.set()
+            return response
+        }
+
+        await fulfillment(of: [audioStartEntered], timeout: 1)
+        let preparingState = await MainActor.run {
+            (
+                state: apiContext.dictationViewModel.state,
+                isInputReady: apiContext.dictationViewModel.isRecordingInputReady,
+                duration: apiContext.dictationViewModel.recordingDuration
+            )
+        }
+        XCTAssertEqual(preparingState.state, .recording)
+        XCTAssertFalse(preparingState.isInputReady)
+        XCTAssertEqual(preparingState.duration, 0)
+
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertFalse(responseReturned.value)
+
+        let conflictingResponse = await apiContext.router.route(HTTPRequest(
+            method: "POST",
+            path: "/v1/dictation/start",
+            queryParams: [:],
+            headers: [:],
+            body: Data()
+        ))
+        let conflictingJSON = try Self.jsonObject(conflictingResponse)
+        XCTAssertEqual(conflictingResponse.status, 409)
+        XCTAssertEqual(
+            (conflictingJSON["error"] as? [String: Any])?["message"] as? String,
+            "Dictation is not idle"
+        )
+
+        audioStartGate.signal()
+        let response = await responseTask.value
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(Set(json.keys), Set(["id", "status", "workflow_id", "workflow_name"]))
+        XCTAssertNotNil(UUID(uuidString: try XCTUnwrap(json["id"] as? String)))
+        XCTAssertEqual(json["status"] as? String, "recording")
+        XCTAssertEqual(json["workflow_id"] as? String, workflowID)
+        XCTAssertEqual(json["workflow_name"] as? String, "AirPods readiness")
+        let isInputReady = await MainActor.run {
+            apiContext.dictationViewModel.isRecordingInputReady
+        }
+        XCTAssertTrue(isInputReady)
+
+        await MainActor.run {
+            _ = apiContext.dictationViewModel.apiStopRecording()
+        }
+    }
+
     func testWorkflowDictationStartRejectsMalformedUnknownAndDisabledWorkflow() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?
@@ -4878,13 +5038,16 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testApiStartRecording_skipsStartSoundForBluetoothInput() async throws {
+    func testBluetoothDictationStartIsNonBlockingAndDelaysTimerUntilReady() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
         let originalAudioDuckingEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingEnabled)
         let originalAudioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel)
         var events: [String] = []
+        let audioStartEntered = expectation(description: "Bluetooth audio start entered")
+        let audioStartGate = DispatchSemaphore(value: 0)
+        defer { audioStartGate.signal() }
         let bluetoothDeviceID = AudioDeviceID(409)
         let soundService = MockSoundService { event, enabled in
             guard event == .recordingStarted, enabled else { return }
@@ -4947,20 +5110,94 @@ final class APIRouterAndHandlersTests: XCTestCase {
             return true
         }
         context.audioRecordingService.startRecordingOverride = {
-            XCTAssertTrue(context.audioRecordingService.selectedInputDeviceUsesBluetoothTransport)
-            events.append("start_audio")
+            audioStartEntered.fulfill()
+            audioStartGate.wait()
         }
 
         _ = context.dictationViewModel.apiStartRecording()
 
-        XCTAssertEqual(events, ["start_audio"])
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
         XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+        XCTAssertEqual(context.dictationViewModel.recordingDuration, 0)
+        XCTAssertTrue(events.isEmpty)
+
+        await fulfillment(of: [audioStartEntered], timeout: 1)
+        XCTAssertTrue(context.audioRecordingService.selectedInputDeviceUsesBluetoothTransport)
+        XCTAssertTrue(context.audioRecordingService.hasExplicitDeviceSelection)
+
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(context.dictationViewModel.recordingDuration, 0)
+
+        audioStartGate.signal()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+
+        XCTAssertEqual(events, ["duck_audio_0.3"])
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
 
         context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
 
-        XCTAssertEqual(events, ["start_audio", "duck_audio_0.3"])
+        XCTAssertEqual(events, ["duck_audio_0.3"])
         XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
-        XCTAssertTrue(context.audioRecordingService.hasExplicitDeviceSelection)
+    }
+
+    @MainActor
+    func testBluetoothPreparationCanBeStoppedBeforeReadiness() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedInputDeviceUID)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.inputDevicePriorityList)
+        let defaultInputDeviceID = AudioDeviceID(939)
+        let audioStartEntered = expectation(description: "Bluetooth preparation entered")
+        let audioStartGate = DispatchSemaphore(value: 0)
+        defer { audioStartGate.signal() }
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+            Self.restoreSelectedInputDeviceUID(originalSelectedInputDeviceUID)
+            Self.restoreUserDefault(originalPriorityList, forKey: UserDefaultsKeys.inputDevicePriorityList)
+        }
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioDeviceTransportResolver: FakeAudioDeviceTransportResolver(
+                transports: [defaultInputDeviceID: kAudioDeviceTransportTypeBluetooth]
+            ),
+            audioDeviceDefaultInputController: APIFakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: defaultInputDeviceID
+            ),
+            audioRecordingBluetoothInputRouteStabilizer: FakeBluetoothInputRouteStabilizer { _, _ in true }
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.startRecordingOverride = {
+            audioStartEntered.fulfill()
+            audioStartGate.wait()
+        }
+        context.audioRecordingService.stopRecordingOverride = { _ in [] }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await fulfillment(of: [audioStartEntered], timeout: 1)
+
+        let stoppedSessionID = context.dictationViewModel.apiStopRecording()
+
+        XCTAssertEqual(stoppedSessionID, sessionID)
+        XCTAssertEqual(context.dictationViewModel.recordingDuration, 0)
+        XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+
+        audioStartGate.signal()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        try await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertFalse(context.audioRecordingService.isRecording)
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
+        XCTAssertEqual(
+            context.dictationViewModel.apiDictationSession(id: sessionID)?.error,
+            String(localized: "Cancelled")
+        )
     }
 
     @MainActor
@@ -5077,7 +5314,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    func testApiStartRecordingFallsBackToSystemDefaultWhenPriorityMicrophonesUnavailable() async throws {
+    func testDictationStartUsesBluetoothSystemDefaultWhenPriorityMicrophonesAreUnavailable() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let originalSelectedInputDeviceUID = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedInputDeviceUID)
         let originalPriorityList = UserDefaults.standard.object(forKey: UserDefaultsKeys.inputDevicePriorityList)
@@ -5104,7 +5341,12 @@ final class APIRouterAndHandlersTests: XCTestCase {
             ),
             audioDeviceDefaultInputController: APIFakeAudioInputDeviceDefaultController(
                 defaultInputDeviceID: defaultInputDeviceID
-            )
+            ),
+            audioRecordingBluetoothInputRouteStabilizer: FakeBluetoothInputRouteStabilizer { inputDeviceID, reason in
+                XCTAssertEqual(inputDeviceID, defaultInputDeviceID)
+                XCTAssertEqual(reason, "recording-start")
+                return true
+            }
         )
         let context = try XCTUnwrap(dictationContext)
         context.audioDeviceService.inputDevices = []
@@ -5118,7 +5360,15 @@ final class APIRouterAndHandlersTests: XCTestCase {
             XCTAssertFalse(context.audioRecordingService.hasExplicitDeviceSelection)
         }
 
-        _ = context.dictationViewModel.apiStartRecording()
+        _ = await context.dictationViewModel.apiStartRecordingAwaitingReadiness()
+        XCTAssertTrue(context.audioRecordingService.selectedInputDeviceUsesBluetoothTransport)
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+
+        context.audioRecordingService.testingNotifyFirstRecordingAudioBuffer()
+
+        XCTAssertTrue(context.dictationViewModel.isRecordingInputReady)
+        _ = context.dictationViewModel.apiStopRecording()
     }
 
     #if !APPSTORE
@@ -5838,7 +6088,15 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     @MainActor
-    private static func makeAPIContext(appSupportDirectory: URL, withMockTranscriptionPlugin: Bool = false) -> APIContext {
+    private static func makeAPIContext(
+        appSupportDirectory: URL,
+        withMockTranscriptionPlugin: Bool = false,
+        audioDeviceTransportResolver: AudioDeviceTransportResolving = CoreAudioDeviceTransportResolver(),
+        audioDeviceBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
+        audioDeviceSelectionEngineValidator: AudioInputSelectionEngineValidating = AVAudioInputSelectionEngineValidator(),
+        audioDeviceDefaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController(),
+        audioRecordingBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer()
+    ) -> APIContext {
         EventBus.shared = EventBus()
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
         let ttsProvider = MockTTSProviderPlugin()
@@ -5881,7 +6139,9 @@ final class APIRouterAndHandlersTests: XCTestCase {
             modelManager.selectProvider(mockPlugin.providerId)
         }
         let audioFileService = AudioFileService()
-        let audioRecordingService = AudioRecordingService()
+        let audioRecordingService = AudioRecordingService(
+            bluetoothInputRouteStabilizer: audioRecordingBluetoothInputRouteStabilizer
+        )
         let audioRecorderService = AudioRecorderService()
         audioRecorderService.recordingsDirectoryOverride = appSupportDirectory.appendingPathComponent("recordings")
         let hotkeyService = HotkeyService()
@@ -5894,7 +6154,12 @@ final class APIRouterAndHandlersTests: XCTestCase {
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
         let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
         let soundService = SoundService()
-        let audioDeviceService = AudioDeviceService()
+        let audioDeviceService = AudioDeviceService(
+            transportResolver: audioDeviceTransportResolver,
+            bluetoothInputRouteStabilizer: audioDeviceBluetoothInputRouteStabilizer,
+            selectionEngineValidator: audioDeviceSelectionEngineValidator,
+            defaultInputDeviceController: audioDeviceDefaultInputController
+        )
         let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
         let promptProcessingService = PromptProcessingService()
         let appFormatterService = AppFormatterService()
@@ -5964,6 +6229,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel,
             audioRecordingService: audioRecordingService,
+            audioDeviceService: audioDeviceService,
             audioRecorderViewModel: audioRecorderViewModel,
             audioRecorderService: audioRecorderService,
             textInsertionService: textInsertionService,
@@ -6305,7 +6571,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     }
 
     private static func makeEmptyLLMFallbackDefaults() -> (suiteName: String, defaults: UserDefaults) {
-        let suiteName = "APIRouterAndHandlersTests.LLMFallbacks.\(UUID().uuidString)"
+        let suiteName = "TypeWhisperIntegrationTests.LLMFallbacks.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         defaults.set(Data("[]".utf8), forKey: UserDefaultsKeys.llmFallbackPriorityList)
@@ -6432,7 +6698,7 @@ final class APIRouterAndHandlersTests: XCTestCase {
     func testPromptProcessingUsesStableProviderIdsAndLegacyAliases() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
-        let suiteName = "APIRouterAndHandlersTests.LegacyLLMAlias.\(UUID().uuidString)"
+        let suiteName = "TypeWhisperIntegrationTests.LegacyLLMAlias.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/docs/specs/2026-07-15-optional-recording-cancel-confirmation-design.md
+++ b/docs/specs/2026-07-15-optional-recording-cancel-confirmation-design.md
@@ -47,7 +47,7 @@ Add focused regression coverage proving:
 5. Disabling recording confirmation does not change the two-press processing cancellation behavior.
 6. Preference persistence round-trips through `UserDefaults`.
 
-Run the focused `APIRouterAndHandlersTests` cancellation tests and the relevant settings/defaults tests, followed by the normal project build or broader test suite appropriate for the changed files.
+Run the focused `TypeWhisperIntegrationTests` cancellation tests and the relevant settings/defaults tests, followed by the normal project build or broader test suite appropriate for the changed files.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Context

Issue #938 reports that AirPods dictation presents an active recording state before the Bluetooth microphone is actually delivering usable audio, which can drop the first words.

The production reproduction made the timing mismatch explicit:

- TypeWhisper 1.6.0 (1017) stopped dictation after exactly 1.0 second with `No audio data was recorded.`
- The separate microphone test began showing AirPods input levels after approximately 1.5 seconds.
- AirPods output continued to work, isolating the failure to Bluetooth microphone startup.

Closes #938

## What changed

- Move Bluetooth dictation startup onto a serial audio-start queue while keeping UI state changes on the main actor.
- Track every engine replacement with a generation so stale buffers cannot confirm readiness or enter the recording.
- Wait dynamically for up to five seconds for the selected or system-default Bluetooth microphone:
  - confirm readiness after one non-silent converted buffer plus two current buffers with gaps no larger than 250 ms;
  - use three seconds of continuous, format-valid silent buffers only as a silence fallback;
  - recover from missing, stalled, route-changed, or format-changed streams within the shared deadline.
- Stage samples from the final startup generation and promote them when readiness is confirmed.
- Start the timer, streaming, media side effects, and recording-ready event only after confirmed readiness.
- Show a spinner and localized `Preparing microphone` label while Bluetooth input is preparing, while preserving the `Never` indicator visibility setting.
- Make PTT release, toggle, Escape, API stop, and dictionary-training cancellation unwind pending startup and discard staged/recovery audio.
- Keep `POST /v1/dictation/start` response-compatible while waiting internally for microphone readiness.
- Rename the broad `APIRouterAndHandlersTests` suite to `TypeWhisperIntegrationTests`.
- Revalidate the active dictionary-training sample after asynchronous microphone startup so a re-entrant training reset cannot mutate a replacement sample.
- Replace the dictionary cancellation test's fixed scheduler yields with a bounded startup barrier.

There are no external API or response-schema changes.

## Verification

Focused test run from fresh DerivedData:

```bash
derived_data="$(mktemp -d /tmp/typewhisper-938.XXXXXX)"
xcodebuild test -quiet \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS' \
  -derivedDataPath "$derived_data" \
  -allowProvisioningUpdates \
  APP_GROUP_ID='2D8ALY3LCL.com.typewhisper.mac' \
  DEVELOPMENT_TEAM='2D8ALY3LCL' \
  CODE_SIGN_STYLE='Automatic' \
  CODE_SIGN_IDENTITY='Apple Development' \
  -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests \
  -only-testing:TypeWhisperTests/AudioRecordingServiceSelectedDeviceTests \
  -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests \
  -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests \
  -only-testing:TypeWhisperTests/IndicatorPresentationStateTests \
  -only-testing:TypeWhisperTests/LanguageLocalizationTests \
  -only-testing:TypeWhisperTests/DictionaryTrainingServiceTests \
  -only-testing:TypeWhisperTests/NotchIndicatorLayoutTests
```

Result: 301 passed, 0 failed, 0 skipped.

Follow-up run for the final Escape and CodeRabbit changes:

```bash
xcodebuild test -quiet \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS' \
  -derivedDataPath '/tmp/typewhisper-938-escape.AAx03p' \
  -allowProvisioningUpdates \
  APP_GROUP_ID='2D8ALY3LCL.com.typewhisper.mac' \
  DEVELOPMENT_TEAM='2D8ALY3LCL' \
  CODE_SIGN_STYLE='Automatic' \
  CODE_SIGN_IDENTITY='Apple Development' \
  -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testBluetoothPreparationCanBeStoppedBeforeReadiness \
  -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testBluetoothPreparationCanBeCancelledByEscapeBeforeReadiness \
  -only-testing:TypeWhisperTests/DictionaryTrainingServiceTests
```

Result: 14 passed, 0 failed, 0 skipped.

Signed development build:

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run \
  /Users/marco/.codex/worktrees/2eed/typewhisper-mac
```

Result: build, signing, App Group validation, and launch succeeded.

## Manual AirPods acceptance

Verified on the production-reproduction AirPods setup:

- AirPods dictation succeeds with both explicit microphone selection and AirPods as the macOS system-default input.
- Stable internal readiness was observed at approximately 1.64-1.75 seconds; typical hotkey-to-ready time was approximately 2.2 seconds.
- One cold application start reached ready in approximately 4.15 seconds, within the five-second deadline.
- The original false one-second `No audio data was recorded.` failure no longer occurs.
- A second toggle approximately 0.60 seconds after start cancelled preparation cleanly, with no late ready event, new history item, error, or recovery file.
- The built-in MacBook microphone and the unchanged microphone-test path remain working controls.
- Speech that occurs before macOS delivers the first AirPods input buffer cannot be reconstructed. Samples actually delivered during preparation are retained and promoted when readiness is confirmed.

The originally proposed ten-cold-start matrix per selection mode was not completed; the observations above reflect the concrete manual runs performed during this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Bluetooth microphone startup with readiness tracking, cancellation, and more reliable recovery.
  * Added asynchronous recording preparation for dictation and dictionary training.
  * API dictation starts now wait for recording readiness before responding.
  * Added clearer “Preparing microphone” status indicators across supported layouts, including German localization.

* **Bug Fixes**
  * Canceling during microphone preparation now stops pending startup cleanly.
  * Prevented late recording starts from modifying replaced training sessions.
  * Improved audio engine recovery and concurrent dictation handling.

* **Tests**
  * Expanded integration and cancellation coverage for Bluetooth readiness and recording flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->