### PR TITLE
Polish settings UI: dashboard animations, hover effects, and layout consistency

### DIFF
--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -9,6 +9,7 @@ struct PremiumSettingsView: View {
     @ObservedObject private var correctionLearningService: TargetAppCorrectionLearningService
     @AppStorage(UserDefaultsKeys.targetAppCorrectionLearningEnabled) private var targetAppCorrectionLearningEnabled = false
     @State private var confirmingAccountDeletion = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let settingsNavigation: SettingsNavigationCoordinator
 
@@ -32,13 +33,17 @@ struct PremiumSettingsView: View {
             Divider()
 
             ScrollView {
-                premiumAccountCard
+                VStack(alignment: .leading, spacing: SettingsLayoutMetrics.sectionSpacing) {
+                    premiumAccountCard
 
-                if license.hasCommercialLicense || premiumAccount.hasPremiumEntitlement {
-                    premiumControlCenter
-                } else {
-                    lockedPremiumLanding
+                    if license.hasCommercialLicense || premiumAccount.hasPremiumEntitlement {
+                        premiumControlCenter
+                    } else {
+                        lockedPremiumLanding
+                    }
                 }
+                .padding(SettingsLayoutMetrics.pagePadding)
+                .frame(maxWidth: 760, alignment: .topLeading)
             }
         }
         .frame(minWidth: 560, minHeight: 360, alignment: .topLeading)
@@ -97,9 +102,6 @@ struct PremiumSettingsView: View {
                 }
             }
         }
-        .frame(maxWidth: 760, alignment: .leading)
-        .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
-        .padding(.top, SettingsLayoutMetrics.pagePadding)
     }
 
     private var featureColumns: [GridItem] {
@@ -153,8 +155,6 @@ struct PremiumSettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(SettingsLayoutMetrics.pagePadding)
-        .frame(maxWidth: 760, alignment: .topLeading)
     }
 
     private var lockedPremiumHero: some View {
@@ -163,6 +163,7 @@ struct PremiumSettingsView: View {
                 Image(systemName: "sparkles")
                     .font(.system(size: 34, weight: .semibold))
                     .foregroundStyle(.yellow)
+                    .symbolEffect(.variableColor.iterative.reversing, options: .repeating.speed(0.4), isActive: !reduceMotion)
                     .frame(width: 58, height: 58)
                     .background(
                         RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)
@@ -193,7 +194,6 @@ struct PremiumSettingsView: View {
                 Spacer(minLength: 12)
             }
         }
-        .frame(maxWidth: 640, alignment: .topLeading)
     }
 
     private func premiumLandingFeatureCard(
@@ -270,7 +270,6 @@ struct PremiumSettingsView: View {
                 premiumLockedActionButton
             }
         }
-        .frame(maxWidth: 640, alignment: .leading)
     }
 
     private var premiumLockedActionButton: some View {
@@ -319,8 +318,6 @@ struct PremiumSettingsView: View {
 
             CloudFolderSyncSettingsView(controller: syncController)
         }
-        .padding(SettingsLayoutMetrics.pagePadding)
-        .frame(maxWidth: 760, alignment: .topLeading)
     }
 
     private var premiumControlHeader: some View {
@@ -328,6 +325,7 @@ struct PremiumSettingsView: View {
             Image(systemName: "sparkles")
                 .font(.title2)
                 .foregroundStyle(.yellow)
+                .symbolEffect(.variableColor.iterative.reversing, options: .repeating.speed(0.4), isActive: !reduceMotion)
                 .frame(width: 44, height: 44)
                 .background(
                     RoundedRectangle(cornerRadius: SettingsLayoutMetrics.compactCornerRadius, style: .continuous)

--- a/TypeWhisper/Views/SettingsVisualComponents.swift
+++ b/TypeWhisper/Views/SettingsVisualComponents.swift
@@ -43,6 +43,10 @@ struct SettingsPageHeader<Actions: View>: View {
             actions
                 .controlSize(.small)
         }
+        // Consistent header height across pages: a trailing accessory (e.g. the
+        // Statistics period picker) must not make the bar taller than a
+        // title-only header. Summary (two-line) headers still grow past this.
+        .frame(minHeight: 28)
         .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
         .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -19,6 +19,7 @@ struct SetupWizardView: View {
     @State private var isActivatingParakeet = false
     @State private var manuallySelectedSetupProviderId: String?
     @State private var isLogoHovering = false
+    @State private var isMovingForward = true
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var isTrialFieldFocused: Bool
 
@@ -115,7 +116,8 @@ struct SetupWizardView: View {
         trialText = ""
         manuallySelectedSetupProviderId = nil
         UserDefaults.standard.set(0, forKey: UserDefaultsKeys.setupWizardCurrentStep)
-        withAnimation(.easeInOut(duration: 0.18)) {
+        isMovingForward = false
+        withAnimation(.easeInOut(duration: 0.3)) {
             currentStep = 0
         }
     }
@@ -198,31 +200,38 @@ struct SetupWizardView: View {
     private var stepContent: some View {
         ScrollView {
             VStack(spacing: 18) {
-                VStack(spacing: 5) {
-                    Text(currentWizardStep.title)
-                        .font(.title2.weight(.bold))
-                        .multilineTextAlignment(.center)
-                        .accessibilityAddTraits(.isHeader)
+                VStack(spacing: 18) {
+                    VStack(spacing: 5) {
+                        Text(currentWizardStep.title)
+                            .font(.title2.weight(.bold))
+                            .multilineTextAlignment(.center)
+                            .accessibilityAddTraits(.isHeader)
 
-                    Text(currentWizardStep.subtitle)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-                .padding(.top, 12)
+                        Text(currentWizardStep.subtitle)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.top, 12)
 
-                switch currentWizardStep {
-                case .welcome:
-                    welcomeStep
-                case .permissions:
-                    permissionsStep
-                case .hotkey:
-                    hotkeyStep
-                case .engineAI:
-                    engineAIStep
-                case .finish:
-                    finishStep
+                    switch currentWizardStep {
+                    case .welcome:
+                        welcomeStep
+                    case .permissions:
+                        permissionsStep
+                    case .hotkey:
+                        hotkeyStep
+                    case .engineAI:
+                        engineAIStep
+                    case .finish:
+                        finishStep
+                    }
                 }
+                // Slide each step in from the direction of travel (forward from
+                // the trailing edge, back from the leading edge); fall back to a
+                // plain fade under Reduce Motion.
+                .id(currentWizardStep)
+                .transition(stepTransition)
             }
             .frame(maxWidth: 620)
             .frame(maxWidth: .infinity)
@@ -232,11 +241,23 @@ struct SetupWizardView: View {
         .scrollIndicators(.never)
     }
 
+    /// Directional slide+fade for step changes; plain fade under Reduce Motion.
+    private var stepTransition: AnyTransition {
+        if reduceMotion { return .opacity }
+        let insertionEdge: Edge = isMovingForward ? .trailing : .leading
+        let removalEdge: Edge = isMovingForward ? .leading : .trailing
+        return .asymmetric(
+            insertion: .move(edge: insertionEdge).combined(with: .opacity),
+            removal: .move(edge: removalEdge).combined(with: .opacity)
+        )
+    }
+
     private var footer: some View {
         HStack(spacing: 12) {
             if currentStep > 0 {
                 Button(localizedAppText("Back", de: "Zurück")) {
-                    withAnimation(.easeInOut(duration: 0.18)) {
+                    isMovingForward = false
+                    withAnimation(.easeInOut(duration: 0.3)) {
                         currentStep -= 1
                     }
                 }
@@ -304,7 +325,8 @@ struct SetupWizardView: View {
             return
         }
 
-        withAnimation(.easeInOut(duration: 0.18)) {
+        isMovingForward = true
+        withAnimation(.easeInOut(duration: 0.3)) {
             currentStep = min(currentStep + 1, SetupWizardStep.allCases.count - 1)
         }
     }

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -206,13 +206,9 @@ struct StatisticsView: View {
                     // Keep the y-axis fixed so the bars visibly grow from the
                     // baseline instead of the whole chart rescaling.
                     .chartYScale(domain: 0...chartYMax)
-                    .onAppear {
-                        guard !animateBars else { return }
-                        if reduceMotion {
-                            animateBars = true
-                        } else {
-                            withAnimation(.easeOut(duration: 0.6)) { animateBars = true }
-                        }
+                    .onAppear { startBarAnimation() }
+                    .onChange(of: viewModel.selectedTimePeriod) { _, _ in
+                        startBarAnimation()
                     }
                     .accessibilityElement(children: .ignore)
                     .accessibilityAddTraits(.isStaticText)
@@ -229,6 +225,19 @@ struct StatisticsView: View {
         // top edge, and the axis stays stable while the bars animate up.
         let peak = viewModel.chartData.map(\.wordCount).max() ?? 0
         return max(Int((Double(peak) * 1.15).rounded(.up)), 1)
+    }
+
+    /// Drops the activity bars to the baseline and animates them up. Runs on first
+    /// appearance and re-arms on every period change so the bars re-grow each time.
+    private func startBarAnimation() {
+        animateBars = false
+        guard !reduceMotion else {
+            animateBars = true
+            return
+        }
+        DispatchQueue.main.async {
+            withAnimation(.easeOut(duration: 0.6)) { animateBars = true }
+        }
     }
 
     private var chartAccessibilitySummary: Text {

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -7,6 +7,8 @@ struct StatisticsView: View {
 
     @State private var hoveredDate: Date?
     @State private var hoverLocation: CGPoint = .zero
+    @State private var animateBars = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -148,7 +150,7 @@ struct StatisticsView: View {
                     Chart(viewModel.chartData) { point in
                         BarMark(
                             x: .value(String(localized: "Date"), point.date, unit: .day),
-                            y: .value(String(localized: "Words"), point.wordCount)
+                            y: .value(String(localized: "Words"), animateBars ? point.wordCount : 0)
                         )
                         .foregroundStyle(
                             hoveredDate != nil && Calendar.current.isDate(point.date, inSameDayAs: hoveredDate!)
@@ -201,12 +203,32 @@ struct StatisticsView: View {
                     }
                     }
                     .frame(height: 200)
+                    // Keep the y-axis fixed so the bars visibly grow from the
+                    // baseline instead of the whole chart rescaling.
+                    .chartYScale(domain: 0...chartYMax)
+                    .onAppear {
+                        guard !animateBars else { return }
+                        if reduceMotion {
+                            animateBars = true
+                        } else {
+                            withAnimation(.easeOut(duration: 0.6)) { animateBars = true }
+                        }
+                    }
                     .accessibilityElement(children: .ignore)
                     .accessibilityAddTraits(.isStaticText)
                     .accessibilityLabel(chartAccessibilitySummary)
                 }
             }
         }
+    }
+
+    /// Fixed upper bound for the activity chart's y-axis (with a little headroom),
+    /// so bars animate up into a stable axis rather than rescaling as they grow.
+    private var chartYMax: Int {
+        // ~15% headroom above the tallest bar so it doesn't sit flush against the
+        // top edge, and the axis stays stable while the bars animate up.
+        let peak = viewModel.chartData.map(\.wordCount).max() ?? 0
+        return max(Int((Double(peak) * 1.15).rounded(.up)), 1)
     }
 
     private var chartAccessibilitySummary: Text {
@@ -452,7 +474,7 @@ private struct StatisticsStatCard: View {
                     .font(.title2)
                     .foregroundStyle(Color.accentColor)
                     .accessibilityHidden(true)
-                Text(value)
+                CountUpText(value: value)
                     .font(.title)
                     .fontWeight(.bold)
                     .monospacedDigit()
@@ -480,7 +502,7 @@ struct StatisticsMetricCard: View {
                     .font(.title2)
                     .foregroundStyle(Color.accentColor)
                     .accessibilityHidden(true)
-                Text(value)
+                CountUpText(value: value)
                     .font(.title)
                     .fontWeight(.bold)
                     .monospacedDigit()
@@ -520,5 +542,51 @@ struct StatisticsMetricCard: View {
                 .monospacedDigit()
         }
         .foregroundStyle(isPositive ? .green : .red)
+    }
+}
+
+// MARK: - Count-up number
+
+/// Renders a stat value, counting up from zero on appear when the value is a
+/// plain whole number (e.g. "42", "1,234"). Values with units or non-numeric
+/// characters (e.g. "3d", "12:34", "18 WPM") are shown as-is so nothing is
+/// mis-animated. Respects Reduce Motion.
+private struct CountUpText: View {
+    let value: String
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animate = false
+
+    /// The integer to count up to, but only when `value` is a plain whole number
+    /// with no grouping separators or units, so the displayed count-up matches the
+    /// source string exactly (values like "3d", "12:34", "42.5", "1,234" are left
+    /// untouched).
+    private var target: Int? {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        guard let intValue = Int(trimmed), "\(intValue)" == trimmed else { return nil }
+        return intValue
+    }
+
+    var body: some View {
+        if let target, !reduceMotion {
+            AnimatableNumberText(number: animate ? Double(target) : 0)
+                .onAppear { withAnimation(.easeOut(duration: 0.7)) { animate = true } }
+        } else {
+            Text(value)
+        }
+    }
+}
+
+/// A `Text` whose numeric content animates smoothly via `Animatable`.
+private struct AnimatableNumberText: View, Animatable {
+    var number: Double
+
+    nonisolated var animatableData: Double {
+        get { number }
+        set { number = newValue }
+    }
+
+    var body: some View {
+        // Plain integer string (no grouping) to match the source value formatting.
+        Text("\(Int(number.rounded()))")
     }
 }

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -476,17 +476,12 @@ private struct StatisticsStatCard: View {
     /// Overrides `value` for VoiceOver, e.g. spelling out "3 days" instead of the compact "3d" badge text.
     var accessibilityValue: String?
 
-    @State private var hovering = false
-    @State private var iconBounce = 0
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     var body: some View {
         SettingsCard {
             VStack(spacing: 6) {
                 Image(systemName: systemImage)
                     .font(.title2)
                     .foregroundStyle(Color.accentColor)
-                    .symbolEffect(.bounce, value: iconBounce)
                     .accessibilityHidden(true)
                 CountUpText(value: value)
                     .font(.title)
@@ -497,17 +492,6 @@ private struct StatisticsStatCard: View {
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)
-        }
-        .scaleEffect(hovering && !reduceMotion ? 1.02 : 1.0)
-        .shadow(
-            color: .black.opacity(hovering && !reduceMotion ? 0.16 : 0),
-            radius: hovering && !reduceMotion ? 8 : 0,
-            y: hovering && !reduceMotion ? 3 : 0
-        )
-        .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: hovering)
-        .onHover { isHovering in
-            hovering = isHovering
-            if isHovering && !reduceMotion { iconBounce += 1 }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text("\(title), \(accessibilityValue ?? value)"))
@@ -520,17 +504,12 @@ struct StatisticsMetricCard: View {
     let systemImage: String
     var trend: Double?
 
-    @State private var hovering = false
-    @State private var iconBounce = 0
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     var body: some View {
         SettingsCard {
             VStack(spacing: 6) {
                 Image(systemName: systemImage)
                     .font(.title2)
                     .foregroundStyle(Color.accentColor)
-                    .symbolEffect(.bounce, value: iconBounce)
                     .accessibilityHidden(true)
                 CountUpText(value: value)
                     .font(.title)
@@ -544,17 +523,6 @@ struct StatisticsMetricCard: View {
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)
-        }
-        .scaleEffect(hovering && !reduceMotion ? 1.02 : 1.0)
-        .shadow(
-            color: .black.opacity(hovering && !reduceMotion ? 0.16 : 0),
-            radius: hovering && !reduceMotion ? 8 : 0,
-            y: hovering && !reduceMotion ? 3 : 0
-        )
-        .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: hovering)
-        .onHover { isHovering in
-            hovering = isHovering
-            if isHovering && !reduceMotion { iconBounce += 1 }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(trendAwareAccessibilityLabel)

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -476,12 +476,17 @@ private struct StatisticsStatCard: View {
     /// Overrides `value` for VoiceOver, e.g. spelling out "3 days" instead of the compact "3d" badge text.
     var accessibilityValue: String?
 
+    @State private var hovering = false
+    @State private var iconBounce = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         SettingsCard {
             VStack(spacing: 6) {
                 Image(systemName: systemImage)
                     .font(.title2)
                     .foregroundStyle(Color.accentColor)
+                    .symbolEffect(.bounce, value: iconBounce)
                     .accessibilityHidden(true)
                 CountUpText(value: value)
                     .font(.title)
@@ -492,6 +497,17 @@ private struct StatisticsStatCard: View {
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)
+        }
+        .scaleEffect(hovering && !reduceMotion ? 1.02 : 1.0)
+        .shadow(
+            color: .black.opacity(hovering ? 0.16 : 0),
+            radius: hovering ? 8 : 0,
+            y: hovering ? 3 : 0
+        )
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hovering)
+        .onHover { isHovering in
+            hovering = isHovering
+            if isHovering && !reduceMotion { iconBounce += 1 }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text("\(title), \(accessibilityValue ?? value)"))
@@ -504,12 +520,17 @@ struct StatisticsMetricCard: View {
     let systemImage: String
     var trend: Double?
 
+    @State private var hovering = false
+    @State private var iconBounce = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         SettingsCard {
             VStack(spacing: 6) {
                 Image(systemName: systemImage)
                     .font(.title2)
                     .foregroundStyle(Color.accentColor)
+                    .symbolEffect(.bounce, value: iconBounce)
                     .accessibilityHidden(true)
                 CountUpText(value: value)
                     .font(.title)
@@ -523,6 +544,17 @@ struct StatisticsMetricCard: View {
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)
+        }
+        .scaleEffect(hovering && !reduceMotion ? 1.02 : 1.0)
+        .shadow(
+            color: .black.opacity(hovering ? 0.16 : 0),
+            radius: hovering ? 8 : 0,
+            y: hovering ? 3 : 0
+        )
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hovering)
+        .onHover { isHovering in
+            hovering = isHovering
+            if isHovering && !reduceMotion { iconBounce += 1 }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(trendAwareAccessibilityLabel)

--- a/TypeWhisper/Views/StatisticsView.swift
+++ b/TypeWhisper/Views/StatisticsView.swift
@@ -500,11 +500,11 @@ private struct StatisticsStatCard: View {
         }
         .scaleEffect(hovering && !reduceMotion ? 1.02 : 1.0)
         .shadow(
-            color: .black.opacity(hovering ? 0.16 : 0),
-            radius: hovering ? 8 : 0,
-            y: hovering ? 3 : 0
+            color: .black.opacity(hovering && !reduceMotion ? 0.16 : 0),
+            radius: hovering && !reduceMotion ? 8 : 0,
+            y: hovering && !reduceMotion ? 3 : 0
         )
-        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hovering)
+        .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: hovering)
         .onHover { isHovering in
             hovering = isHovering
             if isHovering && !reduceMotion { iconBounce += 1 }
@@ -547,11 +547,11 @@ struct StatisticsMetricCard: View {
         }
         .scaleEffect(hovering && !reduceMotion ? 1.02 : 1.0)
         .shadow(
-            color: .black.opacity(hovering ? 0.16 : 0),
-            radius: hovering ? 8 : 0,
-            y: hovering ? 3 : 0
+            color: .black.opacity(hovering && !reduceMotion ? 0.16 : 0),
+            radius: hovering && !reduceMotion ? 8 : 0,
+            y: hovering && !reduceMotion ? 3 : 0
         )
-        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hovering)
+        .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: hovering)
         .onHover { isHovering in
             hovering = isHovering
             if isHovering && !reduceMotion { iconBounce += 1 }


### PR DESCRIPTION
## Summary

A set of small UI polish touches across the settings surfaces.

**Animations**
- **Statistics chart** — bars grow from the baseline on open (against a fixed y-axis so they visibly rise), and re-animate on each time-period change.
- **Statistics numbers** — whole-number stat cards count up from zero on appear. Values with units/formatting (durations, streak days, WPM, grouped numbers) are shown as-is so nothing is mis-animated.
- **Stat cards (Home & Statistics)** — hover elevation (subtle scale + shadow) plus an SF Symbol icon bounce on hover.
- **Setup wizard** — steps slide in the direction of travel (forward from the trailing edge, back from the leading edge) with a fade, instead of swapping abruptly.
- **Premium** — the sparkles hero icons get a slow shimmer (variableColor).

**Layout consistency**
- **SettingsPageHeader** — a minimum row height so a trailing accessory (e.g. the Statistics period picker) no longer makes the header bar taller than a title-only header. Two-line summary headers still grow.
- **Premium** — page content is wrapped in one width-capped column so the account card, hero, feature cards and callout all share the same width and edges (previously each section applied its own max-width/padding, so the account card was wider than the cards below it).

Everything that moves respects **Reduce Motion** (no count-up, hover scale/bounce, slide, or shimmer when the setting is enabled). VoiceOver reads each stat's final value, not the animating number.

## Test Plan

- [ ] Ran `scripts/pr-preflight.sh`
- [x] Built and ran locally
- [x] Tested manually: Statistics (bars rise + re-arm on period change; integer cards count up incl. 5-digit values; hover lift + icon bounce), setup wizard forward/back slide, Premium column alignment + shimmer, header heights consistent across pages
- [x] No regressions in existing features


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved Setup Wizard navigation with directional slide+fade transitions and smoother restart/back/forward timing.
  * Enhanced Statistics visuals with reduced-motion-aware activity bar animation, stable chart scaling, and count-up number rendering.
  * Refined Premium Settings layout alignment/spacing and standardized the settings page header height.
* **Accessibility**
  * Animations now respect the system Reduce Motion setting across the Setup Wizard, Statistics activity chart/cards, and Premium sparkles effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->